### PR TITLE
Fix frame.separation_3d() when frames have velocity data

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1310,8 +1310,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 
-        return Distance((self.cartesian -
-                         other_in_self_system.cartesian).norm())
+        # TODO: these represent_as calls drop the differentials, but assume a
+        # velocity differential with key "s"
+        self_car = self.represent_as(r.CartesianRepresentation, s=None)
+        other_car = other_in_self_system.represent_as(r.CartesianRepresentation,
+                                                      s=None)
+        return Distance((self_car - other_car).norm())
 
     @property
     def cartesian(self):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -417,6 +417,16 @@ def test_sep():
     sep3d = i3.separation_3d(i4)
     assert_allclose(sep3d.to(u.kpc), np.array([1, 1])*u.kpc)
 
+    # check that it works even with velocities
+    i5 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[5, 6]*u.kpc,
+              pm_ra_cosdec=[1, 2]*u.mas/u.yr, pm_dec=[3, 4]*u.mas/u.yr,
+              radial_velocity=[5, 6]*u.km/u.s)
+    i6 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[7, 8]*u.kpc,
+              pm_ra_cosdec=[1, 2]*u.mas/u.yr, pm_dec=[3, 4]*u.mas/u.yr,
+              radial_velocity=[5, 6]*u.km/u.s)
+
+    sep3d = i5.separation_3d(i6)
+    assert_allclose(sep3d.to(u.kpc), np.array([2, 2])*u.kpc)
 
 def test_time_inputs():
     """


### PR DESCRIPTION
At present, `separation_3d()` doesn't work when a frame has velocity data attached. This fixes the method to drop the differentials before doing the representation arithmetic.

cc @eteq @mhvk 