### PR TITLE
Using ``serialize_method`` instead of astropy_native for writing

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -202,15 +202,9 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     return t
 
 
-def write_table_fits(input, output, overwrite=False, astropy_native=False):
+def write_table_fits(input, output, overwrite=False):
     """
     Write a Table object to a FITS file
-
-    If the ``astropy_native`` argument is ``True``, then astropy core objects in
-    the input Table, also called "mixin columns", will be converted to their
-    respective representations in FITS tables. Currently this is limited to
-    `~astropy.time.Time` columns in the input Table, in which case they will be
-    converted to FITS columns which adhere to the FITS Time standard.
 
     Parameters
     ----------
@@ -220,12 +214,9 @@ def write_table_fits(input, output, overwrite=False, astropy_native=False):
         The filename to write the table to.
     overwrite : bool
         Whether to overwrite any existing file without warning.
-    astropy_native : bool, optional
-        Write native astropy objects as per their respective FITS standard
-        specifications. Default is False.
     """
 
-    table_hdu = table_to_hdu(input, astropy_native=astropy_native)
+    table_hdu = table_to_hdu(input)
 
     # Check if output file already exists
     if isinstance(output, string_types) and os.path.exists(output):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -433,24 +433,15 @@ def writeto(filename, data, header=None, output_verify='exception',
                 checksum=checksum)
 
 
-def table_to_hdu(table, astropy_native=False):
+def table_to_hdu(table):
     """
     Convert an `~astropy.table.Table` object to a FITS
     `~astropy.io.fits.BinTableHDU`.
-
-    If the ``astropy_native`` argument is ``True``, then astropy core objects in
-    the input Table, also called "mixin columns", will be converted to their
-    respective representations in FITS binary tables. Currently this is limited to
-    `~astropy.time.Time` columns in the input Table, in which case they will be
-    converted to FITS columns which adhere to the FITS Time standard.
 
     Parameters
     ----------
     table : astropy.table.Table
         The table to convert.
-    astropy_native : bool
-        Write native astropy objects as per their respective FITS standard
-        specifications. Default is False.
 
     Returns
     -------
@@ -481,13 +472,7 @@ def table_to_hdu(table, astropy_native=False):
 
         time_cols = table.columns.isinstance(Time)
         if time_cols:
-            if astropy_native is True:
-                table, hdr = time_to_fits(table)
-            else:
-                # Shallow copy of the input table
-                table = table.copy(copy_data=False)
-                for col in time_cols:
-                    table.replace_column(col.info.name, Column(col.value))
+            table, hdr = time_to_fits(table)
 
     # Create a new HDU object
     if table.masked:

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -355,6 +355,9 @@ def time_to_fits(table):
     location = None
 
     for col in time_cols:
+        # By default, Time objects are written in full precision, i.e. we store both
+        # jd1 and jd2 (serialize_method['fits'] = 'jd1_jd2'). Formatted values for
+        # Time can be stored if the user explicitly chooses to do so.
         if col.info.serialize_method['fits'] == 'formatted_value':
             newtable.replace_column(col.info.name, Column(col.value))
             continue

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -355,6 +355,10 @@ def time_to_fits(table):
     location = None
 
     for col in time_cols:
+        if col.info.serialize_method['fits'] == 'formatted_value':
+            newtable.replace_column(col.info.name, Column(col.value))
+            continue
+
         # The following is necessary to deal with multi-dimensional ``Time`` objects
         # (i.e. where Time.shape is non-trivial).
         jd12 = np.array([col.jd1, col.jd2])

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -177,6 +177,8 @@ class TestFitsTime(FitsTestCase):
         assert not isinstance(tm.meta['MJD-OBS'], Time)
         assert tm.meta['MJD-OBS'] == t.meta['MJD-OBS']
 
+        assert (tm['a'] == t['a'].value).all()
+
     @pytest.mark.parametrize('table_types', (Table, QTable))
     def test_time_loc_unit(self, table_types):
         """

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -129,6 +129,7 @@ class TestFitsTime(FitsTestCase):
         t.meta['MJD-OBS'] = 56670
 
         # Test for default read/write behaviour (raw data)
+        t['a'].info.serialize_method['fits'] = 'formatted_value'
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
         tm = table_types.read(self.temp('time.fits'), format='fits')
 
@@ -141,8 +142,8 @@ class TestFitsTime(FitsTestCase):
         assert tm.meta['MJD-OBS'] == t.meta['MJD-OBS']
 
         # Test for native astropy objects read/write behaviour
-        t.write(self.temp('time.fits'), format='fits', overwrite=True,
-                astropy_native=True)
+        t['a'].info.serialize_method['fits'] = 'jd1_jd2'
+        t.write(self.temp('time.fits'), format='fits', overwrite=True)
         tm = table_types.read(self.temp('time.fits'), format='fits',
                               astropy_native=True)
 
@@ -162,8 +163,7 @@ class TestFitsTime(FitsTestCase):
         # Explicitly specified Time Scale
         t.meta['TIMESYS'] = 'ET'
 
-        t.write(self.temp('time.fits'), format='fits', overwrite=True,
-                astropy_native=True)
+        t.write(self.temp('time.fits'), format='fits', overwrite=True)
         tm = table_types.read(self.temp('time.fits'), format='fits',
                               astropy_native=True)
 
@@ -196,8 +196,7 @@ class TestFitsTime(FitsTestCase):
         hdr['OBSGEO-Y'] == t['a'].location.y.to_value(unit='m')
         hdr['OBSGEO-Z'] == t['a'].location.z.to_value(unit='m')
 
-        t.write(self.temp('time.fits'), format='fits', overwrite=True,
-                astropy_native=True)
+        t.write(self.temp('time.fits'), format='fits', overwrite=True)
         tm = table_types.read(self.temp('time.fits'), format='fits',
                               astropy_native=True)
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -128,21 +128,8 @@ class TestFitsTime(FitsTestCase):
         t.meta['DATE'] = '1999-01-01T00:00:00'
         t.meta['MJD-OBS'] = 56670
 
-        # Test for default read/write behaviour (raw data)
-        t['a'].info.serialize_method['fits'] = 'formatted_value'
-        t.write(self.temp('time.fits'), format='fits', overwrite=True)
-        tm = table_types.read(self.temp('time.fits'), format='fits')
-
-        # Test DATE
-        assert not isinstance(tm.meta['DATE'], Time)
-        assert tm.meta['DATE'] == t.meta['DATE']
-
-        # Test MJD-xxx
-        assert not isinstance(tm.meta['MJD-OBS'], Time)
-        assert tm.meta['MJD-OBS'] == t.meta['MJD-OBS']
-
-        # Test for native astropy objects read/write behaviour
-        t['a'].info.serialize_method['fits'] = 'jd1_jd2'
+        # Test for default write behaviour (full precision) and read it
+        # back using native astropy objects; thus, ensure its round-trip
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
         tm = table_types.read(self.temp('time.fits'), format='fits',
                               astropy_native=True)
@@ -176,6 +163,19 @@ class TestFitsTime(FitsTestCase):
         assert isinstance(tm.meta['MJD-OBS'], Time)
         assert tm.meta['MJD-OBS'].value == t.meta['MJD-OBS']
         assert tm.meta['MJD-OBS'].scale == FITS_DEPRECATED_SCALES[t.meta['TIMESYS']]
+
+        # Test for conversion of time data to its value, as defined by its format
+        t['a'].info.serialize_method['fits'] = 'formatted_value'
+        t.write(self.temp('time.fits'), format='fits', overwrite=True)
+        tm = table_types.read(self.temp('time.fits'), format='fits')
+
+        # Test DATE
+        assert not isinstance(tm.meta['DATE'], Time)
+        assert tm.meta['DATE'] == t.meta['DATE']
+
+        # Test MJD-xxx
+        assert not isinstance(tm.meta['MJD-OBS'], Time)
+        assert tm.meta['MJD-OBS'] == t.meta['MJD-OBS']
 
     @pytest.mark.parametrize('table_types', (Table, QTable))
     def test_time_loc_unit(self, table_types):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -184,7 +184,7 @@ def test_io_time_write_fits(tmpdir, table_types):
         # Assert that the non-time columns' data round-trips
         assert (tm[name] == t[name]).all()
 
-    # Test for default read/write behaviour (raw data)
+    # Test for conversion of time data to its value, as defined by its format
     for scale in time.TIME_SCALES:
         for ab in ('a', 'b'):
             name = ab + scale

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -155,7 +155,7 @@ def test_io_time_write_fits(tmpdir, table_types):
     filename = str(tmpdir.join('table-tmp'))
 
     # Show that FITS format succeeds
-    t.write(filename, format='fits', overwrite=True, astropy_native=True)
+    t.write(filename, format='fits', overwrite=True)
     tm = table_types.read(filename, format='fits', astropy_native=True)
 
     for scale in time.TIME_SCALES:
@@ -185,6 +185,11 @@ def test_io_time_write_fits(tmpdir, table_types):
         assert (tm[name] == t[name]).all()
 
     # Test for default read/write behaviour (raw data)
+    for scale in time.TIME_SCALES:
+        for ab in ('a', 'b'):
+            name = ab + scale
+            t[name].info.serialize_method['fits'] = 'formatted_value'
+
     t.write(filename, format='fits', overwrite=True)
     tm = table_types.read(filename, format='fits')
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -306,10 +306,7 @@ precision. For example::
     >>> tm['a'] == t['a']
     array([ True,  True], dtype=bool)
 
-Note that even with ``astropy_native=True``, numerical columns with units will
-be stored as `~astropy.table.Column` instances, that is, they will not be
-converted to `~astropy.units.Quantity` objects. For that, one should use
-`~astropy.table.QTable` (but otherwise, the classes behave identically).
+The same will work with ``QTable``.
 
 In addition to binary table columns, various global time informational FITS
 keywords are treated specially with ``astropy_native=True``.  In particular
@@ -372,8 +369,7 @@ to ``t['a']`` will then store ``[100.0 200.0]`` instead of
     >>> from astropy.table import Table
     >>> from astropy.coordinates import EarthLocation
     >>> t = Table()
-    >>> t['a'] = Time([100.0, 200.0], scale='tt', format='mjd',
-    ...               location=EarthLocation(-2446354, 4237210, 4077985, unit='m'))
+    >>> t['a'] = Time([100.0, 200.0], scale='tt', format='mjd')
     >>> t['a'].info.serialize_method['fits'] = 'formatted_value'
     >>> t.write('my_table.fits', overwrite=True)
     >>> tm = Table.read('my_table.fits')

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -309,8 +309,7 @@ precision. For example::
 Note that even with ``astropy_native=True``, numerical columns with units will
 be stored as `~astropy.table.Column` instances, that is, they will not be
 converted to `~astropy.units.Quantity` objects. For that, one should use
-`~astropy.table.QTable`; for that class, ``astropy_native`` works in the
-same way.
+`~astropy.table.QTable` (but otherwise, the classes behave identically).
 
 In addition to binary table columns, various global time informational FITS
 keywords are treated specially with ``astropy_native=True``.  In particular

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -367,7 +367,7 @@ no extra metadata in the header. This is the "lossy" version, but can help
 portability. For the above example, the FITS column corresponding
 to ``t['a']`` will then store ``[100.0 200.0]`` instead of
 ``[[ 2400100.5, 0. ], [ 2400200.5, 0. ]]``. This is done by using a special
-``info.serialze_method`` attribute, as in the following example::
+``info.serialize_method`` attribute, as in the following example::
 
     >>> from astropy.time import Time
     >>> from astropy.table import Table


### PR DESCRIPTION
``time_col.info.serialize_method['fits'] == 'jd1_jd2'`` is the default, due to which, for writing of Time columns, the default behaviour is full precision (jd1, jd2) format. For writing the actual representation values of the time columns, we explicitly set ``time_col.info.serialize_method['fits'] = 'formatted_value'`` to get the formatted value.

@taldcroft @mhvk @hamogu