### PR TITLE
Use import numpy as np instead of just import numpy in wcs docs

### DIFF
--- a/docs/wcs/examples/from_file.py
+++ b/docs/wcs/examples/from_file.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, print_function
 
-import numpy
+import numpy as np
 from astropy import wcs
 from astropy.io import fits
 import sys
@@ -23,7 +23,7 @@ def load_wcs_from_file(filename):
 
     # Three pixel coordinates of interest.
     # Note we've silently assumed a NAXIS=2 image here
-    pixcrd = numpy.array([[0, 0], [24, 38], [45, 98]], numpy.float_)
+    pixcrd = np.array([[0, 0], [24, 38], [45, 98]], np.float_)
 
     # Convert pixel coordinates to world coordinates
     # The second argument is "origin" -- in this case we're declaring we
@@ -37,7 +37,7 @@ def load_wcs_from_file(filename):
 
     # These should be the same as the original pixel coordinates, modulo
     # some floating-point error.
-    assert numpy.max(numpy.abs(pixcrd - pixcrd2)) < 1e-6
+    assert np.max(np.abs(pixcrd - pixcrd2)) < 1e-6
 
 
 if __name__ == '__main__':

--- a/docs/wcs/examples/programmatic.py
+++ b/docs/wcs/examples/programmatic.py
@@ -3,7 +3,7 @@
 
 from __future__ import division, print_function
 
-import numpy
+import numpy as np
 from astropy import wcs
 from astropy.io import fits
 
@@ -14,13 +14,13 @@ w = wcs.WCS(naxis=2)
 # Set up an "Airy's zenithal" projection
 # Vector properties may be set with Python lists, or Numpy arrays
 w.wcs.crpix = [-234.75, 8.3393]
-w.wcs.cdelt = numpy.array([-0.066667, 0.066667])
+w.wcs.cdelt = np.array([-0.066667, 0.066667])
 w.wcs.crval = [0, -90]
 w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
 w.wcs.set_pv([(2, 1, 45.0)])
 
 # Some pixel coordinates of interest.
-pixcrd = numpy.array([[0, 0], [24, 38], [45, 98]], numpy.float_)
+pixcrd = np.array([[0, 0], [24, 38], [45, 98]], np.float_)
 
 # Convert pixel coordinates to world coordinates
 world = w.wcs_pix2world(pixcrd, 1)
@@ -32,7 +32,7 @@ print(pixcrd2)
 
 # These should be the same as the original pixel coordinates, modulo
 # some floating-point error.
-assert numpy.max(numpy.abs(pixcrd - pixcrd2)) < 1e-6
+assert np.max(np.abs(pixcrd - pixcrd2)) < 1e-6
 
 # Now, write out the WCS object as a FITS header
 header = w.to_header()


### PR DESCRIPTION
In most other docs and code we use `import numpy as np` and it seemed odd that it's not the case here (and I just copied parts of these examples into a test-case and had to edit the `numpy`s to `np` to make it work).