### PR TITLE
Fixes for HomogeneousList

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -437,6 +437,14 @@ astropy.utils
 - Fixed a bug that caused ``get_pkg_data_fileobj`` to not work correctly when
   used with non-local data from inside packages. [#6724]
 
+- Fixed ``HomogeneousList`` when setting one item or a slice. [#6773]
+
+- Also check the type when creating a new instance of
+  ``HomogeneousList``. [#6773]
+
+- Make ``HomogeneousList`` work with iterators and generators when creating the
+  instance, extending it or using when setting a slice. [#6773]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,14 @@ astropy.utils
   original. This is needed so that the Python 3 ``super`` without arguments
   works for decorated classes. [#6615]
 
+- Fixed ``HomogeneousList`` when setting one item or a slice. [#6773]
+
+- Also check the type when creating a new instance of
+  ``HomogeneousList``. [#6773]
+
+- Make ``HomogeneousList`` work with iterators and generators when creating the
+  instance, extending it, or using when setting a slice. [#6773]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -436,14 +444,6 @@ astropy.utils
 
 - Fixed a bug that caused ``get_pkg_data_fileobj`` to not work correctly when
   used with non-local data from inside packages. [#6724]
-
-- Fixed ``HomogeneousList`` when setting one item or a slice. [#6773]
-
-- Also check the type when creating a new instance of
-  ``HomogeneousList``. [#6773]
-
-- Make ``HomogeneousList`` work with iterators and generators when creating the
-  instance, extending it or using when setting a slice. [#6773]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -21,7 +21,8 @@ class HomogeneousList(list):
             An initial set of values.
         """
         self._types = types
-        list.__init__(self, values)
+        list.__init__(self)
+        self.extend(values)
 
     def _assert(self, x):
         if not isinstance(x, self._types):
@@ -30,13 +31,17 @@ class HomogeneousList(list):
                 "type '{}'".format(self._types))
 
     def __iadd__(self, other):
-        for x in other:
-            self._assert(x)
-        return list.__iadd__(self, other)
+        self.extend(other)
+        return self
 
-    def __setitem__(self, x):
-        self._assert(x)
-        return list.__setitem__(self, x)
+    def __setitem__(self, idx, value):
+        if isinstance(idx, slice):
+            value = list(value)
+            for item in value:
+                self._assert(item)
+        else:
+            self._assert(value)
+        return list.__setitem__(self, idx, value)
 
     def append(self, x):
         self._assert(x)
@@ -49,4 +54,4 @@ class HomogeneousList(list):
     def extend(self, x):
         for item in x:
             self._assert(item)
-        return list.extend(self, x)
+            list.append(self, item)

--- a/astropy/utils/collections.py
+++ b/astropy/utils/collections.py
@@ -21,7 +21,7 @@ class HomogeneousList(list):
             An initial set of values.
         """
         self._types = types
-        list.__init__(self)
+        super().__init__()
         self.extend(values)
 
     def _assert(self, x):
@@ -41,17 +41,17 @@ class HomogeneousList(list):
                 self._assert(item)
         else:
             self._assert(value)
-        return list.__setitem__(self, idx, value)
+        return super().__setitem__(idx, value)
 
     def append(self, x):
         self._assert(x)
-        return list.append(self, x)
+        return super().append(x)
 
     def insert(self, i, x):
         self._assert(x)
-        return list.insert(self, i, x)
+        return super().insert(i, x)
 
     def extend(self, x):
         for item in x:
             self._assert(item)
-            list.append(self, item)
+            super().append(item)

--- a/astropy/utils/tests/test_collections.py
+++ b/astropy/utils/tests/test_collections.py
@@ -22,11 +22,13 @@ def test_homogeneous_list2():
 def test_homogeneous_list3():
     l = collections.HomogeneousList(int)
     l.append(5)
+    assert l == [5]
 
 
 def test_homogeneous_list4():
     l = collections.HomogeneousList(int)
     l.extend([5])
+    assert l == [5]
 
 
 @raises(TypeError)
@@ -38,11 +40,19 @@ def test_homogeneous_list5():
 def test_homogeneous_list_setitem_works():
     l = collections.HomogeneousList(int, [1, 2, 3])
     l[1] = 5
+    assert l == [1, 5, 3]
 
 
 def test_homogeneous_list_setitem_works_with_slice():
     l = collections.HomogeneousList(int, [1, 2, 3])
     l[0:1] = [10, 20, 30]
+    assert l == [10, 20, 30, 2, 3]
+
+    l[:] = [5, 4, 3]
+    assert l == [5, 4, 3]
+
+    l[::2] = [2, 1]
+    assert l == [2, 4, 1]
 
 
 def test_homogeneous_list_init_got_invalid_type():

--- a/astropy/utils/tests/test_collections.py
+++ b/astropy/utils/tests/test_collections.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pytest
+
 from ...tests.helper import raises
 
 from .. import collections
@@ -31,3 +33,35 @@ def test_homogeneous_list4():
 def test_homogeneous_list5():
     l = collections.HomogeneousList(int, [1, 2, 3])
     l[1] = 5.0
+
+
+def test_homogeneous_list_setitem_works():
+    l = collections.HomogeneousList(int, [1, 2, 3])
+    l[1] = 5
+
+
+def test_homogeneous_list_setitem_works_with_slice():
+    l = collections.HomogeneousList(int, [1, 2, 3])
+    l[0:1] = [10, 20, 30]
+
+
+def test_homogeneous_list_init_got_invalid_type():
+    with pytest.raises(TypeError):
+        collections.HomogeneousList(int, [1, 2., 3])
+
+
+def test_homogeneous_list_works_with_generators():
+    hl = collections.HomogeneousList(int, (i for i in range(3)))
+    assert hl == [0, 1, 2]
+
+    hl = collections.HomogeneousList(int)
+    hl.extend(i for i in range(3))
+    assert hl == [0, 1, 2]
+
+    hl = collections.HomogeneousList(int)
+    hl[0:1] = (i for i in range(3))
+    assert hl == [0, 1, 2]
+
+    hl = collections.HomogeneousList(int)
+    hl += (i for i in range(3))
+    assert hl == [0, 1, 2]


### PR DESCRIPTION
I don't know how user-facing this class is but it's used in votable. However I noticed several very weird (and wrong) stuff in there.

Instead of using the hard-coded `list.methodname` calls we can use `super()` in astropy 3.x but that wouldn't work for 2.0.x. If this is merged one could consider a follow-up PR that uses `super` there.