### PR TITLE
add ver argument for init in subclasses of ValidHDU.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ astropy.io.fits
 - Expanded the FITS ``Column`` interface to accept attributes pertaining to the FITS
   World Coordinate System, which includes spatial(celestial) and time coordinates. [#6359]
 
+- Added ``ver`` attribute to set the ``EXTVER`` header keyword to ``ImageHDU``
+  and ``TableHDU``. [#6454]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -882,10 +882,12 @@ class _ValidHDU(_BaseHDU, _Verify):
     Base class for all HDUs which are not corrupted.
     """
 
-    def __init__(self, data=None, header=None, name=None, **kwargs):
+    def __init__(self, data=None, header=None, name=None, ver=None, **kwargs):
         super(_ValidHDU, self).__init__(data=data, header=header)
         if name is not None:
             self.name = name
+        if ver is not None:
+            self.ver = ver
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -1091,8 +1091,11 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             rescaled unless scale_back is explicitly set to `False`.
             (default: None)
 
-        ver : int > 0, optional
-            The name of the HDU, will be the value of the keyword ``EXTVER``.
+        ver : int > 0 or None, optional
+            The ver of the HDU, will be the value of the keyword ``EXTVER``.
+            If not given or None, it defaults to the value of the ``EXTVER``
+            card of the ``header`` or 1.
+            (default: None)
         """
 
         # This __init__ currently does nothing differently from the base class,

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -135,6 +135,8 @@ class _ImageBaseHDU(_ValidHDU):
         # well)
         if 'name' in kwargs and kwargs['name']:
             self.name = kwargs['name']
+        if 'ver' in kwargs and kwargs['ver']:
+            self.ver = kwargs['ver']
 
         # Set to True if the data or header is replaced, indicating that
         # update_header should be called
@@ -1051,7 +1053,8 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
     _extension = 'IMAGE'
 
     def __init__(self, data=None, header=None, name=None,
-                 do_not_scale_image_data=False, uint=True, scale_back=None):
+                 do_not_scale_image_data=False, uint=True, scale_back=None,
+                 ver=None):
         """
         Construct an image HDU.
 
@@ -1087,6 +1090,9 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
             operations on the data.  Pseudo-unsigned integers are automatically
             rescaled unless scale_back is explicitly set to `False`.
             (default: None)
+
+        ver : int > 0, optional
+            The name of the HDU, will be the value of the keyword ``EXTVER``.
         """
 
         # This __init__ currently does nothing differently from the base class,
@@ -1095,7 +1101,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         super(ImageHDU, self).__init__(
             data=data, header=header, name=name,
             do_not_scale_image_data=do_not_scale_image_data, uint=uint,
-            scale_back=scale_back)
+            scale_back=scale_back, ver=ver)
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -246,6 +246,11 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         Name to be populated in ``EXTNAME`` keyword.
     uint : bool, optional
         Set to `True` if the table contains unsigned integer columns.
+    ver : int > 0 or None, optional
+        The ver of the HDU, will be the value of the keyword ``EXTVER``.
+        If not given or None, it defaults to the value of the ``EXTVER``
+        card of the ``header`` or 1.
+        (default: None)
     """
 
     _manages_own_heap = False
@@ -258,9 +263,9 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     which perform their own heap maintenance.
     """
 
-    def __init__(self, data=None, header=None, name=None, uint=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None):
         super(_TableBaseHDU, self).__init__(data=data, header=header,
-                                            name=name)
+                                            name=name, ver=ver)
 
         if header is not None and not isinstance(header, Header):
             raise ValueError('header must be a Header object.')
@@ -373,6 +378,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         # created, or that it overrides the existing EXTNAME if different
         if name:
             self.name = name
+        if ver is not None:
+            self.ver = ver
 
     @classmethod
     def match_header(cls, header):
@@ -694,6 +701,11 @@ class TableHDU(_TableBaseHDU):
         Header to be used.
     name : str
         Name to be populated in ``EXTNAME`` keyword.
+    ver : int > 0 or None, optional
+        The ver of the HDU, will be the value of the keyword ``EXTVER``.
+        If not given or None, it defaults to the value of the ``EXTVER``
+        card of the ``header`` or 1.
+        (default: None)
 
     """
 
@@ -706,8 +718,8 @@ class TableHDU(_TableBaseHDU):
     __format_RE = re.compile(
         r'(?P<code>[ADEFIJ])(?P<width>\d+)(?:\.(?P<prec>\d+))?')
 
-    def __init__(self, data=None, header=None, name=None):
-        super(TableHDU, self).__init__(data, header, name=name)
+    def __init__(self, data=None, header=None, name=None, ver=None):
+        super(TableHDU, self).__init__(data, header, name=name, ver=ver)
 
     @classmethod
     def match_header(cls, header):
@@ -801,13 +813,18 @@ class BinTableHDU(_TableBaseHDU):
         Name to be populated in ``EXTNAME`` keyword.
     uint : bool, optional
         Set to `True` if the table contains unsigned integer columns.
+    ver : int > 0 or None, optional
+        The ver of the HDU, will be the value of the keyword ``EXTVER``.
+        If not given or None, it defaults to the value of the ``EXTVER``
+        card of the ``header`` or 1.
+        (default: None)
 
     """
 
     _extension = 'BINTABLE'
     _ext_comment = 'binary table extension'
 
-    def __init__(self, data=None, header=None, name=None, uint=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None):
         from ....table import Table
         if isinstance(data, Table):
             from ..convenience import table_to_hdu
@@ -817,7 +834,8 @@ class BinTableHDU(_TableBaseHDU):
             data = hdu.data
             header = hdu.header
 
-        super(BinTableHDU, self).__init__(data, header, name=name, uint=uint)
+        super(BinTableHDU, self).__init__(
+            data, header, name=name, uint=uint, ver=ver)
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -54,6 +54,27 @@ class TestImageFunctions(FitsTestCase):
         assert hdu.name == 'FOO'
         assert hdu.header['EXTNAME'] == 'FOO'
 
+    def test_constructor_ver_arg(self):
+        def assert_ver_is(hdu, reference_ver):
+            assert hdu.ver == reference_ver
+            assert hdu.header['EXTVER'] == reference_ver
+        hdu = fits.ImageHDU()
+        assert hdu.ver == 1
+        assert 'EXTVER' not in hdu.header
+
+        hdu.ver = 1
+        assert_ver_is(hdu, 1)
+
+        # Passing name to constructor
+        hdu = fits.ImageHDU(ver=2)
+        assert_ver_is(hdu, 2)
+
+        # And overriding a header with a different extver
+        hdr = fits.Header()
+        hdr['EXTVER'] = 3
+        hdu = fits.ImageHDU(header=hdr, ver=4)
+        assert_ver_is(hdu, 4)
+
     def test_constructor_copies_header(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/153

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -58,8 +58,9 @@ class TestImageFunctions(FitsTestCase):
         def assert_ver_is(hdu, reference_ver):
             assert hdu.ver == reference_ver
             assert hdu.header['EXTVER'] == reference_ver
+
         hdu = fits.ImageHDU()
-        assert hdu.ver == 1
+        assert hdu.ver == 1  # defaults to 1
         assert 'EXTVER' not in hdu.header
 
         hdu.ver = 1
@@ -74,6 +75,14 @@ class TestImageFunctions(FitsTestCase):
         hdr['EXTVER'] = 3
         hdu = fits.ImageHDU(header=hdr, ver=4)
         assert_ver_is(hdu, 4)
+
+        # The header card is not overridden if ver is None or not passed in
+        hdr = fits.Header()
+        hdr['EXTVER'] = 5
+        hdu = fits.ImageHDU(header=hdr, ver=None)
+        assert_ver_is(hdu, 5)
+        hdu = fits.ImageHDU(header=hdr)
+        assert_ver_is(hdu, 5)
 
     def test_constructor_copies_header(self):
         """

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1527,6 +1527,28 @@ class TestTableFunctions(FitsTestCase):
             assert hdu.name == 'FOO'
             assert hdu.header['EXTNAME'] == 'FOO'
 
+    def test_constructor_ver_arg(self):
+        for hducls in [fits.BinTableHDU, fits.TableHDU]:
+            # First test some default assumptions
+            hdu = hducls()
+            assert hdu.ver == 1
+            assert 'EXTVER' not in hdu.header
+            hdu.ver = 2
+            assert hdu.ver == 2
+            assert hdu.header['EXTVER'] == 2
+
+            # Passing name to constructor
+            hdu = hducls(ver=3)
+            assert hdu.ver == 3
+            assert hdu.header['EXTVER'] == 3
+
+            # And overriding a header with a different extver
+            hdr = fits.Header()
+            hdr['EXTVER'] = 4
+            hdu = hducls(header=hdr, ver=5)
+            assert hdu.ver == 5
+            assert hdu.header['EXTVER'] == 5
+
     def test_unicode_colname(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/5204


### PR DESCRIPTION
This is WIP for now (passes locally but I want to see if it passes against the complete matrix). 

I'm still testing why it's not working if I pass the `**kwargs` to `super` in `ImageHDU.__init__`.

Related #6453 