### PR TITLE
Pass keyboard interrupt to pytest when using setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,6 +279,10 @@ astropy.table
 
 astropy.tests
 ^^^^^^^^^^^^^
+- Fixed the test command that is run from ``setuptools`` to allow it to
+  gracefully handle keyboard interrupts and pass them on to the ``pytest``
+  subprocess. This prompts ``pytest`` to teardown and display useful traceback
+  and test information [#6369]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -222,9 +222,16 @@ class AstropyTest(Command, object):
             # already done by another core.  Compilation is an
             # insignificant fraction of total testing time, though, so
             # it's probably not worth worrying about.
-            retcode = subprocess.call([sys.executable, '-B', '-c', cmd],
-                                      cwd=self.testing_path, close_fds=False)
-
+            testproc = subprocess.Popen(
+                [sys.executable, '-B', '-c', cmd],
+                cwd=self.testing_path, close_fds=False)
+            retcode = testproc.wait()
+        except KeyboardInterrupt:
+            import signal
+            # If a keyboard interrupt is handled, pass it to the test
+            # subprocess to prompt pytest to initiate its teardown
+            testproc.send_signal(signal.SIGINT)
+            retcode = testproc.wait()
         finally:
             # Remove temporary directory
             shutil.rmtree(self.tmp_dir)


### PR DESCRIPTION
This fixes #3460 and allows `pytest` to teardown cleanly and produce useful traceback information when it receives a keyboard interrupt while running under `setuptools`.