### PR TITLE
Making CCDData.read() less strict for input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -268,6 +268,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Updating CCDData.read() to be more flexible with inputs, don't try to
+  delete keywords that are missing from the header. [#6388]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -416,11 +416,7 @@ def _generate_wcs_and_update_header(hdr):
     wcs_header = wcs.to_header(relax=True)
     for k in wcs_header:
         if k not in _KEEP_THESE_KEYWORDS_IN_HEADER:
-            try:
-                del new_hdr[k]
-            except KeyError:
-                # Keyword does not exist in the original header
-                pass
+            new_hdr.remove(k, ignore_missing=True)
     return (new_hdr, wcs)
 
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -416,7 +416,11 @@ def _generate_wcs_and_update_header(hdr):
     wcs_header = wcs.to_header(relax=True)
     for k in wcs_header:
         if k not in _KEEP_THESE_KEYWORDS_IN_HEADER:
-            del new_hdr[k]
+            try:
+                del new_hdr[k]
+            except KeyError:
+                # Keyword does not exist in the original header
+                pass
     return (new_hdr, wcs)
 
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -3,8 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import os
-
 import numpy as np
 import pytest
 
@@ -15,7 +13,8 @@ from ... import units as u
 from ... import log
 from ...wcs import WCS
 from ...utils import NumpyRNGContext
-from ...utils.data import get_pkg_data_filename, get_pkg_data_filenames, get_pkg_data_contents
+from ...utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
+                           get_pkg_data_contents)
 
 from ..ccddata import CCDData
 
@@ -640,6 +639,11 @@ def test_wcs_keywords_removed_from_header():
     ccd = CCDData.read(data_file)
     wcs_header = ccd.wcs.to_header()
     assert not (set(wcs_header) & set(ccd.meta) - keepers)
+
+    # Make sure that exceptions are not raised when trying to remove missing
+    # keywords. o4sp040b0_raw.fits of io.fits is missing keyword 'PC1_1'.
+    data_file1 = get_pkg_data_filename('../../io/fits/tests/data/o4sp040b0_raw.fits')
+    ccd = CCDData.read(data_file1, unit='count')
 
 
 def test_wcs_keyword_removal_for_wcs_test_files():


### PR DESCRIPTION
This should fix #6386 and another related issue with the too strict unit parsing.