### PR TITLE
WIP: Test using --remote-data on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -397,6 +397,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fixed bugs in remote data handling and also in IERS unit test related to path
+  URL, and URI normalization on Windows. [#6651]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -544,8 +544,6 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
     get_pkg_data_fileobj : returns a file-like object with the data
     """
 
-    data_name = os.path.normpath(data_name)
-
     if remote_timeout is None:
         # use configfile default
         remote_timeout = conf.remote_timeout
@@ -570,7 +568,8 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
         else:
             return hashfn
     else:
-        datafn = _find_pkg_data_path(data_name, package=package)
+        fs_path = os.path.normpath(data_name)
+        datafn = _find_pkg_data_path(fs_path, package=package)
         if os.path.isdir(datafn):
             raise IOError("Tried to access a data file that's actually "
                           "a package data directory")

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -162,8 +162,8 @@ class TestIERS_Auto():
     def test_simple(self):
         iers_a_file_1 = os.path.join(os.path.dirname(__file__), 'finals2000A-2016-02-30-test')
         iers_a_file_2 = os.path.join(os.path.dirname(__file__), 'finals2000A-2016-04-30-test')
-        iers_a_url_1 = 'file://' + os.path.abspath(iers_a_file_1)
-        iers_a_url_2 = 'file://' + os.path.abspath(iers_a_file_2)
+        iers_a_url_1 = os.path.normpath('file://' + os.path.abspath(iers_a_file_1))
+        iers_a_url_2 = os.path.normpath('file://' + os.path.abspath(iers_a_file_2))
 
         with iers.conf.set_temp('iers_auto_url', iers_a_url_1):
 


### PR DESCRIPTION
We have not been testing with `--remote-data` on Windows. The primary purpose of this PR is to confirm a sneaking suspicion that adding the `--remote-data` flag will reveal some bugs that have been overlooked. If that is true, I will either update the PR or submit a new one with relevant fixes.