### PR TITLE
Fix ecliptic transformations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -427,6 +427,9 @@ astropy.coordinates
 - Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6699]
 
 - Improved accuracy of radial velocity corrections in ``SkyCoord.radial_velocity_correction```. [#6861]
+- The precision of ecliptic frames is now much better, after removing the
+  nutation from the rotation and fixing the computation of the position of the
+  Sun. [#6508]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -427,6 +427,7 @@ astropy.coordinates
 - Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6699]
 
 - Improved accuracy of radial velocity corrections in ``SkyCoord.radial_velocity_correction```. [#6861]
+
 - The precision of ecliptic frames is now much better, after removing the
   nutation from the rotation and fixing the computation of the position of the
   Sun. [#6508]

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -5,7 +5,7 @@ from ... import units as u
 from .. import representation as r
 from ..baseframe import BaseCoordinateFrame, RepresentationMapping
 from ..attributes import TimeAttribute
-from .utils import EQUINOX_J2000
+from .utils import EQUINOX_J2000, DEFAULT_OBSTIME
 
 __all__ = ['GeocentricTrueEcliptic', 'BarycentricTrueEcliptic',
            'HeliocentricTrueEcliptic', 'BaseEclipticFrame']
@@ -170,6 +170,7 @@ class HeliocentricTrueEcliptic(BaseEclipticFrame):
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
+    obstime = TimeAttribute(default=DEFAULT_OBSTIME)
 
 
 HeliocentricTrueEcliptic.__doc__ = HeliocentricTrueEcliptic.__doc__.format(

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -20,6 +20,13 @@ from ..errors import UnitsError
 
 
 def _ecliptic_rotation_matrix(equinox):
+    # This code calls pmat06 from ERFA, which retrieves the precession
+    # matrix (including frame bias) according to the IAU 2006 model, but
+    # leaves out the nutation. This matches what ERFA does in the ecm06
+    # function and also brings the results closer to what other libraries
+    # give (see https://github.com/astropy/astropy/pull/6508). However,
+    # notice that this makes the name "TrueEcliptic" misleading, and might
+    # be changed in the future (discussion in the same pull request)
     jd1, jd2 = get_jd12(equinox, 'tt')
     rbp = erfa.pmat06(jd1, jd2)
     obl = erfa.obl06(jd1, jd2)*u.radian

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -21,9 +21,9 @@ from ..errors import UnitsError
 
 def _ecliptic_rotation_matrix(equinox):
     jd1, jd2 = get_jd12(equinox, 'tt')
-    rnpb = erfa.pnm06a(jd1, jd2)
+    rbp = erfa.pmat06(jd1, jd2)
     obl = erfa.obl06(jd1, jd2)*u.radian
-    return matrix_product(rotation_matrix(obl, 'x'), rnpb)
+    return matrix_product(rotation_matrix(obl, 'x'), rbp)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference,

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -74,10 +74,10 @@ def icrs_to_helioecliptic(from_coo, to_frame):
     # get barycentric sun coordinate
     # this goes here to avoid circular import errors
     from ..solar_system import get_body_barycentric
-    bary_sun_pos = get_body_barycentric('sun', to_frame.equinox)
+    bary_sun_pos = get_body_barycentric('sun', to_frame.obstime)
 
     # offset to heliocentric
-    heliocart = from_coo.cartesian + bary_sun_pos
+    heliocart = from_coo.cartesian - bary_sun_pos
 
     # now compute the matrix to precess to the right orientation
     rmat = _ecliptic_rotation_matrix(to_frame.equinox)
@@ -103,7 +103,7 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     from ..solar_system import get_body_barycentric
 
     # get barycentric sun coordinate
-    bary_sun_pos = get_body_barycentric('sun', from_coo.equinox)
+    bary_sun_pos = get_body_barycentric('sun', from_coo.obstime)
 
-    newrepr = intermed_repr - bary_sun_pos
+    newrepr = intermed_repr + bary_sun_pos
     return to_frame.realize_frame(newrepr)

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -24,7 +24,6 @@ def test_against_pytpm_doc_example():
                                         equinox='J2000')
     astropy_out = fk5_in.transform_to(pytpm_out)
 
-    # we check w/i 1 arcmin because there are some subtle differences in pyTPM's ecl definition
     assert pytpm_out.separation(astropy_out) < (1*u.arcsec)
 
 

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -25,7 +25,7 @@ def test_against_pytpm_doc_example():
     astropy_out = fk5_in.transform_to(pytpm_out)
 
     # we check w/i 1 arcmin because there are some subtle differences in pyTPM's ecl definition
-    assert pytpm_out.separation(astropy_out) < (1*u.arcmin)
+    assert pytpm_out.separation(astropy_out) < (1*u.arcsec)
 
 
 def test_ecliptic_heliobary():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -49,13 +49,13 @@ def test_regression_5085():
                                  lon=longitudes,
                                  distance=distances, equinox=times)
     # expected result
-    ras = Longitude([310.50095387, 314.67109863, 319.56507471]*u.deg)
-    decs = Latitude([-18.25190707, -17.1556641, -15.71616651]*u.deg)
-    distances = u.Quantity([1.78309902, 1.710874, 1.61326648]*u.au)
+    ras = Longitude([310.50095400, 314.67109920, 319.56507428]*u.deg)
+    decs = Latitude([-18.25190443, -17.1556676, -15.71616522]*u.deg)
+    distances = u.Quantity([1.78309901, 1.710874, 1.61326649]*u.au)
     expected_result = GCRS(ra=ras, dec=decs,
                            distance=distances, obstime="J2000").cartesian.xyz
     actual_result = coo.transform_to(GCRS(obstime="J2000")).cartesian.xyz
-    assert_quantity_allclose(expected_result, actual_result, rtol=1e-6)
+    assert_quantity_allclose(expected_result, actual_result)
 
 
 def test_regression_3920():

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -55,7 +55,7 @@ def test_regression_5085():
     expected_result = GCRS(ra=ras, dec=decs,
                            distance=distances, obstime="J2000").cartesian.xyz
     actual_result = coo.transform_to(GCRS(obstime="J2000")).cartesian.xyz
-    assert_quantity_allclose(expected_result, actual_result)
+    assert_quantity_allclose(expected_result, actual_result, rtol=1e-6)
 
 
 def test_regression_3920():

--- a/docs/coordinates/solarsystem.rst
+++ b/docs/coordinates/solarsystem.rst
@@ -75,7 +75,7 @@ to the various functions:
   >>> get_body_barycentric('moon', t, ephemeris='builtin')
   ... # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in km
-      (  1.50107516e+08, -866828.92708201, -418980.15909655)>
+      (  1.50107513e+08, -866838.51786769, -418988.57509287)>
 
 For a list of the bodies for which positions can be calculated, do:
 


### PR DESCRIPTION
SOFA/ERFA new functions for ecliptic transformations do not use the nutation matrix (see https://github.com/astropy/astropy/issues/4873#issuecomment-326528463). Adjusting the corresponding Astropy function seemed to fix the precision issues with respect to the rest of the tools.

If this is merged, I think there is no need to go for #4873.

Before/After:

![before](https://user-images.githubusercontent.com/316517/30005055-7228aeb2-90da-11e7-9ea7-204bdf49b4b0.png)

![after](https://user-images.githubusercontent.com/316517/30005057-7884fb30-90da-11e7-981e-3112599b3a6c.png)
