### PR TITLE
Make it possible to use Table.read on FITS files with no copying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,9 +43,9 @@ astropy.io.fits
 - Added ``ver`` attribute to set the ``EXTVER`` header keyword to ``ImageHDU``
   and ``TableHDU``. [#6454]
 
-- The performance for reading FITS tables has been significantly improved
-  for cases where the table contains one or more string columns, in
-  particular when done through ``Table.read``. [#6821]
+- The performance for reading FITS tables has been significantly improved,
+  in particular for cases where the tables contain one or more string columns
+  and when done through ``Table.read``. [#6821]
 
 - The ``Table.read`` now supports a ``memmap=`` keyword argument to control
   whether or not to use  memory mapping when reading the table. [#6821]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,13 +44,16 @@ astropy.io.fits
   and ``TableHDU``. [#6454]
 
 - The performance for reading FITS tables has been significantly improved, in
-  particular when done through ``Table.read``. The ``Table.read`` now also
-  supports a ``memmap=`` keyword argument to indicate whether or not to use
-  memory mapping when reading the table. When reading FITS tables with
-  ``fits.open``, a new keyword argument ``character_as_bytes`` can be passed -
-  when set to `True`, character columns are returned as Numpy byte arrays
-  (Numpy type S) while when set to `False`, the same columns are decoded to
-  Unicode strings (Numpy type U) which uses more memory. [#6821]
+  particular when done through ``Table.read``. [#6821]
+
+- The ``Table.read`` now supports a ``memmap=`` keyword argument to control
+  whether or not to use  memory mapping when reading the table. [#6821]
+
+- When reading FITS tables with ``fits.open``, a new keyword argument
+  ``character_as_bytes`` can be passed - when set to `True`, character columns
+  are returned as Numpy byte arrays (Numpy type S) while when set to `False`,
+  the same columns are decoded to Unicode strings (Numpy type U) which uses more
+  memory. [#6821]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -247,8 +247,9 @@ astropy.table
   methods it was needed only for Python2 usage. [#6655]
 
 - When reading in FITS tables with ``Table.read``, string columns are now
-  represented using Numpy byte (dtype ``S``) arrays rather than Numpy unicode
-  arrays (dtype ``U``). [#6821]
+  represented using Numpy byte (dtype ``S``) arrays rather than Numpy
+  unicode arrays (dtype ``U``). The ``Column`` class then ensures the
+  bytes are automatically converted to string as needed. [#6821]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ astropy.io.fits
   particular when done through ``Table.read``. The ``Table.read`` now also
   supports a ``memmap=`` keyword argument to indicate whether or not to use
   memory mapping when reading the table. When reading FITS tables with
-  ``fits.open``, a new keyworkd argument ``character_as_bytes`` can be passed -
+  ``fits.open``, a new keyword argument ``character_as_bytes`` can be passed -
   when set to `True`, character columns are returned as Numpy byte arrays
   (Numpy type S) while when set to `False`, the same columns are decoded to
   Unicode strings (Numpy type U) which uses more memory. [#6821]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ astropy.io.fits
 - Added ``ver`` attribute to set the ``EXTVER`` header keyword to ``ImageHDU``
   and ``TableHDU``. [#6454]
 
+- The performance for reading FITS tables has been significantly improved, in
+  particular when done through ``Table.read``. The ``Table.read`` now also
+  supports a ``memmap=`` keyword argument to indicate whether or not to use
+  memory mapping when reading the table.
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,7 +43,8 @@ astropy.io.fits
 - Added ``ver`` attribute to set the ``EXTVER`` header keyword to ``ImageHDU``
   and ``TableHDU``. [#6454]
 
-- The performance for reading FITS tables has been significantly improved, in
+- The performance for reading FITS tables has been significantly improved
+  for cases where the table contains one or more string columns, in
   particular when done through ``Table.read``. [#6821]
 
 - The ``Table.read`` now supports a ``memmap=`` keyword argument to control

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,7 +46,11 @@ astropy.io.fits
 - The performance for reading FITS tables has been significantly improved, in
   particular when done through ``Table.read``. The ``Table.read`` now also
   supports a ``memmap=`` keyword argument to indicate whether or not to use
-  memory mapping when reading the table.
+  memory mapping when reading the table. When reading FITS tables with
+  ``fits.open``, a new keyworkd argument ``character_as_bytes`` can be passed -
+  when set to `True`, character columns are returned as Numpy byte arrays
+  (Numpy type S) while when set to `False`, the same columns are decoded to
+  Unicode strings (Numpy type U) which uses more memory. [#6821]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,6 +246,10 @@ astropy.table
   ``convert_bytestring_to_unicode`` and ``convert_unicode_to_bytestring``
   methods it was needed only for Python2 usage. [#6655]
 
+- When reading in FITS tables with ``Table.read``, string columns are now
+  represented using Numpy byte (dtype ``S``) arrays rather than Numpy unicode
+  arrays (dtype ``U``). [#6821]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1227,7 +1227,7 @@ class Column(NotifierMixin):
                         fsize = dims[-1]
                     else:
                         fsize = np.dtype(format.recformat).itemsize
-                    return chararray.array(array, itemsize=fsize)
+                    return chararray.array(array, itemsize=fsize, copy=False)
                 else:
                     return _convert_array(array, np.dtype(format.recformat))
             elif 'L' in format:

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -93,7 +93,9 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
         Whether to use memory mapping, which accesses data on disk as needed. If
         you are only accessing part of the data, this is often more efficient.
         If you want to access all the values in the table, and you are able to
-        fit the table in memory, you may want to try turning memory mapping off.
+        fit the table in memory, you may be better off leaving memory mapping
+        off. However, if your table would not fit in memory, you should set this
+        to `True`.
     """
 
     if isinstance(input, HDUList):

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -144,7 +144,8 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     t = Table(masked=masked)
 
     for col in table.data._coldefs:
-        t.add_column(Column(data=col.array, name=col.name, copy=False))
+        column = Column(data=col.array, name=col.name, copy=False)
+        t.add_column(column, copy=False)
 
     # Copy over null values if needed
     if masked:

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -143,9 +143,10 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     # rather than via the structured array.
     t = Table(masked=masked)
 
+    columns = []
     for col in table.data._coldefs:
-        column = Column(data=col.array, name=col.name, copy=False)
-        t.add_column(column, copy=False)
+        columns.append(Column(data=col.array, name=col.name, copy=False))
+    t.add_columns(columns, copy=False)
 
     # Copy over null values if needed
     if masked:

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -63,7 +63,7 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_fits(input, hdu=None, astropy_native=False):
+def read_table_fits(input, hdu=None, astropy_native=False, memmap=True):
     """
     Read a Table object from an FITS file
 
@@ -89,6 +89,11 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     astropy_native : bool, optional
         Read in FITS columns as native astropy objects where possible instead
         of standard Table Column objects. Default is False.
+    memmap : bool, optional
+        Whether to use memory mapping, which accesses data on disk as needed. If
+        you are only accessing part of the data, this is often more efficient.
+        If you want to access all the values in the table, and you are able to
+        fit the table in memory, you may want to try turning memory mapping off.
     """
 
     if isinstance(input, HDUList):
@@ -127,7 +132,7 @@ def read_table_fits(input, hdu=None, astropy_native=False):
 
     else:
 
-        hdulist = fits_open(input, return_bytes=True)
+        hdulist = fits_open(input, return_bytes=True, memmap=memmap)
 
         try:
             return read_table_fits(hdulist, hdu=hdu,

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -63,7 +63,8 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
+def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
+                    character_as_bytes=True):
     """
     Read a Table object from an FITS file
 
@@ -96,6 +97,13 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
         fit the table in memory, you may be better off leaving memory mapping
         off. However, if your table would not fit in memory, you should set this
         to `True`.
+    character_as_bytes : bool, optional
+        If `True`, string columns are stored as Numpy byte arrays (dtype ``S``)
+        and are converted on-the-fly to unicode strings when accessing
+        individual elements. If you need to use Numpy unicode arrays (dtype
+        ``U``) internally, you should set this to `False`, but note that this
+        will use more memory. If set to `False`, string columns will not be
+        memory-mapped even if ``memmap`` is `True`.
     """
 
     if isinstance(input, HDUList):
@@ -134,7 +142,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
 
     else:
 
-        hdulist = fits_open(input, character_as_bytes=True, memmap=memmap)
+        hdulist = fits_open(input, character_as_bytes=character_as_bytes,
+                            memmap=memmap)
 
         try:
             return read_table_fits(hdulist, hdu=hdu,

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -127,7 +127,7 @@ def read_table_fits(input, hdu=None, astropy_native=False):
 
     else:
 
-        hdulist = fits_open(input)
+        hdulist = fits_open(input, return_bytes=True)
 
         try:
             return read_table_fits(hdulist, hdu=hdu,
@@ -141,7 +141,7 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     # Convert to an astropy.table.Table object
     # Note: in future, it may make more sense to do this column-by-column,
     # rather than via the structured array.
-    t = Table(table.data, masked=masked)
+    t = Table(table.data, masked=masked, copy=False)
 
     # Copy over null values if needed
     if masked:

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -63,7 +63,7 @@ def is_fits(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_fits(input, hdu=None, astropy_native=False, memmap=True):
+def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
     """
     Read a Table object from an FITS file
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -132,7 +132,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
 
     else:
 
-        hdulist = fits_open(input, return_bytes=True, memmap=memmap)
+        hdulist = fits_open(input, character_as_bytes=True, memmap=memmap)
 
         try:
             return read_table_fits(hdulist, hdu=hdu,

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -143,20 +143,24 @@ def read_table_fits(input, hdu=None, astropy_native=False):
     # rather than via the structured array.
     t = Table(masked=masked)
 
+    # In the loop below we access the data using data[col.name] rather than
+    # col.array to make sure that the data is scaled correctly if needed.
+    data = table.data
+
     columns = []
-    for col in table.data._coldefs:
-        columns.append(Column(data=col.array, name=col.name, copy=False))
+    for col in data.columns:
+        columns.append(Column(data=data[col.name], name=col.name, copy=False))
     t.add_columns(columns, copy=False)
 
     # Copy over null values if needed
     if masked:
-        for col in table.data._coldefs:
+        for col in data.columns:
             if col.null is not None:
                 t[col.name].set_fill_value(col.null)
                 t[col.name].mask[t[col.name] == col.null] = True
 
     # Copy over units
-    for col in table.data._coldefs:
+    for col in data.columns:
         if col.unit is not None:
             t[col.name].unit = u.Unit(col.unit, format='fits', parse_strict='silent')
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -145,10 +145,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
     # Check if table is masked
     masked = any(col.null is not None for col in table.columns)
 
-    # Convert to an astropy.table.Table object
-    # Note: in future, it may make more sense to do this column-by-column,
+    # TODO: in future, it may make more sense to do this column-by-column,
     # rather than via the structured array.
-    t = Table(masked=masked)
 
     # In the loop below we access the data using data[col.name] rather than
     # col.array to make sure that the data is scaled correctly if needed.
@@ -172,7 +170,8 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False):
 
         columns.append(column)
 
-    t.add_columns(columns, copy=False)
+    # Create Table object
+    t = Table(columns, masked=masked, copy=False)
 
     # TODO: deal properly with unsigned integers
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -612,10 +612,8 @@ class FITS_rec(np.recarray):
             raise AttributeError(exc.args[0])
 
     def __del__(self):
-
         try:
             del self._coldefs
-
             if self.dtype.fields is not None:
                 for col in self._col_weakrefs:
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -152,7 +152,7 @@ class FITS_rec(np.recarray):
     """
 
     _record_type = FITS_record
-    _return_bytes = False
+    _character_as_bytes = False
 
     def __new__(subtype, input):
         """
@@ -219,7 +219,7 @@ class FITS_rec(np.recarray):
             return
 
         if isinstance(obj, FITS_rec):
-            self._return_bytes = obj._return_bytes
+            self._character_as_bytes = obj._character_as_bytes
 
         if isinstance(obj, FITS_rec) and obj.dtype == self.dtype:
             self._converted = obj._converted
@@ -970,7 +970,7 @@ class FITS_rec(np.recarray):
         elif _bool and field.dtype != bool:
             field = np.equal(field, ord('T'))
         elif _str:
-            if not self._return_bytes:
+            if not self._character_as_bytes:
                 with suppress(UnicodeDecodeError):
                     field = decode_ascii(field)
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -618,7 +618,10 @@ class FITS_rec(np.recarray):
             if self.dtype.fields is not None:
                 for col in self._col_weakrefs:
                     if col.array is not None:
-                        col.array = col.array.copy()
+                        # We use [:] but not copy() here so that the new
+                        # col.array is a view of the same region in memory
+                        # but a differe Python object.
+                        col.array = col.array[:]
 
         # See issues #4690 and #4912
         except (AttributeError, TypeError):  # pragma: no cover

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -612,16 +612,15 @@ class FITS_rec(np.recarray):
             raise AttributeError(exc.args[0])
 
     def __del__(self):
+
         try:
             del self._coldefs
 
             if self.dtype.fields is not None:
                 for col in self._col_weakrefs:
+
                     if col.array is not None:
-                        # We use [:] but not copy() here so that the new
-                        # col.array is a view of the same region in memory
-                        # but a differe Python object.
-                        col.array = col.array[:]
+                        col.array = col.array.copy()
 
         # See issues #4690 and #4912
         except (AttributeError, TypeError):  # pragma: no cover

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -362,10 +362,6 @@ def _convert_time_column(col, column_info):
             # [+/-C]CCYY-MM-DD[Thh:mm:ss[.s...]] where the number of characters
             # from index 20 to the end of string represents the precision
             precision = max(int(col.info.dtype.str[2:]) - 20, 0)
-            if col.info.dtype.kind == 'S':
-                # We need to decode the bytes array because Time only takes
-                # string arrays.
-                col = np.char.decode(col, 'ascii')
             return Time(col, format='fits', scale=column_info['scale'],
                         precision=precision,
                         location=column_info['location'])

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -362,6 +362,10 @@ def _convert_time_column(col, column_info):
             # [+/-C]CCYY-MM-DD[Thh:mm:ss[.s...]] where the number of characters
             # from index 20 to the end of string represents the precision
             precision = max(int(col.info.dtype.str[2:]) - 20, 0)
+            if col.info.dtype.kind == 'S':
+                # We need to decode the bytes array because Time only takes
+                # string arrays.
+                col = np.char.decode(col, 'ascii')
             return Time(col, format='fits', scale=column_info['scale'],
                         precision=precision,
                         location=column_info['location'])

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -114,7 +114,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
             If `True`, image data is not scaled using BSCALE/BZERO values
             when read.
 
-        - **return_bytes** : bool
+        - **character_as_bytes** : bool
 
             Whether to return bytes for string columns. By default this is `False`
             and (unicode) strings are returned, but this does not respect memory

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -114,6 +114,12 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
             If `True`, image data is not scaled using BSCALE/BZERO values
             when read.
 
+        - **return_bytes** : bool
+
+            Whether to return bytes for string columns. By default this is `False`
+            and (unicode) strings are returned, but this does not respect memory
+            mapping and loads the whole column in memory when accessed.
+
         - **ignore_blank** : bool
 
             If `True`, the BLANK keyword is ignored if present.

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -247,6 +247,10 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
+    return_bytes : bool
+        Whether to return bytes for string columns. By default this is `False`
+        and (unicode) strings are returned, but this does not respect memory
+        mapping and loads the whole column in memory when accessed.
     """
 
     _manages_own_heap = False
@@ -259,12 +263,16 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     which perform their own heap maintenance.
     """
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, return_bytes=False):
+
         super().__init__(data=data, header=header, name=name, ver=ver)
 
         if header is not None and not isinstance(header, Header):
             raise ValueError('header must be a Header object.')
+
         self._uint = uint
+        self._return_bytes = return_bytes
+
         if data is DELAYED:
             # this should never happen
             if header is None:
@@ -400,6 +408,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     def data(self):
         data = self._get_tbdata()
         data._coldefs = self.columns
+        data._return_bytes = self._return_bytes
         # Columns should now just return a reference to the data._coldefs
         del self.columns
         return data
@@ -701,6 +710,10 @@ class TableHDU(_TableBaseHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
+    return_bytes : bool
+        Whether to return bytes for string columns. By default this is `False`
+        and (unicode) strings are returned, but this does not respect memory
+        mapping and loads the whole column in memory when accessed.
 
     """
 
@@ -713,8 +726,8 @@ class TableHDU(_TableBaseHDU):
     __format_RE = re.compile(
         r'(?P<code>[ADEFIJ])(?P<width>\d+)(?:\.(?P<prec>\d+))?')
 
-    def __init__(self, data=None, header=None, name=None, ver=None):
-        super().__init__(data, header, name=name, ver=ver)
+    def __init__(self, data=None, header=None, name=None, ver=None, return_bytes=False):
+        super().__init__(data, header, name=name, ver=ver, return_bytes=return_bytes)
 
     @classmethod
     def match_header(cls, header):
@@ -813,13 +826,17 @@ class BinTableHDU(_TableBaseHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
+    return_bytes : bool
+        Whether to return bytes for string columns. By default this is `False`
+        and (unicode) strings are returned, but this does not respect memory
+        mapping and loads the whole column in memory when accessed.
 
     """
 
     _extension = 'BINTABLE'
     _ext_comment = 'binary table extension'
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, return_bytes=False):
         from ....table import Table
         if isinstance(data, Table):
             from ..convenience import table_to_hdu
@@ -829,7 +846,7 @@ class BinTableHDU(_TableBaseHDU):
             data = hdu.data
             header = hdu.header
 
-        super().__init__(data, header, name=name, uint=uint, ver=ver)
+        super().__init__(data, header, name=name, uint=uint, ver=ver, return_bytes=return_bytes)
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -263,7 +263,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     which perform their own heap maintenance.
     """
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, character_as_bytes=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None,
+                 character_as_bytes=False):
 
         super().__init__(data=data, header=header, name=name, ver=ver)
 
@@ -836,7 +837,8 @@ class BinTableHDU(_TableBaseHDU):
     _extension = 'BINTABLE'
     _ext_comment = 'binary table extension'
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, character_as_bytes=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None,
+                 character_as_bytes=False):
         from ....table import Table
         if isinstance(data, Table):
             from ..convenience import table_to_hdu
@@ -846,7 +848,8 @@ class BinTableHDU(_TableBaseHDU):
             data = hdu.data
             header = hdu.header
 
-        super().__init__(data, header, name=name, uint=uint, ver=ver, character_as_bytes=character_as_bytes)
+        super().__init__(data, header, name=name, uint=uint, ver=ver,
+                         character_as_bytes=character_as_bytes)
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -247,7 +247,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
-    return_bytes : bool
+    character_as_bytes : bool
         Whether to return bytes for string columns. By default this is `False`
         and (unicode) strings are returned, but this does not respect memory
         mapping and loads the whole column in memory when accessed.
@@ -263,7 +263,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     which perform their own heap maintenance.
     """
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, return_bytes=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, character_as_bytes=False):
 
         super().__init__(data=data, header=header, name=name, ver=ver)
 
@@ -271,7 +271,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             raise ValueError('header must be a Header object.')
 
         self._uint = uint
-        self._return_bytes = return_bytes
+        self._character_as_bytes = character_as_bytes
 
         if data is DELAYED:
             # this should never happen
@@ -408,7 +408,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     def data(self):
         data = self._get_tbdata()
         data._coldefs = self.columns
-        data._return_bytes = self._return_bytes
+        data._character_as_bytes = self._character_as_bytes
         # Columns should now just return a reference to the data._coldefs
         del self.columns
         return data
@@ -710,7 +710,7 @@ class TableHDU(_TableBaseHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
-    return_bytes : bool
+    character_as_bytes : bool
         Whether to return bytes for string columns. By default this is `False`
         and (unicode) strings are returned, but this does not respect memory
         mapping and loads the whole column in memory when accessed.
@@ -726,8 +726,8 @@ class TableHDU(_TableBaseHDU):
     __format_RE = re.compile(
         r'(?P<code>[ADEFIJ])(?P<width>\d+)(?:\.(?P<prec>\d+))?')
 
-    def __init__(self, data=None, header=None, name=None, ver=None, return_bytes=False):
-        super().__init__(data, header, name=name, ver=ver, return_bytes=return_bytes)
+    def __init__(self, data=None, header=None, name=None, ver=None, character_as_bytes=False):
+        super().__init__(data, header, name=name, ver=ver, character_as_bytes=character_as_bytes)
 
     @classmethod
     def match_header(cls, header):
@@ -826,7 +826,7 @@ class BinTableHDU(_TableBaseHDU):
         If not given or None, it defaults to the value of the ``EXTVER``
         card of the ``header`` or 1.
         (default: None)
-    return_bytes : bool
+    character_as_bytes : bool
         Whether to return bytes for string columns. By default this is `False`
         and (unicode) strings are returned, but this does not respect memory
         mapping and loads the whole column in memory when accessed.
@@ -836,7 +836,7 @@ class BinTableHDU(_TableBaseHDU):
     _extension = 'BINTABLE'
     _ext_comment = 'binary table extension'
 
-    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, return_bytes=False):
+    def __init__(self, data=None, header=None, name=None, uint=False, ver=None, character_as_bytes=False):
         from ....table import Table
         if isinstance(data, Table):
             from ..convenience import table_to_hdu
@@ -846,7 +846,7 @@ class BinTableHDU(_TableBaseHDU):
             data = hdu.data
             header = hdu.header
 
-        super().__init__(data, header, name=name, uint=uint, ver=ver, return_bytes=return_bytes)
+        super().__init__(data, header, name=name, uint=uint, ver=ver, character_as_bytes=character_as_bytes)
 
     @classmethod
     def match_header(cls, header):

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -147,6 +147,25 @@ class TestSingleTable:
         t = Table.read(hdu)
         assert equal_data(t, self.data)
 
+    def test_memmap(self, tmpdir):
+        filename = str(tmpdir.join('test_simple.fts'))
+        t1 = Table(self.data)
+        t1.write(filename, overwrite=True)
+        t2 = Table.read(filename, memmap=False)
+        t3 = Table.read(filename, memmap=True)
+        assert equal_data(t2, t3)
+
+    @pytest.mark.parametrize('memmap', (False, True))
+    def test_character_as_bytes(self, tmpdir, memmap):
+        filename = str(tmpdir.join('test_simple.fts'))
+        t1 = Table(self.data)
+        t1.write(filename, overwrite=True)
+        t2 = Table.read(filename, character_as_bytes=False, memmap=memmap)
+        t3 = Table.read(filename, character_as_bytes=True, memmap=memmap)
+        assert t2['b'].dtype.kind == 'U'
+        assert t3['b'].dtype.kind == 'S'
+        assert equal_data(t2, t3)
+
 
 class TestMultipleHDU:
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -1,4 +1,5 @@
 import os
+import gc
 import pathlib
 import warnings
 
@@ -154,6 +155,10 @@ class TestSingleTable:
         t2 = Table.read(filename, memmap=False)
         t3 = Table.read(filename, memmap=True)
         assert equal_data(t2, t3)
+        # To avoid issues with --open-files, we need to remove references to
+        # data that uses memory mapping and force the garbage collection
+        del t1, t2, t3
+        gc.collect()
 
     @pytest.mark.parametrize('memmap', (False, True))
     def test_character_as_bytes(self, tmpdir, memmap):
@@ -165,6 +170,10 @@ class TestSingleTable:
         assert t2['b'].dtype.kind == 'U'
         assert t3['b'].dtype.kind == 'S'
         assert equal_data(t2, t3)
+        # To avoid issues with --open-files, we need to remove references to
+        # data that uses memory mapping and force the garbage collection
+        del t1, t2, t3
+        gc.collect()
 
 
 class TestMultipleHDU:

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -250,7 +250,7 @@ def test_masking_regression_1795():
     assert np.all(t['c3'].mask == np.array([False, False]))
     assert np.all(t['c4'].mask == np.array([False, False]))
     assert np.all(t['c1'].data == np.array([1, 2]))
-    assert np.all(t['c2'].data == np.array(['abc', 'xy ']))
+    assert np.all(t['c2'].data == np.array([b'abc', b'xy ']))
     assert_allclose(t['c3'].data, np.array([3.70000007153, 6.6999997139]))
     assert np.all(t['c4'].data == np.array([False, True]))
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1481,7 +1481,7 @@ class Table:
         except ValueError:
             raise ValueError("Column {0} does not exist".format(name))
 
-    def add_column(self, col, index=None, name=None, rename_duplicate=False):
+    def add_column(self, col, index=None, name=None, copy=True, rename_duplicate=False):
         """
         Add a new Column object ``col`` to the table.  If ``index``
         is supplied then insert column before ``index`` position
@@ -1568,7 +1568,7 @@ class Table:
         if name is not None:
             name = (name,)
 
-        self.add_columns([col], [index], name, rename_duplicate=rename_duplicate)
+        self.add_columns([col], [index], name, copy=copy, rename_duplicate=rename_duplicate)
 
     def add_columns(self, cols, indexes=None, names=None, copy=True, rename_duplicate=False):
         """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1481,7 +1481,7 @@ class Table:
         except ValueError:
             raise ValueError("Column {0} does not exist".format(name))
 
-    def add_column(self, col, index=None, name=None, copy=True, rename_duplicate=False):
+    def add_column(self, col, index=None, name=None, rename_duplicate=False, copy=True):
         """
         Add a new Column object ``col`` to the table.  If ``index``
         is supplied then insert column before ``index`` position
@@ -1498,6 +1498,8 @@ class Table:
             Column name
         rename_duplicate : bool
             Uniquify column name if it already exist. Default is False.
+        copy : bool
+            Make a copy of the new column. Default is True.
 
         Examples
         --------

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1234,7 +1234,7 @@ class TestConvertNumpyArray():
         for idx in range(len(arr.dtype)):
             assert arr.dtype[idx].byteorder != non_native_order
 
-        with fits.open(filename) as hdul:
+        with fits.open(filename, return_bytes=True) as hdul:
             data = hdul[1].data
             for colname in data.columns.names:
                 assert np.all(data[colname] == arr[colname])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1234,7 +1234,7 @@ class TestConvertNumpyArray():
         for idx in range(len(arr.dtype)):
             assert arr.dtype[idx].byteorder != non_native_order
 
-        with fits.open(filename, return_bytes=True) as hdul:
+        with fits.open(filename, character_as_bytes=True) as hdul:
             data = hdul[1].data
             for colname in data.columns.names:
                 assert np.all(data[colname] == arr[colname])


### PR DESCRIPTION
### Motivation

The intent of this PR was to address (at least from the FITS point of view) the issue described in https://github.com/astropy/astropy/issues/6491 - namely that when using ``Table.read`` with a FITS file, the data is currently copied, which can lead to poor performance.

### Bottom line

With this PR, I can read a 1.8Gb FITS table with some string columns using:

```python
from astropy.table import Table
t = Table.read('../Planes/fun-with-adsb/summary_full.fits')
```

in 2 seconds with 40Mb memory usage:

![after](https://user-images.githubusercontent.com/314716/32599495-a6059680-c534-11e7-91b6-ee225d71dcf1.png)

instead of 50+ seconds and 5Gb of memory:

![before](https://user-images.githubusercontent.com/314716/32567694-f3f6a16c-c4b3-11e7-960b-cc201fb2baaf.png)

In fact, the 2 seconds/40Mb are dominated almost entirely by the import statement, and the read statement takes 40ms. This is a speedup of almost ~1000x! Of course data will then be read as needed from disk, but this means that for accessing specific columns/rows/cells from a table, users could see significant speedup.

### FITS changes

This turned out to be more complicated than I thought. The issue is the following - we can simply add ``copy=False`` inside ``astropy/io/fits/connect.py`` to deal with preventing a copy for non-string columns. However, astropy.io.fits is inefficient when it comes to string columns in that it automatically converts ``A`` columns (which are fundamentally ASCII as far as I understand) to Numpy U(nicode) types. This was described by @taldcroft in: https://github.com/astropy/astropy/issues/6122 - this has two implications: memory mapping is not respected and the whole string columns are read in, and the memory usage is 4x what it needs to be because of the conversion to unicode.

So this PR adds the ability to control whether string columns are converted to unicode in astropy.io.fits with the ``return_bytes`` option to ``fits.open`` (which should be useful in itself), and then makes it so that we use that option for Table.read.

### Table changes

I also had to make it possible for ``add_column`` to take a ``copy`` argument - @taldcroft: was there a reason for not having that originally?

### Time changes

Finally I noticed that there was an issue in the Time parsing from FITS files - passing a Numpy array with S type to Time doesn't actually work so I needed to decode the values. This is inefficient but fixes what I think was a real bug.

### Issues

A few tests are now failing, which are I think related to comparisons with the unicode sandwich comparisons. @taldcroft, could you take a look at the failures since you are the most familiar with that code?

### Testing

A number of changes here require their own unit tests, which I can add if we decide to go ahead with this PR, along with changelog entries.

### Review

This needs a careful look by the FITS maintainers: @saimn @MSeifert04 @drdavella, as well as Table maintainers @taldcroft and @mhvk, and @AustereCuriosity because of the FITS/Time change.

Also @adrn - please test this out (since your comment on Slack prompted me to work on this!)

(this description was edited compared to its original version)

Closes #6122