### PR TITLE
Include pytest-xdist in the dev requirements file

### DIFF
--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -16,3 +16,4 @@ matplotlib
 # below here are used only for tests
 skyfield
 mpmath
+pytest-xdist


### PR DESCRIPTION
It's mentioned as required dependency for parallel tests (http://docs.astropy.org/en/stable/development/testguide.html#running-tests-in-parallel) so it's probably a good fit for the requirements-dev file.