### PR TITLE
Fix jd1 and jd2 format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -391,6 +391,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Initialization of Time instances now is consistent for all formats to
+  ensure that ``-0.5 <= jd2 < 0.5``. [#6653]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -42,8 +42,8 @@ Example
   !astropy.time.Time
   format: mjd
   in_subfmt: '*'
-  jd1: 4857389.5
-  jd2: 0.0
+  jd1: 4857390.0
+  jd2: -0.5
   location: !astropy.coordinates.earth.EarthLocation
     ellipsoid: WGS84
     x: !astropy.units.Quantity

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -249,8 +249,9 @@ class TimeMJD(TimeFormat):
         # values in a vectorized operation.  But in most practical cases the
         # first one is probably biggest.
         self._check_scale(self._scale)  # Validate scale.
-        self.jd1, self.jd2 = day_frac(val1, val2)
-        self.jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
+        jd1, jd2 = day_frac(val1, val2)
+        jd1 += erfa.DJM0  # erfa.DJM0=2400000.5 (from erfam.h)
+        self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     @property
     def value(self):
@@ -378,8 +379,7 @@ class TimeFromEpoch(TimeFormat):
                                   .format(self.name, self.epoch_scale,
                                           self.scale, err))
 
-        self.jd1 = tm._time.jd1
-        self.jd2 = tm._time.jd2
+        self.jd1, self.jd2 = day_frac(tm._time.jd1, tm._time.jd2)
 
     def to_value(self, parent=None):
         # Make sure that scale is the same as epoch scale so we can just
@@ -743,8 +743,9 @@ class TimeString(TimeUnique):
             iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = (
                 self.parse_string(val.item(), subfmts))
 
-        self.jd1, self.jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                                        *iterator.operands[1:])
+        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
+                              *iterator.operands[1:])
+        self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     def str_kwargs(self):
         """

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -568,8 +568,9 @@ class TimeDatetime(TimeUnique):
             imin[...] = dt.minute
             dsec[...] = dt.second + dt.microsecond / 1e6
 
-        self.jd1, self.jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                                        *iterator.operands[1:])
+        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
+                              *iterator.operands[1:])
+        self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     def to_value(self, timezone=None, parent=None):
         """
@@ -1071,7 +1072,8 @@ class TimeEpochDateString(TimeString):
 
         self._check_scale(self._scale)  # validate scale.
         epoch_to_jd = getattr(erfa, self.epoch_to_jd)
-        self.jd1, self.jd2 = epoch_to_jd(iterator.operands[-1])
+        jd1, jd2 = epoch_to_jd(iterator.operands[-1])
+        self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     @property
     def value(self):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1132,3 +1132,14 @@ def test_epoch_date_jd_is_day_fraction():
 
     assert t1.jd1 == 2451545.0
     assert t1.jd2 == 0.0
+
+
+def test_sum_is_equivalent():
+    """
+    Ensure that two equal dates defined in different ways behave equally (#6638)
+    """
+    t0 = Time("J2000", scale="tdb")
+    t1 = Time("2000-01-01 12:00:00", scale="tdb")
+
+    assert t0 == t1
+    assert (t0 + 1 * u.second) == (t1 + 1 * u.second)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -48,16 +48,17 @@ class TestBasic():
         t = Time(times, format='iso', scale='utc')
         assert (repr(t) == "<Time object: scale='utc' format='iso' "
                 "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
-        assert allclose_jd(t.jd1, np.array([2451179.5, 2455197.5]))
-        assert allclose_jd2(t.jd2, np.array([1.4288980208333335e-06,
-                                             0.00000000e+00]))
+        assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
+        assert allclose_jd2(t.jd2, np.array([-0.5+1.4288980208333335e-06,
+                                             -0.50000000e+00]))
 
         # Set scale to TAI
         t = t.tai
         assert (repr(t) == "<Time object: scale='tai' format='iso' "
                 "value=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>")
-        assert allclose_jd(t.jd1, np.array([2451179.5, 2455197.5]))
-        assert allclose_jd2(t.jd2, np.array([0.00037179926839122024, 0.00039351851851851852]))
+        assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
+        assert allclose_jd2(t.jd2, np.array([-0.5+0.00037179926839122024,
+                                             -0.5+0.00039351851851851852]))
 
         # Get a new ``Time`` object which is referenced to the TT scale
         # (internal JD1 and JD1 are now with respect to TT scale)"""
@@ -750,7 +751,7 @@ class TestCopyReplicate():
 
     def test_replicate(self):
         """Test replicate method"""
-        t = Time('2000:001', format='yday', scale='tai',
+        t = Time(['2000:001'], format='yday', scale='tai',
                  location=('45d', '45d'))
         t_yday = t.yday
         t_loc_x = t.location.x.copy()

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1116,3 +1116,19 @@ def test_cache():
     # Check accessing the cache creates an empty dictionary
     assert not t.cache
     assert 'cache' in t.__dict__
+
+
+def test_epoch_date_jd_is_day_fraction():
+    """
+    Ensure that jd1 and jd2 of an epoch Time are respect the (day, fraction) convention
+    (see #6638)
+    """
+    t0 = Time("J2000", scale="tdb")
+
+    assert t0.jd1 == 2451545.0
+    assert t0.jd2 == 0.0
+
+    t1 = Time(datetime.datetime(2000, 1, 1, 12, 0, 0), scale="tdb")
+
+    assert t1.jd1 == 2451545.0
+    assert t1.jd2 == 0.0

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -397,10 +397,10 @@ and ``jd2`` attributes::
 
   >>> t = Time('2010-01-01 00:00:00', scale='utc')
   >>> t.jd1, t.jd2
-  (2455197.5, 0.0)
+  (2455198.0, -0.5)
   >>> t2 = t.tai
   >>> t2.jd1, t2.jd2  # doctest: +FLOAT_CMP
-  (2455197.5, 0.0003935185185185185)
+  (2455198., -0.49960648148148146)
 
 Creating a Time object
 ----------------------
@@ -464,7 +464,7 @@ the two values in a way that maintains the highest precision.  Example::
 
   >>> t = Time(100.0, 0.000001, format='mjd', scale='tt')
   >>> t.jd, t.jd1, t.jd2  # doctest: +FLOAT_CMP
-  (2400100.500001, 2400100.5, 1e-06)
+  (2400100.500001, 2400101.0, -0.499999)
 
 format
 ^^^^^^


### PR DESCRIPTION
This is an attempt to fix #6638. However, as it can be seen in the last commit I didn't fix the original issue: this is because having the same order of magnitude is not enough to achieve perfect precision.

On the other hand, as advised by @mhvk I tried to do `self.jd1, self.jd2 = day_frac(jd1, jd2)` for `TimeString` as well, but several things broke. With this diff:

```diff
diff --git a/astropy/time/formats.py b/astropy/time/formats.py
index a0eee16..b496c4e 100644
--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -743,8 +743,9 @@ class TimeString(TimeUnique):
             iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = (
                 self.parse_string(val.item(), subfmts))
 
-        self.jd1, self.jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
-                                        *iterator.operands[1:])
+        jd1, jd2 = erfa.dtf2d(self.scale.upper().encode('ascii'),
+                              *iterator.operands[1:])
+        self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     def str_kwargs(self):
         """
```

I got several test failures, and the thing is that I am not sure what do do next.

<details>

```
$ pytest astropy/time/tests/ -vInternet access disabled
/home/juanlu/.miniconda36/envs/astropy36_dev/lib/python3.6/importlib/_bootstrap.py:205: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
================================== test session starts ==================================
platform linux -- Python 3.6.2, pytest-3.2.2, py-1.4.34, pluggy-0.4.0 -- /home/juanlu/.miniconda36/envs/astropy36_dev/bin/python
cachedir: .

Running tests with Astropy version 3.0.dev20237.
Running tests in astropy/time/tests/.

Date: 2017-10-04T01:00:14

Platform: Linux-4.10.0-35-generic-x86_64-with-debian-stretch-sid

Executable: /home/juanlu/.miniconda36/envs/astropy36_dev/bin/python

Full Python Version: 
3.6.2 |Continuum Analytics, Inc.| (default, Jul 20 2017, 13:51:32) 
[GCC 4.4.7 20120313 (Red Hat 4.4.7-1)]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.13.3
Scipy: 0.19.1
Matplotlib: not available
h5py: not available
Pandas: not available
Cython: 0.27.1
Using Astropy options: remote_data: none.

rootdir: /home/juanlu/Development/astropy, inifile: setup.cfg
plugins: cov-2.5.1
collected 251 items                                                                      

astropy/time/tests/test_basic.py::TestBasic::test_simple FAILED
astropy/time/tests/test_basic.py::TestBasic::test_different_dimensions PASSED
astropy/time/tests/test_basic.py::TestBasic::test_copy_time[2455197.5] PASSED
astropy/time/tests/test_basic.py::TestBasic::test_copy_time[value1] PASSED
astropy/time/tests/test_basic.py::TestBasic::test_getitem PASSED
astropy/time/tests/test_basic.py::TestBasic::test_properties PASSED
astropy/time/tests/test_basic.py::TestBasic::test_precision PASSED
astropy/time/tests/test_basic.py::TestBasic::test_transforms PASSED
astropy/time/tests/test_basic.py::TestBasic::test_location PASSED
astropy/time/tests/test_basic.py::TestBasic::test_location_array PASSED
astropy/time/tests/test_basic.py::TestBasic::test_all_transforms PASSED
astropy/time/tests/test_basic.py::TestBasic::test_creating_all_formats PASSED
astropy/time/tests/test_basic.py::TestBasic::test_datetime PASSED
astropy/time/tests/test_basic.py::TestBasic::test_epoch_transform PASSED
astropy/time/tests/test_basic.py::TestBasic::test_input_validation PASSED
astropy/time/tests/test_basic.py::TestBasic::test_utc_leap_sec PASSED
astropy/time/tests/test_basic.py::TestBasic::test_init_from_time_objects PASSED
astropy/time/tests/test_basic.py::TestVal2::test_val2_ignored PASSED
astropy/time/tests/test_basic.py::TestVal2::test_val2 PASSED
astropy/time/tests/test_basic.py::TestVal2::test_val_broadcasts_against_val2 PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_input_subformat PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_input_subformat_fail PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_bad_input_subformat PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_output_subformat PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_fits_format PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_yday_format PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_scale_input PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_fits_scale PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_fits_scale_representation PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_scale_default PASSED
astropy/time/tests/test_basic.py::TestSubFormat::test_epoch_times PASSED
astropy/time/tests/test_basic.py::TestSofaErrors::test_bad_time PASSED
astropy/time/tests/test_basic.py::TestCopyReplicate::test_immutable_input PASSED
astropy/time/tests/test_basic.py::TestCopyReplicate::test_replicate FAILED
astropy/time/tests/test_basic.py::TestCopyReplicate::test_copy PASSED
astropy/time/tests/test_basic.py::test_python_builtin_copy PASSED
astropy/time/tests/test_basic.py::test_now PASSED
astropy/time/tests/test_basic.py::test_decimalyear PASSED
astropy/time/tests/test_basic.py::test_fits_year0 PASSED
astropy/time/tests/test_basic.py::test_fits_year10000 PASSED
astropy/time/tests/test_basic.py::test_dir PASSED
astropy/time/tests/test_basic.py::test_bool PASSED
astropy/time/tests/test_basic.py::test_len_size PASSED
astropy/time/tests/test_basic.py::test_TimeFormat_scale PASSED
astropy/time/tests/test_basic.py::test_scale_conversion PASSED
astropy/time/tests/test_basic.py::test_byteorder PASSED
astropy/time/tests/test_basic.py::test_datetime_tzinfo PASSED
astropy/time/tests/test_basic.py::test_subfmts_regex PASSED
astropy/time/tests/test_basic.py::test_set_format_basic PASSED
astropy/time/tests/test_basic.py::test_set_format_shares_subfmt PASSED
astropy/time/tests/test_basic.py::test_set_format_does_not_share_subfmt PASSED
astropy/time/tests/test_basic.py::test_replicate_value_error PASSED
astropy/time/tests/test_basic.py::test_remove_astropy_time PASSED
astropy/time/tests/test_basic.py::test_isiterable PASSED
astropy/time/tests/test_basic.py::test_to_datetime PASSED
astropy/time/tests/test_basic.py::test_to_datetime_pytz PASSED
astropy/time/tests/test_basic.py::test_cache PASSED
astropy/time/tests/test_basic.py::test_epoch_date_jd_is_day_fraction PASSED
astropy/time/tests/test_basic.py::test_sum_is_equivalent PASSED
astropy/time/tests/test_comparisons.py::TestTimeComparisons::test_miscompares PASSED
astropy/time/tests/test_comparisons.py::TestTimeComparisons::test_time PASSED
astropy/time/tests/test_comparisons.py::TestTimeComparisons::test_timedelta PASSED
astropy/time/tests/test_corrs.py::TestHelioBaryCentric::test_heliocentric PASSED
astropy/time/tests/test_corrs.py::TestHelioBaryCentric::test_barycentric PASSED
astropy/time/tests/test_corrs.py::TestHelioBaryCentric::test_arrays PASSED
astropy/time/tests/test_corrs.py::TestHelioBaryCentric::test_ephemerides SKIPPED
astropy/time/tests/test_delta.py::TestTimeDelta::test_sub PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_add PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_add_vector PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_sub_vector PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_copy_timedelta[values0] PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_copy_timedelta[values1] PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_neg_abs PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_mul_div PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_keep_properties PASSED
astropy/time/tests/test_delta.py::TestTimeDelta::test_set_format PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_scales_definition PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tai-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcb-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tcg-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tdb-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[tt-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[ut1-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_time_minus_time[utc-utc] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_minus_delta PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tai-op0] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tai-op1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tcb-op2] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tcb-op3] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tcg-op4] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tcg-op5] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tdb-op6] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tdb-op7] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tt-op8] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[tt-op9] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[ut1-op10] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[ut1-op11] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[utc-op12] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_scales_for_delta_scale_is_none[utc-op13] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[tai] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[tcb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[tcg] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[tdb] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[tt] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[ut1] PASSED
astropy/time/tests/test_delta.py::TestTimeDeltaScales::test_delta_day_is_86400_seconds[utc] PASSED
astropy/time/tests/test_guess.py::TestGuess::test_guess1 PASSED
astropy/time/tests/test_guess.py::TestGuess::test_guess2 PASSED
astropy/time/tests/test_guess.py::TestGuess::test_guess3 PASSED
astropy/time/tests/test_guess.py::TestGuess::test_guess4 PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_ravel PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_flatten PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_transpose PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_diagonal PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_swapaxes PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_reshape PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_shape_setting PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_squeeze PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_add_dimension PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_take PASSED
astropy/time/tests/test_methods.py::TestManipulation::test_broadcast PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw0-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw1-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw2-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw3-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw4-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw5-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw6-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw7-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw8-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw9-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw10-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw11-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw12-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw13-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argfuncs[kw14-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw0-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw1-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw2-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw3-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw4-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw5-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw6-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw7-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw8-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw9-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw10-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw11-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw12-min] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw13-max] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_funcs[kw14-sort] PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argmin PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argmax PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_argsort PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_min PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_max PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_ptp PASSED
astropy/time/tests/test_methods.py::TestArithmetic::test_sort PASSED
astropy/time/tests/test_methods.py::test_regression PASSED
astropy/time/tests/test_pickle.py::TestPickle::test_pickle PASSED
astropy/time/tests/test_precision.py::test_addition PASSED
astropy/time/tests/test_precision.py::test_mult_div PASSED
astropy/time/tests/test_precision.py::test_init_variations PASSED
astropy/time/tests/test_precision.py::test_precision_exceeds_64bit PASSED
astropy/time/tests/test_precision.py::test_through_scale_change PASSED
astropy/time/tests/test_precision.py::test_iso_init PASSED
astropy/time/tests/test_precision.py::test_jd1_is_mult_of_half_or_one PASSED
astropy/time/tests/test_precision.py::test_precision_neg xfail
astropy/time/tests/test_precision.py::test_precision_epoch PASSED
astropy/time/tests/test_precision.py::test_leap_seconds_rounded_correctly PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_valid_quantity_input PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_invalid_quantity_input PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_column_with_and_without_units PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_no_quantity_input_allowed PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_valid_quantity_operations PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeQuantity::test_invalid_quantity_operations PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_valid_quantity_input PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_invalid_quantity_input PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_quantity_output PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_valid_quantity_operations1 PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_valid_quantity_operations2 PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_invalid_quantity_operations PASSED
astropy/time/tests/test_quantity_interaction.py::TestTimeDeltaQuantity::test_invalid_quantity_broadcast PASSED
astropy/time/tests/test_quantity_interaction.py::TestDeltaAttributes::test_delta_ut1_utc PASSED
astropy/time/tests/test_quantity_interaction.py::TestDeltaAttributes::test_delta_tdb_tt PASSED
astropy/time/tests/test_sidereal.py::test_doc_string_contains_models PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input0] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input1] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input2] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input3] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input4] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input5] PASSED
astropy/time/tests/test_sidereal.py::TestERFATestCases::test_iau_models[erfa_test_input6] PASSED
astropy/time/tests/test_sidereal.py::TestST::test_gmst PASSED
astropy/time/tests/test_sidereal.py::TestST::test_gst PASSED
astropy/time/tests/test_sidereal.py::TestST::test_gmst_gst_close PASSED
astropy/time/tests/test_sidereal.py::TestST::test_gmst_independent_of_self_location PASSED
astropy/time/tests/test_sidereal.py::TestST::test_lst[mean] PASSED
astropy/time/tests/test_sidereal.py::TestST::test_lst[apparent] PASSED
astropy/time/tests/test_sidereal.py::TestST::test_lst_needs_location PASSED
astropy/time/tests/test_sidereal.py::TestModelInterpretation::test_model_uniqueness[mean] PASSED
astropy/time/tests/test_sidereal.py::TestModelInterpretation::test_model_uniqueness[apparent] PASSED
astropy/time/tests/test_sidereal.py::TestModelInterpretation::test_wrong_models_raise_exceptions[mean-apparent] PASSED
astropy/time/tests/test_sidereal.py::TestModelInterpretation::test_wrong_models_raise_exceptions[apparent-mean] PASSED
astropy/time/tests/test_ut1.py::TestTimeUT1::test_utc_to_ut1 PASSED
astropy/time/tests/test_ut1.py::TestTimeUT1::test_ut1_to_utc PASSED
astropy/time/tests/test_ut1.py::TestTimeUT1::test_delta_ut1_utc PASSED
astropy/time/tests/test_ut1.py::TestTimeUT1_IERSA::test_ut1_iers_A SKIPPED
astropy/time/tests/test_ut1.py::TestTimeUT1_IERS_Auto::test_ut1_iers_auto SKIPPED

======================================= FAILURES ========================================
_________________________________ TestBasic.test_simple _________________________________

self = <astropy.time.tests.test_basic.TestBasic object at 0x7f72ec7a56d8>

    def test_simple(self):
        times = ['1999-01-01 00:00:00.123456789', '2010-01-01 00:00:00']
        t = Time(times, format='iso', scale='utc')
        assert (repr(t) == "<Time object: scale='utc' format='iso' "
                "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
>       assert allclose_jd(t.jd1, np.array([2451179.5, 2455197.5]))
E       AssertionError: assert False
E        +  where False = allclose_jd(array([ 2451180.,  2455198.]), array([ 2451179.5,  2455197.5]))
E        +    where array([ 2451180.,  2455198.]) = <Time object: scale='utc' format='iso' value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>.jd1
E        +    and   array([ 2451179.5,  2455197.5]) = <built-in function array>([2451179.5, 2455197.5])
E        +      where <built-in function array> = np.array

astropy/time/tests/test_basic.py:51: AssertionError
___________________________ TestCopyReplicate.test_replicate ____________________________

self = <astropy.time.tests.test_basic.TestCopyReplicate object at 0x7f72ea6ac240>

    def test_replicate(self):
        """Test replicate method"""
        t = Time('2000:001', format='yday', scale='tai',
                 location=('45d', '45d'))
        t_yday = t.yday
        t_loc_x = t.location.x.copy()
        t2 = t.replicate()
        assert t.yday == t2.yday
        assert t.format == t2.format
        assert t.scale == t2.scale
        assert t.location == t2.location
        # This is not allowed publicly, but here we hack the internal time
        # and location values to show that t and t2 are sharing references.
        t2._time.jd1 += 100.0
    
        # Need to delete the cached yday attributes (only an issue because
        # of the internal _time hack).
        del t.cache
        del t2.cache
    
>       assert t.yday == t2.yday
E       AssertionError: assert '2000:001:00:00:00.000' == '2000:101:00:00:00.000'
E         - 2000:001:00:00:00.000
E         ?      ^
E         + 2000:101:00:00:00.000
E         ?      ^

astropy/time/tests/test_basic.py:771: AssertionError
============== 2 failed, 245 passed, 3 skipped, 1 xfailed in 2.63 seconds ===============
```
</details>