### PR TITLE
Changing parametrized tests to be pytest 3.2.0 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ matrix:
 
         - os: linux
           env: PYTHON_VERSION=3.4 NUMPY_VERSION=1.9
-               SETUP_CMD='test --open-files'
+               SETUP_CMD='test --open-files'  PYTEST_VERSION=3.2.1
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -237,7 +237,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
+- Pytest <3.1 versions are no longer supported. [#6419]
 
 
 2.0.2 (unreleased)

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -174,14 +174,8 @@ _xfail = pytest.mark.xfail
 
 @pytest.mark.parametrize('distance', [1000*u.au,
                                       10*u.pc,
-                                      pytest.mark.xfail(10*u.kpc),
-                                      pytest.mark.xfail(100*u.kpc)])
-                                      # below is xfail syntax for pytest >=3.1
-                                      # TODO: change to this when the above
-                                      # way of xfailing is turned off in pytest
-                                      # >=4.0
-                                      # pytest.param(10*u.kpc, marks=_xfail),
-                                      # pytest.param(100*u.kpc, marks=_xfail)])
+                                      pytest.param(10*u.kpc, marks=_xfail),
+                                      pytest.param(100*u.kpc, marks=_xfail)])
                                       # TODO:  make these not fail when the
                                       # finite-difference numerical stability
                                       # is improved

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -964,7 +964,7 @@ def test_read_big_table(tmpdir):
 @pytest.mark.parametrize('reader', [0, 1, 2])
 # catch Windows environment since we cannot use _read() with custom fast_reader
 @pytest.mark.parametrize("parallel", [False,
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True)])
+    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows"))])
 def test_data_out_of_range(parallel, reader):
     """
     Numbers with exponents beyond float64 range (|~4.94e-324 to 1.7977e+308|)
@@ -1017,7 +1017,7 @@ def test_data_out_of_range(parallel, reader):
 
 # catch Windows environment since we cannot use _read() with custom fast_reader
 @pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
+    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
     False])
 def test_int_out_of_range(parallel):
     """
@@ -1056,7 +1056,7 @@ def test_int_out_of_range(parallel):
 
 
 @pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
+    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
     False])
 def test_fortran_reader(parallel):
     """
@@ -1099,7 +1099,7 @@ def test_fortran_reader(parallel):
 
 
 @pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
+    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
     False])
 def test_fortran_invalid_exp(parallel):
     """

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -324,8 +324,8 @@ def test_data_noastropy_fallback(monkeypatch):
 @pytest.mark.parametrize(('filename'), [
     'unicode.txt',
     'unicode.txt.gz',
-    pytest.mark.xfail(not HAS_BZ2, reason='no bz2 support')('unicode.txt.bz2'),
-    pytest.mark.xfail(not HAS_XZ, reason='no lzma support')('unicode.txt.xz')])
+    pytest.param('unicode.txt.bz2', marks=pytest.mark.xfail(not HAS_BZ2, reason='no bz2 support')),
+    pytest.param('unicode.txt.xz', marks=pytest.mark.xfail(not HAS_XZ, reason='no lzma support'))])
 def test_read_unicode(filename):
     from ..data import get_pkg_data_contents
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -33,7 +33,7 @@ Running Tests
 There are currently three different ways to invoke Astropy tests. Each
 method invokes `pytest`_ to run the tests but offers different options when
 calling. To run the tests, you will need to make sure you have the `pytest`_
-package (version 2.8 or later) installed.
+package (version 3.1 or later) installed.
 
 In addition to running the Astropy tests, these methods can also be called
 so that they check Python source code for `PEP8 compliance

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,7 +15,7 @@ Astropy has the following strict requirements:
 
 - `Numpy`_ |minimum_numpy_version| or later
 
-- `pytest`_ 2.8 or later
+- `pytest`_ 3.1 or later
 
 Astropy also depends on other packages for optional features:
 

--- a/pip-requirements
+++ b/pip-requirements
@@ -1,1 +1,2 @@
-numpy>=1.7.0
+numpy>=1.9.0
+pytest>=3.1

--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -1,7 +1,7 @@
 -r pip-requirements
 -r pip-requirements-doc
 Cython>=0.21
-jinja2
+jinja2>=2.7
 pyyaml
 scipy
 pandas
@@ -9,6 +9,8 @@ h5py
 beautifulsoup4
 bleach
 jplephem
+scikit-image
+matplotlib
 
 # below here are used only for tests
 skyfield

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
     setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
 
-install_requires = ['pytest>=2.8', 'numpy>=' + astropy.__minimum_numpy_version__]
+install_requires = ['pytest>=3.1', 'numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information
 if is_distutils_display_option():


### PR DESCRIPTION
This should fix #6418 

However this also makes us incompatible with pytest <3.1. 

So overall I'm not sure how to proceed, we definitely need to limit the pytest version in the bugfix branch rather than backport this, but it will probably be fine to release 3.0 with this requirement. The last release incompatible with this change was 3.0.7 and was released on 2017-03-14.

