### PR TITLE
Reverting temporary xfails for semi-randomly failing test

### DIFF
--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -706,7 +706,6 @@ class TestVStack():
                                                     '0.0 foo',
                                                     '1.0  --']
 
-    @pytest.mark.xfail(reason="https://github.com/astropy/astropy/issues/6291")
     def test_col_meta_merge_inner(self, operation_table_type):
         self._setup(operation_table_type)
         t1 = self.t1


### PR DESCRIPTION
This PR is the revert of #6351 that was temporarily put in place before the 2.0 release.

The nature of the original bug (#6291) was such as we couldn't consistently reproduce it, and the only way to really see whether it's solved in the meantime is to let CI catch possible failures.

Ideally this should be backported to the 2.0.x branch, but we should milestone it as such when we are certain that the bug is gone.
(Thus I'm adding the "manual backport" label for now to make sure it'll be noticed at release times...)

