### PR TITLE
making link more clear

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -131,11 +131,16 @@ for more details).
 Working with compressed files
 """""""""""""""""""""""""""""
 
+.. note::
+
+    Files that use compressed HDUs within the FITS file are discussed
+    in :ref:`Compressed Image Data <astropy-io-fits-compressedImageData>`.
+
+
 The :func:`open` function will seamlessly open FITS files that have been
 compressed with gzip, bzip2 or pkzip. Note that in this context we're talking
 about a fits file that has been compressed with one of these utilities - e.g. a
-.fits.gz file. Files that use compressed HDUs within the FITS file are discussed
-in :ref:`Compressed Image Data <astropy-io-fits-compressedImageData>`.
+.fits.gz file. 
 
 There are some limitations with working with compressed files. For example with Zip
 files that contain multiple compressed files, only the first file will be accessible.


### PR DESCRIPTION
For the separate section for FITS file compression.  It's kind of hidden in the text (at least I've always missed it the 3 or 4 times I've looked at that section.  Closes #6220.