### PR TITLE
Fix fitscheck and checksums correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,8 @@ astropy.io.fits
 - Automatically detect and handle compression in FITS files that are opened by
   passing a file handle to ``fits.open`` [#6373]
 
+- Remove the ``nonstandard`` checksum option. [#6571]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -219,6 +221,9 @@ astropy.io.fits
 - Properly handle opening of FITS files from ``http.client.HTTPResponse`` (i.e.
   it now works correctly when passing the results of ``urllib.request.urlopen``
   to ``fits.open``). [#6378]
+
+- Fix the ``fitscheck`` script for updating invalid checksums, or removing
+  checksums. [#6571]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -529,15 +529,6 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
                                'DATASUM' not in self._header))):
             if checksum == 'datasum':
                 self.add_datasum(datasum_keyword=datasum_keyword)
-            elif checksum == 'nonstandard_datasum':
-                self.add_datasum(blocking='nonstandard',
-                                 datasum_keyword=datasum_keyword)
-            elif checksum == 'test':
-                self.add_datasum(self._datasum_comment,
-                                 datasum_keyword=datasum_keyword)
-                self.add_checksum(self._checksum_comment, True,
-                                  checksum_keyword=checksum_keyword,
-                                  datasum_keyword=datasum_keyword)
             elif checksum == 'nonstandard':
                 self.add_checksum(blocking='nonstandard',
                                   checksum_keyword=checksum_keyword,

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -517,7 +517,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                        errs)
         return errs
 
-    def _calculate_datasum(self, blocking):
+    def _calculate_datasum(self):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
@@ -550,7 +550,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
 
             byte_data = d.view(type=np.ndarray, dtype=np.ubyte)
 
-            cs = self._compute_checksum(byte_data, blocking=blocking)
+            cs = self._compute_checksum(byte_data)
 
             # If the data was byteswapped in this method then return it to
             # its original little-endian order.
@@ -564,7 +564,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(GroupsHDU, self)._calculate_datasum(blocking=blocking)
+            return super(GroupsHDU, self)._calculate_datasum()
 
     def _summary(self):
         summary = super(GroupsHDU, self)._summary()

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -803,7 +803,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         return (self.name, self.ver, class_name, len(self._header), shape, format, '')
 
-    def _calculate_datasum(self, blocking):
+    def _calculate_datasum(self):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
@@ -835,8 +835,7 @@ class _ImageBaseHDU(_ValidHDU):
             else:
                 byteswapped = False
 
-            cs = self._compute_checksum(d.flatten().view(np.uint8),
-                                        blocking=blocking)
+            cs = self._compute_checksum(d.flatten().view(np.uint8))
 
             # If the data was byteswapped in this method then return it to
             # its original little-endian order.
@@ -850,8 +849,7 @@ class _ImageBaseHDU(_ValidHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(_ImageBaseHDU, self)._calculate_datasum(
-                blocking=blocking)
+            return super(_ImageBaseHDU, self)._calculate_datasum()
 
 
 class Section(object):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -757,7 +757,7 @@ class TableHDU(_TableBaseHDU):
         self._init_tbdata(data)
         return data.view(self._data_type)
 
-    def _calculate_datasum(self, blocking):
+    def _calculate_datasum(self):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
@@ -772,14 +772,14 @@ class TableHDU(_TableBaseHDU):
 
             d = np.append(bytes_array, padding)
 
-            cs = self._compute_checksum(d, blocking=blocking)
+            cs = self._compute_checksum(d)
             return cs
         else:
             # This is the case where the data has not been read from the file
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(TableHDU, self)._calculate_datasum(blocking)
+            return super(TableHDU, self)._calculate_datasum()
 
     def _verify(self, option='warn'):
         """
@@ -842,14 +842,14 @@ class BinTableHDU(_TableBaseHDU):
         return (card.keyword == 'XTENSION' and
                 xtension in (cls._extension, 'A3DTABLE'))
 
-    def _calculate_datasum_with_heap(self, blocking):
+    def _calculate_datasum_with_heap(self):
         """
         Calculate the value for the ``DATASUM`` card given the input data
         """
 
         with _binary_table_byte_swap(self.data) as data:
             dout = data.view(type=np.ndarray, dtype=np.ubyte)
-            csum = self._compute_checksum(dout, blocking=blocking)
+            csum = self._compute_checksum(dout)
 
             # Now add in the heap data to the checksum (we can skip any gap
             # between the table and the heap since it's all zeros and doesn't
@@ -869,12 +869,11 @@ class BinTableHDU(_TableBaseHDU):
                         if not len(coldata):
                             continue
 
-                        csum = self._compute_checksum(coldata, csum,
-                                                      blocking=blocking)
+                        csum = self._compute_checksum(coldata, csum)
 
             return csum
 
-    def _calculate_datasum(self, blocking):
+    def _calculate_datasum(self):
         """
         Calculate the value for the ``DATASUM`` card in the HDU.
         """
@@ -883,13 +882,13 @@ class BinTableHDU(_TableBaseHDU):
             # This method calculates the datasum while incorporating any
             # heap data, which is obviously not handled from the base
             # _calculate_datasum
-            return self._calculate_datasum_with_heap(blocking)
+            return self._calculate_datasum_with_heap()
         else:
             # This is the case where the data has not been read from the file
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(BinTableHDU, self)._calculate_datasum(blocking)
+            return super(BinTableHDU, self)._calculate_datasum()
 
     def _writedata_internal(self, fileobj):
         size = 0

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -170,25 +170,10 @@ def update(filename):
     Also updates fixes standards violations if possible and requested.
     """
 
-    tmpfile = filename + '.bak'
-    try:
-        tmpfile_written = False
-        with fits.open(filename, do_not_scale_image_data=True) as hdulist:
-            try:
-                output_verify = 'silentfix' if OPTIONS.compliance else 'ignore'
-                hdulist.writeto(tmpfile, checksum=OPTIONS.checksum_kind,
-                                overwrite=True, output_verify=output_verify)
-            except fits.VerifyError:
-                # unfixable errors already noted during verification phase
-                pass
-            else:
-                tmpfile_written = True
-    finally:
-        if os.path.exists(tmpfile):
-            if tmpfile_written:
-                os.replace(tmpfile, filename)
-            else:
-                os.remove(tmpfile)
+    output_verify = 'silentfix' if OPTIONS.compliance else 'ignore'
+    with fits.open(filename, do_not_scale_image_data=True,
+                   checksum=OPTIONS.checksum_kind, mode='update') as hdulist:
+        hdulist.flush(output_verify=output_verify)
 
 
 def process_file(filename):

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -46,6 +46,7 @@ import sys
 import textwrap
 import warnings
 
+from ....tests.helper import catch_warnings
 from ... import fits
 
 
@@ -124,7 +125,7 @@ def verify_checksums(filename):
     Prints a message if any HDU in `filename` has a bad checksum or datasum.
     """
 
-    with warnings.catch_warnings(record=True) as wlist:
+    with catch_warnings() as wlist:
         with fits.open(filename, checksum=OPTIONS.checksum_kind) as hdulist:
             for i, hdu in enumerate(hdulist):
                 # looping on HDUs is needed to read them and verify the

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -13,12 +13,11 @@ regardless of whether or not they currently exist or pass.  Use
 
 Example uses of fitscheck:
 
-1. Verify and update checksums, tolerating non-standard checksums, updating to
-   standard checksum::
+1. Add checksums::
 
-    $ fitscheck --checksum either --write *.fits
+    $ fitscheck --write *.fits
 
-2. Write new checksums,  even if existing checksums are bad or missing::
+2. Write new checksums, even if existing checksums are bad or missing::
 
     $ fitscheck --write --force *.fits
 
@@ -26,19 +25,15 @@ Example uses of fitscheck:
 
     $ fitscheck --compliance *.fits
 
-4. Verify original nonstandard checksums only::
-
-    $ fitscheck --checksum nonstandard *.fits
-
-5. Only check and fix compliance problems,  ignoring checksums::
+4. Only check and fix compliance problems,  ignoring checksums::
 
     $ fitscheck --checksum none --compliance --write *.fits
 
-6. Verify standard interoperable checksums::
+5. Verify standard interoperable checksums::
 
     $ fitscheck *.fits
 
-7. Delete checksum keywords::
+6. Delete checksum keywords::
 
     $ fitscheck --checksum none --write *.fits
 """
@@ -54,6 +49,7 @@ from ... import fits
 
 
 log = logging.getLogger('fitscheck')
+
 
 def handle_options(args):
     if not len(args):
@@ -71,9 +67,9 @@ def handle_options(args):
 
     parser.add_option(
         '-k', '--checksum', dest='checksum_kind',
-        type='choice', choices=['standard', 'nonstandard', 'either', 'none'],
+        type='choice', choices=['standard', 'none'],
         help='Choose FITS checksum mode or none.  Defaults standard.',
-        default='standard', metavar='[standard | nonstandard | either | none]')
+        default='standard', metavar='[standard | none]')
 
     parser.add_option(
         '-w', '--write', dest='write_file',

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -186,7 +186,7 @@ def update(filename):
     finally:
         if os.path.exists(tmpfile):
             if tmpfile_written:
-                os.rename(tmpfile, filename)
+                os.replace(tmpfile, filename)
             else:
                 os.remove(tmpfile)
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -35,7 +35,8 @@ Example uses of fitscheck:
 
 6. Delete checksum keywords::
 
-    $ fitscheck --checksum none --write *.fits
+    $ fitscheck --checksum remove --write *.fits
+
 """
 
 
@@ -67,9 +68,9 @@ def handle_options(args):
 
     parser.add_option(
         '-k', '--checksum', dest='checksum_kind',
-        type='choice', choices=['standard', 'none'],
+        type='choice', choices=['standard', 'remove', 'none'],
         help='Choose FITS checksum mode or none.  Defaults standard.',
-        default='standard', metavar='[standard | none]')
+        default='standard', metavar='[standard | remove | none]')
 
     parser.add_option(
         '-w', '--write', dest='write_file',
@@ -100,6 +101,9 @@ def handle_options(args):
 
     if OPTIONS.checksum_kind == 'none':
         OPTIONS.checksum_kind = False
+    elif OPTIONS.checksum_kind == 'remove':
+        OPTIONS.write_file = True
+        OPTIONS.force = True
 
     return fits_files
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -194,14 +194,14 @@ def process_file(filename):
         return 1
 
 
-def main():
+def main(args=None):
     """
     Processes command line parameters into options and files,  then checks
     or update FITS DATASUM and CHECKSUM keywords for the specified files.
     """
 
     errors = 0
-    fits_files = handle_options(sys.argv[1:])
+    fits_files = handle_options(args or sys.argv[1:])
     setup_logging()
     for filename in fits_files:
         errors += process_file(filename)

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -367,14 +367,6 @@ class TestChecksumFunctions(FitsTestCase):
             if not (hasattr(hdul[0], '_checksum') and not hdul[0]._checksum):
                 pytest.fail(msg='Non-empty CHECKSUM keyword')
 
-            if not (hasattr(hdul[0], '_datasum_comment') and
-                    hdul[0]._datasum_comment):
-                pytest.fail(msg='Missing DATASUM Card comment')
-
-            if not (hasattr(hdul[0], '_checksum_comment') and
-                    not hdul[0]._checksum_comment):
-                pytest.fail(msg='Non-empty CHECKSUM Card comment')
-
     def test_open_update_mode_preserve_checksum(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/148 where
@@ -445,9 +437,3 @@ class TestChecksumFunctions(FitsTestCase):
 
         if not (hasattr(hdu, '_checksum') and hdu._checksum):
             pytest.fail(msg='Missing CHECKSUM keyword')
-
-        if not (hasattr(hdu, '_datasum_comment') and hdu._datasum_comment):
-            pytest.fail(msg='Missing DATASUM Card comment')
-
-        if not (hasattr(hdu, '_checksum_comment') and hdu._checksum_comment):
-            pytest.fail(msg='Missing CHECKSUM Card comment')

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -55,21 +55,6 @@ class TestChecksumFunctions(FitsTestCase):
                 assert hdul[0].header['CHECKSUM'] == 'ZHMkeGKjZGKjbGKj'
                 assert hdul[0].header['DATASUM'] == '4950'
 
-    def test_nonstandard_checksum(self):
-        hdu = fits.PrimaryHDU(np.arange(10.0 ** 6, dtype=np.float64))
-        hdu.writeto(self.temp('tmp.fits'), overwrite=True,
-                    checksum='nonstandard')
-        del hdu
-        with fits.open(self.temp('tmp.fits'), checksum='nonstandard') as hdul:
-            assert 'CHECKSUM' in hdul[0].header
-            assert 'DATASUM' in hdul[0].header
-
-            if not sys.platform.startswith('win32'):
-                # The checksum ends up being different on Windows, possibly due
-                # to slight floating point differences
-                assert hdul[0].header['CHECKSUM'] == 'jD4Am942jC48j948'
-                assert hdul[0].header['DATASUM'] == '4164005614'
-
     def test_scaled_data(self):
         with fits.open(self.data('scale.fits')) as hdul:
             orig_data = hdul[0].data.copy()

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -428,10 +428,10 @@ class TestChecksumFunctions(FitsTestCase):
 
         testfile = self.temp('test.fits')
         with fits.open(self.data('tb.fits')) as hdul:
-            hdul[0].header['DATASUM'] = 'foobar'
-            hdul[0].header['CHECKSUM'] = 'foobar'
-            hdul[1].header['DATASUM'] = 'foobar'
-            hdul[1].header['CHECKSUM'] = 'foobar'
+            hdul[0].header['DATASUM'] = '1       '
+            hdul[0].header['CHECKSUM'] = '8UgqATfo7TfoATfo'
+            hdul[1].header['DATASUM'] = '2349680925'
+            hdul[1].header['CHECKSUM'] = '11daD8bX98baA8bU'
             hdul.writeto(testfile)
 
         with fits.open(testfile) as hdul:

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -1,9 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import sys
 from . import FitsTestCase
 from ..scripts import fitscheck
 from ... import fits
 from ....tests.helper import pytest
+
+on_win32 = sys.platform.startswith('win32')
 
 
 class TestFitscheck(FitsTestCase):
@@ -14,8 +17,9 @@ class TestFitscheck(FitsTestCase):
 
     def test_missing_file(self, capsys):
         assert fitscheck.main(['missing.fits']) == 1
-        stdout, stderr = capsys.readouterr()
-        assert 'No such file or directory' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'No such file or directory' in stderr
 
     def test_valid_file(self, capsys):
         testfile = self.data('checksum.fits')
@@ -24,27 +28,31 @@ class TestFitscheck(FitsTestCase):
         assert fitscheck.main([testfile, '--compliance']) == 0
 
         assert fitscheck.main([testfile, '-v']) == 0
-        stdout, stderr = capsys.readouterr()
-        assert 'OK' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'OK' in stderr
 
     def test_remove_checksums(self, capsys):
         self.copy_file('checksum.fits')
         testfile = self.temp('checksum.fits')
         assert fitscheck.main([testfile, '--checksum', 'remove']) == 1
         assert fitscheck.main([testfile]) == 1
-        stdout, stderr = capsys.readouterr()
-        assert 'MISSING' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'MISSING' in stderr
 
     def test_no_checksums(self, capsys):
         testfile = self.data('arange.fits')
 
         assert fitscheck.main([testfile]) == 1
-        stdout, stderr = capsys.readouterr()
-        assert 'Checksum not found' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'Checksum not found' in stderr
 
         assert fitscheck.main([testfile, '--ignore-missing']) == 0
-        stdout, stderr = capsys.readouterr()
-        assert stderr == ''
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert stderr == ''
 
     def test_overwrite_invalid(self, capsys):
         """
@@ -65,13 +73,15 @@ class TestFitscheck(FitsTestCase):
             hdul.writeto(testfile)
 
         assert fitscheck.main([testfile]) == 1
-        stdout, stderr = capsys.readouterr()
-        assert 'BAD' in stderr
-        assert 'Checksum verification failed' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'BAD' in stderr
+            assert 'Checksum verification failed' in stderr
 
         assert fitscheck.main([testfile, '--write', '--force']) == 1
-        stdout, stderr = capsys.readouterr()
-        assert 'BAD' in stderr
+        if not on_win32:
+            stdout, stderr = capsys.readouterr()
+            assert 'BAD' in stderr
 
         # check that the file was fixed
         assert fitscheck.main([testfile]) == 0

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -1,12 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import sys
 from . import FitsTestCase
 from ..scripts import fitscheck
 from ... import fits
 from ....tests.helper import pytest
-
-on_win32 = sys.platform.startswith('win32')
 
 
 class TestFitscheck(FitsTestCase):
@@ -17,9 +14,8 @@ class TestFitscheck(FitsTestCase):
 
     def test_missing_file(self, capsys):
         assert fitscheck.main(['missing.fits']) == 1
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'No such file or directory' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'No such file or directory' in stderr
 
     def test_valid_file(self, capsys):
         testfile = self.data('checksum.fits')
@@ -28,31 +24,27 @@ class TestFitscheck(FitsTestCase):
         assert fitscheck.main([testfile, '--compliance']) == 0
 
         assert fitscheck.main([testfile, '-v']) == 0
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'OK' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'OK' in stderr
 
     def test_remove_checksums(self, capsys):
         self.copy_file('checksum.fits')
         testfile = self.temp('checksum.fits')
         assert fitscheck.main([testfile, '--checksum', 'remove']) == 1
         assert fitscheck.main([testfile]) == 1
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'MISSING' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'MISSING' in stderr
 
     def test_no_checksums(self, capsys):
         testfile = self.data('arange.fits')
 
         assert fitscheck.main([testfile]) == 1
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'Checksum not found' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'Checksum not found' in stderr
 
         assert fitscheck.main([testfile, '--ignore-missing']) == 0
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert stderr == ''
+        stdout, stderr = capsys.readouterr()
+        assert stderr == ''
 
     def test_overwrite_invalid(self, capsys):
         """
@@ -73,15 +65,13 @@ class TestFitscheck(FitsTestCase):
             hdul.writeto(testfile)
 
         assert fitscheck.main([testfile]) == 1
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'BAD' in stderr
-            assert 'Checksum verification failed' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'BAD' in stderr
+        assert 'Checksum verification failed' in stderr
 
         assert fitscheck.main([testfile, '--write', '--force']) == 1
-        if not on_win32:
-            stdout, stderr = capsys.readouterr()
-            assert 'BAD' in stderr
+        stdout, stderr = capsys.readouterr()
+        assert 'BAD' in stderr
 
         # check that the file was fixed
         assert fitscheck.main([testfile]) == 0

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -1,0 +1,69 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from . import FitsTestCase
+from ..scripts import fitscheck
+from ... import fits
+from ....tests.helper import pytest
+
+
+class TestFitscheck(FitsTestCase):
+    def test_noargs(self):
+        with pytest.raises(SystemExit) as e:
+            fitscheck.main(['-h'])
+        assert e.value.code == 0
+
+    def test_missing_file(self, capsys):
+        assert fitscheck.main(['missing.fits']) == 1
+        stdout, stderr = capsys.readouterr()
+        assert 'No such file or directory' in stderr
+
+    def test_valid_file(self, capsys):
+        testfile = self.data('checksum.fits')
+
+        assert fitscheck.main([testfile]) == 0
+        assert fitscheck.main([testfile, '--compliance']) == 0
+
+        assert fitscheck.main([testfile, '-v']) == 0
+        stdout, stderr = capsys.readouterr()
+        assert 'OK' in stderr
+
+    def test_no_checksums(self, capsys):
+        testfile = self.data('arange.fits')
+
+        assert fitscheck.main([testfile]) == 1
+        stdout, stderr = capsys.readouterr()
+        assert 'Checksum not found' in stderr
+
+        assert fitscheck.main([testfile, '--ignore-missing']) == 0
+        stdout, stderr = capsys.readouterr()
+        assert stderr == ''
+
+    def test_overwrite_invalid(self, capsys):
+        """
+        Tests that invalid checksum or datasum are overwriten when the file is
+        saved.
+        """
+        reffile = self.temp('ref.fits')
+        with fits.open(self.data('tb.fits')) as hdul:
+            hdul.writeto(reffile, checksum=True)
+
+        # replace checksums with wrong ones
+        testfile = self.temp('test.fits')
+        with fits.open(self.data('tb.fits')) as hdul:
+            hdul[0].header['DATASUM'] = '1       '
+            hdul[0].header['CHECKSUM'] = '8UgqATfo7TfoATfo'
+            hdul[1].header['DATASUM'] = '2349680925'
+            hdul[1].header['CHECKSUM'] = '11daD8bX98baA8bU'
+            hdul.writeto(testfile)
+
+        assert fitscheck.main([testfile]) == 1
+        stdout, stderr = capsys.readouterr()
+        assert 'BAD' in stderr
+        assert 'Checksum verification failed' in stderr
+
+        assert fitscheck.main([testfile, '--write', '--force']) == 1
+        stdout, stderr = capsys.readouterr()
+        assert 'BAD' in stderr
+
+        # check that the file was fixed
+        assert fitscheck.main([testfile]) == 0

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -27,6 +27,14 @@ class TestFitscheck(FitsTestCase):
         stdout, stderr = capsys.readouterr()
         assert 'OK' in stderr
 
+    def test_remove_checksums(self, capsys):
+        self.copy_file('checksum.fits')
+        testfile = self.temp('checksum.fits')
+        assert fitscheck.main([testfile, '--checksum', 'remove']) == 1
+        assert fitscheck.main([testfile]) == 1
+        stdout, stderr = capsys.readouterr()
+        assert 'MISSING' in stderr
+
     def test_no_checksums(self, capsys):
         testfile = self.data('arange.fits')
 


### PR DESCRIPTION
Fix #6530, #6058, #5874, and replaces #5875

- Remove the `nonstandard` option (ref https://github.com/astropy/astropy/issues/6530#issuecomment-329750315)
- Fix the fitscheck script that was broken in multiple ways: it is based on the detection of warnings emitted when the checksum is invalid, but putting these warings in `error` mode also means that the files could not be opened without errors to be fixed. Then it was not possible to write new checksum replacing invalid one, so now I store the result of the verification to know if the checksum must be overwritten.
- Also remove a few unused things, and add tests, yay!

It's mostly bugfixes, so should go to v2.0, but I also removed the `nonstandard` option, so not sure... thoughts @pllim @MSeifert04 @bsipocz ?