### PR TITLE
Prevent accidental removal of essential trailing whitespaces in a test

### DIFF
--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -138,18 +138,20 @@ def test_read_right_indented_table():
 
 def test_trailing_spaces_in_row_definition():
     """ Trailing spaces in the row definition column shouldn't matter"""
-    table = """
-# comment (with blank line above)
-   ==== ==== ====    
-   Col1 Col2 Col3
-   ==== ==== ====  
-    3    3.4  foo
-    1    4.5  bar
-   ==== ==== ====  
-"""  # noqa
-    # make sure noone accidentally deletes the trailing whitespaces in the
+    table = (
+        "\n"
+        "# comment (with blank line above)\n"
+        "   ==== ==== ====    \n"
+        "   Col1 Col2 Col3\n"
+        "   ==== ==== ====  \n"
+        "    3    3.4  foo\n"
+        "    1    4.5  bar\n"
+        "   ==== ==== ====  \n"
+    )
+    # make sure no one accidentally deletes the trailing whitespaces in the
     # table.
     assert len(table) == 151
+
     reader = ascii.get_reader(Reader=ascii.RST)
     dat = reader.read(table)
     assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -147,6 +147,9 @@ def test_trailing_spaces_in_row_definition():
     1    4.5  bar
    ==== ==== ====  
 """  # noqa
+    # make sure noone accidentally deletes the trailing whitespaces in the
+    # table.
+    assert len(table) == 151
     reader = ascii.get_reader(Reader=ascii.RST)
     dat = reader.read(table)
     assert_equal(dat.colnames, ["Col1", "Col2", "Col3"])


### PR DESCRIPTION
I've seen several PRs that accidentally deleted the trailing whitespaces in the test. So I thought it may be good to have a test for the correctness of the test, so it will continue to test that trailing whitespaces don't mess with the reader.

To catch these accidental deletions I added an `assert` for the length of the `table`.