### PR TITLE
Deal with leading whitespace when matching latex lines; issue 4295

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -331,6 +331,9 @@ astropy.io.fits
 
 - Fix the ``fitscheck`` script for updating invalid checksums, or removing
   checksums. [#6571]
+  - Strip leading/trailing white-space from latex lines to avoid issues when matching ``\begin{tabular}`` statements.  This is done by introducing a new ``LatexInputter`` class to override the ``BaseInputter``.
+
+- ``astropy.io.fits``
 
 - Fixed potential problems with the compression module [#6732]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,6 +321,11 @@ astropy.io.ascii
 
 - Added support for reading very large tables in chunks to reduce memory
   usage. [#6458]
+  
+- Strip leading/trailing white-space from latex lines to avoid issues when
+  matching ``\begin{tabular}`` statements.  This is done by introducing a new
+  ``LatexInputter`` class to override the ``BaseInputter``. [#6311]
+
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
@@ -331,9 +336,6 @@ astropy.io.fits
 
 - Fix the ``fitscheck`` script for updating invalid checksums, or removing
   checksums. [#6571]
-  - Strip leading/trailing white-space from latex lines to avoid issues when matching ``\begin{tabular}`` statements.  This is done by introducing a new ``LatexInputter`` class to override the ``BaseInputter``.
-
-- ``astropy.io.fits``
 
 - Fixed potential problems with the compression module [#6732]
 

--- a/astropy/io/ascii/tests/t/latex1.tex
+++ b/astropy/io/ascii/tests/t/latex1.tex
@@ -1,10 +1,10 @@
 \begin{table}
 \caption{\ion{Ne}{ix} Ly series and \ion{Mg}{xi} triplet fluxes (errors are 5$1\sigma$ confidence intervals) \label{tab:nely}}
-\begin{tabular}{lrr}\hline
-cola & colb & colc\\
-\hline
-a & 1 & 2\\
-b & 3 & 4\\
-\hline
-\end{tabular}
+  \begin{tabular}{lrr}\hline
+  cola & colb & colc\\
+  \hline
+      a & 1 & 2\\
+      b & 3 & 4\\
+      \hline
+  \end{tabular}
 \end{table}


### PR DESCRIPTION
The code can fail to find lines that begin with whitespace as [discussed in issue 4295](https://github.com/astropy/astropy/issues/4295#issuecomment-312287405).  This fix simple adds a call to `line.strip()` before the regex is compared.

Recommended Reviewer: @hamogu 