### PR TITLE
Fix search_around_* returning Quantity incorrectly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -724,6 +724,11 @@ astropy.coordinates
 - The `~astropy.coordinates.Galactic` frame had an incorrect ording for the
   'u', 'v', and 'w' cartesian coordinates. [#6330]
 
+- The `~astropy.coordinates.search_around_sky`,
+  `~astropy.coordinates.search_around_3d`, and ``SkyCoord`` equivalent methods
+  now correctly yield an `~astropy.coordinate.Angle` as the third return type
+  even if there are no matches (previously it returned a raw Quantity). [#6347]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -726,7 +726,7 @@ astropy.coordinates
 
 - The `~astropy.coordinates.search_around_sky`,
   `~astropy.coordinates.search_around_3d`, and ``SkyCoord`` equivalent methods
-  now correctly yield an `~astropy.coordinate.Angle` as the third return type
+  now correctly yield an `~astropy.coordinates.Angle` as the third return type
   even if there are no matches (previously it returned a raw Quantity). [#6347]
 
 astropy.cosmology

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -344,7 +344,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
         else:
             distunit = coords1.distance.unit
         return (np.array([], dtype=np.int), np.array([], dtype=np.int),
-                u.Quantity([], u.deg),
+                Angle([], u.deg),
                 u.Quantity([], distunit))
 
     # we convert coord1 to match coord2's frame.  We do it this way
@@ -388,7 +388,7 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
             distunit = u.dimensionless_unscaled
         else:
             distunit = coords1.distance.unit
-        d2ds = u.Quantity([], u.deg)
+        d2ds = Angle([], u.deg)
         d3ds = u.Quantity([], distunit)
     else:
         d2ds = coords1[idxs1].separation(coords2[idxs2])

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -11,6 +11,7 @@ import numpy as np
 from ..extern import six
 from .representation import UnitSphericalRepresentation
 from .. import units as u
+from . import Angle
 
 __all__ = ['match_coordinates_3d', 'match_coordinates_sky', 'search_around_3d',
            'search_around_sky']
@@ -238,7 +239,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='kdtree_3d'):
     if len(coords1) == 0 or len(coords2) == 0:
         # Empty array input: return empty match
         return (np.array([], dtype=np.int), np.array([], dtype=np.int),
-                u.Quantity([], u.deg),
+                Angle([], u.deg),
                 u.Quantity([], coords1.distance.unit))
 
     kdt2 = _get_cartesian_kdtree(coords2, storekdtree)
@@ -264,7 +265,7 @@ def search_around_3d(coords1, coords2, distlimit, storekdtree='kdtree_3d'):
     idxs2 = np.array(idxs2, dtype=np.int)
 
     if idxs1.size == 0:
-        d2ds = u.Quantity([], u.deg)
+        d2ds = Angle([], u.deg)
         d3ds = u.Quantity([], coords1.distance.unit)
     else:
         d2ds = coords1[idxs1].separation(coords2[idxs2])
@@ -325,8 +326,6 @@ def search_around_sky(coords1, coords2, seplimit, storekdtree='kdtree_sky'):
     considered an implementation detail, though, so it could change in a future
     release.
     """
-    from . import Angle
-
     if not seplimit.isscalar:
         raise ValueError('seplimit must be a scalar in search_around_sky')
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -429,6 +429,8 @@ def test_regression_6236():
     assert msf4.my_attr == msf3.my_attr
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
+@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_6347():
     sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
     sc2 = SkyCoord([1.1, 2.1]*u.deg, [3.1, 4.1]*u.deg)
@@ -447,6 +449,8 @@ def test_regression_6347():
     assert type(d2d_1) is type(d2d_10)
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
+@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_6347_3d():
     sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5, 6]*u.kpc)
     sc2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5.1, 6.1]*u.kpc)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -445,3 +445,21 @@ def test_regression_6347():
 
     assert len(d2d_1) == 0
     assert type(d2d_1) is type(d2d_10)
+
+
+def test_regression_6347_3d():
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5, 6]*u.kpc)
+    sc2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5.1, 6.1]*u.kpc)
+    sc0 = sc1[:0]
+
+    idx1_10, idx2_10, d2d_10, d3d_10 = sc1.search_around_3d(sc2, 500*u.pc)
+    idx1_1, idx2_1, d2d_1, d3d_1 = sc1.search_around_3d(sc2, 50*u.pc)
+    idx1_0, idx2_0, d2d_0, d3d_0 = sc0.search_around_3d(sc2, 500*u.pc)
+
+    assert len(d2d_10) > 0
+
+    assert len(d2d_0) == 0
+    assert type(d2d_0) is type(d2d_10)
+
+    assert len(d2d_1) == 0
+    assert type(d2d_1) is type(d2d_10)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -427,3 +427,21 @@ def test_regression_6236():
     assert msf3.representation is UnitSphericalRepresentation
     assert msf4.representation is CartesianRepresentation
     assert msf4.my_attr == msf3.my_attr
+
+
+def test_regression_6347():
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
+    sc2 = SkyCoord([1.1, 2.1]*u.deg, [3.1, 4.1]*u.deg)
+    sc0 = sc1[:0]
+
+    idx1_10, idx2_10, d2d_10, d3d_10 = sc1.search_around_sky(sc2, 10*u.arcmin)
+    idx1_1, idx2_1, d2d_1, d3d_1 = sc1.search_around_sky(sc2, 1*u.arcmin)
+    idx1_0, idx2_0, d2d_0, d3d_0 = sc0.search_around_sky(sc2, 10*u.arcmin)
+
+    assert len(d2d_10) == 2
+
+    assert len(d2d_0) == 0
+    assert type(d2d_0) is type(d2d_10)
+
+    assert len(d2d_1) == 0
+    assert type(d2d_1) is type(d2d_10)


### PR DESCRIPTION
This fixes a bug reported on ``astropy-dev``: https://groups.google.com/forum/#!topic/astropy-dev/geYK1VO7ttw .  Essentially, the `search_around_sky` and `search_around_3d` incorrectly return regular `Quantity`when there's no matches, instead of `Angle` (which is what comes out if there are matches).  I don't think that was intended behavior, but rather an oversight when accounting for these "no-match" cases.  So I see this as a bug, which this PR fixes.

Note that I've milestoned it 2.0, but that *might* be too aggressive given that we've already started the release process for 2.0.  If that's the case it can be re-milestoned (and the changelog entry moved) to 2.0.1