### PR TITLE
Small tweak in the affiliated package instructions

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -188,7 +188,9 @@ Starting a new package
     git add README.md
 
 #. Finally, if you plan on using Travis for continuous integration, copy over
-   the ``.travis.yml`` file and edit it::
+   the ``.travis.yml`` file and edit it by replacing "packagname" with your
+   package.  (You can do a lot more to customize the travis builds.  More
+   detail on that below.)::
 
     cp ../template/.travis.yml .
     # edit .travis.yml


### PR DESCRIPTION
While running a short session on using the package template, several people were confused by the line about "edit `.travis.yml`".  This PR tries to clarify *what* they are supposed to edit it to do.

@astrofrog - can you have a quick look and clarify if this is what was meant? (`git blame` says this was you, although 3 years ago, so no worries if you don't remember :wink:)