### PR TITLE
change trans/eph header to be sub-heading

### DIFF
--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -94,7 +94,7 @@ and hence often do not round-trip.
 .. _astropy-coordinates-transforming-ephemerides:
 
 Transformations and Solar-system ephemerides
-********************************************
+============================================
 
 Some transformations (e.g. the transformation between `~astropy.coordinates.ICRS` and
 `~astropy.coordinates.GCRS`) require the use of a Solar-system ephemeris to calculate


### PR DESCRIPTION
This is a very minor doc update.  It looks like #6057 may have accidentally changed a section in the coordinates transformation docs to be a "top-level" heading, instead of a sub-heading as was intended here.  This PR just changes it to be what I think was intended.

cc @bsipocz @helenst 