### PR TITLE
Fix UVW velocities for LSR

### DIFF
--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -127,7 +127,7 @@ class Galactocentric(BaseCoordinateFrame):
         ...                distance=[11.5, 24.12] * u.kpc)
         >>> c.transform_to(coord.Galactocentric) # doctest: +FLOAT_CMP
         <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
-            ( 266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(-11.1,  244.,  7.25) km / s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
+            ( 266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=( 11.1,  232.24,  7.25) km / s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
             [( -9.6083819 ,  -9.40062188,  6.52056066),
              (-21.28302307,  18.76334013,  7.84693855)]>
 
@@ -136,7 +136,7 @@ class Galactocentric(BaseCoordinateFrame):
 
         >>> c.transform_to(coord.Galactocentric(galcen_distance=8.1*u.kpc)) # doctest: +FLOAT_CMP
         <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
-            ( 266.4051, -28.936175)>, galcen_distance=8.1 kpc, galcen_v_sun=(-11.1,  244.,  7.25) km / s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
+            ( 266.4051, -28.936175)>, galcen_distance=8.1 kpc, galcen_v_sun=( 11.1,  232.24,  7.25) km / s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
             [( -9.40785924,  -9.40062188,  6.52066574),
              (-21.08239383,  18.76334013,  7.84798135)]>
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -180,7 +180,7 @@ class Galactocentric(BaseCoordinateFrame):
     galcen_distance = QuantityFrameAttribute(default=8.3*u.kpc)
 
     galcen_v_sun = DifferentialFrameAttribute(
-        default=r.CartesianDifferential([-11.1, 244, 7.25] * u.km/u.s),
+        default=r.CartesianDifferential([11.1, 220+12.24, 7.25] * u.km/u.s),
         allowed_classes=[r.CartesianDifferential])
 
     z_sun = FrameAttribute(default=27.*u.pc)

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -18,7 +18,7 @@ from .galactic import Galactic
 # For speed
 J2000 = Time('J2000')
 
-v_bary_Schoenrich2010 = r.CartesianDifferential([-11.1, 12.24, 7.25]*u.km/u.s)
+v_bary_Schoenrich2010 = r.CartesianDifferential([11.1, 12.24, 7.25]*u.km/u.s)
 
 __all__ = ['LSR', 'GalacticLSR']
 
@@ -38,9 +38,9 @@ class LSR(BaseRADecFrame):
     velocity frame.
 
     We use default values from Schönrich et al. (2010) for the barycentric
-    velocity relative to the LSR, which is defined in Galactic cartesian
-    velocity components
-    :math:`(U, V, W) = (-11.1, 12.24, 7.25)~{{\rm km}}~{{\rm s}}^{{-1}}`. These
+    velocity relative to the LSR, which is defined in Galactic (right-handed)
+    cartesian velocity components
+    :math:`(U, V, W) = (11.1, 12.24, 7.25)~{{\rm km}}~{{\rm s}}^{{-1}}`. These
     values are customizable via the ``v_bary`` argument which specifies the
     velocity of the solar system barycenter with respect to the LSR.
 
@@ -100,11 +100,11 @@ class GalacticLSR(BaseCoordinateFrame):
     velocity frame.
 
     We use default values from Schönrich et al. (2010) for the barycentric
-    velocity relative to the LSR, which is defined in Galactic cartesian
-    velocity components :math:`(U, V, W) = (-11.1, 12.24, 7.25)~
-    {\rm km}~{\rm s}^{-1}`. These values are customizable via the ``v_bary``
-    argument which specifies the velocity of the solar system barycenter with
-    respect to the LSR.
+    velocity relative to the LSR, which is defined in Galactic (right-handed)
+    cartesian velocity components
+    :math:`(U, V, W) = (11.1, 12.24, 7.25)~{{\rm km}}~{{\rm s}}^{{-1}}`. These
+    values are customizable via the ``v_bary`` argument which specifies the
+    velocity of the solar system barycenter with respect to the LSR.
 
     The frame attributes are listed under **Other Parameters**.
 


### PR DESCRIPTION
When I added the LSR velocities from Schoenrich et al. (2010), I incorrectly thought that they used a left handed Galactic coordinate system. @smoh pointed out this figure from their 2012 paper demonstrating that it is actually right-handed:
![image](https://user-images.githubusercontent.com/583379/27704587-16addc36-5cd9-11e7-98fc-81e0adb4ffbc.png)

So, this fixes the values (removes a minus sign).

Of course, this should all be appropriately documented in #6260 