### PR TITLE
Add coverage and pytest-mpl to dev requirements

### DIFF
--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -14,6 +14,8 @@ scikit-image
 matplotlib
 
 # below here are used only for tests
+coverage
 skyfield
 mpmath
 pytest-xdist
+pytest-mpl


### PR DESCRIPTION
Both `coverage` and `pytest-mpl` are optional dependencies when running the tests, with `--coverage` and `--mpl` respectively.