### PR TITLE
Remove Python2 StringIO handling and unnecessary parenthesis

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -11,12 +11,6 @@ import zipfile
 import pytest
 import numpy as np
 
-try:
-    import StringIO
-    HAVE_STRINGIO = True
-except ImportError:
-    HAVE_STRINGIO = False
-
 from . import FitsTestCase
 
 from ..convenience import _getext
@@ -1062,20 +1056,7 @@ class TestFileFunctions(FitsTestCase):
                         if hdu1.data is not None and hdu2.data is not None:
                             assert np.all(hdu1.data == hdu2.data)
 
-    @pytest.mark.skipif('not HAVE_STRINGIO')
-    def test_write_stringio(self):
-        """
-        Regression test for https://github.com/astropy/astropy/issues/2463
-
-        Only test against `StringIO.StringIO` on Python versions that have it.
-        Note: `io.StringIO` is not supported for this purpose as it does not
-        accept a bytes stream.
-        """
-
-        self._test_write_string_bytes_io(StringIO.StringIO())
-
-    @pytest.mark.skipif('not HAVE_STRINGIO')
-    def test_write_stringio_discontiguous(self):
+    def test_write_bytesio_discontiguous(self):
         """
         Regression test related to
         https://github.com/astropy/astropy/issues/2794#issuecomment-55441539
@@ -1086,7 +1067,7 @@ class TestFileFunctions(FitsTestCase):
 
         data = np.arange(100)[::3]
         hdu = fits.PrimaryHDU(data=data)
-        fileobj = StringIO.StringIO()
+        fileobj = io.BytesIO()
         hdu.writeto(fileobj)
 
         fileobj.seek(0)

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -22,13 +22,6 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    # Use for isinstance test only
-    class StringIO:
-        pass
-
 from ...utils import wraps
 from ...utils.exceptions import AstropyUserWarning
 
@@ -332,7 +325,7 @@ def isreadable(f):
     if not hasattr(f, 'read'):
         return False
 
-    if hasattr(f, 'mode') and not any((c in f.mode for c in 'r+')):
+    if hasattr(f, 'mode') and not any(c in f.mode for c in 'r+'):
         return False
 
     # Not closed, has a 'read()' method, and either has no known mode or a
@@ -356,7 +349,7 @@ def iswritable(f):
     if not hasattr(f, 'write'):
         return False
 
-    if hasattr(f, 'mode') and not any((c in f.mode for c in 'wa+')):
+    if hasattr(f, 'mode') and not any(c in f.mode for c in 'wa+'):
         return False
 
     # Note closed, has a 'write()' method, and either has no known mode or a
@@ -707,9 +700,6 @@ def _write_string(f, s):
         s = encode_ascii(s)
     elif not binmode and not isinstance(f, str):
         s = decode_ascii(s)
-    elif isinstance(f, StringIO) and isinstance(s, np.ndarray):
-        # Workaround for StringIO/ndarray incompatibility
-        s = s.data
 
     f.write(s)
 


### PR DESCRIPTION
The `StringIO` module was removed in Python3 and the parenthesis for generator expressions aren't necessary if it's the only argument.