### PR TITLE
More error checking in compression module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 # install Python ourselves using conda.
 language: c
 
+compiler: gcc
+
 os:
     - linux
 
@@ -109,6 +111,7 @@ matrix:
         - os: linux
           stage: Initial tests
           env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
+          compiler: clang
 
         # Pinning conda version temporarily to 4.3.21, as some anaconda
         # packges build with 4.3.27 are faulty and we see this job failing,

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -258,8 +258,8 @@ get_header_value(PyObject* header, char* key) {
    value, "keyword" is a string representing the header-key and the result is
    stored in "val".
    The function returns 0 on success, 1 if the header didn't have the keyword
-   and the default was applied and -1 (with an exception set) if the default was
-   applied but an Exception happened (like a MemoryError or Overflow).
+   and the default was applied and -1 (with an exception set) if an Exception
+   happened (like a MemoryError or Overflow).
 */
 int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
     PyObject* keyval = get_header_value(header, keyword);

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -254,6 +254,13 @@ get_header_value(PyObject* header, char* key) {
 // conversion function (eg. PyString_AsString) an argument to a macro or
 // something, but I'm not sure yet how easy it is to generalize the error
 // handling
+/* The get_header_* functions resemble "Header.get" where "def" is the default
+   value, "keyword" is a string representing the header-key and the result is
+   stored in "val".
+   The function returns 0 on success, 1 if the header didn't have the keyword
+   and the default was applied and -1 (with an exception set) if the default was
+   applied but an Exception happened (like a MemoryError or Overflow).
+*/
 int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
     PyObject* keyval = get_header_value(header, keyword);
 
@@ -353,6 +360,7 @@ int get_header_longlong(PyObject* header, char* keyword, long long* val,
             return -1;
         }
         *val = tmp;
+        return 0;
     } else {
         *val = def;
         return PyErr_Occurred() ? -1 : 1;

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -264,40 +264,38 @@ get_header_value(PyObject* header, char* key) {
 int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
     PyObject* keyval = get_header_value(header, keyword);
 
-    if (keyval != NULL) {
-        PyObject* tmp = PyUnicode_AsLatin1String(keyval);
-        // FITS header values should always be ASCII, but Latin1 is on the
-        // safe side
-        Py_DECREF(keyval);
-        if (tmp == NULL) {
-            /* could always fail to allocate the memory or such like. */
-            return -1;
-        }
-        strncpy(val, PyBytes_AsString(tmp), 72);
-        Py_DECREF(tmp);
-        return 0;
-    } else {
+    if (keyval == NULL) {
         strncpy(val, def, 72);
         return PyErr_Occurred() ? -1 : 1;
     }
+    PyObject* tmp = PyUnicode_AsLatin1String(keyval);
+    // FITS header values should always be ASCII, but Latin1 is on the
+    // safe side
+    Py_DECREF(keyval);
+    if (tmp == NULL) {
+        /* could always fail to allocate the memory or such like. */
+        return -1;
+    }
+    strncpy(val, PyBytes_AsString(tmp), 72);
+    Py_DECREF(tmp);
+    return 0;
 }
 
 
 int get_header_long(PyObject* header, char* keyword, long* val, long def) {
     PyObject* keyval = get_header_value(header, keyword);
 
-    if (keyval != NULL) {
-        long tmp = PyLong_AsLong(keyval);
-        Py_DECREF(keyval);
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        *val = tmp;
-        return 0;
-    } else {
+    if (keyval == NULL) {
         *val = def;
         return PyErr_Occurred() ? -1 : 1;
     }
+    long tmp = PyLong_AsLong(keyval);
+    Py_DECREF(keyval);
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    *val = tmp;
+    return 0;
 }
 
 
@@ -305,7 +303,7 @@ int get_header_int(PyObject* header, char* keyword, int* val, int def) {
     long tmp;
     int ret = get_header_long(header, keyword, &tmp, def);
     if (ret == 0) {
-        if (tmp > INT_MIN && tmp < INT_MAX) {
+        if (tmp >= INT_MIN && tmp <= INT_MAX) {
             *val = (int) tmp;
         } else {
             PyErr_Format(PyExc_OverflowError, "Cannot convert %ld to C 'int'", tmp);
@@ -319,18 +317,17 @@ int get_header_int(PyObject* header, char* keyword, int* val, int def) {
 int get_header_double(PyObject* header, char* keyword, double* val, double def) {
     PyObject* keyval = get_header_value(header, keyword);
 
-    if (keyval != NULL) {
-        double tmp = PyFloat_AsDouble(keyval);
-        Py_DECREF(keyval);
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        *val = tmp;
-        return 0;
-    } else {
+    if (keyval == NULL) {
         *val = def;
         return PyErr_Occurred() ? -1 : 1;
     }
+    double tmp = PyFloat_AsDouble(keyval);
+    Py_DECREF(keyval);
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    *val = tmp;
+    return 0;
 }
 
 
@@ -338,7 +335,7 @@ int get_header_float(PyObject* header, char* keyword, float* val, float def) {
     double tmp;
     int ret = get_header_double(header, keyword, &tmp, def);
     if (ret == 0) {
-        if (tmp > FLT_MIN || tmp < FLT_MAX) { /* don't care about infs! */
+        if (tmp >= FLT_MIN || tmp <= FLT_MAX) { /* don't care about infs! */
             *val = (float) tmp;
         } else {
             PyErr_Format(PyExc_OverflowError, "Cannot convert %f to 'float'", tmp);
@@ -353,18 +350,17 @@ int get_header_longlong(PyObject* header, char* keyword, long long* val,
                         long long def) {
     PyObject* keyval = get_header_value(header, keyword);
 
-    if (keyval != NULL) {
-        long long tmp = PyLong_AsLongLong(keyval);
-        Py_DECREF(keyval);
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        *val = tmp;
-        return 0;
-    } else {
+    if (keyval == NULL) {
         *val = def;
         return PyErr_Occurred() ? -1 : 1;
     }
+    long long tmp = PyLong_AsLongLong(keyval);
+    Py_DECREF(keyval);
+    if (PyErr_Occurred()) {
+        return -1;
+    }
+    *val = tmp;
+    return 0;
 }
 
 

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -90,6 +90,8 @@
 
 /* Include the Python C API */
 
+#include <float.h>
+#include <limits.h>
 #include <math.h>
 #include <string.h>
 
@@ -233,159 +235,128 @@ int compress_type_from_string(char* zcmptype) {
 }
 
 
+PyObject *
+get_header_value(PyObject* header, char* key) {
+    PyObject* hdrkey;
+    PyObject* hdrval;
+    hdrkey = PyUnicode_FromString(key);
+    if (hdrkey == NULL) {
+        return NULL;
+    }
+    hdrval = PyObject_GetItem(header, hdrkey);
+    Py_DECREF(hdrkey);
+    PyErr_Clear();
+    return hdrval;
+}
+
+
 // TODO: It might be possible to simplify these further by making the
 // conversion function (eg. PyString_AsString) an argument to a macro or
 // something, but I'm not sure yet how easy it is to generalize the error
 // handling
 int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    PyObject* tmp;  // Temp pointer to decoded bytes object
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
+    PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval != NULL) {
+        PyObject* tmp = PyUnicode_AsLatin1String(keyval);
         // FITS header values should always be ASCII, but Latin1 is on the
         // safe side
-        tmp = PyUnicode_AsLatin1String(keyval);
+        Py_DECREF(keyval);
+        if (tmp == NULL) {
+            /* could always fail to allocate the memory or such like. */
+            return -1;
+        }
         strncpy(val, PyBytes_AsString(tmp), 72);
         Py_DECREF(tmp);
-        retval = 0;
-    }
-    else {
-        PyErr_Clear();
+        return 0;
+    } else {
         strncpy(val, def, 72);
-        retval = 1;
+        return PyErr_Occurred() ? -1 : 1;
     }
-
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
-}
-
-
-int get_header_int(PyObject* header, char* keyword, int* val, int def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
-
-    if (keyval != NULL) {
-        *val = (int) PyLong_AsLong(keyval);
-        retval = 0;
-    }
-    else {
-        PyErr_Clear();
-        *val = def;
-        retval = 1;
-    }
-
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
 }
 
 
 int get_header_long(PyObject* header, char* keyword, long* val, long def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
+    PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval != NULL) {
-        *val = PyLong_AsLong(keyval);
-        retval = 0;
-    }
-    else {
-        PyErr_Clear();
+        long tmp = PyLong_AsLong(keyval);
+        Py_DECREF(keyval);
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        *val = tmp;
+        return 0;
+    } else {
         *val = def;
-        retval = 1;
+        return PyErr_Occurred() ? -1 : 1;
     }
-
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
 }
 
 
-int get_header_float(PyObject* header, char* keyword, float* val,
-                     float def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
-
-    if (keyval != NULL) {
-        *val = (float) PyFloat_AsDouble(keyval);
-        retval = 0;
+int get_header_int(PyObject* header, char* keyword, int* val, int def) {
+    long tmp;
+    int ret = get_header_long(header, keyword, &tmp, def);
+    if (ret == 0) {
+        if (tmp > INT_MIN && tmp < INT_MAX) {
+            *val = (int) tmp;
+        } else {
+            PyErr_Format(PyExc_OverflowError, "Cannot convert %ld to C 'int'", tmp);
+            ret = -1;
+        }
     }
-    else {
-        PyErr_Clear();
-        *val = def;
-        retval = 1;
-    }
-
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
+    return ret;
 }
 
 
-int get_header_double(PyObject* header, char* keyword, double* val,
-                      double def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
+int get_header_double(PyObject* header, char* keyword, double* val, double def) {
+    PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval != NULL) {
-        *val = PyFloat_AsDouble(keyval);
-        retval = 0;
-    }
-    else {
-        PyErr_Clear();
+        double tmp = PyFloat_AsDouble(keyval);
+        Py_DECREF(keyval);
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        *val = tmp;
+        return 0;
+    } else {
         *val = def;
-        retval = 1;
+        return PyErr_Occurred() ? -1 : 1;
     }
+}
 
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
+
+int get_header_float(PyObject* header, char* keyword, float* val, float def) {
+    double tmp;
+    int ret = get_header_double(header, keyword, &tmp, def);
+    if (ret == 0) {
+        if (tmp > FLT_MIN || tmp < FLT_MAX) { /* don't care about infs! */
+            *val = (float) tmp;
+        } else {
+            PyErr_Format(PyExc_OverflowError, "Cannot convert %f to 'float'", tmp);
+            ret = -1;
+        }
+    }
+    return ret;
 }
 
 
 int get_header_longlong(PyObject* header, char* keyword, long long* val,
                         long long def) {
-    PyObject* keystr;
-    PyObject* keyval;
-    int retval;
-
-    keystr = PyUnicode_FromString(keyword);
-    keyval = PyObject_GetItem(header, keystr);
+    PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval != NULL) {
-        *val = PyLong_AsLongLong(keyval);
-        retval = 0;
-    }
-    else {
-        PyErr_Clear();
+        long long tmp = PyLong_AsLongLong(keyval);
+        Py_DECREF(keyval);
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        *val = tmp;
+    } else {
         *val = def;
-        retval = 1;
+        return PyErr_Occurred() ? -1 : 1;
     }
-
-    Py_DECREF(keystr);
-    Py_XDECREF(keyval);
-    return retval;
 }
 
 

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -236,7 +236,7 @@ int compress_type_from_string(char* zcmptype) {
 
 
 PyObject *
-get_header_value(PyObject* header, char* key) {
+get_header_value(PyObject* header, const char* key) {
     PyObject* hdrkey;
     PyObject* hdrval;
     hdrkey = PyUnicode_FromString(key);
@@ -261,7 +261,8 @@ get_header_value(PyObject* header, char* key) {
    and the default was applied and -1 (with an exception set) if an Exception
    happened (like a MemoryError or Overflow).
 */
-int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
+int get_header_string(PyObject* header, const char* keyword, char* val,
+                      const char* def) {
     PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval == NULL) {
@@ -282,7 +283,7 @@ int get_header_string(PyObject* header, char* keyword, char* val, char* def) {
 }
 
 
-int get_header_long(PyObject* header, char* keyword, long* val, long def) {
+int get_header_long(PyObject* header, const char* keyword, long* val, long def) {
     PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval == NULL) {
@@ -299,7 +300,7 @@ int get_header_long(PyObject* header, char* keyword, long* val, long def) {
 }
 
 
-int get_header_int(PyObject* header, char* keyword, int* val, int def) {
+int get_header_int(PyObject* header, const char* keyword, int* val, int def) {
     long tmp;
     int ret = get_header_long(header, keyword, &tmp, def);
     if (ret == 0) {
@@ -314,7 +315,8 @@ int get_header_int(PyObject* header, char* keyword, int* val, int def) {
 }
 
 
-int get_header_double(PyObject* header, char* keyword, double* val, double def) {
+int get_header_double(PyObject* header, const char* keyword, double* val,
+                      double def) {
     PyObject* keyval = get_header_value(header, keyword);
 
     if (keyval == NULL) {
@@ -331,7 +333,8 @@ int get_header_double(PyObject* header, char* keyword, double* val, double def) 
 }
 
 
-int get_header_float(PyObject* header, char* keyword, float* val, float def) {
+int get_header_float(PyObject* header, const char* keyword, float* val,
+                     float def) {
     double tmp;
     int ret = get_header_double(header, keyword, &tmp, def);
     if (ret == 0) {
@@ -346,7 +349,7 @@ int get_header_float(PyObject* header, char* keyword, float* val, float def) {
 }
 
 
-int get_header_longlong(PyObject* header, char* keyword, long long* val,
+int get_header_longlong(PyObject* header, const char* keyword, long long* val,
                         long long def) {
     PyObject* keyval = get_header_value(header, keyword);
 


### PR DESCRIPTION
I started looking at out C extensions lately and I noticed that some errors aren't checked. For example MemoryErrors or OverflowErrors.

To keep the PR reviewable I only changed the first "few" functions that accessed Header values.

The exceptions are still largely unhandled but I fear that it will be unreviewable if I also add all the error-checkings for these functions. That would be done in a future PR in case this PR makes it :)

I'm not sure how this will affect performance. Error-checking obviously adds some overhead(*) just to catch *very* rare cases. 

---

(*)  not much, I think most of the time will be spent actually compressing the image. Timings with small images showed ~5% slowdown