### PR TITLE
Fix AstropyDeprecationWarning from Time constructor

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -278,8 +278,8 @@ class Time(ShapedLikeNDArray):
             self._init_from_vals(val, val2, format, scale, copy,
                                  precision, in_subfmt, out_subfmt)
 
-        if self.location and (self.location.size > 1 and
-                              self.location.shape != self.shape):
+        if self.location is not None and (self.location.size > 1 and
+                                          self.location.shape != self.shape):
             try:
                 # check the location can be broadcast to self's shape.
                 self.location = np.broadcast_to(self.location, self.shape,


### PR DESCRIPTION
I'm getting an `AstropyDeprecationWarning` from some astroplan tests which construct `Time` objects with locations, which originates from #6590. In the `Time` constructor, there's [an `if` block that states `if self.location and ....`](https://github.com/astropy/astropy/blob/master/astropy/time/core.py#L281). That syntax is now deprecated as `Quantity` objects will not be evaluated as booleans. 

**Note**: this issue is the primary blocker to releasing the next version of astroplan (and probably any other affiliated package that uses `Time` objects)