### PR TITLE
Removing superflous test marked with xfail

### DIFF
--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -526,15 +526,6 @@ def test_conversion_qtable_table():
         assert_table_name_col_equal(qt2, name, qt[name])
 
 
-@pytest.mark.xfail
-def test_column_rename():
-    qt = QTable(MIXIN_COLS)
-    names = qt.colnames
-    for name in names:
-        qt.rename_column(name, name + '2')
-    assert qt.colnames == [name + '2' for name in names]
-
-
 def test_setitem_as_column_name():
     """
     Test for mixin-related regression described in #3321.


### PR DESCRIPTION
This PR is to partially address #6665.

1 of the 3 xpassing tests is a clear case as renaming mixin columns has been implemented since 1.3 (#5469). The PR implementing it also added tests rather than removed the xfail from the existing one, so this one became superfluous and thus I suggest to remove it altogether.