### PR TITLE
Cleanup super for coordinates, table, time and units

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -533,7 +533,7 @@ class Latitude(Angle):
 
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
-        obj = super(Angle, self).__array_wrap__(obj, context=context)
+        obj = super().__array_wrap__(obj, context=context)
         return _no_angle_subclass(obj)
 
     def __array_ufunc__(self, *args, **kwargs):
@@ -657,7 +657,7 @@ class Longitude(Angle):
 
     # Any calculation should drop to Angle
     def __array_wrap__(self, obj, context=None):
-        obj = super(Angle, self).__array_wrap__(obj, context=context)
+        obj = super().__array_wrap__(obj, context=context)
         return _no_angle_subclass(obj)
 
     def __array_ufunc__(self, *args, **kwargs):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -2574,8 +2574,7 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
             d_lon_coslat = cls._get_d_lon_coslat(representation.d_phi, base)
             return cls(d_lon_coslat, -representation.d_theta)
 
-        return super(UnitSphericalDifferential,
-                     cls).from_representation(representation, base)
+        return super().from_representation(representation, base)
 
 
 class SphericalCosLatDifferential(BaseSphericalCosLatDifferential):

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -388,7 +388,7 @@ def test_regression_6236():
     class MySpecialFrame(MyFrame):
         def __init__(self, *args, **kwargs):
             _rep_kwarg = kwargs.get('representation', None)
-            super(MyFrame, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
             if not _rep_kwarg:
                 self.representation = self.default_representation
                 self._data = self.data.represent_as(self.representation)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -314,7 +314,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         state = state[:-1]
 
         # Using super().__setstate__(state) gives
-        # TypeError 'int' object is not iterable
+        # "TypeError 'int' object is not iterable", raised in
         # astropy.table._column_mixins._ColumnGetitemShim.__setstate_cython__()
         # Previously, it seems to have given an infinite recursion.
         # Hence, manually call the right super class to actually set up

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -313,8 +313,11 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         state = state[:-1]
 
-        # Using super(type(self), self).__setstate__() gives an infinite
-        # recursion.  Manually call the right super class to actually set up
+        # Using super().__setstate__(state) gives
+        # TypeError 'int' object is not iterable
+        # astropy.table._column_mixins._ColumnGetitemShim.__setstate_cython__()
+        # Previously, it seems to have given an infinite recursion.
+        # Hence, manually call the right super class to actually set up
         # the array object.
         super_class = ma.MaskedArray if isinstance(self, ma.MaskedArray) else np.ndarray
         super_class.__setstate__(self, state)

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -398,9 +398,8 @@ class Index:
         ----------
         memo : dict
         '''
-        num_cols = self.data.num_cols if self.engine == SortedArray else None
-        # create an actual Index, not a SlicedIndex
-        index = super(Index, Index).__new__(Index)
+        # Bypass Index.__new__ to create an actual Index, not a SlicedIndex.
+        index = super().__new__(self.__class__)
         index.__init__(None, engine=self.engine)
         index.data = deepcopy(self.data, memo)
         index.columns = self.columns[:]  # new list, same columns

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -126,7 +126,7 @@ class TimeInfo(MixinInfo):
         if bound:
             # Specify how to serialize this object depending on context.
             # If ``True`` for a context, then use formatted ``value`` attribute
-            # (e.g. the ISO time string).  If ``False`` then use jd1 and jd2.
+            # (e.g. the ISO time string).  If ``False`` then use float jd1 and jd2.
             self.serialize_method = {'fits': 'jd1_jd2',
                                      'ecsv': 'formatted_value',
                                      'hdf5': 'jd1_jd2',
@@ -864,8 +864,7 @@ class Time(ShapedLikeNDArray):
             new_format = self.format
 
         if callable(method):
-            def apply_method(array):
-                return method(array, *args, **kwargs)
+            apply_method = lambda array: method(array, *args, **kwargs)
 
         else:
             if method == 'replicate':

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -119,14 +119,14 @@ class TimeInfo(MixinInfo):
         return out + self._represent_as_dict_extra_attrs
 
     def __init__(self, bound=False):
-        super(MixinInfo, self).__init__(bound)
+        super().__init__(bound)
 
         # If bound to a data object instance then create the dict of attributes
         # which stores the info attribute values.
         if bound:
             # Specify how to serialize this object depending on context.
             # If ``True`` for a context, then use formatted ``value`` attribute
-            # (e.g. the ISO time string).  If ``False`` then use decimal jd1 and jd2.
+            # (e.g. the ISO time string).  If ``False`` then use jd1 and jd2.
             self.serialize_method = {'fits': 'jd1_jd2',
                                      'ecsv': 'formatted_value',
                                      'hdf5': 'jd1_jd2',
@@ -864,7 +864,9 @@ class Time(ShapedLikeNDArray):
             new_format = self.format
 
         if callable(method):
-            apply_method = lambda array: method(array, *args, **kwargs)
+            def apply_method(array):
+                return method(array, *args, **kwargs)
+
         else:
             if method == 'replicate':
                 apply_method = None
@@ -876,7 +878,8 @@ class Time(ShapedLikeNDArray):
             jd1 = apply_method(jd1)
             jd2 = apply_method(jd2)
 
-        tm = super(Time, self.__class__).__new__(self.__class__)
+        # Get a new instance of our class and set its attributes directly.
+        tm = super().__new__(self.__class__)
         tm._time = TimeJD(jd1, jd2, self.scale, self.precision,
                           self.in_subfmt, self.out_subfmt, from_jd=True)
         # Optional ndarray attributes.

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -1,7 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-
-
 from ...utils.misc import InheritDocstrings
 
 
@@ -14,7 +11,7 @@ class _FormatterMeta(InheritDocstrings):
         else:
             formatter_name = members['name'] = name.lower()
 
-        cls = super(mcls, _FormatterMeta).__new__(mcls, name, bases, members)
+        cls = super().__new__(mcls, name, bases, members)
 
         mcls.registry[formatter_name] = cls
 


### PR DESCRIPTION
This partially addresses #6630, cleaning up `super` calls that still had an explicit dependence for `coordinates`, `table`, `time`, and `units`. Only for table I am not 100% sure, so cc @taldcroft.