### PR TITLE
Break reference cycles when deleting TableColumn

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -798,6 +798,9 @@ astropy.table
 
 - Fix QTable add/insert row for multidimensional Quantity. [#6092]
 
+- Fix a reference cycle problem where memory use could continually
+  increase when reassigning a table or table column. [#6346]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -129,6 +129,11 @@ class TableColumns(OrderedDict):
         names = ("'{0}'".format(x) for x in six.iterkeys(self))
         return "<{1} names=({0})>".format(",".join(names), self.__class__.__name__)
 
+    def __del__(self):
+        for col in self.values():
+            col.info._parent_table = None
+            col.info._parent = None
+
     def _rename_column(self, name, new_name):
         if name == new_name:
             return

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -131,7 +131,6 @@ class TableColumns(OrderedDict):
 
     def __del__(self):
         for col in self.values():
-            col.info._parent_table = None
             col.info._parent = None
 
     def _rename_column(self, name, new_name):
@@ -1727,6 +1726,12 @@ class Table(object):
         # This may raise an exception (e.g. t['a'] = 1) in which case none of
         # the downstream code runs.
         self.replace_column(name, col)
+
+        # This ensures that the refcount of self[name] is the same as if the
+        # table were freshly created by forcing the self.info._parent ref to
+        # be created.  What is not fully understood is why this does not happen
+        # already in all the col.info accesses prior to this one.
+        self[name].info
 
         if 'always' in warns:
             warnings.warn("replaced column '{}'".format(name),


### PR DESCRIPTION
@saimn @eteq @bsipocz @mhvk @astrofrog - this *may* be the ticket on the Table reference cycle problem.  Basically just breaking the reference cycles when the internal TableColumn object is being deleted.  In my testing this did the trick and I could do the following with no increment of memory:
```
In [2]: c = Column(np.arange(1e8), name='a')
In [3]: for ii in range(20): t = Table([c])
In [9]: for ii in range(20): t['a'] = c
```

Fixes #6276