### PR TITLE
Removing NumPy < 1.8 cases in stats.lombscargle

### DIFF
--- a/astropy/stats/lombscargle/implementations/main.py
+++ b/astropy/stats/lombscargle/implementations/main.py
@@ -29,11 +29,7 @@ METHODS = {'slow': lombscargle_slow,
 
 
 def available_methods():
-    methods = ['auto', 'slow', 'chi2', 'cython']
-
-    # Numpy 1.8 or newer required for fast algorithms
-    if hasattr(np.ufunc, 'at'):
-        methods.extend(['fast', 'fastchi2'])
+    methods = ['auto', 'slow', 'chi2', 'cython', 'fast', 'fastchi2']
 
     # Scipy required for scipy algorithm (obviously)
     try:
@@ -89,16 +85,12 @@ def validate_method(method, dy, fit_mean, nterms,
     choose the appropriate method
     """
     methods = available_methods()
-    fast_method_ok = ('fast' in methods)
-    prefer_fast = (fast_method_ok and len(frequency) > 200
+    prefer_fast = (len(frequency) > 200
                    and (assume_regular_frequency or _is_regular(frequency)))
     prefer_scipy = 'scipy' in methods and dy is None and not fit_mean
 
     # automatically choose the appropriate method
     if method == 'auto':
-        if not fast_method_ok:
-            warnings.warn("Fast Lomb-Scargle methods require numpy version "
-                          "1.8 or newer. Using slower methods instead.")
 
         if nterms != 1:
             if prefer_fast:

--- a/astropy/stats/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/stats/lombscargle/implementations/tests/test_utils.py
@@ -6,10 +6,6 @@ from numpy.testing import assert_allclose, assert_equal
 from ..utils import extirpolate, bitceil, trig_sum
 
 
-requires_numpy1_8 = pytest.mark.skipif(not hasattr(np.ufunc, 'at'),
-                                       reason="requires numpy 1.8 or newer")
-
-
 @pytest.mark.parametrize('N', 2 ** np.arange(1, 12))
 @pytest.mark.parametrize('offset', [-1, 0, 1])
 def test_bitceil(N, offset):
@@ -26,7 +22,6 @@ def extirpolate_data():
     return x, y, f
 
 
-@requires_numpy1_8
 @pytest.mark.parametrize('N', [100, None])
 @pytest.mark.parametrize('M', [5])
 def test_extirpolate(N, M, extirpolate_data):
@@ -36,7 +31,6 @@ def test_extirpolate(N, M, extirpolate_data):
     assert_allclose(np.dot(f(x), y), np.dot(f(x_hat), y_hat))
 
 
-@requires_numpy1_8
 @pytest.fixture
 def extirpolate_int_data():
     rng = np.random.RandomState(0)
@@ -47,7 +41,6 @@ def extirpolate_int_data():
     return x, y, f
 
 
-@requires_numpy1_8
 @pytest.mark.parametrize('N', [100, None])
 @pytest.mark.parametrize('M', [5])
 def test_extirpolate_with_integers(N, M, extirpolate_int_data):
@@ -65,7 +58,6 @@ def trig_sum_data():
     return t, h
 
 
-@requires_numpy1_8
 @pytest.mark.parametrize('f0', [0, 1])
 @pytest.mark.parametrize('adjust_t', [True, False])
 @pytest.mark.parametrize('freq_factor', [1, 2])

--- a/astropy/stats/lombscargle/implementations/utils.py
+++ b/astropy/stats/lombscargle/implementations/utils.py
@@ -4,23 +4,6 @@ from math import factorial
 import numpy as np
 
 
-def add_at(arr, ind, vals):
-    """Utility that computes np.add.at()
-
-    The fast version is available only in Numpy 1.8+; for older versions of
-    numpy this defaults to a slower computation.
-    """
-    if hasattr(np.ufunc, 'at'):
-        return np.add.at(arr, ind, vals)
-    else:
-        warnings.warn("Using slow replacement for numpy.add.at(). "
-                      "For ~100x faster results update to numpy 1.8+")
-        arr = np.asarray(arr)
-        ind, vals = np.broadcast_arrays(ind, vals)
-        unq = np.unique(ind)
-        arr[unq] += [vals[ind == i].sum() for i in unq]
-
-
 def bitceil(N):
     """
     Find the bit (i.e. power of 2) immediately greater than or equal to N
@@ -85,7 +68,7 @@ def extirpolate(x, y, N=None, M=4):
 
     # first take care of the easy cases where x is an integer
     integers = (x % 1 == 0)
-    add_at(result, x[integers].astype(int), y[integers])
+    np.add.at(result, x[integers].astype(int), y[integers])
     x, y = x[~integers], y[~integers]
 
     # For each remaining x, find the index describing the extirpolation range.
@@ -99,7 +82,7 @@ def extirpolate(x, y, N=None, M=4):
         if j > 0:
             denominator *= j / (j - M)
         ind = ilo + (M - 1 - j)
-        add_at(result, ind, numerator / (denominator * (x - ind)))
+        np.add.at(result, ind, numerator / (denominator * (x - ind)))
     return result
 
 


### PR DESCRIPTION
NumPy 1.8 isn't be supported anymore so these special cases can be removed.

The `add_at` utility function wasn't documented so it can probably be removed without deprecation warning.

cc @jakevdp @crawfordsm 