### PR TITLE
Add sunpy Longitude180 to allowed mixin classes

### DIFF
--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -17,7 +17,8 @@ __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.coordinates.distances.Distance',
                              'astropy.coordinates.earth.EarthLocation',
                              'astropy.coordinates.sky_coordinate.SkyCoord',
-                             'astropy.table.table.NdarrayMixin')
+                             'astropy.table.table.NdarrayMixin',
+                             'sunpy.coordinates.representation.Longitude180')
 
 
 class SerializedColumn(dict):


### PR DESCRIPTION
This enables ecsv roundtripping for SunPy coordinates.

This patches the following "bug":

```python
from astropy.table import Table
from astropy.coordinates import SkyCoord
import astropy.units as u
import sunpy.coordinates

c = SkyCoord(lon=[-80, 80]*u.deg, lat=[-15,15]*u.deg, frame="heliographic_stonyhurst")

t = Table(data=[c])
t.write("test.ecsv", format="ascii.ecsv")
Table.read("test.ecsv", format="ascii.ecsv")
```
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-1-b7c054701dec> in <module>()
      8 t = Table(data=[c])
      9 t.write("test.ecsv", format="ascii.ecsv")
---> 10 Table.read("test.ecsv", format="ascii.ecsv")

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/table/table.py in read(cls, *args, **kwargs)
   2519         passed through to the underlying data reader (e.g. `~astropy.io.ascii.read`).
   2520         """
-> 2521         out = io_registry.read(cls, *args, **kwargs)
   2522         # For some readers (e.g., ascii.ecsv), the returned `out` class is not
   2523         # guaranteed to be the same as the desired output `cls`.  If so,

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/io/registry.py in read(cls, *args, **kwargs)
    529 
    530         reader = get_reader(format, cls)
--> 531         data = reader(*args, **kwargs)
    532 
    533         if not isinstance(data, cls):

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/io/ascii/connect.py in io_read(format, filename, **kwargs)
     37     from .ui import read
     38     format = re.sub(r'^ascii\.', '', format)
---> 39     return read(filename, format=format, **kwargs)
     40 
     41 

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/io/ascii/ui.py in read(table, guess, **kwargs)
    351                                              ' with fast (no guessing)'})
    352         else:
--> 353             dat = reader.read(table)
    354             _read_trace.append({'kwargs': new_kwargs,
    355                                 'status': 'Success with specified Reader class '

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/io/ascii/core.py in read(self, table)
   1200         if hasattr(self.header, 'table_meta'):
   1201             self.meta['table'].update(self.header.table_meta)
-> 1202         table = self.outputter(cols, self.meta)
   1203         self.cols = self.header.cols
   1204 

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/io/ascii/ecsv.py in __call__(self, cols, meta)
    190         # If no __mixin_columns__ exists then this function just passes back
    191         # the input table.
--> 192         out = serialize._construct_mixins_from_columns(out)
    193 
    194         return out

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/table/serialize.py in _construct_mixins_from_columns(tbl)
    198 
    199     for new_name, obj_attrs in mixin_cols.items():
--> 200         _construct_mixin_from_columns(new_name, obj_attrs, out)
    201 
    202     # If no quantity subclasses are in the output then output as Table.

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/table/serialize.py in _construct_mixin_from_columns(new_name, obj_attrs, out)
    152                 data_attrs_map[val['name']] = name
    153             else:
--> 154                 _construct_mixin_from_columns(name, val, out)
    155                 data_attrs_map[name] = name
    156 

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/table/serialize.py in _construct_mixin_from_columns(new_name, obj_attrs, out)
    183 
    184     info['name'] = new_name
--> 185     col = _construct_mixin_from_obj_attrs_and_info(obj_attrs, info)
    186     out.add_column(col, index=idx)
    187 

/opt/miniconda/envs/sunpy-dev/lib/python3.6/site-packages/astropy/table/serialize.py in _construct_mixin_from_obj_attrs_and_info(obj_attrs, info)
    130     # untrusted code by only importing known astropy classes.
    131     if cls_full_name not in __construct_mixin_classes:
--> 132         raise ValueError('unsupported class for construct {}'.format(cls_full_name))
    133 
    134     mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()

ValueError: unsupported class for construct sunpy.coordinates.representation.Longitude180
```