### PR TITLE
Ensure byte-valued Column inputs to Time are possible.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -446,6 +446,9 @@ astropy.time
 - Initialization of Time instances now is consistent for all formats to
   ensure that ``-0.5 <= jd2 < 0.5``. [#6653]
 
+- Initialization of ``Time`` instances with ``Column`` is now possible
+  also if the ``Column`` has dtype ``S``. [#6832]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -15,6 +15,7 @@ from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation
 from ... import units as u
 from ... import _erfa as erfa
+from ...table import Column
 try:
     import pytz
     HAS_PYTZ = True
@@ -1136,3 +1137,18 @@ def test_sum_is_equivalent():
 
     assert t0 == t1
     assert (t0 + 1 * u.second) == (t1 + 1 * u.second)
+
+
+def test_string_valued_columns():
+    # Columns have a nice shim that translates bytes to string as needed.
+    # Ensure Time can handle these.  Use multi-d array just to be sure.
+    times = [[['{:04d}-{:02d}-{:02d}'.format(y, m, d) for d in range(1, 3)]
+              for m in range(5, 7)] for y in range(2012, 2014)]
+    cutf32 = Column(times)
+    cbytes = cutf32.astype('S')
+    tutf32 = Time(cutf32)
+    tbytes = Time(cbytes)
+    assert np.all(tutf32 == tbytes)
+    tutf32 = Time(Column(['B1950']))
+    tbytes = Time(Column([b'B1950']))
+    assert tutf32 == tbytes


### PR DESCRIPTION
For this purpose, convert all input elements using vectorize rather than nditer, to avoid coercion to arrays and thus allow Column.__getitem__ to do conversion from bytes to string.

This is an alternative to #6823, probably better as less intrusive and more targeted.

This is helpful for #6821.
