### PR TITLE
Fix invalid formatting spec for itersubclasses

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -206,7 +206,7 @@ def itersubclasses(cls, _seen=None):
 
     if not isinstance(cls, type):
         raise TypeError('itersubclasses must be called with '
-                        'new-style classes, not {:.100r}'.format(cls))
+                        'new-style classes, not {!r}'.format(cls))
     if _seen is None:
         _seen = set()
     try:


### PR DESCRIPTION
This currently raises a ValueError because the `.100` isn't valid in `format` and representations are indicated with `!r`.

```
cls = 'abc'
"{:.100r}".format(cls)

=>

ValueError                                Traceback (most recent call last)
      1 cls = 'abc'
----> 2 "{:.100r}".format(cls)

ValueError: Unknown format code 'r' for object of type 'str'
```

I made the PR against 2.0.x directly because it will conflict with #6635 and when that path is removed the patch isn't needed for master anymore.

I didn't include a changelog/test because it's more an internal routine. But I can add both if necessary.