### PR TITLE
wcs: fix for issue 6490

### DIFF
--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -321,7 +321,7 @@ def test_celestial_frame_to_wcs():
     mywcs.wcs.crval = [100, -30]
     mywcs.wcs.set()
     assert_allclose((mywcs.wcs.lonpole, mywcs.wcs.latpole), (180, 60))
-    
+
 
 def test_celestial_frame_to_wcs_extend():
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -279,6 +279,7 @@ def test_celestial_frame_to_wcs():
 
     frame = ICRS()
     mywcs = celestial_frame_to_wcs(frame)
+    mywcs.wcs.set()
     assert tuple(mywcs.wcs.ctype) == ('RA---TAN', 'DEC--TAN')
     assert mywcs.wcs.radesys == 'ICRS'
     assert np.isnan(mywcs.wcs.equinox)
@@ -315,6 +316,12 @@ def test_celestial_frame_to_wcs():
     assert mywcs.wcs.radesys == ''
     assert np.isnan(mywcs.wcs.equinox)
 
+    frame = Galactic()
+    mywcs = celestial_frame_to_wcs(frame, projection='CAR')
+    mywcs.wcs.crval = [100, -30]
+    mywcs.wcs.set()
+    assert_allclose((mywcs.wcs.lonpole, mywcs.wcs.latpole), (180, 60))
+    
 
 def test_celestial_frame_to_wcs_extend():
 

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -131,11 +131,7 @@ def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
     else:
         return None
 
-    wcs.wcs.ctype[0] = xcoord + '-' + projection
-    wcs.wcs.ctype[1] = ycoord + '-' + projection
-
-    # Make sure that e.g. LONPOLE and other parameters are set
-    wcs.wcs.set()
+    wcs.wcs.ctype = [xcoord + '-' + projection, ycoord + '-' + projection]
 
     return wcs
 


### PR DESCRIPTION
Assigning individual members of `ctype` is not supported since it doesn't set the underlying C struct. In addition multiple calls to wcs.set() can fail to reset the struct in some cases. It's best to leave it to the wcs methods to do so.

EDIT: Fix #6490 