### PR TITLE
Limit pytest to <3.2 for circleci tests

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,7 +16,7 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python -c 'import sys; print(sys.maxsize)'
 
-easy_install pytest
+easy_install "pytest<3.2"
 
 python setup.py test
 


### PR DESCRIPTION
This is a temporary fix for #6418 related to https://github.com/astropy/ci-helpers/pull/222, which does this for `AppVeyor` and `travis`.  `CircleCI` is not included in `astropy-ci` as it is used only by the core package and a few affiliated packages (e.g. `photutils` and `regions`).