### PR TITLE
Add a nicer error message when accidentally calling frame.representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -288,6 +288,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Added a nicer error message when accidentally calling ``frame.representation``
+  instead of ``frame.data`` in the context of methods that use ``._apply()``.
+  [#6561]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1139,6 +1139,16 @@ class BaseCoordinateFrame(ShapedLikeNDArray):
         else:
             data = self.data if self.has_data else None
 
+        # This is to provide a slightly nicer error message if the user tries to
+        # use frame_obj.representation instead of frame_obj.data to get the
+        # underlying representation object [e.g., #2890]
+        if inspect.isclass(data):
+            raise TypeError('Class passed as data instead of a representation '
+                            'instance. If you called frame.representation, this'
+                            ' returns the representation class. frame.data '
+                            'returns the instantiated object - you may want to '
+                            ' use this instead.')
+
         # TODO: expose this trickery in docstring?
         representation_cls = kwargs.pop('representation_cls',
                                         self.representation)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -297,6 +297,12 @@ def test_realizing():
     assert f2.equinox == f.equinox
     assert f2.equinox != FK5.get_frame_attr_names()['equinox']
 
+    # Check that a nicer error message is returned:
+    with pytest.raises(TypeError) as excinfo:
+        f.realize_frame(f.representation)
+
+    assert ('Class passed as data instead of a representation' in
+            excinfo.value.args[0])
 
 def test_replicating():
     from ..builtin_frames import ICRS, AltAz


### PR DESCRIPTION
As has stubbed many a person (including me), in astropy.coordinates, `frame.representation` returns the *class* of the current representation, not the data. As such, certain methods of the frame classes that use `_apply()` may crash with cryptic messages if the user forgets, for example, what is demoed in #2890. This just adds a more verbose error message if a class is passed in to `_apply` as data.

This is a possible fix for #2890