### PR TITLE
Update copyright in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
-import datetime
+from datetime import datetime
 import os
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 ON_TRAVIS = os.environ.get('TRAVIS') == 'true'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@
 # Thus, any C-extensions that are needed to build the documentation will *not*
 # be accessible, and the documentation will not build correctly.
 
+import datetime
 import os
 ON_RTD = os.environ.get('READTHEDOCS') == 'True'
 ON_TRAVIS = os.environ.get('TRAVIS') == 'true'
@@ -102,7 +103,7 @@ rst_epilog += """
 
 project = u'Astropy'
 author = u'The Astropy Developers'
-copyright = u'2011-2016, ' + author
+copyright = u'2011-{0}, '.format(datetime.now().year) + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ rst_epilog += """
 
 project = u'Astropy'
 author = u'The Astropy Developers'
-copyright = u'2011-{0}, '.format(datetime.now().year) + author
+copyright = u'2011–{0}, '.format(datetime.now().year) + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ rst_epilog += """
 
 project = u'Astropy'
 author = u'The Astropy Developers'
-copyright = u'2011–{0}, '.format(datetime.now().year) + author
+copyright = u'2011–{0}, '.format(datetime.utcnow().year) + author
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
I noticed this when reviewing the `conf.py` file, and figured we should just auto-fill the current year. Then the pedant in me realized that the hyphen in the copyright should really be an en-dash.