### PR TITLE
Replacing unknown reference in utils.data

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1349,5 +1349,5 @@ def get_cached_urls():
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
         return False
 
-    with _open_shelve(urlmapfn, True) as url2hash:
+    with shelve.open(urlmapfn) as url2hash:
         return list(url2hash.keys())


### PR DESCRIPTION
There was one remaining usage of `_open_shelve` in `utils.data` that has been overlooked in #5978.