### PR TITLE
Removing the INITERROR macro

### DIFF
--- a/astropy/_erfa/core.c.templ
+++ b/astropy/_erfa/core.c.templ
@@ -105,8 +105,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC PyInit__core(void)
 
 {
@@ -115,7 +113,7 @@ PyMODINIT_FUNC PyInit__core(void)
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     import_array();

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -367,12 +367,5 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC
 PyInit_tablewriter(void)
 {
-    PyObject* m;
-
-    m = PyModule_Create(&moduledef);
-
-    if (m == NULL)
-        return NULL;
-
-    return m;
+    return PyModule_Create(&moduledef);
 }

--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -364,8 +364,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#  define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit_tablewriter(void)
 {
@@ -374,7 +372,7 @@ PyInit_tablewriter(void)
     m = PyModule_Create(&moduledef);
 
     if (m == NULL)
-        INITERROR;
+        return NULL;
 
     return m;
 }

--- a/astropy/modeling/src/projections.c.templ
+++ b/astropy/modeling/src/projections.c.templ
@@ -195,8 +195,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit__projections(void)
 
@@ -206,17 +204,17 @@ PyInit__projections(void)
   m = PyModule_Create(&moduledef);
 
   if (m == NULL)
-    INITERROR;
+    return NULL;
 
   import_array();
 
 #ifdef HAVE_WCSLIB_VERSION
   if (PyModule_AddStringConstant(m, "__version__", wcslib_version(NULL))) {
-    INITERROR;
+    return NULL;
   }
 #else
   if (PyModule_AddStringConstant(m, "__version__", "4.x")) {
-    INITERROR;
+    return NULL;
   }
 #endif
 

--- a/astropy/utils/src/compiler.c
+++ b/astropy/utils/src/compiler.c
@@ -88,8 +88,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit__compiler(void)
 
@@ -99,7 +97,7 @@ PyInit__compiler(void)
   m = PyModule_Create(&moduledef);
 
   if (m == NULL)
-    INITERROR;
+    return NULL;
 
   PyModule_AddStringConstant(m, "compiler", COMPILER);
 

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1339,8 +1339,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#  define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit__iterparser(void)
 {
@@ -1348,10 +1346,10 @@ PyInit__iterparser(void)
     m = PyModule_Create(&moduledef);
 
     if (m == NULL)
-        INITERROR;
+        return NULL;
 
     if (PyType_Ready(&IterParserType) < 0)
-        INITERROR;
+        return NULL;
 
     Py_INCREF(&IterParserType);
     PyModule_AddObject(m, "IterParser", (PyObject *)&IterParserType);

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -829,8 +829,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit__wcs(void)
 
@@ -857,7 +855,7 @@ PyInit__wcs(void)
   m = PyModule_Create(&moduledef);
 
   if (m == NULL)
-    INITERROR;
+    return NULL;
 
   import_array();
 
@@ -872,16 +870,16 @@ PyInit__wcs(void)
       _setup_wcs_type(m)          ||
       _define_exceptions(m)) {
     Py_DECREF(m);
-    INITERROR;
+    return NULL;
   }
 
 #ifdef HAVE_WCSLIB_VERSION
   if (PyModule_AddStringConstant(m, "__version__", wcslib_version(NULL))) {
-    INITERROR;
+    return NULL;
   }
 #else
   if (PyModule_AddStringConstant(m, "__version__", "4.x")) {
-    INITERROR;
+    return NULL;
   }
 #endif
 

--- a/astropy/wcs/tests/extension/wcsapi_test.c
+++ b/astropy/wcs/tests/extension/wcsapi_test.c
@@ -38,8 +38,6 @@ static struct PyModuleDef moduledef = {
     NULL
 };
 
-#define INITERROR return NULL
-
 PyMODINIT_FUNC
 PyInit_wcsapi_test(void)
 
@@ -49,8 +47,7 @@ PyInit_wcsapi_test(void)
   m = PyModule_Create(&moduledef);
 
   if (m == NULL) {
-      printf("HERE\n");
-    INITERROR;
+      return NULL;
   }
 
   import_astropy_wcs();


### PR DESCRIPTION
This is a follow-up for #6678. Because we don't support Python 2 anymore there's no need for this compatibility macro anymore.