### PR TITLE
Updating pytest minversion in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,8 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.8
+[tool:pytest]
+minversion = 3.1
 testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled


### PR DESCRIPTION
This was sadly missed out of #6419 where the minversion was already changed to 3.1+ in setup.py and changelog.