### PR TITLE
Configure flake8 to automatically run same options as travis

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ auto_use = True
 
 [flake8]
 exclude = extern,*parsetab.py,*lextab.py
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902
 
 [pycodestyle]
 exclude = extern,*parsetab.py,*lextab.py


### PR DESCRIPTION
Just thought this would be a nice convenience for developers. If we really wanted, we could update `.travis.yml` to run `./setup.py flake8` to avoid duplication of those parameters.

[edit]
It doesn't seem like this really needs a change log update, but let me know if you disagree :)