### PR TITLE
Fix problem where bad column format is not reverted

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -423,6 +423,9 @@ astropy.table
   garbage-collected, and the format function caching mechanism happens
   to re-use the same cache key. [#6714]
 
+- Fixed a problem when setting a column format to an invalid value.  This
+  was supposed to revert to the previous (valid) value but was not. [#6812]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -422,7 +422,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         try:
             # test whether it formats without error exemplarily
             self.pformat(max_lines=1)
-        except TypeError as err:
+        except Exception as err:
             # revert to restore previous format if there was one
             self._format = prev_format
             raise ValueError(

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -290,6 +290,7 @@ class TestFormat():
         #  Invalid format spec
         with pytest.raises(ValueError):
             t['a'].format = 'fail'
+        assert t['a'].format == '%4.2f {0:}'  # format did not change
 
     def test_column_format_with_threshold(self, table_type):
         from ... import conf


### PR DESCRIPTION
#6385 added code to validate `format` when it is set, but in the mean time the expected `TypeError` got changed to a `ValueError`.  The unit testing of this just checks for a `ValueError` but does not check that the `format` got reverted.
```
        try:
            # test whether it formats without error exemplarily
            self.pformat(max_lines=1)
        except TypeError as err:
            # revert to restore previous format if there was one
            self._format = prev_format
            raise ValueError(
                "Invalid format for column '{0}': could not display "
                "values in this column using this format ({1})".format(
                    self.name, err.args[0]))
```
