### PR TITLE
Raise more informative Exception when the fileobj for fits.open is bytes

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -112,6 +112,16 @@ class _File:
             # If fileobj is of type pathlib.Path
             if isinstance(fileobj, pathlib.Path):
                 fileobj = str(fileobj)
+            elif isinstance(fileobj, bytes):
+                # Using bytes as filename is tricky, it's deprecated for Windows
+                # in Python 3.5 (because it could lead to false-positives) but
+                # was fixed and un-deprecated in Python 3.6.
+                # However it requires that the bytes object is encoded with the
+                # file system encoding.
+                # Probably better to error out and ask for a str object instead.
+                # TODO: This could be revised when Python 3.5 support is dropped
+                # See also: https://github.com/astropy/astropy/issues/6789
+                raise TypeError("names should be `str` not `bytes`.")
 
         # Holds mmap instance for files that use mmap
         self._mmap = None

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -34,6 +34,10 @@ class TestCore(FitsTestCase):
     def test_missing_file(self):
         fits.open(self.temp('does-not-exist.fits'))
 
+    def test_filename_is_bytes_object(self):
+        with pytest.raises(TypeError):
+            fits.open(self.data('ascii.fits').encode())
+
     def test_naxisj_check(self):
         hdulist = fits.open(self.data('o4sp040b0_raw.fits'))
 


### PR DESCRIPTION
Fixes #6789 by raising a more descriptive Exception.

It should be possible to make bytes work except for Python < 3.6 on windows (where using bytes as paths-to-file is deprecated - for a <s>semi</s>good reason).