### PR TITLE
Require sphinx 1.6+ compatible sphinx-gallery

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - ipython
   - mpmath
   - pip:
-    - sphinx-gallery>=0.1.9
+    - sphinx-gallery>=0.1.11
     - jplephem

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.9 pillow --no-deps jplephem'
-               SPHINX_VERSION='>1.6'
+               PIP_DEPENDENCIES='sphinx-gallery>=0.1.11 pillow --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different


### PR DESCRIPTION
and remove SPHINX_VERSION as ci-helpers is not limiting it any more