### PR TITLE
Explain d3d in examples and docstring

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -821,7 +821,9 @@ class SkyCoord(ShapedLikeNDArray):
         dist3d : `~astropy.units.Quantity`
             The 3D distance between the closest match for each element
             in this object in ``catalogcoord``. Shape matches this
-            object.
+            object. Unless both this and ``catalogcoord`` have associated
+            distances, this quantity assumes that all sources are at a
+            distance of 1 (dimensionless).
 
         Notes
         -----

--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -156,6 +156,11 @@ of other coordinates. For example, assuming ``ra1``/``dec1`` and
     >>> catalog = SkyCoord(ra=ra2*u.degree, dec=dec2*u.degree)  # doctest: +SKIP
     >>> idx, d2d, d3d = c.match_to_catalog_sky(catalog)  # doctest: +SKIP
 
+The 3-dimensional distances returned ``d3d`` are 3-dimensional distances.
+Unless both source (``c``) and catalog (``catalog``) coordinates have
+associated distances, this quantity assumes that all sources are at a distance
+of 1 (dimensionless).
+
 You can also find the nearest 3d matches, different from the on-sky
 separation shown above only when the coordinates were initialized with
 a ``distance``::


### PR DESCRIPTION
This is to fix #6718. It seemed that the return values of `match_to_catalog_sky` weren't going to change, so I suggest to at least update the docs.