### PR TITLE
Pytest 3.2.0 compatibility fixes for 2.0.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,8 @@ astropy.tests
 - Added error handling for attempting to run tests in parallel without having
   the ``pytest-xdist`` package installed. [#6416]
 
+- Fixed issue running doctests with pytest>=3.2. [#6423, #6430]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -174,23 +174,21 @@ _xfail = pytest.mark.xfail
 
 @pytest.mark.parametrize('distance', [1000*u.au,
                                       10*u.pc,
-                                      pytest.mark.xfail(10*u.kpc),
-                                      pytest.mark.xfail(100*u.kpc)])
-                                      # below is xfail syntax for pytest >=3.1
-                                      # TODO: change to this when the above
-                                      # way of xfailing is turned off in pytest
-                                      # >=4.0
-                                      # pytest.param(10*u.kpc, marks=_xfail),
-                                      # pytest.param(100*u.kpc, marks=_xfail)])
-                                      # TODO:  make these not fail when the
-                                      # finite-difference numerical stability
-                                      # is improved
+                                      10*u.kpc,
+                                      100*u.kpc])
 def test_numerical_limits(distance):
     """
     Tests the numerical stability of the default settings for the finite
     difference transformation calculation.  This is *known* to fail for at
     >~1kpc, but this may be improved in future versions.
     """
+
+    if distance.unit == u.kpc:
+        # pytest.mark.parametrize syntax changed in pytest 3.1 to handle
+        # directly marking xfails, thus the workaround below to support
+        # pytest <3.1 for the 2.0.x LTS
+        pytest.xfail()
+
     time = Time('J2017') + np.linspace(-.5, .5, 100)*u.year
 
     icoo = ICRS(ra=0*u.deg, dec=10*u.deg, distance=distance,

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -963,8 +963,7 @@ def test_read_big_table(tmpdir):
 # fast_reader configurations: False| 'use_fast_converter'=False|True
 @pytest.mark.parametrize('reader', [0, 1, 2])
 # catch Windows environment since we cannot use _read() with custom fast_reader
-@pytest.mark.parametrize("parallel", [False,
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True)])
+@pytest.mark.parametrize("parallel", [False, True])
 def test_data_out_of_range(parallel, reader):
     """
     Numbers with exponents beyond float64 range (|~4.94e-324 to 1.7977e+308|)
@@ -972,6 +971,8 @@ def test_data_out_of_range(parallel, reader):
     the Python parser.
     Test fast converter only to nominal accuracy.
     """
+    if os.name == 'nt':
+        pytest.xfail(reason="Multiprocessing is currently unsupported on Windows")
     # Python reader and strtod() are expected to return precise results
     rtol = 1.e-30
     if reader > 1:
@@ -1016,14 +1017,15 @@ def test_data_out_of_range(parallel, reader):
 
 
 # catch Windows environment since we cannot use _read() with custom fast_reader
-@pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
-    False])
+@pytest.mark.parametrize("parallel", [True, False])
 def test_int_out_of_range(parallel):
     """
     Integer numbers outside int range shall be returned as string columns
     consistent with the standard (Python) parser (no 'upcasting' to float).
     """
+    if os.name == 'nt':
+        pytest.xfail(reason="Multiprocessing is currently unsupported on Windows")
+
     imin = np.iinfo(np.int).min+1
     imax = np.iinfo(np.int).max-1
     huge = '{:d}'.format(imax+2)
@@ -1055,14 +1057,15 @@ def test_int_out_of_range(parallel):
     assert_table_equal(table, expected)
 
 
-@pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
-    False])
+@pytest.mark.parametrize("parallel", [True, False])
 def test_fortran_reader(parallel):
     """
     Make sure that ascii.read() can read Fortran-style exponential notation
     using the fast_reader.
     """
+    if os.name == 'nt':
+        pytest.xfail(reason="Multiprocessing is currently unsupported on Windows")
+
     text = 'A B C\n100.01{:s}+99 2.0 3\n 4.2{:s}-1 5.0{:s}-1 0.6{:s}4'
     expected = Table([[1.0001e101, 0.42], [2, 0.5], [3.0, 6000]],
                      names=('A', 'B', 'C'))
@@ -1098,15 +1101,15 @@ def test_fortran_reader(parallel):
     assert_table_equal(table, expected)
 
 
-@pytest.mark.parametrize("parallel", [
-    pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")(True),
-    False])
+@pytest.mark.parametrize("parallel", [True, False])
 def test_fortran_invalid_exp(parallel):
     """
     Test Fortran-style exponential notation in the fast_reader with invalid
     exponent-like patterns (no triple-digits) to make sure they are returned
     as strings instead, as with the standard C parser.
     """
+    if os.name == 'nt':
+        pytest.xfail(reason="Multiprocessing is currently unsupported on Windows")
     if parallel and TRAVIS:
         pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -207,6 +207,18 @@ def pytest_configure(config):
                 extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
                 raise_on_error=True, verbose=False, encoding='utf-8')
 
+        def reportinfo(self):
+            """
+            Overwrite pytest's ``DoctestItem`` because
+            ``DocTestTextfilePlus`` does not have a ``dtest`` attribute
+            which is used by pytest>=3.2.0 to return the location of the
+            tests.
+
+            For details see `pytest-dev/pytest#2651
+            <https://github.com/pytest-dev/pytest/pull/2651>`_.
+            """
+            return self.fspath, None, "[doctest] %s" % self.name
+
     class DocTestParserPlus(doctest.DocTestParser):
         """
         An extension to the builtin DocTestParser that handles the

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -321,12 +321,15 @@ def test_data_noastropy_fallback(monkeypatch):
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@pytest.mark.parametrize(('filename'), [
-    'unicode.txt',
-    'unicode.txt.gz',
-    pytest.mark.xfail(not HAS_BZ2, reason='no bz2 support')('unicode.txt.bz2'),
-    pytest.mark.xfail(not HAS_XZ, reason='no lzma support')('unicode.txt.xz')])
+@pytest.mark.parametrize(('filename'), ['unicode.txt', 'unicode.txt.gz',
+                                        'unicode.txt.bz2', 'unicode.txt.xz'])
 def test_read_unicode(filename):
+    if filename == 'unicode.txt.bz2' and not HAS_BZ2:
+        pytest.xfail(reason='no bz2 support')
+
+    if filename == 'unicode.txt.xz' and not HAS_XZ:
+        pytest.xfail(reason='no lzma support')
+
     from ..data import get_pkg_data_contents
 
     contents = get_pkg_data_contents(os.path.join('data', filename), encoding='utf-8')


### PR DESCRIPTION
This PR is opened against the bugfix branch to serve as a backport of #6423 (as the tests module got refactored significantly in master). The PR also contains workarounds for the parametrized tests as discussed in https://github.com/astropy/astropy/pull/6419#issuecomment-319977438.