### PR TITLE
Allow specifying differential class in frame init

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -242,6 +242,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         arguments)
     *args, **kwargs
         Coordinates, with names that depend on the subclass.
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -53,6 +53,14 @@ class AltAz(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
+
     Other parameters
     ----------------
     obstime : `~astropy.time.Time`

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -37,6 +37,14 @@ _base_radec_docstring = """Parameters
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
+
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 
 

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -46,6 +46,14 @@ _base_ecliptic_docstring = """.. warning::
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
+
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 
 

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -43,6 +43,14 @@ class Galactic(BaseCoordinateFrame):
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
+
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -95,6 +95,14 @@ class Galactocentric(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
+
     Other parameters
     ----------------
     galcen_coord : `ICRS`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -136,6 +136,14 @@ class GalacticLSR(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
+
     Other parameters
     ----------------
     v_bary : `~astropy.coordinates.representation.CartesianDifferential`

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -41,6 +41,14 @@ class Supergalactic(BaseCoordinateFrame):
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
+
+    differential_cls : `BaseDifferential`, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets
+        the expected input differential class, thereby changing the expected
+        keyword arguments of the data passed in. For example, passing
+        ``differential_cls=CartesianDifferential`` will make the classes
+        expect velocity data with the argument names ``v_x, v_y, v_z``.
     """
 
     frame_specific_representation_info = {


### PR DESCRIPTION
Fixes #6314 

This adds support for specifying a differential class in the frame intializers, which should mirror the way passing in a representation class works. This supports, e.g.:

```python
>>> icrs = coord.ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
...               pm_ra=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
...               radial_velocity=23.42*u.km/u.s,
...               differential_cls=coord.SphericalDifferential)
>>> icrs 
<ICRS Coordinate: (ra, dec) in deg
    ( 8.67,  53.09)
 (pm_ra, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
    ( 4.8, -15.16,  23.42)>
```
(also `differential_cls={'s': coord.CartesianDifferential}`)

This also decouples setting the representation class from setting the differential class, so this is now valid as long as the differential class is compatible with the representation:
```python
icrs.set_representation_cls(s=coord.SphericalCosLatDifferential)
```