### PR TITLE
.ecsv recognized, no need to provide format in Table.read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Allow ECSV files to be auto-identified by ``Table.read`` or ``Table.write`` based
+  on the ``.ecsv`` file name suffix. In this case it is not required to provide the
+  ``format`` keyword. [#6552]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -225,6 +225,7 @@ class Ecsv(basic.Basic):
     """
     _format_name = 'ecsv'
     _description = 'Enhanced CSV'
+    _io_registry_suffix = '.ecsv'
 
     header_class = EcsvHeader
     outputter_class = EcsvOutputter

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -5,6 +5,10 @@ import pytest
 
 from ....table import Table, Column
 
+from ....table.table_helpers import simple_table
+
+import numpy as np
+
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 files = ['t/cds.dat', 't/ipac.dat', 't/daophot.dat', 't/latex1.tex',
@@ -17,6 +21,12 @@ try:
     HAS_BEAUTIFUL_SOUP = True
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 if HAS_BEAUTIFUL_SOUP:
     files.append('t/html.html')
@@ -138,3 +148,11 @@ def test_write_csv(tmpdir):
     t.add_column(Column(name='b', data=['a', 'b', 'c']))
     path = str(tmpdir.join("data.csv"))
     t.write(path)
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_auto_identify_ecsv(tmpdir):
+    tbl = simple_table()
+    tmpfile =  str(tmpdir.join('/tmpFile.ecsv'))
+    tbl.write(tmpfile)
+    tbl2 = Table.read(tmpfile)
+    assert np.all(tbl == tbl2)


### PR DESCRIPTION
The .ecsv files can be recognized now, without providing the format.
Example
`t = Table.read('a.ecsv')`
this will work, no need to specify format.

EDIT: Fix #4596, xref #6265 