### PR TITLE
Remove unexpected *args for textwrap.fill

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -540,7 +540,7 @@ def translate(s, table, deletechars):
     return s.translate(table)
 
 
-def fill(text, width, *args, **kwargs):
+def fill(text, width, **kwargs):
     """
     Like :func:`textwrap.wrap` but preserves existing paragraphs which
     :func:`textwrap.wrap` does not otherwise handle well.  Also handles section
@@ -553,7 +553,7 @@ def fill(text, width, *args, **kwargs):
         if all(len(l) < width for l in t.splitlines()):
             return t
         else:
-            return textwrap.fill(t, width, *args, **kwargs)
+            return textwrap.fill(t, width, **kwargs)
 
     return '\n\n'.join(maybe_fill(p) for p in paragraphs)
 


### PR DESCRIPTION
[`textwrap.fill`](https://docs.python.org/3/library/textwrap.html) only accepts `text` and `width` as positional arguments so this would have raised a TypeError when called anyway.