### PR TITLE
Make it easier to use system version of astropy-helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,11 @@ matrix:
           stage: Initial tests
           env: PIP_DEPENDENCIES='https://github.com/astropy/astropy-helpers/archive/master.zip' SETUP_CMD='test --use-system-astropy-helpers'
 
+        # Testing for now - try using developer version of astropy-helpers
+        - os: linux
+          stage: Initial tests
+          env: SETUP_CMD='test --use-system-astropy-helpers'
+
     allow_failures:
       - os: linux
         env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'

--- a/.travis.yml
+++ b/.travis.yml
@@ -154,6 +154,11 @@ matrix:
           env: NUMPY_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
+        # Testing for now - try using developer version of astropy-helpers
+        - os: linux
+          stage: Initial tests
+          env: PIP_DEPENDENCIES='https://github.com/astropy/astropy-helpers/archive/master.zip' SETUP_CMD='test --use-system-astropy-helpers'
+
     allow_failures:
       - os: linux
         env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: c
 
 compiler: gcc
 
-os:
-    - linux
-
 stage: Comprehensive tests
 
 # Setting sudo to false opts in to Travis-CI container-based builds.
@@ -64,95 +61,6 @@ matrix:
     fast_finish: true
 
     include:
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
-
-        # Try MacOS X. Use a slightly old numpy version to help test against
-        # all supported numpy versions.
-        - os: osx
-          stage: Cron tests
-          env: SETUP_CMD='test --remote-data=astropy'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem' EVENT_TYPE='cron'
-
-        # Check for sphinx doc build warnings - we do this first because it
-        # runs for a long time. The sphinx build also has some additional
-        # dependencies. Using a more stringent locale than UTF-8.
-        - os: linux
-          env: SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
-               LC_CTYPE=C LC_ALL=C LANG=C
-
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time. Since we test the latest Numpy as part of the builds with all
-        # optional dependencies below, we can focus on older builds here.
-        # Numpy 1.11 is tested below in the image tests, 1.12 in the Initial stage test.
-        - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
-               SETUP_CMD='test --open-files'
-
-        # Now try with all optional dependencies.
-        # We also test the two latest matplotlib versions for the image tests.
-        - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='jplephem pytest-mpl'
-               LC_CTYPE=C.ascii LC_ALL=C
-               NUMPY_VERSION=1.11
-               MATPLOTLIB_VERSION=1.5
-
-        - os: linux
-          stage: Initial tests
-          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
-          compiler: clang
-
-        # Pinning conda version temporarily to 4.3.21, as some anaconda
-        # packges build with 4.3.27 are faulty and we see this job failing,
-        # while locally there are no issues when the same version of
-        # packages are installed from pip.
-        # TODO: remove the pinning once the issue is solved upstream.
-        - os: linux
-          env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
-               LC_CTYPE=C.ascii LC_ALL=C
-               CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=2.0
-               EVENT_TYPE='push pull_request cron'
-               CONDA_VERSION=4.3.21
-
-        # Try pre-release version of Numpy without optional dependencies
-        - os: linux
-          env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='push pull_request cron'
-
-        # Do a PEP8/pyflakes test with flake8
-        - os: linux
-          stage: Initial tests
-          env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
-
-        # Try developer version of Numpy with optional dependencies and also
-        # run all remote tests. Since both cases will be potentially
-        # unstable, we combine them into a single unstable build that we can
-        # mark as an allowed failure below.
-        - os: linux
-          env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-
-        # We check numpy-dev also in a job that only runs from cron, so that
-        # we can spot issues sooner. We do not use remote data here, since
-        # that gives too many false positives due to URL timeouts.
-        - os: linux
-          stage: Cron tests
-          env: NUMPY_VERSION=dev EVENT_TYPE='cron'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
         # Testing for now - try using developer version of astropy-helpers
         - os: linux

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -287,6 +287,10 @@ class _Bootstrapper(object):
             config['offline'] = True
             argv.remove('--offline')
 
+        if '--use-system-astropy-helpers' in argv:
+            config['auto_use'] = False
+            argv.remove('--use-system-astropy-helpers')
+
         return config
 
     def run(self):

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -19,9 +19,14 @@ that section, and options therein, determine the next step taken:  If it
 contains an option called ``auto_use`` with a value of ``True``, it will
 automatically call the main function of this module called
 `use_astropy_helpers` (see that function's docstring for full details).
-Otherwise no further action is taken (however,
-``ah_bootstrap.use_astropy_helpers`` may be called manually from within the
-setup.py script).
+Otherwise no further action is taken and by default the system-installed version
+of astropy-helpers will be used (however, ``ah_bootstrap.use_astropy_helpers``
+may be called manually from within the setup.py script).
+
+This behavior can also be controlled using the ``--auto-use`` and
+``--no-auto-use`` command-line flags. For clarity, an alias for
+``--no-auto-use`` is ``--use-system-astropy-helpers``, and we recommend using
+the latter if needed.
 
 Additional options in the ``[ah_boostrap]`` section of setup.cfg have the same
 names as the arguments to `use_astropy_helpers`, and can be used to configure
@@ -279,6 +284,7 @@ class _Bootstrapper(object):
         # of the same name then we will break that.  However there's a catch22
         # here that we can't just do full argument parsing right here, because
         # we don't yet know *how* to parse all possible command-line arguments.
+
         if '--no-git' in argv:
             config['use_git'] = False
             argv.remove('--no-git')
@@ -286,6 +292,14 @@ class _Bootstrapper(object):
         if '--offline' in argv:
             config['offline'] = True
             argv.remove('--offline')
+
+        if '--auto-use' in argv:
+            config['auto_use'] = True
+            argv.remove('--auto-use')
+
+        if '--no-auto-use' in argv:
+            config['auto_use'] = False
+            argv.remove('--no-auto-use')
 
         if '--use-system-astropy-helpers' in argv:
             config['auto_use'] = False


### PR DESCRIPTION
One of the things I often find myself doing is wanting to use my local developer version of astropy-helpers rather than the submodule or PyPI version. This *is* possible already by changing ``auto_use`` to ``False`` in ``setup.cfg``, but there is no way to do this via command-line flags, and ``auto_use`` is a somewhat cryptic option.

This PR does several things:

* It adds ``--auto-use`` and ``--no-auto-use``as command-line flags
* It adds a ``--use-system-astropy-helpers`` flag which is equivalent to ``--no-auto-use`` but I think should be the recommended flag to use since it is a lot more readable (solves https://github.com/astropy/astropy-helpers/issues/350)
* I have temporarily added two Travis jobs, both with the ``--use-system-astropy-helpers`` flag, but one with and one without installing astropy-helpers, to make sure the one without fails
* I removed other Travis jobs for now to not waste CI time

This should **not** be merged! If we agree on the principle and if it works, I think we need to do the following:

* [x] Make the changes done here in ``astropy-helpers`` instead of here first
* [ ] Update ci-helpers so that it's possible to more easily specify a version of astropy-helpers to install, including a 'dev' option. Just to be clear, we should never install astropy-helpers by default, but I want to be able to do ``ASTROPY_HELPERS=dev`` and have it be opt-in to installing the dev version of ``ASTROPY_HELPERS``.
* [ ] Add two cron job builds for this repo: one that runs the tests with the dev version of astropy-helpers, and one that runs the docs with the dev version. I don't think we should make this run in pull requests since this would affect contributors and would add unnecessary builds.

Before we go ahead, what do people think about this general approach?

cc @bsipocz @eteq