### PR TITLE
Improve exception messages in format guessing read trace

### DIFF
--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -657,7 +657,8 @@ class BaseHeader:
                                      .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
-            raise ValueError('Strict name guessing requires at least two columns')
+            raise ValueError('Table format guessing requires at least two columns, got {}'
+                             .format(list(self.colnames)))
 
         if names is not None and len(names) != len(self.colnames):
             raise ValueError('Length of names argument ({0}) does not match number'

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -129,7 +129,8 @@ class FastBasic(metaclass=core.MetaBaseReader):
                                      .format(name))
         # When guessing require at least two columns
         if self.guessing and len(names) <= 1:
-            raise ValueError('Strict name guessing requires at least two columns')
+            raise ValueError('Table format guessing requires at least two columns, got {}'
+                             .format(names))
 
     def write(self, table, output):
         """


### PR DESCRIPTION
This is a teeny mostly-internal change to improve the output of `ascii.get_read_trace()`.  E.g.:
```
In [2]: ascii.read('a,b\n1,2', format='basic', fast_reader=True)
Out[2]: 
<Table length=1>
  a     b  
int64 int64
----- -----
    1     2

In [3]: ascii.get_read_trace()
Out[3]: 
[{'dt': '0.111 ms',
  'kwargs': {'Reader': astropy.io.ascii.fastbasic.FastBasic,
   'fast_reader': True,
   'fill_values': [('', '0')]},
  'status': "ValueError: Table format guessing requires at least two columns, got ['a,b']"},
 {'dt': '0.250 ms',
  'kwargs': {'Reader': astropy.io.ascii.basic.Basic,
   'fast_reader': True,
   'fill_values': [('', '0')]},
  'status': "ValueError: Table format guessing requires at least two columns, got ['a,b']"},
 {'dt': '0.109 ms',
  'kwargs': {'Reader': astropy.io.ascii.basic.Basic,
   'delimiter': '|',
   'fast_reader': True,
   'fill_values': [('', '0')],
   'quotechar': '"'},
  'status': "ValueError: Table format guessing requires at least two columns, got ['a,b']"},
 {'dt': '0.090 ms',
  'kwargs': {'Reader': astropy.io.ascii.basic.Basic,
   'delimiter': '|',
   'fast_reader': True,
   'fill_values': [('', '0')],
   'quotechar': "'"},
  'status': "ValueError: Table format guessing requires at least two columns, got ['a,b']"},
 {'dt': '0.765 ms',
  'kwargs': {'Reader': astropy.io.ascii.basic.Basic,
   'delimiter': ',',
   'fast_reader': True,
   'fill_values': [('', '0')],
   'quotechar': '"'},
  'status': 'Success (guessing)'}]
```

I did not add any explicit new test given the simple change and internal nature of this.  Will do so on request.