### PR TITLE
Add smart axis label visibility to wcsaxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -469,8 +469,8 @@ astropy.visualization
   operator for both classes. [#6531]
 - Added automatic hiding of axes labels when no tick labels are drawn on that
   axis. This parameter can be configured with
-  ``WCSAxes.coords[].set_visibility_rule`` so that labels are auto hidden when no
-  ticks are drawn or always shown. [#6774]
+  ``WCSAxes.coords[*].set_axislabel_visibility_rule`` so that labels are automatically
+  hidden when no ticks are drawn or always shown. [#6774]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -467,6 +467,10 @@ astropy.visualization
   ``WCSPixel2WorldTransform`` classes by setting ``has_inverse`` to ``True``.
   In order to implement a unit test, also implement the equality comparison
   operator for both classes. [#6531]
+- Added automatic hiding of axes labels when no tick labels are drawn on that
+  axis. This parameter can be configured with
+  ``WCSAxes.coords[].set_visibility_rule`` so that labels are auto hidden when no
+  ticks are drawn or always shown. [#6774]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -19,6 +19,7 @@ class AxisLabels(Text):
         self.set_ha('center')
         self.set_va('center')
         self._minpad = minpad
+        self._visiblility_rule = 'labels'
 
     def get_minpad(self, axis):
         try:
@@ -38,7 +39,17 @@ class AxisLabels(Text):
     def set_minpad(self, minpad):
         self._minpad = minpad
 
-    def draw(self, renderer, bboxes, ticklabels_bbox_list, visible_ticks):
+    def set_visibility_rule(self, value):
+        allowed = ['always', 'labels', 'ticks']
+        if value not in allowed:
+            raise ValueError("Axis label visiblility rule must be one of{}".format(' / '.join(allowed)))
+
+        self._visibility_rule = value
+
+    def get_visibility_rule(self):
+        return self._visiblility_rule
+
+    def draw(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
 
         if not self.get_visible():
             return
@@ -46,6 +57,16 @@ class AxisLabels(Text):
         text_size = renderer.points_to_pixels(self.get_size())
 
         for axis in self.get_visible_axes():
+
+            ticklabels_bbox_list = ticklabels_bbox[axis]
+
+            if self.get_visibility_rule() == 'ticks':
+                if not ticks_locs[axis]:
+                    continue
+
+            elif self.get_visibility_rule() == 'labels':
+                if not ticklabels_bbox_list:
+                    continue
 
             padding = text_size * self.get_minpad(axis)
 

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -59,10 +59,11 @@ class AxisLabels(Text):
 
         for axis in self.get_visible_axes():
 
-            # Flatten the bboxes for all coords for this axis.
+            # Flatten the bboxes for all coords and all axes
             ticklabels_bbox_list = []
-            for bbox_coord in ticklabels_bbox.values():
-                ticklabels_bbox_list += bbox_coord[axis]
+            for bbcoord in ticklabels_bbox.values():
+                for bbaxis in bbcoord.values():
+                    ticklabels_bbox_list += bbaxis
 
             if self.get_visibility_rule() == 'ticks':
                 if not ticks_locs[axis]:

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -44,12 +44,13 @@ class AxisLabels(Text):
         if value not in allowed:
             raise ValueError("Axis label visiblility rule must be one of{}".format(' / '.join(allowed)))
 
-        self._visibility_rule = value
+        self._visiblility_rule = value
 
     def get_visibility_rule(self):
         return self._visiblility_rule
 
-    def draw(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
+    def draw(self, renderer, bboxes, ticklabels_bbox,
+             coord_ticklabels_bbox, ticks_locs, visible_ticks):
 
         if not self.get_visible():
             return
@@ -58,14 +59,17 @@ class AxisLabels(Text):
 
         for axis in self.get_visible_axes():
 
-            ticklabels_bbox_list = ticklabels_bbox[axis]
+            # Flatten the bboxes for all coords for this axis.
+            ticklabels_bbox_list = []
+            for bbox_coord in ticklabels_bbox.values():
+                ticklabels_bbox_list += bbox_coord[axis]
 
             if self.get_visibility_rule() == 'ticks':
                 if not ticks_locs[axis]:
                     continue
 
             elif self.get_visibility_rule() == 'labels':
-                if not ticklabels_bbox_list:
+                if not coord_ticklabels_bbox:
                     continue
 
             padding = text_size * self.get_minpad(axis)

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -101,38 +101,38 @@ class AxisLabels(Text):
 
             if isinstance(self._frame, RectangularFrame):
 
-                if len(ticklabels_bbox_list) > 0:
-                    ticklabels_bbox = mtransforms.Bbox.union(ticklabels_bbox_list)
+                if len(ticklabels_bbox_list) > 0 and ticklabels_bbox_list[0] is not None:
+                    coord_ticklabels_bbox[axis] = [mtransforms.Bbox.union(ticklabels_bbox_list)]
                 else:
-                    ticklabels_bbox = None
+                    coord_ticklabels_bbox[axis] = [None]
 
                 if axis == 'l':
-                    if axis in visible_ticks and ticklabels_bbox is not None:
-                        left = ticklabels_bbox.xmin
+                    if axis in visible_ticks and coord_ticklabels_bbox[axis][0] is not None:
+                        left = coord_ticklabels_bbox[axis][0].xmin
                     else:
                         left = xcen
                     xpos = left - padding
                     self.set_position((xpos, ycen))
 
                 elif axis == 'r':
-                    if axis in visible_ticks and ticklabels_bbox is not None:
-                        right = ticklabels_bbox.x1
+                    if axis in visible_ticks and coord_ticklabels_bbox[axis][0] is not None:
+                        right = coord_ticklabels_bbox[axis][0].x1
                     else:
                         right = xcen
                     xpos = right + padding
                     self.set_position((xpos, ycen))
 
                 elif axis == 'b':
-                    if axis in visible_ticks and ticklabels_bbox is not None:
-                        bottom = ticklabels_bbox.ymin
+                    if axis in visible_ticks and coord_ticklabels_bbox[axis][0] is not None:
+                        bottom = coord_ticklabels_bbox[axis][0].ymin
                     else:
                         bottom = ycen
                     ypos = bottom - padding
                     self.set_position((xcen, ypos))
 
                 elif axis == 't':
-                    if axis in visible_ticks and ticklabels_bbox is not None:
-                        top = ticklabels_bbox.y1
+                    if axis in visible_ticks and coord_ticklabels_bbox[axis][0] is not None:
+                        top = coord_ticklabels_bbox[axis][0].y1
                     else:
                         top = ycen
                     ypos = top + padding

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -19,7 +19,7 @@ class AxisLabels(Text):
         self.set_ha('center')
         self.set_va('center')
         self._minpad = minpad
-        self._visiblility_rule = 'labels'
+        self._visibility_rule = 'labels'
 
     def get_minpad(self, axis):
         try:
@@ -42,12 +42,12 @@ class AxisLabels(Text):
     def set_visibility_rule(self, value):
         allowed = ['always', 'labels', 'ticks']
         if value not in allowed:
-            raise ValueError("Axis label visiblility rule must be one of{}".format(' / '.join(allowed)))
+            raise ValueError("Axis label visibility rule must be one of{}".format(' / '.join(allowed)))
 
-        self._visiblility_rule = value
+        self._visibility_rule = value
 
     def get_visibility_rule(self):
-        return self._visiblility_rule
+        return self._visibility_rule
 
     def draw(self, renderer, bboxes, ticklabels_bbox,
              coord_ticklabels_bbox, ticks_locs, visible_ticks):

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -490,6 +490,7 @@ class CoordinateHelper:
 
         self.axislabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox,
+                             coord_ticklabels_bbox=ticklabels_bbox[self],
                              ticks_locs=ticks_locs,
                              visible_ticks=visible_ticks)
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -417,6 +417,26 @@ class CoordinateHelper:
         """
         self.axislabels.set_visible_axes(position)
 
+    def set_axislabel_visibility_rule(self, rule):
+        """
+        Set the rule used to determine when the axis label is drawn.
+
+        Parameters
+        ----------
+        rule : str
+            If the rule is 'always' axis labels will always be drawn on the
+            axis. If the rule is 'ticks' the label will only be drawn if ticks
+            were drawn on that axis. If the rule is 'labels' the axis label
+            will only be drawn if tick labels were drawn on that axis.
+        """
+        self.axislabels.set_visibility_rule(rule)
+
+    def get_axislabel_visibility_rule(self, rule):
+        """
+        Get the rule used to determine when the axis label is drawn.
+        """
+        return self.axislabels.get_visibility_rule()
+
     @property
     def locator(self):
         return self._formatter_locator.locator
@@ -454,22 +474,23 @@ class CoordinateHelper:
 
         renderer.close_group('grid lines')
 
-    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox):
+    def _draw_ticks(self, renderer, bboxes, ticklabels_bbox, ticks_locs):
 
         renderer.open_group('ticks')
 
-        self.ticks.draw(renderer)
+        self.ticks.draw(renderer, ticks_locs)
         self.ticklabels.draw(renderer, bboxes=bboxes,
                              ticklabels_bbox=ticklabels_bbox)
 
         renderer.close_group('ticks')
 
-    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, visible_ticks):
+    def _draw_axislabels(self, renderer, bboxes, ticklabels_bbox, ticks_locs, visible_ticks):
 
         renderer.open_group('axis labels')
 
         self.axislabels.draw(renderer, bboxes=bboxes,
-                             ticklabels_bbox_list=ticklabels_bbox,
+                             ticklabels_bbox=ticklabels_bbox,
+                             ticks_locs=ticks_locs,
                              visible_ticks=visible_ticks)
 
         renderer.close_group('axis labels')

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -354,7 +354,7 @@ class WCSAxes(Axes):
 
             for coord in coords:
                 coord._draw_axislabels(renderer, bboxes=self._bboxes,
-                                       ticklabels_bbox=ticklabels_bbox[coord],
+                                       ticklabels_bbox=ticklabels_bbox,
                                        ticks_locs=ticks_locs[coord],
                                        visible_ticks=visible_ticks)
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from functools import partial
+from collections import defaultdict
 
 import numpy as np
 
@@ -328,7 +330,10 @@ class WCSAxes(Axes):
         # each coordinate axis. For now, just assume it covers the whole sky.
 
         self._bboxes = []
-        self._ticklabels_bbox = []
+        # This generates a structure like [coords][axis] = [...]
+        ticklabels_bbox = defaultdict(partial(defaultdict, list))
+        ticks_locs = defaultdict(partial(defaultdict, list))
+
         visible_ticks = []
 
         for coords in self._all_coords:
@@ -341,14 +346,16 @@ class WCSAxes(Axes):
 
             for coord in coords:
                 coord._draw_ticks(renderer, bboxes=self._bboxes,
-                                  ticklabels_bbox=self._ticklabels_bbox)
+                                  ticklabels_bbox=ticklabels_bbox[coord],
+                                  ticks_locs=ticks_locs[coord])
                 visible_ticks.extend(coord.ticklabels.get_visible_axes())
 
         for coords in self._all_coords:
 
             for coord in coords:
                 coord._draw_axislabels(renderer, bboxes=self._bboxes,
-                                       ticklabels_bbox=self._ticklabels_bbox,
+                                       ticklabels_bbox=ticklabels_bbox[coord],
+                                       ticks_locs=ticks_locs[coord],
                                        visible_ticks=visible_ticks)
 
         self.coords.frame.draw(renderer)

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,6 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from ..core import WCSAxes
+from .... import units as u
 import matplotlib.pyplot as plt
+
+from unittest.mock import patch
+
+import pytest
 
 
 def test_getaxislabel():
@@ -12,3 +17,58 @@ def test_getaxislabel():
     ax.coords[1].set_axislabel("Y")
     assert ax.coords[0].get_axislabel() == "X"
     assert ax.coords[1].get_axislabel() == "Y"
+
+
+@pytest.fixture
+def ax():
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect='equal')
+    fig.add_axes(ax)
+
+    return ax
+
+
+def assert_label_draw(ax, x_label, y_label):
+    ax.coords[0].set_axislabel("Label 1")
+    ax.coords[1].set_axislabel("Label 2")
+
+    with patch.object(ax.coords[0].axislabels, 'set_position') as pos1:
+        with patch.object(ax.coords[1].axislabels, 'set_position') as pos2:
+            ax.figure.canvas.draw()
+
+    assert pos1.call_count == x_label
+    assert pos2.call_count == y_label
+
+
+def test_label_visibility_rules_default(ax):
+    assert_label_draw(ax, True, True)
+
+
+def test_label_visibility_rules_label(ax):
+
+    ax.coords[0].set_ticklabel_visible(False)
+    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+
+    assert_label_draw(ax, False, False)
+
+
+def test_label_visibility_rules_ticks(ax):
+
+    ax.coords[0].set_axislabel_visibility_rule('ticks')
+    ax.coords[1].set_axislabel_visibility_rule('ticks')
+
+    ax.coords[0].set_ticklabel_visible(False)
+    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+
+    assert_label_draw(ax, True, False)
+
+
+def test_label_visibility_rules_always(ax):
+
+    ax.coords[0].set_axislabel_visibility_rule('always')
+    ax.coords[1].set_axislabel_visibility_rule('always')
+
+    ax.coords[0].set_ticklabel_visible(False)
+    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+
+    assert_label_draw(ax, True, True)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -439,6 +439,7 @@ class TestBasic(BaseImageTests):
         ax = fig.add_axes([0.25, 0.25, 0.5, 0.5], projection=wcs, aspect='auto')
         ax.coords[0].set_axislabel("Label 1")
         ax.coords[1].set_axislabel("Label 2")
+        ax.coords[1].set_axislabel_visibility_rule('always')
         ax.coords[1].ticklabels.set_visible(False)
         return fig
 

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -207,4 +207,4 @@ class TickLabels(Text):
                 if not self._exclude_overlapping or bb.count_overlaps(bboxes) == 0:
                     super().draw(renderer)
                     bboxes.append(bb)
-                    ticklabels_bbox.append(bb)
+                    ticklabels_bbox[axis].append(bb)

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -128,7 +128,7 @@ class Ticks(Line2D):
 
     _tickvert_path = Path([[0., 0.], [1., 0.]])
 
-    def draw(self, renderer):
+    def draw(self, renderer, ticks_locs):
         """
         Draw the ticks.
         """
@@ -137,12 +137,12 @@ class Ticks(Line2D):
             return
 
         offset = renderer.points_to_pixels(self.get_ticksize())
-        self._draw_ticks(renderer, self.pixel, self.angle, offset)
+        self._draw_ticks(renderer, self.pixel, self.angle, offset, ticks_locs)
         if self._display_minor_ticks:
             offset = offset * 0.5  # for minor ticksize
-            self._draw_ticks(renderer, self.minor_pixel, self.minor_angle, offset)
+            self._draw_ticks(renderer, self.minor_pixel, self.minor_angle, offset, ticks_locs)
 
-    def _draw_ticks(self, renderer, pixel_array, angle_array, offset):
+    def _draw_ticks(self, renderer, pixel_array, angle_array, offset, ticks_locs):
         """
         Draw the minor ticks.
         """
@@ -176,5 +176,7 @@ class Ticks(Line2D):
 
                 # Reset the tick rotation before moving to the next tick
                 marker_rotation.clear()
+
+                ticks_locs[axis].append(locs)
 
         gc.restore()


### PR DESCRIPTION
This adds configurable behaviour to wcsaxes so if there are no tick labels drawn on an axis the axis label will not be drawn. This can be configured so that the labels are always drawn or so that they are only drawn if ticks are drawn rather than tick labels.

@wafels @astrofrog 