### PR TITLE
Update the opening paragraph on the core index docs page

### DIFF
--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -258,7 +258,7 @@ Other Credits
 * Everyone on the `astropy-dev mailing list`_ and the `Astropy mailing list`_
   for contributing to many discussions and decisions!
 
-(If you have contributed to the Astropy Project and your name is missing,
+(If you have contributed to the ``astropy`` core package and your name is missing,
 please send an email to the coordinators, or
 `open a pull request for this page <https://github.com/astropy/astropy/edit/master/docs/credits.rst>`_
 in the `astropy repository <https://github.com/astropy/astropy>`_)

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -258,7 +258,7 @@ Other Credits
 * Everyone on the `astropy-dev mailing list`_ and the `Astropy mailing list`_
   for contributing to many discussions and decisions!
 
-(If you have contributed to the Astropy project and your name is missing,
+(If you have contributed to the Astropy Project and your name is missing,
 please send an email to the coordinators, or
 `open a pull request for this page <https://github.com/astropy/astropy/edit/master/docs/credits.rst>`_
 in the `astropy repository <https://github.com/astropy/astropy>`_)

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -496,7 +496,7 @@ files manually`_ section since this explains what many of the files do.
    documentation, and if you are hosting your code in GitHub, you might also
    want to read the `Github help <http://help.github.com/>`_ to ensure you know
    how to push your code to GitHub and some recommended workflows that work for
-   the core Astropy project.
+   the core Astropy Project.
 
 #. Once you have started work on the affiliated package, you should register
    your package with the Astropy affiliated package registry. Instructions for

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -5,7 +5,7 @@ Writing Documentation
 *********************
 
 High-quality, consistent documentation for astronomy code is one of
-the major goals of the Astropy project.  Hence, we describe our
+the major goals of the Astropy Project.  Hence, we describe our
 documentation procedures and rules here.  For the astropy core
 project we try to keep to these as closely as possible, while the
 standards for affiliated packages are somewhat looser.

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -677,7 +677,7 @@ Using a signed tag ensures the integrity of the contents of that tag for the
 future.  On a distributed VCS like git, anyone can create a tag of Astropy
 called "0.1" in their repository--and where it's easy to monkey around even
 after the tag has been created.  But only one "0.1" will be signed by one of
-the Astropy project coordinators and will be verifiable with their public key.
+the Astropy Project coordinators and will be verifiable with their public key.
 
 Generating a public/private key pair
 ------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,13 +28,10 @@ Astropy Documentation
 
     .. image:: _static/astropy_logo.pdf
 
-The ``astropy`` core package is a community-driven package which contains key
-functionality and common tools needed for performing astronomy and astrophysics
-with Python.
-
-This package is at the core of the `Astropy Project
-<http://www.astropy.org/about.html>`_, which aims to enable the community to
-develop a robust ecosystem of `Affiliated Packages
+The ``astropy`` package contains key functionality and common tools needed for
+performing astronomy and astrophysics with Python.  It is at the core of the
+`Astropy Project <http://www.astropy.org/about.html>`_, which aims to enable
+the community to develop a robust ecosystem of `Affiliated Packages
 <http://www.astropy.org/affiliated/index.html>`_ covering a broad range of
 needs for astronomical research, data processing, and data analysis.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,9 +28,15 @@ Astropy Documentation
 
     .. image:: _static/astropy_logo.pdf
 
-Welcome to the Astropy documentation! Astropy is a community-driven
-package intended to contain much of the core functionality and some common
-tools needed for performing astronomy and astrophysics with Python.
+The ``astropy`` core package is a community-driven package which contains key
+functionality and common tools needed for performing astronomy and astrophysics
+with Python.
+
+This package is at the core of the `Astropy Project
+<http://www.astropy.org/about.html>`_, which aims to enable the community to
+develop a robust ecosystem of `Affiliated Packages
+<http://www.astropy.org/affiliated/index.html>`_ covering a broad range of
+needs for astronomical research, data processing, and data analysis.
 
 .. _getting-started:
 
@@ -48,7 +54,7 @@ Getting Started
    Tutorials <http://tutorials.astropy.org/>
    Get Help <http://www.astropy.org/help.html>
    Contribute and Report Problems <http://www.astropy.org/contribute.html>
-   About the astropy project <http://www.astropy.org/about.html>
+   About the Astropy Project <http://www.astropy.org/about.html>
 
 .. _user-docs:
 

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -531,7 +531,7 @@ API than if one were to use CFITSIO directly.
 Why did Astropy adopt PyFITS as its FITS reader instead of fitsio?
 ------------------------------------------------------------------
 
-When the Astropy project was first started it was clear from the start that
+When the Astropy Project was first started it was clear from the start that
 one of its core components should be a submodule for reading and writing FITS
 files, as many other components would be likely to depend on this
 functionality.  At the time, the ``fitsio`` package was in its infancy (it

--- a/docs/samp/index.rst
+++ b/docs/samp/index.rst
@@ -75,5 +75,5 @@ Acknowledgments
 ===============
 
 This code is adapted from the `SAMPy <https://pypi.python.org/pypi/sampy>`__
-package written by Luigi Paioro, who has granted the Astropy project permission
+package written by Luigi Paioro, who has granted the Astropy Project permission
 to use the code under a BSD license.

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -216,5 +216,5 @@ Acknowledgments
 
 This code is adapted from the `pynbody
 <https://github.com/pynbody/pynbody>`__ units module written by Andrew
-Pontzen, who has granted the Astropy project permission to use the code
+Pontzen, who has granted the Astropy Project permission to use the code
 under a BSD license.


### PR DESCRIPTION
This puts the `astropy` core package in context with the Astropy Project and also introduces Affiliated Packages at this point.

Also makes `Astropy Project` be consistent (`Project` not `project`).