### PR TITLE
WIP: move column/mixin formatting to Info

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -710,6 +710,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         for attr in ('name', 'unit', 'format', 'description'):
             val = getattr(obj, attr, None)
+            if attr == 'format':
+                print('HERE in _copy_attrs():', type(obj), id(obj), val)
             # if val is not None:
             #     print('Setting {} = {}'.format(attr, val))
             setattr(self, attr, val)

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -342,8 +342,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     def __array_finalize__(self, obj):
         # Tracer()()
-        # print('__array_finalize__ self: {} {} obj: {} {}'
-        #       .format(type(self), id(self), type(obj), id(obj)))
+        print('HERE in __array_finalize__ self: {} {} obj: {} {}'
+              .format(type(self), id(self), type(obj), id(obj)))
         # Obj will be none for direct call to Column() creator
         if obj is None:
             return
@@ -710,10 +710,10 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         for attr in ('name', 'unit', 'format', 'description'):
             val = getattr(obj, attr, None)
-            # if attr == 'format':
-            #     print('HERE in _copy_attrs():', type(obj), id(obj), val)
-            # if val is not None:
-            #     print('Setting {} = {}'.format(attr, val))
+            if attr == 'format':
+                print('HERE in _copy_attrs():', type(obj), id(obj), val)
+            if val is not None:
+                print('Setting {} = {}'.format(attr, val))
             setattr(self, attr, val)
         self.meta = deepcopy(getattr(obj, 'meta', {}))
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1124,6 +1124,9 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
                                meta=meta, copy=copy, copy_indices=copy_indices)
         self = ma.MaskedArray.__new__(cls, data=self_data, mask=mask)
 
+        del self.__dict__['info']
+        self.info = self_data.info
+
         # Note: do not set fill_value in the MaskedArray constructor because this does not
         # go through the fill_value workarounds.
         if fill_value is None and getattr(data, 'fill_value', None) is not None:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -2,12 +2,12 @@
 
 import warnings
 import weakref
-import re
 
 from copy import deepcopy
 
 import numpy as np
 from numpy import ma
+from IPython.core.debugger import Tracer
 
 # Remove this when Numpy no longer emits this warning and that Numpy version
 # becomes the minimum required version for Astropy.
@@ -19,20 +19,14 @@ except ImportError:
     MaskedArrayFutureWarning = None
 
 from ..units import Unit, Quantity
-from ..utils.console import color_print
 from ..utils.metadata import MetaData
 from ..utils.data_info import BaseColumnInfo, dtype_info_name
 from ..utils.misc import dtype_bytes_or_chars
 from . import groups
-from . import pprint
 from .np_utils import fix_column_name
 
 # These "shims" provide __getitem__ implementations for Column and MaskedColumn
 from ._column_mixins import _ColumnGetitemShim, _MaskedColumnGetitemShim
-
-# Create a generic TableFormatter object for use by bare columns with no
-# parent table.
-FORMATTER = pprint.TableFormatter()
 
 
 class StringTruncateWarning(UserWarning):
@@ -141,7 +135,10 @@ class ColumnInfo(BaseColumnInfo):
     This is required when the object is used as a mixin column within a table,
     but can be used as a general way to store meta information.
     """
-    attrs_from_parent = BaseColumnInfo.attr_names
+    # ColumInfo gets all attrs from parent Column except for `format` (which
+    # is handled by BaseColumnInfo so that mixin columns like Quantity have
+    # immediate validation of format).
+    attrs_from_parent = BaseColumnInfo.attr_names - set(['format'])
     _supports_indexing = True
 
     def new_like(self, cols, length, metadata_conflicts='warn', name=None):
@@ -224,7 +221,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         self._name = fix_column_name(name)
         self._parent_table = None
         self.unit = unit
-        self._format = format
+        self.format = format
         self.description = description
         self.meta = meta
         self.indices = deepcopy(getattr(data, 'indices', [])) if \
@@ -308,7 +305,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         5-tuple that has Column-specific state values.
         """
         # Get the Column attributes
-        names = ('_name', '_unit', '_format', 'description', 'meta', 'indices')
+        names = ('_name', '_unit', 'format', 'description', 'meta', 'indices')
         attrs = {name: val for name, val in zip(names, state[-1])}
 
         state = state[:-1]
@@ -344,6 +341,9 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         return reconstruct_func, reconstruct_func_args, state
 
     def __array_finalize__(self, obj):
+        # Tracer()()
+        print('__array_finalize__ self: {} {} obj: {} {}'
+              .format(type(self), id(self), type(obj), id(obj)))
         # Obj will be none for direct call to Column() creator
         if obj is None:
             return
@@ -406,29 +406,11 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     @property
     def format(self):
-        """
-        Format string for displaying values in this column.
-        """
-
-        return self._format
+        return self.info.format
 
     @format.setter
-    def format(self, format_string):
-
-        prev_format = getattr(self, '_format', None)
-
-        self._format = format_string  # set new format string
-
-        try:
-            # test whether it formats without error exemplarily
-            self.pformat(max_lines=1)
-        except Exception as err:
-            # revert to restore previous format if there was one
-            self._format = prev_format
-            raise ValueError(
-                "Invalid format for column '{0}': could not display "
-                "values in this column using this format ({1})".format(
-                    self.name, err.args[0]))
+    def format(self, value):
+        self.info.format = value
 
     @property
     def descr(self):
@@ -483,7 +465,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     @property
     def _formatter(self):
-        return FORMATTER if (self.parent_table is None) else self.parent_table.formatter
+        return self.info._formatter
 
     def pformat(self, max_lines=None, show_name=True, show_unit=False, show_dtype=False,
                 html=False):
@@ -519,10 +501,14 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             List of lines with header and formatted column values
 
         """
-        _pformat_col = self._formatter._pformat_col
-        lines, outs = _pformat_col(self, max_lines, show_name=show_name,
-                                   show_unit=show_unit, show_dtype=show_dtype,
-                                   html=html)
+        # _pformat_col = self._formatter._pformat_col
+        # lines, outs = _pformat_col(self, max_lines, show_name=show_name,
+        #                            show_unit=show_unit, show_dtype=show_dtype,
+        #                            html=html)
+        # return lines
+        lines = self.info.pformat(max_lines=max_lines, show_name=show_name,
+                                  show_unit=show_unit, show_dtype=show_dtype,
+                                  html=html)
         return lines
 
     def pprint(self, max_lines=None, show_name=True, show_unit=False, show_dtype=False):
@@ -549,16 +535,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         show_dtype : bool
             Include column dtype. Default is True.
         """
-        _pformat_col = self._formatter._pformat_col
-        lines, outs = _pformat_col(self, max_lines, show_name=show_name, show_unit=show_unit,
-                                   show_dtype=show_dtype)
-
-        n_header = outs['n_header']
-        for i, line in enumerate(lines):
-            if i < n_header:
-                color_print(line, 'red')
-            else:
-                print(line)
+        self.info.pprint(max_lines=max_lines, show_name=show_name,
+                         show_unit=show_unit, show_dtype=show_dtype)
 
     def more(self, max_lines=None, show_name=True, show_unit=False):
         """Interactively browse column with a paging interface.
@@ -587,9 +565,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             Include a header row for unit. Default is False.
 
         """
-        _more_tabcol = self._formatter._more_tabcol
-        _more_tabcol(self, max_lines=max_lines, show_name=show_name,
-                     show_unit=show_unit)
+        self.info.more(max_lines=max_lines, show_name=show_name, show_unit=show_unit)
 
     @property
     def unit(self):
@@ -725,8 +701,14 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         """
         Copy key column attributes from ``obj`` to self
         """
-        for attr in ('name', 'unit', '_format', 'description'):
+        if getattr(obj, 'description', None) == 'stop':
+            import pdb
+            pdb.set_trace()
+
+        for attr in ('name', 'unit', 'format', 'description'):
             val = getattr(obj, attr, None)
+            if val is not None:
+                print('Setting {} = {}'.format(attr, val))
             setattr(self, attr, val)
         self.meta = deepcopy(getattr(obj, 'meta', {}))
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -342,8 +342,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
     def __array_finalize__(self, obj):
         # Tracer()()
-        print('__array_finalize__ self: {} {} obj: {} {}'
-              .format(type(self), id(self), type(obj), id(obj)))
+        # print('__array_finalize__ self: {} {} obj: {} {}'
+        #       .format(type(self), id(self), type(obj), id(obj)))
         # Obj will be none for direct call to Column() creator
         if obj is None:
             return
@@ -707,8 +707,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         for attr in ('name', 'unit', 'format', 'description'):
             val = getattr(obj, attr, None)
-            if val is not None:
-                print('Setting {} = {}'.format(attr, val))
+            # if val is not None:
+            #     print('Setting {} = {}'.format(attr, val))
             setattr(self, attr, val)
         self.meta = deepcopy(getattr(obj, 'meta', {}))
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -710,8 +710,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         for attr in ('name', 'unit', 'format', 'description'):
             val = getattr(obj, attr, None)
-            if attr == 'format':
-                print('HERE in _copy_attrs():', type(obj), id(obj), val)
+            # if attr == 'format':
+            #     print('HERE in _copy_attrs():', type(obj), id(obj), val)
             # if val is not None:
             #     print('Setting {} = {}'.format(attr, val))
             setattr(self, attr, val)
@@ -1177,10 +1177,16 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
     @property
     def data(self):
-        out = self.view(ma.MaskedArray)
-        # The following is necessary because of a bug in Numpy, which was
-        # fixed in numpy/numpy#2703. The fix should be included in Numpy 1.8.0.
-        out.fill_value = self.fill_value
+        baseclass = self._baseclass
+        try:
+            self._baseclass = np.ndarray
+            out = self.view(ma.MaskedArray)
+        finally:
+            self._baseclass = baseclass
+        # out = self.view(ma.MaskedArray)
+        # # The following is necessary because of a bug in Numpy, which was
+        # # fixed in numpy/numpy#2703. The fix should be included in Numpy 1.8.0.
+        # out.fill_value = self.fill_value
         return out
 
     def filled(self, fill_value=None):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -351,6 +351,9 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         if callable(super().__array_finalize__):
             super().__array_finalize__(obj)
 
+        if not self.shape:
+            return
+
         # Self was created from template (e.g. obj[slice] or (obj * 2))
         # or viewcast e.g. obj.view(Column).  In either case we want to
         # init Column attributes for self from obj if possible.

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -717,3 +717,7 @@ class TableFormatter:
             if i0 >= len(tabcol) - delta_lines:
                 i0 = len(tabcol) - delta_lines
             print("\n")
+
+# Create a generic TableFormatter object for use by bare columns with no
+# parent table.
+FORMATTER = TableFormatter()

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -164,10 +164,13 @@ class TestColumn():
         c1.format = '%d'
         c1.description = 'bb'
         c1.meta = {'bbb': 2}
+        assert c1.format == '%d'
 
         for item in (slice(None, None), slice(None, 1), np.array([0, 2]),
                      np.array([False, True, False])):
+            assert c1.format == '%d'
             c2 = c1[item]
+            assert c1.format == '%d'
             assert c2.name == 'b'
             assert c2.unit is u.km
             assert c2.format == '%d'

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -202,13 +202,11 @@ class DataInfo:
     """
     _stats = ['mean', 'std', 'min', 'max']
     attrs_from_parent = set()
-    attr_names = set(['name', 'unit', 'dtype', 'format', 'description'])
+    attr_names = set(['name', 'unit', 'dtype', 'format', 'description', 'meta'])
     _attrs_no_copy = set()
     _info_summary_attrs = ('dtype', 'shape', 'unit', 'format', 'description', 'class')
     _represent_as_dict_attrs = ()
     _parent_ref = None
-
-    meta = metadata.MetaData()
 
     def __init__(self, bound=False):
         # If bound to a data object instance then create the dict of attributes

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -644,8 +644,10 @@ class BaseColumnInfo(DataInfo):
         try:
             # test whether it formats without error exemplarily
             self.pformat(max_lines=1)
-        except TypeError as err:
-            # revert to restore previous format if there was one
+        except Exception as err:
+            # Something went wrong so revert to restore previous format if there was one.
+            # With Python 3 exception chaining the original exception will also be shown
+            # so we can be safe with the generic Exception catch here.
             self._attrs['format'] = prev_format
             raise ValueError(
                 "Invalid format for column '{0}': could not display "


### PR DESCRIPTION
This is a WIP of moving all the column formatting infrastructure into `Info`.  In particular this makes Quantity much more like Column.  This would also apply to other mixins where it makes sense.
```
In [3]: q = [1,2,3]*u.m

In [4]: q.info.format = '.3f'

In [5]: q.info.pprint()  # Even for a bare quantity, but also within a Table
 None
-----
1.000
2.000
3.000

In [6]: q.info.format = 'asdf'  # Instant validation
ValueError: unable to parse format string asdf for its column.
```
But.. this re-introduced some weird regression, possibly related to MaskedArray and `__array_finalize__` that was fixed in #3023.  Not clear at this point.  @mhvk if you have ideas let me know!
```
In [7]: c1 = MaskedColumn([1,2], format='%d')

In [8]: c1.format
Out[8]: '%d'

In [9]: c2 = c1[:]

In [11]: print(c1.format)  # YIKES!!
None

In [12]: print(c2.format)
None
```
