### PR TITLE
Remove arguments for super (trivial cases)

### DIFF
--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -413,7 +413,7 @@ class ExtraFunction(Function):
             self.args.append(Return(self.ret, self.doc))
 
     def __repr__(self):
-        r = super(ExtraFunction, self).__repr__()
+        r = super().__repr__()
         if r.startswith('Function'):
             r = 'Extra' + r
         return r

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -226,14 +226,14 @@ class set_temp_config(_SetTempPath):
         # cached config objects
         from .configuration import _cfgobjs
 
-        path = super(set_temp_config, self).__enter__()
+        path = super().__enter__()
         _cfgobjs.clear()
         return path
 
     def __exit__(self, *args):
         from .configuration import _cfgobjs
 
-        super(set_temp_config, self).__exit__(*args)
+        super().__exit__(*args)
         _cfgobjs.clear()
 
 

--- a/astropy/constants/codata2010.py
+++ b/astropy/constants/codata2010.py
@@ -18,8 +18,8 @@ class CODATA2010(Constant):
 
     def __new__(cls, abbrev, name, value, unit, uncertainty,
                 reference=default_reference, system=None):
-        return(super(CODATA2010, cls).__new__(cls, abbrev, name, value, unit,
-                        uncertainty, reference, system))
+        return super().__new__(
+            cls, abbrev, name, value, unit, uncertainty, reference, system)
 
 
 class EMCODATA2010(CODATA2010, EMConstant):

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -70,7 +70,7 @@ class ConstantMeta(InheritDocstrings):
                     attr not in exclude):
                 d[attr] = wrap(value)
 
-        return super(ConstantMeta, mcls).__new__(mcls, name, bases, d)
+        return super().__new__(mcls, name, bases, d)
 
 
 class Constant(Quantity, metaclass=ConstantMeta):
@@ -133,7 +133,7 @@ class Constant(Quantity, metaclass=ConstantMeta):
                                            self.reference))
 
     def __quantity_subclass__(self, unit):
-        return super(Constant, self).__quantity_subclass__(unit)[0], False
+        return super().__quantity_subclass__(unit)[0], False
 
     def copy(self):
         """
@@ -192,7 +192,7 @@ class Constant(Quantity, metaclass=ConstantMeta):
         """
 
         instances = self._registry[self.name.lower()]
-        return instances.get('si') or super(Constant, self).si
+        return instances.get('si') or super().si
 
     @property
     def cgs(self):
@@ -201,7 +201,7 @@ class Constant(Quantity, metaclass=ConstantMeta):
         """
 
         instances = self._registry[self.name.lower()]
-        return instances.get('cgs') or super(Constant, self).cgs
+        return instances.get('cgs') or super().cgs
 
     def __array_finalize__(self, obj):
         for attr in ('_abbrev', '_name', '_value', '_unit_string',

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -237,7 +237,7 @@ class Kernel1D(Kernel):
         elif array is not None:
             self._model = None
 
-        super(Kernel1D, self).__init__(array)
+        super().__init__(array)
 
 
 class Kernel2D(Kernel):
@@ -309,7 +309,7 @@ class Kernel2D(Kernel):
         elif array is not None:
             self._model = None
 
-        super(Kernel2D, self).__init__(array)
+        super().__init__(array)
 
 
 def kernel_arithmetics(kernel, value, operation):

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -84,7 +84,7 @@ class Gaussian1DKernel(Kernel1D):
         self._model = models.Gaussian1D(1. / (np.sqrt(2 * np.pi) * stddev),
                                         0, stddev)
         self._default_size = _round_up_to_odd_integer(8 * stddev)
-        super(Gaussian1DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = np.abs(1. - self._array.sum())
 
 
@@ -150,7 +150,7 @@ class Gaussian2DKernel(Kernel2D):
         self._model = models.Gaussian2D(1. / (2 * np.pi * stddev ** 2), 0,
                                         0, stddev, stddev)
         self._default_size = _round_up_to_odd_integer(8 * stddev)
-        super(Gaussian2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = np.abs(1. - self._array.sum())
 
 
@@ -217,7 +217,7 @@ class Box1DKernel(Kernel1D):
         self._model = models.Box1D(1. / width, 0, width)
         self._default_size = _round_up_to_odd_integer(width)
         kwargs['mode'] = 'linear_interp'
-        super(Box1DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
         self.normalize()
 
@@ -287,7 +287,7 @@ class Box2DKernel(Kernel2D):
         self._model = models.Box2D(1. / width ** 2, 0, 0, width, width)
         self._default_size = _round_up_to_odd_integer(width)
         kwargs['mode'] = 'linear_interp'
-        super(Box2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
         self.normalize()
 
@@ -346,7 +346,7 @@ class Tophat2DKernel(Kernel2D):
     def __init__(self, radius, **kwargs):
         self._model = models.Disk2D(1. / (np.pi * radius ** 2), 0, 0, radius)
         self._default_size = _round_up_to_odd_integer(2 * radius)
-        super(Tophat2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
 
 
@@ -406,7 +406,7 @@ class Ring2DKernel(Kernel2D):
         self._model = models.Ring2D(1. / (np.pi * (radius_out ** 2 - radius_in ** 2)),
                                     0, 0, radius_in, width)
         self._default_size = _round_up_to_odd_integer(2 * radius_out)
-        super(Ring2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
 
 
@@ -463,7 +463,7 @@ class Trapezoid1DKernel(Kernel1D):
     def __init__(self, width, slope=1., **kwargs):
         self._model = models.Trapezoid1D(1, 0, width, slope)
         self._default_size = _round_up_to_odd_integer(width + 2. / slope)
-        super(Trapezoid1DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
         self.normalize()
 
@@ -523,7 +523,7 @@ class TrapezoidDisk2DKernel(Kernel2D):
     def __init__(self, radius, slope=1., **kwargs):
         self._model = models.TrapezoidDisk2D(1, 0, 0, radius, slope)
         self._default_size = _round_up_to_odd_integer(2 * radius + 2. / slope)
-        super(TrapezoidDisk2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = 0
         self.normalize()
 
@@ -594,7 +594,7 @@ class MexicanHat1DKernel(Kernel1D):
         amplitude = 1.0 / (np.sqrt(2 * np.pi) * width ** 3)
         self._model = models.MexicanHat1D(amplitude, 0, width)
         self._default_size = _round_up_to_odd_integer(8 * width)
-        super(MexicanHat1DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = np.abs(self._array.sum() / self._array.size)
 
 
@@ -667,7 +667,7 @@ class MexicanHat2DKernel(Kernel2D):
         amplitude = 1.0 / (np.pi * width ** 4)
         self._model = models.MexicanHat2D(amplitude, 0, 0, width)
         self._default_size = _round_up_to_odd_integer(8 * width)
-        super(MexicanHat2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._truncation = np.abs(self._array.sum() / self._array.size)
 
 
@@ -729,7 +729,7 @@ class AiryDisk2DKernel(Kernel2D):
     def __init__(self, radius, **kwargs):
         self._model = models.AiryDisk2D(1, 0, 0, radius)
         self._default_size = _round_up_to_odd_integer(8 * radius)
-        super(AiryDisk2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.normalize()
         self._truncation = None
 
@@ -795,7 +795,7 @@ class Moffat2DKernel(Kernel2D):
                                       0, 0, gamma, alpha)
         fwhm = 2.0 * alpha * (2.0 ** (1.0 / gamma) - 1.0) ** 0.5
         self._default_size = _round_up_to_odd_integer(4.0 * fwhm)
-        super(Moffat2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.normalize()
         self._truncation = None
 
@@ -861,7 +861,7 @@ class Model1DKernel(Kernel1D):
             self._model = model
         else:
             raise TypeError("Must be Fittable1DModel")
-        super(Model1DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class Model2DKernel(Kernel2D):
@@ -929,7 +929,7 @@ class Model2DKernel(Kernel2D):
             self._model = model
         else:
             raise TypeError("Must be Fittable2DModel")
-        super(Model2DKernel, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
 
 class PSFKernel(Kernel2D):
@@ -982,7 +982,7 @@ class CustomKernel(Kernel):
     """
     def __init__(self, array):
         self.array = array
-        super(CustomKernel, self).__init__(self._array)
+        super().__init__(self._array)
 
     @property
     def array(self):

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -108,8 +108,7 @@ class Angle(u.SpecificTypeQuantity):
                        angle.dtype.kind not in 'SUVO')):
                 angle = [Angle(x, unit, copy=False) for x in angle]
 
-        return super(Angle, cls).__new__(cls, angle, unit, dtype=dtype,
-                                         copy=copy)
+        return super().__new__(cls, angle, unit, dtype=dtype, copy=copy)
 
     @staticmethod
     def _tuple_to_float(angle, unit):
@@ -131,7 +130,7 @@ class Angle(u.SpecificTypeQuantity):
         return u.hourangle if unit is u.hour else unit
 
     def _set_unit(self, unit):
-        super(Angle, self)._set_unit(self._convert_unit_to_angle_unit(unit))
+        super()._set_unit(self._convert_unit_to_angle_unit(unit))
 
     @property
     def hour(self):
@@ -504,7 +503,7 @@ class Latitude(Angle):
         # Forbid creating a Lat from a Long.
         if isinstance(angle, Longitude):
             raise TypeError("A Latitude angle cannot be created from a Longitude angle")
-        self = super(Latitude, cls).__new__(cls, angle, unit=unit, **kwargs)
+        self = super().__new__(cls, angle, unit=unit, **kwargs)
         self._validate_angles()
         return self
 
@@ -530,7 +529,7 @@ class Latitude(Angle):
             raise TypeError("A Longitude angle cannot be assigned to a Latitude angle")
         # first check bounds
         self._validate_angles(value)
-        super(Latitude, self).__setitem__(item, value)
+        super().__setitem__(item, value)
 
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
@@ -538,7 +537,7 @@ class Latitude(Angle):
         return _no_angle_subclass(obj)
 
     def __array_ufunc__(self, *args, **kwargs):
-        results = super(Latitude, self).__array_ufunc__(*args, **kwargs)
+        results = super().__array_ufunc__(*args, **kwargs)
         return _no_angle_subclass(results)
 
 
@@ -610,7 +609,7 @@ class Longitude(Angle):
         if isinstance(angle, Latitude):
             raise TypeError("A Longitude angle cannot be created from "
                             "a Latitude angle.")
-        self = super(Longitude, cls).__new__(cls, angle, unit=unit, **kwargs)
+        self = super().__new__(cls, angle, unit=unit, **kwargs)
         if wrap_angle is None:
             wrap_angle = getattr(angle, 'wrap_angle', self._default_wrap_angle)
         self.wrap_angle = wrap_angle
@@ -620,7 +619,7 @@ class Longitude(Angle):
         # Forbid assigning a Lat to a Long.
         if isinstance(value, Latitude):
             raise TypeError("A Latitude angle cannot be assigned to a Longitude angle")
-        super(Longitude, self).__setitem__(item, value)
+        super().__setitem__(item, value)
         self._wrap_internal()
 
     def _wrap_internal(self):
@@ -640,7 +639,7 @@ class Longitude(Angle):
         if np.any(self_angle < wrap_angle_floor) or np.any(self_angle >= wrap_angle):
             wrapped = np.mod(self_angle - wrap_angle, a360) + wrap_angle_floor
             value = u.Quantity(wrapped, self.unit)
-            super(Longitude, self).__setitem__((), value)
+            super().__setitem__((), value)
 
     @property
     def wrap_angle(self):
@@ -652,7 +651,7 @@ class Longitude(Angle):
         self._wrap_internal()
 
     def __array_finalize__(self, obj):
-        super(Longitude, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         self._wrap_angle = getattr(obj, '_wrap_angle',
                                    self._default_wrap_angle)
 
@@ -662,5 +661,5 @@ class Longitude(Angle):
         return _no_angle_subclass(obj)
 
     def __array_ufunc__(self, *args, **kwargs):
-        results = super(Longitude, self).__array_ufunc__(*args, **kwargs)
+        results = super().__array_ufunc__(*args, **kwargs)
         return _no_angle_subclass(results)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -60,7 +60,7 @@ class Attribute(OrderedDescriptor):
     def __init__(self, default=None, secondary_attribute=''):
         self.default = default
         self.secondary_attribute = secondary_attribute
-        super(Attribute, self).__init__()
+        super().__init__()
 
     def convert_input(self, value):
         """
@@ -207,8 +207,7 @@ class CartesianRepresentationAttribute(Attribute):
     """
 
     def __init__(self, default=None, secondary_attribute='', unit=None):
-        super(CartesianRepresentationAttribute, self).__init__(
-            default, secondary_attribute)
+        super().__init__(default, secondary_attribute)
         self.unit = unit
 
     def convert_input(self, value):
@@ -276,7 +275,7 @@ class QuantityAttribute(Attribute):
     """
 
     def __init__(self, default=None, secondary_attribute='', unit=None, shape=None):
-        super(QuantityAttribute, self).__init__(default, secondary_attribute)
+        super().__init__(default, secondary_attribute)
         self.unit = unit
         self.shape = shape
 
@@ -389,7 +388,7 @@ class CoordinateAttribute(Attribute):
 
     def __init__(self, frame, default=None, secondary_attribute=''):
         self._frame = frame
-        super(CoordinateAttribute, self).__init__(default, secondary_attribute)
+        super().__init__(default, secondary_attribute)
 
     def convert_input(self, value):
         """
@@ -453,8 +452,7 @@ class DifferentialAttribute(Attribute):
         else:
             self.allowed_classes = BaseDifferential
 
-        super(DifferentialAttribute, self).__init__(default,
-                                                    secondary_attribute)
+        super().__init__(default, secondary_attribute)
 
     def convert_input(self, value):
         """
@@ -495,21 +493,21 @@ class FrameAttribute(Attribute):
     def __init__(self, *args, **kwargs):
         warnings.warn("FrameAttribute has been renamed to Attribute.",
                       AstropyDeprecationWarning)
-        super(FrameAttribute, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 class TimeFrameAttribute(TimeAttribute):
 
     def __init__(self, *args, **kwargs):
         warnings.warn("TimeFrameAttribute has been renamed to TimeAttribute.",
                       AstropyDeprecationWarning)
-        super(TimeFrameAttribute, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 class QuantityFrameAttribute(QuantityAttribute):
 
     def __init__(self, *args, **kwargs):
         warnings.warn("QuantityFrameAttribute has been renamed to "
                       "QuantityAttribute.", AstropyDeprecationWarning)
-        super(QuantityFrameAttribute, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 class CartesianRepresentationFrameAttribute(CartesianRepresentationAttribute):
 
@@ -517,8 +515,7 @@ class CartesianRepresentationFrameAttribute(CartesianRepresentationAttribute):
         warnings.warn("CartesianRepresentationFrameAttribute has been renamed "
                       "to CartesianRepresentationAttribute.",
                       AstropyDeprecationWarning)
-        super(CartesianRepresentationFrameAttribute, self).__init__(
-            *args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 # do this here to prevent a series of complicated circular imports

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -131,7 +131,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
 
         # somewhat hacky, but this is the best way to get the MRO according to
         # https://mail.python.org/pipermail/python-list/2002-December/167861.html
-        tmp_cls = super(FrameMeta, mcls).__new__(mcls, name, bases, members)
+        tmp_cls = super().__new__(mcls, name, bases, members)
 
         # now look through the whole MRO for the class attributes, raw for
         # frame_attr_names, and leading underscore for others
@@ -172,7 +172,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if 'name' not in members:
             members['name'] = name.lower()
 
-        return super(FrameMeta, mcls).__new__(mcls, name, bases, members)
+        return super().__new__(mcls, name, bases, members)
 
     @staticmethod
     def readonly_prop_factory(members, attr, value):
@@ -203,9 +203,7 @@ class RepresentationMapping(_RepresentationMappingBase):
 
     def __new__(cls, reprname, framename, defaultunit='recommended'):
         # this trick just provides some defaults
-        return super(RepresentationMapping, cls).__new__(cls, reprname,
-                                                         framename,
-                                                         defaultunit)
+        return super().__new__(cls, reprname, framename, defaultunit)
 
 
 class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
@@ -1252,7 +1250,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             raise AttributeError(
                 'Cannot set any frame attribute {0}'.format(attr))
         else:
-            super(BaseCoordinateFrame, self).__setattr__(attr, value)
+            super().__setattr__(attr, value)
 
     def separation(self, other):
         """
@@ -1384,7 +1382,7 @@ class GenericFrame(BaseCoordinateFrame):
             self.frame_attributes[name] = Attribute(default)
             setattr(self, '_' + name, default)
 
-        super(GenericFrame, self).__init__(None)
+        super().__init__(None)
 
     def __getattr__(self, name):
         if '_' + name in self.__dict__:
@@ -1396,4 +1394,4 @@ class GenericFrame(BaseCoordinateFrame):
         if name in self.get_frame_attr_names():
             raise AttributeError("can't set frame attribute '{0}'".format(name))
         else:
-            super(GenericFrame, self).__setattr__(name, value)
+            super().__setattr__(name, value)

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -135,7 +135,7 @@ class AltAz(BaseCoordinateFrame):
     obswl = QuantityAttribute(default=1*u.micron, unit=u.micron)
 
     def __init__(self, *args, **kwargs):
-        super(AltAz, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def secz(self):

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -206,7 +206,7 @@ class Galactocentric(BaseCoordinateFrame):
             galcen_kw['dec'] = kwargs.pop('galcen_dec', self.galcen_coord.dec)
             kwargs['galcen_coord'] = ICRS(**galcen_kw)
 
-        super(Galactocentric, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     @property
     def galcen_ra(self):

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -68,7 +68,7 @@ def make_skyoffset_cls(framecls):
             newname = name[:-5] if name.endswith('Frame') else name
             newname += framecls.__name__
 
-            res = super(SkyOffsetMeta, cls).__new__(cls, newname, bases, members)
+            res = super().__new__(cls, newname, bases, members)
 
             # now go through all the component names and make any spherical names be "lon" and "lat"
             # instead of e.g. "ra" and "dec"
@@ -209,12 +209,12 @@ class SkyOffsetFrame(BaseCoordinateFrame):
         # See above for why this is necessary. Basically, because some child
         # may override __new__, we must override it here to never pass
         # arguments to the object.__new__ method.
-        if super(SkyOffsetFrame, cls).__new__ is object.__new__:
-            return super(SkyOffsetFrame, cls).__new__(cls)
-        return super(SkyOffsetFrame, cls).__new__(cls, *args, **kwargs)
+        if super().__new__ is object.__new__:
+            return super().__new__(cls)
+        return super().__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
-        super(SkyOffsetFrame, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         if self.origin is not None and not self.origin.has_data:
             raise ValueError('The origin supplied to SkyOffsetFrame has no '
                              'data.')

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -139,7 +139,7 @@ class Distance(u.SpecificTypeQuantity):
                                  'given to Distance constructor')
 
         # now we have arguments like for a Quantity, so let it do the work
-        distance = super(Distance, cls).__new__(
+        distance = super().__new__(
             cls, value, unit, dtype=dtype, copy=copy, order=order,
             subok=subok, ndmin=ndmin)
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -243,7 +243,7 @@ class EarthLocation(u.Quantity):
         x, y, z = np.broadcast_arrays(x, y, z)
         struc = np.empty(x.shape, cls._location_dtype)
         struc['x'], struc['y'], struc['z'] = x, y, z
-        return super(EarthLocation, cls).__new__(cls, struc, unit, copy=False)
+        return super().__new__(cls, struc, unit, copy=False)
 
     @classmethod
     def from_geodetic(cls, lon, lat, height=0., ellipsoid=None):
@@ -647,14 +647,14 @@ class EarthLocation(u.Quantity):
         return self['z']
 
     def __getitem__(self, item):
-        result = super(EarthLocation, self).__getitem__(item)
+        result = super().__getitem__(item)
         if result.dtype is self.dtype:
             return result.view(self.__class__)
         else:
             return result.view(u.Quantity)
 
     def __array_finalize__(self, obj):
-        super(EarthLocation, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         if hasattr(obj, '_ellipsoid'):
             self._ellipsoid = obj._ellipsoid
 
@@ -662,7 +662,7 @@ class EarthLocation(u.Quantity):
         if self.shape == ():
             raise IndexError('0-d EarthLocation arrays cannot be indexed')
         else:
-            return super(EarthLocation, self).__len__()
+            return super().__len__()
 
     def _to_value(self, unit, equivalencies=[]):
         """Helper method for to and to_value."""

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -172,4 +172,4 @@ class UnknownSiteException(KeyError):
         self.site = site
         self.attribute = attribute
         self.close_names = close_names
-        return super(UnknownSiteException, self).__init__(message)
+        return super().__init__(message)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -407,7 +407,7 @@ def _make_getter(component):
 #  (non-strict) subclass of the metaclasses of all its bases"
 class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
     def __init__(cls, name, bases, dct):
-        super(MetaBaseRepresentation, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
         # Register representation name (except for BaseRepresentation)
         if cls.__name__ == 'BaseRepresentation':
@@ -475,7 +475,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     def __init__(self, *args, **kwargs):
         # Handle any differentials passed in.
         differentials = kwargs.pop('differentials', None)
-        super(BaseRepresentation, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._differentials = self._validate_differentials(differentials)
 
     def _validate_differentials(self, differentials):
@@ -760,7 +760,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
             Any keyword arguments for ``method``.
 
         """
-        rep = super(BaseRepresentation, self)._apply(method, *args, **kwargs)
+        rep = super()._apply(method, *args, **kwargs)
 
         rep._differentials = dict(
             [(k, diff._apply(method, *args, **kwargs))
@@ -997,8 +997,7 @@ class CartesianRepresentation(BaseRepresentation):
             z = u.Quantity(z, unit, copy=copy, subok=True)
             copy = False
 
-        super(CartesianRepresentation, self).__init__(x, y, z, copy=copy,
-                                                      differentials=differentials)
+        super().__init__(x, y, z, copy=copy, differentials=differentials)
         if not (self._x.unit.physical_type ==
                 self._y.unit.physical_type == self._z.unit.physical_type):
             raise u.UnitsError("x, y, and z should have matching physical types")
@@ -1246,8 +1245,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         return SphericalRepresentation
 
     def __init__(self, lon, lat, differentials=None, copy=True):
-        super(UnitSphericalRepresentation,
-              self).__init__(lon, lat, differentials=differentials, copy=copy)
+        super().__init__(lon, lat, differentials=differentials, copy=copy)
 
     @property
     def _compatible_differentials(self):
@@ -1323,8 +1321,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
                 return other_class(lon=self.lon, lat=self.lat, distance=1.0,
                                    copy=False)
 
-        return super(UnitSphericalRepresentation,
-                     self).represent_as(other_class, differential_class)
+        return super().represent_as(other_class, differential_class)
 
     def __mul__(self, other):
         self._raise_if_has_differentials('multiplication')
@@ -1445,8 +1442,7 @@ class RadialRepresentation(BaseRepresentation):
     attr_classes = OrderedDict([('distance', u.Quantity)])
 
     def __init__(self, distance, differentials=None, copy=True):
-        super(RadialRepresentation, self).__init__(distance, copy=copy,
-                                                   differentials=differentials)
+        super().__init__(distance, copy=copy, differentials=differentials)
 
     @property
     def distance(self):
@@ -1535,9 +1531,8 @@ class SphericalRepresentation(BaseRepresentation):
     _unit_representation = UnitSphericalRepresentation
 
     def __init__(self, lon, lat, distance, differentials=None, copy=True):
-        super(SphericalRepresentation,
-              self).__init__(lon, lat, distance, copy=copy,
-                             differentials=differentials)
+        super().__init__(lon, lat, distance, copy=copy,
+                         differentials=differentials)
         if self._distance.unit.physical_type == 'length':
             self._distance = self._distance.view(Distance)
 
@@ -1598,8 +1593,7 @@ class SphericalRepresentation(BaseRepresentation):
             elif issubclass(other_class, UnitSphericalRepresentation):
                 return other_class(lon=self.lon, lat=self.lat, copy=False)
 
-        return super(SphericalRepresentation,
-                     self).represent_as(other_class, differential_class)
+        return super().represent_as(other_class, differential_class)
 
     def to_cartesian(self):
         """
@@ -1689,9 +1683,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
     recommended_units = {'phi': u.deg, 'theta': u.deg}
 
     def __init__(self, phi, theta, r, differentials=None, copy=True):
-        super(PhysicsSphericalRepresentation,
-              self).__init__(phi, theta, r, copy=copy,
-                             differentials=differentials)
+        super().__init__(phi, theta, r, copy=copy, differentials=differentials)
 
         # Wrap/validate phi/theta
         if copy:
@@ -1760,8 +1752,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
             elif issubclass(other_class, UnitSphericalRepresentation):
                 return other_class(lon=self.phi, lat=90 * u.deg - self.theta)
 
-        return super(PhysicsSphericalRepresentation,
-                     self).represent_as(other_class, differential_class)
+        return super().represent_as(other_class, differential_class)
 
     def to_cartesian(self):
         """
@@ -1848,9 +1839,7 @@ class CylindricalRepresentation(BaseRepresentation):
     recommended_units = {'phi': u.deg}
 
     def __init__(self, rho, phi, z, differentials=None, copy=True):
-        super(CylindricalRepresentation,
-              self).__init__(rho, phi, z, copy=copy,
-                             differentials=differentials)
+        super().__init__(rho, phi, z, copy=copy, differentials=differentials)
 
         if not self._rho.unit.is_equivalent(self._z.unit):
             raise u.UnitsError("rho and z should have matching physical types")
@@ -1923,7 +1912,7 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
     by 'd_', and the class is `~astropy.units.Quantity`.
     """
     def __init__(cls, name, bases, dct):
-        super(MetaBaseDifferential, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
         # Don't do anything for base helper classes.
         if cls.__name__ in ('BaseDifferential', 'BaseSphericalDifferential',
@@ -2173,7 +2162,7 @@ class BaseDifferential(BaseRepresentationOrDifferential,
         # avoid "differential - representation".
         if isinstance(other, BaseRepresentation):
             return NotImplemented
-        return super(BaseDifferential, self).__sub__(other)
+        return super().__sub__(other)
 
     def norm(self, base=None):
         """Vector norm.
@@ -2240,7 +2229,7 @@ class CartesianDifferential(BaseDifferential):
             d_z = u.Quantity(d_z, unit, copy=copy, subok=True)
             copy = False
 
-        super(CartesianDifferential, self).__init__(d_x, d_y, d_z, copy=copy)
+        super().__init__(d_x, d_y, d_z, copy=copy)
         if not (self._d_x.unit.is_equivalent(self._d_y.unit) and
                 self._d_x.unit.is_equivalent(self._d_z.unit)):
             raise u.UnitsError('d_x, d_y and d_z should have equivalent units.')
@@ -2330,8 +2319,7 @@ class BaseSphericalDifferential(BaseDifferential):
                            for c in all_components}
             return SphericalDifferential(**result_args)
 
-        return super(BaseSphericalDifferential,
-                     self)._combine_operation(op, other, reverse)
+        return super()._combine_operation(op, other, reverse)
 
 
 class UnitSphericalDifferential(BaseSphericalDifferential):
@@ -2351,8 +2339,7 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
         return SphericalDifferential
 
     def __init__(self, d_lon, d_lat, copy=True):
-        super(UnitSphericalDifferential,
-              self).__init__(d_lon, d_lat, copy=copy)
+        super().__init__(d_lon, d_lat, copy=copy)
         if not self._d_lon.unit.is_equivalent(self._d_lat.unit):
             raise u.UnitsError('d_lon and d_lat should have equivalent units.')
 
@@ -2362,18 +2349,17 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
         elif isinstance(base, PhysicsSphericalRepresentation):
             scale = base.r
         else:
-            return super(UnitSphericalDifferential, self).to_cartesian(base)
+            return super().to_cartesian(base)
 
         base = base.represent_as(UnitSphericalRepresentation)
-        return scale * super(UnitSphericalDifferential, self).to_cartesian(base)
+        return scale * super().to_cartesian(base)
 
     def represent_as(self, other_class, base=None):
         # Only have enough information to represent other unit-spherical.
         if issubclass(other_class, UnitSphericalCosLatDifferential):
             return other_class(self._d_lon_coslat(base), self.d_lat)
 
-        return super(UnitSphericalDifferential,
-                     self).represent_as(other_class, base)
+        return super().represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
@@ -2388,8 +2374,7 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
         elif isinstance(representation, PhysicsSphericalDifferential):
             return cls(representation.d_phi, -representation.d_theta)
 
-        return super(UnitSphericalDifferential,
-                     cls).from_representation(representation, base)
+        return super().from_representation(representation, base)
 
 
 class SphericalDifferential(BaseSphericalDifferential):
@@ -2408,8 +2393,7 @@ class SphericalDifferential(BaseSphericalDifferential):
     _unit_differential = UnitSphericalDifferential
 
     def __init__(self, d_lon, d_lat, d_distance, copy=True):
-        super(SphericalDifferential, self).__init__(d_lon, d_lat, d_distance,
-                                                    copy=copy)
+        super().__init__(d_lon, d_lat, d_distance, copy=copy)
         if not self._d_lon.unit.is_equivalent(self._d_lat.unit):
             raise u.UnitsError('d_lon and d_lat should have equivalent units.')
 
@@ -2428,8 +2412,7 @@ class SphericalDifferential(BaseSphericalDifferential):
         elif issubclass(other_class, PhysicsSphericalDifferential):
             return other_class(self.d_lon, -self.d_lat, self.d_distance)
         else:
-            return super(SphericalDifferential,
-                         self).represent_as(other_class, base)
+            return super().represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
@@ -2442,8 +2425,7 @@ class SphericalDifferential(BaseSphericalDifferential):
             return cls(representation.d_phi, -representation.d_theta,
                        representation.d_r)
 
-        return super(SphericalDifferential,
-                     cls).from_representation(representation, base)
+        return super().from_representation(representation, base)
 
 
 class BaseSphericalCosLatDifferential(BaseDifferential):
@@ -2533,8 +2515,7 @@ class BaseSphericalCosLatDifferential(BaseDifferential):
                            for c in all_components}
             return SphericalCosLatDifferential(**result_args)
 
-        return super(BaseSphericalCosLatDifferential,
-                     self)._combine_operation(op, other, reverse)
+        return super()._combine_operation(op, other, reverse)
 
 
 class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
@@ -2556,8 +2537,7 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
         return SphericalCosLatDifferential
 
     def __init__(self, d_lon_coslat, d_lat, copy=True):
-        super(UnitSphericalCosLatDifferential,
-              self).__init__(d_lon_coslat, d_lat, copy=copy)
+        super().__init__(d_lon_coslat, d_lat, copy=copy)
         if not self._d_lon_coslat.unit.is_equivalent(self._d_lat.unit):
             raise u.UnitsError('d_lon_coslat and d_lat should have equivalent '
                                'units.')
@@ -2568,20 +2548,17 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
         elif isinstance(base, PhysicsSphericalRepresentation):
             scale = base.r
         else:
-            return super(UnitSphericalCosLatDifferential,
-                         self).to_cartesian(base)
+            return super().to_cartesian(base)
 
         base = base.represent_as(UnitSphericalRepresentation)
-        return scale * super(UnitSphericalCosLatDifferential,
-                             self).to_cartesian(base)
+        return scale * super().to_cartesian(base)
 
     def represent_as(self, other_class, base=None):
         # Only have enough information to represent other unit-spherical.
         if issubclass(other_class, UnitSphericalDifferential):
             return other_class(self._d_lon(base), self.d_lat)
 
-        return super(UnitSphericalCosLatDifferential,
-                     self).represent_as(other_class, base)
+        return super().represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
@@ -2620,8 +2597,7 @@ class SphericalCosLatDifferential(BaseSphericalCosLatDifferential):
                                 ('d_distance', u.Quantity)])
 
     def __init__(self, d_lon_coslat, d_lat, d_distance, copy=True):
-        super(SphericalCosLatDifferential,
-              self).__init__(d_lon_coslat, d_lat, d_distance, copy=copy)
+        super().__init__(d_lon_coslat, d_lat, d_distance, copy=copy)
         if not self._d_lon_coslat.unit.is_equivalent(self._d_lat.unit):
             raise u.UnitsError('d_lon_coslat and d_lat should have equivalent '
                                'units.')
@@ -2640,8 +2616,7 @@ class SphericalCosLatDifferential(BaseSphericalCosLatDifferential):
         elif issubclass(other_class, PhysicsSphericalDifferential):
             return other_class(self._d_lon(base), -self.d_lat, self.d_distance)
 
-        return super(SphericalCosLatDifferential,
-                     self).represent_as(other_class, base)
+        return super().represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
@@ -2656,8 +2631,7 @@ class SphericalCosLatDifferential(BaseSphericalCosLatDifferential):
             return cls(d_lon_coslat, -representation.d_theta,
                        representation.d_r)
 
-        return super(SphericalCosLatDifferential,
-                     cls).from_representation(representation, base)
+        return super().from_representation(representation, base)
 
 
 class RadialDifferential(BaseDifferential):
@@ -2689,8 +2663,7 @@ class RadialDifferential(BaseDifferential):
         elif isinstance(representation, PhysicsSphericalDifferential):
             return cls(representation.d_r)
         else:
-            return super(RadialDifferential,
-                         cls).from_representation(representation, base)
+            return super().from_representation(representation, base)
 
     def _combine_operation(self, op, other, reverse=False):
         if isinstance(other, self.base_representation):
@@ -2708,8 +2681,7 @@ class RadialDifferential(BaseDifferential):
             return SphericalDifferential(**result_args)
 
         else:
-            return super(RadialDifferential,
-                         self)._combine_operation(op, other, reverse)
+            return super()._combine_operation(op, other, reverse)
 
 
 class PhysicsSphericalDifferential(BaseDifferential):
@@ -2727,8 +2699,7 @@ class PhysicsSphericalDifferential(BaseDifferential):
     base_representation = PhysicsSphericalRepresentation
 
     def __init__(self, d_phi, d_theta, d_r, copy=True):
-        super(PhysicsSphericalDifferential,
-              self).__init__(d_phi, d_theta, d_r, copy=copy)
+        super().__init__(d_phi, d_theta, d_r, copy=copy)
         if not self._d_phi.unit.is_equivalent(self._d_theta.unit):
             raise u.UnitsError('d_phi and d_theta should have equivalent '
                                'units.')
@@ -2752,8 +2723,7 @@ class PhysicsSphericalDifferential(BaseDifferential):
         elif issubclass(other_class, RadialDifferential):
             return other_class(self.d_r)
 
-        return super(PhysicsSphericalDifferential,
-                     self).represent_as(other_class, base)
+        return super().represent_as(other_class, base)
 
     @classmethod
     def from_representation(cls, representation, base=None):
@@ -2768,8 +2738,7 @@ class PhysicsSphericalDifferential(BaseDifferential):
             d_phi = representation.d_lon_coslat / np.sin(base.theta)
             return cls(d_phi, -representation.d_lat, representation.d_distance)
 
-        return super(PhysicsSphericalDifferential,
-                     cls).from_representation(representation, base)
+        return super().from_representation(representation, base)
 
 
 class CylindricalDifferential(BaseDifferential):
@@ -2789,7 +2758,6 @@ class CylindricalDifferential(BaseDifferential):
     base_representation = CylindricalRepresentation
 
     def __init__(self, d_rho, d_phi, d_z, copy=False):
-        super(CylindricalDifferential,
-              self).__init__(d_rho, d_phi, d_z, copy=copy)
+        super().__init__(d_rho, d_phi, d_z, copy=copy)
         if not self._d_rho.unit.is_equivalent(self._d_z.unit):
             raise u.UnitsError("d_rho and d_z should have equivalent units.")

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -78,7 +78,7 @@ class SkyCoordInfo(MixinInfo):
 
         self._represent_as_dict_attrs = attrs
 
-        out = super(SkyCoordInfo, self)._represent_as_dict()
+        out = super()._represent_as_dict()
 
         out['representation'] = obj.representation.get_name()
         out['frame'] = obj.frame.name
@@ -533,7 +533,7 @@ class SkyCoord(ShapedLikeNDArray):
         if attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be set, but only via a private
             # variable.  See __getattr__ above.
-            super(SkyCoord, self).__setattr__('_' + attr, val)
+            super().__setattr__('_' + attr, val)
             # Validate it
             frame_transform_graph.frame_attributes[attr].__get__(self)
             # And add to set of extra attributes
@@ -541,7 +541,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         else:
             # Otherwise, do the standard Python attribute setting
-            super(SkyCoord, self).__setattr__(attr, val)
+            super().__setattr__(attr, val)
 
     def __delattr__(self, attr):
         # mirror __setattr__ above
@@ -561,13 +561,13 @@ class SkyCoord(ShapedLikeNDArray):
         if attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be deleted, but need to remove
             # the corresponding private variable.  See __getattr__ above.
-            super(SkyCoord, self).__delattr__('_' + attr)
+            super().__delattr__('_' + attr)
             # Also remove it from the set of extra attributes
             self._extra_frameattr_names -= {attr}
 
         else:
             # Otherwise, do the standard Python attribute setting
-            super(SkyCoord, self).__delattr__(attr)
+            super().__delattr__(attr)
 
     @override__dir__
     def __dir__(self):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -972,8 +972,8 @@ def test_subclass_representation():
 
     class Longitude180(Longitude):
         def __new__(cls, angle, unit=None, wrap_angle=180 * u.deg, **kwargs):
-            self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
-                                                    wrap_angle=wrap_angle, **kwargs)
+            self = super().__new__(cls, angle, unit=unit, wrap_angle=wrap_angle,
+                                   **kwargs)
             return self
 
     class SphericalWrap180Representation(SphericalRepresentation):

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -37,8 +37,8 @@ def test_unit_representation_subclass():
 
     class Longitude180(Longitude):
         def __new__(cls, angle, unit=None, wrap_angle=180*u.deg, **kwargs):
-            self = super(Longitude180, cls).__new__(cls, angle, unit=unit,
-                                                    wrap_angle=wrap_angle, **kwargs)
+            self = super().__new__(cls, angle, unit=unit, wrap_angle=wrap_angle,
+                                   **kwargs)
             return self
 
     class UnitSphericalWrap180Representation(UnitSphericalRepresentation):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -737,8 +737,8 @@ class FunctionTransform(CoordinateTransform):
 
         self.func = func
 
-        super(FunctionTransform, self).__init__(fromsys, tosys,
-            priority=priority, register_graph=register_graph)
+        super().__init__(fromsys, tosys, priority=priority,
+                         register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
         res = self.func(fromcoord, toframe)
@@ -797,8 +797,7 @@ class FunctionTransformWithFiniteDifference(FunctionTransform):
                  finite_difference_frameattr_name='obstime',
                  finite_difference_dt=1*u.second,
                  symmetric_finite_difference=True):
-        super(FunctionTransformWithFiniteDifference, self).__init__(func,
-              fromsys, tosys, priority, register_graph)
+        super().__init__(func, fromsys, tosys, priority, register_graph)
         self.finite_difference_frameattr_name = finite_difference_frameattr_name
         self.finite_difference_dt = finite_difference_dt
         self.symmetric_finite_difference = symmetric_finite_difference
@@ -1116,8 +1115,8 @@ class AffineTransform(BaseAffineTransform):
             raise TypeError('transform_func is not callable')
         self.transform_func = transform_func
 
-        super(AffineTransform, self).__init__(fromsys, tosys, priority=priority,
-                                              register_graph=register_graph)
+        super().__init__(fromsys, tosys, priority=priority,
+                         register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
 
@@ -1168,9 +1167,8 @@ class StaticMatrixTransform(BaseAffineTransform):
         if self.matrix.shape != (3, 3):
             raise ValueError('Provided matrix is not 3 x 3')
 
-        super(StaticMatrixTransform, self).__init__(fromsys, tosys,
-                                                    priority=priority,
-                                                    register_graph=register_graph)
+        super().__init__(fromsys, tosys, priority=priority,
+                         register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
         newrep = self._apply_transform(fromcoord, self.matrix, None)
@@ -1218,9 +1216,8 @@ class DynamicMatrixTransform(BaseAffineTransform):
         def _transform_func(fromcoord, toframe):
             return self.matrix_func(fromcoord, toframe), None
 
-        super(DynamicMatrixTransform, self).__init__(fromsys, tosys,
-                                                     priority=priority,
-                                                     register_graph=register_graph)
+        super().__init__(fromsys, tosys, priority=priority,
+                         register_graph=register_graph)
 
     def __call__(self, fromcoord, toframe):
         M = self.matrix_func(fromcoord, toframe)
@@ -1260,9 +1257,8 @@ class CompositeTransform(CoordinateTransform):
 
     def __init__(self, transforms, fromsys, tosys, priority=1,
                  register_graph=None, collapse_static_mats=True):
-        super(CompositeTransform, self).__init__(fromsys, tosys,
-                                                 priority=priority,
-                                                 register_graph=register_graph)
+        super().__init__(fromsys, tosys, priority=priority,
+                         register_graph=register_graph)
 
         if collapse_static_mats:
             transforms = self._combine_statics(transforms)

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -153,7 +153,7 @@ class CommentedHeader(Basic):
         Read input data (file-like object, filename, list of strings, or
         single string) into a Table and return the result.
         """
-        out = super(CommentedHeader, self).read(table)
+        out = super().read(table)
 
         # Strip off first comment since this is the header line for
         # commented_header format.

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -284,7 +284,7 @@ class Cds(core.BaseReader):
     header_class = CdsHeader
 
     def __init__(self, readme=None):
-        super(Cds, self).__init__()
+        super().__init__()
         self.header.readme = readme
 
     def write(self, table=None):
@@ -314,7 +314,7 @@ class Cds(core.BaseReader):
             for data_start in range(len(lines)):
                 self.data.start_line = data_start
                 with suppress(Exception):
-                    table = super(Cds, self).read(lines)
+                    table = super().read(lines)
                     return table
         else:
-            return super(Cds, self).read(table)
+            return super().read(table)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1004,7 +1004,7 @@ class TableOutputter(BaseOutputter):
 
 class MetaBaseReader(type):
     def __init__(cls, name, bases, dct):
-        super(MetaBaseReader, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
         format = dct.get('_format_name')
         if format is None:

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -143,7 +143,7 @@ class EcsvHeader(basic.BasicHeader):
 
         # Read the first non-commented line of table and split to get the CSV
         # header column names.  This is essentially what the Basic reader does.
-        header_line = next(super(EcsvHeader, self).process_lines(raw_lines))
+        header_line = next(super().process_lines(raw_lines))
         header_names = next(self.splitter([header_line]))
 
         # Check for consistency of the ECSV vs. CSV header column names
@@ -181,7 +181,7 @@ class EcsvOutputter(core.TableOutputter):
 
     def __call__(self, cols, meta):
         # Convert to a Table with all plain Column subclass columns
-        out = super(EcsvOutputter, self).__call__(cols, meta)
+        out = super().__call__(cols, meta)
 
         # If mixin columns exist (based on the special '__mixin_columns__'
         # key in the table ``meta``), then use that information to construct

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -166,7 +166,7 @@ class FastCsv(FastBasic):
     fill_extra_cols = True
 
     def __init__(self, **kwargs):
-        super(FastCsv, self).__init__({'delimiter': ',', 'comment': None}, **kwargs)
+        super().__init__({'delimiter': ',', 'comment': None}, **kwargs)
 
     def write(self, table, output):
         """
@@ -186,7 +186,7 @@ class FastTab(FastBasic):
     _fast = True
 
     def __init__(self, **kwargs):
-        super(FastTab, self).__init__({'delimiter': '\t'}, **kwargs)
+        super().__init__({'delimiter': '\t'}, **kwargs)
         self.strip_whitespace_lines = False
         self.strip_whitespace_fields = False
 
@@ -202,7 +202,7 @@ class FastNoHeader(FastBasic):
     _fast = True
 
     def __init__(self, **kwargs):
-        super(FastNoHeader, self).__init__({'header_start': None, 'data_start': 0}, **kwargs)
+        super().__init__({'header_start': None, 'data_start': 0}, **kwargs)
 
     def write(self, table, output):
         """
@@ -223,7 +223,7 @@ class FastCommentedHeader(FastBasic):
     _fast = True
 
     def __init__(self, **kwargs):
-        super(FastCommentedHeader, self).__init__({}, **kwargs)
+        super().__init__({}, **kwargs)
         # Mimic CommentedHeader's behavior in which data_start
         # is relative to header_start if unspecified; see #2692
         if 'data_start' not in kwargs:
@@ -234,7 +234,7 @@ class FastCommentedHeader(FastBasic):
         Read input data (file-like object, filename, list of strings, or
         single string) into a Table and return the result.
         """
-        out = super(FastCommentedHeader, self).read(table)
+        out = super().read(table)
 
         # Strip off first comment since this is the header line for
         # commented_header format.
@@ -283,7 +283,7 @@ class FastRdb(FastBasic):
     _fast = True
 
     def __init__(self, **kwargs):
-        super(FastRdb, self).__init__({'delimiter': '\t', 'data_start': 2}, **kwargs)
+        super().__init__({'delimiter': '\t', 'data_start': 2}, **kwargs)
         self.strip_whitespace_lines = False
         self.strip_whitespace_fields = False
 

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -294,7 +294,7 @@ class FixedWidth(basic.Basic):
     data_class = FixedWidthData
 
     def __init__(self, col_starts=None, col_ends=None, delimiter_pad=' ', bookend=True):
-        super(FixedWidth, self).__init__()
+        super().__init__()
         self.data.splitter.delimiter_pad = delimiter_pad
         self.data.splitter.bookend = bookend
         self.header.col_starts = col_starts
@@ -343,8 +343,8 @@ class FixedWidthNoHeader(FixedWidth):
     data_class = FixedWidthNoHeaderData
 
     def __init__(self, col_starts=None, col_ends=None, delimiter_pad=' ', bookend=True):
-        super(FixedWidthNoHeader, self).__init__(col_starts, col_ends,
-                            delimiter_pad=delimiter_pad, bookend=bookend)
+        super().__init__(col_starts, col_ends, delimiter_pad=delimiter_pad,
+                         bookend=bookend)
 
 
 class FixedWidthTwoLineHeader(FixedWidthHeader):
@@ -398,7 +398,7 @@ class FixedWidthTwoLine(FixedWidth):
     header_class = FixedWidthTwoLineHeader
 
     def __init__(self, position_line=1, position_char='-', delimiter_pad=None, bookend=False):
-        super(FixedWidthTwoLine, self).__init__(delimiter_pad=delimiter_pad, bookend=bookend)
+        super().__init__(delimiter_pad=delimiter_pad, bookend=bookend)
         self.header.position_line = position_line
         self.header.position_char = position_char
         self.data.start_line = position_line + 1

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -172,7 +172,7 @@ class HTMLOutputter(core.TableOutputter):
                 new_cols.append(col)
                 col_num += 1
 
-        return super(HTMLOutputter, self).__call__(new_cols, meta)
+        return super().__call__(new_cols, meta)
 
 
 class HTMLHeader(core.BaseHeader):
@@ -325,7 +325,7 @@ class HTML(core.BaseReader):
         """
         Initialize classes for HTML reading and writing.
         """
-        super(HTML, self).__init__()
+        super().__init__()
         self.html = deepcopy(htmldict)
         if 'multicol' not in htmldict:
             self.html['multicol'] = True
@@ -339,7 +339,7 @@ class HTML(core.BaseReader):
         """
 
         self.outputter = HTMLOutputter()
-        return super(HTML, self).read(table)
+        return super().read(table)
 
     def write(self, table):
         """

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -424,7 +424,7 @@ class Ipac(basic.Basic):
     header_class = IpacHeader
 
     def __init__(self, definition='ignore', DBMS=False):
-        super(Ipac, self).__init__()
+        super().__init__()
         # Usually the header is not defined in __init__, but here it need a keyword
         if definition in ['ignore', 'left', 'right']:
             self.header.ipac_definition = definition

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -85,7 +85,7 @@ class LatexSplitter(core.BaseSplitter):
         if not last_line.endswith(r'\\'):
             lines[-1] = last_line + r'\\'
 
-        return super(LatexSplitter, self).__call__(lines)
+        return super().__call__(lines)
 
     def process_line(self, line):
         """Remove whitespace at the beginning or end of line. Also remove
@@ -303,7 +303,7 @@ class Latex(core.BaseReader):
     def __init__(self, ignore_latex_commands=['hline', 'vspace', 'tableline'],
                  latexdict={}, caption='', col_align=None):
 
-        super(Latex, self).__init__()
+        super().__init__()
 
         self.latex = {}
         # The latex dict drives the format of the table and needs to be shared

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -18,7 +18,7 @@ class SimpleRSTHeader(FixedWidthHeader):
     position_char = '='
 
     def get_fixedwidth_params(self, line):
-        vals, starts, ends = super(SimpleRSTHeader, self).get_fixedwidth_params(line)
+        vals, starts, ends = super().get_fixedwidth_params(line)
         # The right hand column can be unbounded
         ends[-1] = None
         return vals, starts, ends
@@ -54,9 +54,9 @@ class RST(FixedWidth):
     header_class = SimpleRSTHeader
 
     def __init__(self):
-        super(RST, self).__init__(delimiter_pad=None, bookend=False)
+        super().__init__(delimiter_pad=None, bookend=False)
 
     def write(self, lines):
-        lines = super(RST, self).write(lines)
+        lines = super().write(lines)
         lines = [lines[1]] + lines + [lines[1]]
         return lines

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -139,7 +139,7 @@ class SExtractor(core.BaseReader):
         Read input data (file-like object, filename, list of strings, or
         single string) into a Table and return the result.
         """
-        out = super(SExtractor, self).read(table)
+        out = super().read(table)
         # remove the comments
         if 'comments' in out.meta:
             del out.meta['comments']

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -202,7 +202,7 @@ class _ColumnFormat(_BaseColumnFormat):
     """
 
     def __new__(cls, format):
-        self = super(_ColumnFormat, cls).__new__(cls, format)
+        self = super().__new__(cls, format)
         self.repeat, self.format, self.option = _parse_tformat(format)
         self.format = self.format.upper()
         if self.format in ('P', 'Q'):
@@ -266,7 +266,7 @@ class _AsciiColumnFormat(_BaseColumnFormat):
     """
 
     def __new__(cls, format, strict=False):
-        self = super(_AsciiColumnFormat, cls).__new__(cls, format)
+        self = super().__new__(cls, format)
         self.format, self.width, self.precision = \
             _parse_ascii_tformat(format, strict)
 
@@ -318,7 +318,7 @@ class _FormatX(str):
     def __new__(cls, repeat=1):
         nbytes = ((repeat - 1) // 8) + 1
         # use an array, even if it is only ONE u1 (i.e. use tuple always)
-        obj = super(_FormatX, cls).__new__(cls, repr((nbytes,)) + 'u1')
+        obj = super().__new__(cls, repr((nbytes,)) + 'u1')
         obj.repeat = repeat
         return obj
 
@@ -345,7 +345,7 @@ class _FormatP(str):
     _descriptor_format = '2i4'
 
     def __new__(cls, dtype, repeat=None, max=None):
-        obj = super(_FormatP, cls).__new__(cls, cls._descriptor_format)
+        obj = super().__new__(cls, cls._descriptor_format)
         obj.format = NUMPY2FITS[dtype]
         obj.dtype = dtype
         obj.repeat = repeat
@@ -1801,7 +1801,7 @@ class _AsciiColDefs(ColDefs):
     _col_format_cls = _AsciiColumnFormat
 
     def __init__(self, input, ascii=True):
-        super(_AsciiColDefs, self).__init__(input)
+        super().__init__(input)
 
         # if the format of an ASCII column has no width, add one
         if not isinstance(input, _AsciiColDefs):
@@ -1843,11 +1843,11 @@ class _AsciiColDefs(ColDefs):
         return ['a' + str(w) for w in widths]
 
     def add_col(self, column):
-        super(_AsciiColDefs, self).add_col(column)
+        super().add_col(column)
         self._update_field_metrics()
 
     def del_col(self, col_name):
-        super(_AsciiColDefs, self).del_col(col_name)
+        super().del_col(col_name)
         self._update_field_metrics()
 
     def _update_field_metrics(self):

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -317,7 +317,7 @@ class FITSDiff(_BaseDiff):
         self.diff_hdus = []
 
         try:
-            super(FITSDiff, self).__init__(a, b)
+            super().__init__(a, b)
         finally:
             if close_a:
                 a.close()
@@ -460,7 +460,7 @@ class HDUDiff(_BaseDiff):
         self.diff_headers = None
         self.diff_data = None
 
-        super(HDUDiff, self).__init__(a, b)
+        super().__init__(a, b)
 
     def _diff(self):
         if self.a.name != self.b.name:
@@ -640,7 +640,7 @@ class HeaderDiff(_BaseDiff):
             raise TypeError('HeaderDiff can only diff astropy.io.fits.Header '
                             'objects or strings containing FITS headers.')
 
-        super(HeaderDiff, self).__init__(a, b)
+        super().__init__(a, b)
 
     # TODO: This doesn't pay much attention to the *order* of the keywords,
     # except in the case of duplicate keywords.  The order should be checked
@@ -850,7 +850,7 @@ class ImageDataDiff(_BaseDiff):
         # the images, but not the different values
         self.diff_total = 0
 
-        super(ImageDataDiff, self).__init__(a, b)
+        super().__init__(a, b)
 
     def _diff(self):
         if self.a.shape != self.b.shape:
@@ -948,10 +948,10 @@ class RawDataDiff(ImageDataDiff):
         self.diff_dimensions = ()
         self.diff_bytes = []
 
-        super(RawDataDiff, self).__init__(a, b, numdiffs=numdiffs)
+        super().__init__(a, b, numdiffs=numdiffs)
 
     def _diff(self):
-        super(RawDataDiff, self)._diff()
+        super()._diff()
         if self.diff_dimensions:
             self.diff_dimensions = (self.diff_dimensions[0][0],
                                     self.diff_dimensions[1][0])
@@ -1072,7 +1072,7 @@ class TableDataDiff(_BaseDiff):
         self.diff_ratio = 0
         self.diff_total = 0
 
-        super(TableDataDiff, self).__init__(a, b)
+        super().__init__(a, b)
 
     def _diff(self):
         # Much of the code for comparing columns is similar to the code for

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -177,7 +177,7 @@ class FITS_rec(np.recarray):
         column_state = state[-2]
         state = state[:-2]
 
-        super(FITS_rec, self).__setstate__(state)
+        super().__setstate__(state)
 
         self._col_weakrefs = weakref.WeakSet()
 
@@ -191,8 +191,7 @@ class FITS_rec(np.recarray):
         values that get used in __setstate__.
         """
 
-        reconst_func, reconst_func_args, state = \
-            super(FITS_rec, self).__reduce__()
+        reconst_func, reconst_func_args, state = super().__reduce__()
 
         # Define FITS_rec-specific attrs that get added to state
         column_state = []
@@ -477,7 +476,7 @@ class FITS_rec(np.recarray):
 
     def __getitem__(self, key):
         if self._coldefs is None:
-            return super(FITS_rec, self).__getitem__(key)
+            return super().__getitem__(key)
 
         if isinstance(key, str):
             return self.field(key)
@@ -518,7 +517,7 @@ class FITS_rec(np.recarray):
 
     def __setitem__(self, key, value):
         if self._coldefs is None:
-            return super(FITS_rec, self).__setitem__(key, value)
+            return super().__setitem__(key, value)
 
         if isinstance(key, str):
             self[key][:] = value
@@ -559,7 +558,7 @@ class FITS_rec(np.recarray):
         any data.
         """
 
-        new = super(FITS_rec, self).copy(order=order)
+        new = super().copy(order=order)
 
         new.__dict__ = copy.deepcopy(self.__dict__)
         return new
@@ -1211,7 +1210,7 @@ class FITS_rec(np.recarray):
 
         # The the index of the "end" column of the record, beyond
         # which we can't write
-        end = super(FITS_rec, self).field(-1).itemsize
+        end = super().field(-1).itemsize
         starts.append(end + starts[-1])
 
         if col_idx > 0:
@@ -1302,8 +1301,7 @@ def _rstrip_inplace(array, chars=None):
 
 class _UnicodeArrayEncodeError(UnicodeEncodeError):
     def __init__(self, encoding, object_, start, end, reason, index):
-        super(_UnicodeArrayEncodeError, self).__init__(encoding, object_,
-                start, end, reason)
+        super().__init__(encoding, object_, start, end, reason)
         self.index = index
 
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -148,7 +148,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
         """
 
         klass = _hdu_class_from_header(cls, header)
-        return super(_BaseHDU, cls).__new__(klass)
+        return super().__new__(klass)
 
     def __init__(self, data=None, header=None, *args, **kwargs):
         if header is None:
@@ -867,7 +867,7 @@ class _ValidHDU(_BaseHDU, _Verify):
     """
 
     def __init__(self, data=None, header=None, name=None, ver=None, **kwargs):
-        super(_ValidHDU, self).__init__(data=data, header=header)
+        super().__init__(data=data, header=header)
 
         # NOTE:  private data members _checksum and _datasum are used by the
         # utility script "fitscheck" to detect missing checksums.
@@ -1545,7 +1545,7 @@ class ExtensionHDU(_ValidHDU):
 
     def _verify(self, option='warn'):
 
-        errs = super(ExtensionHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
 
         # Verify location and value of mandatory keywords.
         naxis = self._header.get('NAXIS', 0)

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -136,7 +136,7 @@ class CompImageHeader(Header):
         if self._is_reserved_keyword(keyword):
             return
 
-        super(CompImageHeader, self).__setitem__(key, value)
+        super().__setitem__(key, value)
 
         if index is not None:
             remapped_keyword = self._remap_keyword(keyword)
@@ -148,7 +148,7 @@ class CompImageHeader(Header):
             # If given a slice pass that on to the superclass and bail out
             # early; we only want to make updates to _table_header when given
             # a key specifying a single keyword
-            return super(CompImageHeader, self).__delitem__(key)
+            return super().__delitem__(key)
 
         if isinstance(key, int):
             keyword, index = self._keyword_from_index(key)
@@ -160,7 +160,7 @@ class CompImageHeader(Header):
         if key not in self:
             raise KeyError("Keyword {!r} not found.".format(key))
 
-        super(CompImageHeader, self).__delitem__(key)
+        super().__delitem__(key)
 
         remapped_keyword = self._remap_keyword(keyword)
 
@@ -187,8 +187,7 @@ class CompImageHeader(Header):
         if self._is_reserved_keyword(card.keyword):
             return
 
-        super(CompImageHeader, self).append(card=card, useblanks=useblanks,
-                                            bottom=bottom, end=end)
+        super().append(card=card, useblanks=useblanks, bottom=bottom, end=end)
 
         remapped_keyword = self._remap_keyword(card.keyword)
         card = Card(remapped_keyword, card.value, card.comment)
@@ -236,8 +235,7 @@ class CompImageHeader(Header):
         remapped_index = self._remap_index(key)
         remapped_keyword = self._remap_keyword(card.keyword)
 
-        super(CompImageHeader, self).insert(key, card, useblanks=useblanks,
-                                            after=after)
+        super().insert(key, card, useblanks=useblanks, after=after)
 
         card = Card(remapped_keyword, card.value, card.comment)
 
@@ -255,7 +253,7 @@ class CompImageHeader(Header):
         if self._is_reserved_keyword(keyword):
             return
 
-        super(CompImageHeader, self)._update(card)
+        super()._update(card)
 
         if keyword in Card._commentary_keywords:
             # Otherwise this will result in a duplicate insertion
@@ -286,9 +284,8 @@ class CompImageHeader(Header):
                 remapped_before = self._remap_keyword(before)
             remapped_after = None
 
-        super(CompImageHeader, self)._relativeinsert(card, before=before,
-                                                     after=after,
-                                                     replace=replace)
+        super()._relativeinsert(card, before=before, after=after,
+                                replace=replace)
 
         remapped_keyword = self._remap_keyword(keyword)
 
@@ -633,11 +630,11 @@ class CompImageHDU(BinTableHDU):
 
         if data is DELAYED:
             # Reading the HDU from a file
-            super(CompImageHDU, self).__init__(data=data, header=header)
+            super().__init__(data=data, header=header)
         else:
             # Create at least a skeleton HDU that matches the input
             # header and data (if any were input)
-            super(CompImageHDU, self).__init__(data=None, header=header)
+            super().__init__(data=None, header=header)
 
             # Store the input image data
             self.data = data
@@ -1831,8 +1828,7 @@ class CompImageHDU(BinTableHDU):
             # handles it properly
             self.__dict__['data'] = self.compressed_data
 
-        return super(CompImageHDU, self)._prewriteto(checksum=checksum,
-                                                     inplace=inplace)
+        return super()._prewriteto(checksum=checksum, inplace=inplace)
 
     def _writeheader(self, fileobj):
         """
@@ -1850,7 +1846,7 @@ class CompImageHDU(BinTableHDU):
         """
 
         try:
-            return super(CompImageHDU, self)._writedata(fileobj)
+            return super()._writedata(fileobj)
         finally:
             # Restore the .data attribute to its rightful value (if any)
             if hasattr(self, '_imagedata'):
@@ -1860,7 +1856,7 @@ class CompImageHDU(BinTableHDU):
                 del self.data
 
     def _close(self, closed=True):
-        super(CompImageHDU, self)._close(closed=closed)
+        super()._close(closed=closed)
 
         # Also make sure to close access to the compressed data mmaps
         if (closed and self._data_loaded and

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -20,7 +20,7 @@ class Group(FITS_record):
 
     def __init__(self, input, row=0, start=None, end=None, step=None,
                  base=None):
-        super(Group, self).__init__(input, row, start, end, step, base)
+        super().__init__(input, row, start, end, step, base)
 
     @property
     def parnames(self):
@@ -202,14 +202,14 @@ class GroupData(FITS_rec):
         return self
 
     def __array_finalize__(self, obj):
-        super(GroupData, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         if isinstance(obj, GroupData):
             self.parnames = obj.parnames
         elif isinstance(obj, FITS_rec):
             self.parnames = obj._coldefs.names
 
     def __getitem__(self, key):
-        out = super(GroupData, self).__getitem__(key)
+        out = super().__getitem__(key)
         if isinstance(out, GroupData):
             out.parnames = self.parnames
         return out
@@ -267,7 +267,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     """
 
     def __init__(self, data=None, header=None):
-        super(GroupsHDU, self).__init__(data=data, header=header)
+        super().__init__(data=data, header=header)
 
         # Update the axes; GROUPS HDUs should always have at least one axis
         if len(self._axes) <= 0:
@@ -499,7 +499,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
         return size
 
     def _verify(self, option='warn'):
-        errs = super(GroupsHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
 
         # Verify locations and values of mandatory keywords.
         self.req_cards('NAXIS', 2,
@@ -564,10 +564,10 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(GroupsHDU, self)._calculate_datasum()
+            return super()._calculate_datasum()
 
     def _summary(self):
-        summary = super(GroupsHDU, self)._summary()
+        summary = super()._summary()
         name, ver, classname, length, shape, format, gcount = summary
 
         # Drop the first axis from the shape

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -221,7 +221,7 @@ class HDUList(list, _Verify):
                 raise TypeError("Element {} in the HDUList input is "
                                 "not an HDU.".format(idx))
 
-        super(HDUList, self).__init__(hdus)
+        super().__init__(hdus)
 
         if file is None:
             # Only do this when initializing from an existing list of HDUs
@@ -234,7 +234,7 @@ class HDUList(list, _Verify):
             while self._read_next_hdu():
                 pass
 
-        return super(HDUList, self).__len__()
+        return super().__len__()
 
     def __repr__(self):
         # In order to correctly repr an HDUList we need to load all the
@@ -242,7 +242,7 @@ class HDUList(list, _Verify):
         while self._read_next_hdu():
             pass
 
-        return super(HDUList, self).__repr__()
+        return super().__repr__()
 
     def __iter__(self):
         # While effectively this does the same as:
@@ -279,7 +279,7 @@ class HDUList(list, _Verify):
             # Just in case the max_idx is negative...
             max_idx = self._positive_index_of(max_idx)
 
-            number_loaded = super(HDUList, self).__len__()
+            number_loaded = super().__len__()
 
             if max_idx >= number_loaded:
                 # We need more than we have, try loading up to and including
@@ -292,7 +292,7 @@ class HDUList(list, _Verify):
                         break
 
             try:
-                hdus = super(HDUList, self).__getitem__(key)
+                hdus = super().__getitem__(key)
             except IndexError as e:
                 # Raise a more helpful IndexError if the file was not fully read.
                 if self._read_all:
@@ -308,8 +308,8 @@ class HDUList(list, _Verify):
         # a very large number of HDUs could blow the stack, so use a loop
         # instead
         try:
-            return self._try_while_unread_hdus(super(HDUList, self).__getitem__,
-                                            self._positive_index_of(key))
+            return self._try_while_unread_hdus(super().__getitem__,
+                                               self._positive_index_of(key))
         except IndexError as e:
             # Raise a more helpful IndexError if the file was not fully read.
             if self._read_all:
@@ -348,8 +348,7 @@ class HDUList(list, _Verify):
                 raise ValueError('{} is not an HDU.'.format(hdu))
 
         try:
-            self._try_while_unread_hdus(super(HDUList, self).__setitem__,
-                                        _key, hdu)
+            self._try_while_unread_hdus(super().__setitem__, _key, hdu)
         except IndexError:
             raise IndexError('Extension {} is out of bound or not found.'
                             .format(key))
@@ -368,7 +367,7 @@ class HDUList(list, _Verify):
             key = self._positive_index_of(key)
             end_index = len(self) - 1
 
-        self._try_while_unread_hdus(super(HDUList, self).__delitem__, key)
+        self._try_while_unread_hdus(super().__delitem__, key)
 
         if (key == end_index or key == -1 and not self._resize):
             self._truncate = True
@@ -542,8 +541,8 @@ class HDUList(list, _Verify):
                 hdu1 = ImageHDU(self[0].data, self[0].header)
 
                 # Insert it into position 1, then delete HDU at position 0.
-                super(HDUList, self).insert(1, hdu1)
-                super(HDUList, self).__delitem__(0)
+                super().insert(1, hdu1)
+                super().__delitem__(0)
 
             if not isinstance(hdu, (PrimaryHDU, _NonstandardHDU)):
                 # You passed in an Extension HDU but we need a Primary HDU.
@@ -557,7 +556,7 @@ class HDUList(list, _Verify):
                     # we append the new Extension HDU.
                     phdu = PrimaryHDU()
 
-                    super(HDUList, self).insert(0, phdu)
+                    super().insert(0, phdu)
                     index = 1
         else:
             if isinstance(hdu, GroupsHDU):
@@ -569,7 +568,7 @@ class HDUList(list, _Verify):
                 # so create an Extension HDU from the input Primary HDU.
                 hdu = ImageHDU(hdu.data, hdu.header)
 
-        super(HDUList, self).insert(index, hdu)
+        super().insert(index, hdu)
         hdu._new = True
         self._resize = True
         self._truncate = False
@@ -613,9 +612,9 @@ class HDUList(list, _Verify):
                     # simple Primary HDU and append that first before
                     # we append the new Extension HDU.
                     phdu = PrimaryHDU()
-                    super(HDUList, self).append(phdu)
+                    super().append(phdu)
 
-        super(HDUList, self).append(hdu)
+        super().append(hdu)
         hdu._new = True
         self._resize = True
         self._truncate = False
@@ -1105,7 +1104,7 @@ class HDUList(list, _Verify):
                     hdu = _BaseHDU.fromstring(data, **kwargs)
                     self._data = data[hdu._data_offset + hdu._data_size:]
 
-                super(HDUList, self).append(hdu)
+                super().append(hdu)
                 if len(self) == 1:
                     # Check for an extension HDU and update the EXTEND
                     # keyword of the primary HDU accordingly

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -40,7 +40,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         from .groups import GroupsHDU
 
-        super(_ImageBaseHDU, self).__init__(data=data, header=header)
+        super().__init__(data=data, header=header)
 
         if header is not None:
             if not isinstance(header, Header):
@@ -569,7 +569,7 @@ class _ImageBaseHDU(_ValidHDU):
         self.update_header()
         self._verify_blank()
 
-        return super(_ImageBaseHDU, self)._verify(option)
+        return super()._verify(option)
 
     def _verify_blank(self):
         # Probably not the best place for this (it should probably happen
@@ -608,7 +608,7 @@ class _ImageBaseHDU(_ValidHDU):
             # with the correct post-rescaling headers
             _ = self.data
 
-        return super(_ImageBaseHDU, self)._prewriteto(checksum, inplace)
+        return super()._prewriteto(checksum, inplace)
 
     def _writedata_internal(self, fileobj):
         size = 0
@@ -849,7 +849,7 @@ class _ImageBaseHDU(_ValidHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(_ImageBaseHDU, self)._calculate_datasum()
+            return super()._calculate_datasum()
 
 
 class Section(object):
@@ -994,7 +994,7 @@ class PrimaryHDU(_ImageBaseHDU):
             (default: None)
         """
 
-        super(PrimaryHDU, self).__init__(
+        super().__init__(
             data=data, header=header,
             do_not_scale_image_data=do_not_scale_image_data, uint=uint,
             ignore_blank=ignore_blank,
@@ -1017,7 +1017,7 @@ class PrimaryHDU(_ImageBaseHDU):
                 card.value)
 
     def update_header(self):
-        super(PrimaryHDU, self).update_header()
+        super().update_header()
 
         # Update the position of the EXTEND keyword if it already exists
         if 'EXTEND' in self._header:
@@ -1028,7 +1028,7 @@ class PrimaryHDU(_ImageBaseHDU):
             self._header.set('EXTEND', after=after)
 
     def _verify(self, option='warn'):
-        errs = super(PrimaryHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
 
         # Verify location and value of mandatory keywords.
         # The EXTEND keyword is only mandatory if the HDU has extensions; this
@@ -1097,7 +1097,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         # This __init__ currently does nothing differently from the base class,
         # and is only explicitly defined for the docstring.
 
-        super(ImageHDU, self).__init__(
+        super().__init__(
             data=data, header=header, name=name,
             do_not_scale_image_data=do_not_scale_image_data, uint=uint,
             scale_back=scale_back, ver=ver)
@@ -1115,7 +1115,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         ImageHDU verify method.
         """
 
-        errs = super(ImageHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
         naxis = self._header.get('NAXIS', 0)
         # PCOUNT must == 0, GCOUNT must == 1; the former is verified in
         # ExtensionHDU._verify, however ExtensionHDU._verify allows PCOUNT

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -260,8 +260,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     """
 
     def __init__(self, data=None, header=None, name=None, uint=False, ver=None):
-        super(_TableBaseHDU, self).__init__(data=data, header=header,
-                                            name=name, ver=ver)
+        super().__init__(data=data, header=header, name=name, ver=ver)
 
         if header is not None and not isinstance(header, Header):
             raise ValueError('header must be a Header object.')
@@ -527,14 +526,14 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                     format = format_cls(format.dtype, repeat=format.repeat,
                                         max=_max)
                     self._header['TFORM' + str(idx + 1)] = format.tform
-        return super(_TableBaseHDU, self)._prewriteto(checksum, inplace)
+        return super()._prewriteto(checksum, inplace)
 
     def _verify(self, option='warn'):
         """
         _TableBaseHDU verify method.
         """
 
-        errs = super(_TableBaseHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
         self.req_cards('NAXIS', None, lambda v: (v == 2), 2, option, errs)
         self.req_cards('BITPIX', None, lambda v: (v == 8), 8, option, errs)
         self.req_cards('TFIELDS', 7,
@@ -578,7 +577,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         return (self.name, self.ver, class_name, ncards, dims, format)
 
     def _update_column_removed(self, columns, idx):
-        super(_TableBaseHDU, self)._update_column_removed(columns, idx)
+        super()._update_column_removed(columns, idx)
 
         # Fix the header to reflect the column removal
         self._clear_table_keywords(index=idx)
@@ -715,7 +714,7 @@ class TableHDU(_TableBaseHDU):
         r'(?P<code>[ADEFIJ])(?P<width>\d+)(?:\.(?P<prec>\d+))?')
 
     def __init__(self, data=None, header=None, name=None, ver=None):
-        super(TableHDU, self).__init__(data, header, name=name, ver=ver)
+        super().__init__(data, header, name=name, ver=ver)
 
     @classmethod
     def match_header(cls, header):
@@ -779,14 +778,14 @@ class TableHDU(_TableBaseHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(TableHDU, self)._calculate_datasum()
+            return super()._calculate_datasum()
 
     def _verify(self, option='warn'):
         """
         `TableHDU` verify method.
         """
 
-        errs = super(TableHDU, self)._verify(option=option)
+        errs = super()._verify(option=option)
         self.req_cards('PCOUNT', None, lambda v: (v == 0), 0, option, errs)
         tfields = self._header['TFIELDS']
         for idx in range(tfields):
@@ -830,8 +829,7 @@ class BinTableHDU(_TableBaseHDU):
             data = hdu.data
             header = hdu.header
 
-        super(BinTableHDU, self).__init__(
-            data, header, name=name, uint=uint, ver=ver)
+        super().__init__(data, header, name=name, uint=uint, ver=ver)
 
     @classmethod
     def match_header(cls, header):
@@ -888,7 +886,7 @@ class BinTableHDU(_TableBaseHDU):
             # yet.  We can handle that in a generic manner so we do it in the
             # base class.  The other possibility is that there is no data at
             # all.  This can also be handled in a generic manner.
-            return super(BinTableHDU, self)._calculate_datasum()
+            return super()._calculate_datasum()
 
     def _writedata_internal(self, fileobj):
         size = 0

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -2009,7 +2009,7 @@ class _HeaderComments(_CardAccessor):
         returned cards.  Otherwise the comment of a single card is returned.
         """
 
-        item = super(_HeaderComments, self).__getitem__(item)
+        item = super().__getitem__(item)
         if isinstance(item, _HeaderComments):
             # The item key was a slice
             return item
@@ -2039,7 +2039,7 @@ class _HeaderCommentaryCards(_CardAccessor):
     """
 
     def __init__(self, header, keyword=''):
-        super(_HeaderCommentaryCards, self).__init__(header)
+        super().__init__(header)
         self._keyword = keyword
         self._count = self._header.count(self._keyword)
         self._indices = slice(self._count).indices(self._count)

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -17,7 +17,7 @@ class TestChecksumFunctions(FitsTestCase):
 
     # All checksums have been verified against CFITSIO
     def setup(self):
-        super(TestChecksumFunctions, self).setup()
+        super().setup()
         self._oldfilters = warnings.filters[:]
         warnings.filterwarnings(
             'error',
@@ -32,7 +32,7 @@ class TestChecksumFunctions(FitsTestCase):
         _ValidHDU._get_timestamp = lambda self: '2013-12-20T13:36:10'
 
     def teardown(self):
-        super(TestChecksumFunctions, self).teardown()
+        super().teardown()
         warnings.filters = self._oldfilters
         _ValidHDU._get_timestamp = self._old_get_timestamp
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -201,7 +201,7 @@ class TestCore(FitsTestCase):
     def test_unfixable_missing_card(self):
         class TestHDU(fits.hdu.base.NonstandardExtHDU):
             def _verify(self, option='warn'):
-                errs = super(TestHDU, self)._verify(option)
+                errs = super()._verify(option)
                 hdu.req_cards('TESTKW', None, None, None, 'fix', errs)
                 return errs
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2283,7 +2283,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
     """
 
     def setup(self):
-        super(TestRecordValuedKeywordCards, self).setup()
+        super().setup()
         self._test_header = fits.Header()
         self._test_header.set('DP1', 'NAXIS: 2')
         self._test_header.set('DP1', 'AXIS.1: 1')

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -146,7 +146,7 @@ class NotifierMixin(object):
         # objects it will be necessary when HDU objects' states are restored to
         # re-register themselves as listeners on their new column instances.
         try:
-            state = super(NotifierMixin, self).__getstate__()
+            state = super().__getstate__()
         except AttributeError:
             # Chances are the super object doesn't have a getstate
             state = self.__dict__.copy()

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -108,12 +108,12 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         if '_is_dynamic' not in members:
             members['_is_dynamic'] = mcls._is_dynamic
 
-        return super(_ModelMeta, mcls).__new__(mcls, name, bases, members)
+        return super().__new__(mcls, name, bases, members)
 
     def __init__(cls, name, bases, members):
         # Make sure OrderedDescriptorContainer gets to run before doing
         # anything else
-        super(_ModelMeta, cls).__init__(name, bases, members)
+        super().__init__(name, bases, members)
 
         if cls._parameters_:
             if hasattr(cls, '_param_names'):
@@ -443,7 +443,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
         # For the sake of familiarity start the output with the standard class
         # __repr__
-        parts = [super(_ModelMeta, cls).__repr__()]
+        parts = [super().__repr__()]
 
         if not cls._is_concrete:
             return parts[0]
@@ -675,7 +675,7 @@ class Model(metaclass=_ModelMeta):
     input_units_equivalencies = None
 
     def __init__(self, *args, **kwargs):
-        super(Model, self).__init__()
+        super().__init__()
         meta = kwargs.pop('meta', None)
         if meta is not None:
             self.meta = meta
@@ -2228,7 +2228,7 @@ class _CompoundModelMeta(_ModelMeta):
 
         try:
             # Annoyingly, this will only work for Python 3.3+
-            basedir = super(_CompoundModelMeta, cls).__dir__()
+            basedir = super().__dir__()
         except AttributeError:
             basedir = list(set((dir(type(cls)) + list(cls.__dict__))))
 
@@ -2241,7 +2241,7 @@ class _CompoundModelMeta(_ModelMeta):
         return basedir
 
     def __reduce__(cls):
-        rv = super(_CompoundModelMeta, cls).__reduce__()
+        rv = super().__reduce__()
 
         if isinstance(rv, tuple):
             # Delete _evaluate from the members dict
@@ -2761,7 +2761,7 @@ class _CompoundModel(Model, metaclass=_CompoundModelMeta):
             ('Expression', expression),
             ('Components', '\n' + indent(components))
         ]
-        return super(_CompoundModel, self)._format_str(keywords=keywords)
+        return super()._format_str(keywords=keywords)
 
     def __getattr__(self, attr):
         # This __getattr__ is necessary, because _CompoundModelMeta creates

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -80,7 +80,7 @@ class _FitterMeta(abc.ABCMeta):
     registry = set()
 
     def __new__(mcls, name, bases, members):
-        cls = super(_FitterMeta, mcls).__new__(mcls, name, bases, members)
+        cls = super().__new__(mcls, name, bases, members)
 
         if not inspect.isabstract(cls) and not name.startswith('_'):
             mcls.registry.add(cls)
@@ -609,7 +609,7 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
                          'param_jac': None,
                          'param_cov': None}
 
-        super(LevMarLSQFitter, self).__init__()
+        super().__init__()
 
     def objective_function(self, fps, *args):
         """
@@ -768,7 +768,7 @@ class SLSQPLSQFitter(Fitter):
     supported_constraints = SLSQP.supported_constraints
 
     def __init__(self):
-        super(SLSQPLSQFitter, self).__init__(optimizer=SLSQP, statistic=leastsquare)
+        super().__init__(optimizer=SLSQP, statistic=leastsquare)
         self.fit_info = {}
 
     @fitter_unit_support
@@ -834,8 +834,7 @@ class SimplexLSQFitter(Fitter):
     supported_constraints = Simplex.supported_constraints
 
     def __init__(self):
-        super(SimplexLSQFitter, self).__init__(optimizer=Simplex,
-                                               statistic=leastsquare)
+        super().__init__(optimizer=Simplex, statistic=leastsquare)
         self.fit_info = {}
 
     @fitter_unit_support

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -307,7 +307,7 @@ class Gaussian2D(Fittable2DModel):
         kwargs['bounds'].setdefault('x_stddev', (FLOAT_EPSILON, None))
         kwargs['bounds'].setdefault('y_stddev', (FLOAT_EPSILON, None))
 
-        super(Gaussian2D, self).__init__(
+        super().__init__(
             amplitude=amplitude, x_mean=x_mean, y_mean=y_mean,
             x_stddev=x_stddev, y_stddev=y_stddev, theta=theta, **kwargs)
 
@@ -1486,7 +1486,7 @@ class Ring2D(Fittable2DModel):
         elif width is None:
             width = self.width.default
 
-        super(Ring2D, self).__init__(
+        super().__init__(
             amplitude=amplitude, x_0=x_0, y_0=y_0, r_in=r_in, width=width,
             **kwargs)
 

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -55,7 +55,7 @@ class Mapping(FittableModel):
                                  for idx in range(n_inputs))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
-        super(Mapping, self).__init__(name=name, meta=meta)
+        super().__init__(name=name, meta=meta)
 
     @property
     def inputs(self):
@@ -158,7 +158,7 @@ class Identity(Mapping):
 
     def __init__(self, n_inputs, name=None, meta=None):
         mapping = tuple(range(n_inputs))
-        super(Identity, self).__init__(mapping, name=name, meta=meta)
+        super().__init__(mapping, name=name, meta=meta)
 
     def __repr__(self):
         if self.name is None:

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -107,7 +107,7 @@ class SLSQP(Optimization):
 
     def __init__(self):
         from scipy.optimize import fmin_slsqp
-        super(SLSQP, self).__init__(fmin_slsqp)
+        super().__init__(fmin_slsqp)
         self.fit_info = {
             'final_func_val': None,
             'numiter': None,
@@ -189,7 +189,7 @@ class Simplex(Optimization):
 
     def __init__(self):
         from scipy.optimize import fmin as simplex
-        super(Simplex, self).__init__(simplex)
+        super().__init__(simplex)
         self.fit_info = {
             'final_func_val': None,
             'numiter': None,

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -212,7 +212,7 @@ class Parameter(OrderedDescriptor):
     def __init__(self, name='', description='', default=None, unit=None,
                  getter=None, setter=None, fixed=False, tied=False, min=None,
                  max=None, bounds=None, model=None):
-        super(Parameter, self).__init__()
+        super().__init__()
 
         self._name = name
         self.__doc__ = self._description = description.strip()

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -76,7 +76,7 @@ class PolynomialBase(FittableModel):
             # Parameter.__set__ method here
             param.__set__(self, value)
         else:
-            super(PolynomialBase, self).__setattr__(attr, value)
+            super().__setattr__(attr, value)
 
 
 class PolynomialModel(PolynomialBase):
@@ -94,7 +94,7 @@ class PolynomialModel(PolynomialBase):
         self._order = self.get_num_coeff(self.n_inputs)
         self._param_names = self._generate_coeff_names(self.n_inputs)
 
-        super(PolynomialModel, self).__init__(
+        super().__init__(
             n_models=n_models, model_set_axis=model_set_axis, name=name,
             meta=meta, **params)
 
@@ -196,7 +196,7 @@ class OrthoPolynomialBase(PolynomialBase):
         self.y_window = y_window
         self._param_names = self._generate_coeff_names()
 
-        super(OrthoPolynomialBase, self).__init__(
+        super().__init__(
             n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
 
@@ -306,8 +306,7 @@ class OrthoPolynomialBase(PolynomialBase):
         return self.imhorner(x, y, invcoeff)
 
     def prepare_inputs(self, x, y, **kwargs):
-        inputs, format_info = \
-                super(OrthoPolynomialBase, self).prepare_inputs(x, y, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
 
@@ -358,7 +357,7 @@ class Chebyshev1D(PolynomialModel):
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
         self.window = window
-        super(Chebyshev1D, self).__init__(
+        super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
 
@@ -464,7 +463,7 @@ class Hermite1D(PolynomialModel):
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
         self.window = window
-        super(Hermite1D, self).__init__(
+        super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
 
@@ -571,7 +570,7 @@ class Hermite2D(OrthoPolynomialBase):
     def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
                  y_domain=None, y_window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        super(Hermite2D, self).__init__(
+        super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
             model_set_axis=model_set_axis, name=name, meta=meta, **params)
@@ -694,7 +693,7 @@ class Legendre1D(PolynomialModel):
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
         self.window = window
-        super(Legendre1D, self).__init__(
+        super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
 
@@ -787,13 +786,12 @@ class Polynomial1D(PolynomialModel):
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
         self.window = window
-        super(Polynomial1D, self).__init__(
+        super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(Polynomial1D, self).prepare_inputs(x, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
         return (x,), format_info
@@ -887,7 +885,7 @@ class Polynomial2D(PolynomialModel):
     def __init__(self, degree, x_domain=[-1, 1], y_domain=[-1, 1],
                  x_window=[-1, 1], y_window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        super(Polynomial2D, self).__init__(
+        super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
         self.x_domain = x_domain
@@ -896,8 +894,7 @@ class Polynomial2D(PolynomialModel):
         self.y_window = y_window
 
     def prepare_inputs(self, x, y, **kwargs):
-        inputs, format_info = \
-                super(Polynomial2D, self).prepare_inputs(x, y, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
 
@@ -1064,7 +1061,7 @@ class Chebyshev2D(OrthoPolynomialBase):
     def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
                  y_domain=None, y_window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        super(Chebyshev2D, self).__init__(
+        super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
             model_set_axis=model_set_axis, name=name, meta=meta, **params)
@@ -1194,7 +1191,7 @@ class Legendre2D(OrthoPolynomialBase):
     def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
                  y_domain=None, y_window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
-        super(Legendre2D, self).__init__(
+        super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
             model_set_axis=model_set_axis, name=name, meta=meta, **params)
@@ -1286,9 +1283,8 @@ class _SIP1D(PolynomialBase):
         self.coeff_prefix = coeff_prefix
         self._param_names = self._generate_coeff_names(coeff_prefix)
 
-        super(_SIP1D, self).__init__(n_models=n_models,
-                                     model_set_axis=model_set_axis,
-                                     name=name, meta=meta, **params)
+        super().__init__(n_models=n_models, model_set_axis=model_set_axis,
+                         name=name, meta=meta, **params)
 
     def __repr__(self):
         return self._format_repr(args=[self.order, self.coeff_prefix])
@@ -1413,9 +1409,8 @@ class SIP(Model):
                               model_set_axis=model_set_axis, **a_coeff)
         self.sip1d_b = _SIP1D(b_order, coeff_prefix='B', n_models=n_models,
                               model_set_axis=model_set_axis, **b_coeff)
-        super(SIP, self).__init__(n_models=n_models,
-                                  model_set_axis=model_set_axis, name=name,
-                                  meta=meta)
+        super().__init__(n_models=n_models, model_set_axis=model_set_axis,
+                         name=name, meta=meta)
 
     def __repr__(self):
         return '<{0}({1!r})>'.format(self.__class__.__name__,
@@ -1487,9 +1482,8 @@ class InverseSIP(Model):
         self.sip1d_bp = Polynomial2D(degree=bp_order,
                                      model_set_axis=model_set_axis,
                                      **bp_coeff_params)
-        super(InverseSIP, self).__init__(n_models=n_models,
-                                         model_set_axis=model_set_axis,
-                                         name=name, meta=meta)
+        super().__init__(n_models=n_models, model_set_axis=model_set_axis,
+                         name=name, meta=meta)
 
     def __repr__(self):
         return '<{0}({1!r})>'.format(self.__class__.__name__,

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -205,7 +205,7 @@ class Pix2Sky_ZenithalPerspective(Pix2SkyProjection, Zenithal):
     def __init__(self, mu=mu.default, gamma=gamma.default, **kwargs):
         # units : mu - in spherical radii, gamma - in deg
         # TODO: Support quantity objects here and in similar contexts
-        super(Pix2Sky_ZenithalPerspective, self).__init__(mu, gamma, **kwargs)
+        super().__init__(mu, gamma, **kwargs)
 
     @mu.validator
     def mu(self, value):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -150,7 +150,7 @@ class EulerAngleRotation(_EulerRotation, Model):
         if any(qs) and not all(qs):
             raise TypeError("All parameters should be of the same type - float or Quantity.")
 
-        super(EulerAngleRotation, self).__init__(phi=phi, theta=theta, psi=psi, **kwargs)
+        super().__init__(phi=phi, theta=theta, psi=psi, **kwargs)
 
     def inverse(self):
         return self.__class__(phi=-self.psi,
@@ -159,7 +159,7 @@ class EulerAngleRotation(_EulerRotation, Model):
                               axes_order=self.axes_order[::-1])
 
     def evaluate(self, alpha, delta, phi, theta, psi):
-        a, b = super(EulerAngleRotation, self).evaluate(alpha, delta, phi, theta, psi, self.axes_order)
+        a, b = super().evaluate(alpha, delta, phi, theta, psi, self.axes_order)
         return a, b
 
 
@@ -176,12 +176,12 @@ class _SkyRotation(_EulerRotation, Model):
         qs = [isinstance(par, u.Quantity) for par in [lon, lat, lon_pole]]
         if any(qs) and not all(qs):
             raise TypeError("All parameters should be of the same type - float or Quantity.")
-        super(_SkyRotation, self).__init__(lon, lat, lon_pole, **kwargs)
+        super().__init__(lon, lat, lon_pole, **kwargs)
         self.axes_order = 'zxz'
 
     def _evaluate(self, phi, theta, lon, lat, lon_pole):
-        alpha, delta = super(_SkyRotation, self).evaluate(phi, theta, lon, lat,
-                                                          lon_pole, self.axes_order)
+        alpha, delta = super().evaluate(phi, theta, lon, lat, lon_pole,
+                                        self.axes_order)
         mask = alpha < 0
         if isinstance(mask, np.ndarray):
             alpha[mask] += 360
@@ -225,7 +225,7 @@ class RotateNative2Celestial(_SkyRotation):
         return {'alpha_C': u.deg, 'delta_C': u.deg}
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
-        super(RotateNative2Celestial, self).__init__(lon, lat, lon_pole, **kwargs)
+        super().__init__(lon, lat, lon_pole, **kwargs)
 
     def evaluate(self, phi_N, theta_N, lon, lat, lon_pole):
         """
@@ -250,8 +250,7 @@ class RotateNative2Celestial(_SkyRotation):
         phi = lon_pole - np.pi / 2
         theta = - (np.pi / 2 - lat)
         psi = -(np.pi / 2 + lon)
-        alpha_C, delta_C = super(RotateNative2Celestial, self)._evaluate(phi_N, theta_N,
-                                                                         phi, theta, psi)
+        alpha_C, delta_C = super()._evaluate(phi_N, theta_N, phi, theta, psi)
         return alpha_C, delta_C
 
     @property
@@ -295,7 +294,7 @@ class RotateCelestial2Native(_SkyRotation):
         return {'phi_N': u.deg, 'theta_N': u.deg}
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
-        super(RotateCelestial2Native, self).__init__(lon, lat, lon_pole, **kwargs)
+        super().__init__(lon, lat, lon_pole, **kwargs)
 
     def evaluate(self, alpha_C, delta_C, lon, lat, lon_pole):
         """
@@ -320,8 +319,7 @@ class RotateCelestial2Native(_SkyRotation):
         phi = (np.pi / 2 + lon)
         theta = (np.pi / 2 - lat)
         psi = -(lon_pole - np.pi / 2)
-        phi_N, theta_N = super(RotateCelestial2Native, self)._evaluate(alpha_C, delta_C,
-                                                                       phi, theta, psi)
+        phi_N, theta_N = super()._evaluate(alpha_C, delta_C, phi, theta, psi)
 
         return phi_N, theta_N
 

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -101,7 +101,7 @@ class _Tabular(Model):
         n_models = kwargs.get('n_models', 1)
         if n_models > 1:
             raise NotImplementedError('Only n_models=1 is supported.')
-        super(_Tabular, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if lookup_table is None:
             raise ValueError('Must provide a lookup table.')

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -145,7 +145,7 @@ class IdentifyRecord(Record):
         function (modelname) coefficients
     """
     def __init__(self, recstr):
-        super(IdentifyRecord, self).__init__(recstr)
+        super().__init__(recstr)
         self._flatcoeff = self.fields['coefficients'].flatten()
         self.x = self.fields['features'][:, 0]
         self.y = self.get_ydata()
@@ -203,7 +203,7 @@ class FitcoordsRecord(Record):
 
     """
     def __init__(self, recstr):
-        super(FitcoordsRecord, self).__init__(recstr)
+        super().__init__(recstr)
         self._surface = self.fields['surface'].flatten()
         self.modelname = iraf_models_map[self._surface[0]]
         self.xorder = self._surface[1]
@@ -252,7 +252,7 @@ class ReidentifyRecord(IDB):
     Represents a database record for the onedspec.reidentify task
     """
     def __init__(self, databasestr):
-        super(ReidentifyRecord, self).__init__(databasestr)
+        super().__init__(databasestr)
         self.x = np.array([r.x for r in self.records])
         self.y = self.get_ydata()
         self.z = np.array([r.z for r in self.records])

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -18,8 +18,7 @@ class NonFittableModel(Model):
     a = Parameter()
 
     def __init__(self, a, model_set_axis=None):
-        super(NonFittableModel, self).__init__(
-            a, model_set_axis=model_set_axis)
+        super().__init__(a, model_set_axis=model_set_axis)
 
     @staticmethod
     def evaluate():
@@ -146,7 +145,7 @@ def test_custom_model_subclass():
         # Override the evaluate from model_a
         @classmethod
         def evaluate(cls, x, a):
-            return -super(model_b, cls).evaluate(x, a)
+            return -super().evaluate(x, a)
 
     b = model_b()
     assert b.param_names == ('a',)

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -36,7 +36,7 @@ class SetterModel(FittableModel):
 
     def __init__(self, xc, yc, p):
         self.p = p  # p is a value intended to be used by the setter
-        super(SetterModel, self).__init__()
+        super().__init__()
         self.xc = xc
         self.yc = yc
 
@@ -56,7 +56,7 @@ class TParModel(Model):
     e = Parameter()
 
     def __init__(self, coeff, e, **kwargs):
-        super(TParModel, self).__init__(coeff=coeff, e=e, **kwargs)
+        super().__init__(coeff=coeff, e=e, **kwargs)
 
     @staticmethod
     def evaluate(coeff, e):

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -363,7 +363,7 @@ class _BoundingBox(tuple):
     _model = None
 
     def __new__(cls, input_, _model=None):
-        self = super(_BoundingBox, cls).__new__(cls, input_)
+        self = super().__new__(cls, input_)
         if _model is not None:
             # Bind this _BoundingBox (most likely a subclass) to a Model
             # instance so that its __call__ can access the model

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -158,7 +158,7 @@ class CCDData(NDDataArray):
         if 'header' in kwd:
             raise ValueError("can't have both header and meta.")
 
-        super(CCDData, self).__init__(*args, **kwd)
+        super().__init__(*args, **kwd)
 
         # Check if a unit is set. This can be temporarly disabled by the
         # _CCDDataUnit contextmanager.

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -84,7 +84,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         flags = kwd.pop('flags', None)
 
         # Initialize with the parent...
-        super(NDDataArray, self).__init__(data, *args, **kwd)
+        super().__init__(data, *args, **kwd)
 
         # ...then reset uncertainty to force it to go through the
         # setter logic below. In base NDData all that is done is to

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -119,7 +119,7 @@ class NDData(NDDataBase):
         # but before the NDDataBase did call the uncertainty
         # setter. But if anyone wants to alter this behaviour again the call
         # to the superclass NDDataBase should be in here.
-        super(NDData, self).__init__()
+        super().__init__()
 
         # Check if data is any type from which to collect some implicitly
         # passed parameters.

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -102,7 +102,7 @@ class SubNDData(NDDataArray):
     NDData.convert_unit_to
     """
     def __init__(self, *arg, **kwd):
-        super(SubNDData, self).__init__(*arg, **kwd)
+        super().__init__(*arg, **kwd)
         if self.unit is None:
             raise ValueError("Unit for subclass must be specified")
         if self.wcs is None:

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -41,7 +41,7 @@ class FakeNumpyArray(object):
     These attributes are checked for by NDData.
     """
     def __init__(self):
-        super(FakeNumpyArray, self).__init__()
+        super().__init__()
 
     def shape(self):
         pass

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -7,7 +7,7 @@ from ..nddata_base import NDDataBase
 
 class MinimalSubclass(NDDataBase):
     def __init__(self):
-        super(MinimalSubclass, self).__init__()
+        super().__init__()
 
     @property
     def data(self):
@@ -15,23 +15,23 @@ class MinimalSubclass(NDDataBase):
 
     @property
     def mask(self):
-        return super(MinimalSubclass, self).mask
+        return super().mask
 
     @property
     def unit(self):
-        return super(MinimalSubclass, self).unit
+        return super().unit
 
     @property
     def wcs(self):
-        return super(MinimalSubclass, self).wcs
+        return super().wcs
 
     @property
     def meta(self):
-        return super(MinimalSubclass, self).meta
+        return super().meta
 
     @property
     def uncertainty(self):
-        return super(MinimalSubclass, self).uncertainty
+        return super().uncertainty
 
 
 def test_nddata_base_subclass():

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -425,14 +425,14 @@ class Events(FitnessFunc):
                           'recommended that you run random trials on signal-'
                           'free noise to calibrate ncp_prior to achieve a '
                           'desired false positive rate.', AstropyUserWarning)
-        super(Events, self).__init__(p0, gamma, ncp_prior)
+        super().__init__(p0, gamma, ncp_prior)
 
     def fitness(self, N_k, T_k):
         # eq. 19 from Scargle 2012
         return N_k * (np.log(N_k) - np.log(T_k))
 
     def validate_input(self, t, x, sigma):
-        t, x, sigma = super(Events, self).validate_input(t, x, sigma)
+        t, x, sigma = super().validate_input(t, x, sigma)
         if x is not None and np.any(x % 1 > 0):
             raise ValueError("x must be integer counts for fitness='events'")
         return t, x, sigma
@@ -461,10 +461,10 @@ class RegularEvents(FitnessFunc):
     """
     def __init__(self, dt, p0=0.05, gamma=None, ncp_prior=None):
         self.dt = dt
-        super(RegularEvents, self).__init__(p0, gamma, ncp_prior)
+        super().__init__(p0, gamma, ncp_prior)
 
     def validate_input(self, t, x, sigma):
-        t, x, sigma = super(RegularEvents, self).validate_input(t, x, sigma)
+        t, x, sigma = super().validate_input(t, x, sigma)
         if not np.all((x == 0) | (x == 1)):
             raise ValueError("Regular events must have only 0 and 1 in x")
         return t, x, sigma
@@ -502,7 +502,7 @@ class PointMeasures(FitnessFunc):
         ignored.
     """
     def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
-        super(PointMeasures, self).__init__(p0, gamma, ncp_prior)
+        super().__init__(p0, gamma, ncp_prior)
 
     def fitness(self, a_k, b_k):
         # eq. 41 from Scargle 2012
@@ -511,4 +511,4 @@ class PointMeasures(FitnessFunc):
     def validate_input(self, t, x, sigma):
         if x is None:
             raise ValueError("x must be specified for point measures")
-        return super(PointMeasures, self).validate_input(t, x, sigma)
+        return super().validate_input(t, x, sigma)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -345,8 +345,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if obj is None:
             return
 
-        if callable(super(BaseColumn, self).__array_finalize__):
-            super(BaseColumn, self).__array_finalize__(obj)
+        if callable(super().__array_finalize__):
+            super().__array_finalize__(obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to
@@ -376,7 +376,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
            we also want to consistently return an array rather than a column
            (see #1446 and #1685)
         """
-        out_arr = super(BaseColumn, self).__array_wrap__(out_arr, context)
+        out_arr = super().__array_wrap__(out_arr, context)
         if (self.shape != out_arr.shape or
             (isinstance(out_arr, BaseColumn) and
              (context is not None and context[0] in _comparison_functions))):
@@ -818,16 +818,16 @@ class Column(BaseColumn):
         if isinstance(data, MaskedColumn) and np.any(data.mask):
             raise TypeError("Cannot convert a MaskedColumn with masked value to a Column")
 
-        self = super(Column, cls).__new__(cls, data=data, name=name, dtype=dtype,
-                                          shape=shape, length=length, description=description,
-                                          unit=unit, format=format, meta=meta,
-                                          copy=copy, copy_indices=copy_indices)
+        self = super().__new__(
+            cls, data=data, name=name, dtype=dtype, shape=shape, length=length,
+            description=description, unit=unit, format=format, meta=meta,
+            copy=copy, copy_indices=copy_indices)
         return self
 
     def __setattr__(self, item, value):
         if not isinstance(self, MaskedColumn) and item == "mask":
             raise AttributeError("cannot set mask value to a column in non-masked Table")
-        super(Column, self).__setattr__(item, value)
+        super().__setattr__(item, value)
 
         if item == 'unit' and issubclass(self.dtype.type, np.number):
             try:
@@ -1161,7 +1161,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         if fill_value is None:
             fill_value = self.fill_value
 
-        data = super(MaskedColumn, self).filled(fill_value)
+        data = super().filled(fill_value)
         # Use parent table definition of Column if available
         column_cls = self.parent_table.Column if (self.parent_table is not None) else Column
         out = column_cls(name=self.name, data=data, unit=self.unit,

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -65,7 +65,7 @@ class Index(object):
         Whether the values of the index must be unique
     '''
     def __new__(cls, *args, **kwargs):
-        self = super(Index, cls).__new__(cls)
+        self = super().__new__(cls)
 
         # If (and only if) unpickling for protocol >= 2, then args and kwargs
         # are both empty.  The class __init__ requires at least the `columns`
@@ -736,7 +736,7 @@ class TableIndices(list):
     '''
 
     def __init__(self, lst):
-        super(TableIndices, self).__init__(lst)
+        super().__init__(lst)
 
     def __getitem__(self, item):
         '''
@@ -762,7 +762,7 @@ class TableIndices(list):
             # index search failed
             raise IndexError("No index found for {0}".format(item))
 
-        return super(TableIndices, self).__getitem__(item)
+        return super().__getitem__(item)
 
 
 class TableLoc(object):
@@ -837,7 +837,7 @@ class TableILoc(TableLoc):
     '''
 
     def __init__(self, table):
-        super(TableILoc, self).__init__(table)
+        super().__init__(table)
 
     def __getitem__(self, item):
         if isinstance(item, tuple):

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -13,7 +13,7 @@ class ColumnOrderList(list):
     """
 
     def sort(self, *args, **kwargs):
-        super(ColumnOrderList, self).sort()
+        super().sort()
 
         column_keys = ['name', 'unit', 'datatype', 'format', 'description', 'meta']
         in_dict = dict(self)
@@ -44,7 +44,7 @@ class ColumnDict(dict):
         Return items as a ColumnOrderList, which sorts in the preferred
         way for column attributes.
         """
-        return ColumnOrderList(super(ColumnDict, self).items())
+        return ColumnOrderList(super().items())
 
 
 def _construct_odict(load, node):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -89,7 +89,7 @@ class TableColumns(OrderedDict):
                 else:
                     newcols.append(col)
             cols = newcols
-        super(TableColumns, self).__init__(cols)
+        super().__init__(cols)
 
     def __getitem__(self, item):
         """Get items from a TableColumns object.
@@ -119,7 +119,7 @@ class TableColumns(OrderedDict):
         if item in self:
             raise ValueError("Cannot replace column '{0}'.  Use Table.replace_column() instead."
                              .format(item))
-        super(TableColumns, self).__setitem__(item, value)
+        super().__setitem__(item, value)
 
     def __repr__(self):
         names = ("'{0}'".format(x) for x in self.keys())
@@ -2566,16 +2566,16 @@ class Table(object):
         return self.copy(False)
 
     def __lt__(self, other):
-        return super(Table, self).__lt__(other)
+        return super().__lt__(other)
 
     def __gt__(self, other):
-        return super(Table, self).__gt__(other)
+        return super().__gt__(other)
 
     def __le__(self, other):
-        return super(Table, self).__le__(other)
+        return super().__le__(other)
 
     def __ge__(self, other):
-        return super(Table, self).__ge__(other)
+        return super().__ge__(other)
 
     def __eq__(self, other):
 
@@ -2778,7 +2778,7 @@ class QTable(Table):
             qcol.info = col.info
             col = qcol
         else:
-            col = super(QTable, self)._convert_col_for_table(col)
+            col = super()._convert_col_for_table(col)
 
         return col
 
@@ -2801,8 +2801,8 @@ class NdarrayMixin(np.ndarray):
         if obj is None:
             return
 
-        if callable(super(NdarrayMixin, self).__array_finalize__):
-            super(NdarrayMixin, self).__array_finalize__(obj)
+        if callable(super().__array_finalize__):
+            super().__array_finalize__(obj)
 
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to
@@ -2814,7 +2814,7 @@ class NdarrayMixin(np.ndarray):
         # patch to pickle Quantity objects (ndarray subclasses), see
         # http://www.mail-archive.com/numpy-discussion@scipy.org/msg02446.html
 
-        object_state = list(super(NdarrayMixin, self).__reduce__())
+        object_state = list(super().__reduce__())
         object_state[2] = (object_state[2], self.__dict__)
         return tuple(object_state)
 
@@ -2823,5 +2823,5 @@ class NdarrayMixin(np.ndarray):
         # http://www.mail-archive.com/numpy-discussion@scipy.org/msg02446.html
 
         nd_state, own_state = state
-        super(NdarrayMixin, self).__setstate__(nd_state)
+        super().__setstate__(nd_state)
         self.__dict__.update(own_state)

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -52,7 +52,7 @@ def assert_col_equal(col, array):
 @pytest.mark.usefixtures('table_types')
 class TestIndex(SetupData):
     def _setup(self, main_col, table_types):
-        super(TestIndex, self)._setup(table_types)
+        super()._setup(table_types)
         self.main_col = main_col
         if isinstance(main_col, u.Quantity):
             self._table_type = QTable

--- a/astropy/table/tests/test_subclass.py
+++ b/astropy/table/tests/test_subclass.py
@@ -69,9 +69,9 @@ class ParamsRow(table.Row):
 
     def __getitem__(self, item):
         if item not in self.colnames:
-            return super(ParamsRow, self).__getitem__('params')[item]
+            return super().__getitem__('params')[item]
         else:
-            return super(ParamsRow, self).__getitem__(item)
+            return super().__getitem__(item)
 
     def keys(self):
         out = [name for name in self.colnames if name != 'params']

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -244,7 +244,7 @@ class Time(ShapedLikeNDArray):
         if isinstance(val, cls):
             self = val.replicate(format=format, copy=copy)
         else:
-            self = super(Time, cls).__new__(cls)
+            self = super().__new__(cls)
 
         return self
 
@@ -1543,7 +1543,7 @@ class TimeDelta(Time):
                 self.SCALES = TIME_DELTA_TYPES[scale]
 
     def replicate(self, *args, **kwargs):
-        out = super(TimeDelta, self).replicate(*args, **kwargs)
+        out = super().replicate(*args, **kwargs)
         out.SCALES = self.SCALES
         return out
 
@@ -1747,7 +1747,7 @@ def _make_array(val, copy=False):
 class OperandTypeError(TypeError):
     def __init__(self, left, right, op=None):
         op_string = '' if op is None else ' for {0}'.format(op)
-        super(OperandTypeError, self).__init__(
+        super().__init__(
             "Unsupported operand type(s){0}: "
             "'{1}' and '{2}'".format(op_string,
                                      left.__class__.__name__,

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -77,7 +77,7 @@ class TimeFormatMeta(type):
     _registry = TIME_FORMATS
 
     def __new__(mcls, name, bases, members):
-        cls = super(TimeFormatMeta, mcls).__new__(mcls, name, bases, members)
+        cls = super().__new__(mcls, name, bases, members)
 
         # Register time formats that have a name, but leave out astropy_time since
         # it is not a user-accessible format and is only used for initialization into
@@ -338,8 +338,8 @@ class TimeFromEpoch(TimeFormat):
         self.epoch = epoch
 
         # Now create the TimeFormat object as normal
-        super(TimeFromEpoch, self).__init__(val1, val2, scale, precision,
-                                            in_subfmt, out_subfmt, from_jd)
+        super().__init__(val1, val2, scale, precision, in_subfmt, out_subfmt,
+                         from_jd)
 
     def set_jds(self, val1, val2):
         """
@@ -847,7 +847,7 @@ class TimeISO(TimeString):
                 raise ValueError("Time input terminating in 'Z' must have "
                                  "scale='UTC'")
             timestr = timestr[:-1]
-        return super(TimeISO, self).parse_string(timestr, subfmts)
+        return super().parse_string(timestr, subfmts)
 
 
 class TimeISOT(TimeISO):
@@ -987,7 +987,7 @@ class TimeFITS(TimeString):
 
     def format_string(self, str_fmt, **kwargs):
         """Format time-string: append the scale to the normal ISOT format."""
-        time_str = super(TimeFITS, self).format_string(str_fmt, **kwargs)
+        time_str = super().format_string(str_fmt, **kwargs)
         if self._fits_scale and self._fits_realization:
             return '{0}({1}({2}))'.format(time_str, self._fits_scale,
                                           self._fits_realization)
@@ -1003,7 +1003,7 @@ class TimeFITS(TimeString):
             jd = self.jd1 + self.jd2
             if jd.min() < 1721425.5 or jd.max() >= 5373484.5:
                 self.out_subfmt = 'long' + self.out_subfmt
-        return super(TimeFITS, self).value
+        return super().value
 
 
 class TimeEpochDate(TimeFormat):
@@ -1036,7 +1036,7 @@ class TimeBesselianEpoch(TimeEpochDate):
                              "as the interpretation would be ambiguous. "
                              "Use float with Besselian year instead. ")
 
-        return super(TimeBesselianEpoch, self)._check_val_type(val1, val2)
+        return super()._check_val_type(val1, val2)
 
 
 class TimeJulianEpoch(TimeEpochDate):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1759,7 +1759,7 @@ class _UnitMetaClass(InheritDocstrings):
         if isinstance(represents, UnitBase):
             # This has the effect of calling the real __new__ and
             # __init__ on the Unit class.
-            return super(_UnitMetaClass, self).__call__(
+            return super().__call__(
                 s, represents, format=format, namespace=namespace, doc=doc)
 
         # or interpret a Quantity (now became unit), string or number?
@@ -1989,7 +1989,7 @@ class CompositeUnit(UnitBase):
 
     def __repr__(self):
         if len(self._bases):
-            return super(CompositeUnit, self).__repr__()
+            return super().__repr__()
         else:
             if self._scale != 1.0:
                 return 'Unit(dimensionless with a scale of {0})'.format(

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -150,7 +150,7 @@ class Fits(generic.Generic):
 
     @classmethod
     def parse(cls, s, debug=False):
-        result = super(Fits, cls).parse(s, debug)
+        result = super().parse(s, debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported for "
                              "FITS units.")

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -491,9 +491,8 @@ class FunctionQuantity(Quantity):
             unit = cls._unit_class(physical_unit, function_unit=unit)
 
         # initialise!
-        return super(FunctionQuantity,
-                     cls).__new__(cls, value, unit, dtype=dtype, copy=copy,
-                                  order=order, subok=subok, ndmin=ndmin)
+        return super().__new__(cls, value, unit, dtype=dtype, copy=copy,
+                               order=order, subok=subok, ndmin=ndmin)
 
     # ↓↓↓ properties not found in Quantity
     @property
@@ -546,14 +545,13 @@ class FunctionQuantity(Quantity):
                                 "quantities that are not dimensionless."
                                 .format(context[0].__name__))
 
-        return super(FunctionQuantity, self).__array_prepare__(obj, context)
+        return super().__array_prepare__(obj, context)
 
     def __quantity_subclass__(self, unit):
         if isinstance(unit, FunctionUnitBase):
             return self.__class__, True
         else:
-            return super(FunctionQuantity,
-                         self).__quantity_subclass__(unit)[0], False
+            return super().__quantity_subclass__(unit)[0], False
 
     def _set_unit(self, unit):
         if not isinstance(unit, self._unit_class):
@@ -640,8 +638,7 @@ class FunctionQuantity(Quantity):
     # Ensure Quantity methods are used only if they make sense.
     def _wrap_function(self, function, *args, **kwargs):
         if function in self._supported_functions:
-            return super(FunctionQuantity,
-                         self)._wrap_function(function, *args, **kwargs)
+            return super()._wrap_function(function, *args, **kwargs)
 
         # For dimensionless, we can convert to regular quantities.
         if all(arg.unit.physical_unit == dimensionless_unscaled

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -120,7 +120,7 @@ class MagUnit(LogUnit):
     def __init__(self, *args, **kwargs):
         # Ensure we recognize magnitude zero points here.
         with mag0.enable():
-            super(MagUnit, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     @property
     def _default_function_unit(self):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -632,8 +632,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                        for input_, converter in zip(inputs, converters))
 
         # Call our superclass's __array_ufunc__
-        result = super(Quantity, self).__array_ufunc__(function, method,
-                                                       *arrays, **kwargs)
+        result = super().__array_ufunc__(function, method, *arrays, **kwargs)
         # If unit is None, a plain array is expected (e.g., comparisons), which
         # means we're done.
         # We're also done if the result was None (for method 'at') or
@@ -789,7 +788,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         # patch to pickle Quantity objects (ndarray subclasses), see
         # http://www.mail-archive.com/numpy-discussion@scipy.org/msg02446.html
 
-        object_state = list(super(Quantity, self).__reduce__())
+        object_state = list(super().__reduce__())
         object_state[2] = (object_state[2], self.__dict__)
         return tuple(object_state)
 
@@ -798,7 +797,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         # http://www.mail-archive.com/numpy-discussion@scipy.org/msg02446.html
 
         nd_state, own_state = state
-        super(Quantity, self).__setstate__(nd_state)
+        super().__setstate__(nd_state)
         self.__dict__.update(own_state)
 
     info = QuantityInfo()
@@ -992,7 +991,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     def __eq__(self, other):
         try:
             try:
-                return super(Quantity, self).__eq__(other)
+                return super().__eq__(other)
             except DeprecationWarning:
                 # We treat the DeprecationWarning separately, since it may
                 # mask another Exception.  But we do not want to just use
@@ -1006,7 +1005,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     def __ne__(self, other):
         try:
             try:
-                return super(Quantity, self).__ne__(other)
+                return super().__ne__(other)
             except DeprecationWarning:
                 return np.not_equal(self, other)
         except UnitsError:
@@ -1024,7 +1023,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             except UnitsError:  # let other try to deal with it
                 return NotImplemented
 
-        return super(Quantity, self).__mul__(other)
+        return super().__mul__(other)
 
     def __imul__(self, other):
         """In-place multiplication between `Quantity` objects and others."""
@@ -1033,7 +1032,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             self._set_unit(other * self.unit)
             return self
 
-        return super(Quantity, self).__imul__(other)
+        return super().__imul__(other)
 
     def __rmul__(self, other):
         """ Right Multiplication between `Quantity` objects and other
@@ -1051,7 +1050,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             except UnitsError:  # let other try to deal with it
                 return NotImplemented
 
-        return super(Quantity, self).__truediv__(other)
+        return super().__truediv__(other)
 
     def __itruediv__(self, other):
         """Inplace division between `Quantity` objects and other objects."""
@@ -1060,7 +1059,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             self._set_unit(self.unit / other)
             return self
 
-        return super(Quantity, self).__itruediv__(other)
+        return super().__itruediv__(other)
 
     def __rtruediv__(self, other):
         """ Right Division between `Quantity` objects and other objects."""
@@ -1068,7 +1067,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         if isinstance(other, (UnitBase, str)):
             return self._new_view(1. / self.value, other / self.unit)
 
-        return super(Quantity, self).__rtruediv__(other)
+        return super().__rtruediv__(other)
 
     def __div__(self, other):
         """ Division between `Quantity` objects. """
@@ -1097,7 +1096,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return self._new_view(self.value ** float(other),
                                   self.unit ** other)
 
-        return super(Quantity, self).__pow__(other)
+        return super().__pow__(other)
 
     # For Py>=3.5
     def __matmul__(self, other, reverse=False):
@@ -1145,7 +1144,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
     def __getitem__(self, key):
         try:
-            out = super(Quantity, self).__getitem__(key)
+            out = super().__getitem__(key)
         except IndexError:
             # We want zero-dimensional Quantity objects to behave like scalars,
             # so they should raise a TypeError rather than an IndexError.
@@ -1364,7 +1363,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     # http://docs.scipy.org/doc/numpy/reference/arrays.ndarray.html#array-conversion
 
     def item(self, *args):
-        return self._new_view(super(Quantity, self).item(*args))
+        return self._new_view(super().item(*args))
 
     def tolist(self):
         raise NotImplementedError("cannot make a list of Quantities.  Get "
@@ -1671,8 +1670,7 @@ class SpecificTypeQuantity(Quantity):
         if unit.is_equivalent(self._equivalent_unit):
             return type(self), True
         else:
-            return super(SpecificTypeQuantity,
-                         self).__quantity_subclass__(unit)[0], False
+            return super().__quantity_subclass__(unit)[0], False
 
     def _set_unit(self, unit):
         if unit is None or not unit.is_equivalent(self._equivalent_unit):
@@ -1682,4 +1680,4 @@ class SpecificTypeQuantity(Quantity):
                 (", but no unit was given." if unit is None else
                  ", so cannot set it to '{0}'.".format(unit)))
 
-        super(SpecificTypeQuantity, self)._set_unit(unit)
+        super()._set_unit(unit)

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -248,7 +248,7 @@ class DataInfo(object):
 
     def __getattr__(self, attr):
         if attr.startswith('_'):
-            return super(DataInfo, self).__getattribute__(attr)
+            return super().__getattribute__(attr)
 
         if attr in self.attrs_from_parent:
             return getattr(self._parent, attr)
@@ -256,7 +256,7 @@ class DataInfo(object):
         try:
             value = self._attrs[attr]
         except KeyError:
-            super(DataInfo, self).__getattribute__(attr)  # Generate AttributeError
+            super().__getattribute__(attr)  # Generate AttributeError
 
         # Weak ref for parent table
         if attr == 'parent_table' and callable(value):
@@ -287,7 +287,7 @@ class DataInfo(object):
 
         # Private attr names get directly set
         if attr.startswith('_'):
-            super(DataInfo, self).__setattr__(attr, value)
+            super().__setattr__(attr, value)
             return
 
         # Finally this must be an actual data attribute that this class is handling.
@@ -417,7 +417,7 @@ class DataInfo(object):
 
     def __repr__(self):
         if self._parent is None:
-            return super(DataInfo, self).__repr__()
+            return super().__repr__()
 
         out = StringIO()
         self.__call__(out=out)
@@ -606,7 +606,7 @@ class MixinInfo(BaseColumnInfo):
             new_name = fix_column_name(value)  # Ensure col name is numpy compatible
             self.parent_table.columns._rename_column(self.name, new_name)
 
-        super(MixinInfo, self).__setattr__(attr, value)
+        super().__setattr__(attr, value)
 
 
 class ParentDtypeInfo(MixinInfo):

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -617,7 +617,7 @@ class classproperty(property):
 
             return wrapper
 
-        return super(classproperty, cls).__new__(cls)
+        return super().__new__(cls)
 
     def __init__(self, fget, doc=None, lazy=False):
         self._lazy = lazy
@@ -625,7 +625,7 @@ class classproperty(property):
             self._cache = {}
         fget = self._wrap_fget(fget)
 
-        super(classproperty, self).__init__(fget=fget, doc=doc)
+        super().__init__(fget=fget, doc=doc)
 
         # There is a buglet in Python where self.__doc__ doesn't
         # get set properly on instances of property subclasses if
@@ -644,7 +644,7 @@ class classproperty(property):
             # function (which takes the class as its sole argument)
             val = self.fget.__wrapped__(objtype)
         else:
-            val = super(classproperty, self).__get__(obj, objtype=objtype)
+            val = super().__get__(obj, objtype=objtype)
 
         if self._lazy:
             if objtype is None:
@@ -655,7 +655,7 @@ class classproperty(property):
         return val
 
     def getter(self, fget):
-        return super(classproperty, self).getter(self._wrap_fget(fget))
+        return super().getter(self._wrap_fget(fget))
 
     def setter(self, fset):
         raise NotImplementedError(
@@ -723,7 +723,7 @@ class lazyproperty(property):
     """
 
     def __init__(self, fget, fset=None, fdel=None, doc=None):
-        super(lazyproperty, self).__init__(fget, fset, fdel, doc)
+        super().__init__(fget, fset, fdel, doc)
         self._key = self.fget.__name__
 
     def __get__(self, obj, owner=None):

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -83,7 +83,7 @@ class MergeStrategyMeta(type):
     """
 
     def __new__(mcls, name, bases, members):
-        cls = super(MergeStrategyMeta, mcls).__new__(mcls, name, bases, members)
+        cls = super().__new__(mcls, name, bases, members)
 
         # Wrap ``merge`` classmethod to catch any exception and re-raise as
         # MergeConflictError.

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -527,7 +527,7 @@ class InheritDocstrings(type):
                         val.__doc__ = super_method.__doc__
                         break
 
-        super(InheritDocstrings, cls).__init__(name, bases, dct)
+        super().__init__(name, bases, dct)
 
 
 class OrderedDescriptor(metaclass=abc.ABCMeta):
@@ -593,7 +593,7 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
         # between themselves
         self.__order = OrderedDescriptor._nextid
         OrderedDescriptor._nextid += 1
-        super(OrderedDescriptor, self).__init__()
+        super().__init__()
 
     def __lt__(self, other):
         """
@@ -660,7 +660,7 @@ class OrderedDescriptorContainer(type):
     ...
     ...     def __init__(self, type):
     ...         # Make sure not to forget to call the super __init__
-    ...         super(TypedAttribute, self).__init__()
+    ...         super().__init__()
     ...         self.type = type
     ...
     ...     def __get__(self, obj, objtype=None):
@@ -810,8 +810,7 @@ class OrderedDescriptorContainer(type):
             instances = OrderedDict((key, value) for value, key in instances)
             setattr(cls, descriptor_cls._class_attribute_, instances)
 
-        super(OrderedDescriptorContainer, cls).__init__(cls_name, bases,
-                                                        members)
+        super().__init__(cls_name, bases, members)
 
 
 LOCALE_LOCK = threading.Lock()
@@ -1047,8 +1046,7 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
 
 class IncompatibleShapeError(ValueError):
     def __init__(self, shape_a, shape_a_idx, shape_b, shape_b_idx):
-        super(IncompatibleShapeError, self).__init__(
-                shape_a, shape_a_idx, shape_b, shape_b_idx)
+        super().__init__(shape_a, shape_a_idx, shape_b, shape_b_idx)
 
 
 def check_broadcast(*shapes):

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -21,7 +21,7 @@ class FakeTTY(io.StringIO):
     def __new__(cls, encoding=None):
         # Return a new subclass of FakeTTY with the requested encoding
         if encoding is None:
-            return super(FakeTTY, cls).__new__(cls)
+            return super().__new__(cls)
 
         # Since we're using unicode_literals in this module ensure that this is
         # a 'str' object (since a class name can't be unicode in Python 2.7)
@@ -32,7 +32,7 @@ class FakeTTY(io.StringIO):
         return cls.__new__(cls)
 
     def __init__(self, encoding=None):
-        super(FakeTTY, self).__init__()
+        super().__init__()
 
     def write(self, s):
         if isinstance(s, bytes):
@@ -41,7 +41,7 @@ class FakeTTY(io.StringIO):
         elif self.encoding is not None:
             s.encode(self.encoding)
 
-        return super(FakeTTY, self).write(s)
+        return super().write(s)
 
     def isatty(self):
         return True

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -174,9 +174,8 @@ class PercentileInterval(AsymmetricPercentileInterval):
     def __init__(self, percentile, n_samples=None):
         lower_percentile = (100 - percentile) * 0.5
         upper_percentile = 100 - lower_percentile
-        super(PercentileInterval, self).__init__(lower_percentile,
-                                                 upper_percentile,
-                                                 n_samples=n_samples)
+        super().__init__(
+            lower_percentile, upper_percentile, n_samples=n_samples)
 
 
 class ZScaleInterval(BaseInterval):

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -64,7 +64,7 @@ class ImageNormalize(Normalize):
     def __init__(self, data=None, interval=None, vmin=None, vmax=None,
                  stretch=LinearStretch(), clip=False):
         # this super call checks for matplotlib
-        super(ImageNormalize, self).__init__(vmin=vmin, vmax=vmax, clip=clip)
+        super().__init__(vmin=vmin, vmax=vmax, clip=clip)
 
         self.vmin = vmin
         self.vmax = vmax

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -134,7 +134,7 @@ class PowerStretch(BaseStretch):
     """
 
     def __init__(self, a):
-        super(PowerStretch, self).__init__()
+        super().__init__()
         self.power = a
 
     def __call__(self, values, clip=True, out=None):
@@ -167,7 +167,7 @@ class PowerDistStretch(BaseStretch):
     def __init__(self, a=1000.0):
         if a == 1:  # singularity
             raise ValueError("a cannot be set to 1")
-        super(PowerDistStretch, self).__init__()
+        super().__init__()
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
@@ -203,7 +203,7 @@ class InvertedPowerDistStretch(BaseStretch):
     def __init__(self, a=1000.0):
         if a == 1:  # singularity
             raise ValueError("a cannot be set to 1")
-        super(InvertedPowerDistStretch, self).__init__()
+        super().__init__()
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
@@ -230,7 +230,7 @@ class SquaredStretch(PowerStretch):
     """
 
     def __init__(self):
-        super(SquaredStretch, self).__init__(2)
+        super().__init__(2)
 
     @property
     def inverse(self):
@@ -254,7 +254,7 @@ class LogStretch(BaseStretch):
     """
 
     def __init__(self, a=1000.0):
-        super(LogStretch, self).__init__()
+        super().__init__()
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
@@ -287,7 +287,7 @@ class InvertedLogStretch(BaseStretch):
     """
 
     def __init__(self, a):
-        super(InvertedLogStretch, self).__init__()
+        super().__init__()
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
@@ -324,7 +324,7 @@ class AsinhStretch(BaseStretch):
     """
 
     def __init__(self, a=0.1):
-        super(AsinhStretch, self).__init__()
+        super().__init__()
         self.a = a
 
     def __call__(self, values, clip=True, out=None):
@@ -356,7 +356,7 @@ class SinhStretch(BaseStretch):
     """
 
     def __init__(self, a=1./3.):
-        super(SinhStretch, self).__init__()
+        super().__init__()
         self.a = a
 
     def __call__(self, values, clip=True, out=None):
@@ -462,7 +462,7 @@ class ContrastBiasStretch(BaseStretch):
     """
 
     def __init__(self, contrast, bias):
-        super(ContrastBiasStretch, self).__init__()
+        super().__init__()
         self.contrast = contrast
         self.bias = bias
 
@@ -502,7 +502,7 @@ class InvertedContrastBiasStretch(BaseStretch):
     """
 
     def __init__(self, contrast, bias):
-        super(InvertedContrastBiasStretch, self).__init__()
+        super().__init__()
         self.contrast = contrast
         self.bias = bias
 

--- a/astropy/visualization/transform.py
+++ b/astropy/visualization/transform.py
@@ -29,7 +29,7 @@ class CompositeTransform(BaseTransform):
     """
 
     def __init__(self, transform_1, transform_2):
-        super(CompositeTransform, self).__init__()
+        super().__init__()
         self.transform_1 = transform_1
         self.transform_2 = transform_2
 

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -13,7 +13,7 @@ class AxisLabels(Text):
 
     def __init__(self, frame, minpad=1, *args, **kwargs):
         self._frame = frame
-        super(AxisLabels, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.set_clip_on(True)
         self.set_visible_axes('all')
         self.set_ha('center')
@@ -119,7 +119,7 @@ class AxisLabels(Text):
 
                 self.set_position((xcen + dx, ycen + dy))
 
-            super(AxisLabels, self).draw(renderer)
+            super().draw(renderer)
 
-            bb = super(AxisLabels, self).get_window_extent(renderer)
+            bb = super().get_window_extent(renderer)
             bboxes.append(bb)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -78,7 +78,7 @@ class WCSAxes(Axes):
                  transData=None, slices=None, frame_class=RectangularFrame,
                  **kwargs):
 
-        super(WCSAxes, self).__init__(fig, rect, **kwargs)
+        super().__init__(fig, rect, **kwargs)
         self._bboxes = []
 
         self.frame_class = frame_class
@@ -171,7 +171,7 @@ class WCSAxes(Axes):
                 X = X.transpose(FLIP_TOP_BOTTOM)
                 kwargs['origin'] = 'lower'
 
-        return super(WCSAxes, self).imshow(X, *args, **kwargs)
+        return super().imshow(X, *args, **kwargs)
 
     def plot_coord(self, *args, **kwargs):
         """
@@ -224,7 +224,7 @@ class WCSAxes(Axes):
 
             args = tuple(plot_data) + args[1:]
 
-        super(WCSAxes, self).plot(*args, **kwargs)
+        super().plot(*args, **kwargs)
 
     def reset_wcs(self, wcs=None, slices=None, transform=None, coord_meta=None):
         """
@@ -322,7 +322,7 @@ class WCSAxes(Axes):
         # We need to make sure that that frame path is up to date
         self.coords.frame._update_patch_path()
 
-        super(WCSAxes, self).draw(renderer, inframe)
+        super().draw(renderer, inframe)
 
         # Here need to find out range of all coordinates, and update range for
         # each coordinate axis. For now, just assume it covers the whole sky.

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -106,10 +106,8 @@ class AngleFormatterLocator(BaseFormatterLocator):
     def __init__(self, values=None, number=None, spacing=None, format=None):
         self._unit = u.degree
         self._sep = None
-        super(AngleFormatterLocator, self).__init__(values=values,
-                                                    number=number,
-                                                    spacing=spacing,
-                                                    format=format)
+        super().__init__(values=values, number=number, spacing=spacing,
+                         format=format)
 
     @property
     def spacing(self):
@@ -340,10 +338,8 @@ class ScalarFormatterLocator(BaseFormatterLocator):
         elif values is not None:
             self._unit = values.unit
             self._format_unit = values.unit
-        super(ScalarFormatterLocator, self).__init__(values=values,
-                                                     number=number,
-                                                     spacing=spacing,
-                                                     format=format)
+        super().__init__(values=values, number=number, spacing=spacing,
+                         format=format)
 
     @property
     def format_unit(self):

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -93,7 +93,7 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
 
     def __init__(self, parent_axes, transform, path=None):
 
-        super(BaseFrame, self).__init__()
+        super().__init__()
 
         self.parent_axes = parent_axes
         self._transform = transform

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -87,4 +87,4 @@ class SphericalCircle(Polygon):
         # Create polygon vertices
         vertices = np.array([lon, lat]).transpose()
 
-        super(SphericalCircle, self).__init__(vertices, **kwargs)
+        super().__init__(vertices, **kwargs)

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -21,7 +21,7 @@ from ....tests.image_tests import IMAGE_REFERENCE_DIR
 class DistanceToLonLat(CurvedTransform):
 
     def __init__(self, R=6e3):
-        super(DistanceToLonLat, self).__init__()
+        super().__init__()
         self.R = R
 
     def transform(self, xy):
@@ -39,7 +39,7 @@ class DistanceToLonLat(CurvedTransform):
 class LonLatToDistance(CurvedTransform):
 
     def __init__(self, R=6e3):
-        super(LonLatToDistance, self).__init__()
+        super().__init__()
         self.R = R
 
     def transform(self, lamphi):

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -17,7 +17,7 @@ class TickLabels(Text):
     def __init__(self, frame, *args, **kwargs):
         self.clear()
         self._frame = frame
-        super(TickLabels, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.set_clip_on(True)
         self.set_visible_axes('all')
         self.pad = 0.3
@@ -154,7 +154,7 @@ class TickLabels(Text):
 
                     # Set initial position and find bounding box
                     self.set_position((x, y))
-                    bb = super(TickLabels, self).get_window_extent(renderer)
+                    bb = super().get_window_extent(renderer)
 
                     # Find width and height, as well as angle at which we
                     # transition which side of the label we use to anchor the
@@ -198,13 +198,13 @@ class TickLabels(Text):
                     self.set_ha('center')
                     self.set_va('center')
 
-                bb = super(TickLabels, self).get_window_extent(renderer)
+                bb = super().get_window_extent(renderer)
 
                 # TODO: the problem here is that we might get rid of a label
                 # that has a key starting bit such as -0:30 where the -0
                 # might be dropped from all other labels.
 
                 if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
-                    super(TickLabels, self).draw(renderer)
+                    super().draw(renderer)
                     bboxes.append(bb)
                     ticklabels_bbox.append(bb)

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -64,7 +64,7 @@ class WCSWorld2PixelTransform(CurvedTransform):
     """
 
     def __init__(self, wcs, slice=None):
-        super(WCSWorld2PixelTransform, self).__init__()
+        super().__init__()
         self.wcs = wcs
         if self.wcs.wcs.naxis > 2:
             if slice is None:
@@ -119,7 +119,7 @@ class WCSPixel2WorldTransform(CurvedTransform):
     """
 
     def __init__(self, wcs, slice=None):
-        super(WCSPixel2WorldTransform, self).__init__()
+        super().__init__()
         self.wcs = wcs
         self.slice = slice
         if self.slice is not None:
@@ -190,7 +190,7 @@ class WCSPixel2WorldTransform(CurvedTransform):
 class CoordinateTransform(CurvedTransform):
 
     def __init__(self, input_system, output_system):
-        super(CoordinateTransform, self).__init__()
+        super().__init__()
         self._input_system_name = input_system
         self._output_system_name = output_system
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -188,7 +188,7 @@ class NoConvergence(Exception):
     """
 
     def __init__(self, *args, **kwargs):
-        super(NoConvergence, self).__init__(*args)
+        super().__init__(*args)
 
         self.best_solution = kwargs.pop('best_solution', None)
         self.accuracy = kwargs.pop('accuracy', None)


### PR DESCRIPTION
This removes the arguments for `super` for the trivial cases (first argument the class and the second argument the argument to be bound). 

There are still dozens of places where removing the arguments could change the behavior. I didn't want to touch those, most looked like copy&paste mistakes but some seemed genuine. Probably better to do that later on a per-subpackage basis.