### PR TITLE
Fixing test after h5py upstream error message change

### DIFF
--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -492,6 +492,7 @@ def test_metadata_very_large_fails_compatibility_mode(tmpdir):
                  overwrite=True, compatibility_mode=True)
     assert len(w) == 2
 
+    # Error message slightly changed in h5py 2.7.1, thus the 2part assert
     assert str(w[1].message).startswith(
         "Attributes could not be written to the output HDF5 "
         "file: Unable to create attribute ")

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -494,7 +494,8 @@ def test_metadata_very_large_fails_compatibility_mode(tmpdir):
 
     assert str(w[1].message).startswith(
         "Attributes could not be written to the output HDF5 "
-        "file: Unable to create attribute (Object header message is too large)")
+        "file: Unable to create attribute ")
+    assert "bject header message is too large" in str(w[1].message)
 
 
 @pytest.mark.skipif('not HAS_H5PY')


### PR DESCRIPTION
Closes #6534 

@pllim - sadly this issue will affect the py3 builds as well, the travis builds have just simply not yet picked up the new version.