### PR TITLE
Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ language: c
 os:
     - linux
 
+stage: tests
+
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
@@ -46,9 +48,13 @@ env:
         # E902 - IOError
         - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902"
 
-    matrix:
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+stages:
+   # Do the style check and a single test job, don't proceed if it fails
+   - name: single_test
+   # Do the rest of the tests
+   - name: tests
+   - name: cron_only
+     if: type = cron
 
 matrix:
 
@@ -57,9 +63,13 @@ matrix:
 
     include:
 
+        - env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+        - env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+
         # Try MacOS X. Use a slightly old numpy version to help test against
         # all supported numpy versions.
         - os: osx
+          stage: cron_only
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem' NUMPY_VERSION=1.12
@@ -93,6 +103,7 @@ matrix:
                MATPLOTLIB_VERSION=1.5
 
         - os: linux
+          stage: single_test
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
@@ -108,6 +119,7 @@ matrix:
 
         # Do a PEP8/pyflakes test with flake8
         - os: linux
+          stage: single_test
           env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
 
         # Try developer version of Numpy with optional dependencies and also
@@ -122,12 +134,13 @@ matrix:
         # we can spot issues sooner. We do not use remote data here, since
         # that gives too many false positives due to URL timeouts.
         - os: linux
+          stage: cron_only
           env: NUMPY_VERSION=dev
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               EVENT_TYPE='cron'
 
     allow_failures:
-      - env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+      - os: linux
+        env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
 install:
@@ -140,6 +153,8 @@ script:
 
 after_success:
     - if [[ $SETUP_CMD == *--coverage* ]]; then
-        cpp-coveralls -E ".*convolution.*" -E ".*_erfa.*" -E ".*\.l" -E ".*\.y" -E ".*flexed.*" -E ".*cextern.*" -E ".*_np_utils.*" -E ".*cparser.*" -E ".*cython_impl.*" --dump c-coveralls.json;
-        coveralls --merge=c-coveralls.json --rcfile='astropy/tests/coveragerc';
+        if [ $TRAVIS_REPO_SLUG = "astropy/astropy" -o $TRAVIS_PULL_REQUEST_SLUG = "astropy/astropy" ]; then
+          cpp-coveralls -E ".*convolution.*" -E ".*_erfa.*" -E ".*\.l" -E ".*\.y" -E ".*flexed.*" -E ".*cextern.*" -E ".*_np_utils.*" -E ".*cparser.*" -E ".*cython_impl.*" --dump c-coveralls.json;
+          coveralls --merge=c-coveralls.json --rcfile='astropy/tests/coveragerc';
+        fi;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: c
 os:
     - linux
 
-stage: tests
+stage: Comprehensive tests
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
@@ -50,10 +50,10 @@ env:
 
 stages:
    # Do the style check and a single test job, don't proceed if it fails
-   - name: single_test
+   - name: Initial tests
    # Do the rest of the tests
-   - name: tests
-   - name: cron_only
+   - name: Comprehensive tests
+   - name: Cron tests
      if: type = cron
 
 matrix:
@@ -63,13 +63,16 @@ matrix:
 
     include:
 
-        - env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-        - env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
+
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
         # Try MacOS X. Use a slightly old numpy version to help test against
         # all supported numpy versions.
         - os: osx
-          stage: cron_only
+          stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem' NUMPY_VERSION=1.12
@@ -103,8 +106,8 @@ matrix:
                MATPLOTLIB_VERSION=1.5
 
         - os: linux
-          stage: single_test
-          env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
+          stage: Initial tests
+          env: SETUP_CMD='test --coverage -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
                LC_CTYPE=C.ascii LC_ALL=C
@@ -119,7 +122,7 @@ matrix:
 
         # Do a PEP8/pyflakes test with flake8
         - os: linux
-          stage: single_test
+          stage: Initial tests
           env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
 
         # Try developer version of Numpy with optional dependencies and also
@@ -134,7 +137,7 @@ matrix:
         # we can spot issues sooner. We do not use remote data here, since
         # that gives too many false positives due to URL timeouts.
         - os: linux
-          stage: cron_only
+          stage: Cron tests
           env: NUMPY_VERSION=dev
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem' NUMPY_VERSION=1.12
+               PIP_DEPENDENCIES='jplephem' EVENT_TYPE='cron'
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -90,7 +90,7 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
-        # Numpy 1.11 is tested below in the image tests, 1.12 in the OSX test.
+        # Numpy 1.11 is tested below in the image tests, 1.12 in the Initial stage test.
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
                SETUP_CMD='test --open-files'
@@ -107,7 +107,10 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          env: SETUP_CMD='test --coverage -a "--mpl"'
+          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
+
+        - os: linux
+          env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
                LC_CTYPE=C.ascii LC_ALL=C
@@ -138,7 +141,7 @@ matrix:
         # that gives too many false positives due to URL timeouts.
         - os: linux
           stage: Cron tests
-          env: NUMPY_VERSION=dev
+          env: NUMPY_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
     allow_failures:


### PR DESCRIPTION
This should show the basic concept of using travis build stages. Note that the current PR has the purpose of point out the logic, the details of what exact tests should be scheduled in which stage is TBD (as well as there may be a [travis bug](https://github.com/travis-ci/beta-features/issues/28#issuecomment-330726366), too that we need to temporarily workaround that I'm happy to do if we agree to have the feature).

The current thinking, based on discussion with @astrofrog today at the coordination meeting is the following:

First we run the pep8 test. If a commit fails on that, we don't run the rest of the tests.
Second we run one test setup, preferably that has all the optional dependencies. However it would be good not to have the coverage running as well, as it may causes troubles when people are running travis on their own forks. Alternative to deal with that coverage issue in the yml file.
Third we run the rest of the matrix, except the OSX build
Last we run the OSX build, but only for master push/merge commits and/or cron triggers. This identification of being a cron trigger will come directly from travis, so unlike our usual mechanism in ci-helpers, the jobs doesn't need to be started up to recognize their cron/non-cron status, but that happens automatically during the preprocessing by travis.