### PR TITLE
WIP: Verify FITS units

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -11,7 +11,7 @@ from .verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from . import conf
 from ...extern.six import string_types, integer_types, text_type, binary_type
 from ...utils.exceptions import AstropyUserWarning
-
+from ...units.format.fits import Fits
 
 __all__ = ['Card', 'Undefined']
 
@@ -49,6 +49,9 @@ class Card(_Verify):
     # This will match any printable ASCII character excluding '='
     _keywd_hierarch_RE = re.compile(r'^(?:HIERARCH +)?(?:^[ -<>-~]+ ?)+$',
                                     re.I)
+
+    # String for a unit keyword
+    _keywd_UNIT_RE = re.compile(r'BUNIT|TUNIT[0-9]{1,4}$')
 
     # A number sub-string, either an integer or a float in fixed or
     # scientific notation.  One for FSC and one for non-FSC (NFSC) format:
@@ -1121,6 +1124,17 @@ class Card(_Verify):
                              'string: {!r}).'.format(self.keyword, valuecomment),
                     fix_text=fix_text,
                     fix=self._fix_value))
+
+        # verify the unit, if relevant
+        if self._keywd_UNIT_RE.match(keyword):
+            try:
+                Fits.parse(self.value)
+            except ValueError:
+                errs.append(self.run_option(
+                    option,
+                    err_text='Unit {!r} for keyword {!r} does not conform '
+                             'to FITS standard'.format(self.value, keyword),
+                    fixable=False))
 
         # verify the comment (string), it is never fixable
         m = self._value_NFSC_RE.match(valuecomment)


### PR DESCRIPTION
This makes sure that when a FITS header is verified, invalid units in the FITS standard cause a verification failure in the standard ``verify`` framework. Now because of the default verification behavior we have, this will cause errors when writing:

```python
In [1]: from astropy.io import fits

In [2]: hdu = fits.PrimaryHDU()

In [3]: hdu.header['BUNIT'] = 'slice'

In [4]: hdu.writeto('test.fits', overwrite=True)
...
VerifyError: 
Verification reported errors:
HDU 0:
    Card 4:
        Unit 'slice' for keyword 'BUNIT' does not conform to FITS standard
Note: astropy.io.fits uses zero-based indexing.
```

But be silent when reading. This overall behavior is consistent with the robustness principle *Be conservative in what you do, be liberal in what you accept from others* and this is why verification fails when writing files.

I just want to be clear that this is a **backward-incompatible change** and will break some user's scripts or potentially pipelines that are using units that violate the FITS standard. But in a way this can be treated as fixing previously incorrect behavior, and the files that are being written *are* buggy according to FITS.

The most common issue is that users write units in all-caps, when units are in fact case sensitive. An example where this matters is that it's not clear if 'MJY' is mega or milli-jansky.

So before I go ahead and add tests, changelog, etc. I just want to check whether we are ok with this backward-incompatibility. One thing we could do to ease the pain is that when a VerifyError is raised on writing, we also provide a one-line instruction on how to change this error to a warning or ignore it.

One option would be to make it so that some verification warnings can *never* be raised as an error, which means this would never actually break code but just emit warnings at worst. We could potentially do this and then after a few versions make these warnings become errors on writing (a kind of deprecation process in a way)

Yet another option is to default to warning instead of error-ing on writing.

cc @MSeifert04 @saimn @embray 
also cc @mwcraig @crawfordsm (just thought this might be relevant in terms of ccdproc)