### PR TITLE
Include pytest as RTD dependency

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - beautifulsoup4
   - ipython
   - mpmath
+  - pytest
   - pip:
     - sphinx-gallery>=0.1.12
     - jplephem


### PR DESCRIPTION
Fix #6825 

Is this the correct fix? I suspect it is related to the recent `pytest` refactoring?