### PR TITLE
Draw tick labels atop, not beneath, gridlines in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,10 +292,10 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Tick labels are now drawn on top of, rather than underneath, gridlines
-  in WCS axes. This improves legibility in situations where tick labels
-  may be on the interior of the axes frame, such as the right ascension
-  axis of an all-sky Aitoff or Mollweide projection. [#6361]
+- Ticks and tick labels are now drawn on top of, rather than underneath,
+  gridlines in WCS axes. This improves legibility in situations where
+  tick labels may be on the interior of the axes frame, such as the right
+  ascension axis of an all-sky Aitoff or Mollweide projection. [#6361]
 
 astropy.vo
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,6 +292,11 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Tick labels are now drawn on top of, rather than underneath, gridlines
+  in WCS axes. This improves legibility in situations where tick labels
+  may be on the interior of the axes frame, such as the right ascension
+  axis of an all-sky Aitoff or Mollweide projection. [#6361]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,7 +292,7 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Ticks and tick labels are now drawn on top of, rather than underneath,
+- Ticks and tick labels are now drawn in front of, rather than behind,
   gridlines in WCS axes. This improves legibility in situations where
   tick labels may be on the interior of the axes frame, such as the right
   ascension axis of an all-sky Aitoff or Mollweide projection. [#6361]

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -4,9 +4,6 @@ import matplotlib
 
 MPL_VERSION = LooseVersion(matplotlib.__version__)
 
-ROOT = "http://data.astropy.org/testing/astropy/2017-07-06T17:59:08.793939"
+ROOT = "http://data.astropy.org/testing/astropy/2017-07-12T14:12:26.217559"
 
-if MPL_VERSION >= LooseVersion('1.5.0'):
-    IMAGE_REFERENCE_DIR = ROOT + '/1.5.x/'
-else:
-    IMAGE_REFERENCE_DIR = ROOT + '/1.4.x/'
+IMAGE_REFERENCE_DIR = ROOT + '/1.5.x/'

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -434,8 +434,6 @@ class CoordinateHelper(object):
         self._update_ticks()
 
         self.ticks.draw(renderer)
-        self.ticklabels.draw(renderer, bboxes=bboxes,
-                             ticklabels_bbox=ticklabels_bbox)
 
         if self.grid_lines_kwargs['visible']:
 
@@ -457,6 +455,9 @@ class CoordinateHelper(object):
                 for line in self._grid.collections:
                     line.set(**self.grid_lines_kwargs)
                     line.draw(renderer)
+
+        self.ticklabels.draw(renderer, bboxes=bboxes,
+                             ticklabels_bbox=ticklabels_bbox)
 
         renderer.close_group('coordinate_axis')
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -427,13 +427,11 @@ class CoordinateHelper(object):
     def formatter(self):
         return self._formatter_locator.formatter
 
-    def _draw(self, renderer, bboxes, ticklabels_bbox):
+    def _draw_grid(self, renderer):
 
         renderer.open_group('coordinate_axis')
 
         self._update_ticks()
-
-        self.ticks.draw(renderer)
 
         if self.grid_lines_kwargs['visible']:
 
@@ -456,6 +454,13 @@ class CoordinateHelper(object):
                     line.set(**self.grid_lines_kwargs)
                     line.draw(renderer)
 
+        renderer.close_group('coordinate_axis')
+
+    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox):
+
+        renderer.open_group('coordinate_axis')
+
+        self.ticks.draw(renderer)
         self.ticklabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox)
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -429,7 +429,7 @@ class CoordinateHelper(object):
 
     def _draw_grid(self, renderer):
 
-        renderer.open_group('coordinate_axis')
+        renderer.open_group('grid lines')
 
         self._update_ticks()
 
@@ -454,17 +454,17 @@ class CoordinateHelper(object):
                     line.set(**self.grid_lines_kwargs)
                     line.draw(renderer)
 
-        renderer.close_group('coordinate_axis')
+        renderer.close_group('grid lines')
 
     def _draw_ticks(self, renderer, bboxes, ticklabels_bbox):
 
-        renderer.open_group('coordinate_axis')
+        renderer.open_group('ticks')
 
         self.ticks.draw(renderer)
         self.ticklabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox)
 
-        renderer.close_group('coordinate_axis')
+        renderer.close_group('ticks')
 
     def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, visible_ticks):
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -337,8 +337,13 @@ class WCSAxes(Axes):
 
             coords.frame.update()
             for coord in coords:
-                coord._draw(renderer, bboxes=self._bboxes,
-                            ticklabels_bbox=self._ticklabels_bbox)
+                coord._draw_grid(renderer)
+
+        for coords in self._all_coords:
+
+            for coord in coords:
+                coord._draw_ticks(renderer, bboxes=self._bboxes,
+                                  ticklabels_bbox=self._ticklabels_bbox)
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
         for coords in self._all_coords:


### PR DESCRIPTION
It makes the tick labels easier to read on axes where ticks are drawn inside the frame, such as the right ascension ticks on an all-sky Aitoff or Mollweide plot.

## Example code

Here's some example code:

```python
from astropy.io.fits import Header
from astropy.wcs import WCS
from astropy import units as u
from astropy.visualization.wcsaxes.frame import EllipticalFrame
from matplotlib import pyplot as plt
import numpy as np

header = Header((('NAXIS',  2),
                 ('NAXIS1', 360),
                 ('NAXIS2', 180),
                 ('CRPIX1', 180.0),
                 ('CRPIX2', 90.0),
                 ('CRVAL1', 180.0),
                 ('CRVAL2', 0.0),
                 ('CDELT1', -2 * np.sqrt(2) / np.pi),
                 ('CDELT2', 2 * np.sqrt(2) / np.pi),
                 ('CTYPE1', 'RA---AIT'),
                 ('CTYPE2', 'DEC--AIT'),
                 ('RADESYS', 'ICRS')))

wcs = WCS(header)

ax = plt.axes(projection=wcs, frame_class=EllipticalFrame, aspect=1)
ax.set_xlim(0, header['NAXIS1'] - 1)
ax.set_ylim(0, header['NAXIS2'] - 1)
ax.coords['ra'].set_ticks(spacing=2 * u.hourangle)
ax.coords['ra'].set_major_formatter('hh')
ax.coords['dec'].set_ticks(spacing=30 * u.deg)
ax.grid()
plt.savefig('test.png')
```

## Before the change

Here is the output of the sample code before the change. Notice that the right ascension ticks and tick labels are partly obscured by the grid.

![test-bad](https://user-images.githubusercontent.com/728407/28081488-a8df46e2-662c-11e7-95b0-ff779ee4d048.png)

## After the change

Here it the output of the sample code after the change.

![test-good](https://user-images.githubusercontent.com/728407/28081527-cd87294c-662c-11e7-8615-d9329782aff0.png)
