### PR TITLE
Read compressed FITS files from file handles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,8 @@ astropy.io.ascii
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+- Automatically detect and handle compression in FITS files that are opened by
+  passing a file handle to ``fits.open`` [#6373]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,7 @@ astropy.io.ascii
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+
 - Automatically detect and handle compression in FITS files that are opened by
   passing a file handle to ``fits.open`` [#6373]
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -449,7 +449,7 @@ class _File(object):
         return self.compression is not None
 
     def _open_fileobj(self, fileobj, mode, overwrite):
-        """Open a FITS file from a file object or a GzipFile object."""
+        """Open a FITS file from a file object (including compressed files)."""
 
         closed = fileobj_closed(fileobj)
         fmode = fileobj_mode(fileobj) or IO_FITS_MODES[mode]

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -465,7 +465,16 @@ class _File(object):
         # Attempt to determine if the file represented by the open file object
         # is compressed
         try:
+            # We need to account for the possibility that the underlying file
+            # handle may have been opened with either 'ab' or 'ab+', which
+            # means that the current file position is at the end of the file.
+            if mode in ['ostream', 'append']:
+                self._file.seek(0)
             magic = self._file.read(4)
+            # No matter whether the underlying file was opened with 'ab' or
+            # 'ab+', we need to return to the beginning of the file in order
+            # to properly process the FITS header (and handle the possibility
+            # of a compressed file).
             self._file.seek(0)
         except (IOError,OSError):
             return

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -458,19 +458,6 @@ class _File(object):
             self._overwrite_existing(overwrite, fileobj, closed)
 
         if not closed:
-            # Although we have a specific mapping in IO_FITS_MODES from our
-            # custom file modes to raw file object modes, many of the latter
-            # can be used appropriately for the former.  So determine whether
-            # the modes match up appropriately
-            if ((mode in ('readonly', 'denywrite', 'copyonwrite') and
-                    not ('r' in fmode or '+' in fmode)) or
-                    (mode == 'append' and fmode not in ('ab+', 'rb+')) or
-                    (mode == 'ostream' and
-                     not ('w' in fmode or 'a' in fmode or '+' in fmode)) or
-                    (mode == 'update' and fmode not in ('rb+', 'wb+'))):
-                raise ValueError(
-                    "Mode argument '{}' does not match mode of the input "
-                    "file ({}).".format(mode, fmode))
             self._file = fileobj
         elif isfile(fileobj):
             self._file = fileobj_open(self.name, IO_FITS_MODES[mode])

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -111,15 +111,19 @@ class _File(object):
 
         if mode is None:
             if _is_random_access_file_backed(fileobj):
-                fmode = fileobj_mode(fileobj)
-                # If the mode is unsupported just leave it as None; we'll
-                # catch this case below
-                mode = FILE_MODES.get(fmode)
+                mode = fileobj_mode(fileobj)
             else:
                 mode = 'readonly'  # The default
 
         if mode not in IO_FITS_MODES:
-            raise ValueError("Mode '{}' not recognized".format(mode))
+            if mode in ['r', 'w']:
+                raise ValueError(
+                    ("Text mode '{}' not supported: " +
+                    "files must be opened in binary mode").format(mode))
+            new_mode = FILE_MODES.get(mode)
+            if new_mode not in IO_FITS_MODES:
+                raise ValueError("Mode '{}' not recognized".format(mode))
+            mode = new_mode
 
         # Handle raw URLs
         if (isinstance(fileobj, string_types) and

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -124,7 +124,8 @@ class _File(object):
         # Holds mmap instance for files that use mmap
         self._mmap = None
 
-        mode = _normalize_fits_mode(mode)
+        if mode is not None and mode not in IO_FITS_MODES:
+            raise ValueError("Mode '{}' not recognized".format(mode))
         if isfile(fileobj):
             objmode = _normalize_fits_mode(fileobj_mode(fileobj))
             if mode is not None and mode != objmode:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -27,7 +27,7 @@ from ....utils.decorators import deprecated_renamed_argument
 from ....extern.six.moves import range
 
 
-def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
+def fitsopen(name, mode=None, memmap=None, save_backup=False,
              cache=True, lazy_load_hdus=None, **kwargs):
     """Factory function to open a FITS file and return an `HDUList` object.
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -27,7 +27,7 @@ from ....utils.decorators import deprecated_renamed_argument
 from ....extern.six.moves import range
 
 
-def fitsopen(name, mode=None, memmap=None, save_backup=False,
+def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
              cache=True, lazy_load_hdus=None, **kwargs):
     """Factory function to open a FITS file and return an `HDUList` object.
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -8,6 +8,7 @@ import mmap
 import os
 import warnings
 import zipfile
+import six
 
 import pytest
 import numpy as np
@@ -597,6 +598,27 @@ class TestFileFunctions(FitsTestCase):
 
     @pytest.mark.skipif(six.PY2,
         reason="urrlib has incompatible Py2 API, but we will deprecate anyway")
+    def test_open_file_handle(self):
+        # Make sure we can open a FITS file from an open file handle
+        with open(self.data('test0.fits'), 'rb') as handle:
+            with fits.open(handle) as fitsfile:
+                pass
+
+        with open(self.temp('temp.fits'), 'wb') as handle:
+            with fits.open(handle) as fitsfile:
+                pass
+
+        # Opening without explicitly specifying binary mode should fail
+        with pytest.raises(ValueError):
+            with open(self.data('test0.fits')) as handle:
+                with fits.open(handle) as fitsfile:
+                    pass
+
+        with pytest.raises(ValueError):
+            with open(self.temp('temp.fits'), 'w') as handle:
+                with fits.open(handle) as fitsfile:
+                    pass
+
     def test_open_from_url(self):
         import urllib.request
         file_url = "file:///" + self.data('test0.fits')
@@ -628,14 +650,27 @@ class TestFileFunctions(FitsTestCase):
                         pass
 
     def test_open_gzipped(self):
+        gzip_file = self._make_gzip_file()
         with ignore_warnings():
-            assert len(fits.open(self._make_gzip_file())) == 5
+            with fits.open(gzip_file) as fits_handle:
+                assert fits_handle._file.compression == 'gzip'
+                assert len(fits_handle) == 5
+            with fits.open(gzip.GzipFile(gzip_file)) as fits_handle:
+                assert fits_handle._file.compression == 'gzip'
+                assert len(fits_handle) == 5
+
+    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
+    def test_open_gzipped_from_handle(self):
+        with open(self._make_gzip_file(), 'rb') as handle:
+            with fits.open(handle) as fits_handle:
+                assert fits_handle._file.compression == 'gzip'
 
     def test_detect_gzipped(self):
         """Test detection of a gzip file when the extension is not .gz."""
-
         with ignore_warnings():
-            assert len(fits.open(self._make_gzip_file('test0.fz'))) == 5
+            with fits.open(self._make_gzip_file('test0.fz')) as fits_handle:
+                assert fits_handle._file.compression == 'gzip'
+                assert len(fits_handle) == 5
 
     def test_writeto_append_mode_gzip(self):
         """Regression test for
@@ -660,14 +695,31 @@ class TestFileFunctions(FitsTestCase):
             assert hdul[0].header == h.header
 
     def test_open_bzipped(self):
+        bzip_file = self._make_bzip2_file()
         with ignore_warnings():
-            assert len(fits.open(self._make_bzip2_file())) == 5
+            with fits.open(bzip_file) as fits_handle:
+                assert fits_handle._file.compression == 'bzip2'
+                assert len(fits_handle) == 5
+
+            with fits.open(bz2.BZ2File(bzip_file)) as fits_handle:
+                assert fits_handle._file.compression == 'bzip2'
+                assert len(fits_handle) == 5
+
+    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
+    @pytest.mark.skipif(six.PY2,
+        reason = "API difference in bz2 in 2.7, but will be deprecated anyway")
+    def test_open_bzipped_from_handle(self):
+        with open(self._make_bzip2_file(), 'rb') as handle:
+            with fits.open(handle) as fits_handle:
+                assert fits_handle._file.compression == 'bzip2'
+                assert len(fits_handle) == 5
 
     def test_detect_bzipped(self):
         """Test detection of a bzip2 file when the extension is not .bz2."""
-
         with ignore_warnings():
-            assert len(fits.open(self._make_bzip2_file('test0.xx'))) == 5
+            with fits.open(self._make_bzip2_file('test0.xx')) as fits_handle:
+                assert fits_handle._file.compression == 'bzip2'
+                assert len(fits_handle) == 5
 
     def test_writeto_bzip2_fileobj(self):
         """Test writing to a bz2.BZ2File file like object"""
@@ -691,13 +743,21 @@ class TestFileFunctions(FitsTestCase):
             assert hdul[0].header == h.header
 
     def test_open_zipped(self):
-        zf = self._make_zip_file()
-
+        zip_file = self._make_zip_file()
         with ignore_warnings():
-            assert len(fits.open(self._make_zip_file())) == 5
+            with fits.open(zip_file) as fits_handle:
+                assert fits_handle._file.compression == 'zip'
+                assert len(fits_handle) == 5
+            with fits.open(zipfile.ZipFile(zip_file)) as fits_handle:
+                assert fits_handle._file.compression == 'zip'
+                assert len(fits_handle) == 5
 
-        with ignore_warnings():
-            assert len(fits.open(zipfile.ZipFile(zf))) == 5
+    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
+    def test_open_zipped_from_handle(self):
+        with open(self._make_zip_file(), 'rb') as handle:
+            with fits.open(handle) as fits_handle:
+                assert fits_handle._file.compression == 'zip'
+                assert len(fits_handle) == 5
 
     def test_detect_zipped(self):
         """Test detection of a zip file when the extension is not .zip."""

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -8,7 +8,6 @@ import mmap
 import os
 import warnings
 import zipfile
-import six
 
 import pytest
 import numpy as np
@@ -659,7 +658,6 @@ class TestFileFunctions(FitsTestCase):
                 assert fits_handle._file.compression == 'gzip'
                 assert len(fits_handle) == 5
 
-    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
     def test_open_gzipped_from_handle(self):
         with open(self._make_gzip_file(), 'rb') as handle:
             with fits.open(handle) as fits_handle:
@@ -705,7 +703,6 @@ class TestFileFunctions(FitsTestCase):
                 assert fits_handle._file.compression == 'bzip2'
                 assert len(fits_handle) == 5
 
-    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
     @pytest.mark.skipif(six.PY2,
         reason = "API difference in bz2 in 2.7, but will be deprecated anyway")
     def test_open_bzipped_from_handle(self):
@@ -752,7 +749,6 @@ class TestFileFunctions(FitsTestCase):
                 assert fits_handle._file.compression == 'zip'
                 assert len(fits_handle) == 5
 
-    @pytest.mark.xfail(reason="FITS does not recognize compressed file handle")
     def test_open_zipped_from_handle(self):
         with open(self._make_zip_file(), 'rb') as handle:
             with fits.open(handle) as fits_handle:

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -595,8 +595,6 @@ class TestFileFunctions(FitsTestCase):
             assert os.path.exists(self.temp('foobar.fits'))
             os.remove(self.temp('foobar.fits'))
 
-    @pytest.mark.skipif(six.PY2,
-        reason="urrlib has incompatible Py2 API, but we will deprecate anyway")
     def test_open_file_handle(self):
         # Make sure we can open a FITS file from an open file handle
         with open(self.data('test0.fits'), 'rb') as handle:
@@ -613,11 +611,22 @@ class TestFileFunctions(FitsTestCase):
                 with fits.open(handle) as fitsfile:
                     pass
 
-        with pytest.raises(ValueError):
-            with open(self.temp('temp.fits'), 'w') as handle:
-                with fits.open(handle) as fitsfile:
-                    pass
+        # All of these read modes should fail
+        for mode in ['r', 'rt', 'a', 'at']:
+            with pytest.raises(ValueError):
+                with open(self.data('test0.fits'), mode=mode) as handle:
+                    with fits.open(handle) as fitsfile:
+                        pass
 
+        # These write modes should fail as well
+        for mode in ['w', 'wt']:
+            with pytest.raises(ValueError):
+                with open(self.temp('temp.fits'), mode=mode) as handle:
+                    with fits.open(handle) as fitsfile:
+                        pass
+
+    @pytest.mark.skipif(six.PY2,
+        reason="urrlib has incompatible Py2 API, but we will deprecate anyway")
     def test_open_from_url(self):
         import urllib.request
         file_url = "file:///" + self.data('test0.fits')

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -612,18 +612,40 @@ class TestFileFunctions(FitsTestCase):
                     pass
 
         # All of these read modes should fail
-        for mode in ['r', 'rt', 'a', 'at']:
+        for mode in ['r', 'rt', 'r+', 'rt+', 'a', 'at', 'a+', 'at+']:
             with pytest.raises(ValueError):
                 with open(self.data('test0.fits'), mode=mode) as handle:
                     with fits.open(handle) as fitsfile:
                         pass
 
         # These write modes should fail as well
-        for mode in ['w', 'wt']:
+        for mode in ['w', 'wt', 'w+', 'wt+']:
             with pytest.raises(ValueError):
                 with open(self.temp('temp.fits'), mode=mode) as handle:
                     with fits.open(handle) as fitsfile:
                         pass
+
+    def test_fits_file_handle_mode_combo(self):
+        # This should work fine since no mode is given
+        with open(self.data('test0.fits'), 'rb') as handle:
+            with fits.open(handle) as fitsfile:
+                pass
+
+        # This should work fine since the modes are compatible
+        with open(self.data('test0.fits'), 'rb') as handle:
+            with fits.open(handle, mode='readonly') as fitsfile:
+                pass
+
+        # These modes should also agree
+        with open(self.data('test0.fits'), 'rb') as handle:
+            with fits.open(handle, mode='rb') as fitsfile:
+                pass
+
+        # This should not work since the modes conflict
+        with pytest.raises(ValueError):
+            with open(self.data('test0.fits'), 'rb') as handle:
+                with fits.open(handle, mode='ostream') as fitsfile:
+                    pass
 
     @pytest.mark.skipif(six.PY2,
         reason="urrlib has incompatible Py2 API, but we will deprecate anyway")
@@ -1133,7 +1155,7 @@ class TestFileFunctions(FitsTestCase):
             hdulist = fits.HDUList(hdu)
             filename = self.temp('test.fits')
 
-            with open(filename, mode='wb+') as fileobj:
+            with open(filename, mode='wb') as fileobj:
                 hdulist.writeto(fileobj)
 
         assert ("Not enough space on disk: requested 8000, available 0. "

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -602,7 +602,7 @@ class TestFileFunctions(FitsTestCase):
                 pass
 
         with open(self.temp('temp.fits'), 'wb') as handle:
-            with fits.open(handle) as fitsfile:
+            with fits.open(handle, mode='ostream') as fitsfile:
                 pass
 
         # Opening without explicitly specifying binary mode should fail

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -636,11 +636,6 @@ class TestFileFunctions(FitsTestCase):
             with fits.open(handle, mode='readonly') as fitsfile:
                 pass
 
-        # These modes should also agree
-        with open(self.data('test0.fits'), 'rb') as handle:
-            with fits.open(handle, mode='rb') as fitsfile:
-                pass
-
         # This should not work since the modes conflict
         with pytest.raises(ValueError):
             with open(self.data('test0.fits'), 'rb') as handle:


### PR DESCRIPTION
This fixes #5948. It is now possible to open compressed FITS files using file handles:
```python
from astropy.io import fits

with open('example.fits.gz', 'rb') as fh:
    # Automatically detects that the file handle corresponds to a gzip file
    with fits.open(fh) as fits_handle:
        # do stuff
```

This was already possible when calling `fits.open` with a string corresponding to a path or with a compression file object (e.g. `gzip.GzipFile`). This PR also adds a number of unit tests to verify the new functionality and to improve coverage of existing functionality.