### PR TITLE
Fix SkyCoord creation from other SkyCoords improperly copying frame attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,8 +64,8 @@ astropy.table
 
 - Added support for reading and writing ``astropy.time.Time`` Table columns
   to and from FITS tables, to the extent supported by the FITS standard. [#6176]
-  
-- Improved exception handling and error messages when column ``format`` 
+
+- Improved exception handling and error messages when column ``format``
   attribute is incorrect for the column type. [#6385]
 
 astropy.tests
@@ -155,7 +155,7 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
-- When setting the column ``format`` attribute the value is now immediately 
+- When setting the column ``format`` attribute the value is now immediately
   validated. Previously one could set to any value and it was only checked
   when actually formatting the column. [#6385]
 
@@ -194,9 +194,6 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-
-- Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
-  coordinate objects from being written out to ECSV files. [#6448]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
@@ -287,6 +284,9 @@ astropy.coordinates
 
 - Ensure transformations via ICRS also work for coordinates that use cartesian
   representations. [#6440]
+
+- Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
+  coordinate objects from being written out to ECSV files. [#6448]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -195,6 +195,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
+  coordinate objects from being written out to ECSV files. [#6448]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1703,7 +1703,14 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # get the frame attributes from the first one, because from above we
             # know it matches all the others
             for fattrnm in frame_transform_graph.frame_attributes:
-                valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
+                fattrnm_data_name = '_' + fattrnm
+                # the hasattr is crucial here, because if we don't do that, all
+                # *non-set* frame attributes on the input SkyCoord will
+                # be passed into the new one as None kwargs.  This makes the
+                # initializer set it base on the default, rather than being
+                # not set at all (which is the desired behavior)
+                if hasattr(scs[0], fattrnm_data_name):
+                    valid_kwargs[fattrnm] = getattr(scs[0], fattrnm_data_name)
 
             # Now combine the values, to be used below
             values = []

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -208,8 +208,11 @@ class SkyCoord(ShapedLikeNDArray):
 
         frame = kwargs['frame']
         frame_attr_names = frame.get_frame_attr_names()
-        # Set internal versions of object state attributes
-        self._extra_attr_names = set()
+
+        # these are frame attributes set on this SkyCoord but *not* a part of
+        # the frame object this SkyCoord contains
+        self._extra_frameattr_names = set()
+
         for attr in kwargs:
             if (attr not in frame_attr_names and
                 attr in frame_transform_graph.frame_attributes):
@@ -286,7 +289,7 @@ class SkyCoord(ShapedLikeNDArray):
             # this to get all the right attributes
             self._sky_coord_frame = self_frame._apply(method, *args, **kwargs)
             out = SkyCoord(self, representation=self.representation, copy=False)
-            for attr in self._extra_attr_names:
+            for attr in self._extra_frameattr_names:
                 value = getattr(self, attr)
                 if getattr(value, 'size', 1) > 1:
                     value = apply_method(value)
@@ -537,7 +540,7 @@ class SkyCoord(ShapedLikeNDArray):
             # Validate it
             frame_transform_graph.frame_attributes[attr].__get__(self)
             # And add to set of extra attributes
-            self._extra_attr_names |= {attr}
+            self._extra_frameattr_names |= {attr}
 
         else:
             # Otherwise, do the standard Python attribute setting
@@ -563,7 +566,7 @@ class SkyCoord(ShapedLikeNDArray):
             # the corresponding private variable.  See __getattr__ above.
             super(SkyCoord, self).__delattr__('_' + attr)
             # Also remove it from the set of extra attributes
-            self._extra_attr_names -= {attr}
+            self._extra_frameattr_names -= {attr}
 
         else:
             # Otherwise, do the standard Python attribute setting
@@ -1522,7 +1525,7 @@ def _get_frame(args, kwargs):
 
     if isinstance(frame, SkyCoord):
         # Copy any extra attributes if they are not explicitly given.
-        for attr in frame._extra_attr_names:
+        for attr in frame._extra_frameattr_names:
             kwargs.setdefault(attr, getattr(frame, attr))
         frame = frame.frame
 
@@ -1706,7 +1709,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # extras in the SkyCoord
             for fattrnm in scs[0].frame.frame_attributes:
                 valid_kwargs[fattrnm] = getattr(scs[0].frame, fattrnm)
-            for fattrnm in scs[0]._extra_attr_names:
+            for fattrnm in scs[0]._extra_frameattr_names:
                 valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
 
             # Now combine the values, to be used below

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1700,17 +1700,14 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             # Now use the first to determine if they are all UnitSpherical
             allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
 
-            # get the frame attributes from the first one, because from above we
-            # know it matches all the others
-            for fattrnm in frame_transform_graph.frame_attributes:
-                fattrnm_data_name = '_' + fattrnm
-                # the hasattr is crucial here, because if we don't do that, all
-                # *non-set* frame attributes on the input SkyCoord will
-                # be passed into the new one as None kwargs.  This makes the
-                # initializer set it base on the default, rather than being
-                # not set at all (which is the desired behavior)
-                if hasattr(scs[0], fattrnm_data_name):
-                    valid_kwargs[fattrnm] = getattr(scs[0], fattrnm_data_name)
+            # get the frame attributes from the first coord in the list, because
+            # from the above we know it matches all the others.  First copy over
+            # the attributes that are in the frame itself, then copy over any
+            # extras in the SkyCoord
+            for fattrnm in scs[0].frame.frame_attributes:
+                valid_kwargs[fattrnm] = getattr(scs[0].frame, fattrnm)
+            for fattrnm in scs[0]._extra_attr_names:
+                valid_kwargs[fattrnm] = getattr(scs[0], fattrnm)
 
             # Now combine the values, to be used below
             values = []

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -28,6 +28,12 @@ from ...table import Table
 from ...tests.helper import assert_quantity_allclose, catch_warnings, quantity_allclose
 from .test_matching import HAS_SCIPY, OLDER_SCIPY
 
+try:
+    import yaml  # pylint: disable=W0611
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
 
 def test_regression_5085():
     """
@@ -517,12 +523,13 @@ def test_gcrs_itrs_cartesian_repr():
     gcrs.transform_to(ITRS)
 
 
+@pytest.mark.skipif('not HAS_YAML')
 def test_regression_6446():
     # this succeeds even before 6446:
     sc1 = SkyCoord([1, 2], [3, 4], unit='deg')
     t1 = Table([sc1])
     sio1 = io.StringIO()
-    t1.write(sio1, format='ascii.ecsv', overwrite=True)
+    t1.write(sio1, format='ascii.ecsv')
 
     # but this fails due to the 6446 bug
     c1 = SkyCoord(1, 3, unit='deg')
@@ -530,6 +537,23 @@ def test_regression_6446():
     sc2 = SkyCoord([c1, c2])
     t2 = Table([sc2])
     sio2 = io.StringIO()
-    t2.write(sio2, format='ascii.ecsv', overwrite=True)
+    t2.write(sio2, format='ascii.ecsv')
 
     assert sio1.getvalue() == sio2.getvalue()
+
+
+def test_regression_6448():
+    """
+    This tests the more narrow problem reported in 6446 that 6448 is meant to
+    fix. `test_regression_6446` also covers this, but this test is provided
+    so that this is still tested even if YAML isn't installed.
+    """
+    sc1 = SkyCoord([1, 2], [3, 4], unit='deg')
+    # this should always succeed even prior to 6448
+    assert sc1.galcen_v_sun is None
+
+    c1 = SkyCoord(1, 3, unit='deg')
+    c2 = SkyCoord(2, 4, unit='deg')
+    sc2 = SkyCoord([c1, c2])
+    # without 6448 this fails
+    assert sc2.galcen_v_sun is None

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -9,10 +9,10 @@ place to live
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-import io
-
 import pytest
 import numpy as np
+
+from ...extern import six
 
 from ... import units as u
 from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
@@ -528,7 +528,7 @@ def test_regression_6446():
     # this succeeds even before 6446:
     sc1 = SkyCoord([1, 2], [3, 4], unit='deg')
     t1 = Table([sc1])
-    sio1 = io.StringIO()
+    sio1 = six.StringIO()
     t1.write(sio1, format='ascii.ecsv')
 
     # but this fails due to the 6446 bug
@@ -536,7 +536,7 @@ def test_regression_6446():
     c2 = SkyCoord(2, 4, unit='deg')
     sc2 = SkyCoord([c1, c2])
     t2 = Table([sc2])
-    sio2 = io.StringIO()
+    sio2 = six.StringIO()
     t2.write(sio2, format='ascii.ecsv')
 
     assert sio1.getvalue() == sio2.getvalue()


### PR DESCRIPTION
This PR fixes *part* of the problem reported in #6446 : when you create a `SkyCoord` from a list of other `SkyCoord`s, it turns out that all the frame attributes get set to their default values *instead* of being left un-set.  That's a bug in how the frame attributes get copied over, and this PR fixes it.

Fixes #6446 (although note there is sort of a second bug in #6446 ... but that's the topic of #6447)

cc @larrybradley @adrn @taldcroft 