### PR TITLE
Add mirror for Matplotlib image tests and fix use of mirror when --remote-data=astropy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -408,6 +408,9 @@ astropy.tests
 
 - Fixed a bug that caused the doctestplus plugin to not work nicely with the hypothesis package. [#6605]
 
+- Fixed a bug that meant that the data.astropy.org mirror could not be used when
+  using --remote-data=astropy. [#6724]
+
 astropy.time
 ^^^^^^^^^^^^
 
@@ -422,6 +425,9 @@ astropy.utils
 
 - Fixed bugs in remote data handling and also in IERS unit test related to path
   URL, and URI normalization on Windows. [#6651]
+
+- Fixed a bug that caused ``get_pkg_data_fileobj`` to not work correctly when
+  used with non-local data from inside packages. [#6724]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -121,9 +121,15 @@ def get_builtin_sites():
     return SiteRegistry.from_json(jsondb)
 
 
-def get_downloaded_sites(jsonurl='http://data.astropy.org/coordinates/sites.json'):
+def get_downloaded_sites(jsonurl=None):
     """
     Load observatory database from data.astropy.org and parse into a SiteRegistry
     """
-    jsondb = json.loads(get_file_contents(jsonurl, show_progress=False))
+
+    if jsonurl is None:
+        content = get_pkg_data_contents('coordinates/sites.json')
+    else:
+        content = get_file_contents(jsonurl)
+
+    jsondb = json.loads(content)
     return SiteRegistry.from_json(jsondb)

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -28,7 +28,7 @@ def test_builtin_sites():
 
 
 @remote_data(source='astropy')
-def test_online_stes():
+def test_online_sites():
     reg = get_downloaded_sites()
 
     keck = reg['keck']

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -52,7 +52,7 @@ def check_internet_off(original_function, allow_astropy_data=False):
             valid_hosts = ('localhost', '127.0.0.1')
 
         if allow_astropy_data:
-            for valid_host in ('data.astropy.org', 'astropy.stsci.edu'):
+            for valid_host in ('data.astropy.org', 'astropy.stsci.edu', 'www.astropy.org'):
                 valid_host_ip = socket.gethostbyname(valid_host)
                 valid_hosts += (valid_host, valid_host_ip)
 

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -4,6 +4,7 @@ import matplotlib
 
 MPL_VERSION = LooseVersion(matplotlib.__version__)
 
-ROOT = "http://data.astropy.org/testing/astropy/2017-07-12T14:12:26.217559"
+ROOT = "http://{server}/testing/astropy/2017-07-12T14:12:26.217559/{mpl_version}/"
 
-IMAGE_REFERENCE_DIR = ROOT + '/1.5.x/'
+IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version='1.5.x') + ',' +
+                       ROOT.format(server='www.astropy.org/astropy-data', mpl_version='1.5.x'))

--- a/astropy/tests/tests/test_socketblocker.py
+++ b/astropy/tests/tests/test_socketblocker.py
@@ -14,7 +14,7 @@ from ..disable_internet import no_internet
 def test_outgoing_fails():
     with pytest.raises(IOError):
         with no_internet():
-            urlopen('http://www.astropy.org')
+            urlopen('http://www.python.org')
 
 
 class StoppableHTTPServer(HTTPServer, object):

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -48,7 +48,7 @@ class Conf(_config.ConfigNamespace):
         'http://data.astropy.org/',
         'Primary URL for astropy remote data site.')
     dataurl_mirror = _config.ConfigItem(
-        'http://astropy.org/astropy-data/',
+        'http://www.astropy.org/astropy-data/',
         'Mirror URL for astropy remote data site.')
     remote_timeout = _config.ConfigItem(
         10.,

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -446,13 +446,13 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
         all_urls = (conf.dataurl, conf.dataurl_mirror)
         for url in all_urls:
             try:
-                return get_readable_fileobj(url + datafn, encoding=encoding,
+                return get_readable_fileobj(url + data_name, encoding=encoding,
                                             cache=cache)
             except urllib.error.URLError as e:
                 pass
         urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
         raise urllib.error.URLError("Failed to download {0} from the following "
-                                    "repositories:\n\n{1}".format(datafn, urls))
+                                    "repositories:\n\n{1}".format(data_name, urls))
 
 
 def get_pkg_data_filename(data_name, package=None, show_progress=True,

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -449,7 +449,7 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
     monkeypatch.setattr(tempfile, 'tempdir', str(tmpdir))
 
     # Call get_readable_fileobj() as a context manager
-    with get_readable_fileobj(url) as fileobj:  # noqa
+    with get_readable_fileobj(url):
         pass
 
     # Get listing of files in temporary directory

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -17,7 +17,7 @@ import pytest
 from ..data import (_get_download_cache_locs, CacheMissingWarning,
                     get_pkg_data_filename, get_readable_fileobj)
 
-from ...tests.helper import remote_data, raises, pytest, catch_warnings
+from ...tests.helper import remote_data, raises, catch_warnings
 
 TESTURL = 'http://www.astropy.org'
 
@@ -25,21 +25,21 @@ TESTURL = 'http://www.astropy.org'
 
 
 try:
-    import bz2  # pylint: disable=W0611
+    import bz2  # noqa
 except ImportError:
     HAS_BZ2 = False
 else:
     HAS_BZ2 = True
 
 try:
-    import lzma
+    import lzma  # noqa
 except ImportError:
     HAS_XZ = False
 else:
     HAS_XZ = True
 
 
-@remote_data
+@remote_data('astropy')
 def test_download_nocache():
     from ..data import download_file
 
@@ -47,7 +47,7 @@ def test_download_nocache():
     assert os.path.isfile(fnout)
 
 
-@remote_data
+@remote_data('astropy')
 def test_download_parallel():
     from ..data import download_files_in_parallel
 
@@ -57,7 +57,7 @@ def test_download_parallel():
     assert all([os.path.isfile(f) for f in fnout]), fnout
 
 
-@remote_data
+@remote_data('astropy')
 def test_download_noprogress():
     from ..data import download_file
 
@@ -65,7 +65,7 @@ def test_download_noprogress():
     assert os.path.isfile(fnout)
 
 
-@remote_data
+@remote_data('astropy')
 def test_download_cache():
 
     from ..data import download_file, clear_download_cache
@@ -98,7 +98,7 @@ def test_download_cache():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data
+@remote_data('astropy')
 def test_url_nocache():
 
     from ..data import get_readable_fileobj
@@ -107,7 +107,7 @@ def test_url_nocache():
         assert page.read().find('Astropy') > -1
 
 
-@remote_data
+@remote_data('astropy')
 def test_find_by_hash():
 
     from ..data import get_readable_fileobj, get_pkg_data_filename, clear_download_cache
@@ -126,17 +126,19 @@ def test_find_by_hash():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data
-def test_find_by_hash():
+@remote_data('astropy')
+def test_find_invalid():
     from ..data import get_pkg_data_filename
 
-    # this is of course not a real data file and not on any remote server, but it should *try* to go to the remote server
+    # this is of course not a real data file and not on any remote server, but
+    # it should *try* to go to the remote server
     with pytest.raises(urllib.error.URLError):
         get_pkg_data_filename('kjfrhgjklahgiulrhgiuraehgiurhgiuhreglhurieghruelighiuerahiulruli')
 
 
 # Package data functions
-@pytest.mark.parametrize(('filename'), ['local.dat', 'local.dat.gz', 'local.dat.bz2', 'local.dat.xz'])
+@pytest.mark.parametrize(('filename'), ['local.dat', 'local.dat.gz',
+                                        'local.dat.bz2', 'local.dat.xz'])
 def test_local_data_obj(filename):
     from ..data import get_pkg_data_fileobj
 
@@ -176,7 +178,6 @@ def bad_compressed(request, tmpdir):
 
 
 def test_local_data_obj_invalid(bad_compressed):
-    from ..data import get_pkg_data_fileobj
 
     is_bz2 = bad_compressed.endswith('.bz2')
     is_xz = bad_compressed.endswith('.xz')
@@ -271,7 +272,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
-@remote_data
+@remote_data('astropy')
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
@@ -369,14 +370,16 @@ def test_read_unicode(filename):
     contents = get_pkg_data_contents(os.path.join('data', filename), encoding='binary')
     assert isinstance(contents, bytes)
     x = contents.splitlines()[1]
-    assert x == b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0\xd7\x95\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:]
+    assert x == (b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0"
+                 b"\xd7\x95\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:])
 
 
 def test_compressed_stream():
     import base64
     from ..data import get_readable_fileobj
 
-    gzipped_data = b"H4sICIxwG1AAA2xvY2FsLmRhdAALycgsVkjLzElVANKlxakpCpl5CiUZqQolqcUl8Tn5yYk58SmJJYnxWmCRzLx0hbTSvOSSzPy8Yi5nf78QV78QLgAlLytnRQAAAA=="
+    gzipped_data = (b"H4sICIxwG1AAA2xvY2FsLmRhdAALycgsVkjLzElVANKlxakpCpl5CiUZqQ"
+                    b"olqcUl8Tn5yYk58SmJJYnxWmCRzLx0hbTSvOSSzPy8Yi5nf78QV78QLgAlLytnRQAAAA==")
     gzipped_data = base64.b64decode(gzipped_data)
     assert isinstance(gzipped_data, bytes)
 
@@ -403,7 +406,7 @@ def test_compressed_stream():
         assert f.read().rstrip() == b'CONTENT'
 
 
-@remote_data
+@remote_data('astropy')
 def test_invalid_location_download():
     """
     checks that download_file gives a URLError and not an AttributeError,
@@ -412,7 +415,7 @@ def test_invalid_location_download():
     from ..data import download_file
 
     with pytest.raises(urllib.error.URLError):
-        download_file('http://astropy.org/nonexistentfile')
+        download_file('http://www.astropy.org/nonexistentfile')
 
 
 def test_invalid_location_download_noconnect():
@@ -426,7 +429,7 @@ def test_invalid_location_download_noconnect():
         download_file('http://astropy.org/nonexistentfile')
 
 
-@remote_data
+@remote_data('astropy')
 def test_is_url_in_cache():
     from ..data import download_file, is_url_in_cache
 
@@ -446,7 +449,7 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
     monkeypatch.setattr(tempfile, 'tempdir', str(tmpdir))
 
     # Call get_readable_fileobj() as a context manager
-    with get_readable_fileobj(url) as fileobj:
+    with get_readable_fileobj(url) as fileobj:  # noqa
         pass
 
     # Get listing of files in temporary directory
@@ -460,10 +463,11 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
 def test_path_objects_get_readable_fileobj():
     fpath = pathlib.Path(get_pkg_data_filename(os.path.join('data', 'local.dat')))
     with get_readable_fileobj(fpath) as f:
-        assert f.read().rstrip() == 'This file is used in the test_local_data_* testing functions\nCONTENT'
+        assert f.read().rstrip() == ('This file is used in the test_local_data_* '
+                                     'testing functions\nCONTENT')
 
 
-@remote_data
+@remote_data('astropy')
 def test_get_cached_urls():
     from ..data import download_file, get_cached_urls
     download_file(TESTURL, cache=True, show_progress=False)


### PR DESCRIPTION
This adds a mirror for the Matplotlib image tests (requires pytest-mpl >= 0.9).

While doing this I realized that our mirror system never actually worked when using ``--remote-data=astropy`` because the mirror didn't have an allowed URL - for instance today data.astropy.org was a bit slow so https://github.com/astropy/astropy/pull/6729 failed - what happened is that first data.astropy.org failed due to timeout, then the mirror server failed because it wasn't allowed. This PR also fixes this, so I think we should see way fewer remote errors now across the board (hopefully).