### PR TITLE
Redo: split pytest plugins into individual modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Split pytest plugins into separate modules. [#6384]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -1,0 +1,341 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..extern import six
+
+import doctest
+import fnmatch
+import imp
+import os
+import re
+import sys
+
+import pytest
+
+from .output_checker import AstropyOutputChecker, FIX
+
+try:
+    import importlib.machinery as importlib_machinery
+except ImportError:  # Python 2.7
+    importlib_machinery = None
+
+# these pytest hooks allow us to mark tests and run the marked tests with
+# specific command line options.
+
+
+def pytest_addoption(parser):
+
+    parser.addoption("--doctest-plus", action="store_true",
+                     help="enable running doctests with additional "
+                     "features not found in the normal doctest "
+                     "plugin")
+
+    parser.addoption("--doctest-rst", action="store_true",
+                     help="enable running doctests in .rst documentation")
+
+    parser.addini("doctest_plus", "enable running doctests with additional "
+                  "features not found in the normal doctest plugin")
+
+    parser.addini("doctest_norecursedirs",
+                  "like the norecursedirs option but applies only to doctest "
+                  "collection", type="args", default=())
+
+    parser.addini("doctest_rst",
+                  "Run the doctests in the rst documentation",
+                  default=False)
+
+
+# We monkey-patch in our replacement doctest OutputChecker.  Not
+# great, but there isn't really an API to replace the checker when
+# using doctest.testfile, unfortunately.
+doctest.OutputChecker = AstropyOutputChecker
+
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+
+
+def pytest_configure(config):
+
+    doctest_plugin = config.pluginmanager.getplugin('doctest')
+    if (doctest_plugin is None or config.option.doctestmodules or not
+            (config.getini('doctest_plus') or config.option.doctest_plus)):
+        return
+
+    # These are the default doctest options we use for everything.
+    # There shouldn't be any need to manually put them in doctests
+    # themselves.
+    opts = (doctest.ELLIPSIS |
+            doctest.NORMALIZE_WHITESPACE |
+            FIX)
+
+    class DocTestModulePlus(doctest_plugin.DoctestModule):
+        # pytest 2.4.0 defines "collect".  Prior to that, it defined
+        # "runtest".  The "collect" approach is better, because we can
+        # skip modules altogether that have no doctests.  However, we
+        # need to continue to override "runtest" so that the built-in
+        # behavior (which doesn't do whitespace normalization or
+        # handling __doctest_skip__) doesn't happen.
+        def collect(self):
+            if self.fspath.basename == "conftest.py":
+                try:
+                    module = self.config._conftest.importconftest(self.fspath)
+                except AttributeError:  # pytest >= 2.8.0
+                    module = self.config.pluginmanager._importconftest(self.fspath)
+            else:
+                try:
+                    module = self.fspath.pyimport()
+                    # Just ignore searching modules that can't be imported when
+                    # collecting doctests
+                except ImportError:
+                    return
+
+            # uses internal doctest module parsing mechanism
+            finder = DocTestFinderPlus()
+            runner = doctest.DebugRunner(verbose=False, optionflags=opts,
+                                         checker=AstropyOutputChecker())
+            for test in finder.find(module):
+                if test.examples:  # skip empty doctests
+                    if config.getvalue("remote_data") != 'any':
+                        for example in test.examples:
+                            if example.options.get(REMOTE_DATA):
+                                example.options[doctest.SKIP] = True
+
+                    yield doctest_plugin.DoctestItem(
+                        test.name, self, runner, test)
+
+    class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+        def runtest(self):
+            # satisfy `FixtureRequest` constructor...
+            self.funcargs = {}
+            fixture_request = doctest_plugin._setup_fixtures(self)
+
+            failed, tot = doctest.testfile(
+                str(self.fspath), module_relative=False,
+                optionflags=opts, parser=DocTestParserPlus(),
+                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
+                raise_on_error=True, verbose=False, encoding='utf-8')
+
+    class DocTestParserPlus(doctest.DocTestParser):
+        """
+        An extension to the builtin DocTestParser that handles the
+        special directives for skipping tests.
+
+        The directives are:
+
+           - ``.. doctest-skip::``: Skip the next doctest chunk.
+
+           - ``.. doctest-requires:: module1, module2``: Skip the next
+             doctest chunk if the given modules/packages are not
+             installed.
+
+           - ``.. doctest-skip-all``: Skip all subsequent doctests.
+        """
+
+        def parse(self, s, name=None):
+            result = doctest.DocTestParser.parse(self, s, name=name)
+
+            # result is a sequence of alternating text chunks and
+            # doctest.Example objects.  We need to look in the text
+            # chunks for the special directives that help us determine
+            # whether the following examples should be skipped.
+
+            required = []
+            skip_next = False
+            skip_all = False
+
+            for entry in result:
+                if isinstance(entry, six.string_types) and entry:
+                    required = []
+                    skip_next = False
+                    lines = entry.strip().splitlines()
+
+                    if '.. doctest-skip-all' in (x.strip() for x in lines):
+                        skip_all = True
+                        continue
+
+                    if not len(lines):
+                        continue
+
+                    last_line = lines[-1]
+                    match = re.match(
+                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
+                    if match:
+                        marker = match.group(1)
+                        if (marker is None or
+                                (marker.strip() == 'win32' and
+                                 sys.platform == 'win32')):
+                            skip_next = True
+                            continue
+
+                    match = re.match(
+                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
+                        last_line)
+                    if match:
+                        required = re.split(r'\s*,?\s*', match.group(1))
+                elif isinstance(entry, doctest.Example):
+                    if (skip_all or skip_next or
+                        not DocTestFinderPlus.check_required_modules(required)):
+                        entry.options[doctest.SKIP] = True
+
+                    if (config.getvalue('remote_data') != 'any' and
+                        entry.options.get(REMOTE_DATA)):
+                        entry.options[doctest.SKIP] = True
+
+            return result
+
+    config.pluginmanager.register(
+        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
+                    config.getini('doctest_rst') or config.option.doctest_rst),
+        'doctestplus')
+
+    # Remove the doctest_plugin, or we'll end up testing the .rst
+    # files twice.
+    config.pluginmanager.unregister(doctest_plugin)
+
+
+class DoctestPlus(object):
+    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
+                 run_rst_doctests):
+        """
+        doctest_module_item_cls should be a class inheriting
+        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
+        running of a single doctest found in a Python module.  This is passed
+        in as an argument because the actual class to be used may not be
+        available at import time, depending on whether or not the doctest
+        plugin for py.test is available.
+        """
+        self._doctest_module_item_cls = doctest_module_item_cls
+        self._doctest_textfile_item_cls = doctest_textfile_item_cls
+        self._run_rst_doctests = run_rst_doctests
+
+        # Directories to ignore when adding doctests
+        self._ignore_paths = []
+
+    def pytest_ignore_collect(self, path, config):
+        """Skip paths that match any of the doctest_norecursedirs patterns."""
+
+        for pattern in config.getini("doctest_norecursedirs"):
+            if path.check(fnmatch=pattern):
+                # Apparently pytest_ignore_collect causes files not to be
+                # collected by any test runner; for DoctestPlus we only want to
+                # avoid creating doctest nodes for them
+                self._ignore_paths.append(path)
+                break
+
+        return False
+
+    def pytest_collect_file(self, path, parent):
+        """Implements an enhanced version of the doctest module from py.test
+        (specifically, as enabled by the --doctest-modules option) which
+        supports skipping all doctests in a specific docstring by way of a
+        special ``__doctest_skip__`` module-level variable.  It can also skip
+        tests that have special requirements by way of
+        ``__doctest_requires__``.
+
+        ``__doctest_skip__`` should be a list of functions, classes, or class
+        methods whose docstrings should be ignored when collecting doctests.
+
+        This also supports wildcard patterns.  For example, to run doctests in
+        a class's docstring, but skip all doctests in its modules use, at the
+        module level::
+
+            __doctest_skip__ = ['ClassName.*']
+
+        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
+        to the module itself, in case its module-level docstring contains
+        doctests.
+
+        ``__doctest_requires__`` should be a dictionary mapping wildcard
+        patterns (in the same format as ``__doctest_skip__``) to a list of one
+        or more modules that should be *importable* in order for the tests to
+        run.  For example, if some tests require the scipy module to work they
+        will be skipped unless ``import scipy`` is possible.  It is also
+        possible to use a tuple of wildcard patterns as a key in this dict::
+
+            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
+
+        """
+
+        for ignore_path in self._ignore_paths:
+            if ignore_path.common(path) == ignore_path:
+                return None
+
+        if path.ext == '.py':
+            if path.basename == 'conf.py':
+                return None
+
+            # Don't override the built-in doctest plugin
+            return self._doctest_module_item_cls(path, parent)
+        elif self._run_rst_doctests and path.ext == '.rst':
+            # Ignore generated .rst files
+            parts = str(path).split(os.path.sep)
+            if (path.basename.startswith('_') or
+                    any(x.startswith('_') for x in parts) or
+                    any(x == 'api' for x in parts)):
+                return None
+
+            # TODO: Get better names on these items when they are
+            # displayed in py.test output
+            return self._doctest_textfile_item_cls(path, parent)
+
+
+class DocTestFinderPlus(doctest.DocTestFinder):
+    """Extension to the default `doctest.DoctestFinder` that supports
+    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
+    """
+
+    # Caches the results of import attempts
+    _import_cache = {}
+
+    @classmethod
+    def check_required_modules(cls, mods):
+        for mod in mods:
+            if mod in cls._import_cache:
+                if not cls._import_cache[mod]:
+                    return False
+            try:
+                imp.find_module(mod)
+            except ImportError:
+                cls._import_cache[mod] = False
+                return False
+            else:
+                cls._import_cache[mod] = True
+        return True
+
+    def find(self, obj, name=None, module=None, globs=None,
+             extraglobs=None):
+        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
+                                           extraglobs)
+        if (hasattr(obj, '__doctest_skip__') or
+                hasattr(obj, '__doctest_requires__')):
+            if name is None and hasattr(obj, '__name__'):
+                name = obj.__name__
+            else:
+                raise ValueError("DocTestFinder.find: name must be given "
+                                 "when obj.__name__ doesn't exist: {!r}".format(
+                        (type(obj),)))
+
+            def test_filter(test):
+                for pat in getattr(obj, '__doctest_skip__', []):
+                    if pat == '*':
+                        return False
+                    elif pat == '.' and test.name == name:
+                        return False
+                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
+                        return False
+
+                reqs = getattr(obj, '__doctest_requires__', {})
+                for pats, mods in six.iteritems(reqs):
+                    if not isinstance(pats, tuple):
+                        pats = (pats,)
+                    for pat in pats:
+                        if not fnmatch.fnmatch(test.name,
+                                               '.'.join((name, pat))):
+                            continue
+                        if not self.check_required_modules(mods):
+                            return False
+                return True
+
+            tests = list(filter(test_filter, tests))
+
+        return tests
+

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -338,4 +338,3 @@ class DocTestFinderPlus(doctest.DocTestFinder):
             tests = list(filter(test_filter, tests))
 
         return tests
-

--- a/astropy/tests/pytest_openfiles.py
+++ b/astropy/tests/pytest_openfiles.py
@@ -1,0 +1,107 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import imp
+import os
+
+try:
+    import importlib.machinery as importlib_machinery
+except ImportError:  # Python 2.7
+    importlib_machinery = None
+
+
+def pytest_addoption(parser):
+
+    parser.addoption("--open-files", action="store_true",
+                     help="fail if any test leaves files open")
+
+    parser.addini("open_files_ignore",
+                  "when used with the --open-files option, allows "
+                  "specifying names of files that may be ignored when "
+                  "left open between tests--files in this list are matched "
+                  "may be specified by their base name (ignoring their full "
+                  "path) or by absolute path", type="args", default=())
+
+# Open file detection.
+#
+# This works by calling out to psutil to get the list of open files
+# held by the process both before and after the test.  If something is
+# still open after the test that wasn't open before the test, an
+# AssertionError is raised.
+#
+# This is not thread-safe.  We're not currently running our tests
+# multi-threaded, but that is worth noting.
+
+
+def _get_open_file_list():
+    import psutil
+    files = []
+    p = psutil.Process()
+
+    if importlib_machinery is not None:
+        suffixes = tuple(importlib_machinery.all_suffixes())
+    else:
+        suffixes = tuple(info[0] for info in imp.get_suffixes())
+
+    files = [x.path for x in p.open_files() if not x.path.endswith(suffixes)]
+
+    return set(files)
+
+
+def pytest_runtest_setup(item):
+    # Store a list of the currently opened files so we can compare
+    # against them when the test is done.
+    if item.config.getvalue('open_files'):
+        item.open_files = _get_open_file_list()
+
+
+def pytest_runtest_teardown(item, nextitem):
+    # a "skipped" test will not have been called with
+    # pytest_runtest_setup, so therefore won't have an
+    # "open_files" member
+    if (not item.config.getvalue('open_files') or
+            not hasattr(item, 'open_files')):
+        return
+
+    start_open_files = item.open_files
+    del item.open_files
+
+    open_files = _get_open_file_list()
+
+    # This works in tandem with the test_open_file_detection test to
+    # ensure that it creates one extra open file.
+    if item.name == 'test_open_file_detection':
+        assert len(start_open_files) + 1 == len(open_files)
+        return
+
+    not_closed = set()
+    open_files_ignore = item.config.getini('open_files_ignore')
+    for filename in open_files:
+        ignore = False
+
+        for ignored in open_files_ignore:
+            if not os.path.isabs(ignored):
+                if os.path.basename(filename) == ignored:
+                    ignore = True
+                    break
+            else:
+                if filename == ignored:
+                    ignore = True
+                    break
+
+        if ignore:
+            continue
+
+        if filename not in start_open_files:
+            not_closed.add(filename)
+
+    if len(not_closed):
+        msg = ['File(s) not closed:']
+        for name in not_closed:
+            msg.append('  {0}'.format(name))
+        raise AssertionError('\n'.join(msg))

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -9,13 +9,9 @@ from __future__ import (absolute_import, division, print_function,
 import __future__
 
 from ..extern import six
-from ..extern.six.moves import filter, range
 
 import ast
-import doctest
 import datetime
-import fnmatch
-import imp
 import io
 import locale
 import math
@@ -30,8 +26,6 @@ import pytest
 from ..config.paths import set_temp_config, set_temp_cache
 from .helper import treat_deprecations_as_exceptions, ignore_warnings
 from .helper import enable_deprecations_as_exceptions  # pylint: disable=W0611
-from .disable_internet import turn_off_internet, turn_on_internet
-from .output_checker import AstropyOutputChecker, FIX
 from ..utils.argparse import writeable_directory
 from ..utils.introspection import resolve_name
 
@@ -40,28 +34,16 @@ try:
 except ImportError:  # Python 2.7
     importlib_machinery = None
 
+pytest_plugins = ('astropy.tests.pytest_doctestplus',
+                  'astropy.tests.pytest_openfiles',
+                  'astropy.tests.pytest_repeat',
+                  'astropy.tests.pytest_remotedata')
+
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
 
 
 def pytest_addoption(parser):
-
-    # The following means that if --remote-data is not specified, the default
-    # is 'none', but if it is specified without arguments (--remote-data), it
-    # defaults to '--remote-data=any'.
-    parser.addoption("--remote-data", nargs="?", const='any', default='none',
-                     help="run tests with online data")
-
-    parser.addoption("--open-files", action="store_true",
-                     help="fail if any test leaves files open")
-
-    parser.addoption("--doctest-plus", action="store_true",
-                     help="enable running doctests with additional "
-                     "features not found in the normal doctest "
-                     "plugin")
-
-    parser.addoption("--doctest-rst", action="store_true",
-                     help="enable running doctests in .rst documentation")
 
     parser.addoption("--config-dir", nargs='?', type=writeable_directory,
                      help="specify directory for storing and retrieving the "
@@ -76,18 +58,6 @@ def pytest_addoption(parser):
                           "Astropy cache during tests (default is "
                           "to use a temporary directory created by the test "
                           "runner)")
-
-    parser.addini("doctest_plus", "enable running doctests with additional "
-                  "features not found in the normal doctest plugin")
-
-    parser.addini("doctest_norecursedirs",
-                  "like the norecursedirs option but applies only to doctest "
-                  "collection", type="args", default=())
-
-    parser.addini("doctest_rst",
-                  "Run the doctests in the rst documentation",
-                  default=False)
-
     parser.addini("config_dir",
                   "specify directory for storing and retrieving the "
                   "Astropy configuration during tests (default is "
@@ -102,362 +72,9 @@ def pytest_addoption(parser):
                   "to use a temporary directory created by the test "
                   "runner)", default=None)
 
-    parser.addini("open_files_ignore",
-                  "when used with the --open-files option, allows "
-                  "specifying names of files that may be ignored when "
-                  "left open between tests--files in this list are matched "
-                  "may be specified by their base name (ignoring their full "
-                  "path) or by absolute path", type="args", default=())
-
-    parser.addoption('--repeat', action='store',
-                     help='Number of times to repeat each test')
-
-
-def pytest_generate_tests(metafunc):
-
-    # If the repeat option is set, we add a fixture for the repeat count and
-    # parametrize the tests over the repeats. Solution adapted from:
-    # http://stackoverflow.com/q/21764473/180783
-
-    if metafunc.config.option.repeat is not None:
-        count = int(metafunc.config.option.repeat)
-        metafunc.fixturenames.append('tmp_ct')
-        metafunc.parametrize('tmp_ct', range(count))
-
-
-# We monkey-patch in our replacement doctest OutputChecker.  Not
-# great, but there isn't really an API to replace the checker when
-# using doctest.testfile, unfortunately.
-doctest.OutputChecker = AstropyOutputChecker
-
-
-REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
-
 
 def pytest_configure(config):
     treat_deprecations_as_exceptions()
-
-    config.getini('markers').append(
-        'remote_data: Run tests that require data from remote servers')
-
-    # Monkeypatch to deny access to remote resources unless explicitly told
-    # otherwise
-
-    if config.getoption('remote_data') != 'any':
-        turn_off_internet(verbose=config.option.verbose,
-                          allow_astropy_data=config.getoption('remote_data') == 'astropy')
-
-    doctest_plugin = config.pluginmanager.getplugin('doctest')
-    if (doctest_plugin is None or config.option.doctestmodules
-            or not (config.getini('doctest_plus').lower() in ['true', 'enabled']
-                    or config.option.doctest_plus)):
-        return
-
-    # These are the default doctest options we use for everything.
-    # There shouldn't be any need to manually put them in doctests
-    # themselves.
-    opts = (doctest.ELLIPSIS |
-            doctest.NORMALIZE_WHITESPACE |
-            FIX)
-
-    class DocTestModulePlus(doctest_plugin.DoctestModule):
-        # pytest 2.4.0 defines "collect".  Prior to that, it defined
-        # "runtest".  The "collect" approach is better, because we can
-        # skip modules altogether that have no doctests.  However, we
-        # need to continue to override "runtest" so that the built-in
-        # behavior (which doesn't do whitespace normalization or
-        # handling __doctest_skip__) doesn't happen.
-        def collect(self):
-            if self.fspath.basename == "conftest.py":
-                try:
-                    module = self.config._conftest.importconftest(self.fspath)
-                except AttributeError:  # pytest >= 2.8.0
-                    module = self.config.pluginmanager._importconftest(self.fspath)
-            else:
-                try:
-                    module = self.fspath.pyimport()
-                    # Just ignore searching modules that can't be imported when
-                    # collecting doctests
-                except ImportError:
-                    return
-
-            # uses internal doctest module parsing mechanism
-            finder = DocTestFinderPlus()
-            runner = doctest.DebugRunner(verbose=False, optionflags=opts,
-                                         checker=AstropyOutputChecker())
-            for test in finder.find(module):
-                if test.examples:  # skip empty doctests
-                    if config.getvalue("remote_data") != 'any':
-                        for example in test.examples:
-                            if example.options.get(REMOTE_DATA):
-                                example.options[doctest.SKIP] = True
-
-                    yield doctest_plugin.DoctestItem(
-                        test.name, self, runner, test)
-
-    class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
-        def runtest(self):
-            # satisfy `FixtureRequest` constructor...
-            self.funcargs = {}
-            fixture_request = doctest_plugin._setup_fixtures(self)
-
-            failed, tot = doctest.testfile(
-                str(self.fspath), module_relative=False,
-                optionflags=opts, parser=DocTestParserPlus(),
-                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
-                raise_on_error=True, verbose=False, encoding='utf-8')
-
-    class DocTestParserPlus(doctest.DocTestParser):
-        """
-        An extension to the builtin DocTestParser that handles the
-        special directives for skipping tests.
-
-        The directives are:
-
-           - ``.. doctest-skip::``: Skip the next doctest chunk.
-
-           - ``.. doctest-requires:: module1, module2``: Skip the next
-             doctest chunk if the given modules/packages are not
-             installed.
-
-           - ``.. doctest-skip-all``: Skip all subsequent doctests.
-        """
-
-        def parse(self, s, name=None):
-            result = doctest.DocTestParser.parse(self, s, name=name)
-
-            # result is a sequence of alternating text chunks and
-            # doctest.Example objects.  We need to look in the text
-            # chunks for the special directives that help us determine
-            # whether the following examples should be skipped.
-
-            required = []
-            skip_next = False
-            skip_all = False
-
-            for entry in result:
-                if isinstance(entry, six.string_types) and entry:
-                    required = []
-                    skip_next = False
-                    lines = entry.strip().splitlines()
-
-                    if '.. doctest-skip-all' in (x.strip() for x in lines):
-                        skip_all = True
-                        continue
-
-                    if not len(lines):
-                        continue
-
-                    last_line = lines[-1]
-                    match = re.match(
-                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
-                    if match:
-                        marker = match.group(1)
-                        if (marker is None or
-                                (marker.strip() == 'win32' and
-                                 sys.platform == 'win32')):
-                            skip_next = True
-                            continue
-
-                    match = re.match(
-                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
-                        last_line)
-                    if match:
-                        required = re.split(r'\s*,?\s*', match.group(1))
-                elif isinstance(entry, doctest.Example):
-                    if (skip_all or skip_next or
-                        not DocTestFinderPlus.check_required_modules(required)):
-                        entry.options[doctest.SKIP] = True
-
-                    if (config.getvalue('remote_data') != 'any' and
-                        entry.options.get(REMOTE_DATA)):
-                        entry.options[doctest.SKIP] = True
-
-            return result
-
-    config.pluginmanager.register(
-        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
-                    config.getini('doctest_rst') or config.option.doctest_rst),
-        'doctestplus')
-
-    # Remove the doctest_plugin, or we'll end up testing the .rst
-    # files twice.
-    config.pluginmanager.unregister(doctest_plugin)
-
-
-class DoctestPlus(object):
-    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
-                 run_rst_doctests):
-        """
-        doctest_module_item_cls should be a class inheriting
-        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
-        running of a single doctest found in a Python module.  This is passed
-        in as an argument because the actual class to be used may not be
-        available at import time, depending on whether or not the doctest
-        plugin for py.test is available.
-        """
-        self._doctest_module_item_cls = doctest_module_item_cls
-        self._doctest_textfile_item_cls = doctest_textfile_item_cls
-        self._run_rst_doctests = run_rst_doctests
-
-        # Directories to ignore when adding doctests
-        self._ignore_paths = []
-
-    def pytest_ignore_collect(self, path, config):
-        """Skip paths that match any of the doctest_norecursedirs patterns."""
-
-        for pattern in config.getini("doctest_norecursedirs"):
-            if path.check(fnmatch=pattern):
-                # Apparently pytest_ignore_collect causes files not to be
-                # collected by any test runner; for DoctestPlus we only want to
-                # avoid creating doctest nodes for them
-                self._ignore_paths.append(path)
-                break
-
-        return False
-
-    def pytest_collect_file(self, path, parent):
-        """Implements an enhanced version of the doctest module from py.test
-        (specifically, as enabled by the --doctest-modules option) which
-        supports skipping all doctests in a specific docstring by way of a
-        special ``__doctest_skip__`` module-level variable.  It can also skip
-        tests that have special requirements by way of
-        ``__doctest_requires__``.
-
-        ``__doctest_skip__`` should be a list of functions, classes, or class
-        methods whose docstrings should be ignored when collecting doctests.
-
-        This also supports wildcard patterns.  For example, to run doctests in
-        a class's docstring, but skip all doctests in its modules use, at the
-        module level::
-
-            __doctest_skip__ = ['ClassName.*']
-
-        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
-        to the module itself, in case its module-level docstring contains
-        doctests.
-
-        ``__doctest_requires__`` should be a dictionary mapping wildcard
-        patterns (in the same format as ``__doctest_skip__``) to a list of one
-        or more modules that should be *importable* in order for the tests to
-        run.  For example, if some tests require the scipy module to work they
-        will be skipped unless ``import scipy`` is possible.  It is also
-        possible to use a tuple of wildcard patterns as a key in this dict::
-
-            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
-
-        """
-
-        for ignore_path in self._ignore_paths:
-            if ignore_path.common(path) == ignore_path:
-                return None
-
-        if path.ext == '.py':
-            if path.basename == 'conf.py':
-                return None
-
-            # Don't override the built-in doctest plugin
-            return self._doctest_module_item_cls(path, parent)
-        elif self._run_rst_doctests and path.ext == '.rst':
-            # Ignore generated .rst files
-            parts = str(path).split(os.path.sep)
-            if (path.basename.startswith('_') or
-                    any(x.startswith('_') for x in parts) or
-                    any(x == 'api' for x in parts)):
-                return None
-
-            # TODO: Get better names on these items when they are
-            # displayed in py.test output
-            return self._doctest_textfile_item_cls(path, parent)
-
-
-class DocTestFinderPlus(doctest.DocTestFinder):
-    """Extension to the default `doctest.DoctestFinder` that supports
-    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
-    """
-
-    # Caches the results of import attempts
-    _import_cache = {}
-
-    @classmethod
-    def check_required_modules(cls, mods):
-        for mod in mods:
-            if mod in cls._import_cache:
-                if not cls._import_cache[mod]:
-                    return False
-            try:
-                imp.find_module(mod)
-            except ImportError:
-                cls._import_cache[mod] = False
-                return False
-            else:
-                cls._import_cache[mod] = True
-        return True
-
-    def find(self, obj, name=None, module=None, globs=None,
-             extraglobs=None):
-        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
-                                           extraglobs)
-        if (hasattr(obj, '__doctest_skip__') or
-                hasattr(obj, '__doctest_requires__')):
-            if name is None and hasattr(obj, '__name__'):
-                name = obj.__name__
-            else:
-                raise ValueError("DocTestFinder.find: name must be given "
-                                 "when obj.__name__ doesn't exist: {!r}".format(
-                        (type(obj),)))
-
-            def test_filter(test):
-                for pat in getattr(obj, '__doctest_skip__', []):
-                    if pat == '*':
-                        return False
-                    elif pat == '.' and test.name == name:
-                        return False
-                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
-                        return False
-
-                reqs = getattr(obj, '__doctest_requires__', {})
-                for pats, mods in six.iteritems(reqs):
-                    if not isinstance(pats, tuple):
-                        pats = (pats,)
-                    for pat in pats:
-                        if not fnmatch.fnmatch(test.name,
-                                               '.'.join((name, pat))):
-                            continue
-                        if not self.check_required_modules(mods):
-                            return False
-                return True
-
-            tests = list(filter(test_filter, tests))
-
-        return tests
-
-
-# Open file detection.
-#
-# This works by calling out to psutil to get the list of open files
-# held by the process both before and after the test.  If something is
-# still open after the test that wasn't open before the test, an
-# AssertionError is raised.
-#
-# This is not thread-safe.  We're not currently running our tests
-# multi-threaded, but that is worth noting.
-
-
-def _get_open_file_list():
-    import psutil
-    files = []
-    p = psutil.Process()
-
-    if importlib_machinery is not None:
-        suffixes = tuple(importlib_machinery.all_suffixes())
-    else:
-        suffixes = tuple(info[0] for info in imp.get_suffixes())
-
-    files = [x.path for x in p.open_files() if not x.path.endswith(suffixes)]
-
-    return set(files)
-
 
 def pytest_runtest_setup(item):
     config_dir = item.config.getini('config_dir')
@@ -476,27 +93,6 @@ def pytest_runtest_setup(item):
         item.set_temp_cache = set_temp_cache(cache_dir)
         item.set_temp_cache.__enter__()
 
-    # Store a list of the currently opened files so we can compare
-    # against them when the test is done.
-    if item.config.getvalue('open_files'):
-        item.open_files = _get_open_file_list()
-
-    remote_data = item.keywords.get('remote_data')
-
-    remote_data_config = item.config.getvalue("remote_data")
-
-    if remote_data is not None:
-
-        source = remote_data.kwargs.get('source', 'any')
-
-        if source not in ('astropy', 'any'):
-            raise ValueError("source should be 'astropy' or 'any'")
-
-        if remote_data_config == 'none':
-            pytest.skip("need --remote-data option to run")
-        elif remote_data_config == 'astropy':
-            if source == 'any':
-                pytest.skip("need --remote-data option to run")
 
 
 def pytest_runtest_teardown(item, nextitem):
@@ -504,51 +100,6 @@ def pytest_runtest_teardown(item, nextitem):
         item.set_temp_cache.__exit__()
     if hasattr(item, 'set_temp_config'):
         item.set_temp_config.__exit__()
-
-    # a "skipped" test will not have been called with
-    # pytest_runtest_setup, so therefore won't have an
-    # "open_files" member
-    if (not item.config.getvalue('open_files') or
-            not hasattr(item, 'open_files')):
-        return
-
-    start_open_files = item.open_files
-    del item.open_files
-
-    open_files = _get_open_file_list()
-
-    # This works in tandem with the test_open_file_detection test to
-    # ensure that it creates one extra open file.
-    if item.name == 'test_open_file_detection':
-        assert len(start_open_files) + 1 == len(open_files)
-        return
-
-    not_closed = set()
-    open_files_ignore = item.config.getini('open_files_ignore')
-    for filename in open_files:
-        ignore = False
-
-        for ignored in open_files_ignore:
-            if not os.path.isabs(ignored):
-                if os.path.basename(filename) == ignored:
-                    ignore = True
-                    break
-            else:
-                if filename == ignored:
-                    ignore = True
-                    break
-
-        if ignore:
-            continue
-
-        if filename not in start_open_files:
-            not_closed.add(filename)
-
-    if len(not_closed):
-        msg = ['File(s) not closed:']
-        for name in not_closed:
-            msg.append('  {0}'.format(name))
-        raise AssertionError('\n'.join(msg))
 
 
 PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
@@ -792,16 +343,6 @@ class NoUnicodeLiteralsModule(ModifiedModule):
                             return ast.copy_location(ast.Str(s=s), node)
                 return node
         return NonAsciiLiteral().visit(tree)
-
-
-def pytest_unconfigure():
-    """
-    Cleanup post-testing
-    """
-    # restore internet connectivity (only lost if remote_data=False and
-    # turn_off_internet previously called)
-    # this is harmless / does nothing if socket connections were never disabled
-    turn_on_internet()
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/astropy/tests/pytest_remotedata.py
+++ b/astropy/tests/pytest_remotedata.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .helper import pytest
+from .disable_internet import turn_off_internet, turn_on_internet
+
+
+def pytest_addoption(parser):
+
+    # The following means that if --remote-data is not specified, the default
+    # is 'none', but if it is specified without arguments (--remote-data), it
+    # defaults to '--remote-data=any'.
+    parser.addoption("--remote-data", nargs="?", const='any', default='none',
+                     help="run tests with online data")
+
+
+def pytest_configure(config):
+    config.getini('markers').append(
+        'remote_data: Run tests that require data from remote servers')
+
+    # Monkeypatch to deny access to remote resources unless explicitly told
+    # otherwise
+
+    if config.getoption('remote_data') != 'any':
+        turn_off_internet(verbose=config.option.verbose,
+                          allow_astropy_data=config.getoption('remote_data') == 'astropy')
+
+
+def pytest_unconfigure():
+    """
+    Cleanup post-testing
+    """
+    # restore internet connectivity (only lost if remote_data=False and
+    # turn_off_internet previously called)
+    # this is harmless / does nothing if socket connections were never disabled
+    turn_on_internet()
+
+
+def pytest_runtest_setup(item):
+
+    remote_data = item.keywords.get('remote_data')
+
+    remote_data_config = item.config.getvalue("remote_data")
+
+    if remote_data is not None:
+
+        source = remote_data.kwargs.get('source', 'any')
+
+        if source not in ('astropy', 'any'):
+            raise ValueError("source should be 'astropy' or 'any'")
+
+        if remote_data_config == 'none':
+            pytest.skip("need --remote-data option to run")
+        elif remote_data_config == 'astropy':
+            if source == 'any':
+                pytest.skip("need --remote-data option to run")

--- a/astropy/tests/pytest_repeat.py
+++ b/astropy/tests/pytest_repeat.py
@@ -1,0 +1,27 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..extern.six.moves import range
+
+
+def pytest_addoption(parser):
+
+    parser.addoption('--repeat', action='store',
+                     help='Number of times to repeat each test')
+
+
+def pytest_generate_tests(metafunc):
+
+    # If the repeat option is set, we add a fixture for the repeat count and
+    # parametrize the tests over the repeats. Solution adapted from:
+    # http://stackoverflow.com/q/21764473/180783
+
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+        metafunc.fixturenames.append('tmp_ct')
+        metafunc.parametrize('tmp_ct', range(count))


### PR DESCRIPTION
I took @cadair's work from #5770 and rebased it on the current `master`. The tests pass for me locally in both Python 2.7 and 3.6, but maybe integration testing will reveal some issues that I missed. It might be good to consider this WIP for the moment.