### PR TITLE
Remove unnecessary contextlib.closing decorator

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -997,8 +997,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                 if url_key in url2hash:
                     return url2hash[url_key]
 
-        with contextlib.closing(urllib.request.urlopen(
-                remote_url, timeout=timeout)) as remote:
+        with urllib.request.urlopen(remote_url, timeout=timeout) as remote:
             # keep a hash to rename the local file to the hashed name
             hash = hashlib.md5()
 


### PR DESCRIPTION
The `contextlib.closing` shouldn't be necessary for Python3 anymore.