### PR TITLE
Read ASCII tables in chunks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -271,6 +271,9 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Added support for reading very large tables in chunks to reduce memory
+  usage. [#6458]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1361,8 +1361,7 @@ extra_reader_pars = ('Reader', 'Inputter', 'Outputter',
                      'data_start', 'data_end', 'converters', 'encoding',
                      'data_Splitter', 'header_Splitter',
                      'names', 'include_names', 'exclude_names', 'strict_names',
-                     'fill_values', 'fill_include_names', 'fill_exclude_names',
-                     'chunk_size')
+                     'fill_values', 'fill_include_names', 'fill_exclude_names')
 
 
 def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1361,7 +1361,8 @@ extra_reader_pars = ('Reader', 'Inputter', 'Outputter',
                      'data_start', 'data_end', 'converters', 'encoding',
                      'data_Splitter', 'header_Splitter',
                      'names', 'include_names', 'exclude_names', 'strict_names',
-                     'fill_values', 'fill_include_names', 'fill_exclude_names')
+                     'fill_values', 'fill_include_names', 'fill_exclude_names',
+                     'chunk_size')
 
 
 def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -6,6 +6,7 @@ import math
 import multiprocessing
 import mmap
 import warnings
+import copy
 
 import numpy as np
 cimport numpy as np
@@ -202,13 +203,9 @@ cdef class CParser:
                   fill_include_names=None,
                   fill_exclude_names=None,
                   fill_extra_cols=0,
-                  fast_reader=True):
+                  fast_reader=None):
 
-        # Handle fast_reader parameter (True or dict specifying options)
-        if fast_reader is True or fast_reader == 'force':
-            fast_reader = {}
-        elif fast_reader is False: # shouldn't happen
-            raise core.ParameterError("fast_reader cannot be False for fast readers")
+        # Handle fast_reader parameter
         expchar = fast_reader.pop('exponent_style', 'E').upper()
         # parallel and use_fast_reader are False by default, but only the latter
         # supports Fortran double precision notation

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -142,7 +142,7 @@ cdef class FileString:
         return len(self.mmap)
 
     def __getitem__(self, i):
-        return self.mmap[i] if six.PY2 else chr(self.mmap[i])
+        return self.mmap[i]
 
     def splitlines(self):
         """

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -421,6 +421,8 @@ cdef class CParser:
         cdef int i
         cdef size_t index
 
+        # Build up chunkindices which has the indices for all N chunks
+        # in an length N+1 array.
         for i in range(1, N):
             index = max(offset + chunksize * i, chunkindices[i - 1])
             while index < source_len and self.source[index] != '\n':
@@ -435,6 +437,7 @@ cdef class CParser:
         chunkindices.append(source_len)
         cdef list processes = []
 
+        # Create and start N parallel processes to read the N chunks
         for i in range(N):
             process = multiprocessing.Process(target=_read_chunk, args=(self,
                 chunkindices[i], chunkindices[i + 1],
@@ -442,10 +445,15 @@ cdef class CParser:
             processes.append(process)
             process.start()
 
+        # Define outputs in advance
         cdef list chunks = [None] * N
         cdef list comments_chunks = [None] * N
         cdef dict failed_procs = {}
 
+        # Asyncronously get the read results for the N chunks.  These
+        # come back in a non-deterministic order using the ``queue``
+        # to return results and the chunk index as ``proc``.  ``queue.get()``
+        # is blocking and waiting for a result.
         for i in range(N):
             queue_ret, err, proc = queue.get()
             if isinstance(err, Exception):
@@ -454,9 +462,12 @@ cdef class CParser:
                 raise err
             elif err is not None: # err is (error code, error line)
                 failed_procs[proc] = err
+
             comments, data = queue_ret
             comments_chunks[proc] = comments
             chunks[proc] = data
+
+        # Accumulate all the comments through file into a single list of comments
         for chunk in comments_chunks:
             line_comments.extend(chunk)
 
@@ -478,6 +489,9 @@ cdef class CParser:
             seen_str[name] = False
             seen_numeric[name] = False
 
+        # Go through each chunk and each column name and see if it was parsed
+        # as both a string in at least one chunck and/or numeric in at least
+        # one chunk.
         for chunk in chunks:
             for name in chunk:
                 if chunk[name].dtype.kind in ('S', 'U'):
@@ -486,19 +500,31 @@ cdef class CParser:
                 elif len(chunk[name]) > 0: # ignore empty chunk columns
                     seen_numeric[name] = True
 
+        # Go through each column name and see if it was parsed as both
+        # string and float in different chunks.  If so reconvert back
+        # to string.
         reconvert_cols = []
-
         for i, name in enumerate(self.names):
             if seen_str[name] and seen_numeric[name]:
                 # Reconvert to str to avoid conversion issues, e.g.
                 # 5 (int) -> 5.0 (float) -> 5.0 (string)
                 reconvert_cols.append(i)
 
+        # Slightly confusing: put the list of col numbers to reconvert
+        # onto the queue.  All of the reading processes are blocked and
+        # waiting for a value on the reconvert_queue.  One-by-one each
+        # process will manage to be first in line and get the value,
+        # handle, and the put reconvert_cols back on the queue for
+        # another waiting process.
+        # CONSIDER just putting reconvert_cols on the queue N times
+        # in a row here and don't have _read_chunk do that chaining.
         reconvert_queue.put(reconvert_cols)
         for process in processes:
             process.join() # wait for each process to finish
         try:
             while True:
+                # Each column that was reconverted gets passed back in the queue
+                # and is then substituted over the original (incorrect) type.
                 reconverted, proc, col = queue.get(False)
                 chunks[proc][self.names[col]] = reconverted
         except Queue.Empty:
@@ -528,6 +554,7 @@ cdef class CParser:
                         break
                     line_no += num_rows
 
+        # Concatenate the chunk data, one column at a time.
         ret = {}
         for name in self.get_names():
             col_chunks = [chunk.pop(name) for chunk in chunks]
@@ -536,6 +563,7 @@ cdef class CParser:
             else:
                 ret[name] = np.concatenate(col_chunks)
 
+        # Clean up processes
         for process in processes:
             process.terminate()
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -93,7 +93,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
         fast_reader = self.kwargs.get('fast_reader', True)
         if not isinstance(fast_reader, dict):
             fast_reader = {}
-            # else fast_reader = copy.deepcopy(fast_reader)  # this gets munged later
+
         fast_reader.pop('enable', None)
         self.return_header_chars = fast_reader.pop('return_header_chars', False)
         self.kwargs['fast_reader'] = fast_reader
@@ -126,6 +126,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
         return out
 
     def make_table(self, data, comments):
+        """Actually make the output table give the data and comments."""
         meta = OrderedDict()
         if comments:
             meta['comments'] = comments
@@ -247,6 +248,11 @@ class FastCommentedHeader(FastBasic):
             self.data_start = 0
 
     def make_table(self, data, comments):
+        """
+        Actually make the output table give the data and comments.  This is
+        slightly different from the base FastBasic method in the way comments
+        are handled.
+        """
         meta = OrderedDict()
         if comments:
             meta['comments'] = comments[1:]

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import re
+import copy
 from collections import OrderedDict
 
 from . import core
@@ -88,7 +89,11 @@ class FastBasic(metaclass=core.MetaBaseReader):
             raise core.ParameterError("The C reader does not use a Splitter class")
 
         self.strict_names = self.kwargs.pop('strict_names', False)
-        self.return_header_chars = self.kwargs['fast_reader'].pop('return_header_chars', False)
+
+        fast_reader = copy.copy(self.kwargs.get('fast_reader', {}))
+        self.return_header_chars = fast_reader.pop('return_header_chars', False)
+        fast_reader.pop('enable', None)
+        self.kwargs['fast_reader'] = fast_reader
 
         self.engine = cparser.CParser(table, self.strip_whitespace_lines,
                                       self.strip_whitespace_fields,

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1306,7 +1306,7 @@ def test_read_chunks_input_types():
     fpath = 't/test5.dat'
     t1 = ascii.read(fpath, header_start=1, data_start=3)
 
-    for fp in (fpath, open(fpath, 'rb'), open(fpath, 'rb').read()):
+    for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
         t_gen = ascii.read(fp, header_start=1, data_start=3,
                            fast_reader={'chunk_size': 400, 'chunk_generator': True})
         ts = list(t_gen)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1366,11 +1366,13 @@ def test_read_chunks_chunk_size_too_small():
     assert 'no newline found in chunk (chunk_size too small?)' in str(err)
 
 
-@pytest.mark.xfail
 def test_read_chunks_table_changes():
-    """Column changes type between chunks"""
-    col = ['a b'] + ['1.12334 xyz'] * 50 + ['abcdefg 555'] * 50
+    """Column changes type or size between chunks.  This also tests the case with
+    no final newline.
+    """
+    col = ['a b c'] + ['1.12334 xyz a'] * 50 + ['abcdefg 555 abc'] * 50
     table = '\n'.join(col)
     t1 = ascii.read(table, guess=False)
     t2 = ascii.read(table, fast_reader={'chunk_size': 100})
-    assert np.all(t1 == t2)
+    for name in t1.colnames:
+        assert np.all(t1[name] == t2[name])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -120,7 +120,7 @@ def test_read_with_names_arg(fast_reader):
     """
     Test that a bad value of `names` raises an exception.
     """
-    with pytest.raises((ValueError, cparser.CParserError)):
+    with pytest.raises(ValueError):
         ascii.read(['c d', 'e f'], names=('a', ), guess=False, fast_reader=fast_reader)
 
 
@@ -248,19 +248,19 @@ def test_empty_table_no_header(fast_reader):
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_wrong_quote(fast_reader):
-    with pytest.raises((ascii.InconsistentTableError, cparser.CParserError)):
+    with pytest.raises(ascii.InconsistentTableError):
         ascii.read('t/simple.txt', guess=False, fast_reader=fast_reader)
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_extra_data_col(fast_reader):
-    with pytest.raises((ascii.InconsistentTableError, cparser.CParserError)):
+    with pytest.raises(ascii.InconsistentTableError):
         ascii.read('t/bad.txt', fast_reader=fast_reader)
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
 def test_extra_data_col2(fast_reader):
-    with pytest.raises((ascii.InconsistentTableError, cparser.CParserError)):
+    with pytest.raises(ascii.InconsistentTableError):
         ascii.read('t/simple5.txt', delimiter='|', fast_reader=fast_reader)
 
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1326,11 +1326,12 @@ def test_read_chunks_input_types():
         assert np.all(t1 == t3)
 
 
-def test_read_chunks_formats():
+@pytest.mark.parametrize('masked', [True, False])
+def test_read_chunks_formats(masked):
     """
     Test different supported formats for chunked reading.
     """
-    t1 = simple_table(size=100, cols=10, kinds='fS')
+    t1 = simple_table(size=100, cols=10, kinds='fS', masked=masked)
     for i, name in enumerate(t1.colnames):
         t1.rename_column(name, 'col{}'.format(i + 1))
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1374,5 +1374,7 @@ def test_read_chunks_table_changes():
     table = '\n'.join(col)
     t1 = ascii.read(table, guess=False)
     t2 = ascii.read(table, fast_reader={'chunk_size': 100})
-    for name in t1.colnames:
-        assert np.all(t1[name] == t2[name])
+
+    # This also confirms that the dtypes are exactly the same, i.e.
+    # the string itemsizes are the same.
+    assert np.all(t1 == t2)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1331,7 +1331,7 @@ def test_read_chunks_formats(masked):
     """
     Test different supported formats for chunked reading.
     """
-    t1 = simple_table(size=100, cols=10, kinds='fS', masked=masked)
+    t1 = simple_table(size=102, cols=10, kinds='fS', masked=masked)
     for i, name in enumerate(t1.colnames):
         t1.rename_column(name, 'col{}'.format(i + 1))
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1297,17 +1297,17 @@ def test_unsupported_read_with_encoding(tmpdir):
                    encoding='latin1', format='fast_csv')
 
 
-
 def test_read_chunks_input_types():
     """
     Test chunked reading for different input types: file path, file object,
     and string input.
     """
     fpath = 't/test5.dat'
-    t1 = ascii.read(fpath, header_start=1, data_start=3)
+    t1 = ascii.read(fpath, header_start=1, data_start=3, )
 
     for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
         t_gen = ascii.read(fp, header_start=1, data_start=3,
+                           guess=False, format='fast_basic',
                            fast_reader={'chunk_size': 400, 'chunk_generator': True})
         ts = list(t_gen)
         for t in ts:
@@ -1341,7 +1341,7 @@ def test_read_chunks_formats():
         out = StringIO()
         ascii.write(t1, out, format=format)
         t_gen = ascii.read(out.getvalue(), format=format,
-                           fast_reader={'chunk_size': 300, 'chunk_generator': True})
+                           fast_reader={'chunk_size': 400, 'chunk_generator': True})
         ts = list(t_gen)
         for t in ts:
             for col, col1 in zip(t.columns.values(), t1.columns.values()):
@@ -1353,7 +1353,7 @@ def test_read_chunks_formats():
         assert np.all(t1 == t2)
 
         # Now read the full table in chunks
-        t3 = ascii.read(out.getvalue(), format=format, fast_reader={'chunk_size': 300})
+        t3 = ascii.read(out.getvalue(), format=format, fast_reader={'chunk_size': 400})
         assert np.all(t1 == t3)
 
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1330,7 +1330,7 @@ def test_read_chunks_formats():
     """
     Test different supported formats for chunked reading.
     """
-    t1 = simple_table(size=100, cols=10)
+    t1 = simple_table(size=100, cols=10, kinds='fS')
     for i, name in enumerate(t1.colnames):
         t1.rename_column(name, 'col{}'.format(i + 1))
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -698,7 +698,7 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
                 if chunk[idx] == '\n':
                     break
             else:
-                raise ValueError('no newline found in chunk')
+                raise ValueError('no newline found in chunk (chunk_size too small?)')
 
             # Stick on the header to the chunk part up to (and including) the
             # last newline.

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -16,6 +16,7 @@ import copy
 import time
 import warnings
 import contextlib
+from io import StringIO
 
 from . import core
 from . import basic
@@ -670,9 +671,8 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
 
     # Convert table-as-string to a File object.  Finding a newline implies
     # that the string is not a filename.
-    if (isinstance(table, six.string_types) and
-            ('\n' in table or '\r' in table)):
-        table = six.moves.cStringIO(table)
+    if (isinstance(table, str) and ('\n' in table or '\r' in table)):
+        table = StringIO(table)
         fileobj_context = passthrough_fileobj
     elif hasattr(table, 'read') and hasattr(table, 'seek'):
         fileobj_context = passthrough_fileobj

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -360,20 +360,21 @@ def read(table, guess=None, **kwargs):
         # Try the fast reader version of `format` first if applicable.  Note that
         # if user specified a fast format (e.g. format='fast_basic') this test
         # will fail and the else-clause below will be used.
-        if fast_reader['enable'] and format is not None and 'fast_{0}'.format(format) \
-                                                        in core.FAST_CLASSES:
+        if fast_reader['enable'] and 'fast_{0}'.format(format) in core.FAST_CLASSES:
             fast_kwargs = copy.deepcopy(new_kwargs)
             fast_kwargs['Reader'] = core.FAST_CLASSES['fast_{0}'.format(format)]
             fast_reader_rdr = get_reader(**fast_kwargs)
             try:
                 dat = fast_reader_rdr.read(table)
                 _read_trace.append({'kwargs': fast_kwargs,
-                                    'Reader': fast_reader.__class__,
+                                    'Reader': fast_reader_rdr.__class__,
                                     'status': 'Success with fast reader (no guessing)'})
-            except (core.ParameterError, cparser.CParserError) as e:
+            except (core.ParameterError, cparser.CParserError) as err:
                 # special testing value to avoid falling back on the slow reader
                 if fast_reader['enable'] == 'force':
-                    raise e
+                    raise core.InconsistentTableError(
+                        'fast reader {} exception: {}'
+                        .format(fast_reader_rdr.__class__, err))
                 # If the fast reader doesn't work, try the slow version
                 dat = reader.read(table)
                 _read_trace.append({'kwargs': new_kwargs,

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -642,16 +642,22 @@ def _read_in_chunks(table, **kwargs):
     if chunk_generator:
         return _read_in_chunks_generator(table, chunk_size, **kwargs)
 
-    # TO DO: stack more efficiently (both in speed and memory)
-    # by extending columns individually in a single output table.
-    tbls = list(_read_in_chunks_generator(table, chunk_size, **kwargs))
+    tbl_chunks = _read_in_chunks_generator(table, chunk_size, **kwargs)
+    tbl0 = next(tbl_chunks)
+    # Numpy won't allow resizing the original so make a copy here.
+    out_cols = [col.data.copy() for col in tbl0.itercols()]
 
-    # No meta after first table
-    if len(tbls) > 1:
-        for tbl in tbls[1:]:
-            tbl.meta.clear()
+    for tbl in tbl_chunks:
+        col_len = len(tbl)
+        for out_col, col, name in zip(out_cols, tbl.itercols(), tbl.colnames):
+            out_col.resize(len(out_col) + col_len, refcheck=False)
+            out_col[-col_len:] = col.data
 
-    return vstack(tbls)
+    # Make final table from numpy arrays
+    out = tbl0.__class__(out_cols, names=tbl0.colnames, meta=tbl0.meta,
+                         copy=False)
+
+    return out
 
 
 def _read_in_chunks_generator(table, chunk_size, **kwargs):

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -250,7 +250,7 @@ def read(table, guess=None, **kwargs):
             If supplied with a value > 0 then read the table in chunks of
             approximately ``chunk_size`` bytes. Default is reading table in one pass.
         chunk_generator : bool
-            If True and ``chunk_size > 0`` then return a generator that returns a
+            If True and ``chunk_size > 0`` then return an iterator that returns a
             table for each chunk.  The default is to return a single stacked table
             for all the chunks.
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -702,7 +702,7 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
 
             # Step backwards from last character in chunk and find first newline
             for idx in range(len(chunk) - 1, -1, -1):
-                if chunk[idx] == '\n':
+                if final_chunk or chunk[idx] == '\n':
                     break
             else:
                 raise ValueError('no newline found in chunk (chunk_size too small?)')

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -699,7 +699,7 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
 
         while True:
             chunk = fh.read(chunk_size)
-            # Got fewer chars than requested, must be end of fie
+            # Got fewer chars than requested, must be end of file
             final_chunk = len(chunk) < chunk_size
 
             # If this is the last chunk and there is only whitespace then break

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -337,6 +337,7 @@ def read(table, guess=None, **kwargs):
             try:
                 dat = fast_reader.read(table)
                 _read_trace.append({'kwargs': fast_kwargs,
+                                    'Reader': fast_reader.__class__,
                                     'status': 'Success with fast reader (no guessing)'})
             except (core.ParameterError, cparser.CParserError) as e:
                 # special testing value to avoid falling back on the slow reader
@@ -345,11 +346,13 @@ def read(table, guess=None, **kwargs):
                 # If the fast reader doesn't work, try the slow version
                 dat = reader.read(table)
                 _read_trace.append({'kwargs': new_kwargs,
+                                    'Reader': reader.__class__,
                                     'status': 'Success with slow reader after failing'
                                              ' with fast (no guessing)'})
         else:
             dat = reader.read(table)
             _read_trace.append({'kwargs': new_kwargs,
+                                'Reader': reader.__class__,
                                 'status': 'Success with specified Reader class '
                                           '(no guessing)'})
 
@@ -469,7 +472,9 @@ def _guess(table, read_kwargs, format, fast_reader):
             reader = get_reader(**guess_kwargs)
             reader.guessing = True
             dat = reader.read(table)
-            _read_trace.append({'kwargs': guess_kwargs, 'status': 'Success (guessing)',
+            _read_trace.append({'kwargs': guess_kwargs,
+                                'Reader': reader.__class__,
+                                'status': 'Success (guessing)',
                                 'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
             return dat
 
@@ -485,6 +490,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             reader = get_reader(**read_kwargs)
             dat = reader.read(table)
             _read_trace.append({'kwargs': read_kwargs,
+                                'Reader': reader.__class__,
                                 'status': 'Success with original kwargs without strict_names '
                                           '(guessing)'})
             return dat

--- a/docs/io/ascii/fast_ascii_io.rst
+++ b/docs/io/ascii/fast_ascii_io.rst
@@ -67,12 +67,13 @@ These parameters are:
 .. _fast_conversion_opts:
 
 Parallel and fast conversion options
-====================================
+------------------------------------
 In addition to ``True`` and ``False``, the parameter ``fast_reader`` can also
 be a dict specifying any of three additional parameters, ``parallel``,
 ``use_fast_converter`` and ``exponent_style``. For example::
 
-   >>> ascii.read('data.txt', format='basic', fast_reader={'parallel': True, 'use_fast_converter': True}) # doctest: +SKIP
+   >>> ascii.read('data.txt', format='basic',
+   ...            fast_reader={'parallel': True, 'use_fast_converter': True}) # doctest: +SKIP
 
 These options allow for even faster table reading when enabled, but both are
 disabled by default because they come with some caveats.
@@ -92,21 +93,8 @@ The special setting ``'fortran'`` enables auto-detection of any valid
 exponent character under Fortran notation.
 For details see the section on :ref:`fortran_style_exponents`.
 
-Writing
-=======
-The fast engine supports the same functionality as the ordinary writing engine
-and is generally about 2 to 4 times faster than the ordinary engine. An IPython
-notebook testing the relative performance of the fast writer against the
-ordinary writing system and the data analysis library `Pandas
-<http://pandas.pydata.org/>`__ is available `here <http://nbviewer.jupyter.org/github/astropy/astropy-notebooks/blob/master/io/ascii/ascii_write_bench.ipynb>`__.
-The speed advantage of the faster engine is greatest for integer data and least
-for floating-point data; the fast engine is around 3.6 times faster for a
-sample file including a mixture of floating-point, integer, and text data.
-Also note that stripping string values slows down the writing process, so
-specifying ``strip_whitespace=False`` can improve performance.
-
 Fast converter
-==============
+--------------
 Input floating-point values should ideally be converted to the
 nearest possible floating-point approximation; that is, the conversion
 should be correct within half of the distance between the two closest
@@ -131,6 +119,24 @@ within 0.5 ULP and about 90% within 1.0 ULP. Another notebook analyzing
 the fast converter's behavior with extreme values (such as subnormals
 and values out of the range of floats) is available `here
 <http://nbviewer.jupyter.org/github/astropy/astropy-notebooks/blob/master/io/ascii/test_converter.ipynb>`__.
+
+Reading large tables
+--------------------
+For reading very large tables using the fast reader see the section on
+:ref:`chunk_reading`.
+
+Writing
+=======
+The fast engine supports the same functionality as the ordinary writing engine
+and is generally about 2 to 4 times faster than the ordinary engine. An IPython
+notebook testing the relative performance of the fast writer against the
+ordinary writing system and the data analysis library `Pandas
+<http://pandas.pydata.org/>`__ is available `here <http://nbviewer.ipython.org/github/astropy/astropy-notebooks/blob/master/io/ascii/ascii_write_bench.ipynb>`__.
+The speed advantage of the faster engine is greatest for integer data and least
+for floating-point data; the fast engine is around 3.6 times faster for a
+sample file including a mixture of floating-point, integer, and text data.
+Also note that stripping string values slows down the writing process, so
+specifying ``strip_whitespace=False`` can improve performance.
 
 Speed gains
 ===========

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -96,6 +96,8 @@ disable the fast engine::
 
    >>> data = ascii.read(lines, format='csv', fast_reader=False)
 
+For reading very large tables see the section on :ref:`chunk_reading`.
+
 .. Note::
 
    Reading a table which contains unicode characters is supported; if you need

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -564,3 +564,75 @@ in a function::
    # Create an RDB reader and override the splitter.process_val function
    rdb_reader = astropy.io.ascii.get_reader(Reader=astropy.io.ascii.Rdb)
    rdb_reader.data.splitter.process_val = process_val
+
+.. _chunk_reading:
+
+Reading large tables in chunks
+==============================
+
+The default process for reading ASCII tables is not memory efficient and may
+temporarily require much more memory than the size of the file (up to a factor
+of 5 to 10).  In cases where the temporary memory requirement exceeds available
+memory this can cause significant slowdown when disk cache gets used.
+
+In this situation there is a way to read the table in smaller chunks which are
+limited in size.  There are two possible ways to do this:
+
+- Read the table in chunks and aggregate the final table along the way.  This
+  uses only somewhat more memory than the final table requires.
+- Use a Python generator function to return a `~astropy.table.Table` object for
+  each chunk of the input table.  This allows for scanning through arbitrarily
+  large tables since it never returns the final aggregate table.
+
+The chunk reading functionality is most useful for very large tables, so this is
+available only for the :ref:`fast_ascii_io` readers.  The following formats are
+supported: ``tab``, ``csv``, ``no_header``, ``rdb``, and ``basic``.
+
+In order to read a table in chunks one must provide the ``fast_reader`` keyword
+argument with a ``dict`` that includes the ``chunk_size`` key with the value
+being the approximate size (in bytes) of each chunk of the input table to read.
+In addition, if one provides a ``chunk_generator`` key which is set to
+``True``, then instead of returning a single table for the whole input it
+returns an iterator that provides a table for each chunk of the input.
+
+**Example**: Reading an entire table while limiting peak memory usage.
+::
+
+  # Read a large CSV table in 100 Mb chunks.
+
+  tbl = ascii.read('large_table.csv', format='csv', guess=False,
+                   fast_reader={'chunk_size': 100 * 1000000})
+
+**Example**: Reading the table in chunks with an iterator.
+
+Here we iterate over a CSV table and select all rows where the ``Vmag`` column is
+less than 8.0 (e.g. all stars in table brighter than 8.0 mag).  We collect all
+these sub-tables and then stack them at the end.
+::
+
+  from astropy.table import vstack
+
+  # tbls is an iterator over the chunks (no actual reading done yet)
+  tbls = ascii.read('large_table.csv', format='csv', guess=False,
+                    fast_reader={'chunk_size': 100 * 1000000,
+                                 'chunk_generator': True})
+
+  out_tbls = []
+
+  # At this point the file is actually read in chunks.
+  for tbl in tbls:
+      bright = tbl['Vmag'] < 8.0
+      if np.count_nonzero(bright):
+          out_tbls.append(tbl[bright])
+
+  out_tbl = vstack(out_tbls)
+
+.. Note:: **Performance**
+
+  Specifying the ``format`` explicitly and using ``guess=False`` is a good idea
+  for large tables.  This prevent unneccesary guessing in the typical case
+  where the format is already known.
+
+  The ``chunk_size`` should generally be set to the largest value that is 
+  reasonable given available system memory.  There is overhead associated
+  with processing each chunk, so the fewer chunks the better.

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -586,7 +586,10 @@ limited in size.  There are two possible ways to do this:
 
 The chunk reading functionality is most useful for very large tables, so this is
 available only for the :ref:`fast_ascii_io` readers.  The following formats are
-supported: ``tab``, ``csv``, ``no_header``, ``rdb``, and ``basic``.
+supported: ``tab``, ``csv``, ``no_header``, ``rdb``, and ``basic``.  The
+``commented_header`` format is not directly supported, but as a workaround one
+can read using the ``no_header`` format and explicitly supply the column names
+using the ``names`` argument.
 
 In order to read a table in chunks one must provide the ``fast_reader`` keyword
 argument with a ``dict`` that includes the ``chunk_size`` key with the value


### PR DESCRIPTION
Fixes #3334 

This revives an old effort to be able to read large ASCII table files in smaller chunks.  This implementation deals strictly with the fast (C/Cython-based) routines, since that would be the preferred way to read most large ASCII tables.  As such it is a bit intricate.  However, the good news is that all the formats supported by the fast reader, except for `commented_header`, are supported for chunked reading.

This implementation allows for reading a big file in chunks and then returning a single stacked table, OR getting the table chunks one at a time via a generator.  The latter mode could be useful for scan-processing a large table where you don't actually need to keep everything in memory.

To do:

- [x] Fix a Py3 test failure that looks like a 4-byte unicode vs. bytes problem
- [x] Docs
- [x] More tests
- [x] Squash intermediate commits that include an earlier idea which didn't pan out
- [x] ~Change the `table.vstack` of the chunked tables into something more efficient.  `vstack` has a lot of general purpose checking and machinery that isn't needed here.~  LEAVE this for now.  Doing this in a memory efficient way is actually a bit tricky because `Column` cannot be resized in place.

For this PR punted on getting `commented_header` to work, but suggest a work-around in the docs.  The way this was implemented in the fast reader is special-case from the rest that is a bit orthogonal to what I'm doing here so I am not immediately sure of a solution.