### PR TITLE
remove registry from modeling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,8 @@ astropy.modeling
 - Removed deprecated ``GaussianAbsorption1D`` model.
   Use ``Const1D - Gaussian1D`` instead. [#6542]
 
+- Removed the registry from modeling. [#6706]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -81,11 +81,6 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
     Parameter descriptors declared at the class-level of Model subclasses.
     """
 
-    registry = set()
-    """
-    A registry of all known concrete (non-abstract) Model subclasses.
-    """
-
     _is_dynamic = False
     """
     This flag signifies whether this class was created in the "normal" way,
@@ -127,9 +122,6 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
         cls._create_inverse_property(members)
         cls._create_bounding_box_property(members)
         cls._handle_special_methods(members)
-
-        if not inspect.isabstract(cls) and not name.startswith('_'):
-            cls.registry.add(cls)
 
     def __repr__(cls):
         """


### PR DESCRIPTION
Reduce memory and resolve #6673.
As the issue explains the registry increases memory usage, mostly because compound models are saved there as well (together with copies of the instances of their submodels).
This PR completely removes the registry (shoul dit be deprecated first)?

Alternatively we can stop including the compound model classes.
But I wonder what the use of the registry is.
