### PR TITLE
Update astropy-helpers to v2.0

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -7,7 +7,7 @@
 name: astropy
 
 dependencies:
-  - python=3.5*
+  - python>=3
   - numpy
   - cython
   - matplotlib

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -27,10 +27,10 @@ package.
 """
 
 ##############################################################################
-# Let’s suppose you are planning to visit picturesque Bear Mountain State Park
-# in New York, USA. You’re bringing your telescope with you (of course), and
+# Let's suppose you are planning to visit picturesque Bear Mountain State Park
+# in New York, USA. You're bringing your telescope with you (of course), and
 # someone told you M33 is a great target to observe there. You happen to know
-# you’re free at 11:00 pm local time, and you want to know if it will be up.
+# you're free at 11:00 pm local time, and you want to know if it will be up.
 # Astropy can answer that.
 #
 # Make print work the same in all versions of Python, set up numpy,

--- a/examples/io/create-mef.py
+++ b/examples/io/create-mef.py
@@ -21,7 +21,7 @@ import os
 
 ##############################################################################
 # HDUList objects are used to hold all the HDUs in a FITS file. This
-# ``HDUList`` class is a subclass of Python’s builtin `list`. and can be
+# ``HDUList`` class is a subclass of Python's builtin `list`. and can be
 # created from scratch. For example, to create a FITS file with
 # three extensions:
 

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -33,13 +33,13 @@ hdu.writeto('large.fits')
 
 ##############################################################################
 # However, a 40000 x 40000 array of doubles is nearly twelve gigabytes! Most
-# systems won’t be able to create that in memory just to write out to disk. In
+# systems won't be able to create that in memory just to write out to disk. In
 # order to create such a large file efficiently requires a little extra work,
 # and a few assumptions.
 #
 # First, it is helpful to anticipate about how large (as in, how many keywords)
 # the header will have in it. FITS headers must be written in 2880 byte
-# blocks–large enough for 36 keywords per block (including the END keyword in
+# blocks, large enough for 36 keywords per block (including the END keyword in
 # the final block). Typical headers have somewhere between 1 and 4 blocks,
 # though sometimes more.
 #
@@ -62,7 +62,7 @@ while len(header) < (36 * 4 - 1):
 ##############################################################################
 # Now adjust the NAXISn keywords to the desired size of the array, and write
 # only the header out to a file. Using the ``hdu.writeto()`` method will cause
-# astropy to “helpfully” reset the NAXISn keywords to match the size of the
+# astropy to "helpfully" reset the NAXISn keywords to match the size of the
 # dummy array. That is because it works hard to ensure that only valid FITS
 # files are written. Instead, we can write just the header to a file using the
 # `astropy.io.fits.Header.tofile` method:
@@ -86,7 +86,7 @@ with open('large.fits', 'rb+') as fobj:
     # write:
     fobj.seek(len(header.tostring()) + (40000 * 40000 * 8) - 1)
     fobj.write(b'\0')
-    
+
 ##############################################################################
 # More generally, this can be written:
 
@@ -102,7 +102,7 @@ with open('large.fits', 'rb+') as fobj:
 # the HFS+ filesystem used by most Macs) this is a very fast, efficient
 # operation. On other systems your mileage may vary.
 #
-# This isn’t the only way to build up a large file, but probably one of the
+# This isn't the only way to build up a large file, but probably one of the
 # safest. This method can also be used to create large multi-extension FITS
 # files, with a little care.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,12 +25,6 @@ bitmap = static/wininst_background.bmp
 [ah_bootstrap]
 auto_use = True
 
-[zest.releaser]
-prereleaser.middle = astropy.utils.release.prereleaser_middle
-releaser.middle = astropy.utils.release.releaser_middle
-postreleaser.before = astropy.utils.release.postreleaser_before
-postreleaser.middle = astropy.utils.release.postreleaser_middle
-
 [flake8]
 exclude = extern,*parsetab.py,*lextab.py
 


### PR DESCRIPTION
This PR update astropy_helpers to contain the fix required for #6323. Fixes #6323 if CI is passed, though we probably want to keep this PR as a placeholder to update helpers to the final 2.0 release.

Also an RTD fix is piggybacking here, to avoid having to run CI on it (it doesn't have any effect on CI whatsoever).