### PR TITLE
Rename inconsistent argument names in docstrings

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -204,7 +204,7 @@ def get_constellation(coord, short_name=False, constellation_list='iau'):
 
     Parameters
     ----------
-    coords : coordinate object
+    coord : coordinate object
         The object to determine the constellation of.
     short_name : bool
         If True, the returned names are the IAU-sanctioned abbreviated

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -184,7 +184,7 @@ def calc_moon(t):
 
     Parameters
     -----------
-    time : `~astropy.time.Time`
+    t : `~astropy.time.Time`
         Time of observation.
 
     Returns

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -549,7 +549,7 @@ class Card(_Verify):
 
         Parameters
         ----------
-        key : or str
+        keyword : or str
             A keyword value or a ``keyword.field-specifier`` value
         """
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -222,7 +222,7 @@ def check_string(string, attr_name, config=None, pos=None):
     string : str
         An astronomical year string
 
-    field : str
+    attr_name : str
         The name of the field this year was found in (used for error
         message)
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -981,7 +981,7 @@ class Polynomial2D(PolynomialModel):
         Parameters
         ----------
         x, y : array
-        coeff : array of coefficients in inverse lexical order
+        coeffs : array of coefficients in inverse lexical order
         """
 
         alpha = self._invlex()

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -269,7 +269,7 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
 
     Parameters
     ----------
-    dat : array-like
+    data : array-like
         Input array or object that can be converted to an array.
     c : float, optional
         Tuning constant for the biweight estimator (default = 9.0).

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1495,7 +1495,7 @@ def cdf_from_intervals(breaks, totals):
     ----------
     breaks : array of floats of length N
         The boundaries of successive intervals.
-    weights : array of floats of length N-1
+    totals : array of floats of length N-1
         The weight for each interval.
 
     Returns

--- a/astropy/visualization/wcsaxes/grid_paths.py
+++ b/astropy/visualization/wcsaxes/grid_paths.py
@@ -91,7 +91,7 @@ def get_gridline_path(world, pixel):
 
     Parameters
     ----------
-    lon_lat : `~numpy.ndarray`
+    world : `~numpy.ndarray`
         The longitude and latitude values along the curve, given as a (n,2)
         array.
     pixel : `~numpy.ndarray`


### PR DESCRIPTION
Where the documented argument name wasn't the actual name of the argument