### PR TITLE
Fix creating SkyCoord from list of SkyCoord objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,10 @@ astropy.coordinates
   instead of ``frame.data`` in the context of methods that use ``._apply()``.
   [#6561]
 
+- Creating a new ``SkyCoord`` from a list of multiple ``SkyCoord`` objects now
+  yield the correct type of frame, and works at all for non-equatorial frames.
+  [#6612]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1563,6 +1563,14 @@ def _get_frame(args, kwargs):
     # if a coordinate is supplied in the args list.  If the frame still had not
     # been set by this point and a coordinate was supplied, then use that frame.
     for arg in args:
+        # this catches the "single list passed in" case.  For that case we want
+        # to allow the first argument to set the class.  That's OK because
+        # _parse_coordinate_arg goes and checks that the frames match between
+        # the first and all the others
+        if (isinstance(arg, (collections.Sequence, np.ndarray)) and
+             len(args) == 1 and len(arg) > 0):
+            arg = arg[0]
+
         coord_frame_cls = None
         if isinstance(arg, BaseCoordinateFrame):
             coord_frame_cls = arg.__class__

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -564,3 +564,16 @@ def test_regression_6597():
     sc1 = SkyCoord([c1, c2])
 
     assert sc1.frame.name == frame_name
+
+
+def test_regression_6597_2():
+    """
+    This tests the more subtle flaw that #6597 indirectly uncovered: that even
+    in the case that the frames are ra/dec, they still might be the wrong *kind*
+    """
+    frame = FK4(equinox='J1949')
+    c1 = SkyCoord(1, 3, unit='deg', frame=frame)
+    c2 = SkyCoord(2, 4, unit='deg', frame=frame)
+    sc1 = SkyCoord([c1, c2])
+
+    assert sc1.frame.name == frame.name

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -555,3 +555,12 @@ def test_regression_6448():
     sc2 = SkyCoord([c1, c2])
     # without 6448 this fails
     assert sc2.galcen_v_sun is None
+
+
+def test_regression_6597():
+    frame_name = 'galactic'
+    c1 = SkyCoord(1, 3, unit='deg', frame=frame_name)
+    c2 = SkyCoord(2, 4, unit='deg', frame=frame_name)
+    sc1 = SkyCoord([c1, c2])
+
+    assert sc1.frame.name == frame_name


### PR DESCRIPTION
As pointed out in #6597, there was a flaw in the implementation of `SkyCoord` that made it fail when you try to pass in non-equatorial frames as a list of multiple `SkyCoord` objects.  It turns out the problem was deeper: it was treating *all* such frames as ICRS, even if you were to have passed in an FK5 or the like.  This PR fixes that flaw.

It thereby fixes #6597