### PR TITLE
Fix broken compilation of CFITSIO with recent gcc

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -36,10 +36,11 @@ def _get_compression_extension():
                 # CFITSIO
                 cfg['extra_compile_args'].extend([
                     '-Wno-unused-variable', '-Wno-parentheses',
-                    '-Wno-uninitialized', '-Wno-format',
+                    '-Wno-uninitialized', '-Wno-format-overflow',
                     '-Wno-strict-prototypes', '-Wno-unused', '-Wno-comments',
                     '-Wno-switch', '-Wno-strict-aliasing', '-Wno-return-type',
-                    '-Wno-address'
+                    '-Wno-address', '-Wno-unused-result',
+                    '-Wno-misleading-indentation'
                 ])
 
         cfitsio_path = os.path.join('cextern', 'cfitsio')


### PR DESCRIPTION
Currently, in compiling cfitsio, a number of warnings are turned off so that there isn't too much junk being produced about which we have no control (really, these should be passed on to upstream...). But on newer versions of gcc, `-Werror=format-security` (which is done by default) raises an error if one also defines `-Wformat`. So, adjusted the additional compilation flags for CFITSIO to exclude the specific format problem that is encountered: `-Wno-format-overflow`. Also added `-Wno-unused-result` and `-Wno-misleading-indentation` to get rid of additional warning messages.

Now what I don't know is whether this breaks older versions of gcc...

EDIT: this particular problem occurs on gcc 6.4.0; on gcc 7.1, contrary to what is stated below, it works fine, as noted by @saimn: https://github.com/astropy/astropy/pull/6474#issuecomment-325579049