### PR TITLE
Pass timeout through download_files_in_parallel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,9 +203,6 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``download_files_in_parallel`` now respects the given ``timeout`` value.
-  [#6658]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -399,6 +396,9 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
+
+- ``download_files_in_parallel`` now respects the given ``timeout`` value.
+  [#6658]
 
 - Fixed bugs in remote data handling and also in IERS unit test related to path
   URL, and URI normalization on Windows. [#6651]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,6 +203,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- ``download_files_in_parallel`` now respects the given ``timeout`` value.
+  [#6658]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -18,6 +18,9 @@ import socket
 import sys
 import time
 import urllib
+import urllib.error
+import urllib.parse
+import urllib.request
 import shelve
 
 from tempfile import NamedTemporaryFile, gettempdir
@@ -1136,7 +1139,7 @@ def download_files_in_parallel(urls, cache=False, show_progress=True,
         is `True`)
 
     timeout : float, optional
-        Timeout for the requests in seconds (default is the
+        Timeout for each individual requests in seconds (default is the
         configurable `astropy.utils.data.Conf.remote_timeout`).
 
     Returns

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -985,10 +985,6 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     missing_cache = False
 
-    if timeout is None:
-        # use configfile default
-        timeout = conf.remote_timeout()
-
     if cache:
         try:
             dldir, urlmapfn = _get_download_cache_locs()
@@ -1117,7 +1113,7 @@ def is_url_in_cache(url_key):
 
 
 def _do_download_files_in_parallel(args):
-    return download_file(*args, show_progress=False)
+    return download_file(*args)
 
 
 def download_files_in_parallel(urls, cache=False, show_progress=True,
@@ -1158,15 +1154,11 @@ def download_files_in_parallel(urls, cache=False, show_progress=True,
     else:
         progress = io.BytesIO()
 
-    if timeout is None:
-        # use configfile default
-        timeout = REMOTE_TIMEOUT()
-
     # Combine duplicate URLs
     combined_urls = list(set(urls))
     combined_paths = ProgressBar.map(
         _do_download_files_in_parallel,
-        [(x, cache) for x in combined_urls],
+        [(x, cache, False, timeout) for x in combined_urls],
         file=progress,
         multiprocess=True)
     paths = []

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -47,6 +47,17 @@ def test_download_nocache():
 
 
 @remote_data
+def test_download_parallel():
+    from ..data import download_files_in_parallel
+
+    fnout = download_files_in_parallel(
+        ['http://data.astropy.org',
+         'https://astropy.stsci.edu/data/intersphinx/README'],
+        cache=True)  # cache=True is needed for Windows (see issue #6662)
+    assert all([os.path.isfile(f) for f in fnout]), fnout
+
+
+@remote_data
 def test_download_noprogress():
     from ..data import download_file
 


### PR DESCRIPTION
Previously the `timeout` argument was simply ignored.