### PR TITLE
Changing warning to exception for unsupported python versions

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -14,8 +14,8 @@ from warnings import warn
 __minimum_python_version__ = '3.5'
 __minimum_numpy_version__ = '1.9.0'
 
+class TooOldPythonError(Exception): pass
 if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    class TooOldPythonError(Exception): pass
     raise TooOldPythonError("Astropy does not support Python < {}".format(__minimum_python_version__))
 
 

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -15,7 +15,8 @@ __minimum_python_version__ = '3.5'
 __minimum_numpy_version__ = '1.9.0'
 
 if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    raise Exception("Astropy does not support Python < {}".format(__minimum_python_version__))
+    class TooOldPythonError(Exception): pass
+    raise TooOldPythonError("Astropy does not support Python < {}".format(__minimum_python_version__))
 
 
 def _is_astropy_source(path=None):

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -15,7 +15,7 @@ __minimum_python_version__ = '3.5'
 __minimum_numpy_version__ = '1.9.0'
 
 if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    warn("Astropy does not support Python < {}".format(__minimum_python_version__))
+    raise Exception("Astropy does not support Python < {}".format(__minimum_python_version__))
 
 
 def _is_astropy_source(path=None):


### PR DESCRIPTION
This PR addresses the issue that astropy is tried to be built even when the python version is unsupported. This PR builds on #6594. 

I argue that this can be very misleading, and a straight up error may be better to clear up the situation early on.  E.g. this build should have get to that stage of failing on some python3 only syntax, it should have got an exception much earlier pointing out that the python version is not supported:
https://travis-ci.org/astropy/astroquery/jobs/278620291#L862

I'm very open to suggestion what the actual type* of the error should be. 

(The quick history dig up shows that @embray preferred warnings here:
https://github.com/astropy/astropy/pull/4486#issuecomment-171691455)

(* I like a custom one, TooOldPythonError, best)