### PR TITLE
Removing further python2 mentions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -167,6 +167,9 @@ astropy.io.misc
   dataset instead of the HDF5 dataset attributes. This allows for metadata of
   any dimensions. [#6304]
 
+- Deprecated the ``usecPickle`` kwarg of ``fnunpickle`` and ``fnpickle`` as
+  it was needed only for Python2 usage. [#6655]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
@@ -194,6 +197,10 @@ astropy.table
 - When setting the column ``format`` attribute the value is now immediately
   validated. Previously one could set to any value and it was only checked
   when actually formatting the column. [#6385]
+
+- Deprecated the ``python3_only`` kwarg of the
+  ``convert_bytestring_to_unicode`` and ``convert_unicode_to_bytestring``
+  methods it was needed only for Python2 usage. [#6655]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -422,20 +422,14 @@ class DefaultSplitter(BaseSplitter):
         if self.process_line:
             lines = [self.process_line(x) for x in lines]
 
-        # In Python 2.x the inputs to csv cannot be unicode.  In Python 3 these
-        # lines do nothing.
-        escapechar = None if self.escapechar is None else str(self.escapechar)
-        quotechar = None if self.quotechar is None else str(self.quotechar)
-        delimiter = None if self.delimiter is None else str(self.delimiter)
-
-        if delimiter == r'\s':
-            delimiter = ' '
+        if self.delimiter == r'\s':
+            self.delimiter = ' '
 
         csv_reader = csv.reader(lines,
-                                delimiter=delimiter,
+                                delimiter=self.delimiter,
                                 doublequote=self.doublequote,
-                                escapechar=escapechar,
-                                quotechar=quotechar,
+                                escapechar=self.escapechar,
+                                quotechar=self.quotechar,
                                 quoting=self.quoting,
                                 skipinitialspace=self.skipinitialspace
                                 )
@@ -447,16 +441,13 @@ class DefaultSplitter(BaseSplitter):
 
     def join(self, vals):
 
-        # In Python 2.x the inputs to csv cannot be unicode
-        escapechar = None if self.escapechar is None else str(self.escapechar)
-        quotechar = None if self.quotechar is None else str(self.quotechar)
         delimiter = ' ' if self.delimiter is None else str(self.delimiter)
 
         if self.csv_writer is None:
             self.csv_writer = CsvWriter(delimiter=delimiter,
                                         doublequote=self.doublequote,
-                                        escapechar=escapechar,
-                                        quotechar=quotechar,
+                                        escapechar=self.escapechar,
+                                        quotechar=self.quotechar,
                                         quoting=self.quoting,
                                         lineterminator='')
         if self.process_val:

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -40,12 +40,11 @@ def test_convert_overflow(fast_reader):
     Test reading an extremely large integer, which falls through to
     string due to an overflow error (#2234). The C parsers used to
     return inf (kind 'f') for this.
-    Kind should be 'S' in Python2, 'U' in Python3.
     """
-    expected_kind = ('S', 'U')
+    expected_kind = 'U'
     dat = ascii.read(['a', '1' * 10000], format='basic',
                      fast_reader=fast_reader, guess=False)
-    assert dat['a'].dtype.kind in expected_kind
+    assert dat['a'].dtype.kind == expected_kind
 
 
 def test_guess_with_names_arg():

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -413,8 +413,8 @@ def writeto(filename, data, header=None, output_verify='exception',
 
     overwrite : bool, optional
         If ``True``, overwrite the output file if it exists. Raises an
-        ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-        output file exists. Default is ``False``.
+        ``OSError`` if ``False`` and the output file exists. Default is
+        ``False``.
 
         .. versionchanged:: 1.3
            ``overwrite`` replaces the deprecated ``clobber`` argument.
@@ -869,8 +869,8 @@ def tabledump(filename, datafile=None, cdfile=None, hfile=None, ext=1,
 
     overwrite : bool, optional
         If ``True``, overwrite the output file if it exists. Raises an
-        ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-        output file exists. Default is ``False``.
+        ``OSError`` if ``False`` and the output file exists. Default is
+        ``False``.
 
         .. versionchanged:: 1.3
            ``overwrite`` replaces the deprecated ``clobber`` argument.

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -149,8 +149,8 @@ class _BaseDiff:
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
-            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-            output file exists. Default is ``False``.
+            ``OSError`` if ``False`` and the output file exists. Default is
+            ``False``.
 
             .. versionchanged:: 1.3
                ``overwrite`` replaces the deprecated ``clobber`` argument.

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1151,24 +1151,19 @@ class FITS_rec(np.recarray):
     def _scale_back_strings(self, col_idx, input_field, output_field):
         # There are a few possibilities this has to be able to handle properly
         # The input_field, which comes from the _converted column is of dtype
-        # 'Sn' (where n in string length) on Python 2--this is maintain the
-        # existing user expectation of not being returned Python 2-style
-        # unicode strings.  One Python 3 the array in _converted is of dtype
-        # 'Un' so that elements read out of the array are normal Python 3 str
+        # 'Un' so that elements read out of the array are normal str
         # objects (i.e. unicode strings)
         #
         # At the other end the *output_field* may also be of type 'S' or of
-        # type 'U'.  It will *usually* be of type 'S' (regardless of Python
-        # version) because when reading an existing FITS table the raw data is
-        # just ASCII strings, and represented in Numpy as an S array.
-        # However, when a user creates a new table from scratch, they *might*
-        # pass in a column containing unicode strings (dtype 'U'), especially
-        # on Python 3 where this will be the default.  Therefore the
-        # output_field of the raw array is actually a unicode array.  But we
-        # still want to make sure the data is encodable as ASCII.  Later when
-        # we write out the array we use, in the dtype 'U' case, a different
-        # write routine that writes row by row and encodes any 'U' columns to
-        # ASCII.
+        # type 'U'.  It will *usually* be of type 'S' because when reading
+        # an existing FITS table the raw data is just ASCII strings, and
+        # represented in Numpy as an S array.  However, when a user creates
+        # a new table from scratch, they *might* pass in a column containing
+        # unicode strings (dtype 'U').  Therefore the output_field of the
+        # raw array is actually a unicode array.  But we still want to make
+        # sure the data is encodable as ASCII.  Later when we write out the
+        # array we use, in the dtype 'U' case, a different write routine
+        # that writes row by row and encodes any 'U' columns to ASCII.
 
         # If the output_field is non-ASCII we will worry about ASCII encoding
         # later when writing; otherwise we can do it right here

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -355,8 +355,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
-            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-            output file exists. Default is ``False``.
+            ``OSError`` if ``False`` and the output file exists. Default is
+            ``False``.
 
             .. versionchanged:: 1.3
                ``overwrite`` replaces the deprecated ``clobber`` argument.
@@ -402,10 +402,9 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
                 raise TypeError(
                     'The provided object {!r} does not contain an underlying '
                     'memory buffer.  fromstring() requires an object that '
-                    'supports the buffer interface such as bytes, str '
-                    '(in Python 2.x but not in 3.x), buffer, memoryview, '
-                    'ndarray, etc.  This restriction is to ensure that '
-                    'efficient access to the array/table data is possible.'
+                    'supports the buffer interface such as bytes, buffer, '
+                    'memoryview, ndarray, etc.  This restriction is to ensure '
+                    'that efficient access to the array/table data is possible.'
                     .format(data))
 
             if header is None:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -269,9 +269,7 @@ class HDUList(list, _Verify):
             max_idx = key.stop
             # Check for and handle the case when no maximum was
             # specified (e.g. [1:]).
-            # The first part of the or below is for python 2.7, the second
-            # part for python 3.
-            if max_idx == sys.maxsize or max_idx is None:
+            if max_idx is None:
                 # We need all of the HDUs, so load them
                 # and reset the maximum to the actual length.
                 max_idx = len(self)
@@ -435,10 +433,9 @@ class HDUList(list, _Verify):
             raise TypeError(
                 'The provided object {} does not contain an underlying '
                 'memory buffer.  fromstring() requires an object that '
-                'supports the buffer interface such as bytes, str '
-                '(in Python 2.x but not in 3.x), buffer, memoryview, '
-                'ndarray, etc.  This restriction is to ensure that '
-                'efficient access to the array/table data is possible.'
+                'supports the buffer interface such as bytes, buffer, '
+                'memoryview, ndarray, etc.  This restriction is to ensure '
+                'that efficient access to the array/table data is possible.'
                 ''.format(data))
 
         return cls._readfrom(data=data, **kwargs)
@@ -832,8 +829,8 @@ class HDUList(list, _Verify):
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
-            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-            output file exists. Default is ``False``.
+            ``OSError`` if ``False`` and the output file exists. Default is
+            ``False``.
 
             .. versionchanged:: 1.3
                ``overwrite`` replaces the deprecated ``clobber`` argument.

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1041,8 +1041,8 @@ class BinTableHDU(_TableBaseHDU):
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
-            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-            output file exists. Default is ``False``.
+            ``OSError`` if ``False`` and the output file exists. Default is
+            ``False``.
 
             .. versionchanged:: 1.3
                ``overwrite`` replaces the deprecated ``clobber`` argument.

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -665,8 +665,8 @@ class Header:
 
         overwrite : bool, optional
             If ``True``, overwrite the output file if it exists. Raises an
-            ``OSError`` (``IOError`` for Python 2) if ``False`` and the
-            output file exists. Default is ``False``.
+            ``OSError`` if ``False`` and the output file exists. Default is
+            ``False``.
 
             .. versionchanged:: 1.3
                ``overwrite`` replaces the deprecated ``clobber`` argument.

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1982,14 +1982,10 @@ class TestHeaderFunctions(FitsTestCase):
         First regression test for
         https://github.com/spacetelescope/PyFITS/issues/37
 
-        Although test_assign_unicode ensures that Python 2 `unicode` objects
-        and Python 3 `str` objects containing non-ASCII characters cannot be
-        assigned to headers, there is a bug that allows Python 2 `str` objects
-        of arbitrary encoding containing non-ASCII characters to be passed
-        through.
+        Although test_assign_unicode ensures that `str` objects containing
+        non-ASCII characters cannot be assigned to headers.
 
-        On Python 3 it should not be possible to assign bytes to a header at
-        all.
+        It should not be possible to assign bytes to a header at all.
         """
 
         h = fits.Header()

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -692,7 +692,6 @@ class TestImageFunctions(FitsTestCase):
             # signed int array of the same bit width
             max_uint = (2 ** int_size) - 1
             if int_size == 64:
-                # Otherwise may get an overflow error, at least on Python 2
                 max_uint = np.uint64(int_size)
 
             dtype = 'uint{}'.format(int_size)

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -9,7 +9,7 @@ part of a larger framework or standard.
 __all__ = ['fnpickle', 'fnunpickle']
 
 
-def fnunpickle(fileorname, number=0, usecPickle=True):
+def fnunpickle(fileorname, number=0):
     """ Unpickle pickled objects from a specified file and return the contents.
 
     Parameters
@@ -22,9 +22,6 @@ def fnunpickle(fileorname, number=0, usecPickle=True):
         this specifies the number of objects to be unpickled, and a list will
         be returned with exactly that many objects. If <0, all objects in the
         file will be unpickled and returned as a list.
-    usecPickle : bool
-        If True, the :mod:`cPickle` module is to be used in place of
-        :mod:`pickle` (cPickle is faster). This only applies for python 2.x.
 
     Raises
     ------
@@ -72,7 +69,7 @@ def fnunpickle(fileorname, number=0, usecPickle=True):
     return res
 
 
-def fnpickle(object, fileorname, usecPickle=True, protocol=None, append=False):
+def fnpickle(object, fileorname, protocol=None, append=False):
     """Pickle an object to a specified file.
 
     Parameters
@@ -82,9 +79,6 @@ def fnpickle(object, fileorname, usecPickle=True, protocol=None, append=False):
     fileorname : str or file-like
         The filename or file into which the `object` should be pickled. If a
         file object, it should have been opened in binary mode.
-    usecPickle : bool
-        If True (default), the :mod:`cPickle` module is to be used in place of
-        :mod:`pickle` (cPickle is faster). This only applies for python 2.x.
     protocol : int or None
         Pickle protocol to use - see the :mod:`pickle` module for details on
         these options. If None, the most recent protocol will be used.

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -6,21 +6,12 @@ part of a larger framework or standard.
 
 import warnings
 
-from ...utils.exceptions import AstropyDeprecationWarning
+from ...utils.exceptions import AstropyDeprecationWarning, NoValue
 
 __all__ = ['fnpickle', 'fnunpickle']
 
 
-def fnunpickle(filename, **kwargs):
-    # temporary function to handle deprecated and removed keywords
-    if 'usecPickle' in kwargs:
-        warnings.warn('The "usecPickle" keyword is now deprecated.',
-                      AstropyDeprecationWarning)
-        del kwargs['usecPickle']
-    return _fnunpickle(filename, **kwargs)
-
-
-def _fnunpickle(fileorname, number=0):
+def fnunpickle(fileorname, number=0, usecPickle=NoValue):
     """ Unpickle pickled objects from a specified file and return the contents.
 
     Parameters
@@ -48,6 +39,10 @@ def _fnunpickle(fileorname, number=0):
         file.
 
     """
+
+    if usecPickle is not NoValue:
+        warnings.warn('The "usecPickle" keyword is now deprecated.',
+                      AstropyDeprecationWarning)
 
     import pickle
 
@@ -80,16 +75,8 @@ def _fnunpickle(fileorname, number=0):
     return res
 
 
-def fnpickle(object, fileorname, **kwargs):
-    # temporary function to handle deprecated and removed keywords
-    if 'usecPickle' in kwargs:
-        warnings.warn('The "usecPickle" keyword is now deprecated.',
-                      AstropyDeprecationWarning)
-        del kwargs['usecPickle']
-    return _fnpickle(object, fileorname, **kwargs)
-
-
-def _fnpickle(object, fileorname, protocol=None, append=False):
+def fnpickle(object, fileorname, usecPickle=NoValue, protocol=None,
+             append=False):
     """Pickle an object to a specified file.
 
     Parameters
@@ -99,15 +86,19 @@ def _fnpickle(object, fileorname, protocol=None, append=False):
     fileorname : str or file-like
         The filename or file into which the `object` should be pickled. If a
         file object, it should have been opened in binary mode.
-    protocol : int or None
+    protocol : int or None, keyword only
         Pickle protocol to use - see the :mod:`pickle` module for details on
         these options. If None, the most recent protocol will be used.
-    append : bool
+    append : bool, keyword only
         If True, the object is appended to the end of the file, otherwise the
         file will be overwritten (if a file object is given instead of a
         file name, this has no effect).
 
     """
+
+    if usecPickle is not NoValue:
+        warnings.warn('The "usecPickle" keyword is now deprecated.',
+                      AstropyDeprecationWarning)
 
     import pickle
 
@@ -126,7 +117,3 @@ def _fnpickle(object, fileorname, protocol=None, append=False):
     finally:
         if close:
             f.close()
-
-
-fnpickle.__doc__ = _fnpickle.__doc__
-fnunpickle.__doc__ = _fnunpickle.__doc__

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -86,10 +86,10 @@ def fnpickle(object, fileorname, usecPickle=NoValue, protocol=None,
     fileorname : str or file-like
         The filename or file into which the `object` should be pickled. If a
         file object, it should have been opened in binary mode.
-    protocol : int or None, keyword only
+    protocol : int or None
         Pickle protocol to use - see the :mod:`pickle` module for details on
         these options. If None, the most recent protocol will be used.
-    append : bool, keyword only
+    append : bool
         If True, the object is appended to the end of the file, otherwise the
         file will be overwritten (if a file object is given instead of a
         file name, this has no effect).

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -4,12 +4,23 @@ This module contains simple input/output related functionality that is not
 part of a larger framework or standard.
 """
 
+import warnings
 
+from ...utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['fnpickle', 'fnunpickle']
 
 
-def fnunpickle(fileorname, number=0):
+def fnunpickle(filename, **kwargs):
+    # temporary function to handle deprecated and removed keywords
+    if 'usecPickle' in kwargs:
+        warnings.warn('The "usecPickle" keyword is now deprecated.',
+                      AstropyDeprecationWarning)
+        del kwargs['usecPickle']
+    return _fnunpickle(filename, **kwargs)
+
+
+def _fnunpickle(fileorname, number=0):
     """ Unpickle pickled objects from a specified file and return the contents.
 
     Parameters
@@ -69,7 +80,16 @@ def fnunpickle(fileorname, number=0):
     return res
 
 
-def fnpickle(object, fileorname, protocol=None, append=False):
+def fnpickle(object, fileorname, **kwargs):
+    # temporary function to handle deprecated and removed keywords
+    if 'usecPickle' in kwargs:
+        warnings.warn('The "usecPickle" keyword is now deprecated.',
+                      AstropyDeprecationWarning)
+        del kwargs['usecPickle']
+    return _fnpickle(object, fileorname, **kwargs)
+
+
+def _fnpickle(object, fileorname, protocol=None, append=False):
     """Pickle an object to a specified file.
 
     Parameters
@@ -106,3 +126,7 @@ def fnpickle(object, fileorname, protocol=None, append=False):
     finally:
         if close:
             f.close()
+
+
+fnpickle.__doc__ = _fnpickle.__doc__
+fnunpickle.__doc__ = _fnunpickle.__doc__

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -3,6 +3,8 @@
 import pytest
 
 from .. import fnpickle, fnunpickle
+from ....tests.helper import catch_warnings
+from ....utils.exceptions import AstropyDeprecationWarning
 
 
 def test_fnpickling_simple(tmpdir):
@@ -15,7 +17,7 @@ def test_fnpickling_simple(tmpdir):
 
     obj1 = 'astring'
     fnpickle(obj1, fn)
-    res = fnunpickle(fn)
+    res = fnunpickle(fn, 0)
     assert obj1 == res
 
     # now try with a file-like object instead of a string
@@ -24,6 +26,9 @@ def test_fnpickling_simple(tmpdir):
     with open(fn, 'rb') as f:
         res = fnunpickle(f)
         assert obj1 == res
+
+    with catch_warnings(AstropyDeprecationWarning):
+        fnunpickle(fn, 0, True)
 
 
 class ToBePickled:

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -18,23 +18,11 @@ def test_fnpickling_simple(tmpdir):
     res = fnunpickle(fn)
     assert obj1 == res
 
-    # try without cPickle
-    fnpickle(obj1, fn, usecPickle=False)
-    res = fnunpickle(fn, usecPickle=False)
-    assert obj1 == res
-
     # now try with a file-like object instead of a string
     with open(fn, 'wb') as f:
         fnpickle(obj1, f)
     with open(fn, 'rb') as f:
         res = fnunpickle(f)
-        assert obj1 == res
-
-    # same without cPickle
-    with open(fn, 'wb') as f:
-        fnpickle(obj1, f, usecPickle=False)
-    with open(fn, 'rb') as f:
-        res = fnunpickle(f, usecPickle=False)
         assert obj1 == res
 
 

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -22,8 +22,7 @@ classes to define custom YAML tags for the following astropy classes:
 
 .. Note ::
 
-   This module requires PyYaml version 3.12 or later, which in turn requires
-   Python 2.7 or Python 3.4 or later.
+   This module requires PyYaml version 3.12 or later.
 
 Example
 =======

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -994,7 +994,7 @@ def test_no_resource_check():
 
 
 def test_instantiate_vowarning():
-    # This used to raise a deprecation exception on Python 2.6.
+    # This used to raise a deprecation exception.
     # See https://github.com/astropy/astroquery/pull/276
     VOWarning(())
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -180,13 +180,9 @@ class AstropyLogger(Logger):
             message = str(args[0])
 
         mod_path = args[2]
-        # Now that we have the module's path, we look through
-        # sys.modules to find the module object and thus the
-        # fully-package-specified module name.  On Python 2, the
-        # module.__file__ is the compiled file name, not the .py, so
-        # we have to ignore the extension.  On Python 3,
-        # module.__file__ is the original source file name, so things
-        # are more direct.
+        # Now that we have the module's path, we look through sys.modules to
+        # find the module object and thus the fully-package-specified module
+        # name.  The module.__file__ is the original source file name.
         mod_name = None
         mod_path, ext = os.path.splitext(mod_path)
         for name, mod in list(sys.modules.items()):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -225,8 +225,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
             modname = '__main__'
 
         new_cls = type(name, (cls,), {})
-        # On Python 2 __module__ must be a str, not unicode
-        new_cls.__module__ = str(modname)
+        new_cls.__module__ = modname
 
         if hasattr(cls, '__qualname__'):
             if new_cls.__module__ == '__main__':
@@ -2226,11 +2225,7 @@ class _CompoundModelMeta(_ModelMeta):
         all of its parameters.
         """
 
-        try:
-            # Annoyingly, this will only work for Python 3.3+
-            basedir = super().__dir__()
-        except AttributeError:
-            basedir = list(set((dir(type(cls)) + list(cls.__dict__))))
+        basedir = super().__dir__()
 
         if cls._tree is not None:
             for name in cls.param_names:
@@ -2292,10 +2287,7 @@ class _CompoundModelMeta(_ModelMeta):
         if cls._evaluate is None:
             func = cls._tree.evaluate(BINARY_OPERATORS,
                                       getter=cls._model_evaluate_getter)[0]
-            # Making this a staticmethod isn't strictly necessary for Python 3,
-            # but it is necessary on Python 2 since looking up cls._evaluate
-            # will return an unbound method otherwise
-            cls._evaluate = staticmethod(func)
+            cls._evaluate = func
         inputs = args[:cls.n_inputs]
         params = iter(args[cls.n_inputs:])
         result = cls._evaluate(inputs, params)

--- a/astropy/stats/lombscargle/implementations/utils.py
+++ b/astropy/stats/lombscargle/implementations/utils.py
@@ -11,7 +11,6 @@ def bitceil(N):
     Roughly equivalent to int(2 ** np.ceil(np.log2(N)))
     """
     if hasattr(int, 'bit_length'):
-        # Python 2.7 and 3.x
         return 1 << int(N - 1).bit_length()
     else:
         N = int(N) - 1

--- a/astropy/stats/lombscargle/implementations/utils.py
+++ b/astropy/stats/lombscargle/implementations/utils.py
@@ -10,13 +10,7 @@ def bitceil(N):
     Note: this works for numbers up to 2 ** 64.
     Roughly equivalent to int(2 ** np.ceil(np.log2(N)))
     """
-    if hasattr(int, 'bit_length'):
-        return 1 << int(N - 1).bit_length()
-    else:
-        N = int(N) - 1
-        for i in [1, 2, 4, 8, 16, 32]:
-            N |= N >> i
-        return N + 1
+    return 1 << int(N - 1).bit_length()
 
 
 def extirpolate(x, y, N=None, M=4):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,7 @@ from ..utils import isiterable, ShapedLikeNDArray
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
-from ..utils.exceptions import AstropyDeprecationWarning
+from ..utils.exceptions import AstropyDeprecationWarning, NoValue
 
 from . import groups
 from .pprint import TableFormatter
@@ -2010,15 +2010,7 @@ class Table:
 
         self._init_from_cols(newcols)
 
-    def convert_bytestring_to_unicode(self, **kwargs):
-        # temporary method to handle deprecated and removed keywords
-        if 'python3_only' in kwargs:
-            warnings.warn('The "python3_only" keyword is now deprecated.',
-                          AstropyDeprecationWarning)
-            del kwargs['python3_only']
-        return self._convert_bytestring_to_unicode(**kwargs)
-
-    def _convert_bytestring_to_unicode(self):
+    def convert_bytestring_to_unicode(self, python3_only=NoValue):
         """
         Convert bytestring columns (dtype.kind='S') to unicode (dtype.kind='U') assuming
         ASCII encoding.
@@ -2028,17 +2020,13 @@ class Table:
         for memory but allows scripts to manipulate string arrays with
         natural syntax.
         """
-        self._convert_string_dtype('S', 'U')
-
-    def convert_unicode_to_bytestring(self, **kwargs):
-        # temporary method to handle deprecated and removed keywords
-        if 'python3_only' in kwargs:
+        if python3_only is not NoValue:
             warnings.warn('The "python3_only" keyword is now deprecated.',
                           AstropyDeprecationWarning)
-            del kwargs['python3_only']
-        return self._convert_unicode_to_bytestring(**kwargs)
 
-    def _convert_unicode_to_bytestring(self):
+        self._convert_string_dtype('S', 'U')
+
+    def convert_unicode_to_bytestring(self, python3_only=NoValue):
         """
         Convert ASCII-only unicode columns (dtype.kind='U') to bytestring (dtype.kind='S').
 
@@ -2047,6 +2035,10 @@ class Table:
         advantage of numpy automated conversion which works for strings that
         are pure ASCII.
         """
+        if python3_only is not NoValue:
+            warnings.warn('The "python3_only" keyword is now deprecated.',
+                          AstropyDeprecationWarning)
+
         self._convert_string_dtype('U', 'S')
 
     def keep_columns(self, names):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -398,8 +398,8 @@ class Table:
         if dtype is None:
             dtype = [None] * n_cols
 
-        # Numpy does not support Unicode column names on Python 2, or
-        # bytes column names on Python 3, so fix them up now.
+        # Numpy does not support bytes column names on Python 3, so fix them
+        # up now.
         names = [fix_column_name(name) for name in names]
 
         self._check_names_dtype(names, dtype, n_cols)
@@ -1980,7 +1980,7 @@ class Table:
         for name in names:
             self.columns.pop(name)
 
-    def _convert_string_dtype(self, in_kind, out_kind, python3_only):
+    def _convert_string_dtype(self, in_kind, out_kind):
         """
         Convert string-like columns to/from bytestring and unicode (internal only).
 
@@ -1990,8 +1990,6 @@ class Table:
             Input dtype.kind
         out_kind : str
             Output dtype.kind
-        python3_only : bool
-            Only do this operation for Python 3
         """
 
         # If there are no `in_kind` columns then do nothing
@@ -2010,48 +2008,28 @@ class Table:
 
         self._init_from_cols(newcols)
 
-    def convert_bytestring_to_unicode(self, python3_only=False):
+    def convert_bytestring_to_unicode(self):
         """
         Convert bytestring columns (dtype.kind='S') to unicode (dtype.kind='U') assuming
         ASCII encoding.
 
-        Internally this changes string columns to represent each character in the string
-        with a 4-byte UCS-4 equivalent, so it is inefficient for memory but allows Python
-        3 scripts to manipulate string arrays with natural syntax.
-
-        The ``python3_only`` parameter is provided as a convenience so that code can
-        be written in a Python 2 / 3 compatible way::
-
-          >>> t = Table.read('my_data.fits')
-          >>> t.convert_bytestring_to_unicode(python3_only=True)
-
-        Parameters
-        ----------
-        python3_only : bool
-            Only do this operation for Python 3
+        Internally this changes string columns to represent each character
+        in the string with a 4-byte UCS-4 equivalent, so it is inefficient
+        for memory but allows scripts to manipulate string arrays with
+        natural syntax.
         """
-        self._convert_string_dtype('S', 'U', python3_only)
+        self._convert_string_dtype('S', 'U')
 
-    def convert_unicode_to_bytestring(self, python3_only=False):
+    def convert_unicode_to_bytestring(self):
         """
         Convert ASCII-only unicode columns (dtype.kind='U') to bytestring (dtype.kind='S').
 
-        When exporting a unicode string array to a file in Python 3, it may be desirable
-        to encode unicode columns as bytestrings.  This routine takes advantage of numpy
-        automated conversion which works for strings that are pure ASCII.
-
-        The ``python3_only`` parameter is provided as a convenience so that code can
-        be written in a Python 2 / 3 compatible way::
-
-          >>> t.convert_unicode_to_bytestring(python3_only=True)
-          >>> t.write('my_data.fits')
-
-        Parameters
-        ----------
-        python3_only : bool
-            Only do this operation for Python 3
+        When exporting a unicode string array to a file, it may be desirable
+        to encode unicode columns as bytestrings.  This routine takes
+        advantage of numpy automated conversion which works for strings that
+        are pure ASCII.
         """
-        self._convert_string_dtype('U', 'S', python3_only)
+        self._convert_string_dtype('U', 'S')
 
     def keep_columns(self, names):
         '''

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,6 +17,8 @@ from ..utils import isiterable, ShapedLikeNDArray
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
+from ..utils.exceptions import AstropyDeprecationWarning
+
 from . import groups
 from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
@@ -2008,7 +2010,15 @@ class Table:
 
         self._init_from_cols(newcols)
 
-    def convert_bytestring_to_unicode(self):
+    def convert_bytestring_to_unicode(self, **kwargs):
+        # temporary method to handle deprecated and removed keywords
+        if 'python3_only' in kwargs:
+            warnings.warn('The "python3_only" keyword is now deprecated.',
+                          AstropyDeprecationWarning)
+            del kwargs['python3_only']
+        return self._convert_bytestring_to_unicode(**kwargs)
+
+    def _convert_bytestring_to_unicode(self):
         """
         Convert bytestring columns (dtype.kind='S') to unicode (dtype.kind='U') assuming
         ASCII encoding.
@@ -2020,7 +2030,15 @@ class Table:
         """
         self._convert_string_dtype('S', 'U')
 
-    def convert_unicode_to_bytestring(self):
+    def convert_unicode_to_bytestring(self, **kwargs):
+        # temporary method to handle deprecated and removed keywords
+        if 'python3_only' in kwargs:
+            warnings.warn('The "python3_only" keyword is now deprecated.',
+                          AstropyDeprecationWarning)
+            del kwargs['python3_only']
+        return self._convert_unicode_to_bytestring(**kwargs)
+
+    def _convert_unicode_to_bytestring(self):
         """
         Convert ASCII-only unicode columns (dtype.kind='U') to bytestring (dtype.kind='S').
 

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -525,7 +525,6 @@ def test_pprint_py3_bytes():
     """
     Test for #1346 and #4944. Make sure a bytestring (dtype=S<N>) in Python 3
     is printed correctly (without the "b" prefix like b'string').
-    Also make sure special characters are printed in Python 2.
     """
     val = bytes('val', encoding='utf-8')
     blah = u'bläh'.encode('utf-8')

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -38,9 +38,7 @@ __all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
 remote_data = pytest.mark.remote_data
 
 
-# This is for Python 2.x and 3.x compatibility.  distutils expects
-# options to all be byte strings on Python 2 and Unicode strings on
-# Python 3.
+# distutils expects options to be Unicode strings
 def _fix_user_options(options):
     def to_str_or_none(x):
         if x is None:
@@ -134,14 +132,6 @@ _modules_to_ignore_on_import = set([
     'setuptools'])
 _warnings_to_ignore_entire_module = set([])
 _warnings_to_ignore_by_pyver = {
-    (3, 4): set([
-        # py.test reads files with the 'U' flag, which is now
-        # deprecated in Python 3.4.
-        r"'U' mode is deprecated",
-        # BeautifulSoup4 triggers warning in stdlib's html module.x
-        r"The strict argument and mode are deprecated\.",
-        r"The value of convert_charrefs will become True in 3\.5\. "
-        r"You are encouraged to set the value explicitly\."]),
     (3, 5): set([
         # py.test reads files with the 'U' flag, which is
         # deprecated.
@@ -366,7 +356,7 @@ def assert_follows_unicode_guidelines(
     roundtrip : module, optional
         When provided, this namespace will be used to evaluate
         ``repr(x)`` and ensure that it roundtrips.  It will also
-        ensure that ``__bytes__(x)`` and ``__unicode__(x)`` roundtrip.
+        ensure that ``__bytes__(x)`` roundtrip.
         If not provided, no roundtrip testing will be performed.
     """
     from .. import conf

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -5,17 +5,6 @@ import os
 import types
 
 
-# Compatibility subpackages that should only be used on Python 2
-_py2_packages = set([
-    'astropy.extern.configobj_py2',
-])
-
-# Same but for Python 3
-_py3_packages = set([
-    'astropy.extern.configobj_py3',
-])
-
-
 def test_imports():
     """
     This just imports all modules in astropy, making sure they don't have any
@@ -43,12 +32,9 @@ def test_imports():
         raise AttributeError('package to generate config items for does not '
                              'have __file__ or __path__')
 
-    excludes = _py2_packages
-
     prefix = package.__name__ + '.'
 
     def onerror(name):
-        if not any(name.startswith(excl) for excl in excludes):
             # A legitimate error occurred in a module that wasn't excluded
             raise
 

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -35,8 +35,8 @@ def test_imports():
     prefix = package.__name__ + '.'
 
     def onerror(name):
-            # A legitimate error occurred in a module that wasn't excluded
-            raise
+        # A legitimate error occurred in a module that wasn't excluded
+        raise
 
     for imper, nm, ispkg in pkgutil.walk_packages(pkgpath, prefix,
                                                   onerror=onerror):

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -87,7 +87,7 @@ class QuantityInput:
         A decorator for validating the units of arguments to functions.
 
         Unit specifications can be provided as keyword arguments to the decorator,
-        or by using Python 3's function annotation syntax. Arguments to the decorator
+        or by using function annotation syntax. Arguments to the decorator
         take precedence over any function annotations present.
 
         A `~astropy.units.UnitsError` will be raised if the unit attribute of
@@ -108,14 +108,13 @@ class QuantityInput:
         Examples
         --------
 
-        Python 2 and 3::
+        .. code-block:: python
 
             import astropy.units as u
             @u.quantity_input(myangle=u.arcsec)
             def myfunction(myangle):
                 return myangle**2
 
-        Python 3 only:
 
         .. code-block:: python3
 
@@ -124,7 +123,7 @@ class QuantityInput:
             def myfunction(myangle: u.arcsec):
                 return myangle**2
 
-        Also in Python 3 you can specify a return value annotation, which will
+        Also you can specify a return value annotation, which will
         cause the function to always return a `~astropy.units.Quantity` in that
         unit.
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -116,7 +116,7 @@ class QuantityInput:
                 return myangle**2
 
 
-        .. code-block:: python3
+        .. code-block:: python
 
             import astropy.units as u
             @u.quantity_input
@@ -127,7 +127,7 @@ class QuantityInput:
         cause the function to always return a `~astropy.units.Quantity` in that
         unit.
 
-        .. code-block:: python3
+        .. code-block:: python
 
             import astropy.units as u
             @u.quantity_input

--- a/astropy/units/function/magnitude_zero_points.py
+++ b/astropy/units/function/magnitude_zero_points.py
@@ -14,8 +14,6 @@ To enable them, do::
 import numpy as _numpy
 from ..core import UnitBase, def_unit
 
-# One cannot import L_bol0 directly, or the order of imports of units and
-# constants starts to matter on python2. [#5121]
 from ...constants import si as _si
 from .. import si, astrophys
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -904,12 +904,10 @@ def test_arrays():
         qseclen0array[0]
     assert isinstance(qseclen0array.value, int)
 
-    # but with multiple dtypes, single elements are OK; need to use str()
-    # since numpy under python2 cannot handle unicode literals
     a = np.array([(1., 2., 3.), (4., 5., 6.), (7., 8., 9.)],
-                 dtype=[(str('x'), float),
-                        (str('y'), float),
-                        (str('z'), float)])
+                 dtype=[('x', float),
+                        ('y', float),
+                        ('z', float)])
     qkpc = u.Quantity(a, u.kpc)
     assert not qkpc.isscalar
     qkpc0 = qkpc[0]

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -137,8 +137,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
 
     encoding : str, optional
         When `None` (default), returns a file-like object with a
-        ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (``unicode``) objects, using
+        ``read`` method that returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -216,10 +215,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
             import gzip
             fileobj_new = gzip.GzipFile(fileobj=fileobj, mode='rb')
             fileobj_new.read(1)  # need to check that the file is really gzip
-        except (IOError, EOFError):  # invalid gzip file
-            fileobj.seek(0)
-            fileobj_new.close()
-        except struct.error:  # invalid gzip file on Python 3
+        except (IOError, EOFError, struct.error):  # invalid gzip file
             fileobj.seek(0)
             fileobj_new.close()
         else:
@@ -369,8 +365,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
 
     encoding : str, optional
         When `None` (default), returns a file-like object with a
-        ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (``unicode``) objects, using
+        ``read`` method returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -387,8 +382,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
         already-cached local copy will be accessed. If False, the
         file-like object will directly access the resource (e.g. if a
         remote URL is accessed, an object like that from
-        `urllib2.urlopen` on Python 2 or `urllib.request.urlopen` on
-        Python 3 is returned).
+        `urllib.request.urlopen` is returned).
 
     Returns
     -------
@@ -624,8 +618,7 @@ def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
 
     encoding : str, optional
         When `None` (default), returns a file-like object with a
-        ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (``unicode``) objects, using
+        ``read`` method that returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.
@@ -642,8 +635,7 @@ def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
         already-cached local copy will be accessed. If False, the
         file-like object will directly access the resource (e.g. if a
         remote URL is accessed, an object like that from
-        `urllib2.urlopen` on Python 2 or `urllib.request.urlopen` on
-        Python 3 is returned).
+        `urllib.request.urlopen` is returned).
 
     Returns
     -------
@@ -754,8 +746,7 @@ def get_pkg_data_fileobjs(datadir, package=None, pattern='*', encoding=None):
 
     encoding : str, optional
         When `None` (default), returns a file-like object with a
-        ``read`` method that on Python 2.x returns `bytes` objects and
-        on Python 3.x returns `str` (``unicode``) objects, using
+        ``read`` method that returns `str` (``unicode``) objects, using
         `locale.getpreferredencoding` as an encoding.  This matches
         the default behavior of the built-in `open` when no ``mode``
         argument is provided.

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -77,8 +77,7 @@ def dtype_info_name(dtype):
     type that matches the dtype::
 
       Numpy          S<N>      U<N>
-      Python 2      str<N>  unicode<N>
-      Python 3    bytes<N>   str<N>
+      Python      bytes<N>   str<N>
 
     Parameters
     ----------

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -121,7 +121,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         # If this is an extension function, we can't call
         # functools.wraps on it, but we normally don't care.
         # This crazy way to get the type of a wrapper descriptor is
-        # straight out of the Python 3.3 inspect module docs.
+        # straight out of the inspect module docs.
         if type(func) is not type(str.__dict__['__add__']):  # nopep8
             deprecated_func = functools.wraps(func)(deprecated_func)
 
@@ -379,11 +379,6 @@ def deprecated_renamed_argument(old_name, new_name, since,
     In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
     is applied to all renamed arguments) or must also be a `tuple` or `list`
     with values for each of the arguments.
-
-    .. warning::
-        This decorator needs to access the original signature of the decorated
-        function. Therefore this decorator must be the **first** decorator on
-        any function if it needs to work for Python before version 3.4.
     """
     cls_iter = (list, tuple)
     if isinstance(old_name, cls_iter):
@@ -424,7 +419,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 if param.kind == param.POSITIONAL_OR_KEYWORD:
                     position[i] = keys.index(new_name[i])
 
-                # 2.) Keyword only argument (Python 3 only):
+                # 2.) Keyword only argument:
                 elif param.kind == param.KEYWORD_ONLY:
                     # These cannot be specified by position.
                     position[i] = None
@@ -667,9 +662,6 @@ class classproperty(property):
         def fget(obj):
             return orig_fget(obj.__class__)
 
-        # Set the __wrapped__ attribute manually for support on Python 2
-        fget.__wrapped__ = orig_fget
-
         return fget
 
 
@@ -798,14 +790,7 @@ class sharedmethod(classmethod):
             mcls = type(objtype)
             clsmeth = getattr(mcls, self.__func__.__name__, None)
             if callable(clsmeth):
-                if isinstance(clsmeth, types.MethodType):
-                    # This case will generally only apply on Python 2, which
-                    # uses MethodType for unbound methods; Python 3 has no
-                    # particular concept of unbound methods and will just
-                    # return a function
-                    func = clsmeth.__func__
-                else:
-                    func = clsmeth
+                func = clsmeth
             else:
                 func = self.__func__
 
@@ -859,8 +844,7 @@ def _get_function_args_internal(func):
     Utility function for `wraps`.
 
     Reads the argspec for the given function and converts it to arguments
-    for `make_function_with_signature`.  This requires different
-    implementations on Python 2 versus Python 3.
+    for `make_function_with_signature`.
     """
 
     argspec = inspect.getfullargspec(func)

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -121,7 +121,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         # If this is an extension function, we can't call
         # functools.wraps on it, but we normally don't care.
         # This crazy way to get the type of a wrapper descriptor is
-        # straight out of the inspect module docs.
+        # straight out of the Python 3.3 inspect module docs.
         if type(func) is not type(str.__dict__['__add__']):  # nopep8
             deprecated_func = functools.wraps(func)(deprecated_func)
 

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -42,3 +42,12 @@ class AstropyBackwardsIncompatibleChangeWarning(AstropyWarning):
     The suggested procedure is to issue this warning for the version in
     which the change occurs, and remove it for all following versions.
     """
+
+class NoValue:
+    """Special keyword value.
+
+    This class may be used as the default value assigned to a
+    deprecated keyword in order to check if it has been given a user
+    defined value.
+    """
+    pass

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -43,11 +43,15 @@ class AstropyBackwardsIncompatibleChangeWarning(AstropyWarning):
     which the change occurs, and remove it for all following versions.
     """
 
-class NoValue:
+class _NoValue:
     """Special keyword value.
 
     This class may be used as the default value assigned to a
     deprecated keyword in order to check if it has been given a user
     defined value.
     """
-    pass
+    def __repr__(self):
+        return 'astropy.utils.exceptions.NoValue'
+
+
+NoValue = _NoValue()

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -3,12 +3,9 @@
 """Functions related to Python runtime introspection."""
 
 
-
-
 import inspect
 import re
 import types
-
 
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',
@@ -57,8 +54,7 @@ def resolve_name(name, *additional_parts):
     if additional_parts:
         name = name + '.' + additional_parts
 
-    # Note: On python 2 these must be str objects and not unicode
-    parts = [str(part) for part in name.split('.')]
+    parts = name.split('.')
 
     if len(parts) == 1:
         # No dots in the name--just a straight up module import

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -95,9 +95,8 @@ def format_exception(msg, *args, **kwargs):
 
     .. note::
         This uses `sys.exc_info` to gather up the information needed to fill
-        in the formatting arguments. Python 2.x and 3.x have slightly
-        different behavior regarding `sys.exc_info` (the latter will not
-        carry it outside a handled exception), so it's not wise to use this
+        in the formatting arguments. Since `sys.exc_info` is not carried
+        outside a handled exception, it's not wise to use this
         outside of an ``except`` clause - if it is, this will substitute
         '<unkown>' for the 4 formatting arguments.
     """
@@ -370,7 +369,7 @@ class JsonCustomEncoder(json.JSONEncoder):
         * Numpy array or number
         * Complex number
         * Set
-        * Bytes (Python 3)
+        * Bytes
         * astropy.UnitBase
         * astropy.Quantity
 

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 
 
-
 import io
-import locale
 
 import pytest
 
@@ -23,9 +21,7 @@ class FakeTTY(io.StringIO):
         if encoding is None:
             return super().__new__(cls)
 
-        # Since we're using unicode_literals in this module ensure that this is
-        # a 'str' object (since a class name can't be unicode in Python 2.7)
-        encoding = str(encoding)
+        encoding = encoding
         cls = type(encoding.title() + cls.__name__, (cls,),
                    {'encoding': encoding})
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -226,8 +226,7 @@ def test_deprecated_class_with_super():
 def test_deprecated_class_with_custom_metaclass():
     """
     Regression test for an issue where deprecating a class with a metaclass
-    other than type did not restore the metaclass properly (at least not
-    on Python 3).
+    other than type did not restore the metaclass properly.
     """
 
     with catch_warnings(AstropyDeprecationWarning) as w:

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -63,34 +63,6 @@ def test_find_mod_objs():
     assert namedtuple not in objs
 
 
-def test_isinstancemethod():
-    """
-    Note, this is an exact copy of the doctest in `isinstancemethod`'s
-    docstring.
-
-    It is included here as well so that it can be tested on Python 2 and 3
-    which require very different implementations.  Once we enable running
-    doctests on Python 3 this extra test can be dropped.
-    """
-
-    class MetaClass(type):
-        def a_classmethod(cls): pass
-
-    class MyClass(metaclass=MetaClass):
-        def an_instancemethod(self): pass
-
-        @classmethod
-        def another_classmethod(cls): pass
-
-        @staticmethod
-        def a_staticmethod(): pass
-
-    assert not isinstancemethod(MyClass, MyClass.a_classmethod)
-    assert not isinstancemethod(MyClass, MyClass.another_classmethod)
-    assert not isinstancemethod(MyClass, MyClass.a_staticmethod)
-    assert isinstancemethod(MyClass, MyClass.an_instancemethod)
-
-
 def _minversion_test():
     from types import ModuleType
     test_module = ModuleType(str("test_module"))

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -35,7 +35,7 @@ def determine_64_bit_int():
     """
     The only configuration parameter needed at compile-time is how to
     specify a 64-bit signed integer.  Python's ctypes module can get us
-    that information, but it is only available in Python 2.5 or later.
+    that information.
     If we can't be absolutely certain, we default to "long long int",
     which is correct on most platforms (x86, x86_64).  If we find
     platforms where this heuristic doesn't work, we may need to

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -821,9 +821,7 @@ def test_locale():
     orig_locale = locale.getlocale(locale.LC_NUMERIC)[0]
 
     try:
-        # str('fr_FR') because otherwise it will be a unicode string, which
-        # breaks setlocale on Python 2
-        locale.setlocale(locale.LC_NUMERIC, str('fr_FR'))
+        locale.setlocale(locale.LC_NUMERIC, 'fr_FR')
     except locale.Error:
         pytest.xfail(
             "Can't set to 'fr_FR' locale, perhaps because it is not installed "


### PR DESCRIPTION
This PR aims to remove more python <3.5 related code, comments and docstring.

There are two more additional places for possible further refactoring. One is #6652, while the other is in table. Probably it's not worth the API change to remove these, so probably removing the comment is sufficient enough.

```
    # Define keys and values for Python 2 and 3 source compatibility
    def keys(self):
        return list(OrderedDict.keys(self))

    def values(self):
       return list(OrderedDict.values(self))
```