### PR TITLE
Rearrange import order in io.misc.connect

### DIFF
--- a/astropy/io/misc/connect.py
+++ b/astropy/io/misc/connect.py
@@ -2,11 +2,10 @@
 # This file connects any readers/writers defined in io.misc to the
 # astropy.table.Table class
 
-
-from .hdf5 import read_table_hdf5, write_table_hdf5, is_hdf5
-
 from .. import registry as io_registry
 from ...table import Table
+
+from .hdf5 import read_table_hdf5, write_table_hdf5, is_hdf5
 
 io_registry.register_reader('hdf5', Table, read_table_hdf5)
 io_registry.register_writer('hdf5', Table, write_table_hdf5)


### PR DESCRIPTION
Fix #6604 (doc build failure in Python 3.6)

Note: Even if this doesn't fix the problem (although now I can build doc successfully in my local Python 3.6 but I worry that the failure is transient and just happen not to appear when I ran it) at least import order is "cleaner"; i.e., import upper-level sub-package before local modules within the same sub-package.

c/c @MSeifert04 @saimn @drdavella 