### PR TITLE
Use direct imports for pytest

### DIFF
--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -2,9 +2,10 @@
 
 import math
 import numpy as np
+import pytest
+
 from ..convolve import convolve, convolve_fft, convolve_models
 from ...modeling import models, fitting
-from ...tests.helper import pytest
 from ...utils.misc import NumpyRNGContext
 from numpy.testing import assert_allclose, assert_almost_equal
 

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -6,6 +6,7 @@ Tests that relate to evaluating models with quantity parameters
 
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 
@@ -13,7 +14,7 @@ from ..core import Model
 from ..models import Gaussian1D
 from ... import units as u
 from ...units import UnitsError
-from ...tests.helper import pytest, assert_quantity_allclose
+from ...tests.helper import assert_quantity_allclose
 
 
 # We start off by taking some simple cases where the units are defined by

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -6,11 +6,12 @@ Tests that relate to fitting models with quantity parameters
 
 
 import numpy as np
+import pytest
 
 from ..models import Gaussian1D
 from ... import units as u
 from ...units import UnitsError
-from ...tests.helper import pytest, assert_quantity_allclose
+from ...tests.helper import assert_quantity_allclose
 from ...utils import NumpyRNGContext
 from .. import fitting
 

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -6,6 +6,7 @@ Tests that relate to using quantities/units on parameters of models.
 
 
 import numpy as np
+import pytest
 
 from ..core import Model, Fittable1DModel, InputParameterError
 from ..parameters import Parameter, ParameterDefinitionError
@@ -13,7 +14,7 @@ from ..models import (Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial,
                       Rotation2D)
 from ... import units as u
 from ...units import UnitsError
-from ...tests.helper import pytest, assert_quantity_allclose
+from ...tests.helper import assert_quantity_allclose
 from ... import coordinates as coord
 
 

--- a/astropy/stats/lombscargle/tests/test_statistics.py
+++ b/astropy/stats/lombscargle/tests/test_statistics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
 try:
@@ -8,7 +9,6 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from ....tests.helper import pytest
 from .. import LombScargle
 from .._statistics import (cdf_single, pdf_single, fap_single, inv_fap_single,
                            METHODS)

--- a/astropy/stats/lombscargle/tests/test_utils.py
+++ b/astropy/stats/lombscargle/tests/test_utils.py
@@ -1,7 +1,7 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 
-from ....tests.helper import pytest
 from ..utils import convert_normalization, compute_chi2_ref
 from ..core import LombScargle
 

--- a/astropy/stats/tests/test_spatial.py
+++ b/astropy/stats/tests/test_spatial.py
@@ -1,10 +1,10 @@
 
 import numpy as np
+import pytest
 
 from numpy.testing.utils import assert_allclose
 from ..spatial import RipleysKEstimator
 from ...utils.misc import NumpyRNGContext
-from ...tests.helper import pytest
 
 
 a = np.array([[1, 4], [2, 5], [3, 6]])

--- a/astropy/tests/pytest_remotedata.py
+++ b/astropy/tests/pytest_remotedata.py
@@ -4,7 +4,7 @@ These plugins modify the behavior of py.test and are meant to be imported
 into conftest.py in the root directory.
 """
 
-from .helper import pytest
+import pytest
 from .disable_internet import turn_off_internet, turn_on_internet
 
 


### PR DESCRIPTION
Bundled pytest was removed in v2.0 (#5694) so it must now be imported directly.
Most of theses changes should be backported (see https://github.com/astropy/astropy/pull/6726#issuecomment-336376866), but there may be conflicts for the others:
```
~/dev/astropy v2.0.x
❯ grep -ir "helper import pytest"
docs/development/testguide.rst:    from ...tests.helper import pytest
astropy/convolution/tests/test_convolve_models.py:from ...tests.helper import pytest
astropy/modeling/tests/test_quantities_fitting.py:from ...tests.helper import pytest, assert_quantity_allclose
astropy/modeling/tests/test_quantities_parameters.py:from ...tests.helper import pytest, assert_quantity_allclose
astropy/modeling/tests/test_quantities_evaluation.py:from ...tests.helper import pytest, assert_quantity_allclose
astropy/stats/tests/test_spatial.py:from ...tests.helper import pytest
```