### PR TITLE
Cache table formatting funcs in col.info not pprint module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -381,6 +381,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fixed a problem when printing a table when a column is deleted and
+  garbage-collected, and the format function caching mechanism happens
+  to re-use the same cache key. [#6714]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -945,8 +945,8 @@ cdef class FastWriter:
                 if col.format is None and not col.dtype.kind == 'S':
                     self.format_funcs.append(None)
                 else:
-                    self.format_funcs.append(pprint._format_funcs.get(
-                        (col.format, col.name), pprint.get_auto_format_func(col.name)))
+                    self.format_funcs.append(col.info._format_funcs.get(
+                        col.format, pprint.get_auto_format_func(col)))
                 # col is a numpy.ndarray, so we convert it to
                 # an ordinary list because csv.writer will call
                 # np.array_str() on each numpy value, which is

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -19,7 +19,7 @@ from . import core
 from . import fixedwidth
 from . import basic
 from ...utils.exceptions import AstropyUserWarning
-from ...table.pprint import _format_funcs, get_auto_format_func
+from ...table.pprint import get_auto_format_func
 
 
 class IpacFormatErrorDBMS(Exception):
@@ -272,9 +272,8 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             # This may be incompatible with mixin columns
             null = col.fill_values[core.masked]
             try:
-                format_key = (col_format, col.info.name)
-                auto_format_func = get_auto_format_func(id(col))
-                format_func = _format_funcs.get(format_key, auto_format_func)
+                auto_format_func = get_auto_format_func(col)
+                format_func = col.info._format_funcs.get(col_format, auto_format_func)
                 nullist.append((format_func(col_format, null)).strip())
             except Exception:
                 # It is possible that null and the column values have different

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -453,7 +453,7 @@ class TableFormatter:
                     raise ValueError(
                         'Unable to parse format string "{0}" for entry "{1}" '
                         'in column "{2}"'.format(col_format, col[idx],
-                                                 col.name))
+                                                 col.info.name))
 
         outs['show_length'] = show_length
         outs['n_header'] = n_header

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -20,11 +20,7 @@ def default_format_func(format_, val):
         return str(val)
 
 
-_format_funcs = {}
-
-
 # The first three functions are helpers for _auto_format_func
-
 
 def _use_str_for_masked_values(format_func):
     """Wrap format function to trap masked values.
@@ -48,7 +44,7 @@ def _possible_string_format_functions(format_):
 
 
 def get_auto_format_func(
-        col_name=None,
+        col=None,
         possible_string_format_functions=_possible_string_format_functions):
     """
     Return a wrapped ``auto_format_func`` function which is used in
@@ -81,9 +77,8 @@ def get_auto_format_func(
         if format_ is None:
             return default_format_func(format_, val)
 
-        format_key = (format_, col_name)
-        if format_key in _format_funcs:
-            return _format_funcs[format_key](format_, val)
+        if format_ in col.info._format_funcs:
+            return col.info._format_funcs[format_](format_, val)
 
         if callable(format_):
             format_func = lambda format_, val: format_(val)
@@ -135,7 +130,7 @@ def get_auto_format_func(
             # wrap them in a function that traps them.
             format_func = _use_str_for_masked_values(format_func)
 
-        _format_funcs[format_key] = format_func
+        col.info._format_funcs[format_] = format_func
         return out
 
     return _auto_format_func
@@ -419,9 +414,8 @@ class TableFormatter:
                                                 None)
         pssf = (getattr(col.info, 'possible_string_format_functions', None) or
                 _possible_string_format_functions)
-        auto_format_func = get_auto_format_func(id(col), pssf)
-        format_key = (col_format, id(col))
-        format_func = _format_funcs.get(format_key, auto_format_func)
+        auto_format_func = get_auto_format_func(col, pssf)
+        format_func = col.info._format_funcs.get(col_format, auto_format_func)
 
         if len(col) > max_lines:
             if show_length is None:

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -446,6 +446,14 @@ class BaseColumnInfo(DataInfo):
     # depending on context.
     _serialize_context = None
 
+    def __init__(self, bound=False):
+        super().__init__(bound=bound)
+
+        # If bound to a data object instance then add a _format_funcs dict
+        # for caching functions for print formatting.
+        if bound:
+            self._format_funcs = {}
+
     def iter_str_vals(self):
         """
         This is a mixin-safe version of Column.iter_str_vals.


### PR DESCRIPTION
Fixes #6703 

"The column format is currently cached in a global dictionary keyed with the format and id() of the column. The problem is that when the table/column get garbage collected, a totally different column can be later placed in the same memory location and thus have the same id(). That may seem unlikely, but I've been encountering this seemingly random bug in real code (and in photutils CI testing)."

This PR moves the cache dict (`_format_funcs`) into the column `Info` object instead of being a common dict in the `pprint` module.  This should fix the issue since the cache is specific to the column.  I added a test but was not able to reproduce the problem on my Mac with current master.  It would be good if @larrybradley can try demonstrating that the new test fails on master but passes with this PR.

The 7369e5a commit fixes a minor unrelated bug where the exception catching for a bad format actually raised an unexpected exception for a mixin column that has no `name` attribute.  This is a leftover of adding mixing columns where one should always use `col.info.name` not `col.name`.

