### PR TITLE
Add old *FrameAttribute classes to coordinates/__init__.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -243,6 +243,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Added old frame attribute classes back to top-level namespace of
+  ``astropy.coordinates``. [#6357]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -24,6 +24,11 @@ from .funcs import *
 from .calculation import *
 from .solar_system import *
 
+# This is for backwards-compatibility -- can be removed in v3.0 when the
+# deprecation warnings are removed
+from .attributes import (TimeFrameAttribute, QuantityFrameAttribute,
+                         CartesianRepresentationFrameAttribute)
+
 __doc__ += builtin_frames._transform_graph_docs + """
 
 .. note::

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -467,3 +467,40 @@ def test_regression_6347_3d():
 
     assert len(d2d_1) == 0
     assert type(d2d_1) is type(d2d_10)
+
+def test_regression_6300():
+    """Check that importing old frame attribute names from astropy.coordinates
+    still works. See comments at end of #6300
+    """
+    from ...utils.exceptions import AstropyDeprecationWarning
+    from .. import CartesianRepresentation
+    from .. import (TimeFrameAttribute, QuantityFrameAttribute,
+                    CartesianRepresentationFrameAttribute)
+
+    with catch_warnings() as found_warnings:
+        attr = TimeFrameAttribute(default=Time("J2000"))
+
+        for w in found_warnings:
+            if issubclass(w.category, AstropyDeprecationWarning):
+                break
+        else:
+            assert False, "Deprecation warning not raised"
+
+    with catch_warnings() as found_warnings:
+        attr = QuantityFrameAttribute(default=5*u.km)
+
+        for w in found_warnings:
+            if issubclass(w.category, AstropyDeprecationWarning):
+                break
+        else:
+            assert False, "Deprecation warning not raised"
+
+    with catch_warnings() as found_warnings:
+        attr = CartesianRepresentationFrameAttribute(
+            default=CartesianRepresentation([5,6,7]*u.kpc))
+
+        for w in found_warnings:
+            if issubclass(w.category, AstropyDeprecationWarning):
+                break
+        else:
+            assert False, "Deprecation warning not raised"


### PR DESCRIPTION
See discussion at end of #6300.

The `*FrameAttribute` classes were renamed to `*Attribute` (with the old names still present with deprecation warnings), but the deprecated class names were not imported to the top-level 
 `astropy.coordinates`. This broke SunPy's import:
```python
from astropy.coordinates import TimeFrameAttribute
```

This adds the old (deprecated) frame classes back to the `coordinates/__init__.py` and adds a regression test to check the import.

cc @Cadair 