### PR TITLE
Fix double Notes section in docstring

### DIFF
--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -129,12 +129,10 @@ class NDArithmeticMixin:
     uncertainty. This behaviour is also explained in the docstring for the
     different arithmetic operations.
 
-    Notes
-    -----
-    1. It is not tried to decompose the units, mainly due to the internal
-       mechanics of `~astropy.units.Quantity`, so the resulting data might have
-       units like ``km/m`` if you divided for example 100km by 5m. So this
-       Mixin has adopted this behaviour.
+    Decomposing the units is not attempted, mainly due to the internal mechanics
+    of `~astropy.units.Quantity`, so the resulting data might have units like
+    ``km/m`` if you divided for example 100km by 5m. So this Mixin has adopted
+    this behaviour.
 
     Examples
     --------


### PR DESCRIPTION
Trivial but numpydoc v0.7 is picky about this