### PR TITLE
Fix DocTestTextfilePlus.obj to not raise exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -349,6 +349,8 @@ astropy.tests
 
 - Fixed a bug that causes tests for rst files to not be run on certain platforms. [#6555]
 
+- Fixed a bug that caused the doctestplus plugin to not work nicely with the hypothesis package. [#6605]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -100,6 +100,13 @@ def pytest_configure(config):
                         test.name, self, runner, test)
 
     class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+
+        # Some pytest plugins such as hypothesis try and access the 'obj'
+        # attribute, and by default this returns an error for this class
+        # so we override it here to avoid any issues.
+        def obj(self):
+            pass
+
         def runtest(self):
             # satisfy `FixtureRequest` constructor...
             self.funcargs = {}


### PR DESCRIPTION
At the moment, DocTestTextfilePlus.obj raises an error if accessed. However, hypothesis uses that attribute and this causes issues like: https://github.com/cdeil/healpix/issues/32

This PR does the 'easy' fix of simply overwriting ``obj`` so that it returns ``None``, which keeps hypothesis happy. But there may be a better fix?

@drdavella if merged, this will have to be back-ported to the pytest plugins (I'd like to get this fix in 2.0.3 so it has to be merged in master)

cc @Cadair @eteq
