### PR TITLE
Add Acknowledgment section and Depsy badge to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,15 @@ with the Astropy Project, see http://dashboard.astropy.org.
     :target: http://numfocus.org
     :alt: Powered by NumFOCUS
 
+
+Acknowledging or Citing Astropy
+-------------------------------
+
 .. image:: http://depsy.org/api/package/pypi/astropy/badge.svg
     :target: http://depsy.org/package/python/astropy
     :alt: Research software impact
+
+
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,11 @@ with the Astropy Project, see http://dashboard.astropy.org.
     :target: http://numfocus.org
     :alt: Powered by NumFOCUS
 
+.. image::
+http://depsy.org/api/package/pypi/astropy/badge.svg
+    :target: http://depsy.org/package/python/astropy
+    :alt: Research software impact
+
 License
 -------
 Astropy is licensed under a 3-clause BSD style license - see the

--- a/README.rst
+++ b/README.rst
@@ -48,8 +48,7 @@ with the Astropy Project, see http://dashboard.astropy.org.
     :target: http://numfocus.org
     :alt: Powered by NumFOCUS
 
-.. image::
-http://depsy.org/api/package/pypi/astropy/badge.svg
+.. image:: http://depsy.org/api/package/pypi/astropy/badge.svg
     :target: http://depsy.org/package/python/astropy
     :alt: Research software impact
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Acknowledging or Citing Astropy
 
 If you use Astropy for work/research presented in a publication
 (whether directly, or as a dependency to another package), we ask that you
-cite the `Astropy Paper <http://dx.doi.org/10.1051/0004-6361/201322068>`
+cite the `Astropy Paper <http://dx.doi.org/10.1051/0004-6361/201322068>`_
 (`ADS<http://adsabs.harvard.edu/abs/2013A%26A...558A..33A>`)
 
 License

--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,9 @@ If you use Astropy for work/research presented in a publication
 (whether directly, or as a dependency to another package), we ask that you
 cite the `Astropy Paper <http://dx.doi.org/10.1051/0004-6361/201322068>`_
 (`ADS <http://adsabs.harvard.edu/abs/2013A%26A...558A..33A>`_ -
-`BibTeX <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&data_type=BIBTEX&db_key=AST&nocookieset=1>`_). We provide the following as a standard acknowledgment you can use if there is not a specific place to cite the paper:
+`BibTeX <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&data_type=BIBTEX&db_key=AST&nocookieset=1>`_). We provide the following as a standard acknowledgment you can use if there is not a specific place to cite the paper::
 
-$ This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).
+    This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,10 @@ Acknowledging or Citing Astropy
 If you use Astropy for work/research presented in a publication
 (whether directly, or as a dependency to another package), we ask that you
 cite the `Astropy Paper <http://dx.doi.org/10.1051/0004-6361/201322068>`_
-(`ADS<http://adsabs.harvard.edu/abs/2013A%26A...558A..33A>`)
+(`ADS <http://adsabs.harvard.edu/abs/2013A%26A...558A..33A>`_ -
+`BibTeX <http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode=2013A%26A...558A..33A&data_type=BIBTEX&db_key=AST&nocookieset=1>`_). We provide the following as a standard acknowledgment you can use if there is not a specific place to cite the paper:
+
+$ This research made use of Astropy, a community-developed core Python package for Astronomy (Astropy Collaboration, 2013).
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,10 @@ Acknowledging or Citing Astropy
     :target: http://depsy.org/package/python/astropy
     :alt: Research software impact
 
-
+If you use Astropy for work/research presented in a publication
+(whether directly, or as a dependency to another package), we ask that you
+cite the `Astropy Paper <http://dx.doi.org/10.1051/0004-6361/201322068>`
+(`ADS<http://adsabs.harvard.edu/abs/2013A%26A...558A..33A>`)
 
 License
 -------


### PR DESCRIPTION
I suggest that we be more explicit [with the request](http://www.astropy.org/acknowledging.html) that Astropy be acknowledged (and the paper cited) by users in their publications.  

This PR simply adds a short section to the README, in case users aren't visiting the website and/or seeing the acknowledgment request. 

Astropy also [boasts a 100th percentile](http://depsy.org/package/python/astropy) score on [Depsy](http://depsy.org/), which tracks the impact of research code. You can read more about Depsy[ in this recent *Nature* piece](http://www.nature.com/news/the-unsung-heroes-of-scientific-software-1.19100). In case we want to show this off, I've added the Depsy badge to the acknowledgment section, as well. 

[![Research software impact](http://depsy.org/api/package/pypi/astropy/badge.svg)](http://depsy.org/package/python/astropy)

Here's a preview of what this PR looks like. 

![ack](https://user-images.githubusercontent.com/2238418/28594087-a6c944d0-715c-11e7-86e8-c032a3cbba0a.png)

