### PR TITLE
Fix bug with writing FITS diffs to files in Py3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix bug when writing the results of ``fitsdiff`` to files. [#6726]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -293,7 +293,7 @@ def main():
     if opts.quiet:
         out_file = None
     elif opts.output_file:
-        out_file = open(opts.output_file, 'wb')
+        out_file = open(opts.output_file, 'w')
         close_file = True
     else:
         out_file = sys.stdout


### PR DESCRIPTION
This is a "backport" to 2.0.x. There's not a test for this case currently. It would be easy enough to add one, but it would need to be "forward" ported.

@saimn, @MSeifert04 let me know if you want me to add a unit test.