### PR TITLE
No longer require LaTeX for docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,8 @@ addons:
     apt:
         packages:
             - graphviz
-            - texlive-latex-extra
-            - dvipng
             - language-pack-de
+
 env:
     global:
         # Set defaults to avoid repeating in most cases

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -412,6 +412,11 @@ astropy.vo
 astropy.wcs
 ^^^^^^^^^^^
 
+Other Changes and Additions
+---------------------------
+
+- No longer require LaTeX to build the documentation locally and
+  use mathjax instead. [#6696]
 
 2.0.2 (2017-09-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -416,7 +416,7 @@ Other Changes and Additions
 ---------------------------
 
 - No longer require LaTeX to build the documentation locally and
-  use mathjax instead. [#6696]
+  use mathjax instead. [#6701]
 
 2.0.2 (2017-09-08)
 ==================

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -162,7 +162,7 @@ class FitnessFunc:
     ``fitness(self, **kwargs)``:
       Compute the fitness given a set of named arguments.
       Arguments accepted by fitness must be among ``[T_k, N_k, a_k, b_k, c_k]``
-      (See Scargle2012_ for details on the meaning of these parameters).
+      (See [1]_ for details on the meaning of these parameters).
 
     Additionally, other methods may be overloaded as well:
 
@@ -180,14 +180,14 @@ class FitnessFunc:
 
     ``p0_prior(self, N)``:
       Specify the form of the prior given the false-alarm probability ``p0``
-      (See Scargle2012_ for details).
+      (See [1]_ for details).
 
     For examples of implemented fitness functions, see :class:`Events`,
     :class:`RegularEvents`, and :class:`PointMeasures`.
 
     References
     ----------
-    .. [Scargle2012] Scargle, J et al. (2012)
+    .. [1] Scargle, J et al. (2012)
        http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
     """
     def __init__(self, p0=0.05, gamma=None, ncp_prior=None):

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -438,22 +438,6 @@ packages:
 
 .. note::
 
-    Sphinx also requires a reasonably modern LaTeX installation to render
-    equations.  Per the `Sphinx documentation
-    <http://sphinx-doc.org/builders.html?highlight=latex#sphinx.builders.latex.LaTeXBuilder>`_,
-    for the TexLive distribution the following packages are required to be
-    installed:
-
-    * latex-recommended
-    * latex-extra
-    * fonts-recommended
-
-    For other LaTeX distributions your mileage may vary. To build the PDF
-    documentation using LaTeX, the ``fonts-extra`` TexLive package or the
-    ``inconsolata`` CTAN package are also required.
-
-.. note::
-
     If sphinx-gallery is not installed, you will see many Sphinx warnings
     building the documentation, e.g.::
 


### PR DESCRIPTION
Replaces https://github.com/astropy/astropy/pull/6696 - there were issues with GitHub yesterday and I'm not able to re-open that PR or add commits to it.