### PR TITLE
objtype cannot be None without calling __get__ directly

### DIFF
--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -617,22 +617,16 @@ class classproperty(property):
         if doc is not None:
             self.__doc__ = doc
 
-    def __get__(self, obj, objtype=None):
+    def __get__(self, obj, objtype):
         if self._lazy and objtype in self._cache:
             return self._cache[objtype]
 
-        if objtype is not None:
-            # The base property.__get__ will just return self here;
-            # instead we pass objtype through to the original wrapped
-            # function (which takes the class as its sole argument)
-            val = self.fget.__wrapped__(objtype)
-        else:
-            val = super().__get__(obj, objtype=objtype)
+        # The base property.__get__ will just return self here;
+        # instead we pass objtype through to the original wrapped
+        # function (which takes the class as its sole argument)
+        val = self.fget.__wrapped__(objtype)
 
         if self._lazy:
-            if objtype is None:
-                objtype = obj.__class__
-
             self._cache[objtype] = val
 
         return val

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -614,6 +614,7 @@ class classproperty(property):
         # get set properly on instances of property subclasses if
         # the doc argument was used rather than taking the docstring
         # from fget
+        # Related Python issue: https://bugs.python.org/issue24766
         if doc is not None:
             self.__doc__ = doc
 


### PR DESCRIPTION
Even if it could then `property.__get__` wouldn't take keyword arguments and fail with a `TypeError`:

```
from astropy.utils.decorators import classproperty

class A:
    @classproperty
    def a(self):
        return 1
    
A.__dict__['a'].__get__(A.a, None)
# TypeError: wrapper __get__ doesn't take keyword arguments

A.__dict__['a'].__get__(A.a)
# TypeError: wrapper __get__ doesn't take keyword arguments
```

It's just dead code (see also [one of the latest coverage reports](https://coveralls.io/builds/13593119/source?filename=astropy%2Futils%2Fdecorators.py#L629)).

Tagging with 3.0 because I'm not sure if there are weird Python 2 cases around (I don't think so, but you never know with Python 2).