### PR TITLE
WIP: attempt to fix non-caching behavior of download_files_in_parallel

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,5 +35,5 @@ install:
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test"
+    - "%CMD_IN_ENV% python setup.py test --remote-data"
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -37,6 +37,9 @@ __all__ = [
     'download_files_in_parallel', 'is_url_in_cache', 'get_cached_urls']
 
 
+__main_pid = None
+
+
 class Conf(_config.ConfigNamespace):
     """
     Configuration parameters for `astropy.utils.data`.
@@ -1162,6 +1165,9 @@ def download_files_in_parallel(urls, cache=False, show_progress=True,
         # use configfile default
         timeout = REMOTE_TIMEOUT()
 
+    global __main_pid
+    __main_pid = os.getpid()
+
     # Combine duplicate URLs
     combined_urls = list(set(urls))
     combined_paths = ProgressBar.map(
@@ -1181,9 +1187,12 @@ _tempfilestodel = []
 
 
 @atexit.register
-def _deltemps():
+def _deltemps(check_pid=True):
 
     global _tempfilestodel
+
+    if check_pid and os.getpid() != __main_pid:
+        return
 
     if _tempfilestodel is not None:
         while len(_tempfilestodel) > 0:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -320,7 +320,7 @@ def test_data_noastropy_fallback(monkeypatch):
     # now remove it so tests don't clutter up the temp dir this should get
     # called at exit, anyway, but we do it here just to make sure it's working
     # correctly
-    data._deltemps()
+    data._deltemps(check_pid=False)
     assert not os.path.isfile(fnout)
 
     assert len(w) > 0
@@ -458,3 +458,12 @@ def test_get_cached_urls():
     download_file(TESTURL, cache=True, show_progress=False)
 
     assert TESTURL in get_cached_urls()
+
+
+@remote_data
+def test_download_in_parallel_nocache():
+    from ..data import download_files_in_parallel
+
+    urls = ['https://www.google.com', 'https://www.wikipedia.org']
+    dwn = download_files_in_parallel(urls, cache=False)
+    assert all([os.path.isfile(f) for f in dwn]), dwn


### PR DESCRIPTION
This is an (admittedly somewhat crude) attempt to fix the issue with `download_files_in_parallel` reported in #6662. I had to allow appveyor to temporarily run with `--remote-data` in order to properly test this fix.