### PR TITLE
Typo in import: pyreadyline -> pyreadline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -457,6 +457,9 @@ astropy.utils
 - Fix the ``finddiff`` option in ``find_current_module`` to properly deal
   with submodules. [#6767]
 
+- Fixed ``pyreadline`` import in ``utils.console.isatty`` for older IPython
+  versions on Windows. [#6800]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -162,7 +162,7 @@ def isatty(file):
         # pyreadline.Console objects if pyreadline is available; this should
         # be considered a TTY.
         try:
-            from pyreadyline.console import Console as PyreadlineConsole
+            from pyreadline.console import Console as PyreadlineConsole
         except ImportError:
             return False
 


### PR DESCRIPTION
Just a typo in an import.

Note sure about the milestone and if this needs a changelog because IPython 2 is pretty old and it only affects Windows.