### PR TITLE
add a deepcopy method to compound models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,9 +51,8 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
 
 - Add unit support for tabular models. [#6529]
-  - Compound models now have a method deepcopy() which returns a new compound mdoels and
-    makes a copy of all child models. [#6515]
-  - A deepcopy() method was added to models. [#6515]
+
+- A ``deepcopy()`` method was added to models. [#6515]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,7 @@ astropy.modeling
 - Add unit support for tabular models. [#6529]
   - Compound models now have a method deepcopy() which returns a new compound mdoels and
     makes a copy of all child models. [#6515]
+  - A deepcopy() method was added to models. [#6515]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
 
 - Add unit support for tabular models. [#6529]
+  - Compound models now have a method deepcopy() which returns a new compound mdoels and
+    makes a copy of all child models. [#6515]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2905,7 +2905,7 @@ class _CompoundModel(Model):
         Return a deep copy of a compound model.
         """
         new_model = self.copy()
-        new_model._submodels = [model.copy() for model in self._submodels]
+        new_model._submodels = [model.deepcopy() for model in self._submodels]
         return new_model
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1551,6 +1551,14 @@ class Model(object):
 
         return copy.deepcopy(self)
 
+    def deepcopy(self):
+        """
+        Return a deep copy of this model.
+
+        """
+
+        return copy.deepcopy(self)
+
     @sharedmethod
     def rename(self, name):
         """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2892,6 +2892,14 @@ class _CompoundModel(Model):
                 units_for_data[param] = units_for_data_sub[param_sub]
         return units_for_data
 
+    def deepcopy(self):
+        """
+        Return a deep copy of a compound model.
+        """
+        new_model = self.copy()
+        new_model._submodels = [model.copy() for model in self._submodels]
+        return new_model
+
 
 def custom_model(*args, **kwargs):
     """

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -375,3 +375,13 @@ def test_custom_bounding_box_1d():
 def test_n_submodels_in_single_models():
     assert models.Gaussian1D.n_submodels() == 1
     assert models.Gaussian2D.n_submodels() == 1
+
+
+def test_compound_deepcopy():
+    model = (models.Gaussian1D(10, 2,3) | models.Shift(2)) & models.Rotation2D(21.3)
+    new_model = model.deepcopy()
+    assert id(model) != id(new_model)
+    assert id(model._submodels) != id(new_model._submodels)
+    assert id(model._submodels[0]) != id(new_model._submodels[0])
+    assert id(model._submodels[1]) != id(new_model._submodels[1])
+    assert id(model._submodels[2]) != id(new_model._submodels[2])


### PR DESCRIPTION
`Model.copy()` is a method which claims to make a deep copy of the model. This actually only works for single models.`_CompoundModel.copy()` returns a shallow copy. I have a use case where I need a deep copy of a compound model. This PR adds a method `_CompoundModel.deepcopy()` which does this. I think it's useful to keep the shallow copy of a compound model as a separate method as there may be use cases where having a shallow copy is beneficial. 

As a side note, I've looked at the other subpackages and my impression is that with few exceptions `obj.copy()` is a deep copy of the object. The `WCS` object, being one of the exceptions, has a `copy` and `deepcopy` methods. This PR is in line with the WCS behaviour.

Edit: Added a `deepcopy()` method to single models as well which is currently the same as the `copy()` method. I wonder if it's useful to have shallow copies of a single model but this will be a change in functionality.