### PR TITLE
Add bintrees to travis and as optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl'
+               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -14,19 +14,20 @@ from ..column import BaseColumn
 try:
     import bintrees
 except ImportError:
-    _HAS_BINTREES = False
+    HAS_BINTREES = False
 else:
-    _HAS_BINTREES = True
+    HAS_BINTREES = True
 
 
-if _HAS_BINTREES:
-    @pytest.fixture(params=[BST, FastBST, FastRBT, SortedArray])
-    def engine(request):
-        return request.param
+if HAS_BINTREES:
+    available_engines = [BST, FastBST, FastRBT, SortedArray]
 else:
-    @pytest.fixture(params=[BST, SortedArray])
-    def engine(request):
-        return request.param
+    available_engines = [BST, SortedArray]
+
+
+@pytest.fixture(params=available_engines)
+def engine(request):
+    return request.param
 
 
 _col = [1, 2, 3, 4, 5]

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -4,17 +4,29 @@ import pytest
 import numpy as np
 
 from .test_table import SetupData
-from ..bst import BST, FastRBT
+from ..bst import BST, FastRBT, FastBST
 from ..sorted_array import SortedArray
 from ..table import QTable, Row
 from ... import units as u
 from ...time import Time
 from ..column import BaseColumn
 
+try:
+    import bintrees
+except ImportError:
+    _HAS_BINTREES = False
+else:
+    _HAS_BINTREES = True
 
-@pytest.fixture(params=[BST, FastRBT, SortedArray])
-def engine(request):
-    return request.param
+
+if _HAS_BINTREES:
+    @pytest.fixture(params=[BST, FastBST, FastRBT, SortedArray])
+    def engine(request):
+        return request.param
+else:
+    @pytest.fixture(params=[BST, SortedArray])
+    def engine(request):
+        return request.param
 
 
 _col = [1, 2, 3, 4, 5]

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -54,6 +54,9 @@ Astropy also depends on other packages for optional features:
 - `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3):
   Used for testing the entry point discovery functionality in `astropy.modeling.fitting`
 
+- `bintrees <https://pypi.python.org/pypi/bintrees>`_ for *possible speedups*
+  with ``Table`` indexing.
+
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -54,8 +54,9 @@ Astropy also depends on other packages for optional features:
 - `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3):
   Used for testing the entry point discovery functionality in `astropy.modeling.fitting`
 
-- `bintrees <https://pypi.python.org/pypi/bintrees>`_ for *possible speedups*
-  with ``Table`` indexing.
+- `bintrees <https://pypi.python.org/pypi/bintrees>`_ for faster ``FastRBT`` and
+  ``FastBST`` indexing engines with ``Table``, although these will still be
+  slower in most cases than the default indexing engine.
 
 However, note that these only need to be installed if those particular features
 are needed. Astropy will import even if these dependencies are not installed.

--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -7,6 +7,7 @@ scipy
 pandas
 h5py
 beautifulsoup4
+bintrees
 bleach
 jplephem
 scikit-image


### PR DESCRIPTION
It's given as ["optional dependency"](https://github.com/astropy/astropy/blob/master/astropy/table/bst.py#L670) in the code but isn't listed.