### PR TITLE
Enable subtraction syntax for inverting and composing WCS transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,12 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Enable Matplotlib's subtraction shorthand syntax for composing and
+  inverting trasformations for the ``WCSWorld2PixelTransform`` and
+  ``WCSPixel2WorldTransform`` classes by setting ``has_inverse`` to ``True``.
+  In order to implement a unit test, also implement the equality comparison
+  operator for both classes. [#6531]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/tests/test_transforms.py
+++ b/astropy/visualization/wcsaxes/tests/test_transforms.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from matplotlib.transforms import Affine2D
+from matplotlib.transforms import Affine2D, IdentityTransform
 
 from ....wcs import WCS
 
@@ -22,6 +22,29 @@ WCS3D.wcs.cunit = ['km', 'km', 'km']
 WCS3D.wcs.crpix = [614.5, 856.5, 333]
 WCS3D.wcs.cdelt = [6.25, 6.25, 23]
 WCS3D.wcs.crval = [0., 0., 1.]
+
+
+def test_shorthand_inversion():
+    """Test that the Matplotlib subtraction shorthand for composing and
+    inverting transformations works."""
+    w1 = WCS(naxis=2)
+    w1.wcs.ctype = ['RA---TAN', 'DEC--TAN']
+    w1.wcs.crpix = [256.0, 256.0]
+    w1.wcs.cdelt = [-0.05, 0.05]
+    w1.wcs.crval = [120.0, -19.0]
+
+    w2 = WCS(naxis=2)
+    w2.wcs.ctype = ['RA---SIN', 'DEC--SIN']
+    w2.wcs.crpix = [256.0, 256.0]
+    w2.wcs.cdelt = [-0.05, 0.05]
+    w2.wcs.crval = [235.0, +23.7]
+
+    t1 = WCSWorld2PixelTransform(w1)
+    t2 = WCSWorld2PixelTransform(w2)
+
+    assert t1 - t2 == t1 + t2.inverted()
+    assert t1 - t2 != t2.inverted() + t1
+    assert t1 - t1 == IdentityTransform()
 
 
 # We add Affine2D to catch the fact that in Matplotlib, having a Composite

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -63,6 +63,8 @@ class WCSWorld2PixelTransform(CurvedTransform):
     WCS transformation from world to pixel coordinates
     """
 
+    has_inverse = True
+
     def __init__(self, wcs, slice=None):
         super().__init__()
         self.wcs = wcs
@@ -78,6 +80,10 @@ class WCSWorld2PixelTransform(CurvedTransform):
                 self.y_index = slice.index('y')
         else:
             self.slice = None
+
+    def __eq__(self, other):
+        return (isinstance(other, type(self)) and self.wcs == other.wcs
+                and self.slice == other.slice)
 
     @property
     def input_dims(self):
@@ -118,6 +124,8 @@ class WCSPixel2WorldTransform(CurvedTransform):
     WCS transformation from pixel to world coordinates
     """
 
+    has_inverse = True
+
     def __init__(self, wcs, slice=None):
         super().__init__()
         self.wcs = wcs
@@ -125,6 +133,10 @@ class WCSPixel2WorldTransform(CurvedTransform):
         if self.slice is not None:
             self.x_index = slice.index('x')
             self.y_index = slice.index('y')
+
+    def __eq__(self, other):
+        return (isinstance(other, type(self)) and self.wcs == other.wcs
+                and self.slice == other.slice)
 
     @property
     def output_dims(self):
@@ -188,6 +200,8 @@ class WCSPixel2WorldTransform(CurvedTransform):
 
 
 class CoordinateTransform(CurvedTransform):
+
+    has_inverse = True
 
     def __init__(self, input_system, output_system):
         super().__init__()


### PR DESCRIPTION
Enable the Matplotlib's subtraction shorthand syntax for composing and inverting trasformations for the `WCSWorld2PixelTransform` and `WCSPixel2WorldTransform` classes by setting `has_inverse` to `True`. In order to implement a unit test, also implement the equality comparison operator for both classes.