### PR TITLE
Remove arguments for super in io.fits

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1417,7 +1417,7 @@ class CompImageHDU(BinTableHDU):
     def compressed_data(self):
         # First we will get the table data (the compressed
         # data) from the file, if there is any.
-        compressed_data = super(BinTableHDU, self).data
+        compressed_data = super().data
         if isinstance(compressed_data, np.rec.recarray):
             # Make sure not to use 'del self.data' so we don't accidentally
             # go through the self.data.fdel and close the mmap underlying

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -127,7 +127,7 @@ class _ErrList(list):
     """
 
     def __new__(cls, val=None, unit='Element'):
-        return super(cls, cls).__new__(cls, val)
+        return super().__new__(cls, val)
 
     def __init__(self, val=None, unit='Element'):
         self.unit = unit


### PR DESCRIPTION
Related: #6630 

These were the cases where the arguments weren't straight-forward because it didn't use the current class as first argument. Locally it passes the tests when the arguments are removed.