### PR TITLE
Add ipython_widget option to ProgressBar.map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -289,6 +289,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- The ``astropy.utils.console.ProgressBar.map`` class method now supports the
+  ``ipython_widget`` option. You can now pass it both ``multiprocess=True`` and
+  ``ipython_widget=True`` to get both multiprocess speedup and a progress bar
+  widget in an IPython Notebook. [#6368]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- The ``astropy.utils.console.ProgressBar.map`` class method now supports the
+  ``ipython_widget`` option. You can now pass it both ``multiprocess=True`` and
+  ``ipython_widget=True`` to get both multiprocess speedup and a progress bar
+  widget in an IPython Notebook. [#6368]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -288,11 +293,6 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
-
-- The ``astropy.utils.console.ProgressBar.map`` class method now supports the
-  ``ipython_widget`` option. You can now pass it both ``multiprocess=True`` and
-  ``ipython_widget=True`` to get both multiprocess speedup and a progress bar
-  widget in an IPython Notebook. [#6368]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -691,8 +691,8 @@ class ProgressBar(six.Iterator):
         pass
 
     @classmethod
-    def map(cls, function, items, multiprocess=False, ipython_widget=False,
-            file=None, step=100):
+    def map(cls, function, items, multiprocess=False, file=None, step=100,
+            ipython_widget=False):
         """
         Does a `map` operation while displaying a progress bar with
         percentage complete.

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -691,7 +691,8 @@ class ProgressBar(six.Iterator):
         pass
 
     @classmethod
-    def map(cls, function, items, multiprocess=False, file=None, step=100):
+    def map(cls, function, items, multiprocess=False, ipython_widget=False,
+            file=None, step=100):
         """
         Does a `map` operation while displaying a progress bar with
         percentage complete.
@@ -716,6 +717,10 @@ class ProgressBar(six.Iterator):
             If `True`, use the `multiprocessing` module to distribute each
             task to a different processor core.
 
+        ipython_widget : bool, optional
+            If `True`, the progress bar will display as an IPython
+            notebook widget.
+
         file : writeable file-like object, optional
             The file to write the progress bar to.  Defaults to
             `sys.stdout`.  If ``file`` is not a tty (as determined by
@@ -735,9 +740,12 @@ class ProgressBar(six.Iterator):
         if file is None:
             file = _get_stdout()
 
-        with cls(len(items), file=file) as bar:
-            default_step = max(int(float(len(items)) / bar._bar_length), 1)
-            chunksize = min(default_step, step)
+        with cls(len(items), ipython_widget=ipython_widget, file=file) as bar:
+            if bar._ipython_widget:
+                chunksize = step
+            else:
+                default_step = max(int(float(len(items)) / bar._bar_length), 1)
+                chunksize = min(default_step, step)
             if not multiprocess:
                 for i, item in enumerate(items):
                     results.append(function(item))


### PR DESCRIPTION
This makes it possible to use the multiprocess option and also display a nice progress bar widget in an IPython Notebook.