### PR TITLE
Remove unnecessary __getobjwrapper in sharedmethod

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -810,10 +810,6 @@ class sharedmethod(classmethod):
         this implements the Example.identify classmethod
     """
 
-    def __getobjwrapper(func):
-        return func
-
-    @__getobjwrapper
     def __get__(self, obj, objtype=None):
         if obj is None:
             mcls = type(objtype)
@@ -833,8 +829,6 @@ class sharedmethod(classmethod):
             return self._make_method(func, objtype)
         else:
             return self._make_method(self.__func__, obj)
-
-    del __getobjwrapper
 
     if not six.PY2:
         # The 'instancemethod' type of Python 2 and the method type of


### PR DESCRIPTION
This is a residual from the python 2.6 compatibility era and wasn't removed (although unnecessary) in #4486.

In it's current form it's just a no-op.