### PR TITLE
Update config file in anticipation of future testing updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -347,6 +347,8 @@ astropy.tests
 
 - Fixed issue caused by antivirus software in response to malformed compressed
   files used for testing. [#6522]
+- Updated top-level config file to properly ignore top-level directories.
+  [#6449]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,8 @@ show-response = 1
 
 [pytest]
 minversion = 2.8
-norecursedirs = ".*" "*.egg-info" "build" "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures" "astropy_helpers"
+testpaths = "astropy" "docs"
+norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
 addopts = --pyargs -p no:warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,10 +14,10 @@ show-response = 1
 
 [pytest]
 minversion = 2.8
-norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
+norecursedirs = ".*" "*.egg-info" "build" "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures" "astropy_helpers"
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
-addopts = -p no:warnings
+addopts = --pyargs -p no:warnings
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
In anticipation of eventually being able to invoke tests directly from `pytest`, it is necessary to update `setup.cfg` to make sure all top-level directories that we want to ignore during testing are actually being ignored. 

Also, according to the [pytest documentation](https://docs.pytest.org/en/latest/goodpractices.html#tests-as-part-of-application-code) we need to add the `--pyargs` command line argument since our tests are integrated with application code.

These changes are based on work from #6437. Even if that PR is not integrated as-is, this is a necessary update.