### PR TITLE
Allow to pass htmldict option to the jsviewer writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach'
         - PIP_DEPENDENCIES=''
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ astropy.table
 - Improved exception handling and error messages when column ``format``
   attribute is incorrect for the column type. [#6385]
 
+- Allow to pass ``htmldict`` option to the jsviewer writer. [#6551]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -172,7 +172,7 @@ class JSViewer(object):
 
 def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
                          table_class="display compact", jskwargs=None,
-                         css=DEFAULT_CSS):
+                         css=DEFAULT_CSS, htmldict=None):
     if table_id is None:
         table_id = 'table{id}'.format(id=id(table))
 
@@ -181,7 +181,7 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
 
     sortable_columns = [i for i, col in enumerate(table.columns.values())
                         if col.dtype.kind in 'iufc']
-    htmldict = {
+    htmldict_ = {
         'table_id': table_id,
         'table_class': table_class,
         'css': css,
@@ -189,10 +189,12 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
         'jsfiles': jsv.jquery_urls,
         'js': jsv.html_js(table_id=table_id, sort_columns=sortable_columns)
     }
+    if htmldict:
+        htmldict_.update(htmldict)
 
     if max_lines < len(table):
         table = table[:max_lines]
-    table.write(filename, format='html', htmldict=htmldict)
+    table.write(filename, format='html', htmldict=htmldict_)
 
 
 io_registry.register_writer('jsviewer', Table, write_table_jsviewer)

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -181,7 +181,7 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
 
     sortable_columns = [i for i, col in enumerate(table.columns.values())
                         if col.dtype.kind in 'iufc']
-    htmldict_ = {
+    html_options = {
         'table_id': table_id,
         'table_class': table_class,
         'css': css,
@@ -190,11 +190,11 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
         'js': jsv.html_js(table_id=table_id, sort_columns=sortable_columns)
     }
     if htmldict:
-        htmldict_.update(htmldict)
+        html_options.update(htmldict)
 
     if max_lines < len(table):
         table = table[:max_lines]
-    table.write(filename, format='html', htmldict=htmldict_)
+    table.write(filename, format='html', htmldict=html_options)
 
 
 io_registry.register_writer('jsviewer', Table, write_table_jsviewer)

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -5,6 +5,7 @@ import pytest
 
 from ..table import Table
 from ... import extern
+from ...utils.xml.writer import HAS_BLEACH
 
 try:
     import IPython  # pylint: disable=W0611
@@ -105,16 +106,18 @@ def test_write_jsviewer_default(tmpdir):
         assert f.read().strip() == ref.strip()
 
 
+@pytest.mark.skipif('not HAS_BLEACH')
 def test_write_jsviewer_options(tmpdir):
     t = Table()
     t['a'] = [1, 2, 3, 4, 5]
-    t['b'] = ['a', 'b', 'c', 'd', 'e']
+    t['b'] = ['<b>a</b>', 'b', 'c', 'd', 'e']
     t['a'].unit = 'm'
 
     tmpfile = tmpdir.join('test.html').strpath
-
     t.write(tmpfile, format='jsviewer', table_id='test', max_lines=3,
-            jskwargs={'display_length': 5}, table_class='display hover')
+            jskwargs={'display_length': 5}, table_class='display hover',
+            htmldict=dict(raw_html_cols='b'))
+
     ref = REFERENCE % dict(
         lines=format_lines(t['a'][:3], t['b'][:3]),
         table_class='display hover',

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -48,6 +48,9 @@ Astropy also depends on other packages for optional features:
 
 - `setuptools <https://pythonhosted.org/setuptools/>`_: Used for discovery of entry points which are used to insert fitters into modeling.fitting
 
+- `bleach <https://bleach.readthedocs.io/>`_: Used to sanitize text when
+  disabling HTML escaping in the :class:`~astropy.table.Table` HTML writer.
+
 - `mock <https://github.com/testing-cabal/mock>`_ (python <= 3.2) or `unittest.mock <https://docs.python.org/dev/library/unittest.mock.html>`_ (python > 3.3):
   Used for testing the entry point discovery functionality in `astropy.modeling.fitting`
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -410,7 +410,7 @@ By default, ``serialize_method['fits']`` in a Time column ``info`` is equal to
 .. _table_io_hdf5:
 
 HDF5
---------
+----
 
 .. _HDF5: http://www.hdfgroup.org/HDF5/
 .. _h5py: http://www.h5py.org/
@@ -464,6 +464,34 @@ used to ensure that the data is compressed on disk::
 
     >>> t.write('new_file.hdf5', path='updated_data', compression=True)
 
+
+
+.. _table_io_jsviewer:
+
+JSViewer
+--------
+
+Provides an interactive HTML export of a Table, like the
+:class:`~astropy.io.ascii.HTML` writer but using the DataTables_ library, which
+allow to visualize interactively an HTML table (with columns sorting, search,
+pagination).
+
+To write a table ``t`` to a new file::
+
+    >>> t.write('new_table.html', format='jsviewer')
+
+Several additional parameters can be used:
+
+- *table_id*: the HTML id of the ``<table>`` tag, defaults to ``'table{id}'``
+  where ``id`` is the id of the Table object.
+- *max_lines*: maximum number of lines.
+- *table_class*: HTML classes added to the ``<table>`` tag, can be useful to
+  customize the style of the table.
+- *jskwargs*: additional arguments passed to :class:`~astropy.table.JSViewer`.
+- *css*: CSS style, default to ``astropy.table.jsviewer.DEFAULT_CSS``.
+- *htmldict*: additional arguments passed to :class:`~astropy.io.ascii.HTML`.
+
+.. _Datatables: https://www.datatables.net/
 
 
 


### PR DESCRIPTION
This is needed to specify that a column should not be escaped, as with the HTML writer. 