### PR TITLE
Removing more bundled pytest imports

### DIFF
--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -13,13 +13,12 @@ deviations from the original APE5 plan.
 """
 
 import pytest
-
 import numpy as np
 from numpy.random import randn
 from numpy import testing as npt
-from ...tests.helper import (quantity_allclose as allclose,
-                             assert_quantity_allclose as assert_allclose)
 
+from ...tests.helper import (raises, quantity_allclose as allclose,
+                             assert_quantity_allclose as assert_allclose)
 from ... import units as u
 from ... import time
 from ... import coordinates as coords
@@ -30,8 +29,6 @@ except ImportError:
     HAS_SCIPY = False
 else:
     HAS_SCIPY = True
-
-raises = pytest.raises
 
 
 def test_representations_api():

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -12,17 +12,17 @@ this package, like ``test_sky_coord.py``, ``test_frames.py``, or
 deviations from the original APE5 plan.
 """
 
+import pytest
+
 import numpy as np
 from numpy.random import randn
 from numpy import testing as npt
-from ...tests.helper import (pytest, quantity_allclose as allclose,
+from ...tests.helper import (quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
-raises = pytest.raises
 
 from ... import units as u
 from ... import time
 from ... import coordinates as coords
-from ..errors import *
 
 try:
     import scipy  # pylint: disable=W0611
@@ -30,6 +30,8 @@ except ImportError:
     HAS_SCIPY = False
 else:
     HAS_SCIPY = True
+
+raises = pytest.raises
 
 
 def test_representations_api():

--- a/astropy/coordinates/tests/test_atc_replacements.py
+++ b/astropy/coordinates/tests/test_atc_replacements.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-
 """Test replacements for ERFA functions atciqz and aticq."""
 
 from itertools import product
-from ...tests.helper import (pytest,
-                             assert_quantity_allclose as assert_allclose)
 
+import pytest
+
+from ...tests.helper import assert_quantity_allclose as assert_allclose
 from ...time import Time
-
 from ... import _erfa as erfa
 from .utils import randomly_sample_sphere
 from ..builtin_frames.utils import get_jd12, atciqz, aticq

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
+import pytest
 import numpy as np
 
 from ... import units as u
@@ -9,7 +9,7 @@ from ..distances import Distance
 from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
                               Supergalactic, Galactocentric, HCRS, GCRS, LSR)
 from .. import SkyCoord
-from ...tests.helper import (pytest, quantity_allclose as allclose,
+from ...tests.helper import (quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from .. import EarthLocation, CartesianRepresentation
 from ...time import Time

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -3,11 +3,11 @@
 
 """
 
+import pytest
 import numpy as np
 
 from ... import units as u
-from ...tests.helper import (pytest, remote_data,
-                             quantity_allclose as allclose,
+from ...tests.helper import (remote_data, quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 """
 This module contains tests for the name resolve convenience module.
 """
@@ -8,12 +7,13 @@ This module contains tests for the name resolve convenience module.
 import time
 import urllib.request
 
+import pytest
 import numpy as np
 
 from ..name_resolve import (get_icrs_coordinates, NameResolveError,
                             sesame_database, _parse_response, sesame_url)
 from ..sky_coordinate import SkyCoord
-from ...tests.helper import remote_data, pytest
+from ...tests.helper import remote_data
 from ... import units as u
 
 _cached_ngc3642 = dict()

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1,32 +1,30 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 from copy import deepcopy
 from collections import OrderedDict
 
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
 from ... import units as u
-from ...tests.helper import (pytest, assert_quantity_allclose as
+from ...tests.helper import (assert_quantity_allclose as
                              assert_allclose_quantity)
-from ...utils import isiterable, IncompatibleShapeError, check_broadcast
+from ...utils import isiterable
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
 from ..representation import (REPRESENTATION_CLASSES,
                               DIFFERENTIAL_CLASSES,
-                              BaseRepresentation, BaseDifferential,
+                              BaseRepresentation,
                               SphericalRepresentation,
                               UnitSphericalRepresentation,
                               SphericalCosLatDifferential,
-                              UnitSphericalCosLatDifferential,
                               CartesianRepresentation,
                               CylindricalRepresentation,
                               PhysicsSphericalRepresentation,
                               CartesianDifferential,
                               SphericalDifferential,
-                              CylindricalDifferential,
                               _combine_xyz)
 
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -6,14 +6,14 @@ Tests for the SkyCoord class.  Note that there are also SkyCoord tests in
 test_api_ape5.py
 """
 
-
 import copy
 
+import pytest
 import numpy as np
 import numpy.testing as npt
 
 from ... import units as u
-from ...tests.helper import (pytest, remote_data, catch_warnings,
+from ...tests.helper import (remote_data, catch_warnings,
                              quantity_allclose,
                              assert_quantity_allclose as assert_allclose)
 from ..representation import REPRESENTATION_CLASSES

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
+import pytest
 import numpy as np
 
 from ... import units as u
@@ -9,9 +9,7 @@ from ..distances import Distance
 from ..builtin_frames import ICRS, FK5, Galactic, AltAz, SkyOffsetFrame
 from .. import SkyCoord, EarthLocation
 from ...time import Time
-from ...tests.helper import (pytest, quantity_allclose as allclose,
-                             assert_quantity_allclose as assert_allclose)
-
+from ...tests.helper import assert_quantity_allclose as assert_allclose
 
 
 @pytest.mark.parametrize("inradec,expectedlatlon, tolsep", [

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -1,4 +1,5 @@
 
+import pytest
 import numpy as np
 
 from ...time import Time
@@ -11,7 +12,7 @@ from ..solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
                             _apparent_position_in_true_coordinates,
                             get_body_barycentric, get_body_barycentric_posvel)
 from ..funcs import get_sun
-from ...tests.helper import (pytest, remote_data, assert_quantity_allclose,
+from ...tests.helper import (remote_data, assert_quantity_allclose,
                              quantity_allclose)
 
 try:

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import inspect
 
+import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings, pytest
+from ...tests.helper import catch_warnings
 from ...utils.exceptions import AstropyUserWarning
 from ... import units as u
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import gc
 import sys
 import copy
 from io import StringIO
 from collections import OrderedDict
 
+import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
 from ...io import fits
-from ...tests.helper import (pytest, assert_follows_unicode_guidelines,
+from ...tests.helper import (assert_follows_unicode_guidelines,
                              ignore_warnings, catch_warnings)
 from ...utils.data import get_pkg_data_filename
 from ... import table

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -1,8 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
 from ... import units as u
 from ...coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
 from .. import Time, TimeDelta
-from ...tests.helper import (pytest, remote_data)
+from ...tests.helper import remote_data
 
 try:
     import jplephem  # pylint: disable=W0611

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -9,11 +9,12 @@ import pickle
 import decimal
 from fractions import Fraction
 
+import pytest
 import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
 
-from ...tests.helper import raises, pytest
+from ...tests.helper import raises
 from ...utils import isiterable, minversion
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -17,7 +17,7 @@ import pytest
 from ..data import (_get_download_cache_locs, CacheMissingWarning,
                     get_pkg_data_filename, get_readable_fileobj)
 
-from ...tests.helper import remote_data, raises, pytest, catch_warnings
+from ...tests.helper import remote_data, raises, catch_warnings
 
 TESTURL = 'http://www.astropy.org'
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import os
 import warnings
 
+import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -11,7 +11,7 @@ from .... import units as u
 from ....wcs import WCS
 from ....io import fits
 from ....coordinates import SkyCoord
-from ....tests.helper import catch_warnings, pytest
+from ....tests.helper import catch_warnings
 
 from ..core import WCSAxes
 from ..utils import get_coord_meta

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1,19 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-
-
 import io
 import os
 import warnings
 from datetime import datetime
 
+import pytest
 import numpy as np
 from numpy.testing import (
     assert_allclose, assert_array_almost_equal, assert_array_almost_equal_nulp,
     assert_array_equal)
 
-from ...tests.helper import raises, catch_warnings, pytest
+from ...tests.helper import raises, catch_warnings
 from ... import wcs
 from .. import _wcs
 from ...utils.data import (


### PR DESCRIPTION
and some other minor import cleanup in the same files.

These were sadly missed out in #6729 and only noticed them after that one was merged.

(``grep -r pytest astropy|grep import|grep tests.helper``)