### PR TITLE
Remove deprecated abc.abstractproperty

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -184,9 +184,9 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         return name
 
     # The two methods that any subclass has to define.
-    # Should be replaced by abstractclassmethod once we support only PY3
+    @classmethod
     @abc.abstractmethod
-    def from_cartesian(self, other):
+    def from_cartesian(cls, other):
         """Create a representation of this class from a supplied Cartesian one.
 
         Parameters

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -106,7 +106,8 @@ class Projection(Model):
     # This sets the circumference to 360 deg so that arc length is measured in deg.
     r0 = 180 * u.deg / np.pi
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def inverse(self):
         """
         Inverse projection--all projection models must provide an inverse.

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -86,7 +86,10 @@ class _Tabular(Model):
     standard_broadcasting = False
     outputs = ('y',)
 
-    lookup_table = abc.abstractproperty()
+    @property
+    @abc.abstractmethod
+    def lookup_table(self):
+        pass
 
     _is_dynamic = True
 

--- a/astropy/nddata/nddata_base.py
+++ b/astropy/nddata/nddata_base.py
@@ -2,7 +2,7 @@
 # This module implements the base NDDataBase class.
 
 
-from abc import ABCMeta, abstractproperty, abstractmethod
+from abc import ABCMeta, abstractmethod
 
 
 __all__ = ['NDDataBase']
@@ -21,13 +21,15 @@ class NDDataBase(metaclass=ABCMeta):
     def __init__(self):
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def data(self):
         """The stored dataset.
         """
         pass
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def mask(self):
         """Mask for the dataset.
 
@@ -36,19 +38,22 @@ class NDDataBase(metaclass=ABCMeta):
         """
         return None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def unit(self):
         """Unit for the dataset.
         """
         return None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def wcs(self):
         """World coordinate system (WCS) for the dataset.
         """
         return None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def meta(self):
         """Additional meta information about the dataset.
 
@@ -56,7 +61,8 @@ class NDDataBase(metaclass=ABCMeta):
         """
         return None
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def uncertainty(self):
         """Uncertainty in the dataset.
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -2,7 +2,7 @@
 
 
 import numpy as np
-from abc import ABCMeta, abstractproperty, abstractmethod
+from abc import ABCMeta, abstractmethod
 from copy import deepcopy
 import weakref
 
@@ -96,7 +96,8 @@ class NDUncertainty(metaclass=ABCMeta):
         self.array = array
         self.parent_nddata = None  # no associated NDData - until it is set!
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def uncertainty_type(self):
         """`str` : Short description of the type of uncertainty.
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -2,7 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Function Units and Quantities."""
 
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
@@ -50,7 +50,8 @@ class FunctionUnitBase(metaclass=ABCMeta):
     """
     # ↓↓↓ the following four need to be set by subclasses
     # Make this a property so we can ensure subclasses define it.
-    @abstractproperty
+    @property
+    @abstractmethod
     def _default_function_unit(self):
         """Default function unit corresponding to the function.
 
@@ -60,7 +61,8 @@ class FunctionUnitBase(metaclass=ABCMeta):
 
     # This has to be a property because the function quantity will not be
     # known at unit definition time, as it gets defined after.
-    @abstractproperty
+    @property
+    @abstractmethod
     def _quantity_class(self):
         """Function quantity class corresponding to this function unit.
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -568,15 +568,17 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
     # thread-safe though.
     _nextid = 1
 
-    _class_attribute_ = abc.abstractproperty()
-    """
-    Subclasses should define this attribute to the name of an attribute on
-    classes containing this subclass.  That attribute will contain the mapping
-    of all instances of that `OrderedDescriptor` subclass defined in the class
-    body.  If the same descriptor needs to be used with different classes,
-    each with different names of this attribute, multiple subclasses will be
-    needed.
-    """
+    @property
+    @abc.abstractmethod
+    def _class_attribute_(self):
+        """
+        Subclasses should define this attribute to the name of an attribute on
+        classes containing this subclass.  That attribute will contain the mapping
+        of all instances of that `OrderedDescriptor` subclass defined in the class
+        body.  If the same descriptor needs to be used with different classes,
+        each with different names of this attribute, multiple subclasses will be
+        needed.
+        """
 
     _name_attribute_ = None
     """
@@ -876,7 +878,8 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
     # copies rather than views of data (see the special-case treatment of
     # 'flatten' in Time).
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def shape(self):
         """The shape of the instance and underlying arrays."""
 


### PR DESCRIPTION
`abc.abstractproperty` was [deprecated in 3.3](https://docs.python.org/3/library/abc.html#abc.abstractproperty) and the recommended way is to use `property` and `abc.abstractmethod`.