### PR TITLE
Remove useless backslashes (pep8 E502)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
         # E722 - do not use bare except
         # E901 - SyntaxError or IndentationError
         # E902 - IOError
-        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E722,E901,E902"
+        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902"
 
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1549,9 +1549,9 @@ def test_z_at_value_roundtrip():
     # Test distance functions between two redshifts
     z2 = 2.0
     func_z1z2 = [lambda z1: core.Planck13._comoving_distance_z1z2(z1, z2),
-                 lambda z1: \
+                 lambda z1:
                  core.Planck13._comoving_transverse_distance_z1z2(z1, z2),
-                 lambda z1: \
+                 lambda z1:
                  core.Planck13.angular_diameter_distance_z1z2(z1, z2)]
     for func in func_z1z2:
         fval = func(z)

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -73,7 +73,7 @@ def test_identify_table():
     assert html.identify_table(soup, {}, 0) is False
     assert html.identify_table(None, {}, 0) is False
 
-    soup = BeautifulSoup('<table id="foo"><tr><th>A</th></tr><tr>' \
+    soup = BeautifulSoup('<table id="foo"><tr><th>A</th></tr><tr>'
                          '<td>B</td></tr></table>').table
     assert html.identify_table(soup, {}, 2) is False
     assert html.identify_table(soup, {}, 1) is True  # Default index of 1

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -362,15 +362,15 @@ class LinearLSQFitter(object):
         if has_fixed:
 
             # The list of fixed params is the complement of those being fitted:
-            fixparam_indices = [idx for idx in\
-                                range(len(model_copy.param_names))\
+            fixparam_indices = [idx for idx in
+                                range(len(model_copy.param_names))
                                 if idx not in fitparam_indices]
 
             # Construct matrix of user-fixed parameters that can be dotted with
             # the corresponding fit_deriv() terms, to evaluate corrections to
             # the dependent variable in order to fit only the remaining terms:
             fixparams = np.asarray([getattr(model_copy,
-                                            model_copy.param_names[idx]).value\
+                                            model_copy.param_names[idx]).value
                                     for idx in fixparam_indices])
 
         if len(farg) == 2:
@@ -509,8 +509,8 @@ class FittingWithOutlierRemoval(object):
     def __str__(self):
         return ("Fitter: {0}\nOutlier function: {1}\nNum. of iterations: {2}" +
                 ("\nOutlier func. args.: {3}"))\
-                .format(self.fitter__class__.__name__,\
-                        self.outlier_func.__name__, self.niter,\
+                .format(self.fitter__class__.__name__,
+                        self.outlier_func.__name__, self.niter,
                         self.outlier_kwargs)
 
     def __repr__(self):

--- a/astropy/utils/compat/_funcsigs.py
+++ b/astropy/utils/compat/_funcsigs.py
@@ -735,7 +735,7 @@ class Signature(object):
                 # Signature object (but let's have this check here
                 # to ensure correct behaviour just in case)
                 raise TypeError('{arg!r} parameter is positional only, '
-                                'but was passed as a keyword'. \
+                                'but was passed as a keyword'.
                                 format(arg=param.name))
 
             if param.kind == _VAR_KEYWORD:
@@ -753,7 +753,7 @@ class Signature(object):
                 # arguments.
                 if (not partial and param.kind != _VAR_POSITIONAL and
                                                     param.default is _empty):
-                    raise TypeError('{arg!r} parameter lacking default value'. \
+                    raise TypeError('{arg!r} parameter lacking default value'.
                                     format(arg=param_name))
 
             else:

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -84,7 +84,7 @@ if _wcs is not None:
 
     if not _wcs._sanity_check():
         raise RuntimeError(
-        "astropy.wcs did not pass its sanity check for your build " \
+        "astropy.wcs did not pass its sanity check for your build "
         "on your platform.")
 
     WCSBase = _wcs._Wcs


### PR DESCRIPTION
These backslashes are rather ugly :wink: 

For reference, this was done with autopep8:

    autopep8 -ir --select E502 astropy/