### PR TITLE
Refer to the deprecation()‘s caller instead of utils.decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,10 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- For the ``deprecated_renamed_argument`` decorator, refer to the deprecation‘s
+  caller instead of ``astropy.utils.decorators``, to makes it easier to find
+  where the deprecation warnings comes from. [#6422]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -479,7 +479,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                             'and will be removed in a future version. '
                             'Use argument "{2}" instead.'
                             ''.format(old_name[i], since[i], new_name[i]),
-                            AstropyDeprecationWarning)
+                            AstropyDeprecationWarning, stacklevel=2)
 
                     # Check if the newkeyword was given as well.
                     newarg_in_args = (position[i] is not None and

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -289,7 +289,7 @@ def test_deprecated_argument():
             assert method(clobber=1) == 1
             assert len(w) == 1
             assert '1.3' in str(w[0].message)
-            assert 'utils/tests/test_decorators.py' in str(w[0].filename)
+            assert 'test_decorators.py' in str(w[0].filename)
 
         # Using both. Both keyword
         with pytest.raises(TypeError):
@@ -319,7 +319,7 @@ def test_deprecated_argument_in_kwargs():
         assert test(clobber=1) == 1
         assert len(w) == 1
         assert '1.3' in str(w[0].message)
-        assert 'utils/tests/test_decorators.py' in str(w[0].filename)
+        assert 'test_decorators.py' in str(w[0].filename)
 
     # Using both. Both keyword
     with pytest.raises(TypeError):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -289,6 +289,7 @@ def test_deprecated_argument():
             assert method(clobber=1) == 1
             assert len(w) == 1
             assert '1.3' in str(w[0].message)
+            assert 'utils/tests/test_decorators.py' in str(w[0].filename)
 
         # Using both. Both keyword
         with pytest.raises(TypeError):
@@ -318,6 +319,7 @@ def test_deprecated_argument_in_kwargs():
         assert test(clobber=1) == 1
         assert len(w) == 1
         assert '1.3' in str(w[0].message)
+        assert 'utils/tests/test_decorators.py' in str(w[0].filename)
 
     # Using both. Both keyword
     with pytest.raises(TypeError):


### PR DESCRIPTION
Fixes #6349