### PR TITLE
Allow for v2.0.x series compatibility with pytest-astropy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,12 +106,13 @@ matrix:
         # Pinning conda version temporarily to 4.3.21, as some anaconda
         # packges build with 4.3.27 are faulty and we see this job failing,
         # while locally there are no issues when the same version of
-        # packages are installed from pip.
+        # packages are installed from pip.  Also make sure that series v2.0.x
+        # is compatible with pytest-astropy
         # TODO: remove the pinning once the issue is solved upstream.
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-mpl bintrees'
+               PIP_DEPENDENCIES='cpp-coveralls objgraph jplephem pytest-astropy pytest-mpl bintrees'
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,7 @@ astropy.tests
 
 - Fixed a bug that meant that the data.astropy.org mirror could not be used when
   using --remote-data=astropy. [#6724]
+- Split pytest plugins into separate modules. [#6384]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,8 @@ astropy.tests
   using --remote-data=astropy. [#6724]
 - Split pytest plugins into separate modules. [#6384]
 
+- Fixed a bug that caused the doctestplus plugin to not work nicely with the hypothesis package. [#6605]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -2,7 +2,8 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the astropy tree.
 
-from .tests.pytest_plugins import *
+from .tests.pytest_plugins import PYTEST_HEADER_MODULES
+from .tests.helper import enable_deprecations_as_exceptions
 
 try:
     import matplotlib

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -2,7 +2,7 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the astropy tree.
 
-from .tests.pytest_plugins import PYTEST_HEADER_MODULES
+from .tests.pytest_plugins import *
 from .tests.helper import enable_deprecations_as_exceptions
 
 try:

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -789,6 +789,9 @@ def test_unicode_sandwich_compare(class1, class2):
     else:
         obj2 = class2(['a', 'b'])
 
+    if six.PY2 and class2 == str:
+        return pytest.skip()
+
     assert np.all((obj1 == obj2) == [True, False])
     assert np.all((obj2 == obj1) == [True, False])
 

--- a/astropy/tests/__init__.py
+++ b/astropy/tests/__init__.py
@@ -4,3 +4,25 @@ This package contains utilities to run the astropy test suite, tools
 for writing tests, and general tests that are not associated with a
 particular package.
 """
+
+# NOTE: This is retained only for backwards compatibility. Affiliated packages
+# should no longer import `disable_internet` from `astropy.tests`. It is now
+# available from `pytest_remotedata`. However, this is not the recommended
+# mechanism for controlling access to remote data in tests. Instead, packages
+# should make use of decorators provided by the pytest_remotedata plugin:
+# - `@pytest.mark.remote_data` for tests that require remote data access
+# - `@pytest.mark.internet_off` for tests that should only run when remote data
+#       access is disabled.
+# Remote data access for the test suite is controlled by the `--remote-data`
+# command line flag. This is either passed to `pytest` directly or to the
+# `setup.py test` command.
+#
+# TODO: This import should eventually be removed once backwards compatibility
+# is no longer supported.
+
+try:
+    # This should only be necessary during testing, in which case the test
+    # package must be installed anyway.
+    from pytest_remotedata import disable_internet
+except ImportError:
+    pass

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -1,0 +1,341 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..extern import six
+
+import doctest
+import fnmatch
+import imp
+import os
+import re
+import sys
+
+import pytest
+
+from .output_checker import AstropyOutputChecker, FIX
+
+try:
+    import importlib.machinery as importlib_machinery
+except ImportError:  # Python 2.7
+    importlib_machinery = None
+
+# these pytest hooks allow us to mark tests and run the marked tests with
+# specific command line options.
+
+
+def pytest_addoption(parser):
+
+    parser.addoption("--doctest-plus", action="store_true",
+                     help="enable running doctests with additional "
+                     "features not found in the normal doctest "
+                     "plugin")
+
+    parser.addoption("--doctest-rst", action="store_true",
+                     help="enable running doctests in .rst documentation")
+
+    parser.addini("doctest_plus", "enable running doctests with additional "
+                  "features not found in the normal doctest plugin")
+
+    parser.addini("doctest_norecursedirs",
+                  "like the norecursedirs option but applies only to doctest "
+                  "collection", type="args", default=())
+
+    parser.addini("doctest_rst",
+                  "Run the doctests in the rst documentation",
+                  default=False)
+
+
+# We monkey-patch in our replacement doctest OutputChecker.  Not
+# great, but there isn't really an API to replace the checker when
+# using doctest.testfile, unfortunately.
+doctest.OutputChecker = AstropyOutputChecker
+
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+
+
+def pytest_configure(config):
+
+    doctest_plugin = config.pluginmanager.getplugin('doctest')
+    if (doctest_plugin is None or config.option.doctestmodules or not
+            (config.getini('doctest_plus') or config.option.doctest_plus)):
+        return
+
+    # These are the default doctest options we use for everything.
+    # There shouldn't be any need to manually put them in doctests
+    # themselves.
+    opts = (doctest.ELLIPSIS |
+            doctest.NORMALIZE_WHITESPACE |
+            FIX)
+
+    class DocTestModulePlus(doctest_plugin.DoctestModule):
+        # pytest 2.4.0 defines "collect".  Prior to that, it defined
+        # "runtest".  The "collect" approach is better, because we can
+        # skip modules altogether that have no doctests.  However, we
+        # need to continue to override "runtest" so that the built-in
+        # behavior (which doesn't do whitespace normalization or
+        # handling __doctest_skip__) doesn't happen.
+        def collect(self):
+            if self.fspath.basename == "conftest.py":
+                try:
+                    module = self.config._conftest.importconftest(self.fspath)
+                except AttributeError:  # pytest >= 2.8.0
+                    module = self.config.pluginmanager._importconftest(self.fspath)
+            else:
+                try:
+                    module = self.fspath.pyimport()
+                    # Just ignore searching modules that can't be imported when
+                    # collecting doctests
+                except ImportError:
+                    return
+
+            # uses internal doctest module parsing mechanism
+            finder = DocTestFinderPlus()
+            runner = doctest.DebugRunner(verbose=False, optionflags=opts,
+                                         checker=AstropyOutputChecker())
+            for test in finder.find(module):
+                if test.examples:  # skip empty doctests
+                    if config.getvalue("remote_data") != 'any':
+                        for example in test.examples:
+                            if example.options.get(REMOTE_DATA):
+                                example.options[doctest.SKIP] = True
+
+                    yield doctest_plugin.DoctestItem(
+                        test.name, self, runner, test)
+
+    class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+        def runtest(self):
+            # satisfy `FixtureRequest` constructor...
+            self.funcargs = {}
+            fixture_request = doctest_plugin._setup_fixtures(self)
+
+            failed, tot = doctest.testfile(
+                str(self.fspath), module_relative=False,
+                optionflags=opts, parser=DocTestParserPlus(),
+                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
+                raise_on_error=True, verbose=False, encoding='utf-8')
+
+    class DocTestParserPlus(doctest.DocTestParser):
+        """
+        An extension to the builtin DocTestParser that handles the
+        special directives for skipping tests.
+
+        The directives are:
+
+           - ``.. doctest-skip::``: Skip the next doctest chunk.
+
+           - ``.. doctest-requires:: module1, module2``: Skip the next
+             doctest chunk if the given modules/packages are not
+             installed.
+
+           - ``.. doctest-skip-all``: Skip all subsequent doctests.
+        """
+
+        def parse(self, s, name=None):
+            result = doctest.DocTestParser.parse(self, s, name=name)
+
+            # result is a sequence of alternating text chunks and
+            # doctest.Example objects.  We need to look in the text
+            # chunks for the special directives that help us determine
+            # whether the following examples should be skipped.
+
+            required = []
+            skip_next = False
+            skip_all = False
+
+            for entry in result:
+                if isinstance(entry, six.string_types) and entry:
+                    required = []
+                    skip_next = False
+                    lines = entry.strip().splitlines()
+
+                    if '.. doctest-skip-all' in (x.strip() for x in lines):
+                        skip_all = True
+                        continue
+
+                    if not len(lines):
+                        continue
+
+                    last_line = lines[-1]
+                    match = re.match(
+                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
+                    if match:
+                        marker = match.group(1)
+                        if (marker is None or
+                                (marker.strip() == 'win32' and
+                                 sys.platform == 'win32')):
+                            skip_next = True
+                            continue
+
+                    match = re.match(
+                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
+                        last_line)
+                    if match:
+                        required = re.split(r'\s*,?\s*', match.group(1))
+                elif isinstance(entry, doctest.Example):
+                    if (skip_all or skip_next or
+                        not DocTestFinderPlus.check_required_modules(required)):
+                        entry.options[doctest.SKIP] = True
+
+                    if (config.getvalue('remote_data') != 'any' and
+                        entry.options.get(REMOTE_DATA)):
+                        entry.options[doctest.SKIP] = True
+
+            return result
+
+    config.pluginmanager.register(
+        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
+                    config.getini('doctest_rst') or config.option.doctest_rst),
+        'doctestplus')
+
+    # Remove the doctest_plugin, or we'll end up testing the .rst
+    # files twice.
+    config.pluginmanager.unregister(doctest_plugin)
+
+
+class DoctestPlus(object):
+    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
+                 run_rst_doctests):
+        """
+        doctest_module_item_cls should be a class inheriting
+        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
+        running of a single doctest found in a Python module.  This is passed
+        in as an argument because the actual class to be used may not be
+        available at import time, depending on whether or not the doctest
+        plugin for py.test is available.
+        """
+        self._doctest_module_item_cls = doctest_module_item_cls
+        self._doctest_textfile_item_cls = doctest_textfile_item_cls
+        self._run_rst_doctests = run_rst_doctests
+
+        # Directories to ignore when adding doctests
+        self._ignore_paths = []
+
+    def pytest_ignore_collect(self, path, config):
+        """Skip paths that match any of the doctest_norecursedirs patterns."""
+
+        for pattern in config.getini("doctest_norecursedirs"):
+            if path.check(fnmatch=pattern):
+                # Apparently pytest_ignore_collect causes files not to be
+                # collected by any test runner; for DoctestPlus we only want to
+                # avoid creating doctest nodes for them
+                self._ignore_paths.append(path)
+                break
+
+        return False
+
+    def pytest_collect_file(self, path, parent):
+        """Implements an enhanced version of the doctest module from py.test
+        (specifically, as enabled by the --doctest-modules option) which
+        supports skipping all doctests in a specific docstring by way of a
+        special ``__doctest_skip__`` module-level variable.  It can also skip
+        tests that have special requirements by way of
+        ``__doctest_requires__``.
+
+        ``__doctest_skip__`` should be a list of functions, classes, or class
+        methods whose docstrings should be ignored when collecting doctests.
+
+        This also supports wildcard patterns.  For example, to run doctests in
+        a class's docstring, but skip all doctests in its modules use, at the
+        module level::
+
+            __doctest_skip__ = ['ClassName.*']
+
+        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
+        to the module itself, in case its module-level docstring contains
+        doctests.
+
+        ``__doctest_requires__`` should be a dictionary mapping wildcard
+        patterns (in the same format as ``__doctest_skip__``) to a list of one
+        or more modules that should be *importable* in order for the tests to
+        run.  For example, if some tests require the scipy module to work they
+        will be skipped unless ``import scipy`` is possible.  It is also
+        possible to use a tuple of wildcard patterns as a key in this dict::
+
+            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
+
+        """
+
+        for ignore_path in self._ignore_paths:
+            if ignore_path.common(path) == ignore_path:
+                return None
+
+        if path.ext == '.py':
+            if path.basename == 'conf.py':
+                return None
+
+            # Don't override the built-in doctest plugin
+            return self._doctest_module_item_cls(path, parent)
+        elif self._run_rst_doctests and path.ext == '.rst':
+            # Ignore generated .rst files
+            parts = str(path).split(os.path.sep)
+            if (path.basename.startswith('_') or
+                    any(x.startswith('_') for x in parts) or
+                    any(x == 'api' for x in parts)):
+                return None
+
+            # TODO: Get better names on these items when they are
+            # displayed in py.test output
+            return self._doctest_textfile_item_cls(path, parent)
+
+
+class DocTestFinderPlus(doctest.DocTestFinder):
+    """Extension to the default `doctest.DoctestFinder` that supports
+    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
+    """
+
+    # Caches the results of import attempts
+    _import_cache = {}
+
+    @classmethod
+    def check_required_modules(cls, mods):
+        for mod in mods:
+            if mod in cls._import_cache:
+                if not cls._import_cache[mod]:
+                    return False
+            try:
+                imp.find_module(mod)
+            except ImportError:
+                cls._import_cache[mod] = False
+                return False
+            else:
+                cls._import_cache[mod] = True
+        return True
+
+    def find(self, obj, name=None, module=None, globs=None,
+             extraglobs=None):
+        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
+                                           extraglobs)
+        if (hasattr(obj, '__doctest_skip__') or
+                hasattr(obj, '__doctest_requires__')):
+            if name is None and hasattr(obj, '__name__'):
+                name = obj.__name__
+            else:
+                raise ValueError("DocTestFinder.find: name must be given "
+                                 "when obj.__name__ doesn't exist: {!r}".format(
+                        (type(obj),)))
+
+            def test_filter(test):
+                for pat in getattr(obj, '__doctest_skip__', []):
+                    if pat == '*':
+                        return False
+                    elif pat == '.' and test.name == name:
+                        return False
+                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
+                        return False
+
+                reqs = getattr(obj, '__doctest_requires__', {})
+                for pats, mods in six.iteritems(reqs):
+                    if not isinstance(pats, tuple):
+                        pats = (pats,)
+                    for pat in pats:
+                        if not fnmatch.fnmatch(test.name,
+                                               '.'.join((name, pat))):
+                            continue
+                        if not self.check_required_modules(mods):
+                            return False
+                return True
+
+            tests = list(filter(test_filter, tests))
+
+        return tests
+

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -338,4 +338,3 @@ class DocTestFinderPlus(doctest.DocTestFinder):
             tests = list(filter(test_filter, tests))
 
         return tests
-

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -116,6 +116,19 @@ if find_loader('pytest_doctestplus') is None:
                     extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
                     raise_on_error=True, verbose=False, encoding='utf-8')
 
+            def reportinfo(self):
+                """
+                Overwrite pytest's ``DoctestItem`` because
+                ``DocTestTextfilePlus`` does not have a ``dtest`` attribute
+                which is used by pytest>=3.2.0 to return the location of the
+                tests.
+
+                For details see `pytest-dev/pytest#2651
+                <https://github.com/pytest-dev/pytest/pull/2651>`_.
+                """
+                return self.fspath, None, "[doctest] %s" % self.name
+
+
         class DocTestParserPlus(doctest.DocTestParser):
             """
             An extension to the builtin DocTestParser that handles the

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -105,6 +105,13 @@ if find_loader('pytest_doctestplus') is None:
                             test.name, self, runner, test)
 
         class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+
+            # Some pytest plugins such as hypothesis try and access the 'obj'
+            # attribute, and by default this returns an error for this class
+            # so we override it here to avoid any issues.
+            def obj(self):
+                pass
+
             def runtest(self):
                 # satisfy `FixtureRequest` constructor...
                 self.funcargs = {}
@@ -141,7 +148,6 @@ if find_loader('pytest_doctestplus') is None:
                - ``.. doctest-requires:: module1, module2``: Skip the next
                  doctest chunk if the given modules/packages are not
                  installed.
-
                - ``.. doctest-skip-all``: Skip all subsequent doctests.
             """
 

--- a/astropy/tests/pytest_doctestplus.py
+++ b/astropy/tests/pytest_doctestplus.py
@@ -1,340 +1,342 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+from pkgutil import find_loader
+# This is necessary to prevent pytest from reading the doctestplus plugin when
+# the pytest_doctestplus standalone package is installed
+if find_loader('pytest_doctestplus') is None:
+    from ..extern import six
 
-from ..extern import six
+    import doctest
+    import fnmatch
+    import imp
+    import os
+    import re
+    import sys
 
-import doctest
-import fnmatch
-import imp
-import os
-import re
-import sys
+    import pytest
 
-import pytest
+    from .output_checker import AstropyOutputChecker, FIX
 
-from .output_checker import AstropyOutputChecker, FIX
+    try:
+        import importlib.machinery as importlib_machinery
+    except ImportError:  # Python 2.7
+        importlib_machinery = None
 
-try:
-    import importlib.machinery as importlib_machinery
-except ImportError:  # Python 2.7
-    importlib_machinery = None
-
-# these pytest hooks allow us to mark tests and run the marked tests with
-# specific command line options.
-
-
-def pytest_addoption(parser):
-
-    parser.addoption("--doctest-plus", action="store_true",
-                     help="enable running doctests with additional "
-                     "features not found in the normal doctest "
-                     "plugin")
-
-    parser.addoption("--doctest-rst", action="store_true",
-                     help="enable running doctests in .rst documentation")
-
-    parser.addini("doctest_plus", "enable running doctests with additional "
-                  "features not found in the normal doctest plugin")
-
-    parser.addini("doctest_norecursedirs",
-                  "like the norecursedirs option but applies only to doctest "
-                  "collection", type="args", default=())
-
-    parser.addini("doctest_rst",
-                  "Run the doctests in the rst documentation",
-                  default=False)
+    # these pytest hooks allow us to mark tests and run the marked tests with
+    # specific command line options.
 
 
-# We monkey-patch in our replacement doctest OutputChecker.  Not
-# great, but there isn't really an API to replace the checker when
-# using doctest.testfile, unfortunately.
-doctest.OutputChecker = AstropyOutputChecker
+    def pytest_addoption(parser):
+        parser.addoption("--doctest-plus", action="store_true",
+                         help="enable running doctests with additional "
+                         "features not found in the normal doctest "
+                         "plugin")
 
-REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+        parser.addoption("--doctest-rst", action="store_true",
+                         help="enable running doctests in .rst documentation")
+
+        parser.addini("doctest_plus", "enable running doctests with additional "
+                      "features not found in the normal doctest plugin")
+
+        parser.addini("doctest_norecursedirs",
+                      "like the norecursedirs option but applies only to doctest "
+                      "collection", type="args", default=())
+
+        parser.addini("doctest_rst",
+                      "Run the doctests in the rst documentation",
+                      default=False)
 
 
-def pytest_configure(config):
+    # We monkey-patch in our replacement doctest OutputChecker.  Not
+    # great, but there isn't really an API to replace the checker when
+    # using doctest.testfile, unfortunately.
+    doctest.OutputChecker = AstropyOutputChecker
 
-    doctest_plugin = config.pluginmanager.getplugin('doctest')
-    if (doctest_plugin is None or config.option.doctestmodules or not
-            (config.getini('doctest_plus') or config.option.doctest_plus)):
-        return
+    REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
 
-    # These are the default doctest options we use for everything.
-    # There shouldn't be any need to manually put them in doctests
-    # themselves.
-    opts = (doctest.ELLIPSIS |
-            doctest.NORMALIZE_WHITESPACE |
-            FIX)
 
-    class DocTestModulePlus(doctest_plugin.DoctestModule):
-        # pytest 2.4.0 defines "collect".  Prior to that, it defined
-        # "runtest".  The "collect" approach is better, because we can
-        # skip modules altogether that have no doctests.  However, we
-        # need to continue to override "runtest" so that the built-in
-        # behavior (which doesn't do whitespace normalization or
-        # handling __doctest_skip__) doesn't happen.
-        def collect(self):
-            if self.fspath.basename == "conftest.py":
+    def pytest_configure(config):
+
+        doctest_plugin = config.pluginmanager.getplugin('doctest')
+        if (doctest_plugin is None or config.option.doctestmodules or not
+                (config.getini('doctest_plus') or config.option.doctest_plus)):
+            return
+
+        # These are the default doctest options we use for everything.
+        # There shouldn't be any need to manually put them in doctests
+        # themselves.
+        opts = (doctest.ELLIPSIS |
+                doctest.NORMALIZE_WHITESPACE |
+                FIX)
+
+        class DocTestModulePlus(doctest_plugin.DoctestModule):
+            # pytest 2.4.0 defines "collect".  Prior to that, it defined
+            # "runtest".  The "collect" approach is better, because we can
+            # skip modules altogether that have no doctests.  However, we
+            # need to continue to override "runtest" so that the built-in
+            # behavior (which doesn't do whitespace normalization or
+            # handling __doctest_skip__) doesn't happen.
+            def collect(self):
+                if self.fspath.basename == "conftest.py":
+                    try:
+                        module = self.config._conftest.importconftest(self.fspath)
+                    except AttributeError:  # pytest >= 2.8.0
+                        module = self.config.pluginmanager._importconftest(self.fspath)
+                else:
+                    try:
+                        module = self.fspath.pyimport()
+                        # Just ignore searching modules that can't be imported when
+                        # collecting doctests
+                    except ImportError:
+                        return
+
+                # uses internal doctest module parsing mechanism
+                finder = DocTestFinderPlus()
+                runner = doctest.DebugRunner(verbose=False, optionflags=opts,
+                                             checker=AstropyOutputChecker())
+                for test in finder.find(module):
+                    if test.examples:  # skip empty doctests
+                        if config.getvalue("remote_data") != 'any':
+                            for example in test.examples:
+                                if example.options.get(REMOTE_DATA):
+                                    example.options[doctest.SKIP] = True
+
+                        yield doctest_plugin.DoctestItem(
+                            test.name, self, runner, test)
+
+        class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
+            def runtest(self):
+                # satisfy `FixtureRequest` constructor...
+                self.funcargs = {}
+                fixture_request = doctest_plugin._setup_fixtures(self)
+
+                failed, tot = doctest.testfile(
+                    str(self.fspath), module_relative=False,
+                    optionflags=opts, parser=DocTestParserPlus(),
+                    extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
+                    raise_on_error=True, verbose=False, encoding='utf-8')
+
+        class DocTestParserPlus(doctest.DocTestParser):
+            """
+            An extension to the builtin DocTestParser that handles the
+            special directives for skipping tests.
+
+            The directives are:
+
+               - ``.. doctest-skip::``: Skip the next doctest chunk.
+
+               - ``.. doctest-requires:: module1, module2``: Skip the next
+                 doctest chunk if the given modules/packages are not
+                 installed.
+
+               - ``.. doctest-skip-all``: Skip all subsequent doctests.
+            """
+
+            def parse(self, s, name=None):
+                result = doctest.DocTestParser.parse(self, s, name=name)
+
+                # result is a sequence of alternating text chunks and
+                # doctest.Example objects.  We need to look in the text
+                # chunks for the special directives that help us determine
+                # whether the following examples should be skipped.
+
+                required = []
+                skip_next = False
+                skip_all = False
+
+                for entry in result:
+                    if isinstance(entry, six.string_types) and entry:
+                        required = []
+                        skip_next = False
+                        lines = entry.strip().splitlines()
+
+                        if '.. doctest-skip-all' in (x.strip() for x in lines):
+                            skip_all = True
+                            continue
+
+                        if not len(lines):
+                            continue
+
+                        last_line = lines[-1]
+                        match = re.match(
+                            r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
+                        if match:
+                            marker = match.group(1)
+                            if (marker is None or
+                                    (marker.strip() == 'win32' and
+                                     sys.platform == 'win32')):
+                                skip_next = True
+                                continue
+
+                        match = re.match(
+                            r'\.\.\s+doctest-requires\s*::\s+(.*)',
+                            last_line)
+                        if match:
+                            required = re.split(r'\s*,?\s*', match.group(1))
+                    elif isinstance(entry, doctest.Example):
+                        if (skip_all or skip_next or
+                            not DocTestFinderPlus.check_required_modules(required)):
+                            entry.options[doctest.SKIP] = True
+
+                        if (config.getvalue('remote_data') != 'any' and
+                            entry.options.get(REMOTE_DATA)):
+                            entry.options[doctest.SKIP] = True
+
+                return result
+
+        config.pluginmanager.register(
+            DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
+                        config.getini('doctest_rst') or config.option.doctest_rst),
+            'doctestplus')
+
+        # Remove the doctest_plugin, or we'll end up testing the .rst
+        # files twice.
+        config.pluginmanager.unregister(doctest_plugin)
+
+
+    class DoctestPlus(object):
+        def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
+                     run_rst_doctests):
+            """
+            doctest_module_item_cls should be a class inheriting
+            `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
+            running of a single doctest found in a Python module.  This is passed
+            in as an argument because the actual class to be used may not be
+            available at import time, depending on whether or not the doctest
+            plugin for py.test is available.
+            """
+            self._doctest_module_item_cls = doctest_module_item_cls
+            self._doctest_textfile_item_cls = doctest_textfile_item_cls
+            self._run_rst_doctests = run_rst_doctests
+
+            # Directories to ignore when adding doctests
+            self._ignore_paths = []
+
+        def pytest_ignore_collect(self, path, config):
+            """Skip paths that match any of the doctest_norecursedirs patterns."""
+
+            for pattern in config.getini("doctest_norecursedirs"):
+                if path.check(fnmatch=pattern):
+                    # Apparently pytest_ignore_collect causes files not to be
+                    # collected by any test runner; for DoctestPlus we only want to
+                    # avoid creating doctest nodes for them
+                    self._ignore_paths.append(path)
+                    break
+
+            return False
+
+        def pytest_collect_file(self, path, parent):
+            """Implements an enhanced version of the doctest module from py.test
+            (specifically, as enabled by the --doctest-modules option) which
+            supports skipping all doctests in a specific docstring by way of a
+            special ``__doctest_skip__`` module-level variable.  It can also skip
+            tests that have special requirements by way of
+            ``__doctest_requires__``.
+
+            ``__doctest_skip__`` should be a list of functions, classes, or class
+            methods whose docstrings should be ignored when collecting doctests.
+
+            This also supports wildcard patterns.  For example, to run doctests in
+            a class's docstring, but skip all doctests in its modules use, at the
+            module level::
+
+                __doctest_skip__ = ['ClassName.*']
+
+            You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
+            to the module itself, in case its module-level docstring contains
+            doctests.
+
+            ``__doctest_requires__`` should be a dictionary mapping wildcard
+            patterns (in the same format as ``__doctest_skip__``) to a list of one
+            or more modules that should be *importable* in order for the tests to
+            run.  For example, if some tests require the scipy module to work they
+            will be skipped unless ``import scipy`` is possible.  It is also
+            possible to use a tuple of wildcard patterns as a key in this dict::
+
+                __doctest_requires__ = {('func1', 'func2'): ['scipy']}
+
+            """
+
+            for ignore_path in self._ignore_paths:
+                if ignore_path.common(path) == ignore_path:
+                    return None
+
+            if path.ext == '.py':
+                if path.basename == 'conf.py':
+                    return None
+
+                # Don't override the built-in doctest plugin
+                return self._doctest_module_item_cls(path, parent)
+            elif self._run_rst_doctests and path.ext == '.rst':
+                # Ignore generated .rst files
+                parts = str(path).split(os.path.sep)
+                if (path.basename.startswith('_') or
+                        any(x.startswith('_') for x in parts) or
+                        any(x == 'api' for x in parts)):
+                    return None
+
+                # TODO: Get better names on these items when they are
+                # displayed in py.test output
+                return self._doctest_textfile_item_cls(path, parent)
+
+
+    class DocTestFinderPlus(doctest.DocTestFinder):
+        """Extension to the default `doctest.DoctestFinder` that supports
+        ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
+        """
+
+        # Caches the results of import attempts
+        _import_cache = {}
+
+        @classmethod
+        def check_required_modules(cls, mods):
+            for mod in mods:
+                if mod in cls._import_cache:
+                    if not cls._import_cache[mod]:
+                        return False
                 try:
-                    module = self.config._conftest.importconftest(self.fspath)
-                except AttributeError:  # pytest >= 2.8.0
-                    module = self.config.pluginmanager._importconftest(self.fspath)
-            else:
-                try:
-                    module = self.fspath.pyimport()
-                    # Just ignore searching modules that can't be imported when
-                    # collecting doctests
+                    imp.find_module(mod)
                 except ImportError:
-                    return
-
-            # uses internal doctest module parsing mechanism
-            finder = DocTestFinderPlus()
-            runner = doctest.DebugRunner(verbose=False, optionflags=opts,
-                                         checker=AstropyOutputChecker())
-            for test in finder.find(module):
-                if test.examples:  # skip empty doctests
-                    if config.getvalue("remote_data") != 'any':
-                        for example in test.examples:
-                            if example.options.get(REMOTE_DATA):
-                                example.options[doctest.SKIP] = True
-
-                    yield doctest_plugin.DoctestItem(
-                        test.name, self, runner, test)
-
-    class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
-        def runtest(self):
-            # satisfy `FixtureRequest` constructor...
-            self.funcargs = {}
-            fixture_request = doctest_plugin._setup_fixtures(self)
-
-            failed, tot = doctest.testfile(
-                str(self.fspath), module_relative=False,
-                optionflags=opts, parser=DocTestParserPlus(),
-                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
-                raise_on_error=True, verbose=False, encoding='utf-8')
-
-    class DocTestParserPlus(doctest.DocTestParser):
-        """
-        An extension to the builtin DocTestParser that handles the
-        special directives for skipping tests.
-
-        The directives are:
-
-           - ``.. doctest-skip::``: Skip the next doctest chunk.
-
-           - ``.. doctest-requires:: module1, module2``: Skip the next
-             doctest chunk if the given modules/packages are not
-             installed.
-
-           - ``.. doctest-skip-all``: Skip all subsequent doctests.
-        """
-
-        def parse(self, s, name=None):
-            result = doctest.DocTestParser.parse(self, s, name=name)
-
-            # result is a sequence of alternating text chunks and
-            # doctest.Example objects.  We need to look in the text
-            # chunks for the special directives that help us determine
-            # whether the following examples should be skipped.
-
-            required = []
-            skip_next = False
-            skip_all = False
-
-            for entry in result:
-                if isinstance(entry, six.string_types) and entry:
-                    required = []
-                    skip_next = False
-                    lines = entry.strip().splitlines()
-
-                    if '.. doctest-skip-all' in (x.strip() for x in lines):
-                        skip_all = True
-                        continue
-
-                    if not len(lines):
-                        continue
-
-                    last_line = lines[-1]
-                    match = re.match(
-                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
-                    if match:
-                        marker = match.group(1)
-                        if (marker is None or
-                                (marker.strip() == 'win32' and
-                                 sys.platform == 'win32')):
-                            skip_next = True
-                            continue
-
-                    match = re.match(
-                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
-                        last_line)
-                    if match:
-                        required = re.split(r'\s*,?\s*', match.group(1))
-                elif isinstance(entry, doctest.Example):
-                    if (skip_all or skip_next or
-                        not DocTestFinderPlus.check_required_modules(required)):
-                        entry.options[doctest.SKIP] = True
-
-                    if (config.getvalue('remote_data') != 'any' and
-                        entry.options.get(REMOTE_DATA)):
-                        entry.options[doctest.SKIP] = True
-
-            return result
-
-    config.pluginmanager.register(
-        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
-                    config.getini('doctest_rst') or config.option.doctest_rst),
-        'doctestplus')
-
-    # Remove the doctest_plugin, or we'll end up testing the .rst
-    # files twice.
-    config.pluginmanager.unregister(doctest_plugin)
-
-
-class DoctestPlus(object):
-    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
-                 run_rst_doctests):
-        """
-        doctest_module_item_cls should be a class inheriting
-        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
-        running of a single doctest found in a Python module.  This is passed
-        in as an argument because the actual class to be used may not be
-        available at import time, depending on whether or not the doctest
-        plugin for py.test is available.
-        """
-        self._doctest_module_item_cls = doctest_module_item_cls
-        self._doctest_textfile_item_cls = doctest_textfile_item_cls
-        self._run_rst_doctests = run_rst_doctests
-
-        # Directories to ignore when adding doctests
-        self._ignore_paths = []
-
-    def pytest_ignore_collect(self, path, config):
-        """Skip paths that match any of the doctest_norecursedirs patterns."""
-
-        for pattern in config.getini("doctest_norecursedirs"):
-            if path.check(fnmatch=pattern):
-                # Apparently pytest_ignore_collect causes files not to be
-                # collected by any test runner; for DoctestPlus we only want to
-                # avoid creating doctest nodes for them
-                self._ignore_paths.append(path)
-                break
-
-        return False
-
-    def pytest_collect_file(self, path, parent):
-        """Implements an enhanced version of the doctest module from py.test
-        (specifically, as enabled by the --doctest-modules option) which
-        supports skipping all doctests in a specific docstring by way of a
-        special ``__doctest_skip__`` module-level variable.  It can also skip
-        tests that have special requirements by way of
-        ``__doctest_requires__``.
-
-        ``__doctest_skip__`` should be a list of functions, classes, or class
-        methods whose docstrings should be ignored when collecting doctests.
-
-        This also supports wildcard patterns.  For example, to run doctests in
-        a class's docstring, but skip all doctests in its modules use, at the
-        module level::
-
-            __doctest_skip__ = ['ClassName.*']
-
-        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
-        to the module itself, in case its module-level docstring contains
-        doctests.
-
-        ``__doctest_requires__`` should be a dictionary mapping wildcard
-        patterns (in the same format as ``__doctest_skip__``) to a list of one
-        or more modules that should be *importable* in order for the tests to
-        run.  For example, if some tests require the scipy module to work they
-        will be skipped unless ``import scipy`` is possible.  It is also
-        possible to use a tuple of wildcard patterns as a key in this dict::
-
-            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
-
-        """
-
-        for ignore_path in self._ignore_paths:
-            if ignore_path.common(path) == ignore_path:
-                return None
-
-        if path.ext == '.py':
-            if path.basename == 'conf.py':
-                return None
-
-            # Don't override the built-in doctest plugin
-            return self._doctest_module_item_cls(path, parent)
-        elif self._run_rst_doctests and path.ext == '.rst':
-            # Ignore generated .rst files
-            parts = str(path).split(os.path.sep)
-            if (path.basename.startswith('_') or
-                    any(x.startswith('_') for x in parts) or
-                    any(x == 'api' for x in parts)):
-                return None
-
-            # TODO: Get better names on these items when they are
-            # displayed in py.test output
-            return self._doctest_textfile_item_cls(path, parent)
-
-
-class DocTestFinderPlus(doctest.DocTestFinder):
-    """Extension to the default `doctest.DoctestFinder` that supports
-    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
-    """
-
-    # Caches the results of import attempts
-    _import_cache = {}
-
-    @classmethod
-    def check_required_modules(cls, mods):
-        for mod in mods:
-            if mod in cls._import_cache:
-                if not cls._import_cache[mod]:
+                    cls._import_cache[mod] = False
                     return False
-            try:
-                imp.find_module(mod)
-            except ImportError:
-                cls._import_cache[mod] = False
-                return False
-            else:
-                cls._import_cache[mod] = True
-        return True
+                else:
+                    cls._import_cache[mod] = True
+            return True
 
-    def find(self, obj, name=None, module=None, globs=None,
-             extraglobs=None):
-        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
-                                           extraglobs)
-        if (hasattr(obj, '__doctest_skip__') or
-                hasattr(obj, '__doctest_requires__')):
-            if name is None and hasattr(obj, '__name__'):
-                name = obj.__name__
-            else:
-                raise ValueError("DocTestFinder.find: name must be given "
-                                 "when obj.__name__ doesn't exist: {!r}".format(
-                        (type(obj),)))
+        def find(self, obj, name=None, module=None, globs=None,
+                 extraglobs=None):
+            tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
+                                               extraglobs)
+            if (hasattr(obj, '__doctest_skip__') or
+                    hasattr(obj, '__doctest_requires__')):
+                if name is None and hasattr(obj, '__name__'):
+                    name = obj.__name__
+                else:
+                    raise ValueError("DocTestFinder.find: name must be given "
+                                     "when obj.__name__ doesn't exist: {!r}".format(
+                            (type(obj),)))
 
-            def test_filter(test):
-                for pat in getattr(obj, '__doctest_skip__', []):
-                    if pat == '*':
-                        return False
-                    elif pat == '.' and test.name == name:
-                        return False
-                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
-                        return False
-
-                reqs = getattr(obj, '__doctest_requires__', {})
-                for pats, mods in six.iteritems(reqs):
-                    if not isinstance(pats, tuple):
-                        pats = (pats,)
-                    for pat in pats:
-                        if not fnmatch.fnmatch(test.name,
-                                               '.'.join((name, pat))):
-                            continue
-                        if not self.check_required_modules(mods):
+                def test_filter(test):
+                    for pat in getattr(obj, '__doctest_skip__', []):
+                        if pat == '*':
                             return False
-                return True
+                        elif pat == '.' and test.name == name:
+                            return False
+                        elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
+                            return False
 
-            tests = list(filter(test_filter, tests))
+                    reqs = getattr(obj, '__doctest_requires__', {})
+                    for pats, mods in six.iteritems(reqs):
+                        if not isinstance(pats, tuple):
+                            pats = (pats,)
+                        for pat in pats:
+                            if not fnmatch.fnmatch(test.name,
+                                                   '.'.join((name, pat))):
+                                continue
+                            if not self.check_required_modules(mods):
+                                return False
+                    return True
 
-        return tests
+                tests = list(filter(test_filter, tests))
+
+            return tests

--- a/astropy/tests/pytest_openfiles.py
+++ b/astropy/tests/pytest_openfiles.py
@@ -1,0 +1,107 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import imp
+import os
+
+try:
+    import importlib.machinery as importlib_machinery
+except ImportError:  # Python 2.7
+    importlib_machinery = None
+
+
+def pytest_addoption(parser):
+
+    parser.addoption("--open-files", action="store_true",
+                     help="fail if any test leaves files open")
+
+    parser.addini("open_files_ignore",
+                  "when used with the --open-files option, allows "
+                  "specifying names of files that may be ignored when "
+                  "left open between tests--files in this list are matched "
+                  "may be specified by their base name (ignoring their full "
+                  "path) or by absolute path", type="args", default=())
+
+# Open file detection.
+#
+# This works by calling out to psutil to get the list of open files
+# held by the process both before and after the test.  If something is
+# still open after the test that wasn't open before the test, an
+# AssertionError is raised.
+#
+# This is not thread-safe.  We're not currently running our tests
+# multi-threaded, but that is worth noting.
+
+
+def _get_open_file_list():
+    import psutil
+    files = []
+    p = psutil.Process()
+
+    if importlib_machinery is not None:
+        suffixes = tuple(importlib_machinery.all_suffixes())
+    else:
+        suffixes = tuple(info[0] for info in imp.get_suffixes())
+
+    files = [x.path for x in p.open_files() if not x.path.endswith(suffixes)]
+
+    return set(files)
+
+
+def pytest_runtest_setup(item):
+    # Store a list of the currently opened files so we can compare
+    # against them when the test is done.
+    if item.config.getvalue('open_files'):
+        item.open_files = _get_open_file_list()
+
+
+def pytest_runtest_teardown(item, nextitem):
+    # a "skipped" test will not have been called with
+    # pytest_runtest_setup, so therefore won't have an
+    # "open_files" member
+    if (not item.config.getvalue('open_files') or
+            not hasattr(item, 'open_files')):
+        return
+
+    start_open_files = item.open_files
+    del item.open_files
+
+    open_files = _get_open_file_list()
+
+    # This works in tandem with the test_open_file_detection test to
+    # ensure that it creates one extra open file.
+    if item.name == 'test_open_file_detection':
+        assert len(start_open_files) + 1 == len(open_files)
+        return
+
+    not_closed = set()
+    open_files_ignore = item.config.getini('open_files_ignore')
+    for filename in open_files:
+        ignore = False
+
+        for ignored in open_files_ignore:
+            if not os.path.isabs(ignored):
+                if os.path.basename(filename) == ignored:
+                    ignore = True
+                    break
+            else:
+                if filename == ignored:
+                    ignore = True
+                    break
+
+        if ignore:
+            continue
+
+        if filename not in start_open_files:
+            not_closed.add(filename)
+
+    if len(not_closed):
+        msg = ['File(s) not closed:']
+        for name in not_closed:
+            msg.append('  {0}'.format(name))
+        raise AssertionError('\n'.join(msg))

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -9,13 +9,9 @@ from __future__ import (absolute_import, division, print_function,
 import __future__
 
 from ..extern import six
-from ..extern.six.moves import filter, range
 
 import ast
-import doctest
 import datetime
-import fnmatch
-import imp
 import io
 import locale
 import math
@@ -30,8 +26,6 @@ import pytest
 from ..config.paths import set_temp_config, set_temp_cache
 from .helper import treat_deprecations_as_exceptions, ignore_warnings
 from .helper import enable_deprecations_as_exceptions  # pylint: disable=W0611
-from .disable_internet import turn_off_internet, turn_on_internet
-from .output_checker import AstropyOutputChecker, FIX
 from ..utils.argparse import writeable_directory
 from ..utils.introspection import resolve_name
 
@@ -40,28 +34,16 @@ try:
 except ImportError:  # Python 2.7
     importlib_machinery = None
 
+pytest_plugins = ('astropy.tests.pytest_doctestplus',
+                  'astropy.tests.pytest_openfiles',
+                  'astropy.tests.pytest_repeat',
+                  'astropy.tests.pytest_remotedata')
+
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
 
 
 def pytest_addoption(parser):
-
-    # The following means that if --remote-data is not specified, the default
-    # is 'none', but if it is specified without arguments (--remote-data), it
-    # defaults to '--remote-data=any'.
-    parser.addoption("--remote-data", nargs="?", const='any', default='none',
-                     help="run tests with online data")
-
-    parser.addoption("--open-files", action="store_true",
-                     help="fail if any test leaves files open")
-
-    parser.addoption("--doctest-plus", action="store_true",
-                     help="enable running doctests with additional "
-                     "features not found in the normal doctest "
-                     "plugin")
-
-    parser.addoption("--doctest-rst", action="store_true",
-                     help="enable running doctests in .rst documentation")
 
     parser.addoption("--config-dir", nargs='?', type=writeable_directory,
                      help="specify directory for storing and retrieving the "
@@ -76,18 +58,6 @@ def pytest_addoption(parser):
                           "Astropy cache during tests (default is "
                           "to use a temporary directory created by the test "
                           "runner)")
-
-    parser.addini("doctest_plus", "enable running doctests with additional "
-                  "features not found in the normal doctest plugin")
-
-    parser.addini("doctest_norecursedirs",
-                  "like the norecursedirs option but applies only to doctest "
-                  "collection", type="args", default=())
-
-    parser.addini("doctest_rst",
-                  "Run the doctests in the rst documentation",
-                  default=False)
-
     parser.addini("config_dir",
                   "specify directory for storing and retrieving the "
                   "Astropy configuration during tests (default is "
@@ -102,396 +72,9 @@ def pytest_addoption(parser):
                   "to use a temporary directory created by the test "
                   "runner)", default=None)
 
-    parser.addini("open_files_ignore",
-                  "when used with the --open-files option, allows "
-                  "specifying names of files that may be ignored when "
-                  "left open between tests--files in this list are matched "
-                  "may be specified by their base name (ignoring their full "
-                  "path) or by absolute path", type="args", default=())
-
-    parser.addoption('--repeat', action='store',
-                     help='Number of times to repeat each test')
-
-
-def pytest_generate_tests(metafunc):
-
-    # If the repeat option is set, we add a fixture for the repeat count and
-    # parametrize the tests over the repeats. Solution adapted from:
-    # http://stackoverflow.com/q/21764473/180783
-
-    if metafunc.config.option.repeat is not None:
-        count = int(metafunc.config.option.repeat)
-        metafunc.fixturenames.append('tmp_ct')
-        metafunc.parametrize('tmp_ct', range(count))
-
-
-# We monkey-patch in our replacement doctest OutputChecker.  Not
-# great, but there isn't really an API to replace the checker when
-# using doctest.testfile, unfortunately.
-doctest.OutputChecker = AstropyOutputChecker
-
-
-REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
-
 
 def pytest_configure(config):
     treat_deprecations_as_exceptions()
-
-    config.getini('markers').append(
-        'remote_data: Run tests that require data from remote servers')
-
-    # Monkeypatch to deny access to remote resources unless explicitly told
-    # otherwise
-
-    if config.getoption('remote_data') != 'any':
-        turn_off_internet(verbose=config.option.verbose,
-                          allow_astropy_data=config.getoption('remote_data') == 'astropy')
-
-    doctest_plugin = config.pluginmanager.getplugin('doctest')
-    if (doctest_plugin is None or config.option.doctestmodules
-            or not (config.getini('doctest_plus').lower() in ['true', 'enabled']
-                    or config.option.doctest_plus)):
-        return
-
-    # These are the default doctest options we use for everything.
-    # There shouldn't be any need to manually put them in doctests
-    # themselves.
-    opts = (doctest.ELLIPSIS |
-            doctest.NORMALIZE_WHITESPACE |
-            FIX)
-
-    class DocTestModulePlus(doctest_plugin.DoctestModule):
-        # pytest 2.4.0 defines "collect".  Prior to that, it defined
-        # "runtest".  The "collect" approach is better, because we can
-        # skip modules altogether that have no doctests.  However, we
-        # need to continue to override "runtest" so that the built-in
-        # behavior (which doesn't do whitespace normalization or
-        # handling __doctest_skip__) doesn't happen.
-        def collect(self):
-            if self.fspath.basename == "conftest.py":
-                try:
-                    module = self.config._conftest.importconftest(self.fspath)
-                except AttributeError:  # pytest >= 2.8.0
-                    module = self.config.pluginmanager._importconftest(self.fspath)
-            else:
-                try:
-                    module = self.fspath.pyimport()
-                    # Just ignore searching modules that can't be imported when
-                    # collecting doctests
-                except ImportError:
-                    return
-
-            # uses internal doctest module parsing mechanism
-            finder = DocTestFinderPlus()
-            runner = doctest.DebugRunner(verbose=False, optionflags=opts,
-                                         checker=AstropyOutputChecker())
-            for test in finder.find(module):
-                if test.examples:  # skip empty doctests
-                    if config.getvalue("remote_data") != 'any':
-                        for example in test.examples:
-                            if example.options.get(REMOTE_DATA):
-                                example.options[doctest.SKIP] = True
-
-                    yield doctest_plugin.DoctestItem(
-                        test.name, self, runner, test)
-
-    class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
-
-        # Some pytest plugins such as hypothesis try and access the 'obj'
-        # attribute, and by default this returns an error for this class
-        # so we override it here to avoid any issues.
-        def obj(self):
-            pass
-
-        def runtest(self):
-            # satisfy `FixtureRequest` constructor...
-            self.funcargs = {}
-            fixture_request = doctest_plugin._setup_fixtures(self)
-
-            failed, tot = doctest.testfile(
-                str(self.fspath), module_relative=False,
-                optionflags=opts, parser=DocTestParserPlus(),
-                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
-                raise_on_error=True, verbose=False, encoding='utf-8')
-
-        def reportinfo(self):
-            """
-            Overwrite pytest's ``DoctestItem`` because
-            ``DocTestTextfilePlus`` does not have a ``dtest`` attribute
-            which is used by pytest>=3.2.0 to return the location of the
-            tests.
-
-            For details see `pytest-dev/pytest#2651
-            <https://github.com/pytest-dev/pytest/pull/2651>`_.
-            """
-            return self.fspath, None, "[doctest] %s" % self.name
-
-    class DocTestParserPlus(doctest.DocTestParser):
-        """
-        An extension to the builtin DocTestParser that handles the
-        special directives for skipping tests.
-
-        The directives are:
-
-           - ``.. doctest-skip::``: Skip the next doctest chunk.
-
-           - ``.. doctest-requires:: module1, module2``: Skip the next
-             doctest chunk if the given modules/packages are not
-             installed.
-
-           - ``.. doctest-skip-all``: Skip all subsequent doctests.
-        """
-
-        def parse(self, s, name=None):
-            result = doctest.DocTestParser.parse(self, s, name=name)
-
-            # result is a sequence of alternating text chunks and
-            # doctest.Example objects.  We need to look in the text
-            # chunks for the special directives that help us determine
-            # whether the following examples should be skipped.
-
-            required = []
-            skip_next = False
-            skip_all = False
-
-            for entry in result:
-                if isinstance(entry, six.string_types) and entry:
-                    required = []
-                    skip_next = False
-                    lines = entry.strip().splitlines()
-
-                    if '.. doctest-skip-all' in (x.strip() for x in lines):
-                        skip_all = True
-                        continue
-
-                    if not len(lines):
-                        continue
-
-                    last_line = lines[-1]
-                    match = re.match(
-                        r'\.\.\s+doctest-skip\s*::(\s+.*)?', last_line)
-                    if match:
-                        marker = match.group(1)
-                        if (marker is None or
-                                (marker.strip() == 'win32' and
-                                 sys.platform == 'win32')):
-                            skip_next = True
-                            continue
-
-                    match = re.match(
-                        r'\.\.\s+doctest-requires\s*::\s+(.*)',
-                        last_line)
-                    if match:
-                        required = re.split(r'\s*,?\s*', match.group(1))
-                elif isinstance(entry, doctest.Example):
-                    if (skip_all or skip_next or
-                        not DocTestFinderPlus.check_required_modules(required)):
-                        entry.options[doctest.SKIP] = True
-
-                    if (config.getvalue('remote_data') != 'any' and
-                        entry.options.get(REMOTE_DATA)):
-                        entry.options[doctest.SKIP] = True
-
-            return result
-
-    config.pluginmanager.register(
-        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
-                    config.getini('doctest_rst') or config.option.doctest_rst),
-        'doctestplus')
-
-    # Remove the doctest_plugin, or we'll end up testing the .rst
-    # files twice.
-    config.pluginmanager.unregister(doctest_plugin)
-
-
-class DoctestPlus(object):
-    def __init__(self, doctest_module_item_cls, doctest_textfile_item_cls,
-                 run_rst_doctests):
-        """
-        doctest_module_item_cls should be a class inheriting
-        `pytest.doctest.DoctestItem` and `pytest.File`.  This class handles
-        running of a single doctest found in a Python module.  This is passed
-        in as an argument because the actual class to be used may not be
-        available at import time, depending on whether or not the doctest
-        plugin for py.test is available.
-        """
-        self._doctest_module_item_cls = doctest_module_item_cls
-        self._doctest_textfile_item_cls = doctest_textfile_item_cls
-        self._run_rst_doctests = run_rst_doctests
-
-        # Directories to ignore when adding doctests
-        self._ignore_paths = []
-
-    def pytest_ignore_collect(self, path, config):
-        """Skip paths that match any of the doctest_norecursedirs patterns."""
-
-        for pattern in config.getini("doctest_norecursedirs"):
-            if path.check(fnmatch=pattern):
-                # Apparently pytest_ignore_collect causes files not to be
-                # collected by any test runner; for DoctestPlus we only want to
-                # avoid creating doctest nodes for them
-                self._ignore_paths.append(path)
-                break
-
-        return False
-
-    def pytest_collect_file(self, path, parent):
-        """Implements an enhanced version of the doctest module from py.test
-        (specifically, as enabled by the --doctest-modules option) which
-        supports skipping all doctests in a specific docstring by way of a
-        special ``__doctest_skip__`` module-level variable.  It can also skip
-        tests that have special requirements by way of
-        ``__doctest_requires__``.
-
-        ``__doctest_skip__`` should be a list of functions, classes, or class
-        methods whose docstrings should be ignored when collecting doctests.
-
-        This also supports wildcard patterns.  For example, to run doctests in
-        a class's docstring, but skip all doctests in its modules use, at the
-        module level::
-
-            __doctest_skip__ = ['ClassName.*']
-
-        You may also use the string ``'.'`` in ``__doctest_skip__`` to refer
-        to the module itself, in case its module-level docstring contains
-        doctests.
-
-        ``__doctest_requires__`` should be a dictionary mapping wildcard
-        patterns (in the same format as ``__doctest_skip__``) to a list of one
-        or more modules that should be *importable* in order for the tests to
-        run.  For example, if some tests require the scipy module to work they
-        will be skipped unless ``import scipy`` is possible.  It is also
-        possible to use a tuple of wildcard patterns as a key in this dict::
-
-            __doctest_requires__ = {('func1', 'func2'): ['scipy']}
-
-        """
-
-        for ignore_path in self._ignore_paths:
-            if ignore_path.common(path) == ignore_path:
-                return None
-
-        if path.ext == '.py':
-            if path.basename == 'conf.py':
-                return None
-
-            # Don't override the built-in doctest plugin
-            return self._doctest_module_item_cls(path, parent)
-        elif self._run_rst_doctests and path.ext == '.rst':
-            # Ignore generated .rst files
-            parts = str(path).split(os.path.sep)
-
-            # Don't test files that start with a _
-            if path.basename.startswith('_'):
-                return None
-
-            # Don't test files in directories that start with a '_' if those
-            # directories are inside docs. Note that we *should* allow for
-            # example /tmp/_q/docs/file.rst but not /tmp/docs/_build/file.rst
-            # If we don't find 'docs' in the path, we should just skip this
-            # check to be safe. We also want to skip any api sub-directory
-            # of docs.
-            if 'docs' in parts:
-                # We index from the end on the off chance that the temporary
-                # directory includes 'docs' in the path, e.g.
-                # /tmp/docs/371j/docs/index.rst You laugh, but who knows! :)
-                # Also, it turns out lists don't have an rindex method. Huh??!!
-                docs_index = len(parts) - 1 - parts[::-1].index('docs')
-                if any(x.startswith('_') or x == 'api' for x in parts[docs_index:]):
-                    return None
-
-            # TODO: Get better names on these items when they are
-            # displayed in py.test output
-            return self._doctest_textfile_item_cls(path, parent)
-
-
-class DocTestFinderPlus(doctest.DocTestFinder):
-    """Extension to the default `doctest.DoctestFinder` that supports
-    ``__doctest_skip__`` magic.  See `pytest_collect_file` for more details.
-    """
-
-    # Caches the results of import attempts
-    _import_cache = {}
-
-    @classmethod
-    def check_required_modules(cls, mods):
-        for mod in mods:
-            if mod in cls._import_cache:
-                if not cls._import_cache[mod]:
-                    return False
-            try:
-                imp.find_module(mod)
-            except ImportError:
-                cls._import_cache[mod] = False
-                return False
-            else:
-                cls._import_cache[mod] = True
-        return True
-
-    def find(self, obj, name=None, module=None, globs=None,
-             extraglobs=None):
-        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
-                                           extraglobs)
-        if (hasattr(obj, '__doctest_skip__') or
-                hasattr(obj, '__doctest_requires__')):
-            if name is None and hasattr(obj, '__name__'):
-                name = obj.__name__
-            else:
-                raise ValueError("DocTestFinder.find: name must be given "
-                                 "when obj.__name__ doesn't exist: {!r}".format(
-                        (type(obj),)))
-
-            def test_filter(test):
-                for pat in getattr(obj, '__doctest_skip__', []):
-                    if pat == '*':
-                        return False
-                    elif pat == '.' and test.name == name:
-                        return False
-                    elif fnmatch.fnmatch(test.name, '.'.join((name, pat))):
-                        return False
-
-                reqs = getattr(obj, '__doctest_requires__', {})
-                for pats, mods in six.iteritems(reqs):
-                    if not isinstance(pats, tuple):
-                        pats = (pats,)
-                    for pat in pats:
-                        if not fnmatch.fnmatch(test.name,
-                                               '.'.join((name, pat))):
-                            continue
-                        if not self.check_required_modules(mods):
-                            return False
-                return True
-
-            tests = list(filter(test_filter, tests))
-
-        return tests
-
-
-# Open file detection.
-#
-# This works by calling out to psutil to get the list of open files
-# held by the process both before and after the test.  If something is
-# still open after the test that wasn't open before the test, an
-# AssertionError is raised.
-#
-# This is not thread-safe.  We're not currently running our tests
-# multi-threaded, but that is worth noting.
-
-
-def _get_open_file_list():
-    import psutil
-    files = []
-    p = psutil.Process()
-
-    if importlib_machinery is not None:
-        suffixes = tuple(importlib_machinery.all_suffixes())
-    else:
-        suffixes = tuple(info[0] for info in imp.get_suffixes())
-
-    files = [x.path for x in p.open_files() if not x.path.endswith(suffixes)]
-
-    return set(files)
-
 
 def pytest_runtest_setup(item):
     config_dir = item.config.getini('config_dir')
@@ -510,27 +93,6 @@ def pytest_runtest_setup(item):
         item.set_temp_cache = set_temp_cache(cache_dir)
         item.set_temp_cache.__enter__()
 
-    # Store a list of the currently opened files so we can compare
-    # against them when the test is done.
-    if item.config.getvalue('open_files'):
-        item.open_files = _get_open_file_list()
-
-    remote_data = item.keywords.get('remote_data')
-
-    remote_data_config = item.config.getvalue("remote_data")
-
-    if remote_data is not None:
-
-        source = remote_data.kwargs.get('source', 'any')
-
-        if source not in ('astropy', 'any'):
-            raise ValueError("source should be 'astropy' or 'any'")
-
-        if remote_data_config == 'none':
-            pytest.skip("need --remote-data option to run")
-        elif remote_data_config == 'astropy':
-            if source == 'any':
-                pytest.skip("need --remote-data option to run")
 
 
 def pytest_runtest_teardown(item, nextitem):
@@ -538,51 +100,6 @@ def pytest_runtest_teardown(item, nextitem):
         item.set_temp_cache.__exit__()
     if hasattr(item, 'set_temp_config'):
         item.set_temp_config.__exit__()
-
-    # a "skipped" test will not have been called with
-    # pytest_runtest_setup, so therefore won't have an
-    # "open_files" member
-    if (not item.config.getvalue('open_files') or
-            not hasattr(item, 'open_files')):
-        return
-
-    start_open_files = item.open_files
-    del item.open_files
-
-    open_files = _get_open_file_list()
-
-    # This works in tandem with the test_open_file_detection test to
-    # ensure that it creates one extra open file.
-    if item.name == 'test_open_file_detection':
-        assert len(start_open_files) + 1 == len(open_files)
-        return
-
-    not_closed = set()
-    open_files_ignore = item.config.getini('open_files_ignore')
-    for filename in open_files:
-        ignore = False
-
-        for ignored in open_files_ignore:
-            if not os.path.isabs(ignored):
-                if os.path.basename(filename) == ignored:
-                    ignore = True
-                    break
-            else:
-                if filename == ignored:
-                    ignore = True
-                    break
-
-        if ignore:
-            continue
-
-        if filename not in start_open_files:
-            not_closed.add(filename)
-
-    if len(not_closed):
-        msg = ['File(s) not closed:']
-        for name in not_closed:
-            msg.append('  {0}'.format(name))
-        raise AssertionError('\n'.join(msg))
 
 
 PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
@@ -826,16 +343,6 @@ class NoUnicodeLiteralsModule(ModifiedModule):
                             return ast.copy_location(ast.Str(s=s), node)
                 return node
         return NonAsciiLiteral().visit(tree)
-
-
-def pytest_unconfigure():
-    """
-    Cleanup post-testing
-    """
-    # restore internet connectivity (only lost if remote_data=False and
-    # turn_off_internet previously called)
-    # this is harmless / does nothing if socket connections were never disabled
-    turn_on_internet()
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -19,6 +19,7 @@ import os
 import re
 import sys
 import types
+from pkgutil import find_loader
 from collections import OrderedDict
 
 import pytest
@@ -29,20 +30,9 @@ from .helper import enable_deprecations_as_exceptions  # pylint: disable=W0611
 from ..utils.argparse import writeable_directory
 from ..utils.introspection import resolve_name
 
-try:
-    import importlib.machinery as importlib_machinery
-except ImportError:  # Python 2.7
-    importlib_machinery = None
-
-pytest_plugins = ('astropy.tests.pytest_doctestplus',
-                  'astropy.tests.pytest_openfiles',
-                  'astropy.tests.pytest_repeat',
-                  'astropy.tests.pytest_remotedata')
 
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
-
-
 def pytest_addoption(parser):
 
     parser.addoption("--config-dir", nargs='?', type=writeable_directory,

--- a/astropy/tests/pytest_remotedata.py
+++ b/astropy/tests/pytest_remotedata.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from .helper import pytest
+from .disable_internet import turn_off_internet, turn_on_internet
+
+
+def pytest_addoption(parser):
+
+    # The following means that if --remote-data is not specified, the default
+    # is 'none', but if it is specified without arguments (--remote-data), it
+    # defaults to '--remote-data=any'.
+    parser.addoption("--remote-data", nargs="?", const='any', default='none',
+                     help="run tests with online data")
+
+
+def pytest_configure(config):
+    config.getini('markers').append(
+        'remote_data: Run tests that require data from remote servers')
+
+    # Monkeypatch to deny access to remote resources unless explicitly told
+    # otherwise
+
+    if config.getoption('remote_data') != 'any':
+        turn_off_internet(verbose=config.option.verbose,
+                          allow_astropy_data=config.getoption('remote_data') == 'astropy')
+
+
+def pytest_unconfigure():
+    """
+    Cleanup post-testing
+    """
+    # restore internet connectivity (only lost if remote_data=False and
+    # turn_off_internet previously called)
+    # this is harmless / does nothing if socket connections were never disabled
+    turn_on_internet()
+
+
+def pytest_runtest_setup(item):
+
+    remote_data = item.keywords.get('remote_data')
+
+    remote_data_config = item.config.getvalue("remote_data")
+
+    if remote_data is not None:
+
+        source = remote_data.kwargs.get('source', 'any')
+
+        if source not in ('astropy', 'any'):
+            raise ValueError("source should be 'astropy' or 'any'")
+
+        if remote_data_config == 'none':
+            pytest.skip("need --remote-data option to run")
+        elif remote_data_config == 'astropy':
+            if source == 'any':
+                pytest.skip("need --remote-data option to run")

--- a/astropy/tests/pytest_repeat.py
+++ b/astropy/tests/pytest_repeat.py
@@ -1,0 +1,27 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+These plugins modify the behavior of py.test and are meant to be imported
+into conftest.py in the root directory.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from ..extern.six.moves import range
+
+
+def pytest_addoption(parser):
+
+    parser.addoption('--repeat', action='store',
+                     help='Number of times to repeat each test')
+
+
+def pytest_generate_tests(metafunc):
+
+    # If the repeat option is set, we add a fixture for the repeat count and
+    # parametrize the tests over the repeats. Solution adapted from:
+    # http://stackoverflow.com/q/21764473/180783
+
+    if metafunc.config.option.repeat is not None:
+        count = int(metafunc.config.option.repeat)
+        metafunc.fixturenames.append('tmp_ct')
+        metafunc.parametrize('tmp_ct', range(count))

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -198,7 +198,6 @@ class TestRunnerBase(object):
             self.keywords['plugins'] = []
 
         plugins = [
-            'astropy.tests.pytest_plugins',
             'astropy.tests.pytest_repeat'
         ]
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -9,10 +9,11 @@ import shlex
 import sys
 import tempfile
 import warnings
+from pkgutil import find_loader
 from collections import OrderedDict
 
-from ..config.paths import set_temp_config, set_temp_cache
 from ..extern import six
+from ..config.paths import set_temp_config, set_temp_cache
 from ..utils import wraps, find_current_module
 from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
@@ -150,7 +151,7 @@ class TestRunnerBase(object):
             func = getattr(self, keyword)
             result = func(keywords[keyword], keywords)
 
-            # Allow disabaling of options in a subclass
+            # Allow disabling of options in a subclass
             if result is NotImplemented:
                 raise TypeError("run_tests() got an unexpected keyword argument {}".format(keyword))
 
@@ -192,6 +193,26 @@ class TestRunnerBase(object):
             raise TypeError("run_tests() got an unexpected keyword argument {}".format(wrong_kwargs[0]))
 
         args = self._generate_args(**kwargs)
+
+        if 'plugins' not in self.keywords or self.keywords['plugins'] is None:
+            self.keywords['plugins'] = []
+
+        plugins = [
+            'astropy.tests.pytest_plugins',
+            'astropy.tests.pytest_repeat'
+        ]
+
+        if find_loader('pytest_doctestplus') is None:
+            plugins.append('astropy.tests.pytest_doctestplus')
+
+        if find_loader('pytest_openfiles') is None:
+            plugins.append('astropy.tests.pytest_openfiles')
+
+        if find_loader('pytest_remotedata') is None:
+            plugins.append('astropy.tests.pytest_remotedata')
+
+        # Make plugins available to test runner without registering them
+        self.keywords['plugins'].extend(plugins)
 
         # override the config locations to not make a new directory nor use
         # existing cache or config
@@ -308,12 +329,8 @@ class TestRunner(TestRunnerBase):
                 common = os.path.commonprefix((abs_docs_path, abs_test_path))
 
                 if os.path.exists(abs_test_path) and common == abs_docs_path:
-                    # Since we aren't testing any Python files within
-                    # the astropy tree, we need to forcibly load the
-                    # astropy py.test plugins, and then turn on the
-                    # doctest_rst plugin.
-                    all_args.extend(['-p', 'astropy.tests.pytest_plugins',
-                                     '--doctest-rst'])
+                    # Turn on the doctest_rst plugin
+                    all_args.append('--doctest-rst')
                     test_path = abs_test_path
 
             if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
@@ -377,7 +394,7 @@ class TestRunner(TestRunnerBase):
     def remote_data(self, remote_data, kwargs):
         """
         remote_data : {'none', 'astropy', 'any'}, optional
-            Controls whether to run tests marked with @remote_data. This can be
+            Controls whether to run tests marked with @pytest.mark.remote_data. This can be
             set to run no tests with remote data (``none``), only ones that use
             data from http://data.astropy.org (``astropy``), or all tests that
             use remote data (``any``). The default is ``none``.

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -10,8 +10,7 @@ from copy import deepcopy
 import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings
-from ...tests.disable_internet import INTERNET_OFF
+from ...tests.helper import catch_warnings, remote_data
 from ...extern import six
 from ...extern.six.moves import zip
 from ...utils import isiterable
@@ -910,16 +909,9 @@ def test_TimeFormat_scale():
     assert t.unix == t.utc.unix
 
 
+@remote_data
 def test_scale_conversion():
-    if INTERNET_OFF:
-        # With internet off (which is the default for testing) then this will
-        # fall back to the bundled IERS-B table and raise an exception.  But when
-        # testing with --remote-data the IERS_Auto class will get the latest IERS-A
-        # and this works.
-        with pytest.raises(ScaleValueError):
-            Time(Time.now().cxcsec, format='cxcsec', scale='ut1')
-    else:
-        Time(Time.now().cxcsec, format='cxcsec', scale='ut1')
+    Time(Time.now().cxcsec, format='cxcsec', scale='ut1')
 
 
 def test_byteorder():

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -4,7 +4,7 @@ import functools
 import pytest
 import numpy as np
 
-from ...tests.disable_internet import INTERNET_OFF
+from ...tests.helper import remote_data
 from .. import Time
 from ...utils.iers import iers  # used in testing
 
@@ -23,6 +23,7 @@ else:
 class TestTimeUT1():
     """Test Time.ut1 using IERS tables"""
 
+    @remote_data
     def test_utc_to_ut1(self):
         "Test conversion of UTC to UT1, making sure to include a leap second"""
         t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
@@ -40,15 +41,7 @@ class TestTimeUT1():
 
         tnow = Time.now()
 
-        # With internet off (which is the default for testing) then this will
-        # fall back to the bundled IERS-B table and raise an exception.  But when
-        # testing with --remote-data the IERS_Auto class will get the latest IERS-A
-        # and this works.
-        if INTERNET_OFF:
-            with pytest.raises(IndexError):
-                tnow.ut1
-        else:
-            tnow.ut1
+        tnow.ut1
 
     def test_ut1_to_utc(self):
         """Also test the reverse, around the leap second
@@ -88,7 +81,7 @@ class TestTimeUT1_IERSA():
         assert tnow_ut1_jd != tnow.jd
 
 
-@pytest.mark.skipif('INTERNET_OFF')
+@remote_data
 class TestTimeUT1_IERS_Auto():
     def test_ut1_iers_auto(self):
         tnow = Time.now()

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -26,7 +26,6 @@ from ...table import Table, QTable
 from ...utils.data import get_pkg_data_filename, clear_download_cache
 from ... import utils
 from ...utils.exceptions import AstropyWarning
-from ...tests import disable_internet
 
 __all__ = ['Conf', 'conf',
            'IERS', 'IERS_B', 'IERS_A', 'IERS_Auto',
@@ -105,10 +104,6 @@ class Conf(_config.ConfigNamespace):
 
 
 conf = Conf()
-
-# If internet is off for testing then do not download.  This
-# makes most tests fall back to using the built-in IERS-B table.
-conf.auto_download &= not disable_internet.INTERNET_OFF
 
 
 class IERSRangeError(IndexError):

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
+remote_data_strict = true
 addopts = --pyargs -p no:warnings
 
 [bdist_wininst]


### PR DESCRIPTION
This also required a backport of the separation of Astropy's pytest plugins into individual modules.