### PR TITLE
Quantity._repr_latex_ respects precision from np.printoptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -318,6 +318,9 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- Quantity._repr_latex_ now respects precision option from numpy
+  printoptions. [#5965]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -319,7 +319,7 @@ astropy.units
 ^^^^^^^^^^^^^
 
 - Quantity._repr_latex_ now respects precision option from numpy
-  printoptions. [#5965]
+  printoptions. [#6412]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -88,7 +88,12 @@ class Latex(base.Base):
         return r'$\mathrm{{{0}}}$'.format(s)
 
     @classmethod
-    def format_exponential_notation(cls, val):
+    def format_exponential_notation_with_np_precision(cls, val):
+        return cls.format_exponential_notation(val,
+            format_spec='.{0}g'.format(np.get_printoptions()['precision']))
+
+    @classmethod
+    def format_exponential_notation(cls, val, format_spec=".8g"):
         """
         Formats a value in exponential notation for LaTeX.
 
@@ -97,14 +102,16 @@ class Latex(base.Base):
         val : number
             The value to be formatted
 
+        format_spec : str, optional
+            Format used to split up mantissa and exponent
+
         Returns
         -------
         latex_string : str
             The value in exponential notation in a format suitable for LaTeX.
         """
         if np.isfinite(val):
-            m, ex = utils.split_mantissa_exponent(val,
-                np.get_printoptions()['precision'])
+            m, ex = utils.split_mantissa_exponent(val, format_spec)
 
             parts = []
             if m:

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -103,7 +103,8 @@ class Latex(base.Base):
             The value in exponential notation in a format suitable for LaTeX.
         """
         if np.isfinite(val):
-            m, ex = utils.split_mantissa_exponent(val)
+            m, ex = utils.split_mantissa_exponent(val,
+                np.get_printoptions()['precision'])
 
             parts = []
             if m:

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -88,11 +88,6 @@ class Latex(base.Base):
         return r'$\mathrm{{{0}}}$'.format(s)
 
     @classmethod
-    def format_exponential_notation_with_np_precision(cls, val):
-        return cls.format_exponential_notation(val,
-            format_spec='.{0}g'.format(np.get_printoptions()['precision']))
-
-    @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):
         """
         Formats a value in exponential notation for LaTeX.

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -46,7 +46,7 @@ def get_grouped_by_powers(bases, powers):
     return positive, negative
 
 
-def split_mantissa_exponent(v):
+def split_mantissa_exponent(v, precision=8):
     """
     Given a number, split it into its mantissa and base 10 exponent
     parts, each as strings.  If the exponent is too small, it may be
@@ -63,7 +63,7 @@ def split_mantissa_exponent(v):
     -------
     mantissa, exponent : tuple of strings
     """
-    x = "{0:.8g}".format(v).split('e')
+    x = ("{0:." + str(precision) + "g}").format(v).split('e')
     if x[0] != '1.' + '0' * (len(x[0]) - 2):
         m = x[0]
     else:

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -46,24 +46,24 @@ def get_grouped_by_powers(bases, powers):
     return positive, negative
 
 
-def split_mantissa_exponent(v, precision=8):
+def split_mantissa_exponent(v, format_spec=".8g"):
     """
     Given a number, split it into its mantissa and base 10 exponent
     parts, each as strings.  If the exponent is too small, it may be
     returned as the empty string.
 
-    The precise rules are based on Python's "general purpose" (`g`)
-    formatting.
-
     Parameters
     ----------
     v : float
+
+    format_spec : str, optional
+        Number representation formatting string
 
     Returns
     -------
     mantissa, exponent : tuple of strings
     """
-    x = ("{0:." + str(precision) + "g}").format(v).split('e')
+    x = format(v, format_spec).split('e')
     if x[0] != '1.' + '0' * (len(x[0]) - 2):
         m = x[0]
     else:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1271,7 +1271,7 @@ class Quantity(np.ndarray):
         # with array2string
         pops = np.get_printoptions()
         try:
-            formatter = {'float_kind': Latex.format_exponential_notation}
+            formatter = {'float_kind': Latex.format_exponential_notation_with_np_precision}
             if conf.latex_array_threshold > -1:
                 np.set_printoptions(threshold=conf.latex_array_threshold,
                                     formatter=formatter)
@@ -1279,7 +1279,7 @@ class Quantity(np.ndarray):
             # the view is needed for the scalar case - value might be float
             latex_value = np.array2string(
                 self.view(np.ndarray),
-                style=(Latex.format_exponential_notation
+                style=(Latex.format_exponential_notation_with_np_precision
                        if self.dtype.kind == 'f' else repr),
                 max_line_width=np.inf, separator=',~')
             latex_value = latex_value.replace('...', r'\dots')

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1270,8 +1270,13 @@ class Quantity(np.ndarray):
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
         pops = np.get_printoptions()
+
+        format_spec = '.{}g'.format(pops['precision'])
+        def float_formatter(value):
+            return Latex.format_exponential_notation(value, format_spec=format_spec)
+
         try:
-            formatter = {'float_kind': Latex.format_exponential_notation_with_np_precision}
+            formatter = {'float_kind': float_formatter}
             if conf.latex_array_threshold > -1:
                 np.set_printoptions(threshold=conf.latex_array_threshold,
                                     formatter=formatter)
@@ -1279,8 +1284,7 @@ class Quantity(np.ndarray):
             # the view is needed for the scalar case - value might be float
             latex_value = np.array2string(
                 self.view(np.ndarray),
-                style=(Latex.format_exponential_notation_with_np_precision
-                       if self.dtype.kind == 'f' else repr),
+                style=(float_formatter if self.dtype.kind == 'f' else repr),
                 max_line_width=np.inf, separator=',~')
             latex_value = latex_value.replace('...', r'\dots')
         finally:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -837,6 +837,16 @@ class TestQuantityDisplay(object):
         pops = np.get_printoptions()
         oldlat = conf.latex_array_threshold
         try:
+            # check precision behavior
+            q = u.Quantity(987654321.123456789, 'm/s')
+            qa = np.array([7.89123, 123456789.987654321, 0]) * u.cm
+            np.set_printoptions(precision=8)
+            assert q._repr_latex_() == r'$9.8765432 \times 10^{8} \; \mathrm{\frac{m}{s}}$'
+            assert qa._repr_latex_() == r'$[7.89123,~1.2345679 \times 10^{8},~0] \; \mathrm{cm}$'
+            np.set_printoptions(precision=2)
+            assert q._repr_latex_() == r'$9.9 \times 10^{8} \; \mathrm{\frac{m}{s}}$'
+            assert qa._repr_latex_() == r'$[7.9,~1.2 \times 10^{8},~0] \; \mathrm{cm}$'
+
             # check thresholding behavior
             conf.latex_array_threshold = 100  # should be default
             lsmed = qmed._repr_latex_()


### PR DESCRIPTION
Hi @mhvk @hamogu 
This PR fixes #5965 at least in some way. I understand that this may looks like dirty hack so review is welcome. Issue description says that `_repr_latex_` should respects np.printoptions but doesn't say which one of them. Is it only 'precision' or all [np.set_printoptions params](https://docs.scipy.org/doc/numpy/reference/generated/numpy.set_printoptions.html)?