### PR TITLE
Deprecated conversion of quantities to truth values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,11 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- Deprecated conversion of quantities to truth values. Currently, the expression
+  ``bool(0 * u.dimensionless_unscaled)`` evaluates to ``True``. In the future,
+  attempting to convert a ``Quantity`` to a ``bool`` will raise ``ValueError``.
+  [#6580, #6590]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1996,7 +1996,7 @@ class BaseDifferential(BaseRepresentationOrDifferential,
         for name in base.components:
             comp = getattr(base, name)
             d_comp = getattr(self, 'd_{0}'.format(name), None)
-            if d_comp:
+            if d_comp is not None:
                 d_unit = comp.unit / d_comp.unit
                 # Get the si unit without a scale by going via Quantity;
                 # `.si` causes the scale to be included in the value.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -21,6 +21,7 @@ from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
 from .format.latex import Latex
 from ..utils.compat import NUMPY_LT_1_13, NUMPY_LT_1_14
 from ..utils.compat.misc import override__dir__
+from ..utils.exceptions import AstropyDeprecationWarning
 from ..utils.misc import isiterable, InheritDocstrings
 from ..utils.data_info import ParentDtypeInfo
 from .. import config as _config
@@ -1173,6 +1174,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         """Quantities should always be treated as non-False; there is too much
         potential for ambiguity otherwise.
         """
+        warnings.warn('The truth value of a Quantity is ambiguous. '
+                      'In the future this will raise a ValueError.',
+                      AstropyDeprecationWarning)
         return True
 
     def __len__(self):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,9 +14,10 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
 
-from ...tests.helper import raises
+from ...tests.helper import catch_warnings, raises
 from ...utils import isiterable, minversion
 from ...utils.compat import NUMPY_LT_1_14
+from ...utils.exceptions import AstropyDeprecationWarning
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 
@@ -504,6 +505,15 @@ class TestQuantityOperations:
         # mismatched types should never work
         assert not 1. * u.cm == 1.
         assert 1. * u.cm != 1.
+
+        # comparison with zero should raise a deprecation warning
+        for quantity in (1. * u.cm, 1. * u.dimensionless_unscaled):
+            with catch_warnings(AstropyDeprecationWarning) as warning_lines:
+                bool(quantity)
+                assert warning_lines[0].category == AstropyDeprecationWarning
+                assert (str(warning_lines[0].message) == 'The truth value of '
+                        'a Quantity is ambiguous. In the future this will '
+                        'raise a ValueError.')
 
     def test_numeric_converters(self):
         # float, int, long, and __index__ should only work for single


### PR DESCRIPTION
Currently, the expression `bool(0 * u.dimensionless_unscaled)` evaluates to `True`. In the future, attempting to convert a `Quantity` to a `bool` will raise `ValueError`.

Fixes #6580.