### PR TITLE
Remove all imports of remote_data decorator

### DIFF
--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from ..earth import EarthLocation, ELLIPSOIDS
 from ..angles import Longitude, Latitude
-from ...tests.helper import quantity_allclose, remote_data
+from ...tests.helper import quantity_allclose
 from ... import units as u
 from ..name_resolve import NameResolveError
 
@@ -284,7 +284,7 @@ def test_repr_latex():
     somelocation2._repr_latex_()
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_of_address():
     # no match
     with pytest.raises(NameResolveError):

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 
 from ... import units as u
-from ...tests.helper import (remote_data, quantity_allclose as allclose,
+from ...tests.helper import (quantity_allclose as allclose,
                              assert_quantity_allclose as assert_allclose)
 from ...time import Time
 from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
@@ -477,7 +477,7 @@ def test_gcrs_self_transform_closeby():
     assert_allclose(delta, 0.0*u.m, atol=1*u.m)
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_JPLEPHEM')
 def test_ephemerides():
     """

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -13,7 +13,6 @@ import numpy as np
 from ..name_resolve import (get_icrs_coordinates, NameResolveError,
                             sesame_database, _parse_response, sesame_url)
 from ..sky_coordinate import SkyCoord
-from ...tests.helper import remote_data
 from ... import units as u
 
 _cached_ngc3642 = dict()
@@ -103,7 +102,7 @@ _cached_castor["simbad"] = """# castor    #Q22524495
 #====Done (2013-Feb-12,17:00:39z)===="""
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_names():
 
     # First check that sesame is up
@@ -137,7 +136,7 @@ def test_names():
     np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 1)
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.parametrize(("name", "db_dict"), [('NGC 3642', _cached_ngc3642),
                                                ('castor', _cached_castor)])
 def test_database_specify(name, db_dict):

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -1,7 +1,7 @@
 
 import pytest
 
-from ...tests.helper import assert_quantity_allclose, remote_data, quantity_allclose
+from ...tests.helper import assert_quantity_allclose, quantity_allclose
 from ... import units as u
 from .. import Longitude, Latitude, EarthLocation
 from ..sites import get_builtin_sites, get_downloaded_sites, SiteRegistry
@@ -27,7 +27,7 @@ def test_builtin_sites():
     assert exc.value.args[0] == "Site 'nonexistent site' not in database. Use the 'names' attribute to see available sites."
 
 
-@remote_data(source='astropy')
+@pytest.mark.remote_data(source='astropy')
 def test_online_sites():
     reg = get_downloaded_sites()
 
@@ -52,7 +52,7 @@ def test_online_sites():
     assert exc.value.args[0] == "Site 'kec' not in database. Use the 'names' attribute to see available sites. Did you mean one of: 'keck'?'"
 
 
-@remote_data(source='astropy')
+@pytest.mark.remote_data(source='astropy')
 # this will *try* the online so we have to make it remote_data, even though it
 # could fall back on the non-remote version
 def test_EarthLocation_basic():
@@ -85,7 +85,7 @@ def test_EarthLocation_state_offline():
     assert oldreg is not newreg
 
 
-@remote_data(source='astropy')
+@pytest.mark.remote_data(source='astropy')
 def test_EarthLocation_state_online():
     EarthLocation._site_registry = None
     EarthLocation._get_site_registry(force_download=True)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -13,8 +13,7 @@ import numpy as np
 import numpy.testing as npt
 
 from ... import units as u
-from ...tests.helper import (remote_data, catch_warnings,
-                             quantity_allclose,
+from ...tests.helper import (catch_warnings, quantity_allclose,
                              assert_quantity_allclose as assert_allclose)
 from ..representation import REPRESENTATION_CLASSES
 from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
@@ -1216,7 +1215,7 @@ def test_constellations():
     npt.assert_equal(scs.get_constellation(short_name=True), ['UMa']*2)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_constellations_with_nameresolve():
     assert SkyCoord.from_name('And I').get_constellation(short_name=True) == 'And'
 

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -12,8 +12,7 @@ from ..solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
                             _apparent_position_in_true_coordinates,
                             get_body_barycentric, get_body_barycentric_posvel)
 from ..funcs import get_sun
-from ...tests.helper import (remote_data, assert_quantity_allclose,
-                             quantity_allclose)
+from ...tests.helper import assert_quantity_allclose, quantity_allclose
 
 try:
     import jplephem  # pylint: disable=W0611
@@ -37,7 +36,7 @@ skyfield_angular_separation_tolerance = 1*u.arcsec
 skyfield_separation_tolerance = 10*u.km
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif(str('not HAS_SKYFIELD'))
 def test_positions_skyfield():
     """
@@ -148,7 +147,7 @@ class TestPositionsGeocentric:
         assert_quantity_allclose(astropy.distance, horizons.distance,
                                  atol=dist_tol)
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     @pytest.mark.parametrize('body', ('mercury', 'jupiter', 'sun'))
     def test_de432s_planet(self, body):
@@ -166,7 +165,7 @@ class TestPositionsGeocentric:
         assert_quantity_allclose(astropy.distance, horizons.distance,
                                  atol=de432s_distance_tolerance)
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     def test_de432s_moon(self):
         astropy = get_moon(self.t, ephemeris='de432s')
@@ -231,7 +230,7 @@ class TestPositionKittPeak:
         assert_quantity_allclose(astropy.distance, horizons.distance,
                                  atol=dist_tol)
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     @pytest.mark.parametrize('body', ('mercury', 'jupiter'))
     def test_de432s_planet(self, body):
@@ -249,7 +248,7 @@ class TestPositionKittPeak:
         assert_quantity_allclose(astropy.distance, horizons.distance,
                                  atol=de432s_distance_tolerance)
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     def test_de432s_moon(self):
         astropy = get_moon(self.t, ephemeris='de432s')
@@ -266,7 +265,7 @@ class TestPositionKittPeak:
         assert_quantity_allclose(astropy.distance, horizons.distance,
                                  atol=de432s_distance_tolerance)
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     @pytest.mark.parametrize('bodyname', ('mercury', 'jupiter'))
     def test_custom_kernel_spec_body(self, bodyname):
@@ -282,7 +281,7 @@ class TestPositionKittPeak:
         assert_quantity_allclose(coord_by_name.distance, coord_by_kspec.distance)
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_JPLEPHEM')
 @pytest.mark.parametrize('time', (Time('1960-01-12 00:00'),
                                   Time('1980-03-25 00:00'),
@@ -341,7 +340,7 @@ def test_earth_barycentric_velocity_multi_d():
                              atol=2.*u.km/u.s)
 
 
-@remote_data
+@pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_JPLEPHEM')
 @pytest.mark.parametrize(('body', 'pos_tol', 'vel_tol'),
                          (('mercury', 1000.*u.km, 1.*u.km/u.s),

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -20,7 +20,6 @@ from ..file import _File, GZIP_MAGIC
 
 from ....io import fits
 from ....tests.helper import raises, catch_warnings, ignore_warnings
-from ....tests.helper import remote_data
 from ....utils.data import conf, get_pkg_data_filename
 from ....utils import data
 
@@ -653,7 +652,7 @@ class TestFileFunctions(FitsTestCase):
                     with fits.open(urlobj, mode=mode) as fits_handle:
                         pass
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     def test_open_from_remote_url(self):
 
         import urllib.request

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -386,7 +386,7 @@ class TestRunner(TestRunnerBase):
     def remote_data(self, remote_data, kwargs):
         """
         remote_data : {'none', 'astropy', 'any'}, optional
-            Controls whether to run tests marked with @remote_data. This can be
+            Controls whether to run tests marked with @pytest.mark.remote_data. This can be
             set to run no tests with remote data (``none``), only ones that use
             data from http://data.astropy.org (``astropy``), or all tests that
             use remote data (``any``). The default is ``none``.

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings, remote_data
+from ...tests.helper import catch_warnings
 from ...utils import isiterable
 from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation
@@ -906,7 +906,7 @@ def test_TimeFormat_scale():
     assert t.unix == t.utc.unix
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_scale_conversion():
     Time(Time.now().cxcsec, format='cxcsec', scale='ut1')
 

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -4,7 +4,6 @@ import pytest
 from ... import units as u
 from ...coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
 from .. import Time, TimeDelta
-from ...tests.helper import remote_data
 
 try:
     import jplephem  # pylint: disable=W0611
@@ -55,7 +54,7 @@ class TestHelioBaryCentric():
         assert bval_arr[0]-bval1 < 1. * u.us
         assert bval_arr[1]-bval2 < 1. * u.us
 
-    @remote_data
+    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     def test_ephemerides(self):
         bval1 = self.obstime.light_travel_time(self.star, 'barycentric')

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -4,7 +4,6 @@ import functools
 import pytest
 import numpy as np
 
-from ...tests.helper import remote_data
 from .. import Time
 from ...utils.iers import iers  # used in testing
 
@@ -23,7 +22,7 @@ else:
 class TestTimeUT1():
     """Test Time.ut1 using IERS tables"""
 
-    @remote_data
+    @pytest.mark.remote_data
     def test_utc_to_ut1(self):
         "Test conversion of UTC to UT1, making sure to include a leap second"""
         t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
@@ -81,7 +80,7 @@ class TestTimeUT1_IERSA():
         assert tnow_ut1_jd != tnow.jd
 
 
-@remote_data
+@pytest.mark.remote_data
 class TestTimeUT1_IERS_Auto():
     def test_ut1_iers_auto(self):
         tnow = Time.now()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -6,7 +6,7 @@ import urllib.request
 import pytest
 import numpy as np
 
-from ....tests.helper import assert_quantity_allclose, catch_warnings, remote_data
+from ....tests.helper import assert_quantity_allclose, catch_warnings
 from .. import iers
 from .... import units as u
 from ....table import QTable
@@ -152,13 +152,13 @@ class TestIERS_A():
 
 class TestIERS_Auto():
 
-    @remote_data
+    @pytest.mark.remote_data
     def test_no_auto_download(self):
         with iers.conf.set_temp('auto_download', False):
             t = iers.IERS_Auto.open()
         assert type(t) is iers.IERS_B
 
-    @remote_data
+    @pytest.mark.remote_data
     def test_simple(self):
         iers_a_file_1 = os.path.join(os.path.dirname(__file__), 'finals2000A-2016-02-30-test')
         iers_a_file_2 = os.path.join(os.path.dirname(__file__), 'finals2000A-2016-04-30-test')

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -17,7 +17,7 @@ import pytest
 from ..data import (_get_download_cache_locs, CacheMissingWarning,
                     get_pkg_data_filename, get_readable_fileobj)
 
-from ...tests.helper import remote_data, raises, catch_warnings
+from ...tests.helper import raises, catch_warnings
 
 TESTURL = 'http://www.astropy.org'
 
@@ -39,7 +39,7 @@ else:
     HAS_XZ = True
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_download_nocache():
     from ..data import download_file
 
@@ -47,7 +47,7 @@ def test_download_nocache():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_download_parallel():
     from ..data import download_files_in_parallel
 
@@ -57,7 +57,7 @@ def test_download_parallel():
     assert all([os.path.isfile(f) for f in fnout]), fnout
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_download_noprogress():
     from ..data import download_file
 
@@ -65,7 +65,7 @@ def test_download_noprogress():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_download_cache():
 
     from ..data import download_file, clear_download_cache
@@ -98,7 +98,7 @@ def test_download_cache():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_url_nocache():
 
     from ..data import get_readable_fileobj
@@ -107,7 +107,7 @@ def test_url_nocache():
         assert page.read().find('Astropy') > -1
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_find_by_hash():
 
     from ..data import get_readable_fileobj, get_pkg_data_filename, clear_download_cache
@@ -126,7 +126,7 @@ def test_find_by_hash():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_find_invalid():
     from ..data import get_pkg_data_filename
 
@@ -272,7 +272,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
@@ -406,7 +406,7 @@ def test_compressed_stream():
         assert f.read().rstrip() == b'CONTENT'
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_invalid_location_download():
     """
     checks that download_file gives a URLError and not an AttributeError,
@@ -429,7 +429,7 @@ def test_invalid_location_download_noconnect():
         download_file('http://astropy.org/nonexistentfile')
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_is_url_in_cache():
     from ..data import download_file, is_url_in_cache
 
@@ -467,7 +467,7 @@ def test_path_objects_get_readable_fileobj():
                                      'testing functions\nCONTENT')
 
 
-@remote_data('astropy')
+@pytest.mark.remote_data('astropy')
 def test_get_cached_urls():
     from ..data import download_file, get_cached_urls
     download_file(TESTURL, cache=True, show_progress=False)

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -9,7 +9,6 @@ import pytest
 import numpy as np
 
 from .. import data, misc
-from ...tests.helper import remote_data
 
 
 def test_isiterable():
@@ -26,7 +25,7 @@ def test_signal_number_to_name_no_failure():
     misc.signal_number_to_name(0)
 
 
-@remote_data
+@pytest.mark.remote_data
 def test_api_lookup():
     strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)
     objurl = misc.find_api_page(misc, 'dev', False, timeout=3)

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -5,7 +5,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from ....wcs import WCS
-from ....tests.helper import remote_data
 
 from .. import WCSAxes
 from ..frame import BaseFrame
@@ -37,7 +36,7 @@ class HexagonalFrame(BaseFrame):
 
 class TestFrame(BaseImageTests):
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='custom_frame.png',
                                    tolerance=1.5)
@@ -79,7 +78,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_rectangular.png',
                                    tolerance=1.5)
@@ -103,7 +102,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_nonrectangular.png',
                                    tolerance=1.5)
@@ -128,7 +127,7 @@ class TestFrame(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_change_wcs.png',
                                    tolerance=1.5)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -10,7 +10,6 @@ from matplotlib import rc_context
 
 from .... import units as u
 from ....io import fits
-from ....tests.helper import remote_data
 from ....wcs import WCS
 from ....coordinates import SkyCoord
 
@@ -46,7 +45,7 @@ class BaseImageTests:
 
 class TestBasic(BaseImageTests):
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='image_plot.png',
                                    tolerance=1.5)
@@ -59,7 +58,7 @@ class TestBasic(BaseImageTests):
         ax.coords[0].set_ticks([-0.30, 0., 0.20] * u.degree, size=5, width=1)
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='contour_overlay.png',
                                    tolerance=1.5)
@@ -85,7 +84,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='overlay_features_image.png',
                                    tolerance=1.5)
@@ -124,7 +123,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='curvlinear_grid_patches_image.png',
                                    tolerance=1.5)
@@ -158,7 +157,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='cube_slice_image.png',
                                    tolerance=1.5)
@@ -186,7 +185,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='cube_slice_image_lonlat.png',
                                    tolerance=1.5)
@@ -208,7 +207,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, tolerance=1.5)
     def test_plot_coord(self):
         fig = plt.figure(figsize=(6, 6))
@@ -223,7 +222,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, tolerance=1.5)
     def test_plot_line(self):
         fig = plt.figure(figsize=(6, 6))
@@ -238,7 +237,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='changed_axis_units.png',
                                    tolerance=1.5)
@@ -258,7 +257,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='minor_ticks_image.png',
                                    tolerance=1.5)
@@ -279,7 +278,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='ticks_labels.png',
                                    tolerance=1.5)
@@ -309,7 +308,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='rcparams.png',
                                    tolerance=1.5)
@@ -333,7 +332,7 @@ class TestBasic(BaseImageTests):
             ax.coords[1].set_ticks(exclude_overlapping=True)
             return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='tick_angles.png',
                                    tolerance=1.5)
@@ -356,7 +355,7 @@ class TestBasic(BaseImageTests):
         ax.coords['dec'].set_ticks(color='red', size=20)
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='tick_angles_non_square_axes.png',
                                    tolerance=1.5)
@@ -380,7 +379,7 @@ class TestBasic(BaseImageTests):
         ax.coords['dec'].set_ticks(color='red', size=20)
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='set_coord_type.png',
                                    tolerance=1.5)
@@ -400,7 +399,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticks(exclude_overlapping=True)
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='test_ticks_regression_1.png',
                                    tolerance=1.5)
@@ -425,7 +424,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_ticklabel_position('all')
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='test_axislabels_regression.png',
                                    savefig_kwargs={'bbox_inches': 'tight'},
@@ -443,7 +442,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].ticklabels.set_visible(False)
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=1.5)
@@ -480,7 +479,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=1.5)
@@ -525,7 +524,7 @@ class TestBasic(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    tolerance=1.5)
     def test_elliptical_frame(self):

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 
 from .... import units as u
 from ....wcs import WCS
-from ....tests.helper import remote_data
 
 from .. import WCSAxes
 from .test_images import BaseImageTests
@@ -57,7 +56,7 @@ class LonLatToDistance(CurvedTransform):
 
 class TestTransformCoordMeta(BaseImageTests):
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='coords_overlay.png', tolerance=1.5)
     def test_coords_overlay(self):
 
@@ -105,7 +104,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='coords_overlay_auto_coord_meta.png', tolerance=1.5)
     def test_coords_overlay_auto_coord_meta(self):
 
@@ -128,7 +127,7 @@ class TestTransformCoordMeta(BaseImageTests):
 
         return fig
 
-    @remote_data(source='astropy')
+    @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='direct_init.png', tolerance=1.5)
     def test_direct_init(self):
 


### PR DESCRIPTION
This follows #6606. The `remote_data` decorator should no longer be imported from `astropy.tests`, although it is maintained for backwards compatibility. Instead, tests should use `@pytest.mark.remote_data`.