### PR TITLE
HIERARCH ASTROPY convention to store ``FORMAT`` of TIME columns

### DIFF
--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -64,8 +64,11 @@ GLOBAL_TIME_INFO = {'TIMESYS': ('UTC', 'Default time scale'),
                     'JDREF': (0.0, 'Time columns are jd = jd1 + jd2'),
                     'TREFPOS': ('TOPOCENTER', 'Time reference position')}
 
-# AstroPy-specific keywords
-ASTROPY_TIME_KEYWORDS = {'FORMAT' : 'format'}
+# Astropy-specific keywords
+ASTROPY_TIME_KEYWORDS = {'FORMAT'}
+
+# HIERARCH Keyword Convention for Astropy
+astropy_namespace = 'HIERARCH ASTROPY TIME'
 
 
 def _verify_global_info(global_info):
@@ -254,6 +257,7 @@ def _convert_time_column(col, column_info):
         col = Time(col[..., 0], col[..., 1], format='jd',
                    scale=column_info['scale'],
                    location=column_info['location'])
+        col.format = column_info['FORMAT'].lower()
     else:
         warnings.warn(
             'Time column {} is not in the astropy required (jd1, jd2) format. '
@@ -313,7 +317,10 @@ def fits_to_time(hdr, table):
             sub_keys = re.split('(\d+)', key)
             if len(sub_keys) > 1 and sub_keys[-1] == '':
                 idx = sub_keys[-2]
-                time_columns[int(idx)][ASTROPY_TIME_KEYWORDS[key[13:-len(idx)]]] = value
+                base = key[13:-len(idx)]
+                if base in ASTROPY_TIME_KEYWORDS:
+                    time_columns[int(idx)][base] = value
+                    hcopy.remove(key)
 
     if len(hcopy) != len(hdr):
         _verify_global_info(global_info)

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -93,16 +93,9 @@ class TestFitsTime(FitsTestCase):
 
         ideal_col_hdr = {'OBSGEO-X' : t['a'].location.x.value,
                          'OBSGEO-Y' : t['a'].location.y.value,
-<<<<<<< HEAD
                          'OBSGEO-Z' : t['a'].location.z.value}
-=======
-                         'OBSGEO-Z' : t['a'].location.z.value,
-                         'TCTYP1' : t['a'].scale.upper(),
                          'HIERARCH ASTROPY TIME FORMAT1' : t['a'].format.upper(),
-                         'TRPOS1' : 'TOPOCENTER',
-                         'TCTYP2' : t['b'].scale.upper(),
                          'HIERARCH ASTROPY TIME FORMAT2' : t['b'].format.upper()}
->>>>>>> 2279c82... HIERARCH
 
         table, hdr = time_to_fits(t)
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -93,7 +93,7 @@ class TestFitsTime(FitsTestCase):
 
         ideal_col_hdr = {'OBSGEO-X' : t['a'].location.x.value,
                          'OBSGEO-Y' : t['a'].location.y.value,
-                         'OBSGEO-Z' : t['a'].location.z.value}
+                         'OBSGEO-Z' : t['a'].location.z.value,
                          'HIERARCH ASTROPY TIME FORMAT1' : t['a'].format.upper(),
                          'HIERARCH ASTROPY TIME FORMAT2' : t['b'].format.upper()}
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -93,7 +93,16 @@ class TestFitsTime(FitsTestCase):
 
         ideal_col_hdr = {'OBSGEO-X' : t['a'].location.x.value,
                          'OBSGEO-Y' : t['a'].location.y.value,
+<<<<<<< HEAD
                          'OBSGEO-Z' : t['a'].location.z.value}
+=======
+                         'OBSGEO-Z' : t['a'].location.z.value,
+                         'TCTYP1' : t['a'].scale.upper(),
+                         'HIERARCH ASTROPY TIME FORMAT1' : t['a'].format.upper(),
+                         'TRPOS1' : 'TOPOCENTER',
+                         'TCTYP2' : t['b'].scale.upper(),
+                         'HIERARCH ASTROPY TIME FORMAT2' : t['b'].format.upper()}
+>>>>>>> 2279c82... HIERARCH
 
         table, hdr = time_to_fits(t)
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -169,7 +169,7 @@ def test_io_time_write_fits(tmpdir, table_types):
             assert tm[name].scale == t[name].scale
 
             # Assert that the format is jd
-            assert tm[name].format == 'jd'
+            assert tm[name].format == t[name].format
 
             # Assert that the location round-trips
             assert tm[name].location == t[name].location


### PR DESCRIPTION
This PR is just to keep in mind that this convention can be adopted to do so. This can be decided to be merged in, if a unanimous positive review is provided.

HIERARCH ASTROPY TIME FORMATn is used to store ``~astropy.time.Time` format attribute.

P.S this will be rebased on #6176 once merged.