### PR TITLE
Updating sphinx-gallery version

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -23,5 +23,5 @@ dependencies:
   - ipython
   - mpmath
   - pip:
-    - sphinx-gallery>=0.1.11
+    - sphinx-gallery>=0.1.12
     - jplephem

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.11 pillow --no-deps jplephem'
+               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different


### PR DESCRIPTION
Require v0.1.12+ to avoid RemovedInSphinx17Warning

fix #6266