### PR TITLE
Ignore lastfailed (direct pytest invokation) file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ htmlcov
 
 # PyCharm
 .idea
+
+# Pytest
+v


### PR DESCRIPTION
If a test failed when running pytest directly a `v/cache/lastfailed` file is created inside the directory. I'm not sure this is the best way to ignore this file by git but it's not given as untracked anymore.