### PR TITLE
Enable the new remote-data-strict option in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
+remote_data_strict = true
 addopts = --pyargs -p no:warnings
 
 [bdist_wininst]


### PR DESCRIPTION
As of `0.2.0`, the `pytest-remotedata` plugin requires strict error checking to be enabled explicitly. When enabled, if a test attempts to access the internet but is **not** marked with `@pytest.mark.remote_data`, the test will fail.

This is the behavior that Astropy expects, but it now needs to be enabled explicitly.