### PR TITLE
Switching to twine PyPI upload for affiliated packages

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -613,13 +613,12 @@ by ``CHANGES.md`` in the instructions.
    all pass, you can proceed on.
 
 #. If you did the previous step, do ``git clean -fxd`` again to remove anything
-   you made there. Then either release with::
+   you made there. Then you can upload to PyPI via ``twine``::
 
-        python setup.py register build sdist --format=gztar upload
+        twine upload dist/*
 
-   or, if you are concerned about security, you can also use ``twine`` as described
-   in `these <https://packaging.python.org/en/latest/tutorial.html#uploading-your-project-to-pypi>`_
-   instructions. Either way, check that the entry on PyPI is correct, and that
+   as described in `these <https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi>`_
+   instructions. Check that the entry on PyPI is correct, and that
    the tarfile is present.
 
 #. Go back to the master branch and push your changes to github::


### PR DESCRIPTION
This fix closes #6506. This update reflects the recent change to PyPI, which expects uploads via `twine` rather than via the `python setup.py ...upload` command as before. 

EDIT: xref #5120