### PR TITLE
Fix bug stacking unicode columns: width grows by factor of 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix a bug when combining unicode columns via join or vstack.  The character
+  width of the output column was a factor of 4 larger than needed. [#6459]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -26,6 +26,7 @@ from ..units import Unit, Quantity
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, dtype_info_name
+from ..utils.misc import dtype_bits_or_chars
 from ..extern.six.moves import range
 from . import groups
 from . import pprint
@@ -886,7 +887,7 @@ class Column(BaseColumn):
 
         # Parse the array-protocol typestring (e.g. '|U15') of self.dtype which
         # has the character repeat count on the right side.
-        self_str_len = int(re.search(r'(\d+)$', self.dtype.str).group(1))
+        self_str_len = dtype_bits_or_chars(self.dtype)
 
         if value_str_len > self_str_len:
             warnings.warn('truncated right side string(s) longer than {} '

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1108,6 +1108,19 @@ def test_vstack_bytes(operation_table_type):
     assert t2['a'].itemsize == 1
 
 
+def test_vstack_unicode():
+    """
+    Test for problem related to issue #5617 when vstack'ing *unicode*
+    columns.  In this case the character size gets multiplied by 4.
+    """
+    t = table.Table([[u'a']], names=['a'])
+    assert t['a'].itemsize == 4  # 4-byte / char for U dtype
+
+    t2 = table.vstack([t, t])
+    assert len(t2) == 2
+    assert t2['a'].itemsize == 4
+
+
 def test_get_out_class():
     c = table.Column([1, 2])
     mc = table.MaskedColumn([1, 2])

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -4,6 +4,7 @@ This module contains helper functions and classes for handling metadata.
 """
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+
 from ..extern import six
 from ..utils import wraps
 
@@ -15,6 +16,7 @@ from copy import deepcopy
 
 import numpy as np
 from ..utils.exceptions import AstropyWarning
+from ..utils.misc import dtype_bits_or_chars
 
 
 __all__ = ['MergeConflictError', 'MergeConflictWarning', 'MERGE_STRATEGIES',
@@ -65,7 +67,8 @@ def common_dtype(arrs):
     # values or the final arr_common = .. step is unpredictable.
     for i, arr in enumerate(arrs):
         if arr.dtype.kind in ('S', 'U'):
-            arrs[i] = [(u'0' if arr.dtype.kind == 'U' else b'0') * arr.itemsize]
+            arrs[i] = [(u'0' if arr.dtype.kind == 'U' else b'0') *
+                       dtype_bits_or_chars(arr.dtype)]
 
     arr_common = np.array([arr[0] for arr in arrs])
     return arr_common.dtype.str

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -21,6 +21,7 @@ import traceback
 import unicodedata
 import locale
 import threading
+import re
 
 from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
@@ -33,7 +34,8 @@ __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
            'find_api_page', 'is_path_hidden', 'walk_skip_hidden',
            'JsonCustomEncoder', 'indent', 'InheritDocstrings',
            'OrderedDescriptor', 'OrderedDescriptorContainer', 'set_locale',
-           'ShapedLikeNDArray', 'check_broadcast', 'IncompatibleShapeError']
+           'ShapedLikeNDArray', 'check_broadcast', 'IncompatibleShapeError',
+           'dtype_bits_or_chars']
 
 
 def isiterable(obj):
@@ -1104,3 +1106,25 @@ def check_broadcast(*shapes):
         full_shape.append(max_dim)
 
     return tuple(full_shape[::-1])
+
+
+def dtype_bits_or_chars(dtype):
+    """
+    Parse the number out of a dtype.str value like '<U5' or '<f8'.
+
+    See #5819 for discussion on the need for this function for getting
+    the number of characters corresponding to a string dtype.
+
+    Parameters
+    ----------
+    dtype : numpy dtype object
+        Input dtype
+
+    Returns
+    -------
+    bits_or_chars : int or None
+        Bits (for numeric types) or characters (for string types)
+    """
+    match = re.search(r'(\d+)$', dtype.str)
+    out = int(match.group(1)) if match else None
+    return out

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -3,8 +3,10 @@ import abc
 from collections import OrderedDict
 
 import pytest
+import numpy as np
 
 from ..metadata import MetaData, MergeConflictError, merge, enable_merge_strategies
+from ..metadata import common_dtype
 from ...utils import metadata
 from ...io import fits
 
@@ -83,9 +85,6 @@ def test_metadata_merging_conflict_exception():
     data2.meta['somekey'] = {'x': 1, 'y': 999}
     with pytest.raises(MergeConflictError):
         merge(data1.meta, data2.meta, metadata_conflicts='error')
-
-
-import numpy as np
 
 
 def test_metadata_merging():
@@ -189,3 +188,13 @@ def test_metadata_merging_new_strategy():
     assert not MergeConcatStrings.enabled
 
     metadata.MERGE_STRATEGIES = original_merge_strategies
+
+
+def test_common_dtype_string():
+    u3 = np.array([u'123'])
+    u4 = np.array([u'1234'])
+    b3 = np.array([b'123'])
+    b5 = np.array([b'12345'])
+    assert common_dtype([u3, u4]).endswith('U4')
+    assert common_dtype([b5, u4]).endswith('U5')
+    assert common_dtype([b3, b5]).endswith('S5')

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -114,3 +114,11 @@ def test_check_broadcast():
 
     with pytest.raises(ValueError):
         misc.check_broadcast((10, 1), (3,), (4, 1, 2, 3))
+
+
+def test_dtype_bits_or_chars():
+    assert misc.dtype_bits_or_chars(np.dtype(np.float64)) == 8
+    assert misc.dtype_bits_or_chars(np.dtype(object)) is None
+    assert misc.dtype_bits_or_chars(np.dtype(np.int32)) == 4
+    assert misc.dtype_bits_or_chars(np.array(b'12345').dtype) == 5
+    assert misc.dtype_bits_or_chars(np.array(u'12345').dtype) == 5


### PR DESCRIPTION
Somewhat related to #5628 and  #5819.
```
# In Py3

In [2]: t = Table([['a']])

In [3]: t
Out[3]: 
<Table length=1>
col0
str1
----
   a

In [4]: table.vstack([t, t])
Out[4]: 
<Table length=2>
col0
str4
----
   a
   a
```

This does change API ever-so-slightly by factoring out some common code into a new `utils.misc` function (`dtype_bits_or_chars`) and putting it into a common place.  But I would argue that adding a new function here should be OK for backport to 2.0 since it is just adding an obscure little function and the bug is fairly bad.