### PR TITLE
Clarify get_moon() frame and separation in coordinates

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1257,8 +1257,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         .. note::
 
             If the ``other`` coordinate object is in a different frame, it is
-            first transformed to the frame of this object - this can lead to
-            unexpected behavior.
+            first transformed to the frame of this object. This can lead to
+            unintutive behavior if not accounted for. Particularly of note is
+            that ``self.separation(other)`` and ``other.separation(self)`` may
+            not give the same answer in this case.
 
         Parameters
         ----------

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1254,6 +1254,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         Computes on-sky separation between this coordinate and another.
 
+        .. note::
+
+            If the ``other`` coordinate object is in a different frame, it is
+            first transformed to the frame of this object - this can lead to
+            unexpected behavior.
+
         Parameters
         ----------
         other : `~astropy.coordinates.BaseCoordinateFrame`

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -717,8 +717,10 @@ class SkyCoord(ShapedLikeNDArray):
         .. note::
 
             If the ``other`` coordinate object is in a different frame, it is
-            first transformed to the frame of this object - this can lead to
-            unexpected behavior.
+            first transformed to the frame of this object. This can lead to
+            unintutive behavior if not accounted for. Particularly of note is
+            that ``self.separation(other)`` and ``other.separation(self)`` may
+            not give the same answer in this case.
 
         For more on how to use this (and related) functionality, see the
         examples in :doc:`/coordinates/matchsep`.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -714,6 +714,12 @@ class SkyCoord(ShapedLikeNDArray):
         """
         Computes on-sky separation between this coordinate and another.
 
+        .. note::
+
+            If the ``other`` coordinate object is in a different frame, it is
+            first transformed to the frame of this object - this can lead to
+            unexpected behavior.
+
         For more on how to use this (and related) functionality, see the
         examples in :doc:`/coordinates/matchsep`.
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -466,7 +466,8 @@ get_body.__doc__ += indent(_EPHEMERIS_NOTE)[4:]
 def get_moon(time, location=None, ephemeris=None):
     """
     Get a `~astropy.coordinates.SkyCoord` for the Earth's Moon as observed
-    from a location on Earth.
+    from a location on Earth in the `~astropy.coordinates.GCRS` reference
+    system.
 
     Parameters
     ----------
@@ -483,7 +484,8 @@ def get_moon(time, location=None, ephemeris=None):
     Returns
     -------
     skycoord : `~astropy.coordinates.SkyCoord`
-        Coordinate for the Moon
+        Coordinate for the Moon in the `~astropy.coordinates.GCRS` reference
+        system.
 
     Notes
     -----

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -419,7 +419,8 @@ _get_apparent_body_position.__doc__ += indent(_EPHEMERIS_NOTE)[4:]
 def get_body(body, time, location=None, ephemeris=None):
     """
     Get a `~astropy.coordinates.SkyCoord` for a solar system body as observed
-    from a location on Earth.
+    from a location on Earth in the `~astropy.coordinates.GCRS` reference
+    system.
 
     Parameters
     ----------
@@ -484,8 +485,7 @@ def get_moon(time, location=None, ephemeris=None):
     Returns
     -------
     skycoord : `~astropy.coordinates.SkyCoord`
-        Coordinate for the Moon in the `~astropy.coordinates.GCRS` reference
-        system.
+        GCRS Coordinate for the Moon
 
     Notes
     -----


### PR DESCRIPTION
This fixes #6633.

Two minor changes to the `astropy.coordinates` documentation to (a) note which frame `get_moon()` (and `get_body()`) returns, and (b) clarify how `.separation` works on frame and skycoord instances.

cc @petigura