### PR TITLE
Fix coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ script:
 
 after_success:
     - if [[ $SETUP_CMD == *--coverage* ]]; then
-        if [ $TRAVIS_REPO_SLUG = "astropy/astropy" -o $TRAVIS_PULL_REQUEST_SLUG = "astropy/astropy" ]; then
+        if [ "$TRAVIS_REPO_SLUG" = "astropy/astropy" -o "$TRAVIS_PULL_REQUEST_SLUG" = "astropy/astropy" ]; then
           cpp-coveralls -E ".*convolution.*" -E ".*_erfa.*" -E ".*\.l" -E ".*\.y" -E ".*flexed.*" -E ".*cextern.*" -E ".*_np_utils.*" -E ".*cparser.*" -E ".*cython_impl.*" --dump c-coveralls.json;
           coveralls --merge=c-coveralls.json --rcfile='astropy/tests/coveragerc';
         fi;


### PR DESCRIPTION
``TRAVIS_PULL_REQUEST_SLUG`` needs to be quoted since it is not defined on master - this meant coveralls worked on pull requests but not on master, where the ``after_success`` if block returned the following error:

```
-bash: [: too many arguments
```