### PR TITLE
ndarray.reshape doesn't need a tuple it accepts varargs

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -450,7 +450,7 @@ class FITS_rec(np.recarray):
                 if outarr.ndim > 1:
                     # The normal case where the first dimension is the rows
                     inarr_rowsize = inarr[0].size
-                    inarr = inarr.reshape((n, inarr_rowsize))
+                    inarr = inarr.reshape(n, inarr_rowsize)
                     outarr[:, :inarr_rowsize] = inarr
                 else:
                     # Special case for strings where the out array only has one

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -266,8 +266,8 @@ class TestDiff(FitsTestCase):
         assert diff.diff_keyword_comments == {'C': [('C', 'E')]}
 
     def test_trivial_identical_images(self):
-        ia = np.arange(100).reshape((10, 10))
-        ib = np.arange(100).reshape((10, 10))
+        ia = np.arange(100).reshape(10, 10)
+        ib = np.arange(100).reshape(10, 10)
         diff = ImageDataDiff(ia, ib)
         assert diff.identical
         assert diff.diff_total == 0
@@ -313,7 +313,7 @@ class TestDiff(FitsTestCase):
         looking for (or ignoring) header differences.
         """
 
-        data = np.arange(100.0).reshape((10, 10))
+        data = np.arange(100.0).reshape(10, 10)
         hdu = fits.CompImageHDU(data=data)
         hdu.writeto(self.temp('test.fits'))
         hdula = fits.open(self.temp('test.fits'))
@@ -322,7 +322,7 @@ class TestDiff(FitsTestCase):
         assert diff.identical
 
     def test_different_dimensions(self):
-        ia = np.arange(100).reshape((10, 10))
+        ia = np.arange(100).reshape(10, 10)
         ib = np.arange(100) - 1
 
         # Although ib could be reshaped into the same dimensions, for now the
@@ -339,8 +339,8 @@ class TestDiff(FitsTestCase):
         assert 'No further data comparison performed.'
 
     def test_different_pixels(self):
-        ia = np.arange(100).reshape((10, 10))
-        ib = np.arange(100).reshape((10, 10))
+        ia = np.arange(100).reshape(10, 10)
+        ib = np.arange(100).reshape(10, 10)
         ib[0, 0] = 10
         ib[5, 5] = 20
         diff = ImageDataDiff(ia, ib)
@@ -567,7 +567,7 @@ class TestDiff(FitsTestCase):
     def test_identical_files_basic(self):
         """Test identicality of two simple, extensionless files."""
 
-        a = np.arange(100).reshape((10, 10))
+        a = np.arange(100).reshape(10, 10)
         hdu = PrimaryHDU(data=a)
         hdu.writeto(self.temp('testa.fits'))
         hdu.writeto(self.temp('testb.fits'))
@@ -593,7 +593,7 @@ class TestDiff(FitsTestCase):
         count.
         """
 
-        a = np.arange(100).reshape((10, 10))
+        a = np.arange(100).reshape(10, 10)
         phdu = PrimaryHDU(data=a)
         ehdu = ImageHDU(data=a)
         hdula = HDUList([phdu, ehdu])
@@ -616,7 +616,7 @@ class TestDiff(FitsTestCase):
         Test files that have some identical HDUs but one different HDU.
         """
 
-        a = np.arange(100).reshape((10, 10))
+        a = np.arange(100).reshape(10, 10)
         phdu = PrimaryHDU(data=a)
         ehdu = ImageHDU(data=a)
         ehdu2 = ImageHDU(data=(a + 1))

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -532,7 +532,7 @@ class TestHDUListFunctions(FitsTestCase):
         Open files with nulls for header block padding instead of spaces.
         """
 
-        a = np.arange(100).reshape((10, 10))
+        a = np.arange(100).reshape(10, 10)
         hdu = fits.PrimaryHDU(data=a)
         hdu.writeto(self.temp('temp.fits'))
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1908,7 +1908,7 @@ class TestHeaderFunctions(FitsTestCase):
         by several blank cards.
         """
 
-        data = np.arange(100).reshape((10, 10))
+        data = np.arange(100).reshape(10, 10)
         hdu = fits.PrimaryHDU(data=data)
         hdu.header['TESTKW'] = ('Test val', 'This is the END')
         # Add a couple blanks after the END string

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -439,7 +439,7 @@ class TestImageFunctions(FitsTestCase):
         assert np.array_equal(sec[0, ...], dat[0, ...])
 
     def test_section_data_square(self):
-        a = np.arange(4).reshape((2, 2))
+        a = np.arange(4).reshape(2, 2)
         hdu = fits.PrimaryHDU(a)
         hdu.writeto(self.temp('test_new.fits'))
 
@@ -461,7 +461,7 @@ class TestImageFunctions(FitsTestCase):
         assert (d.section[0:2, 0:2] == dat[0:2, 0:2]).all()
 
     def test_section_data_cube(self):
-        a = np.arange(18).reshape((2, 3, 3))
+        a = np.arange(18).reshape(2, 3, 3)
         hdu = fits.PrimaryHDU(a)
         hdu.writeto(self.temp('test_new.fits'))
 
@@ -590,7 +590,7 @@ class TestImageFunctions(FitsTestCase):
         assert (d.section[1:2, 1:3, 2:3] == dat[1:2, 1:3, 2:3]).all()
 
     def test_section_data_four(self):
-        a = np.arange(256).reshape((4, 4, 4, 4))
+        a = np.arange(256).reshape(4, 4, 4, 4)
         hdu = fits.PrimaryHDU(a)
         hdu.writeto(self.temp('test_new.fits'))
 
@@ -1220,7 +1220,7 @@ class TestCompressedImage(FitsTestCase):
         be flattened to two dimensions.
         """
 
-        cube = np.arange(300, dtype=np.float32).reshape((3, 10, 10))
+        cube = np.arange(300, dtype=np.float32).reshape(3, 10, 10)
         hdu = fits.CompImageHDU(data=cube, name='SCI',
                                 compressionType='HCOMPRESS_1',
                                 quantizeLevel=16, tileSize=[5, 5, 1])


### PR DESCRIPTION
There were several instances where the argument for `reshape` was a tuple. The tuple however isn't necessary, one can just as well pass in the new dimensions as varargs.