### PR TITLE
Remove Gitter badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,9 +5,6 @@ Astropy
 .. image:: https://img.shields.io/pypi/v/astropy.svg
     :target: https://pypi.python.org/pypi/astropy
 
-.. image:: https://badges.gitter.im/Join%20Chat.svg
-    :target: https://gitter.im/astropy/astropy
-
 Astropy (http://www.astropy.org) is a package intended to contain much of
 the core functionality and some common tools needed for performing
 astronomy and astrophysics with Python.


### PR DESCRIPTION
I haven't added a slack badge instead since we can't add a single badge (would need join and invite which we'd have to explain etc), and in any case slack doesn't have to be the first point of contact.