### PR TITLE
Fix 32-bit failure for misc.dtype_bytes_or_chars

### DIFF
--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -119,7 +119,8 @@ def test_check_broadcast():
 
 def test_dtype_bytes_or_chars():
     assert misc.dtype_bytes_or_chars(np.dtype(np.float64)) == 8
-    assert misc.dtype_bytes_or_chars(np.dtype(object)) == (8 if NUMPY_LT_1_10 else None)
+    assert misc.dtype_bytes_or_chars(np.dtype(object)) == (
+        np.dtype(object).itemsize if NUMPY_LT_1_10 else None)
     assert misc.dtype_bytes_or_chars(np.dtype(np.int32)) == 4
     assert misc.dtype_bytes_or_chars(np.array(b'12345').dtype) == 5
     assert misc.dtype_bytes_or_chars(np.array(u'12345').dtype) == 5


### PR DESCRIPTION
Use declared size of numpy object rather than assuming it is 8.

See: https://travis-ci.org/MacPython/astropy-wheels/jobs/276775854 for
example failure.