### PR TITLE
Change deprecated decorator on classes to modify the class itself instead of creating a new one

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -263,6 +263,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- The ``deprecated`` decorator applied to a class will now modify the class
+  itself, rather than to create a class that just looks and behave like the
+  original. This is needed so that the Python 3 ``super`` without arguments
+  works for decorated classes. [#6615]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -169,6 +169,37 @@ def test_deprecated_class():
     pickle.dumps(TA)
 
 
+def test_deprecated_class_with_new_method():
+    """
+    Test that a class with __new__ method still works even if it accepts
+    additional arguments.
+    This previously failed because the deprecated decorator would wrap objects
+    __init__ which takes no arguments.
+    """
+    @deprecated('1.0')
+    class A:
+        def __new__(cls, a):
+            return super().__new__(cls)
+
+    # Creating an instance should work but raise a DeprecationWarning
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        A(1)
+    assert len(w) == 1
+
+    @deprecated('1.0')
+    class B:
+        def __new__(cls, a):
+            return super().__new__(cls)
+
+        def __init__(self, a):
+            pass
+
+    # Creating an instance should work but raise a DeprecationWarning
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        B(1)
+    assert len(w) == 1
+
+
 def test_deprecated_class_with_super():
     """
     Regression test for an issue where classes that used `super()` in their
@@ -179,7 +210,7 @@ def test_deprecated_class_with_super():
     @deprecated('100.0')
     class TB(object):
         def __init__(self, a, b):
-            super(TB, self).__init__()
+            super().__init__()
 
     with catch_warnings(AstropyDeprecationWarning) as w:
         TB(1, 2)


### PR DESCRIPTION
This allows using Python 3s "super" without arguments inside the class. It also removes the ability to wrap extension types because that didn't work (and was untested) for most extension types anyway.

For example:

```
from astropy.utils.decorators import deprecated
deprecated_enumerate = deprecated("3.0")(enumerate)  # decorate an extension type
deprecated_enumerate([1, 2, 3])
TypeError                                 Traceback (most recent call last)
<ipython-input-23-6c23c0a003fd> in <module>()
      3 deprecated_enumerate = deprecated("3.0")(enumerate)
      4 
----> 5 deprecated_enumerate([1, 2, 3])

-\lib\site-packages\astropy-3.0.dev20123-py3.5-win-amd64.egg\astropy\utils\decorators.py in deprecated_func(*args, **kwargs)
    116             warnings.warn(message, category, stacklevel=2)
    117 
--> 118             return func(*args, **kwargs)
    119 
    120         # If this is an extension function, we can't call

TypeError: object.__init__() takes no parameters
```

However in the current form it won't work on Python 2 (and so not possible to backport it to astropy 2.x) because one can't reassign `__doc__` on python 2 new-style classes...

Fixes #6614 
However it's not the only way to fix that issue (probably).