### PR TITLE
Add support for GZIP_2 compression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -295,6 +295,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Support the ``GZIP_2`` FITS image compression algorithm as claimed
+  in docs. [#6486]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -734,9 +734,9 @@ class CompImageHDU(BinTableHDU):
             input image header then the default name 'COMPRESSED_IMAGE' is used
 
         compression_type : str, optional
-            compression algorithm 'RICE_1', 'PLIO_1', 'GZIP_1', 'HCOMPRESS_1';
-            if this value is `None`, use value already in the header; if no
-            value already in the header, use 'RICE_1'
+            compression algorithm 'RICE_1', 'PLIO_1', 'GZIP_1', 'GZIP_2',
+            'HCOMPRESS_1'; if this value is `None`, use value already in the
+            header; if no value already in the header, use 'RICE_1'
 
         tile_size : sequence of int, optional
             compression tile sizes as a list; if this value is `None`, use
@@ -805,7 +805,7 @@ class CompImageHDU(BinTableHDU):
 
         # Set the compression type in the table header.
         if compression_type:
-            if compression_type not in ['RICE_1', 'GZIP_1', 'PLIO_1',
+            if compression_type not in ['RICE_1', 'GZIP_1', 'GZIP_2', 'PLIO_1',
                                         'HCOMPRESS_1']:
                 warnings.warn('Unknown compression type provided.  Default '
                               '({}) compression used.'.format(

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -222,6 +222,8 @@ int compress_type_from_string(char* zcmptype) {
         return RICE_1;
     } else if (0 == strcmp(zcmptype, "GZIP_1")) {
         return GZIP_1;
+    } else if (0 == strcmp(zcmptype, "GZIP_2")) {
+        return GZIP_2;
     } else if (0 == strcmp(zcmptype, "PLIO_1")) {
         return PLIO_1;
     } else if (0 == strcmp(zcmptype, "HCOMPRESS_1")) {

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1150,6 +1150,7 @@ class TestCompressedImage(FitsTestCase):
         ('data', 'compression_type', 'quantize_level', 'byte_order'),
         sum([[(np.zeros((2, 10, 10), dtype=np.float32), 'RICE_1', 16, bo),
               (np.zeros((2, 10, 10), dtype=np.float32), 'GZIP_1', -0.01, bo),
+              (np.zeros((2, 10, 10), dtype=np.float32), 'GZIP_2', -0.01, bo),
               (np.zeros((100, 100)) + 1, 'HCOMPRESS_1', 16, bo)]
              for bo in ('<', '>')], []))
     def test_comp_image(self, data, compression_type, quantize_level,


### PR DESCRIPTION
It's already supported in cfitsio, but had been overlooked in the
interface.