### PR TITLE
Only keep Header values from the Primary that are not present in extension.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -314,6 +314,10 @@ astropy.nddata
 
 - Suppress errors during WCS creation in CCDData.read(). [#6500]
 
+- Fixed a problem with ``CCDData.read`` when the extension wasn't given and the
+  primary HDU contained no ``data`` but another HDU did. In that case the header
+  were not correctly combined. [#6489]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -504,7 +504,11 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
             for i in range(len(hdus)):
                 if hdus.fileinfo(i)['datSpan'] > 0:
                     hdu = i
-                    hdr = hdr + hdus[hdu].header
+                    comb_hdr = hdus[hdu].header.copy()
+                    # Add header values from the primary header that aren't
+                    # present in the extension header.
+                    comb_hdr.extend(hdr, unique=True)
+                    hdr = comb_hdr
                     log.info("first HDU with data is extension "
                              "{0}.".format(hdu))
                     break

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -149,17 +149,18 @@ def test_initialize_from_fits_with_ADU_in_header(tmpdir):
 
 def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     fake_img = np.random.random(size=(100, 100))
-    new_hdul = fits.HDUList()
     hdu1 = fits.PrimaryHDU()
     hdu2 = fits.ImageHDU(fake_img)
     hdus = fits.HDUList([hdu1, hdu2])
     filename = tmpdir.join('afile.fits').strpath
     hdus.writeto(filename)
-    ccd = CCDData.read(filename, unit='adu')
+    with catch_warnings(FITSFixedWarning) as w:
+        ccd = CCDData.read(filename, unit='adu')
+    assert len(w) == 0
     # ccd should pick up the unit adu from the fits header...did it?
     np.testing.assert_array_equal(ccd.data, fake_img)
     # check that the header is the combined header
-    assert hdu1.header + hdu2.header == ccd.header
+    assert hdu2.header + hdu1.header == ccd.header
 
 
 def test_initialize_from_fits_with_extension(tmpdir):


### PR DESCRIPTION
In case a CCDData is read from a file and the primary HDU does not contain an image it will search for the first extension with data. In that case the Header is combined, but previously useful values like NAXIS, etc. were discarded in that operation.