### PR TITLE
Getting rid of the imp (usages)

### DIFF
--- a/astropy/stats/lombscargle/implementations/main.py
+++ b/astropy/stats/lombscargle/implementations/main.py
@@ -8,7 +8,6 @@ statement for the various implementations available in this submodule
 __all__ = ['lombscargle', 'available_methods']
 
 import warnings
-import imp
 
 import numpy as np
 
@@ -37,10 +36,11 @@ def available_methods():
 
     # Scipy required for scipy algorithm (obviously)
     try:
-        imp.find_module('scipy')
-        methods.append('scipy')
+        import scipy
     except ImportError:
         pass
+    else:
+        methods.append('scipy')
     return methods
 
 

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-import imp
+import importlib
 import sys
 import warnings
 
@@ -29,8 +29,8 @@ except NameError:
 def setup_function(function):
 
     # Reset modules to default
-    imp.reload(warnings)
-    imp.reload(sys)
+    importlib.reload(warnings)
+    importlib.reload(sys)
 
     # Reset internal original hooks
     log._showwarning_orig = None


### PR DESCRIPTION
The `imp` module was deprecated in Python 3.4 and replaced by `importlib`.

I didn't change the ones in the pytest plugins to avoid conflicts with #6606.