### PR TITLE
Sorting an empty table fails (regression)

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -880,6 +880,8 @@ class Column(BaseColumn):
         # Convert input ``value`` to the string dtype of this column and
         # find the length of the longest string in the array.
         value = np.asanyarray(value, dtype=self.dtype.type)
+        if value.size == 0:
+            return
         value_str_len = np.char.str_len(value).max()
 
         # Parse the array-protocol typestring (e.g. '|U15') of self.dtype which

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1013,6 +1013,10 @@ class TestSort():
         assert np.all(t['x'] == x[idx])
         assert np.all(t['y'] == y[idx])
 
+    def test_empty(self, table_types):
+        t = table_types.Table([[], []], dtype=['f4', 'U1'])
+        t.sort('col1')
+
     def test_multiple(self, table_types):
         t = table_types.Table()
         t.add_column(table_types.Column(name='a', data=[2, 1, 3, 2, 3, 1]))


### PR DESCRIPTION
Sorting an empty Table used to work before Astropy 2.0 : 
```python
In [1]: %astropy
Numpy 1.13.0
Astropy 3.0.dev19200

In [2]: t = Table([[], []], dtype=['f4', 'U1'])
   ...: t.sort('col1')
   ...: 
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-2-25cfd0b552ae> in <module>()
      1 t = Table([[], []], dtype=['f4', 'U1'])
----> 2 t.sort('col1')

~/lib/astropy/astropy/table/table.py in sort(self, keys)
   2460
   2461         for col in self.columns.values():
-> 2462             col[:] = col.take(indexes, axis=0)
   2463
   2464         if sort_index is not None:

~/lib/astropy/astropy/table/column.py in __setitem__(self, index, value)
    889         # Issue warning for string assignment that truncates ``value``
    890         if issubclass(self.dtype.type, np.character):
--> 891             self._check_string_truncate(value)
    892
    893         # update indices

~/lib/astropy/astropy/table/column.py in _check_string_truncate(self, value)
    870         # find the length of the longest string in the array.
    871         value = np.asanyarray(value, dtype=self.dtype.type)
--> 872         value_str_len = np.char.str_len(value).max()
    873
    874         # Parse the array-protocol typestring (e.g. '|U15') of self.dtype which

~/miniconda3/lib/python3.6/site-packages/numpy/core/_methods.py in _amax(a, axis, out, keepdims)
     24 # small reductions
     25 def _amax(a, axis=None, out=None, keepdims=False):
---> 26     return umr_maximum(a, axis, None, out, keepdims)
     27
     28 def _amin(a, axis=None, out=None, keepdims=False):

ValueError: zero-size array to reduction operation maximum which has no identity

```
`git bisect` led me to #5819 which added the `np.char.str_len(value).max()` line. 
ping @taldcroft , not sure what's the best place to check the length of the array ?