### PR TITLE
Addition of "TCAPF" time column keyword to handle astropy formats; enabling 100% round-tripping

### DIFF
--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -39,7 +39,7 @@ TIME_KEYWORDS = ('TIMESYS', 'MJDREF', 'JDREF', 'DATEREF',
 
 
 # Column-specific time override keywords
-COLUMN_TIME_KEYWORDS = ('TCTYP', 'TCUNI', 'TRPOS')
+COLUMN_TIME_KEYWORDS = ('TCTYP', 'TCUNI', 'TRPOS', 'TCAPF')
 
 
 # Column-specific keywords regex
@@ -251,6 +251,7 @@ def _convert_time_column(col, column_info):
         col = Time(col[..., 0], col[..., 1], format='jd',
                    scale=column_info['scale'],
                    location=column_info['location'])
+        col.format = column_info['TCAPF'].lower()
     else:
         warnings.warn(
             'Time column {} is not in the astropy required (jd1, jd2) format. '
@@ -369,6 +370,9 @@ def time_to_fits(table):
         # Time column override keywords
         coord_meta[col.info.name]['coord_type'] = col.scale.upper()
         coord_meta[col.info.name]['coord_unit'] = 'd'
+
+        # Astropy specific keyword for storing Time format
+        hdr.append(Card(keyword='TCAPF{}'.format(n), value=col.format.upper()))
 
         # Time column reference positions
         if col.location is None:

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -91,9 +91,11 @@ class TestFitsTime(FitsTestCase):
                       4237210, 4077985, unit='m'))
         t['b'] = Time([1,2], format='cxcsec', scale='tt')
 
-        ideal_col_hdr = {'OBSGEO-X' : t['a'].location.x.value,
-                         'OBSGEO-Y' : t['a'].location.y.value,
-                         'OBSGEO-Z' : t['a'].location.z.value}
+        ideal_col_hdr = {'OBSGEO-X': t['a'].location.x.value,
+                         'OBSGEO-Y': t['a'].location.y.value,
+                         'OBSGEO-Z': t['a'].location.z.value,
+                         'TCAPF1': t['a'].format.upper(),
+                         'TCAPF2': t['b'].format.upper()} 
 
         table, hdr = time_to_fits(t)
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -169,7 +169,7 @@ def test_io_time_write_fits(tmpdir, table_types):
             assert tm[name].scale == t[name].scale
 
             # Assert that the format is jd
-            assert tm[name].format == 'jd'
+            assert tm[name].format == t[name].format
 
             # Assert that the location round-trips
             assert tm[name].location == t[name].location


### PR DESCRIPTION
This PR supports 100% round-tripping of Time columns through FITS by addition of a new column keyword ``TCAPFn``. This is an astropy specific time column keyword (TC AstroPy Format) used to store format. This is not a FITS standard specification; but it can be used by astropy and will be ignored by other softwares, hence, causing no issues.

This should be merged in, if it seems like the best way to do so. PR [#6421](https://github.com/astropy/astropy/pull/6421) is an alternative to do the same.