### PR TITLE
Rename TooOldPythonError to UnsupportedPythonError

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -15,9 +15,11 @@ __minimum_python_version__ = '3.5'
 __minimum_numpy_version__ = '1.10.0'
 
 
-class TooOldPythonError(Exception): pass
+class UnsupportedPythonError(Exception):
+    pass
+
 if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    raise TooOldPythonError("Astropy does not support Python < {}".format(__minimum_python_version__))
+    raise UnsupportedPythonError("Astropy does not support Python < {}".format(__minimum_python_version__))
 
 
 def _is_astropy_source(path=None):


### PR DESCRIPTION
TooOldPythonError sounds a bit too colloquial

EDIT: Follow up of #6595