### PR TITLE
Fix instances of import of bare urllib package

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -4,7 +4,9 @@ from warnings import warn
 import collections
 import socket
 import json
-import urllib
+import urllib.request
+import urllib.error
+import urllib.parse
 
 import numpy as np
 from .. import units as u

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -12,7 +12,9 @@ reference for that measurement and input the coordinates manually.
 import os
 import re
 import socket
-import urllib
+import urllib.request
+import urllib.parse
+import urllib.error
 
 # Astropy
 from .. import units as u

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -6,7 +6,7 @@ This module contains tests for the name resolve convenience module.
 """
 
 import time
-import urllib
+import urllib.request
 
 import numpy as np
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -8,7 +8,7 @@ import sys
 import gzip
 import base64
 import codecs
-import urllib
+import urllib.request
 import warnings
 
 # THIRD-PARTY

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -14,7 +14,8 @@ import socket
 import subprocess
 import warnings
 import pickle
-import urllib
+import urllib.request
+import urllib.error
 import http.client
 
 # VO

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -17,10 +17,9 @@ import shutil
 import socket
 import sys
 import time
-import urllib
+import urllib.request
 import urllib.error
 import urllib.parse
-import urllib.request
 import shelve
 
 from tempfile import NamedTemporaryFile, gettempdir

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
-import urllib
+import urllib.request
 
 import pytest
 import numpy as np

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -20,7 +20,7 @@ import unicodedata
 import locale
 import threading
 import re
-import urllib
+import urllib.request
 
 from itertools import zip_longest
 from contextlib import contextmanager

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -9,7 +9,8 @@ import os
 import pathlib
 import sys
 import tempfile
-import urllib
+import urllib.request
+import urllib.error
 
 import pytest
 

--- a/astropy/utils/xml/check.py
+++ b/astropy/utils/xml/check.py
@@ -6,7 +6,7 @@ standards compliance.
 
 
 import re
-import urllib
+import urllib.parse
 
 
 def check_id(ID):

--- a/astropy/visualization/wcsaxes/tests/datasets.py
+++ b/astropy/visualization/wcsaxes/tests/datasets.py
@@ -3,7 +3,7 @@
 """
 
 import time
-import urllib
+import urllib.error
 
 from ....utils.data import download_file
 from ....io import fits


### PR DESCRIPTION
I think this one fell through the cracks with the transition to Py3. It's a bit of a mystery to me how this managed to work at all, but I have a guess.

At the top of `astropy/tests/disable_internet.py` is `import urllib.request`. Since this runs as part of the pytest plugins, it means that every time the tests run, every module that has `import urllib` is automatically able to use `urllib.request` as well, purely by accident.

I first noticed this because it caused some occasional weird errors for me locally. If a remote data test experienced a transient timeout, I would often get an error about `urllib.error` not being defined. The module or test that failed would only have `import urllib` at the top, but not `import urllib.error`. I ignored it for awhile, but this is an effort to put things right.

Unfortunately these bugs are kind of hard to reproduce, and it doesn't seem to make sense to have unit tests once it's fixed (imo).