### PR TITLE
Backport DocTestTextfilePlus.obj bugfix to v2.0.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,11 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
-- Fixed a bug that causes tests for rst files to not be run on certain platforms. [#6555, #6608]
+- Fixed a bug that causes tests for rst files to not be run on certain
+  platforms. [#6555, #6608]
+
+- Fixed a bug that caused the doctestplus plugin to not work nicely with the
+  hypothesis package. [#6605, #6609]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -196,6 +196,13 @@ def pytest_configure(config):
                         test.name, self, runner, test)
 
     class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+
+        # Some pytest plugins such as hypothesis try and access the 'obj'
+        # attribute, and by default this returns an error for this class
+        # so we override it here to avoid any issues.
+        def obj(self):
+            pass
+
         def runtest(self):
             # satisfy `FixtureRequest` constructor...
             self.funcargs = {}


### PR DESCRIPTION
This ports the same issue that was addressed in #6605 back to v2.0.x.
