### PR TITLE
add Schechter1D to powerlaw models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-3.0 (unreleased)
+﻿3.0 (unreleased)
 =================
 
 New Features
@@ -39,6 +39,9 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+
+- Add astronomical variation of ``ExponentialCutoffPowerLaw1D``, ``Schechter1D``,
+  eliminating a free parameter for better fitting. [#6375]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-﻿3.0 (unreleased)
+﻿3.0.0 (unreleased)
 =================
 
 New Features

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-﻿3.0.0 (unreleased)
+﻿3.0 (unreleased)
 =================
 
 New Features

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -476,8 +476,7 @@ class Schechter1D(Fittable1DModel):
     Notes
     -----
     Model formula taken from
-    Schechter, P. An analytic expression for the luminosity function for galaxies.
-    APJ, 203, 297-306 (1976)
+    (:ref:`Schechter 1976 <ref-schechter1976>`):
     
     (with :math:`\\phi*` for ``phi_star`` and :math:`\\alpha` for ``alpha``):
         .. math:: f(x) = {\\phi*} (L / L*) ^ {\\alpha} \\exp (-L / L*)
@@ -492,6 +491,14 @@ class Schechter1D(Fittable1DModel):
     power-law form of the function cuts off. Note that the default value for
     ``l_star`` is in units of solar luminosities, in erg/s, to avoid overflow
     errors.
+
+    References
+    ----------
+    
+    .. _ref-schechter1976:
+
+    Schechter, P. An analytic expression for the luminosity function for galaxies.
+    APJ, 203, 297-306 (1976)
         
     Example
     -------

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -500,8 +500,8 @@ class Schechter1D(Fittable1DModel):
 
     .. [1] http://ned.ipac.caltech.edu/level5/Dickey/Dickey2.html
 
-    Example
-    -------
+    Examples
+    --------
     .. plot::
         :include-source:
 

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -463,11 +463,11 @@ class Schechter1D(Fittable1DModel):
     Parameters
     ----------
     phi_star : float
-        Normalization factor
+        Normalization factor.
     l_star : float
-        Reference point
+        Reference point.
     alpha : float
-        Power law index
+        Power law index.
 
     See Also
     --------
@@ -498,7 +498,7 @@ class Schechter1D(Fittable1DModel):
     .. _ref-schechter1976:
 
     Schechter, P. An analytic expression for the luminosity function for galaxies.
-    APJ, 203, 297-306 (1976)
+    APJ, 203, 297-306 (1976).
         
     Example
     -------

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -455,11 +455,11 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
 
 
 class Schechter1D(Fittable1DModel):
-    """
+    r"""
     The Schechter function; a one dimensional power law model with an
     exponential cutoff. It describes the number distribution of galaxies as
     a function of their luminosity.
-    
+
     Parameters
     ----------
     phi_star : float
@@ -472,22 +472,22 @@ class Schechter1D(Fittable1DModel):
     See Also
     --------
     PowerLaw1D, BrokenPowerLaw1D, LogParabola1D, ExponentialCutoffPowerLaw1D
-    
+
     Notes
     -----
     Model formula taken from
     (:ref:`Schechter, P. <ref-schechter1976>`), An analytic expression for the
     luminosity function for galaxies. APJ, 203, 297-306 (1976).
-    
+
     (with :math:`\\phi*` for ``phi_star`` and :math:`\\alpha` for ``alpha``):
         .. math:: f(x) = {\\phi*} (L / L*) ^ {\\alpha} \\exp (-L / L*)
-        
+
     The ``phi_star`` parameter is the normalization factor which defines the
     overall density of galaxes, in units of number/Mpc^3.
-    
+
     The ``alpha`` parameter defines the faint-end slope of the luminosity
     function.
-    
+
     The ``l_star`` parameter is a characteristic galaxy luminosity where the
     power-law form of the function cuts off. Note that the default value for
     ``l_star`` is in units of solar luminosities, in erg/s, to avoid overflow
@@ -504,26 +504,26 @@ class Schechter1D(Fittable1DModel):
     -------
     .. plot::
         :include-source:
-        
+
         import numpy as np
         import matplotlib.pyplot as plt
         from astropy.modeling.fitting import LevMarLSQFitter
         from astropy.modeling import models
-        
+
         # arbitrary data:
         def f(l, phi_star, l_star, alpha):
             return phi_star*(l/l_star)**(alpha)*np.exp(-l/l_star)
         lx = np.logspace(-2, 1, 50)
         l = lx*1.4e10
         # Note that I only used separate l, lx as a preference to easily plot l/l_star
-        
+
         phi = f(l, phi_star = .008, l_star = 1.4e10, alpha = -0.75)
-        
+
         # Fit data to Schechter function using LevMarLSQFitter
         LF_init = models.Schechter1D()
         LF_fit = LevMarLSQFitter()
         LF = LF_fit(LF_init, l, phi)
-        
+
         # Display best fit parameter values
         print('phi_star = %g, l_star = %g, alpha = %g' % (LF.parameters[0], LF.parameters[1], LF.parameters[2]))
 
@@ -534,7 +534,7 @@ class Schechter1D(Fittable1DModel):
         plt.ylabel(r'$\phi$')
         plt.legend()
         plt.show()
-        
+
    """
 
     phi_star = Parameter(default=1.)
@@ -544,7 +544,7 @@ class Schechter1D(Fittable1DModel):
     @staticmethod
     def evaluate(l, phi_star, l_star, alpha):
         """One dimensional exponential cutoff power law model function"""
-        
+
         return phi_star * (l / l_star) ** (alpha) * np.exp(-l / l_star)
 
     @staticmethod
@@ -556,7 +556,7 @@ class Schechter1D(Fittable1DModel):
         d_alpha = phi_star * d_phi_star * np.log(l / l_star)
 
         return [d_phi_star, d_l_star, d_alpha]
-    
+
     @property
     def input_units(self):
         if self.l_star.unit is None:

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -454,6 +454,113 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
                             ('amplitude', outputs_unit['y'])])
 
 
+class Schechter1D(Fittable1DModel):
+    """
+    The Schechter function; a one dimensional power law model with an
+    exponential cutoff. It describes the number distribution of galaxies as
+    a function of their luminosity.
+    
+    Parameters
+    ----------
+    phi_star : float
+        Normalization factor
+    l_star : float
+        Reference point
+    alpha : float
+        Power law index
+
+    See Also
+    --------
+    PowerLaw1D, BrokenPowerLaw1D, LogParabola1D, ExponentialCutoffPowerLaw1D
+    
+    Notes
+    -----
+    Model formula taken from
+    Schechter, P. An analytic expression for the luminosity function for galaxies.
+    APJ, 203, 297-306 (1976)
+    
+    (with :math:`\\phi*` for ``phi_star`` and :math:`\\alpha` for ``alpha``):
+        .. math:: f(x) = {\\phi*} (L / L*) ^ {\\alpha} \\exp (-L / L*)
+        
+    The ``phi_star`` parameter is the normalization factor which defines the
+    overall density of galaxes, in units of number/Mpc^3.
+    
+    The ``alpha`` parameter defines the faint-end slope of the luminosity
+    function.
+    
+    The ``l_star`` parameter is a characteristic galaxy luminosity where the
+    power-law form of the function cuts off. Note that the default value for
+    ``l_star`` is in units of solar luminosities, in erg/s, to avoid overflow
+    errors.
+        
+    Example
+    -------
+    .. plot::
+        :include-source:
+        
+        import numpy as np
+        import matplotlib.pyplot as plt
+        from astropy.modeling.fitting import LevMarLSQFitter
+        from astropy.modeling import models
+        
+        # arbitrary data:
+        def f(l, phi_star, l_star, alpha):
+            return phi_star*(l/l_star)**(alpha)*np.exp(-l/l_star)
+        lx = np.logspace(-2, 1, 50)
+        l = lx*1.4e10
+        # Note that I only used separate l, lx as a preference to easily plot l/l_star
+        
+        phi = f(l, phi_star = .008, l_star = 1.4e10, alpha = -0.75)
+        
+        # Fit data to Schechter function using LevMarLSQFitter
+        LF_init = models.Schechter1D()
+        LF_fit = LevMarLSQFitter()
+        LF = LF_fit(LF_init, l, phi)
+        
+        # Display best fit parameter values
+        print('phi_star = %g, l_star = %g, alpha = %g' % (LF.parameters[0], LF.parameters[1], LF.parameters[2]))
+
+        # Plot data and line of best fit
+        plt.loglog(lx, phi, 'skyblue', marker = 'o')
+        plt.plot(lx, LF(l), 'black', label = r'$\phi* = %.3f, L* = %.2e, \alpha = %.2f$' % (LF.parameters[0], LF.parameters[1], LF.parameters[2]))
+        plt.xlabel('L/L*')
+        plt.ylabel(r'$\phi$')
+        plt.legend()
+        plt.show()
+        
+   """
+
+    phi_star = Parameter(default=1.)
+    l_star = Parameter(default=1e10)
+    alpha = Parameter(default=-1.)
+
+    @staticmethod
+    def evaluate(l, phi_star, l_star, alpha):
+        """One dimensional exponential cutoff power law model function"""
+        
+        return phi_star * (l / l_star) ** (alpha) * np.exp(-l / l_star)
+
+    @staticmethod
+    def fit_deriv(l, phi_star, l_star, alpha):
+        """One dimensional exponential cutoff power law derivative with respect to parameters"""
+
+        d_phi_star = (l / l_star) ** (alpha) * np.exp(-l / l_star)
+        d_l_star = (-alpha * l_star + l) * phi_star * d_phi_star / l_star ** 2
+        d_alpha = phi_star * d_phi_star * np.log(l / l_star)
+
+        return [d_phi_star, d_l_star, d_alpha]
+    
+    @property
+    def input_units(self):
+        if self.l_star.unit is None:
+            return None
+        else:
+            return {'x': self.l_star.unit}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict([('l_star', inputs_unit['x']),
+                            ('phi_star', outputs_unit['y'])])
+
 class LogParabola1D(Fittable1DModel):
     """
     One dimensional log parabola model (sometimes called curved power law).

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -476,7 +476,8 @@ class Schechter1D(Fittable1DModel):
     Notes
     -----
     Model formula taken from
-    (:ref:`Schechter 1976 <ref-schechter1976>`):
+    (:ref:`Schechter, P. <ref-schechter1976>`), An analytic expression for the
+    luminosity function for galaxies. APJ, 203, 297-306 (1976).
     
     (with :math:`\\phi*` for ``phi_star`` and :math:`\\alpha` for ``alpha``):
         .. math:: f(x) = {\\phi*} (L / L*) ^ {\\alpha} \\exp (-L / L*)
@@ -494,12 +495,11 @@ class Schechter1D(Fittable1DModel):
 
     References
     ----------
-    
+
     .. _ref-schechter1976:
 
-    Schechter, P. An analytic expression for the luminosity function for galaxies.
-    APJ, 203, 297-306 (1976).
-        
+    .. [1] http://ned.ipac.caltech.edu/level5/Dickey/Dickey2.html
+
     Example
     -------
     .. plot::

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -16,7 +16,7 @@ from .parameters import Parameter, InputParameterError
 from ..units import Quantity
 
 __all__ = ['PowerLaw1D', 'BrokenPowerLaw1D', 'SmoothlyBrokenPowerLaw1D',
-           'ExponentialCutoffPowerLaw1D', 'LogParabola1D']
+           'ExponentialCutoffPowerLaw1D', 'Schechter1D', 'LogParabola1D']
 
 
 class PowerLaw1D(Fittable1DModel):

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -61,7 +61,7 @@ from ..functional_models import (
 from ..polynomial import Polynomial1D, Polynomial2D
 from ..powerlaws import (
     PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
-    LogParabola1D)
+    Schechter1D, LogParabola1D)
 import numpy as np
 
 # 1D Models

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -178,6 +178,16 @@ models_1D = {
         'log_fit': True
     },
 
+    Schechter1D: {
+        'parameters': [.01, 1e10, -1],
+        'constraints': {},
+        'x_values': [1e+8, 1e+9, 1e+10, 1e+11],
+        'y_values': [9.90049834e-01, 9.04837418e-02, 3.67879441e-03,
+		     4.53999298e-08],
+        'x_lim': [0.01, 10],
+        'log_fit': True
+    },
+
     LogParabola1D: {
         'parameters': [1, 2, 3, 0.1],
         'constraints': {'fixed': {'x_0': True}},


### PR DESCRIPTION
Adding an astronomical variation of the ExponentialCutoffPowerLaw1D, eliminating a free parameter for better fitting.