### PR TITLE
Pre-download sites.json to avoid issues with doctests

### DIFF
--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -1,5 +1,15 @@
 .. include:: references.txt
 
+.. We call EarthLocation.of_site here first to force the downloading
+.. of sites.json so that future doctest output isn't clutted with
+.. "Downloading ... [done]". This can be removed once we have a better
+.. way of ignoring output lines based on pattern-matching, e.g.:
+.. https://github.com/astropy/pytest-doctestplus/issues/11
+
+.. testsetup::
+    >>> from astropy.coordinates import EarthLocation
+    >>> EarthLocation.of_site('greenwich') # doctest: +IGNORE_OUTPUT
+
 Using and Designing Coordinate Frames
 *************************************
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -1,5 +1,15 @@
 .. include:: references.txt
 
+.. We call EarthLocation.of_site here first to force the downloading
+.. of sites.json so that future doctest output isn't clutted with
+.. "Downloading ... [done]". This can be removed once we have a better
+.. way of ignoring output lines based on pattern-matching, e.g.:
+.. https://github.com/astropy/pytest-doctestplus/issues/11
+
+.. testsetup::
+    >>> from astropy.coordinates import EarthLocation
+    >>> EarthLocation.of_site('greenwich') # doctest: +IGNORE_OUTPUT
+
 .. _astropy-coordinates:
 
 *******************************************************


### PR DESCRIPTION
This is a temporary fix for an issue that would be properly dealt with with https://github.com/astropy/pytest-doctestplus/issues/11 - basically sometimes getting observer sites in the doctests causes a 'Downloading' line to appear, so we pre-download this inside a testsetup block (which doesn't appear in rendered documentation) to prevent this.