### PR TITLE
Fix names of Galactic cartesian components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -434,6 +434,12 @@ API Changes
 
 - ``astropy.coordinates``
 
+  - The `~astropy.coordinates.Galactic` frame previously was had the cartesian
+    ordering 'w', 'u', 'v' (for 'x', 'y', and 'z', respectively).  This was an
+    error and against the common convention.  The 'x', 'y', and 'z' axes now
+    map to 'u', 'v', and 'w', following the right-handed ('u' points to
+    the Galactic center) convention. [#6330]
+
   - Removed deprecated ``angles.rotation_matrix`` and
     ``angles.angle_axis``. Use the routines in
     ``coordinates.matrix_utilities`` instead. [#6170]
@@ -599,6 +605,9 @@ Bug Fixes
     convolution.  This error only affects *asymmetric* kernels.  [#6267]
 
 - ``astropy.coordinates``
+
+  - The `~astropy.coordinates.Galactic` frame had an incorrect ording for the
+    'u', 'v', and 'w' cartesian coordinates. [#6330]
 
 - ``astropy.cosmology``
 

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -59,14 +59,14 @@ class Galactic(BaseCoordinateFrame):
             RepresentationMapping('lat', 'b')
         ],
         r.CartesianRepresentation: [
-            RepresentationMapping('x', 'w'),
-            RepresentationMapping('y', 'u'),
-            RepresentationMapping('z', 'v')
+            RepresentationMapping('x', 'u'),
+            RepresentationMapping('y', 'v'),
+            RepresentationMapping('z', 'w')
         ],
         r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'W', u.km/u.s),
-            RepresentationMapping('d_y', 'U', u.km/u.s),
-            RepresentationMapping('d_z', 'V', u.km/u.s)
+            RepresentationMapping('d_x', 'U', u.km/u.s),
+            RepresentationMapping('d_y', 'V', u.km/u.s),
+            RepresentationMapping('d_z', 'W', u.km/u.s)
         ],
         r.SphericalCosLatDifferential: [
             RepresentationMapping('d_lon_coslat', 'pm_l_cosb', u.mas/u.yr),

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -680,7 +680,7 @@ base_unit_attr_sets = [
     ('spherical', u.karcsec, u.karcsec, u.kpc, Latitude, 'l', 'b', 'distance'),
     ('unitspherical', u.karcsec, u.karcsec, None, Latitude, 'l', 'b', None),
     ('physicsspherical', u.karcsec, u.karcsec, u.kpc, Angle, 'phi', 'theta', 'r'),
-    ('cartesian', u.km, u.km, u.km, u.Quantity, 'w', 'u', 'v'),
+    ('cartesian', u.km, u.km, u.km, u.Quantity, 'u', 'v', 'w'),
     ('cylindrical', u.km, u.karcsec, u.km, Angle, 'rho', 'phi', 'z')
 ]
 


### PR DESCRIPTION
Fixes #6328 

This reorders the component names in the `Galactic` frame to be consistent with what I'm familiar with. That is, `u`/`U` point towards the Galactic center (the `x` axis), `v`/`V` point in the direction of Galactic rotation (the `y` axis), and `w`/`W` is `z` and is orthogonal / pointing towards the NGP.

I did this as a separate PR because I wasn't sure if we'd need to backport to previous versions? 

cc @eteq 