### PR TITLE
VO table now writes out as 1.3 by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,8 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug that wrote out VO table as version 1.2 instead of 1.3. [#6521]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -157,13 +157,17 @@ def test_write_with_format():
 
     output = io.BytesIO()
     t.write(output, format='votable', tabledata_format="binary")
-    assert b'BINARY' in output.getvalue()
-    assert b'TABLEDATA' not in output.getvalue()
+    obuff = output.getvalue()
+    assert b'VOTABLE version="1.3"' in obuff
+    assert b'BINARY' in obuff
+    assert b'TABLEDATA' not in obuff
 
     output = io.BytesIO()
     t.write(output, format='votable', tabledata_format="binary2")
-    assert b'BINARY2' in output.getvalue()
-    assert b'TABLEDATA' not in output.getvalue()
+    obuff = output.getvalue()
+    assert b'VOTABLE version="1.3"' in obuff
+    assert b'BINARY2' in obuff
+    assert b'TABLEDATA' not in obuff
 
 
 def test_empty_table():

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -3239,7 +3239,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
     tests for building the rest of the structure depend on it.
     """
 
-    def __init__(self, ID=None, id=None, config=None, pos=None, version="1.2"):
+    def __init__(self, ID=None, id=None, config=None, pos=None, version="1.3"):
         if config is None:
             config = {}
         self._config = config
@@ -3256,9 +3256,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         self._groups = HomogeneousList(Group)
 
         version = str(version)
-        if version not in ("1.0", "1.1", "1.2"):
+        if version not in ("1.0", "1.1", "1.2", "1.3"):
             raise ValueError("'version' should be one of '1.0', '1.1', "
-                             "or '1.2'")
+                             "'1.2', or '1.3'")
 
         self._version = version
 


### PR DESCRIPTION
Fix #6518 

Tests passed locally for me for both these commands
`python setup.py test -P io.votable`
`python setup.py test --remote-data`