### PR TITLE
Second argument to issubdtype should be a NumPy dtype

### DIFF
--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -861,11 +861,10 @@ class ImageDataDiff(_BaseDiff):
             return
 
         # Find the indices where the values are not equal
-        # If neither a nor b are floating point, ignore rtol and atol
-        if not ((np.issubdtype(self.a.dtype, float) or
-                 np.issubdtype(self.a.dtype, complex)) or
-                (np.issubdtype(self.b.dtype, float) or
-                 np.issubdtype(self.b.dtype, complex))):
+        # If neither a nor b are floating point (or complex), ignore rtol and
+        # atol
+        if not (np.issubdtype(self.a.dtype, np.inexact) or
+                np.issubdtype(self.b.dtype, np.inexact)):
             rtol = 0
             atol = 0
         else:
@@ -1176,8 +1175,8 @@ class TableDataDiff(_BaseDiff):
             arra = self.a[col.name]
             arrb = self.b[col.name]
 
-            if (np.issubdtype(arra.dtype, float) and
-                    np.issubdtype(arrb.dtype, float)):
+            if (np.issubdtype(arra.dtype, np.floating) and
+                    np.issubdtype(arrb.dtype, np.floating)):
                 diffs = where_not_allclose(arra, arrb,
                                            rtol=self.rtol,
                                            atol=self.atol)

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -369,7 +369,7 @@ class TestParameterInitialization(object):
         t = TParModel(10, [1, 2])
         assert len(t) == 1
         assert t.model_set_axis is False
-        assert np.issubdtype(t.param_sets.dtype, object)
+        assert np.issubdtype(t.param_sets.dtype, np.object_)
         assert len(t.param_sets) == 2
         assert np.all(t.param_sets[0] == [10])
         assert np.all(t.param_sets[1] == [[1, 2]])
@@ -437,7 +437,7 @@ class TestParameterInitialization(object):
         assert len(t) == 1
         assert t.model_set_axis is False
         assert len(t.param_sets) == 2
-        assert np.issubdtype(t.param_sets.dtype, object)
+        assert np.issubdtype(t.param_sets.dtype, np.object_)
         assert np.all(t.param_sets[0] == [[[10, 20, 30], [40, 50, 60]]])
         assert np.all(t.param_sets[1] == [[1, 2, 3]])
         assert np.all(t.parameters == [10, 20, 30, 40, 50, 60, 1, 2, 3])
@@ -469,7 +469,7 @@ class TestParameterInitialization(object):
         assert len(t) == 2
         assert t.model_set_axis == 0
         assert len(t.param_sets) == 2
-        assert np.issubdtype(t.param_sets.dtype, object)
+        assert np.issubdtype(t.param_sets.dtype, np.object_)
         assert np.all(t.param_sets[0] == [[10], [20]])
         assert np.all(t.param_sets[1] == [[1, 2], [3, 4]])
         assert np.all(t.parameters == [10, 20, 1, 2, 3, 4])
@@ -508,7 +508,7 @@ class TestParameterInitialization(object):
         assert len(t) == 2
         assert t.model_set_axis == 0
         assert len(t.param_sets) == 2
-        assert np.issubdtype(t.param_sets.dtype, object)
+        assert np.issubdtype(t.param_sets.dtype, np.object_)
         assert np.all(t.param_sets[0] == [[[10, 20], [30, 40]],
                                           [[50, 60], [70, 80]]])
         assert np.all(t.param_sets[1] == [[[1, 2]], [[3, 4]]])
@@ -542,7 +542,7 @@ class TestParameterInitialization(object):
         assert len(t) == 2
         assert t.model_set_axis == -1
         assert len(t.param_sets) == 2
-        assert np.issubdtype(t.param_sets.dtype, object)
+        assert np.issubdtype(t.param_sets.dtype, np.object_)
         assert np.all(t.param_sets[0] == [[[10, 50], [20, 60]],
                                           [[30, 70], [40, 80]]])
         assert np.all(t.param_sets[1] == [[[1, 3], [2, 4]]])
@@ -582,7 +582,7 @@ class TestParameterInitialization(object):
         assert len(t4) == 1
         assert t4.coeff.shape == (2, 2)
         assert t4.e.shape == (2,)
-        assert np.issubdtype(t4.param_sets.dtype, object)
+        assert np.issubdtype(t4.param_sets.dtype, np.object_)
         assert np.all(t4.param_sets[0] == [[1, 2], [3, 4]])
         assert np.all(t4.param_sets[1] == [5, 6])
 

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -113,7 +113,7 @@ def test_initialize_from_FITS(ccd_data, tmpdir):
     cd = CCDData.read(filename, unit=u.electron)
     assert cd.shape == (10, 10)
     assert cd.size == 100
-    assert np.issubdtype(cd.data.dtype, np.float)
+    assert np.issubdtype(cd.data.dtype, np.floating)
     for k, v in hdu.header.items():
         assert cd.meta[k] == v
 


### PR DESCRIPTION
On NumPy master it raises a `FutureWarning` if the second argument isn't an original NumPy dtype. This PR fixes that.

Milestoning it as 2.0.3 because I think it's like a bugfix?!