### PR TITLE
Reimplement reportinfo() in doctestplus extension

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,6 +299,8 @@ astropy.tests
 - Added error handling for attempting to run tests in parallel without having
   the ``pytest-xdist`` package installed. [#6416]
 
+- Fixed issue running doctests with pytest>=3.2. [#6423]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -114,6 +114,18 @@ def pytest_configure(config):
                 extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
                 raise_on_error=True, verbose=False, encoding='utf-8')
 
+        def reportinfo(self):
+            """
+            Overwrite pytest's ``DoctestItem`` because
+            ``DocTestTextfilePlus`` does not have a ``dtest`` attribute
+            which is used by pytest>=3.2.0 to return the location of the
+            tests.
+
+            For details see `pytest-dev/pytest#2651
+            <https://github.com/pytest-dev/pytest/pull/2651>`_.
+            """
+            return self.fspath, None, "[doctest] %s" % self.name
+
     class DocTestParserPlus(doctest.DocTestParser):
         """
         An extension to the builtin DocTestParser that handles the


### PR DESCRIPTION
In pytest 3.2.0 the member `dtest` is used in the `reportinfo()` function to report the location of the test examples in the doc, but the doctestplus extension does not pass one in the constructor.

@bsipocz is absolutely right when she mentions that given [pytest's `DoctestItem` constructor](https://github.com/pytest-dev/pytest/blob/master/_pytest/doctest.py#L82):

```python
class DoctestItem(pytest.Item):
    def __init__(self, name, parent, runner=None, dtest=None):
```

One assumes `dtest` can be `None`, but it appears that this has changed over the years and `dtest` is always assumed to be non-`None` and used in some other places, for example:

```python
    def runtest(self):
        _check_all_skipped(self.dtest)
        self.runner.run(self.dtest)
```

I have thought about this and I think the best solution is to fix the `doctestplus` plugin in `astropy`: allowing `dtest` to be `None` in pytest doesn't make sense in the current code because its `runtest` method always uses `self.dtest`, otherwise it wouldn't do anything.

Ref: pytest-dev/pytest#2651

