### PR TITLE
Revert matplotlib.pyplot intersphinx workaround

### DIFF
--- a/docs/development/codeguide_emacs.rst
+++ b/docs/development/codeguide_emacs.rst
@@ -46,7 +46,7 @@ is saved, use::
 
   ;; Automatically remove trailing whitespace when file is saved.
   (add-hook 'python-mode-hook
-    (lambda () (add-to-list 'write-file-functions 'delete-trailing-whitespace)))
+  (lambda () (add-to-list 'write-file-functions 'delete-trailing-whitespace)))
 
 If you want to use this for every type of file, you can use
 ``(add-hook 'before-save-hook 'delete-trailing-whitespace)``.
@@ -61,6 +61,7 @@ default, flycheck_ will check if flake8_ is installed and, if so, use that for
 its syntax checking. To ensure flycheck_ starts upon opening python files, add:
 
 .. code-block:: scheme
+
   (add-hook 'python-mode-hook 'flycheck-mode)
 
 Alternatively, you can just use ``(global-flycheck-mode)`` to run flycheck

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -85,9 +85,3 @@ py:obj RuntimeError
 py:obj NotImplementedError
 py:obj AttributeError
 py:obj NotImplementedError
-
-# Affecting mpl 2.1, may be removed in the future pending on
-# https://github.com/matplotlib/matplotlib/issues/9331
-# TODO: remove the exceptions
-py:obj matplotlib.pyplot
-py:mod matplotlib.pyplot


### PR DESCRIPTION
The issue (#6695) has been resolved upstream (https://github.com/matplotlib/matplotlib/issues/9331#issuecomment-336586000), so this PR reverts our local workaround.

closes #6695