### PR TITLE
Remove maketrans from io.fits.util module

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 
-from .util import _str_to_num, _is_int, maketrans, translate, _words_group
+from .util import _str_to_num, _is_int, translate, _words_group
 from .verify import _Verify, _ErrList, VerifyError, VerifyWarning
 
 from . import conf
@@ -15,8 +15,8 @@ from ...utils.exceptions import AstropyUserWarning
 __all__ = ['Card', 'Undefined']
 
 
-FIX_FP_TABLE = maketrans('de', 'DE')
-FIX_FP_TABLE2 = maketrans('dD', 'eE')
+FIX_FP_TABLE = str.maketrans('de', 'DE')
+FIX_FP_TABLE2 = str.maketrans('dD', 'eE')
 
 
 CARD_LENGTH = 80

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -517,9 +517,6 @@ def fileobj_is_binary(f):
         return True
 
 
-maketrans = str.maketrans
-
-
 def translate(s, table, deletechars):
     if deletechars:
         table = table.copy()


### PR DESCRIPTION
There's actually no need for `maketrans` in the `util` anymore because it's just `str.maketrans`. I added a changelog entry but removed it without deprecation (because it's a utility function). But if you think it would be better to deprecate it first I can change it.