### PR TITLE
Removing __new__ method in _ErrList

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -231,6 +231,16 @@ class TestCore(FitsTestCase):
         hdu = fits.ImageHDU()
         hdu.verify('foobarbaz')
 
+    def test_errlist_basic(self):
+        # Just some tests to make sure that _ErrList is setup correctly.
+        # No arguments
+        error_list = fits.verify._ErrList()
+        assert error_list == []
+        # Some contents - this is not actually working, it just makes sure they
+        # are kept.
+        error_list = fits.verify._ErrList([1, 2, 3])
+        assert error_list == [1, 2, 3]
+
     def test_combined_verify_options(self):
         """
         Test verify options like fix+ignore.

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -126,10 +126,8 @@ class _ErrList(list):
     different class levels.
     """
 
-    def __new__(cls, val=None, unit='Element'):
-        return super().__new__(cls, val)
-
-    def __init__(self, val=None, unit='Element'):
+    def __init__(self, val=(), unit='Element'):
+        super().__init__(val)
         self.unit = unit
 
     def __str__(self):


### PR DESCRIPTION
That's actually just fixing a non-existent issue because all uses of `ErrList` use an empty list as first argument.

However `list.__new__` is a no-op (aside from creating the instance), it will ignore all arguments and always returns an empty list. The "correct way" would be to pass the first argument for the "constructor" to `list.__init__`. But there's an additional problem with the default: `list.__init__` raises an Exception when the "iterable" is None because None is not iterable.

So I removed `__new__` altogether and changed the default to an empty tuple.

I'm not sure this actually requires tests, but I provided them nevertheless.