### PR TITLE
Revert 6277

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -638,15 +638,6 @@ astropy.table
 - Added optional ``axis`` parameter to ``insert`` method for ``Column`` and
   ``MaskedColumn`` classes. [#6092]
 
-- The private ``_parent`` attribute in the ``info`` attribute of table
-  columns was changed from a direct reference to the parent column to a weak
-  reference.  This was in response to a memory leak caused by having a
-  circular reference cycle.  This change means that expressions like
-  ``col[3:5].info`` will now fail because at the point of the ``info``
-  property being evaluated the ``col[3:5]`` weak reference is dead.  Instead
-  force a reference with ``c = col[3:5]`` followed by
-  ``c.info.indices``. [#6277]
-
 astropy.time
 ^^^^^^^^^^^^
 
@@ -802,10 +793,6 @@ astropy.table
 - Fix a problem with vstack for bytes columns in Python 3. [#5628]
 
 - Fix QTable add/insert row for multidimensional Quantity. [#6092]
-
-- Fix memory leak where updating a table column or deleting a table
-  object was not releasing the memory due to a reference cycle
-  in the column ``info`` attributes. [#6277]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -417,14 +417,6 @@ class HTML(core.BaseReader):
                                 w.end(indent=False)
                         col_str_iters = []
                         new_cols_escaped = []
-
-                        # Make a container to hold any new_col objects created
-                        # below for multicolumn elements.  This is purely to
-                        # maintain a reference for these objects during
-                        # subsequent iteration to format column values.  This
-                        # requires that the weakref info._parent be maintained.
-                        new_cols = []
-
                         for col, col_escaped in zip(cols, cols_escaped):
                             if len(col.shape) > 1 and self.html['multicol']:
                                 span = col.shape[1]
@@ -435,7 +427,6 @@ class HTML(core.BaseReader):
                                     new_col_iter_str_vals = self.fill_values(col, new_col.info.iter_str_vals())
                                     col_str_iters.append(new_col_iter_str_vals)
                                     new_cols_escaped.append(col_escaped)
-                                    new_cols.append(new_col)
                             else:
 
                                 col_iter_str_vals = self.fill_values(col, col.info.iter_str_vals())

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -15,7 +15,6 @@ from ... import coordinates
 from ... import table
 from ...utils.data_info import data_info_factory, dtype_info_name
 from ..table_helpers import simple_table
-import pytest
 
 
 def test_table_info_attributes(table_types):
@@ -245,10 +244,3 @@ def test_no_deprecation_warning():
     with warnings.catch_warnings(record=True) as warns:
         t.info()
         assert len(warns) == 0
-
-
-def test_lost_parent_error():
-    c = table.Column([1, 2, 3], name='a')
-    with pytest.raises(AttributeError) as err:
-        c[:].info.name
-    assert 'failed access "info" attribute' in str(err)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -212,39 +212,13 @@ class DataInfo(object):
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
     _represent_as_dict_attrs = ()
-    _parent_ref = None
+    _parent = None
 
     def __init__(self, bound=False):
         # If bound to a data object instance then create the dict of attributes
         # which stores the info attribute values.
         if bound:
             self._attrs = dict((attr, None) for attr in self.attr_names)
-
-    @property
-    def _parent(self):
-        if self._parent_ref is None:
-            return None
-        else:
-            parent = self._parent_ref()
-            if parent is not None:
-                return parent
-
-            else:
-                raise AttributeError("""\
-failed access "info" attribute on a temporary object.
-
-It looks like you have done something like ``col[3:5].info``, i.e.
-you accessed ``info`` from a temporary slice object ``col[3:5]`` that
-only exists momentarily.  This has failed because the reference to
-that temporary object is now lost.  Instead force a permanent
-reference with ``c = col[3:5]`` followed by ``c.info``.""")
-
-    @_parent.setter
-    def _parent(self, value):
-        if value is None:
-            self._parent_ref = None
-        else:
-            self._parent_ref = weakref.ref(value)
 
     def __get__(self, instance, owner_cls):
         if instance is None:

--- a/docs/table/indexing.rst
+++ b/docs/table/indexing.rst
@@ -176,12 +176,10 @@ The *copy_on_getitem* mode forces columns to copy and relabel their indices upon
 slicing. In the absence of this mode, table slices will preserve
 indices while column slices will not::
 
-  >>> ca = t['a'][[1, 3]]
-  >>> ca.info.indices
+  >>> t['a'][[1, 3]].info.indices
   []
   >>> with t.index_mode('copy_on_getitem'):
-  ...    ca = t['a'][[1, 3]]
-  ...    print(ca.info.indices)
+  ...    print(t['a'][[1, 3]].info.indices)
   [ a  rows
   --- ----
     2    0


### PR DESCRIPTION
Fixes #6291.

But unfixes #6276.  The memory leak there is at least well-understood and has been there for a couple of releases with no complaints.  The plan is to come back to this after the 2.0 release and re-do #6277 in a way that doesn't introduce the semi-random exceptions.