### PR TITLE
Fix use of pytest xdist

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -5,7 +5,7 @@ docker info
 cat << EOF | docker run -i \
                         -v ${PWD}:/astropy_src \
                         -a stdin -a stdout -a stderr \
-                        astropy/astropy-32bit-test-env:1.9 \
+                        astropy/astropy-py35-32bit-test-env:1.9 \
                         bash || exit $?
 
 cd /astropy_src
@@ -14,12 +14,15 @@ echo "Output of uname -m:"
 uname -m
 
 echo "Output of sys.maxsize in Python:"
-python -c 'import sys; print(sys.maxsize)'
+python3 -c 'import sys; print(sys.maxsize)'
 
 # The doctestplus plugin in Astropy doesn't work correctly with pytest>=3.2, so
 # we install an older version here
-easy_install "pytest<3.2" pytest-xdist
+easy_install-3.5 pytest pytest-xdist
 
-python setup.py test --parallel=4
+# Install git
+apt-get install -y git
+
+python3 setup.py test --parallel=4
 
 EOF

--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -23,6 +23,6 @@ easy_install-3.5 pytest pytest-xdist
 # Install git
 apt-get install -y git
 
-python3 setup.py test --parallel=4
+PYTHONHASHSEED=42 python3 setup.py test --parallel=4
 
 EOF

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -38,8 +38,8 @@ __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
 # Module-level dict mapping representation string alias names to classes.
 # This is populated by the metaclass init so all representation and differential
 # classes get registered automatically.
-REPRESENTATION_CLASSES = {}
-DIFFERENTIAL_CLASSES = {}
+REPRESENTATION_CLASSES = OrderedDict()
+DIFFERENTIAL_CLASSES = OrderedDict()
 
 
 def _array2string(values, prefix=''):

--- a/astropy/stats/lombscargle/tests/test_statistics.py
+++ b/astropy/stats/lombscargle/tests/test_statistics.py
@@ -102,7 +102,7 @@ def test_inverse_bootstrap(null_data, normalization, use_errs, fmax=5):
     assert_allclose(fap, fap_out, atol=0.05)
 
 
-@pytest.mark.parametrize('method', set(METHODS) - {'bootstrap'})
+@pytest.mark.parametrize('method', sorted(set(METHODS) - {'bootstrap'}))
 @pytest.mark.parametrize('normalization', NORMALIZATIONS)
 @pytest.mark.parametrize('use_errs', [True, False])
 @pytest.mark.parametrize('N', [10, 100, 1000])
@@ -127,7 +127,7 @@ def test_inverses(method, normalization, use_errs, N, T=5, fmax=5):
     assert_allclose(fap, fap_out)
 
 
-@pytest.mark.parametrize('method', METHODS)
+@pytest.mark.parametrize('method', sorted(METHODS))
 @pytest.mark.parametrize('normalization', NORMALIZATIONS)
 def test_false_alarm_smoketest(method, normalization, data):
     if not HAS_SCIPY and method in ['baluev', 'davies']:
@@ -150,9 +150,9 @@ def test_false_alarm_smoketest(method, normalization, data):
         assert np.all(fap[:-1] >= fap[1:])  # monotonically decreasing
 
 
-@pytest.mark.parametrize('method', METHODS)
+@pytest.mark.parametrize('method', sorted(METHODS))
 @pytest.mark.parametrize('use_errs', [True, False])
-@pytest.mark.parametrize('normalization', set(NORMALIZATIONS) - {'psd'})
+@pytest.mark.parametrize('normalization', sorted(set(NORMALIZATIONS) - {'psd'}))
 def test_false_alarm_equivalence(method, normalization, use_errs, data):
     # Note: the PSD normalization is not equivalent to the others, in that it
     # depends on the absolute errors rather than relative errors. Because the

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - docker pull astropy/astropy-32bit-test-env:1.9
+    - docker pull astropy/astropy-py35-32bit-test-env:1.9
 
 test:
   override:


### PR DESCRIPTION
Related to #6556 : updating CircleCI to run on Python 3 caused pytest-xdist to fail when collecting tests. This is because a few tests use set for parametrized values, and the set order is random. (see https://github.com/pytest-dev/pytest-xdist/issues/63).
So the simple fix here is to use a fixed order for the tests. (Note I took the updated CircleCI config from #6556, it was split in multiple commits so I just copied the files, but credits goes to @bsipocz  and @astrofrog :wink: )