### PR TITLE
Error handling for required package for parallel tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Added error handling for attempting to run tests in parallel without having
+  the ``pytest-xdist`` package installed. [#6416]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,9 +210,6 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
-- Added error handling for attempting to run tests in parallel without having
-  the ``pytest-xdist`` package installed. [#6416]
-
 astropy.time
 ^^^^^^^^^^^^
 
@@ -295,6 +292,9 @@ astropy.tests
 ^^^^^^^^^^^^^
 
 - Fixed running the test suite using --parallel. [#6415]
+
+- Added error handling for attempting to run tests in parallel without having
+  the ``pytest-xdist`` package installed. [#6416]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -464,7 +464,7 @@ class TestRunner(TestRunnerBase):
         """
         if parallel != 0:
             try:
-                from xdist import plugin
+                from xdist import plugin # noqa
             except ImportError:
                 raise SystemError(
                     "running tests in parallel requires the pytest-xdist package")

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -462,13 +462,13 @@ class TestRunner(TestRunnerBase):
             number of CPUs.  If parallel is negative, it will use the all
             the cores on the machine.  Requires the ``pytest-xdist`` plugin.
         """
-        try:
-            from xdist import plugin
-        except ImportError:
-            raise SystemError(
-                "running tests in parallel requires the pytest-xdist package")
-
         if parallel != 0:
+            try:
+                from xdist import plugin
+            except ImportError:
+                raise SystemError(
+                    "running tests in parallel requires the pytest-xdist package")
+
             return ['-n', six.text_type(parallel)]
 
         return []

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -462,6 +462,12 @@ class TestRunner(TestRunnerBase):
             number of CPUs.  If parallel is negative, it will use the all
             the cores on the machine.  Requires the ``pytest-xdist`` plugin.
         """
+        try:
+            from xdist import plugin
+        except ImportError:
+            raise SystemError(
+                "running tests in parallel requires the pytest-xdist package")
+
         if parallel != 0:
             return ['-n', six.text_type(parallel)]
 


### PR DESCRIPTION
Fixes #6414. Previously, attempting to run parallel unit tests from `setup.py` without having `pytest-xdist` installed resulted in fairly unhelpful errors.