### PR TITLE
Pin conda version for mpl test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,11 @@ matrix:
           stage: Initial tests
           env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
 
+        # Pinning conda version temporarily to 4.3.21, as some anaconda
+        # packges build with 4.3.27 are faulty and we see this job failing,
+        # while locally there are no issues when the same version of
+        # packages are installed from pip.
+        # TODO: remove the pinning once the issue is solved upstream.
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
@@ -118,6 +123,7 @@ matrix:
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0
                EVENT_TYPE='push pull_request cron'
+               CONDA_VERSION=4.3.21
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux


### PR DESCRIPTION
As we're about to update the conda version in ci-helpers (https://github.com/astropy/ci-helpers/pull/244) as it's needed to be able to access astropy 2.0.2 on the default conda channel, we need pin the conda version for the mpl test here as otherwise it's failing for some probably unrelated reason.

(Using the same version number of packages installed with pip, I don't see any issues locally, nor we see them when using the anaconda provided packages built using their previous infrastructure.)