### PR TITLE
Time allow column unicode sandwich

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -446,6 +446,9 @@ astropy.time
 - Initialization of Time instances now is consistent for all formats to
   ensure that ``-0.5 <= jd2 < 0.5``. [#6653]
 
+- Initialization of ``Time`` instances with ``Column`` is now possible
+  also if the ``Column`` has dtype ``S``. [#6823]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -197,10 +197,11 @@ class Time(ShapedLikeNDArray):
 
     Parameters
     ----------
-    val : sequence, str, number, or `~astropy.time.Time` object
-        Value(s) to initialize the time or times.
-    val2 : sequence, str, or number; optional
-        Value(s) to initialize the time or times.
+    val : sequence, ndarray, number, str, bytes, or `~astropy.time.Time` object
+        Value(s) to initialize the time or times.  Bytes are decoded as ascii.
+    val2 : sequence, ndarray, or number; optional
+        Value(s) to initialize the time or times.  Only used for numerical
+        input, to help preserve precision.
     format : str, optional
         Format of input value(s)
     scale : str, optional
@@ -1498,10 +1499,10 @@ class TimeDelta(Time):
 
     Parameters
     ----------
-    val : numpy ndarray, list, str, number, or `~astropy.time.TimeDelta` object
-        Data to initialize table.
+    val : sequence, ndarray, number, or `~astropy.time.TimeDelta` object
+        Value(s) to initialize the time difference(s).
     val2 : numpy ndarray, list, str, or number; optional
-        Data to initialize table.
+        Additional values, as needed to preserve precision.
     format : str, optional
         Format of input value(s)
     scale : str, optional

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -97,10 +97,11 @@ class TimeFormat(metaclass=TimeFormatMeta):
 
     Parameters
     ----------
-    val1 : numpy ndarray, list, str, or number
-        Data to initialize table.
-    val2 : numpy ndarray, list, str, or number; optional
-        Data to initialize table.
+    val1 : numpy ndarray, list, number, str, or bytes
+        Values to initialize the time or times.  Bytes are decoded as ascii.
+    val2 : numpy ndarray, list, or number; optional
+        Value(s) to initialize the time or times.  Only used for numerical
+        input, to help preserve precision.
     scale : str
         Time scale of input value(s)
     precision : int

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -15,6 +15,7 @@ from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation
 from ... import units as u
 from ... import _erfa as erfa
+from ...table import Column
 try:
     import pytz
     HAS_PYTZ = True
@@ -1136,3 +1137,18 @@ def test_sum_is_equivalent():
 
     assert t0 == t1
     assert (t0 + 1 * u.second) == (t1 + 1 * u.second)
+
+
+def test_string_valued_columns():
+    # Columns have a nice shim that translates bytes to string as needed.
+    # Ensure Time can handle these.  Use multi-d array just to be sure.
+    times = [[['{:04d}-{:02d}-{:02d}'.format(y, m, d) for d in range(1, 3)]
+              for m in range(5, 7)] for y in range(2012, 2014)]
+    cutf32 = Column(times)
+    cbytes = cutf32.astype('S')
+    tutf32 = Time(cutf32)
+    tbytes = Time(cbytes)
+    assert np.all(tutf32 == tbytes)
+    tutf32 = Time(Column(['B1950']))
+    tbytes = Time(Column([b'B1950']))
+    assert tutf32 == tbytes

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1152,3 +1152,16 @@ def test_string_valued_columns():
     tutf32 = Time(Column(['B1950']))
     tbytes = Time(Column([b'B1950']))
     assert tutf32 == tbytes
+
+
+def test_bytes_input():
+    tstring = '2011-01-02T03:04:05'
+    tbytes = b'2011-01-02T03:04:05'
+    assert tbytes.decode('ascii') == tstring
+    t0 = Time(tstring)
+    t1 = Time(tbytes)
+    assert t1 == t0
+    tarray = np.array(tbytes)
+    assert tarray.dtype.kind == 'S'
+    t2 = Time(tarray)
+    assert t2 == t0


### PR DESCRIPTION
Currently, if we pass a `Column` with `dtype='S'` to `Time`, this raises an error even though `Column` itself knows how to translate the bytes to strings. The problem is that in iterating over the column using `np.nditer`, the input is treated as a regular array. There are two possible solutions: use the `multi_index` of the iterator to get the item, so that `Column.__getitem__` can return a string, or just being more generally accepting of bytes input, and treating it as ascii. In this PR, I took the latter approach, as it was simpler and I didn't really see a downside to it.

This is helpful for #6821.
