### PR TITLE
Expanding FITS column to accept coordinate type keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,8 +28,8 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- Expanded the FITS ``Column`` interface to accept attributes pertaining to coordinate
-  systems. [#6359]
+- Expanded the FITS ``Column`` interface to accept attributes pertaining to the FITS
+  World Coordinate System, which includes spatial(celestial) and time coordinates. [#6359]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Expanded the FITS ``Column`` interface to accept attributes pertaining to coordinate
+  systems. [#6359]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -801,7 +801,7 @@ class Column(NotifierMixin):
         if coord_ref_point is None:
             return
 
-        if not _is_int(coord_ref_point):
+        if not _is_int(coord_ref_point) and not isinstance(coord_ref_point, float):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be '
                 'real floating type.')
@@ -811,7 +811,7 @@ class Column(NotifierMixin):
         if coord_ref_value is None:
             return
 
-        if not _is_int(coord_ref_value):
+        if not _is_int(coord_ref_value) and not isinstance(coord_ref_value, float):
             raise AssertionError(
                 'Coordinate value at reference point must be real '
                 'floating type.')
@@ -821,7 +821,7 @@ class Column(NotifierMixin):
         if coord_inc is None:
             return
 
-        if not _is_int(coord_inc):
+        if not _is_int(coord_inc) and not isinstance(coord_inc, float):
             raise AssertionError(
                 'Coordinate increment must be real floating type.')
 
@@ -1081,7 +1081,7 @@ class Column(NotifierMixin):
                      ('coord_inc', coord_inc)]:
             if v is not None and v != '':
                 msg = None
-                if not _is_int(v):
+                if not _is_int(v) and not isinstance(v, float):
                     msg = (
                         "Column {} option ({}n) must be a real floating type (got {!r}). "
                         "The invalid value will be ignored for the purpose of formatting "

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -466,8 +466,8 @@ class Column(NotifierMixin):
 
     def __init__(self, name=None, format=None, unit=None, null=None,
                  bscale=None, bzero=None, disp=None, start=None, dim=None,
-                 coord_type=None, coord_unit=None, coord_ref_value=None,
-                 coord_ref_point=None, coord_inc=None, array=None, ascii=None):
+                 coord_type=None, coord_unit=None, coord_ref_point=None,
+                 coord_ref_value=None, coord_inc=None, array=None, ascii=None):
         """
         Construct a `Column` by specifying attributes.  All attributes
         except ``format`` can be optional; see :ref:`column_creation` and

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -89,7 +89,7 @@ KEYWORD_NAMES = ('TTYPE', 'TFORM', 'TUNIT', 'TNULL', 'TSCAL', 'TZERO',
                  'TCDLT', 'TCRPX')
 KEYWORD_ATTRIBUTES = ('name', 'format', 'unit', 'null', 'bscale', 'bzero',
                       'disp', 'start', 'dim', 'coord_type', 'coord_unit',
-                      'ref_value', 'coord_inc', 'ref_point')
+                      'coord_ref_value', 'coord_inc', 'coord_ref_point')
 """This is a list of the attributes that can be set on `Column` objects."""
 
 
@@ -466,8 +466,8 @@ class Column(NotifierMixin):
 
     def __init__(self, name=None, format=None, unit=None, null=None,
                  bscale=None, bzero=None, disp=None, start=None, dim=None,
-                 coord_type=None, coord_unit=None, ref_value=None,
-                 coord_inc=None, ref_point=None, array=None, ascii=None):
+                 coord_type=None, coord_unit=None, coord_ref_value=None,
+                 coord_inc=None, coord_ref_point=None, array=None, ascii=None):
         """
         Construct a `Column` by specifying attributes.  All attributes
         except ``format`` can be optional; see :ref:`column_creation` and
@@ -510,7 +510,7 @@ class Column(NotifierMixin):
         coord_unit : str, optional
             coordinate/axis unit corresponding to ``TCUNI`` keyword
 
-        ref_value : int-like, optional
+        coord_ref_value : int-like, optional
             coordinate value at reference point corresponding to ``TCRVL``
             keyword
 
@@ -518,7 +518,7 @@ class Column(NotifierMixin):
             coordinate increment at reference point corresponding to ``TCDLT``
             keyword
 
-        ref_point : int-like, optional
+        coord_ref_point : int-like, optional
             pixel coordinate of the reference point corresponding to ``TCRPX``
             keyword
 
@@ -797,11 +797,11 @@ class Column(NotifierMixin):
                 'characters.')
 
     @ColumnAttribute('TCRVL')
-    def ref_value(col, ref_value):
-        if ref_value is None:
+    def coord_ref_value(col, coord_ref_value):
+        if coord_ref_value is None:
             return
 
-        if not _is_int(ref_value):
+        if not _is_int(coord_ref_value):
             raise AssertionError(
                 'Coordinate value at reference point must be real'
                 'floating type.')
@@ -816,11 +816,11 @@ class Column(NotifierMixin):
                 'Coordinate increment must be real floating type.')
 
     @ColumnAttribute('TCRPX')
-    def ref_point(col, ref_point):
-        if ref_point is None:
+    def coord_ref_point(col, coord_ref_point):
+        if coord_ref_point is None:
             return
 
-        if not _is_int(ref_point):
+        if not _is_int(coord_ref_point):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be'
                 'real floating type.')
@@ -885,8 +885,8 @@ class Column(NotifierMixin):
     @classmethod
     def _verify_keywords(cls, name=None, format=None, unit=None, null=None,
                          bscale=None, bzero=None, disp=None, start=None,
-                         dim=None, coord_type=None, coord_unit=None, 
-                         ref_value=None, coord_inc=None, ref_point=None,
+                         dim=None, coord_type=None, coord_unit=None,
+                         coord_ref_value=None, coord_inc=None, coord_ref_point=None,
                          ascii=None):
         """
         Given the keyword arguments used to initialize a Column, specifically
@@ -1066,13 +1066,13 @@ class Column(NotifierMixin):
                     'Coordinate/axis unit (TCUNIn) must be a string.  The invalid '
                     'keyword will be ignored for the purpose of formatting this '
                     'column.'.format(coord_unit))
-            if msg in None:
+            if msg is None:
                 valid['coord_unit'] = coord_unit
             else:
                 invalid['coord_unit'] = (coord_unit, msg)
 
-        for k, v in [('ref_value', ref_value), ('coord_inc', coord_inc),
-                     ('ref_point', ref_point)]:
+        for k, v in [('coord_ref_value', coord_ref_value), ('coord_inc', coord_inc),
+                     ('coord_ref_point', coord_ref_point)]:
             if v is not None and v != '':
                 msg = None
                 if not _is_int(v):

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1080,7 +1080,7 @@ class Column(NotifierMixin):
                         'Column {!r} must be a real floating type (got {!r}).  '
                         'The invalid value will be ignored for the purpose of '
                         'formatting the data in this column.'.format(k, v))
-                if msg in None:
+                if msg is None:
                     valid[k] = v
                 else:
                     invalid[k] = (v, msg)

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1108,7 +1108,7 @@ class Column(NotifierMixin):
                 else:
                     invalid[k] = (v, msg)
 
-        if time_ref_pos is not None and time_ref_pos!='':
+        if time_ref_pos is not None and time_ref_pos != '':
             msg=None
             if not isinstance(time_ref_pos, string_types):
                 msg = (

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -803,9 +803,16 @@ class Column(NotifierMixin):
                 'Coordinate/axis type must be a string of atmost 8 '
                 'characters.')
 
+    @ColumnAttribute('TCUNI')
+    def coord_unit(col, coord_unit):
+        if (coord_unit is not None
+                and not isinstance(coord_unit, string_types)):
+            raise AssertionError(
+                'Coordinate/axis unit must be a string.')
+
     @ColumnAttribute('TCRPX')
     def coord_ref_point(col, coord_ref_point):
-        if (not coord_ref_point is None
+        if (coord_ref_point is not None
                 and not isinstance(coord_ref_point, numbers.Real)):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be '
@@ -813,7 +820,7 @@ class Column(NotifierMixin):
 
     @ColumnAttribute('TCRVL')
     def coord_ref_value(col, coord_ref_value):
-        if (not coord_ref_value is None
+        if (coord_ref_value is not None
                 and not isinstance(coord_ref_value, numbers.Real)):
             raise AssertionError(
                 'Coordinate value at reference point must be real '
@@ -821,14 +828,14 @@ class Column(NotifierMixin):
 
     @ColumnAttribute('TCDLT')
     def coord_inc(col, coord_inc):
-        if (not coord_inc is None
+        if (coord_inc is not None
                 and not isinstance(coord_inc, numbers.Real)):
             raise AssertionError(
                 'Coordinate increment must be real floating type.')
 
     @ColumnAttribute('TRPOS')
     def time_ref_pos(col, time_ref_pos):
-        if (not time_ref_pos is None
+        if (time_ref_pos is not None
                 and not isinstance(time_ref_pos, string_types)):
             raise AssertionError(
                 'Time reference position must be a string.')
@@ -841,7 +848,6 @@ class Column(NotifierMixin):
     disp = ColumnAttribute('TDISP')
     start = ColumnAttribute('TBCOL')
     dim = ColumnAttribute('TDIM')
-    coord_unit = ColumnAttribute('TCUNI')
 
     @lazyproperty
     def ascii(self):

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -6,6 +6,7 @@ import re
 import sys
 import warnings
 import weakref
+import numbers
 
 from functools import reduce
 from collections import OrderedDict
@@ -798,30 +799,24 @@ class Column(NotifierMixin):
 
     @ColumnAttribute('TCRPX')
     def coord_ref_point(col, coord_ref_point):
-        if coord_ref_point is None:
-            return
-
-        if not _is_int(coord_ref_point) and not isinstance(coord_ref_point, float):
+        if (not coord_ref_point is None
+                and not isinstance(coord_ref_point, numbers.Real)):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be '
                 'real floating type.')
 
     @ColumnAttribute('TCRVL')
     def coord_ref_value(col, coord_ref_value):
-        if coord_ref_value is None:
-            return
-
-        if not _is_int(coord_ref_value) and not isinstance(coord_ref_value, float):
+        if (not coord_ref_value is None
+                and not isinstance(coord_ref_value, numbers.Real)):
             raise AssertionError(
                 'Coordinate value at reference point must be real '
                 'floating type.')
 
     @ColumnAttribute('TCDLT')
     def coord_inc(col, coord_inc):
-        if coord_inc is None:
-            return
-
-        if not _is_int(coord_inc) and not isinstance(coord_inc, float):
+        if (not coord_inc is None
+                and not isinstance(coord_inc, numbers.Real)):
             raise AssertionError(
                 'Coordinate increment must be real floating type.')
 
@@ -987,16 +982,17 @@ class Column(NotifierMixin):
                     'table columns (got {!r}).  The invalid keyword will be '
                     'ignored for the purpose of formatting the data in this '
                     'column.'.format(start))
-            try:
-                start = int(start)
-            except (TypeError, ValueError):
-                pass
+            else:
+                try:
+                    start = int(start)
+                except (TypeError, ValueError):
+                    pass
 
-            if not _is_int(start) or start < 1:
-                msg = (
-                    'Column start option (TBCOLn) must be a positive integer '
-                    '(got {!r}).  The invalid value will be ignored for the '
-                    'purpose of formatting the data in this column.'.format(start))
+                if not _is_int(start) or start < 1:
+                    msg = (
+                        'Column start option (TBCOLn) must be a positive integer '
+                        '(got {!r}).  The invalid value will be ignored for the '
+                        'purpose of formatting the data in this column.'.format(start))
 
             if msg is None:
                 valid['start'] = start
@@ -1077,11 +1073,12 @@ class Column(NotifierMixin):
             else:
                 invalid['coord_unit'] = (coord_unit, msg)
 
-        for k, v in [('coord_ref_point', coord_ref_point), ('coord_ref_value', coord_ref_value),
+        for k, v in [('coord_ref_point', coord_ref_point),
+                     ('coord_ref_value', coord_ref_value),
                      ('coord_inc', coord_inc)]:
             if v is not None and v != '':
                 msg = None
-                if not _is_int(v) and not isinstance(v, float):
+                if not isinstance(v, numbers.Real):
                     msg = (
                         "Column {} option ({}n) must be a real floating type (got {!r}). "
                         "The invalid value will be ignored for the purpose of formatting "

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -920,6 +920,8 @@ class Column(NotifierMixin):
                         "the column's character width and will be truncated "
                         "(got {!r}).".format(null))
             else:
+                tnull_formats = ('B', 'I', 'J', 'K')
+
                 if not _is_int(null):
                     # Make this an exception instead of a warning, since any
                     # non-int value is meaningless
@@ -929,11 +931,9 @@ class Column(NotifierMixin):
                         'will be ignored for the purpose of formatting '
                         'the data in this column.'.format(null))
 
-                tnull_formats = ('B', 'I', 'J', 'K')
-
-                if not (format.format in tnull_formats or
-                        (format.format in ('P', 'Q') and
-                         format.p_format in tnull_formats)):
+                elif not (format.format in tnull_formats or
+                          (format.format in ('P', 'Q') and
+                           format.p_format in tnull_formats)):
                     # TODO: We should also check that TNULLn's integer value
                     # is in the range allowed by the column's format
                     msg = (
@@ -957,7 +957,7 @@ class Column(NotifierMixin):
                     'The invalid value will be ignored for the purpose of '
                     'formatting the data in this column.'.format(disp))
 
-            if (isinstance(format, _AsciiColumnFormat) and
+            elif (isinstance(format, _AsciiColumnFormat) and
                     disp[0].upper() == 'L'):
                 # disp is at least one character long and has the 'L' format
                 # which is not recognized for ASCII tables

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -234,7 +234,8 @@ class TestTableFunctions(FitsTestCase):
                 'coord_type': ['', '', '', ''],
                 'coord_unit': ['', '', '', ''],
                 'coord_ref_point': ['', '', '', ''],
-                'coord_ref_value': ['', '', '', '']}
+                'coord_ref_value': ['', '', '', ''],
+                'time_ref_pos': ['', '', '', '']}
 
         assert t[1].columns.info(output=False) == info
 
@@ -2989,9 +2990,9 @@ class TestColumnFunctions(FitsTestCase):
         with pytest.raises(VerifyError) as err:
             c = fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
                             coord_unit=2, coord_ref_point='1', coord_ref_value='1',
-                            coord_inc='1')
+                            coord_inc='1', time_ref_pos=1)
         err_msgs = ['keyword arguments to Column were invalid', 'TNULL', 'TDISP',
-                    'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT']
+                    'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT', 'TRPOS']
         for msg in err_msgs:
             assert msg in str(err.value)
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2975,6 +2975,25 @@ class TestColumnFunctions(FitsTestCase):
         assert np.all(c4.array[0] == c3.array[0])
         assert np.all(c4.array[1] == c3.array[1])
 
+    def test_column_verify_keywords(self):
+        """
+        Test that the keyword arguments used to initialize a Column, specifically
+        those that typically read from a FITS header (so excluding array),
+        are verified to have a valid value.
+        """
+
+        with pytest.raises(AssertionError) as err:
+            c = fits.Column(1, format='I', array=[1, 2, 3, 4, 5])
+        assert 'Column name must be a string able to fit' in str(err.value)
+
+        with pytest.raises(VerifyError) as err:
+            c = fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
+                            coord_unit=2, coord_ref_point='1', coord_ref_value='1',
+                            coord_inc='1')
+        err_msgs = ['keyword arguments to Column were invalid', 'TNULL', 'TDISP',
+                    'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT']
+        for msg in err_msgs:
+            assert msg in str(err.value)
 
 def test_regression_5383():
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2995,6 +2995,26 @@ class TestColumnFunctions(FitsTestCase):
         for msg in err_msgs:
             assert msg in str(err.value)
 
+    def test_column_verify_start(self):
+        """
+        Regression test for https://github.com/astropy/astropy/pull/6359
+
+        Test the validation of the column start position option (ASCII table only),
+        corresponding to ``TBCOL`` keyword.
+        """
+
+        with pytest.raises(VerifyError) as err:
+            c = fits.Column('a', format='B', start='a', array=[1, 2, 3])
+        assert "start option (TBCOLn) is not allowed for binary table columns" in str(err.value)
+
+        with pytest.raises(VerifyError) as err:
+            c = fits.Column('a', format='I', start='a', array=[1, 2, 3])
+        assert "start option (TBCOLn) must be a positive integer (got 'a')." in str(err.value)
+
+        with pytest.raises(VerifyError) as err:
+            c = fits.Column('a', format='I', start='-56', array=[1, 2, 3])
+        assert "start option (TBCOLn) must be a positive integer (got -56)." in str(err.value)
+
 def test_regression_5383():
 
     # Regression test for an undefined variable

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -229,7 +229,12 @@ class TestTableFunctions(FitsTestCase):
                 'bzero': ['', '', 0.4, ''],
                 'disp': ['I11', 'A3', 'G15.7', 'L6'],
                 'start': ['', '', '', ''],
-                'dim': ['', '', '', '']}
+                'dim': ['', '', '', ''],
+                'coord_inc': ['', '', '', ''],
+                'coord_type': ['', '', '', ''],
+                'coord_unit': ['', '', '', ''],
+                'ref_point': ['', '', '', ''],
+                'ref_value': ['', '', '', '']}
 
         assert t[1].columns.info(output=False) == info
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3001,6 +3001,8 @@ class TestColumnFunctions(FitsTestCase):
 
         Test the validation of the column start position option (ASCII table only),
         corresponding to ``TBCOL`` keyword.
+        Test whether the VerifyError message generated is the one with highest priority,
+        i.e. the order of error messages to be displayed is maintained.
         """
 
         with pytest.raises(VerifyError) as err:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -233,8 +233,8 @@ class TestTableFunctions(FitsTestCase):
                 'coord_inc': ['', '', '', ''],
                 'coord_type': ['', '', '', ''],
                 'coord_unit': ['', '', '', ''],
-                'ref_point': ['', '', '', ''],
-                'ref_value': ['', '', '', '']}
+                'coord_ref_point': ['', '', '', ''],
+                'coord_ref_value': ['', '', '', '']}
 
         assert t[1].columns.info(output=False) == info
 

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -265,6 +265,13 @@ header keywords and descriptions:
     disp            TDISP                 display format
     dim             TDIM                  multi-dimensional array spec
     start           TBCOL                 starting position for ASCII table
+    coord_type      TCTYP                 coordinate/axis type
+    coord_unit      TCUNI                 coordinate/axis unit
+    coord_ref_point TCRPX                 pixel coordinate of the reference point
+    coord_ref_value TCRVL                 coordinate value at reference point
+    coord_inc       TCDLT                 coordinate increment at reference point
+    time_ref_pos    TRPOS                 reference position for a time coordinate column
+    ascii                                 specifies a column for an ASCII table
     array                                 the data of the column
 
 


### PR DESCRIPTION
Expanding the FITS Column interface to allow coordinate type keywords (TC*) and their corresponding attributes in FITS Columns. This will be extended soon to incorporate column-by-column conversion for Table columns into FITS columns (as suggested by @mhvk).

Valid FITS keywords have been added and validated.

CC: @taldcroft @hamogu 