### PR TITLE
ProgressBar.map() should return results in order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,15 @@ astropy.utils
   ``astropy.utils.compat.numpy`` module have been deprecated. Use the
   NumPy functions directly. [#6691]
 
+- The ``astropy.utils.console.ProgressBar.map`` class method now returns
+  results in sequential order. Previously, if you set ``multiprocess=True``,
+  then the results could arrive in any arbitrary order, which could be a nasty
+  shock. Although the function will still be evaluated on the items in
+  arbitrary order, the return values will arrive in the same order in which the
+  input items were provided. The method is now a thin wrapper around
+  ``astropy.utils.console.ProgressBar.map_unordered``, which preserves the old
+  behavior. [#6439]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -3,14 +3,13 @@
 
 
 import io
-import time
 
 import numpy as np
 import pytest
 
 
+from . import test_progress_bar_func
 from .. import console
-from ..misc import NumpyRNGContext
 from ... import units as u
 
 
@@ -160,17 +159,10 @@ def test_progress_bar_as_generator():
     assert sum == 1225
 
 
-def mapfunc(i):
-    """An identity function that jitters its execution time by a
-    pseudo-random amount."""
-    with NumpyRNGContext(i):
-        time.sleep(np.random.uniform(0, 0.01))
-    return i
-
-
 def test_progress_bar_map():
     items = list(range(100))
-    result = console.ProgressBar.map(mapfunc, items, step=10, multiprocess=True)
+    result = console.ProgressBar.map(test_progress_bar_func.func,
+                                     items, step=10, multiprocess=True)
     assert items == result
 
 

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -3,11 +3,14 @@
 
 
 import io
+import time
 
+import numpy as np
 import pytest
 
 
 from .. import console
+from ..misc import NumpyRNGContext
 from ... import units as u
 
 
@@ -155,6 +158,20 @@ def test_progress_bar_as_generator():
     for x in console.ProgressBar(50):
         sum += x
     assert sum == 1225
+
+
+def mapfunc(i):
+    """An identity function that jitters its execution time by a
+    pseudo-random amount."""
+    with NumpyRNGContext(i):
+        time.sleep(np.random.uniform(0, 0.01))
+    return i
+
+
+def test_progress_bar_map():
+    items = list(range(100))
+    result = console.ProgressBar.map(mapfunc, items, step=10, multiprocess=True)
+    assert items == result
 
 
 @pytest.mark.parametrize(("seconds", "string"),

--- a/astropy/utils/tests/test_progress_bar_func.py
+++ b/astropy/utils/tests/test_progress_bar_func.py
@@ -1,0 +1,19 @@
+import time
+
+import numpy as np
+
+from ..misc import NumpyRNGContext
+
+
+def func(i):
+    """An identity function that jitters its execution time by a
+    pseudo-random amount.
+
+    FIXME: This function should be defined in test_console.py, but Astropy's
+    `python setup.py test` interacts strangely with Python's `multiprocessing`
+    module. I was getting a mysterious PicklingError until I moved this
+    function into a separate module. (It worked fine in a standalone pytest
+    script.)"""
+    with NumpyRNGContext(i):
+        time.sleep(np.random.uniform(0, 0.01))
+    return i


### PR DESCRIPTION
The `astropy.utils.console.ProgressBar.map` class method now returns results in sequential order. Previously, if you set `multiprocess=True`, then the results could arrive in any arbitrary order, which could be a nasty shock.

Although the function will still be evaluated on the items in arbitrary order, the return values will arrive in the same order in which the input items were provided.

The method is now a thin wrapper around `astropy.utils.console.ProgressBar.map_unordered`, which preserves the old behavior.