### PR TITLE
Use Python3s named keyword-only arguments in some functions instead of popping from kwargs

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -265,14 +265,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     frame_attributes = OrderedDict()
     # Default empty frame_attributes dict
 
-    def __init__(self, *args, **kwargs):
-        copy = kwargs.pop('copy', True)
+    def __init__(self, *args, copy=True, representation=None,
+                 differential_cls=None,**kwargs):
         self._attr_names_with_defaults = []
 
         # TODO: we should be able to deal with an instance, not just a
-        # class or string.
-        representation = kwargs.pop('representation', None)
-        differential_cls = kwargs.pop('differential_cls', None)
+        # class or string for representation and differential_cls.
 
         if representation is not None or differential_cls is not None:
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -471,9 +471,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
 
     recommended_units = {}  # subclasses can override
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, differentials=None, **kwargs):
         # Handle any differentials passed in.
-        differentials = kwargs.pop('differentials', None)
         super().__init__(*args, **kwargs)
         self._differentials = self._validate_differentials(differentials)
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -194,13 +194,12 @@ class SkyCoord(ShapedLikeNDArray):
     # info property.
     info = SkyCoordInfo()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, copy=True, **kwargs):
 
         # Parse the args and kwargs to assemble a sanitized and validated
         # kwargs dict for initializing attributes for this object and for
         # creating the internal self._sky_coord_frame object
         args = list(args)  # Make it mutable
-        copy = kwargs.pop('copy', True)
         kwargs = self._parse_inputs(args, kwargs)
 
         frame = kwargs['frame']

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -651,7 +651,8 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
     return writer
 
 
-def write(table, output=None, format=None, Writer=None, fast_writer=True, **kwargs):
+def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
+          overwrite=None, **kwargs):
     """Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
 
@@ -693,7 +694,6 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, **kwar
         Writer class (DEPRECATED).
 
     """
-    overwrite = kwargs.pop('overwrite', None)
     if isinstance(output, str):
         if os.path.lexists(output):
             if overwrite is None:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -115,7 +115,8 @@ def getheader(filename, *args, **kwargs):
     return header
 
 
-def getdata(filename, *args, **kwargs):
+def getdata(filename, *args, header=None, lower=None, upper=None, view=None,
+            **kwargs):
     """
     Get the data from an extension of a FITS file (and optionally the
     header).
@@ -187,10 +188,6 @@ def getdata(filename, *args, **kwargs):
     """
 
     mode, closed = _get_file_mode(filename)
-    header = kwargs.pop('header', None)
-    lower = kwargs.pop('lower', None)
-    upper = kwargs.pop('upper', None)
-    view = kwargs.pop('view', None)
 
     hdulist, extidx = _getext(filename, mode, *args, **kwargs)
     try:
@@ -271,7 +268,8 @@ def getval(filename, keyword, *args, **kwargs):
     return hdr[keyword]
 
 
-def setval(filename, keyword, *args, **kwargs):
+def setval(filename, keyword, *args, value=None, comment=None, before=None,
+           after=None, savecomment=False, **kwargs):
     """
     Set a keyword's value from a header in a FITS file.
 
@@ -329,12 +327,6 @@ def setval(filename, keyword, *args, **kwargs):
 
     if 'do_not_scale_image_data' not in kwargs:
         kwargs['do_not_scale_image_data'] = True
-
-    value = kwargs.pop('value', None)
-    comment = kwargs.pop('comment', None)
-    before = kwargs.pop('before', None)
-    after = kwargs.pop('after', None)
-    savecomment = kwargs.pop('savecomment', False)
 
     closed = fileobj_closed(filename)
     hdulist, extidx = _getext(filename, 'update', *args, **kwargs)
@@ -948,17 +940,14 @@ if isinstance(tableload.__doc__, str):
     tableload.__doc__ += BinTableHDU._tdump_file_format.replace('\n', '\n    ')
 
 
-def _getext(filename, mode, *args, **kwargs):
+def _getext(filename, mode, *args, ext=None, extname=None, extver=None,
+            **kwargs):
     """
     Open the input file, return the `HDUList` and the extension.
 
     This supports several different styles of extension selection.  See the
     :func:`getdata()` documentation for the different possibilities.
     """
-
-    ext = kwargs.pop('ext', None)
-    extname = kwargs.pop('extname', None)
-    extver = kwargs.pop('extver', None)
 
     err_msg = ('Redundant/conflicting extension arguments(s): {}'.format(
             {'args': args, 'ext': ext, 'extname': extname,

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -478,14 +478,12 @@ def get_writer(data_format, data_class):
                 data_format, data_class.__name__, format_table_str))
 
 
-def read(cls, *args, **kwargs):
+def read(cls, *args, format=None, **kwargs):
     """
     Read in data.
 
     The arguments passed to this method depend on the format.
     """
-
-    format = kwargs.pop('format', None)
 
     ctx = None
     try:
@@ -539,14 +537,12 @@ def read(cls, *args, **kwargs):
     return data
 
 
-def write(data, *args, **kwargs):
+def write(data, *args, format=None, **kwargs):
     """
     Write out data.
 
     The arguments passed to this method depend on the format.
     """
-
-    format = kwargs.pop('format', None)
 
     if format is None:
         path = None

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -674,13 +674,11 @@ class Model(metaclass=_ModelMeta):
     # inputs. Only has an effect if input_units is defined.
     input_units_equivalencies = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, meta=None, name=None, **kwargs):
         super().__init__()
-        meta = kwargs.pop('meta', None)
         if meta is not None:
             self.meta = meta
-
-        self._name = kwargs.pop('name', None)
+        self._name = name
 
         self._initialize_constraints(kwargs)
         # Remaining keyword args are either parameter values or invalid
@@ -1406,7 +1404,8 @@ class Model(metaclass=_ModelMeta):
     def return_units(self, return_units):
         self._return_units = return_units
 
-    def prepare_inputs(self, *inputs, **kwargs):
+    def prepare_inputs(self, *inputs, model_set_axis=None, equivalencies=None,
+                       **kwargs):
         """
         This method is used in `~astropy.modeling.Model.__call__` to ensure
         that all the inputs to the model can be broadcast into compatible
@@ -1417,9 +1416,8 @@ class Model(metaclass=_ModelMeta):
         """
 
         # When we instantiate the model class, we make sure that __call__ can
-        # take the following two keyword arguments.
-        model_set_axis = kwargs.pop('model_set_axis', None)
-        equivalencies = kwargs.pop('equivalencies', None)
+        # take the following two keyword arguments: model_set_axis and
+        # equivalencies.
 
         if model_set_axis is None:
             # By default the model_set_axis for the input is assumed to be the
@@ -2870,7 +2868,7 @@ class _CompoundModel(Model, metaclass=_CompoundModelMeta):
         return new_model
 
 
-def custom_model(*args, **kwargs):
+def custom_model(*args, fit_deriv=None):
     """
     Create a model from a user defined function. The inputs and parameters of
     the model will be inferred from the arguments of the function.
@@ -2938,8 +2936,6 @@ def custom_model(*args, **kwargs):
         >>> model(1, 1)  # doctest: +FLOAT_CMP
         0.3333333333333333
     """
-
-    fit_deriv = kwargs.get('fit_deriv', None)
 
     if len(args) == 1 and callable(args[0]):
         return _custom_model_wrapper(args[0], fit_deriv=fit_deriv)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -22,6 +22,7 @@ import functools
 import operator
 import sys
 import types
+import warnings
 
 from collections import defaultdict, OrderedDict
 from contextlib import suppress
@@ -38,6 +39,7 @@ from ..utils import (sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer,
                      check_broadcast, IncompatibleShapeError, isiterable)
 from ..utils.codegen import make_function_with_signature
+from ..utils.exceptions import AstropyDeprecationWarning
 from .utils import (combine_labels, make_binary_operator_eval,
                     ExpressionTree, AliasDict, get_inputs_and_params,
                     _BoundingBox, _combine_equivalency_dict)
@@ -2868,7 +2870,7 @@ class _CompoundModel(Model, metaclass=_CompoundModelMeta):
         return new_model
 
 
-def custom_model(*args, fit_deriv=None):
+def custom_model(*args, fit_deriv=None, **kwargs):
     """
     Create a model from a user defined function. The inputs and parameters of
     the model will be inferred from the arguments of the function.
@@ -2936,6 +2938,13 @@ def custom_model(*args, fit_deriv=None):
         >>> model(1, 1)  # doctest: +FLOAT_CMP
         0.3333333333333333
     """
+
+    if kwargs:
+        warnings.warn(
+            "Function received unexpected arguments ({}) these "
+            "are ignored but will raise an Exception in the "
+            "future.".format(list(kwargs)),
+            AstropyDeprecationWarning)
 
     if len(args) == 1 and callable(args[0]):
         return _custom_model_wrapper(args[0], fit_deriv=fit_deriv)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -99,7 +99,7 @@ def test_custom_model_signature():
     assert model_a.param_names == ()
     assert model_a.n_inputs == 1
     sig = signature(model_a.__init__)
-    assert list(sig.parameters.keys()) == ['self', 'args', 'kwargs']
+    assert list(sig.parameters.keys()) == ['self', 'args', 'meta', 'name', 'kwargs']
     sig = signature(model_a.__call__)
     assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
                                            'with_bounding_box', 'fill_value',

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -79,12 +79,10 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         shape) onto ``data``.
     """
 
-    def __init__(self, data, *args, **kwd):
-        # Remove the flag argument from input.
-        flags = kwd.pop('flags', None)
+    def __init__(self, data, *args, flags=None, **kwargs):
 
         # Initialize with the parent...
-        super().__init__(data, *args, **kwd)
+        super().__init__(data, *args, **kwargs)
 
         # ...then reset uncertainty to force it to go through the
         # setter logic below. In base NDData all that is done is to

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -827,7 +827,7 @@ class Time(ShapedLikeNDArray):
         """
         return self._apply('copy' if copy else 'replicate', format=format)
 
-    def _apply(self, method, *args, **kwargs):
+    def _apply(self, method, *args, format=None, **kwargs):
         """Create a new time object, possibly applying a method to the arrays.
 
         Parameters
@@ -858,9 +858,7 @@ class Time(ShapedLikeNDArray):
             index or slice : ``_apply('__getitem__', item)``
             broadcast : ``_apply(np.broadcast, shape=new_shape)``
         """
-        new_format = kwargs.pop('format', None)
-        if new_format is None:
-            new_format = self.format
+        new_format = self.format if format is None else format
 
         if callable(method):
             apply_method = lambda array: method(array, *args, **kwargs)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1470,7 +1470,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     # the methods do not always allow calling with keyword arguments.
     # For instance, np.array([0.,2.]).clip(a_min=0., a_max=1.) gives
     # TypeError: 'a_max' is an invalid keyword argument for this function.
-    def _wrap_function(self, function, *args, out=None, **kwargs):
+    def _wrap_function(self, function, *args, unit=None, out=None, **kwargs):
         """Wrap a numpy function that processes self, returning a Quantity.
 
         Parameters
@@ -1500,7 +1500,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         out : `~astropy.units.Quantity`
             Result of the function call, with the unit set properly.
         """
-        unit = kwargs.pop('unit', self.unit)
+        if unit is None:
+            unit = self.unit
         # Ensure we don't loop back by turning any Quantity into array views.
         args = (self.value,) + tuple((arg.value if isinstance(arg, Quantity)
                                       else arg) for arg in args)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1470,7 +1470,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     # the methods do not always allow calling with keyword arguments.
     # For instance, np.array([0.,2.]).clip(a_min=0., a_max=1.) gives
     # TypeError: 'a_max' is an invalid keyword argument for this function.
-    def _wrap_function(self, function, *args, **kwargs):
+    def _wrap_function(self, function, *args, out=None, **kwargs):
         """Wrap a numpy function that processes self, returning a Quantity.
 
         Parameters
@@ -1501,7 +1501,6 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             Result of the function call, with the unit set properly.
         """
         unit = kwargs.pop('unit', self.unit)
-        out = kwargs.pop('out', None)
         # Ensure we don't loop back by turning any Quantity into array views.
         args = (self.value,) + tuple((arg.value if isinstance(arg, Quantity)
                                       else arg) for arg in args)

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -321,7 +321,7 @@ def _write_with_fallback(s, write, fileobj):
     return write
 
 
-def color_print(*args, **kwargs):
+def color_print(*args, end='\n', **kwargs):
     """
     Prints colors and styles to the terminal uses ANSI escape
     sequences.
@@ -353,8 +353,6 @@ def color_print(*args, **kwargs):
     """
 
     file = kwargs.get('file', _get_stdout())
-
-    end = kwargs.get('end', '\n')
 
     write = file.write
     if isatty(file) and conf.use_color:

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -489,7 +489,7 @@ class WCSAxes(Axes):
         else:
             return self.get_window_extent(renderer)
 
-    def grid(self, b=None, axis='both', **kwargs):
+    def grid(self, b=None, axis='both', *, which='major', **kwargs):
         """
         Plot gridlines for both coordinates.
 
@@ -507,7 +507,6 @@ class WCSAxes(Axes):
         if not hasattr(self, 'coords'):
             return
 
-        which = kwargs.pop('which', 'major')
         if which != 'major':
             raise NotImplementedError('Plotting the grid for the minor ticks is '
                                       'not supported.')


### PR DESCRIPTION
This uses named keyword-only arguments in the signature when appropriate. It *should* be fully compatible with Sphinx (but I currently cannot build the docs locally, so this needs confirmation) and allows "nicer" signatures. 

I tried to avoid any backwards-incompatibility so I only changed the easy places.