### PR TITLE
Remove unnecessary io is not None check

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -507,7 +507,7 @@ def fileobj_is_binary(f):
     if hasattr(f, 'binary'):
         return f.binary
 
-    if io is not None and isinstance(f, io.TextIOBase):
+    if isinstance(f, io.TextIOBase):
         return False
 
     mode = fileobj_mode(f)


### PR DESCRIPTION
This is a remnant of an older PyFITS try and except around `import io`: https://github.com/spacetelescope/PyFITS/blob/v3.3.0/lib/pyfits/util.py#L15-L18