### PR TITLE
fix parameter initialization in compound models

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1788,6 +1788,7 @@ class Model(object):
         total_size = 0
 
         for name in self.param_names:
+            unit = None
             param_descr = getattr(self, name)
 
             if params.get(name) is None:
@@ -1844,7 +1845,9 @@ class Model(object):
         # out of Parameter and into Model (renaming them
         # _get/set_parameter_value)
         for name, value in params.items():
+            # value here may be a Quantity object.
             param_descr = getattr(self, name)
+            unit = param_descr.unit
             value = np.array(value)
             orig_unit = param_metrics[name]['orig_unit']
             if param_descr._setter is not None:

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -11,10 +11,12 @@ import numpy as np
 
 from ..core import Model, Fittable1DModel, InputParameterError
 from ..parameters import Parameter, ParameterDefinitionError
-from ..models import Gaussian1D
+from ..models import (Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial,
+                      Rotation2D)
 from ... import units as u
 from ...units import UnitsError
 from ...tests.helper import pytest, assert_quantity_allclose
+from ... import coordinates as coord
 
 
 class BaseTestModel(Fittable1DModel):
@@ -328,3 +330,12 @@ def test_parameter_quantity_comparison():
                                  "dimensionless quantities when other argument "
                                  "is not a quantity (unless the latter is all "
                                  "zero/infinity/nan)")
+
+
+def test_parameters_compound_models():
+    tan = Pix2Sky_TAN()
+    sky_coords = coord.SkyCoord(ra=5.6, dec=-72, unit=u.deg)
+    lon_pole = 180 * u.deg
+    n2c = RotateNative2Celestial(sky_coords.ra, sky_coords.dec, lon_pole)
+    rot = Rotation2D(23)
+    m = rot | n2c


### PR DESCRIPTION
Parameters in compound models with units fail to initialize (correctly) sometimes because units are not always set to None in the beginning of a loop. The test included here is a failing example.