### PR TITLE
In ICRS transforms, do not implicitly assume Spherical representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -258,6 +258,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Ensure transformations via ICRS also work for coordinates that use cartesian
+  representations. [#6440]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -65,7 +65,7 @@ def icrs_to_cirs(icrs_coo, cirs_frame):
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, CIRS, ICRS)
 def cirs_to_icrs(cirs_coo, icrs_frame):
-    srepr = cirs_coo.represent_as(UnitSphericalRepresentation)
+    srepr = cirs_coo.represent_as(SphericalRepresentation)
     cirs_ra = srepr.lon.to_value(u.radian)
     cirs_dec = srepr.lat.to_value(u.radian)
 
@@ -91,7 +91,7 @@ def cirs_to_icrs(cirs_coo, icrs_frame):
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
-                                              distance=cirs_coo.distance,
+                                              distance=srepr.distance,
                                               copy=False)
 
         astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
@@ -169,7 +169,7 @@ def icrs_to_gcrs(icrs_coo, gcrs_frame):
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,
                                  GCRS, ICRS)
 def gcrs_to_icrs(gcrs_coo, icrs_frame):
-    srepr = gcrs_coo.represent_as(UnitSphericalRepresentation)
+    srepr = gcrs_coo.represent_as(SphericalRepresentation)
     gcrs_ra = srepr.lon.to_value(u.radian)
     gcrs_dec = srepr.lat.to_value(u.radian)
 
@@ -201,7 +201,7 @@ def gcrs_to_icrs(gcrs_coo, icrs_frame):
         # include the offset back to the SSB
         intermedrep = SphericalRepresentation(lat=u.Quantity(i_dec, u.radian, copy=False),
                                               lon=u.Quantity(i_ra, u.radian, copy=False),
-                                              distance=gcrs_coo.distance,
+                                              distance=srepr.distance,
                                               copy=False)
 
         astrom_eb = CartesianRepresentation(astrom['eb'], unit=u.au,
@@ -231,7 +231,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         frameattrs['obstime'] = hcrs_frame.obstime
         gcrs_coo = gcrs_coo.transform_to(GCRS(**frameattrs))
 
-    srepr = gcrs_coo.represent_as(UnitSphericalRepresentation)
+    srepr = gcrs_coo.represent_as(SphericalRepresentation)
     gcrs_ra = srepr.lon.to_value(u.radian)
     gcrs_dec = srepr.lat.to_value(u.radian)
 
@@ -263,7 +263,7 @@ def gcrs_to_hcrs(gcrs_coo, hcrs_frame):
         # Note that the distance in intermedrep is *not* a real distance as it
         # does not include the offset back to the Heliocentre
         intermedrep = SphericalRepresentation(lat=i_dec, lon=i_ra,
-                                              distance=gcrs_coo.distance,
+                                              distance=srepr.distance,
                                               copy=False)
 
         # astrom['eh'] and astrom['em'] contain Sun to observer unit vector,

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -504,3 +504,11 @@ def test_regression_6300():
                 break
         else:
             assert False, "Deprecation warning not raised"
+
+
+def test_gcrs_itrs_cartesian_repr():
+    # issue 6436: transformation failed if coordinate representation was
+    # Cartesian
+    gcrs = GCRS(CartesianRepresentation((859.07256, -4137.20368,  5295.56871),
+                                        unit='km'), representation='cartesian')
+    gcrs.transform_to(ITRS)


### PR DESCRIPTION
fixes #6436.

The following did not work before, but works now:
```
gcrs = GCRS(CartesianRepresentation((859.07256, -4137.20368,  5295.56871),
                                    unit='km'), representation='cartesian')
gcrs.transform_to(ITRS)
```
(the odd requirement to tell `GCRS` twice that the representation is cartesian is the subject of issue #6435)

cc @eteq, @StuartLittlefair