### PR TITLE
Added new function celestial_frame_to_wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,10 @@ astropy.vo
 astropy.wcs
 ^^^^^^^^^^^
 
+- Added a new function ``celestial_frame_to_wcs`` to convert from
+  coordinate frames to WCS (the opposite of what ``wcs_to_celestial_frame``
+  currently does. [#6481]
+
 API Changes
 -----------
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -282,6 +282,8 @@ def test_celestial_frame_to_wcs():
     assert tuple(mywcs.wcs.ctype) == ('RA---TAN', 'DEC--TAN')
     assert mywcs.wcs.radesys == 'ICRS'
     assert np.isnan(mywcs.wcs.equinox)
+    assert mywcs.wcs.lonpole == 180
+    assert mywcs.wcs.latpole == 0
 
     frame = FK5(equinox='J1987')
     mywcs = celestial_frame_to_wcs(frame)

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -232,14 +232,42 @@ def celestial_frame_to_wcs(frame, projection='TAN'):
     wcs : :class:`~astropy.wcs.WCS` instance
         The corresponding WCS object
 
+    Examples
+    --------
+
+    ::
+
+        >>> from astropy.wcs.utils import celestial_frame_to_wcs
+        >>> from astropy.coordinates import FK5
+        >>> frame = FK5(equinox='J2010')
+        >>> wcs = celestial_frame_to_wcs(frame)
+        >>> wcs.to_header()
+        WCSAXES =                    2 / Number of coordinate axes
+        CRPIX1  =                  0.0 / Pixel coordinate of reference point
+        CRPIX2  =                  0.0 / Pixel coordinate of reference point
+        CDELT1  =                  1.0 / [deg] Coordinate increment at reference point
+        CDELT2  =                  1.0 / [deg] Coordinate increment at reference point
+        CUNIT1  = 'deg'                / Units of coordinate increment and value
+        CUNIT2  = 'deg'                / Units of coordinate increment and value
+        CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection
+        CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection
+        CRVAL1  =                  0.0 / [deg] Coordinate value at reference point
+        CRVAL2  =                  0.0 / [deg] Coordinate value at reference point
+        LONPOLE =                180.0 / [deg] Native longitude of celestial pole
+        LATPOLE =                  0.0 / [deg] Native latitude of celestial pole
+        RADESYS = 'FK5'                / Equatorial coordinate system
+        EQUINOX =               2010.0 / [yr] Equinox of equatorial coordinates
+
+
     Notes
     -----
 
     To extend this function to frames not defined in astropy.coordinates, you
-    can write your own function which should take a frame instance and a
-    projection (given as a string) and should return either a WCS instance, or
-    `None` if the WCS could not be determined. You can register this function
-    temporarily with::
+    can write your own function which should take a
+    :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass
+    instance and a projection (given as a string) and should return either a WCS
+    instance, or `None` if the WCS could not be determined. You can register
+    this function temporarily with::
 
         >>> from astropy.wcs.utils import celestial_frame_to_wcs, custom_frame_to_wcs_mappings
         >>> with custom_frame_to_wcs_mappings(my_function):

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -134,6 +134,9 @@ def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
     wcs.wcs.ctype[0] = xcoord + '-' + projection
     wcs.wcs.ctype[1] = ycoord + '-' + projection
 
+    # Make sure that e.g. LONPOLE and other parameters are set
+    wcs.wcs.set()
+
     return wcs
 
 

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from .. import units as u
 from ..extern.six.moves import range
-from ..time import Time
 
 from .wcs import WCS, WCSSUB_CELESTIAL
 
@@ -49,6 +48,9 @@ def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.coordinates here to avoid circular imports
     from ..coordinates import FK4, FK4NoETerms, FK5, ICRS, Galactic
+
+    # Import astropy.time here otherwise setup.py fails before extensions are compiled
+    from ..time import Time
 
     # Keep only the celestial part of the axes
     wcs = wcs.sub([WCSSUB_CELESTIAL])


### PR DESCRIPTION
This is to convert astropy.coordinate frames to WCS objects with CTYPE (and optionally other parameters) set. This mirrors what is done in ``wcs_to_celestial_frame`` and will be needed for upcoming functionality in the reproject package.