### PR TITLE
Fix remaining data mirror issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -460,7 +460,7 @@ Other Changes and Additions
 
 - Fixed broken links in the documentation. [#6745]
 
-- Make sure that all tests use the Astropy data mirror if needed. [#6767]
+- Ensured that all tests use the Astropy data mirror if needed. [#6767]
 
 2.0.2 (2017-09-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -437,6 +437,9 @@ astropy.utils
 - Fixed a bug that caused ``get_pkg_data_fileobj`` to not work correctly when
   used with non-local data from inside packages. [#6724]
 
+- Make sure ``get_pkg_data_fileobj`` fails if the URL can not be read, and
+  correctly falls back on the mirror if necessary. [#6767]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -453,6 +456,8 @@ Other Changes and Additions
   use mathjax instead. [#6701]
 
 - Fixed broken links in the documentation. [#6745]
+
+- Make sure that all tests use the Astropy data mirror if needed. [#6767]
 
 2.0.2 (2017-09-08)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -440,6 +440,9 @@ astropy.utils
 - Make sure ``get_pkg_data_fileobj`` fails if the URL can not be read, and
   correctly falls back on the mirror if necessary. [#6767]
 
+- Fix the ``finddiff`` option in ``find_current_module`` to properly deal
+  with submodules. [#6767]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -454,11 +454,13 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
                     fileobj.read(1)
                     fileobj.seek(0)
                     yield fileobj
-            except urllib.error.URLError as e:
+                    break
+            except urllib.error.URLError:
                 pass
-        urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
-        raise urllib.error.URLError("Failed to download {0} from the following "
-                                    "repositories:\n\n{1}".format(data_name, urls))
+        else:
+            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
+            raise urllib.error.URLError("Failed to download {0} from the following "
+                                        "repositories:\n\n{1}".format(data_name, urls))
 
 
 def get_pkg_data_filename(data_name, package=None, show_progress=True,
@@ -832,8 +834,7 @@ def _find_pkg_data_path(data_name, package=None):
     """
 
     if package is None:
-        module = find_current_module(1, True)
-
+        module = find_current_module(1, finddiff=['astropy.utils.data', 'contextlib'])
         if module is None:
             # not called from inside an astropy package.  So just pass name
             # through

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -446,8 +446,13 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
         all_urls = (conf.dataurl, conf.dataurl_mirror)
         for url in all_urls:
             try:
-                return get_readable_fileobj(url + data_name, encoding=encoding,
-                                            cache=cache)
+                fileobj = get_readable_fileobj(url + data_name, encoding=encoding,
+                                               cache=cache)
+                # We need to try and read a byte of the file here to make sure
+                # that the URL does work, otherwise it will be too late later
+                # to fall back on a mirror.
+                fileobj.read(1)
+                fileobj.seek(0)
             except urllib.error.URLError as e:
                 pass
         urls = '\n'.join('  - {0}'.format(url) for url in all_urls)

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -6,7 +6,7 @@
 import inspect
 import re
 import types
-
+import importlib
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',
            'isinstancemethod']
@@ -255,7 +255,7 @@ def find_current_module(depth=1, finddiff=False):
                 if inspect.ismodule(fd):
                     diffmods.append(fd)
                 elif isinstance(fd, str):
-                    diffmods.append(__import__(fd))
+                    diffmods.append(importlib.import_module(fd))
                 elif fd is True:
                     diffmods.append(currmod)
                 else:

--- a/astropy/visualization/wcsaxes/tests/datasets.py
+++ b/astropy/visualization/wcsaxes/tests/datasets.py
@@ -2,10 +2,7 @@
 """Downloads the FITS files that are used in image testing and for building documentation.
 """
 
-import time
-import urllib.error
-
-from ....utils.data import download_file
+from ....utils.data import get_pkg_data_filename
 from ....io import fits
 
 __all__ = ['fetch_msx_hdu',
@@ -15,30 +12,16 @@ __all__ = ['fetch_msx_hdu',
            'fetch_bolocam_hdu',
            ]
 
-MAX_RETRIES = 10
-TIME_BETWEEN_RETRIES = 5
-URL = 'http://data.astropy.org/'
 
-
-def fetch_hdu(filename, cache=True):
-    """Download a FITS file to the cache and open HDU 0.
+def fetch_hdu(filename):
     """
-    for retry in range(MAX_RETRIES):
-        try:
-            path = download_file(URL + filename, cache=cache, timeout=30)
-        except urllib.error.URLError:
-            if retry == MAX_RETRIES - 1:
-                raise
-            else:
-                time.sleep(TIME_BETWEEN_RETRIES)
-        else:
-            break
-    else:
-        raise Exception("Failed to download file {0}".format(filename))
+    Download a FITS file to the cache and open HDU 0.
+    """
+    path = get_pkg_data_filename(filename)
     return fits.open(path)[0]
 
 
-def fetch_msx_hdu(cache=True):
+def fetch_msx_hdu():
     """Fetch the MSX example dataset HDU.
 
     Returns
@@ -46,20 +29,20 @@ def fetch_msx_hdu(cache=True):
     hdu : `~astropy.io.fits.ImageHDU`
         Image HDU
     """
-    return fetch_hdu('galactic_center/gc_msx_e.fits', cache=cache)
+    return fetch_hdu('galactic_center/gc_msx_e.fits')
 
 
-def fetch_rosat_hdu(cache=True):
-    return fetch_hdu('allsky/allsky_rosat.fits', cache=cache)
+def fetch_rosat_hdu():
+    return fetch_hdu('allsky/allsky_rosat.fits')
 
 
-def fetch_twoMASS_k_hdu(cache=True):
-    return fetch_hdu('galactic_center/gc_2mass_k.fits', cache=cache)
+def fetch_twoMASS_k_hdu():
+    return fetch_hdu('galactic_center/gc_2mass_k.fits')
 
 
-def fetch_l1448_co_hdu(cache=True):
-    return fetch_hdu('l1448/l1448_13co.fits', cache=cache)
+def fetch_l1448_co_hdu():
+    return fetch_hdu('l1448/l1448_13co.fits')
 
 
-def fetch_bolocam_hdu(cache=True):
-    return fetch_hdu('galactic_center/gc_bolocam_gps.fits', cache=cache)
+def fetch_bolocam_hdu():
+    return fetch_hdu('galactic_center/gc_bolocam_gps.fits')


### PR DESCRIPTION
There were a few tests that did not fall back on the data server mirror.

This also uncovered an issue that ``get_pkg_data_fileobj`` did not allow the mirror to be used if the primary failed (since an URLError was only raised when reading, not opening the URL)