### PR TITLE
Create invalid compressed data files on the fly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,6 +340,9 @@ astropy.tests
 
 - Fixed issue running doctests with pytest>=3.2. [#6423]
 
+- Fixed issue caused by antivirus software in response to malformed compressed
+  files used for testing. [#6522]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/utils/tests/data/invalid.dat.bz2
+++ b/astropy/utils/tests/data/invalid.dat.bz2
@@ -1,1 +1,0 @@
-BZhinvalid

--- a/astropy/utils/tests/data/invalid.dat.gz
+++ b/astropy/utils/tests/data/invalid.dat.gz
@@ -1,1 +1,0 @@
-‹invalid

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -162,15 +162,18 @@ def bad_compressed(request, tmpdir):
     bz_content = b'BZhinvalid'
     gz_content = b'\x1f\x8b\x08invalid'
 
-    filename = os.path.join(tmpdir, request.param)
-    with open(filename, 'wb') as handle:
-        if filename.endswith('.bz2'):
-            contents = bz_content
-        elif filename.endswith('.gz'):
-            contents = gz_content
-        else:
-            contents = 'invalid'
-        handle.write(contents)
+    datafile = tmpdir.join(request.param)
+    filename = datafile.strpath
+
+    if filename.endswith('.bz2'):
+        contents = bz_content
+    elif filename.endswith('.gz'):
+        contents = gz_content
+    else:
+        contents = 'invalid'
+
+    datafile.write(contents, mode='wb')
+
     return filename
 
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -12,6 +12,8 @@ import os
 import sys
 import tempfile
 
+import pytest
+
 from ..data import (_get_download_cache_locs, CacheMissingWarning,
                     get_pkg_data_filename, get_readable_fileobj)
 
@@ -152,17 +154,46 @@ def test_local_data_obj(filename):
             assert f.read().rstrip() == b'CONTENT'
 
 
-@pytest.mark.parametrize(('filename'), ['invalid.dat.gz', 'invalid.dat.bz2'])
-def test_local_data_obj_invalid(filename):
+@pytest.fixture(params=['invalid.dat.bz2', 'invalid.dat.gz'])
+def bad_compressed(request, tmpdir):
+
+    # These contents have valid headers for their respective file formats, but
+    # are otherwise malformed and invalid.
+    bz_content = b'BZhinvalid'
+    gz_content = b'\x1f\x8b\x08invalid'
+
+    filename = os.path.join(tmpdir, request.param)
+    with open(filename, 'wb') as handle:
+        if filename.endswith('.bz2'):
+            contents = bz_content
+        elif filename.endswith('.gz'):
+            contents = gz_content
+        else:
+            contents = 'invalid'
+        handle.write(contents)
+    return filename
+
+
+def test_local_data_obj_invalid(bad_compressed):
     from ..data import get_pkg_data_fileobj
 
-    if (not HAS_BZ2 and 'bz2' in filename) or (not HAS_XZ and 'xz' in filename):
+    is_bz2 = bad_compressed.endswith('.bz2')
+    is_xz = bad_compressed.endswith('.xz')
+
+    # Note, since these invalid files are created on the fly in order to avoid
+    # problems with detection by antivirus software
+    # (see https://github.com/astropy/astropy/issues/6520), it is no longer
+    # possible to use ``get_pkg_data_fileobj`` to read the files. Technically,
+    # they're not local anymore: they just live in a temporary directory
+    # created by pytest. However, we can still use get_readable_fileobj for the
+    # test.
+    if (not HAS_BZ2 and is_bz2) or (not HAS_XZ and is_xz):
         with pytest.raises(ValueError) as e:
-            with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
+            with get_readable_fileobj(bad_compressed, encoding='binary') as f:
                 f.read()
         assert ' format files are not supported' in str(e)
     else:
-        with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
+        with get_readable_fileobj(bad_compressed, encoding='binary') as f:
             assert f.read().rstrip().endswith(b'invalid')
 
 


### PR DESCRIPTION
This fixes #6520. It creates invalid compressed files at test time so that the presence of such files does not cause an issue with any antivirus software that might be present on the system.

Note that this changes the nature of the test somewhat: the data files are no longer "local" in the sense being tested here. As a result, it is no longer possible to use `get_pkg_data_fileobj` to open the file. It is, however, still possible to use `get_readable_fileobj` to open the file, which seems to still address the intent of the test.