### PR TITLE
Add option for fits table reader to read a subset of columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,11 @@ astropy.table
 - Added support for reading and writing ``astropy.time.Time`` Table columns
   to and from FITS tables, to the extent supported by the FITS standard. [#6176]
 
+- The FITS table reader now has an ``include_columns`` argument that allows
+  reading of a subset of columns from a FITS table into an astropy Table,
+  improving performance when small numbers of columns need to be extracted from
+  a FITS table with many more columns. [#6503]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -155,6 +155,14 @@ class TestSingleTable(object):
         t = Table.read(hdu)
         assert equal_data(t, self.data)
 
+    def test_read_include_columns(self):
+        include_columns = ['a', 'c']
+        hdu = BinTableHDU(self.data)
+
+        t = Table.read(hdu, include_columns=include_columns)
+        assert len(t.columns) == 2
+        assert np.all(np.in1d(t.colnames, include_columns))
+
 
 class TestMultipleHDU(object):
 


### PR DESCRIPTION
This PR adds a keyword to the `io.fits` reader for fits tables that allows the user to ask for the resulting `Table` to have only a *subset* of the columns in the file

Of course, it's always possible to do something like this:
```
tab = Table.read('filename.fits')
newtab = tab['col1', 'col5', 'col20']
```
but testing revealed that it can be quite a bit faster to copy over *only* the desired columns, at least if it's a much smaller subset that's desired then in the whole tables.  And for big tables this performance hit can really matter a lot.

cc @taldcroft 

BTW, this idea was suggested by @yymao (so feedback from him on whether this satisfies what he was thinking would be helpful!)