### PR TITLE
Allow metadata of any dimension in HDF5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ astropy.io.misc
 
   - When writing to HDF5 files, the serialized metadata are now saved in a new
     dataset instead of the HDF5 dataset attributes. This allows for metadata of
-    any dimensions. (#6304)
+    any dimensions. [#6304]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -119,6 +119,10 @@ astropy.io.fits
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
+
+  - When writing to HDF5 files, the serialized metadata are now saved in a new
+    dataset instead of the HDF5 dataset attributes. This allows for metadata of
+    any dimensions. [#6304]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,16 +34,9 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
-astropy.io.registry
-^^^^^^^^^^^^^^^^^^^
   - When writing to HDF5 files, the serialized metadata are now saved in a new
     dataset instead of the HDF5 dataset attributes. This allows for metadata of
-    any dimensions.
-
-
-  - When writing to HDF5 files, the serialized metadata are now saved in a new
-    dataset instead of the HDF5 dataset attributes. This allows for metadata of
-    any dimensions.
+    any dimensions. (#6304)
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -420,11 +413,6 @@ astropy.constants
 
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
-  - When writing to HDF5 files, the serialized metadata are now saved in a new
-    dataset instead of the HDF5 dataset attributes. This allows for metadata of
-    any dimensions.
-
-- ``astropy.io.registry``
 
 - Major change in convolution behavior and keyword arguments. Additional
   details are in the API section. [#5782]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,17 @@ astropy.io.misc
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
+  - When writing to HDF5 files, the serialized metadata are now saved in a new
+    dataset instead of the HDF5 dataset attributes. This allows for metadata of
+    any dimensions.
+
+
+  - When writing to HDF5 files, the serialized metadata are now saved in a new
+    dataset instead of the HDF5 dataset attributes. This allows for metadata of
+    any dimensions.
+
+astropy.io.registry
+^^^^^^^^^^^^^^^^^^^
 
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
@@ -409,6 +420,11 @@ astropy.constants
 
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
+  - When writing to HDF5 files, the serialized metadata are now saved in a new
+    dataset instead of the HDF5 dataset attributes. This allows for metadata of
+    any dimensions.
+
+- ``astropy.io.registry``
 
 - Major change in convolution behavior and keyword arguments. Additional
   details are in the API section. [#5782]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ astropy.io.misc
 ^^^^^^^^^^^^^^^
 
   - When writing to HDF5 files, the serialized metadata are now saved in a new
-    dataset instead of the HDF5 dataset attributes. This allows for metadata of
+    dataset, instead of the HDF5 dataset attributes. This allows for metadata of
     any dimensions. [#6304]
 
 astropy.io.registry

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -300,8 +300,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
                 "file: {0}".format(e))
 
         else:
-            dset2 = output_group.create_dataset(meta_path(name),
-                                                data=header_encoded)
+            output_group.create_dataset(meta_path(name),
+                                        data=header_encoded)
 
     else:
         # Write the meta-data to the file

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -12,7 +12,7 @@ import os
 import warnings
 
 import numpy as np
-from ...utils.exceptions import AstropyUserWarning
+from ...utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 from ...extern import six
 from ...table import meta
 
@@ -20,6 +20,10 @@ HDF5_SIGNATURE = b'\x89HDF\r\n\x1a\n'
 META_KEY = '__table_column_meta__'
 
 __all__ = ['read_table_hdf5', 'write_table_hdf5']
+
+
+def meta_path(path):
+    return path + '.' + META_KEY
 
 
 def _find_all_structured_arrays(handle):
@@ -80,11 +84,17 @@ def read_table_hdf5(input, path=None):
     except ImportError:
         raise Exception("h5py is required to read and write HDF5 files")
 
+    # This function is iterative, and only gets to writing the file when
+    # the input is an hdf5 Group. Moreover, the input variable is changed in
+    # place.
+    # Here, we save its value to be used at the end when the conditions are
+    # right.
+    input_save = input
     if isinstance(input, (h5py.highlevel.File, h5py.highlevel.Group)):
 
         # If a path was specified, follow the path
 
-        if path:
+        if path is not None:
             try:
                 input = input[path]
             except (KeyError, ValueError):
@@ -139,10 +149,20 @@ def read_table_hdf5(input, path=None):
     from ...table import Table
     table = Table(np.array(input))
 
-    # Read the meta-data from the file
-    if META_KEY in input.attrs:
-        header = meta.get_header_from_yaml(
-            h.decode('utf-8') for h in input.attrs[META_KEY])
+    # Read the meta-data from the file. For back-compatibility, we can read
+    # the old file format where the serialized metadata were saved in the
+    # attributes of the HDF5 dataset.
+    # In the new format, instead, metadata are stored in a new dataset in the
+    # same file. This is introduced in Astropy 3.0
+    old_version_meta = META_KEY in input.attrs
+    new_version_meta = path is not None and meta_path(path) in input_save
+    if old_version_meta or new_version_meta:
+        if new_version_meta:
+            header = meta.get_header_from_yaml(
+                h.decode('utf-8') for h in input_save[meta_path(path)])
+        elif old_version_meta:
+            header = meta.get_header_from_yaml(
+                h.decode('utf-8') for h in input.attrs[META_KEY])
         if 'meta' in list(header.keys()):
             table.meta = header['meta']
 
@@ -159,7 +179,8 @@ def read_table_hdf5(input, path=None):
 
 
 def write_table_hdf5(table, output, path=None, compression=False,
-                     append=False, overwrite=False, serialize_meta=False):
+                     append=False, overwrite=False, serialize_meta=False,
+                     compatibility_mode=False):
     """
     Write a Table object to an HDF5 file
 
@@ -237,7 +258,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
             return write_table_hdf5(table, f, path=path,
                                     compression=compression, append=append,
                                     overwrite=overwrite,
-                                    serialize_meta=serialize_meta)
+                                    serialize_meta=serialize_meta,
+                                    compatibility_mode=compatibility_mode)
         finally:
             f.close()
 
@@ -266,11 +288,20 @@ def write_table_hdf5(table, output, path=None, compression=False,
     if serialize_meta:
         header_yaml = meta.get_yaml_from_table(table)
 
-        try:
-            dset.attrs[META_KEY] = [h.encode('utf8') for h in header_yaml]
-        except Exception as e:
-            warnings.warn("Attributes could not be written to the output HDF5 "
-                          "file: {0}".format(e))
+        header_encoded = [h.encode('utf-8') for h in header_yaml]
+        if compatibility_mode:
+            warnings.warn("compatibility mode for writing is deprecated",
+                          AstropyDeprecationWarning)
+            try:
+                dset.attrs[META_KEY] = header_encoded
+            except Exception as e:
+                warnings.warn(
+                "Attributes could not be written to the output HDF5 "
+                "file: {0}".format(e))
+
+        else:
+            dset2 = output_group.create_dataset(meta_path(name),
+                                                data=header_encoded)
 
     else:
         # Write the meta-data to the file

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -401,17 +401,98 @@ def test_preserve_serialized(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
-def test_metadata_too_large(tmpdir):
+def test_preserve_serialized_compatibility_mode(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
 
     t1 = Table()
-    t1['a'] = Column(data=[1, 2, 3])
-    t1.meta["meta"] = "0" * (2**16 + 1)
+    t1['a'] = Column(data=[1, 2, 3], unit="s")
+    t1['a'].meta['a0'] = "A0"
+    t1['a'].meta['a1'] = {"a1": [0, 1]}
+    t1['a'].format = '7.3f'
+    t1['a'].description = 'A column'
+    t1.meta['b'] = 1
+    t1.meta['c'] = {"c0": [0, 1]}
 
     with catch_warnings() as w:
-        t1.write(test_file, path='the_table', serialize_meta=True, overwrite=True)
-    assert len(w) == 1
+        t1.write(test_file, path='the_table', serialize_meta=True,
+                 overwrite=True, compatibility_mode=True)
+
     assert str(w[0].message).startswith(
+        "compatibility mode for writing is deprecated")
+
+    t2 = Table.read(test_file, path='the_table')
+
+    assert t1['a'].unit == t2['a'].unit
+    assert t1['a'].format == t2['a'].format
+    assert t1['a'].description == t2['a'].description
+    assert t1['a'].meta == t2['a'].meta
+    assert t1.meta == t2.meta
+
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+def test_preserve_serialized_in_complicated_path(tmpdir):
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    t1 = Table()
+    t1['a'] = Column(data=[1, 2, 3], unit="s")
+    t1['a'].meta['a0'] = "A0"
+    t1['a'].meta['a1'] = {"a1": [0, 1]}
+    t1['a'].format = '7.3f'
+    t1['a'].description = 'A column'
+    t1.meta['b'] = 1
+    t1.meta['c'] = {"c0": [0, 1]}
+
+    t1.write(test_file, path='the_table/complicated/path', serialize_meta=True,
+             overwrite=True)
+
+    t2 = Table.read(test_file, path='the_table/complicated/path')
+
+    assert t1['a'].format == t2['a'].format
+    assert t1['a'].unit == t2['a'].unit
+    assert t1['a'].description == t2['a'].description
+    assert t1['a'].meta == t2['a'].meta
+    assert t1.meta == t2.meta
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+def test_metadata_very_large(tmpdir):
+    """Test that very large datasets work, now!"""
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    t1 = Table()
+    t1['a'] = Column(data=[1, 2, 3], unit="s")
+    t1['a'].meta['a0'] = "A0"
+    t1['a'].meta['a1'] = {"a1": [0, 1]}
+    t1['a'].format = '7.3f'
+    t1['a'].description = 'A column'
+    t1.meta['b'] = 1
+    t1.meta['c'] = {"c0": [0, 1]}
+    t1.meta["meta_big"] = "0" * (2 ** 16 + 1)
+    t1.meta["meta_biggerstill"] = "0" * (2 ** 18)
+
+    t1.write(test_file, path='the_table', serialize_meta=True, overwrite=True)
+
+    t2 = Table.read(test_file, path='the_table')
+
+    assert t1['a'].unit == t2['a'].unit
+    assert t1['a'].format == t2['a'].format
+    assert t1['a'].description == t2['a'].description
+    assert t1['a'].meta == t2['a'].meta
+    assert t1.meta == t2.meta
+
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+def test_metadata_very_large_fails_compatibility_mode(tmpdir):
+    """Test that very large datasets work, now!"""
+    test_file = str(tmpdir.join('test.hdf5'))
+    t1 = Table()
+    t1['a'] = Column(data=[1, 2, 3])
+    t1.meta["meta"] = "0" * (2 ** 16 + 1)
+    with catch_warnings() as w:
+        t1.write(test_file, path='the_table', serialize_meta=True,
+                 overwrite=True, compatibility_mode=True)
+    assert len(w) == 2
+
+    assert str(w[1].message).startswith(
         "Attributes could not be written to the output HDF5 "
         "file: Unable to create attribute (Object header message is too large)")
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -482,7 +482,7 @@ def test_metadata_very_large(tmpdir):
 
 @pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
 def test_metadata_very_large_fails_compatibility_mode(tmpdir):
-    """Test that very large datasets work, now!"""
+    """Test that very large metadata do not work in compatibility mode."""
     test_file = str(tmpdir.join('test.hdf5'))
     t1 = Table()
     t1['a'] = Column(data=[1, 2, 3])

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -444,10 +444,16 @@ file that has multiple datasets, use *both* the ``overwrite=True`` and
 
 If the metadata of the table cannot be written directly to the HDF5 file 
 (e.g. dictionaries), or if you want to preserve the units and description
-of tables and columns, use using ``serialize_meta=True``::
+of tables and columns, use ``serialize_meta=True``::
 
     >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True)
- 
+
+The way serialized meta are saved in the HDF5 dataset have changed in Astropy 3.0.
+Files in the old format are still read correctly. If for some reason the user wants to *write*
+in the old format, they will specify the (deprecated) `compatibility_mode` keyword
+
+    >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True, compatibility_mode=True)
+
 Finally, when writing to HDF5 files, the ``compression=`` argument can be
 used to ensure that the data is compressed on disk::
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -450,7 +450,7 @@ of tables and columns, use ``serialize_meta=True``::
 
 The way serialized meta are saved in the HDF5 dataset have changed in Astropy 3.0.
 Files in the old format are still read correctly. If for some reason the user wants to *write*
-in the old format, they will specify the (deprecated) `compatibility_mode` keyword
+in the old format, they will specify the (deprecated) ``compatibility_mode`` keyword
 
     >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True, compatibility_mode=True)
 


### PR DESCRIPTION
Instead of using the attributes of the HDF5 table, use a different path which is just `path + META_KEY` to save the serialized metadata. This allows metadata of any dimensions, overcoming the 64k limit of h5py.

Two issues to discuss:
1. Is backwards compatibility needed for files written in the old version of Astropy with the old attributes?
2. Do we need to still allow using the attributes for new files, even if limited by the 64k HDF5 limit?

- [x] I will add tests to ensure that paths that contain subpaths still work