### PR TITLE
Add io.fits test showing that reading from URL works...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,10 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Properly handle opening of FITS files from ``http.client.HTTPResponse`` (i.e.
+  it now works correctly when passing the results of ``urllib.request.urlopen``
+  to ``fits.open``). [#6378]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This addresses issue #4165 and adds a test to `io.fits` showing that opening a FITS file from a URL already appears to work as expected.

It seems like this one probably doesn't need a change log entry?

EDIT: Fix #4165