### PR TITLE
WIP: no longer require LaTeX for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ addons:
     apt:
         packages:
             - graphviz
-            - texlive-latex-extra
-            - dvipng
             - language-pack-de
+
 env:
     global:
         # Set defaults to avoid repeating in most cases

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -438,22 +438,6 @@ packages:
 
 .. note::
 
-    Sphinx also requires a reasonably modern LaTeX installation to render
-    equations.  Per the `Sphinx documentation
-    <http://sphinx-doc.org/builders.html?highlight=latex#sphinx.builders.latex.LaTeXBuilder>`_,
-    for the TexLive distribution the following packages are required to be
-    installed:
-
-    * latex-recommended
-    * latex-extra
-    * fonts-recommended
-
-    For other LaTeX distributions your mileage may vary. To build the PDF
-    documentation using LaTeX, the ``fonts-extra`` TexLive package or the
-    ``inconsolata`` CTAN package are also required.
-
-.. note::
-
     If sphinx-gallery is not installed, you will see many Sphinx warnings
     building the documentation, e.g.::
 


### PR DESCRIPTION
GIven https://github.com/astropy/astropy-helpers/pull/342, which changes from using imgmath to mathjax to render equation in the docs when built locally (which then matches what RTD does), LaTeX is no longer a requirement to build the docs. This is a WIP that will include updating astropy-helpers once I've established that the build fails unless we update the helpers. The docs build 20% faster for me now.