### PR TITLE
Remove more PyFITS references

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -241,12 +241,14 @@ class Card(_Verify):
                     raise ValueError("Keyword 'END' not allowed.")
                 keyword = keyword_upper
             elif self._keywd_hierarch_RE.match(keyword):
-                # In prior versions of PyFITS HIERARCH cards would only be
+                # In prior versions of PyFITS (*) HIERARCH cards would only be
                 # created if the user-supplied keyword explicitly started with
                 # 'HIERARCH '.  Now we will create them automatically for long
                 # keywords, but we still want to support the old behavior too;
                 # the old behavior makes it possible to create HEIRARCH cards
                 # that would otherwise be recognized as RVKCs
+                # (*) This has never affected Astropy, because it was changed
+                # before PyFITS was merged into Astropy!
                 self._hierarch = True
                 self._value_indicator = HIERARCH_VALUE_INDICATOR
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -42,7 +42,7 @@ FITS2NUMPY = {'L': 'i1', 'B': 'u1', 'I': 'i2', 'J': 'i4', 'K': 'i8', 'E': 'f4',
 
 # the inverse dictionary of the above
 NUMPY2FITS = {val: key for key, val in FITS2NUMPY.items()}
-# Normally booleans are represented as ints in pyfits, but if passed in a numpy
+# Normally booleans are represented as ints in Astropy, but if passed in a numpy
 # boolean array, that should be supported
 NUMPY2FITS['b1'] = 'L'
 # Add unsigned types, which will be stored as signed ints with a TZERO card.
@@ -569,7 +569,7 @@ class Column(NotifierMixin):
         for attr in KEYWORD_ATTRIBUTES:
             setattr(self, attr, valid_kwargs.get(attr))
 
-        # TODO: For PyFITS 3.3 try to eliminate the following two special cases
+        # TODO: Try to eliminate the following two special cases
         # for recformat and dim:
         # This is not actually stored as an attribute on columns for some
         # reason
@@ -662,7 +662,7 @@ class Column(NotifierMixin):
 
         # Ideally the .array attribute never would have existed in the first
         # place, or would have been internal-only.  This is a legacy of the
-        # older design from PyFITS that needs to have continued support, for
+        # older design from Astropy that needs to have continued support, for
         # now.
 
         # One of the main problems with this design was that it created a
@@ -1135,7 +1135,7 @@ class Column(NotifierMixin):
         """
 
         # If the given format string is unambiguously a Numpy dtype or one of
-        # the Numpy record format type specifiers supported by PyFITS then that
+        # the Numpy record format type specifiers supported by Astropy then that
         # should take priority--otherwise assume it is a FITS format
         if isinstance(format, np.dtype):
             format, _, _ = _dtype_to_recformat(format)
@@ -1183,7 +1183,7 @@ class Column(NotifierMixin):
                 format = _AsciiColumnFormat(format, strict=True)
 
             # A safe guess which reflects the existing behavior of previous
-            # PyFITS versions
+            # Astropy versions
             guess_format = _ColumnFormat
 
         try:
@@ -2319,10 +2319,10 @@ def _dtype_to_recformat(dtype):
     """
     Utility function for converting a dtype object or string that instantiates
     a dtype (e.g. 'float32') into one of the two character Numpy format codes
-    that have been traditionally used by PyFITS.
+    that have been traditionally used by Astropy.
 
     In particular, use of 'a' to refer to character data is long since
-    deprecated in Numpy, but PyFITS remains heavily invested in its use
+    deprecated in Numpy, but Astropy remains heavily invested in its use
     (something to try to get away from sooner rather than later).
     """
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1148,7 +1148,7 @@ class TableDataDiff(_BaseDiff):
 
         # Like in the old fitsdiff, compare tables on a column by column basis
         # The difficulty here is that, while FITS column names are meant to be
-        # case-insensitive, PyFITS still allows, for the sake of flexibility,
+        # case-insensitive, Astropy still allows, for the sake of flexibility,
         # two columns with the same name but different case.  When columns are
         # accessed in FITS tables, a case-sensitive is tried first, and failing
         # that a case-insensitive match is made.

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -253,7 +253,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     """
     FITS Random Groups HDU class.
 
-    See the :ref:`random-groups` section in the PyFITS documentation for more
+    See the :ref:`random-groups` section in the Astropy documentation for more
     details on working with this type of HDU.
     """
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -982,7 +982,7 @@ class HDUList(list, _Verify):
             if not isinstance(fileobj, _File):
                 # instantiate a FITS file object (ffo)
                 fileobj = _File(fileobj, mode=mode, memmap=memmap, cache=cache)
-            # The pyfits mode is determined by the _File initializer if the
+            # The Astropy mode is determined by the _File initializer if the
             # supplied mode was None
             mode = fileobj.mode
             hdulist = cls(file=fileobj)

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -197,7 +197,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         Sections are mostly obsoleted by memmap support, but should still be
         used to deal with very large scaled images.  See the
-        :ref:`data-sections` section of the PyFITS documentation for more
+        :ref:`data-sections` section of the Astropy documentation for more
         details.
         """
 
@@ -862,7 +862,7 @@ class Section:
     Section slices cannot be assigned to, and modifications to a section are
     not saved back to the underlying file.
 
-    See the :ref:`data-sections` section of the PyFITS documentation for more
+    See the :ref:`data-sections` section of the Astropy documentation for more
     details.
     """
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -35,7 +35,7 @@ from ....utils.decorators import deprecated_renamed_argument
 
 class FITSTableDumpDialect(csv.excel):
     """
-    A CSV dialect for the PyFITS format of ASCII dumps of FITS tables.
+    A CSV dialect for the Astropy format of ASCII dumps of FITS tables.
     """
 
     delimiter = ' '

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -843,8 +843,7 @@ class Header:
         created in the specified position, or appended to the end of the header
         if no position is specified.
 
-        This method is similar to :meth:`Header.update` prior to PyFITS 3.1
-        / Astropy v0.1.
+        This method is similar to :meth:`Header.update` prior to Astropy v0.1.
 
         .. note::
             It should be noted that ``header.set(keyword, value)`` and
@@ -1013,8 +1012,8 @@ class Header:
 
         .. warning::
             As this method works similarly to `dict.update` it is very
-            different from the ``Header.update()`` method in PyFITS versions
-            prior to 3.1.0 (or Astropy v0.1). Use of the old API was
+            different from the ``Header.update()`` method in Astropy v0.1.
+            Use of the old API was
             **deprecated** for a long time and is now removed. Most uses of the
             old API can be replaced as follows:
 

--- a/astropy/io/fits/src/compressionmodule.h
+++ b/astropy/io/fits/src/compressionmodule.h
@@ -42,7 +42,7 @@
 #define CFITSIO_LOSSLESS_COMP_SUPPORTED_VERS 3.22
 
 
-/* These defaults mirror the defaults in pyfits.hdu.compressed */
+/* These defaults mirror the defaults in io.fits.hdu.compressed */
 #define DEFAULT_COMPRESSION_TYPE "RICE_1"
 #define DEFAULT_QUANTIZE_LEVEL 16.0
 #define DEFAULT_HCOMP_SCALE 0

--- a/astropy/io/fits/tests/cfitsio_verify.c
+++ b/astropy/io/fits/tests/cfitsio_verify.c
@@ -1,5 +1,5 @@
 /* This script verifies .fits checksums using CFITSIO to demonstrate
-compatibility with PyFITS.   Since running it requires compiling and
+compatibility with Astropy.   Since running it requires compiling and
 linking against cfitsio,  the script is included as a maintenance
 asset but not automatically compiled and run.
 
@@ -21,7 +21,7 @@ use it; if compilation fails any such tests should be skipped.
 
 char * verify_status(int status)
 {
-	if (status == 1) { 
+	if (status == 1) {
 		return "ok";
 	} else if (status == 0) {
 		return "missing";
@@ -39,28 +39,28 @@ int main(int argc, char *argv[])
 	for (i=1; i<argc; i++) {
 
 		fits_open_file(&fptr, argv[i], READONLY, &status);
-		if (status) { 
+		if (status) {
 			fits_report_error(stderr, status);
-			exit(-1); 
+			exit(-1);
 		}
 
 		fits_get_num_hdus(fptr, &hdunum, &status);
-		if (status) { 
-			fprintf(stderr, "Bad get_num_hdus status for '%s' = %d", 
+		if (status) {
+			fprintf(stderr, "Bad get_num_hdus status for '%s' = %d",
 				argv[i], status);
-			exit(-1); 
+			exit(-1);
 		}
 
 		for (j=0; j<hdunum; j++) {
 			fits_movabs_hdu(fptr, hdunum, &hdutype, &status);
-			if (status) { 
-				fprintf(stderr, "Bad movabs status for '%s[%d]' = %d.", 
+			if (status) {
+				fprintf(stderr, "Bad movabs status for '%s[%d]' = %d.",
 					argv[i], j, status);
 				exit(-1);
 			}
 			fits_verify_chksum(fptr, &dataok, &hduok, &status);
-			if (status) { 
-				fprintf(stderr, "Bad verify status for '%s[%d]' = %d.", 
+			if (status) {
+				fprintf(stderr, "Bad verify status for '%s[%d]' = %d.",
 					argv[i], j, status);
 				exit(-1);
 			}

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -656,7 +656,7 @@ class TestHDUListFunctions(FitsTestCase):
         entire multi-extension FITS file at once.
         """
 
-        # Tests HDUList.fromstring for all of PyFITS' built in test files
+        # Tests HDUList.fromstring for all of Astropy built in test files
         def test_fromstring(filename):
             with fits.open(filename) as hdul:
                 orig_info = hdul.info(output=False)
@@ -692,7 +692,7 @@ class TestHDUListFunctions(FitsTestCase):
         for filename in glob.glob(os.path.join(self.data_dir, '*.fits')):
             if sys.platform == 'win32' and filename == 'zerowidth.fits':
                 # Running this test on this file causes a crash in some
-                # versions of Numpy on Windows.  See PyFITS ticket
+                # versions of Numpy on Windows.  See ticket:
                 # https://aeon.stsci.edu/ssb/trac/pyfits/ticket/174
                 continue
             elif filename.endswith('variable_length_table.fits'):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -656,7 +656,7 @@ class TestHDUListFunctions(FitsTestCase):
         entire multi-extension FITS file at once.
         """
 
-        # Tests HDUList.fromstring for all of Astropy built in test files
+        # Tests HDUList.fromstring for all of Astropy's built in test files
         def test_fromstring(filename):
             with fits.open(filename) as hdul:
                 orig_info = hdul.info(output=False)

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -317,7 +317,7 @@ class TestHeaderFunctions(FitsTestCase):
     def test_equal_only_up_to_column_10(self, capsys):
         # the test of "=" location is only up to column 10
 
-        # This test used to check if PyFITS rewrote this card to a new format,
+        # This test used to check if Astropy rewrote this card to a new format,
         # something like "HISTO   = '=   (1, 2)".  But since ticket #109 if the
         # format is completely wrong we don't make any assumptions and the card
         # should be left alone
@@ -1767,7 +1767,7 @@ class TestHeaderFunctions(FitsTestCase):
 
         # The example for this test requires creating a FITS file containing a
         # slightly misformatted float value.  I can't actually even find a way
-        # to do that directly through PyFITS--it won't let me.
+        # to do that directly through Astropy--it won't let me.
         hdu = fits.PrimaryHDU()
         hdu.header['TEST'] = 5.0022221e-07
         hdu.writeto(self.temp('test.fits'))
@@ -1796,7 +1796,7 @@ class TestHeaderFunctions(FitsTestCase):
         float values like 0.001 the leading zero was unnecessarily being
         stripped off when rewriting the header.  Though leading zeros should be
         removed from integer values to prevent misinterpretation as octal by
-        python (for now PyFITS will still maintain the leading zeros if now
+        python (for now Astropy will still maintain the leading zeros if now
         changes are made to the value, but will drop them if changes are made).
         """
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -319,7 +319,7 @@ class TestTableFunctions(FitsTestCase):
     def test_column_endianness(self):
         """
         Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/77
-        (PyFITS doesn't preserve byte order of non-native order column arrays)
+        (Astropy doesn't preserve byte order of non-native order column arrays)
         """
 
         a = [1., 2., 3., 4.]
@@ -1804,7 +1804,7 @@ class TestTableFunctions(FitsTestCase):
             raw_bytes = f.read()
 
         # Artificially truncate TDIM in the header; this seems to be the
-        # easiest way to do this while getting around pyfits' insistence on the
+        # easiest way to do this while getting around Astropys insistence on the
         # data and header matching perfectly; again, we have no interest in
         # making it possible to write files in this format, only read them
         with open(self.temp('test.fits'), 'wb') as f:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1804,7 +1804,7 @@ class TestTableFunctions(FitsTestCase):
             raw_bytes = f.read()
 
         # Artificially truncate TDIM in the header; this seems to be the
-        # easiest way to do this while getting around Astropys insistence on the
+        # easiest way to do this while getting around Astropy's insistence on the
         # data and header matching perfectly; again, we have no interest in
         # making it possible to write files in this format, only read them
         with open(self.temp('test.fits'), 'wb') as f:

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1875,8 +1875,8 @@ PyWcsprm_to_header(
     goto exit;
   }
 
-  /* Just return the raw header string.  PyFITS on the Python side will help
-     to parse and use this information. */
+  /* Just return the raw header string.  astropy.io.fits on the Python side will
+     help to parse and use this information. */
   result = PyUnicode_FromStringAndSize(header, (Py_ssize_t)nkeyrec * 80);
 
  exit:

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -93,7 +93,7 @@ unexpected behavior.
 
 For the most common cases, however, such as reading and updating FITS headers,
 images, and tables, `astropy.io.fits`. is very stable and well-tested.  Before
-every Astropy/PyFITS release it is ensured that all its tests pass on a variety
+every Astropy release it is ensured that all its tests pass on a variety
 of platforms, and those tests cover the majority of use-cases (until new corner
 cases are discovered).
 
@@ -139,14 +139,14 @@ Why does opening a file work in CFITSIO, ds9, etc. but not in Astropy?
 As mentioned elsewhere in this FAQ, there are many unusual corner cases when
 dealing with FITS files.  It's possible that a file should work, but isn't
 support due to a bug.  Sometimes it's even possible for a file to work in an
-older version of Astropy or PyFITS, but not a newer version due to a regression
+older version of Astropy, but not a newer version due to a regression
 that isn't tested for yet.
 
 Another problem with the FITS format is that, as old as it is, there are many
 conventions that appear in files from certain sources that do not meet the FITS
 standard.  And yet they are so common-place that it is necessary to support
 them in any FITS readers.  CONTINUE cards are one such example.  There are
-non-standard conventions supported by Astropy/PyFITS that are not supported by
+non-standard conventions supported by Astropy that are not supported by
 CFITSIO and possibly vice-versa.  You may have hit one of those cases.
 
 If Astropy is having trouble opening a file, a good way to rule out whether not
@@ -374,7 +374,7 @@ can be stored in a 64-bit float with full precision.  So FITS also supports a
 "free" format in which the ASCII representation can be stored anywhere, using
 the full 70 bytes of the card (after the keyword).
 
-Currently Astropy/PyFITS only supports writing fixed format (it can read both
+Currently Astropy only supports writing fixed format (it can read both
 formats), so all floating point values assigned to a header are stored in the
 fixed format.  There are plans to add support for more flexible formatting.
 
@@ -493,7 +493,7 @@ Comparison with Other FITS Readers
 What is the difference between astropy.io.fits and fitsio?
 ----------------------------------------------------------
 
-The `astropy.io.fits` module (originally PyFITS) is a "pure Python" FITS
+The `astropy.io.fits` module is a "pure Python" FITS
 reader in that all the code for parsing the FITS file format is in Python,
 though Numpy is used to provide access to the FITS data via the
 `~numpy.ndarray` interface.  `astropy.io.fits` currently also accesses the
@@ -573,11 +573,11 @@ of thousands of FITS files in succession (in either case the difference is
 not even an order of magnitude).
 
 Where data is concerned the situation is a little more complicated, and
-requires some understanding of how PyFITS is implemented versus CFITSIO and
+requires some understanding of how Astropy is implemented versus CFITSIO and
 ``fitsio``.  First it's important to understand how they differ in terms of
 memory management.
 
-`astropy.io.fits`/PyFITS uses mmap, by default, to provide access to the raw
+`astropy.io.fits` uses mmap, by default, to provide access to the raw
 binary data in FITS files.  Mmap is a system call (or in most cases these days
 a wrapper in your libc for a lower-level system call) which allows user-space
 applications to essentially do the same thing your OS is doing when it uses a
@@ -654,7 +654,7 @@ Astropy the test is written:
 
 .. code:: python
 
-    def read_test_pyfits(filename):
+    def read_test_astropy(filename):
         with fits.open(filename, memmap=True) as hdul:
             data = hdul[0].data
             c = data.copy()
@@ -667,7 +667,7 @@ using:
 
     for filename in filenames:
         print(filename)
-        %timeit read_test_pyfits(filename)
+        %timeit read_test_astropy(filename)
 
 where ``filenames`` is just a list of the aforementioned generated sample
 files.  The results were::
@@ -742,7 +742,7 @@ common example is how FITS represents boolean values in binary tables.
 Another, significantly more complicated example, is variable length arrays.
 
 As explained in "`Why is reading rows out of a FITS table so slow?`_",
-`astropy.io.fits`/PyFITS does not currently handle some of these cases as
+`astropy.io.fits` does not currently handle some of these cases as
 efficiently as it could, in particular in cases where a user only wishes to
 read a few rows out of a table.  Fitsio, on the other hand, has a better
 interface for copying one row at a time out of a table and performing the

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -39,11 +39,11 @@ the rest of PyFITS functions without this extension module.
 What is the development status of PyFITS?
 -----------------------------------------
 
-PyFITS is written and maintained by the Science Software Branch at the `Space
+PyFITS was written and maintained by the Science Software Branch at the `Space
 Telescope Science Institute`_, and is licensed by AURA_ under a `3-clause BSD
 license`_ (see `LICENSE.txt`_ in the PyFITS source code).
 
-It is now primarily developed as primarily as a component of Astropy
+It is now exclusively developed as a component of Astropy
 (`astropy.io.fits`) rather than as a stand-alone module.  There are a few
 reasons for this: The first is simply to reduce development effort; the
 overhead of maintaining both PyFITS *and* `astropy.io.fits` in separate code
@@ -52,19 +52,14 @@ bases is non-trivial.  The second is that there are many features of Astropy
 greatly.  Since PyFITS is already integrated into Astropy, it makes more sense
 to continue development there rather than make Astropy a dependency of PyFITS.
 
-PyFITS' current primary developer and active maintainer is `Erik Bray`_, though
-patch submissions are welcome from anyone.  PyFITS is now primarily developed
-in a Git repository for ease of merging to and from Astropy.  Patches and issue
-reports can be posted to the `GitHub project`_ for PyFITS, or for Astropy.
+PyFITS' past primary developer and active maintainer was `Erik Bray`_.  There
+is a `GitHub project`_ for PyFITS but PyFITS is not actively developed anymore
+so patches and issue reports should be posted on the Astropy issue tracker.
 There is also a legacy `Trac site`_ with some older issue reports still open,
 but new issues should be submitted via GitHub if possible.  An `SVN mirror`_ of
 the repository is still maintained as well.
 
-The current stable release series is 3.3.x.  Each 3.3.x release tries to
-contain only bug fixes, and to not introduce any significant behavioral or API
-changes (though this isn't guaranteed to be perfect).  Patch releases for older
-release series may be released upon request.  Older versions of PyFITS (2.4 and
-earlier) are no longer actively supported.
+The current (and probably last) stable release is 3.4.0.
 
 .. _Space Telescope Science Institute: http://www.stsci.edu/
 .. _AURA: http://www.aura-astronomy.org/

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -52,20 +52,18 @@ bases is non-trivial.  The second is that there are many features of Astropy
 greatly.  Since PyFITS is already integrated into Astropy, it makes more sense
 to continue development there rather than make Astropy a dependency of PyFITS.
 
-PyFITS' past primary developer and active maintainer was `Erik Bray`_.  There
-is a `GitHub project`_ for PyFITS but PyFITS is not actively developed anymore
+PyFITS' past primary developer and active maintainer was Erik Bray.  There
+is a `GitHub project`_ for PyFITS, but PyFITS is not actively developed anymore
 so patches and issue reports should be posted on the Astropy issue tracker.
 There is also a legacy `Trac site`_ with some older issue reports still open,
-but new issues should be submitted via GitHub if possible.  An `SVN mirror`_ of
-the repository is still maintained as well.
+but new issues should be submitted via GitHub if possible.
 
-The current (and probably last) stable release is 3.4.0.
+The current (and last) stable release is 3.4.0.
 
 .. _Space Telescope Science Institute: http://www.stsci.edu/
 .. _AURA: http://www.aura-astronomy.org/
 .. _3-clause BSD license: http://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22New_BSD_License.22_or_.22Modified_BSD_License.22.29
 .. _LICENSE.txt: https://aeon.stsci.edu/ssb/trac/pyfits/browser/trunk/LICENSE.txt
-.. _Erik Bray: mailto:embray@stsci.edu
 .. _Trac site: https://aeon.stsci.edu/ssb/trac/pyfits/
 .. _SVN mirror: https://aeon.stsci.edu/ssb/svn/pyfits/
 .. _GitHub project: https://github.com/spacetelescope/PyFITS
@@ -488,7 +486,7 @@ Comparison with Other FITS Readers
 What is the difference between astropy.io.fits and fitsio?
 ----------------------------------------------------------
 
-The `astropy.io.fits` module is a "pure Python" FITS
+The `astropy.io.fits` module (originally PyFITS) is a "pure Python" FITS
 reader in that all the code for parsing the FITS file format is in Python,
 though Numpy is used to provide access to the FITS data via the
 `~numpy.ndarray` interface.  `astropy.io.fits` currently also accesses the
@@ -568,7 +566,7 @@ of thousands of FITS files in succession (in either case the difference is
 not even an order of magnitude).
 
 Where data is concerned the situation is a little more complicated, and
-requires some understanding of how Astropy is implemented versus CFITSIO and
+requires some understanding of how ``astropy.io.fits`` is implemented versus CFITSIO and
 ``fitsio``.  First it's important to understand how they differ in terms of
 memory management.
 

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -65,7 +65,6 @@ The current (and last) stable release is 3.4.0.
 .. _3-clause BSD license: http://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22New_BSD_License.22_or_.22Modified_BSD_License.22.29
 .. _LICENSE.txt: https://aeon.stsci.edu/ssb/trac/pyfits/browser/trunk/LICENSE.txt
 .. _Trac site: https://aeon.stsci.edu/ssb/trac/pyfits/
-.. _SVN mirror: https://aeon.stsci.edu/ssb/svn/pyfits/
 .. _GitHub project: https://github.com/spacetelescope/PyFITS
 
 
@@ -566,9 +565,9 @@ of thousands of FITS files in succession (in either case the difference is
 not even an order of magnitude).
 
 Where data is concerned the situation is a little more complicated, and
-requires some understanding of how ``astropy.io.fits`` is implemented versus CFITSIO and
-``fitsio``.  First it's important to understand how they differ in terms of
-memory management.
+requires some understanding of how `astropy.io.fits` is implemented versus
+CFITSIO and ``fitsio``.  First it's important to understand how they differ in
+terms of memory management.
 
 `astropy.io.fits` uses mmap, by default, to provide access to the raw
 binary data in FITS files.  Mmap is a system call (or in most cases these days

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -197,7 +197,7 @@ If a user does not need the entire image(s) at the same time, e.g. processing
 images(s) ten rows at a time, the :attr:`~ImageHDU.section` attribute of an
 HDU can be used to alleviate such memory problems.
 
-With Astropys improved support for memory-mapping, the sections feature is not
+With Astropy's improved support for memory-mapping, the sections feature is not
 as necessary as it used to be for handling very large images.  However, if the
 image's data is scaled with non-trivial BSCALE/BZERO values, accessing the data
 in sections may still be necessary under the current implementation.  Memmap is

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -126,7 +126,7 @@ before and after the data is touched::
 
 .. warning::
 
-    An important caveat to be aware of when dealing with scaled data in PyFITS,
+    An important caveat to be aware of when dealing with scaled data in Astropy,
     is that when accessing the data via the ``.data`` attribute, the data is
     automatically scaled with the BZERO and BSCALE parameters.  If the file was
     opened in "update" mode, it will be saved with the rescaled data.  This
@@ -197,7 +197,7 @@ If a user does not need the entire image(s) at the same time, e.g. processing
 images(s) ten rows at a time, the :attr:`~ImageHDU.section` attribute of an
 HDU can be used to alleviate such memory problems.
 
-With PyFITS' improved support for memory-mapping, the sections feature is not
+With Astropys improved support for memory-mapping, the sections feature is not
 as necessary as it used to be for handling very large images.  However, if the
 image's data is scaled with non-trivial BSCALE/BZERO values, accessing the data
 in sections may still be necessary under the current implementation.  Memmap is
@@ -222,7 +222,7 @@ Here is an example of getting the median image from 3 input images of the size
         output[j:k, :] = np.median([x1, x2, x3], axis=0)
 
 Data in each :attr:`~ImageHDU.section` does not need to be contiguous for
-memory savings to be possible.  PyFITS will do its best to join together
+memory savings to be possible.  Astropy will do its best to join together
 discontiguous sections of the array while reading as little as possible into
 main memory.
 

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -46,7 +46,7 @@ The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`.  A
 :class:`FITS_rec` can be instantiated directly using the same initialization
 format presented for plain recarrays as in the example above.  One may also
-instantiate a new :class:`FITS_rec` from a list of PyFITS `Column` objects
+instantiate a new :class:`FITS_rec` from a list of Astropy `Column` objects
 using the :meth:`FITS_rec.from_columns` class method.  This has the exact same
 semantics as :meth:`BinTableHDU.from_columns` and
 :meth:`TableHDU.from_columns`, except that it only returns an actual FITS_rec
@@ -316,7 +316,7 @@ or directly use the :meth:`BinTableHDU.from_columns` method::
 
 .. note::
 
-    Users familiar with older versions of PyFITS or Astropy will wonder what
+    Users familiar with older versions of Astropy will wonder what
     happened to ``astropy.io.fits.new_table``. :meth:`BinTableHDU.from_columns`
     and its companion for ASCII tables :meth:`TableHDU.from_columns` are the
     same in the arguments they accept and their behavior.  They just make it

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -46,7 +46,7 @@ The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`.  A
 :class:`FITS_rec` can be instantiated directly using the same initialization
 format presented for plain recarrays as in the example above.  One may also
-instantiate a new :class:`FITS_rec` from a list of ``astropy.io.fits`` `Column`
+instantiate a new :class:`FITS_rec` from a list of `astropy.io.fits.Column`
 objects using the :meth:`FITS_rec.from_columns` class method.  This has the
 exact same semantics as :meth:`BinTableHDU.from_columns` and
 :meth:`TableHDU.from_columns`, except that it only returns an actual FITS_rec

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -46,9 +46,9 @@ The underlying data structure used for FITS tables is a class called
 :class:`FITS_rec` which is a specialized subclass of `numpy.recarray`.  A
 :class:`FITS_rec` can be instantiated directly using the same initialization
 format presented for plain recarrays as in the example above.  One may also
-instantiate a new :class:`FITS_rec` from a list of Astropy `Column` objects
-using the :meth:`FITS_rec.from_columns` class method.  This has the exact same
-semantics as :meth:`BinTableHDU.from_columns` and
+instantiate a new :class:`FITS_rec` from a list of ``astropy.io.fits`` `Column`
+objects using the :meth:`FITS_rec.from_columns` class method.  This has the
+exact same semantics as :meth:`BinTableHDU.from_columns` and
 :meth:`TableHDU.from_columns`, except that it only returns an actual FITS_rec
 array and not a whole HDU object.
 

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -104,11 +104,11 @@ ASCII tables it is not technically a valid format.  ASCII table format codes
 technically require a character width for each column, such as ``'I10'`` to
 create a column that can hold integers up to 10 characters wide.
 
-However, PyFITS allows the width specification to be omitted in some cases.
+However, Astropy allows the width specification to be omitted in some cases.
 When it is omitted from ``'I'`` format columns the minimum width needed to
 accurately represent all integers in the column is used.  The only problem with
 using this shortcut is its ambiguity with the binary table ``'I'`` format, so
-specifying ``ascii=True`` is a good practice (though PyFITS will still figure
+specifying ``ascii=True`` is a good practice (though Astropy will still figure
 out what you meant in most cases).
 
 


### PR DESCRIPTION
There were some PyFITS mentions in the narrative docs. This PR removes (most) of them. The ones remaining are either in the "appendix" or in the start-section that contains a mention the `from astropy.io import fits as pyfits` that people wanting to migrate still often use.

Milestoning as 2.0.3 but probably cannot be backported if #6664 isn't backported.