### PR TITLE
Fix test with duplicated name

### DIFF
--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2470,7 +2470,7 @@ class TestTableFunctions(FitsTestCase):
             readfile(self.data('memtest.fits'))
 
     @pytest.mark.skipif(str('not HAVE_OBJGRAPH'))
-    def test_reference_leak(self, tmpdir):
+    def test_reference_leak2(self, tmpdir):
         """
         Regression test for https://github.com/astropy/astropy/pull/4539
 


### PR DESCRIPTION
2 tests functions had the same name, `test_reference_leak`, so the first one was not run.
Milestoned for v2.0 as it should backport easily.