### PR TITLE
Add parallax kwarg to distance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The ``Distance`` object now accepts a ``parallax`` with angular units in the
+  initializer, and supports retrieving a parallax (as an angle) via the
+  ``.parallax`` attributes. [#6855]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- The ``Distance`` object now accepts a ``parallax`` with angular units in the
-  initializer, and supports retrieving a parallax (as an angle) via the
-  ``.parallax`` attributes. [#6855]
+- The ``Distance`` object now accepts ``parallax`` as a keyword in the
+  initializer, and supports retrieving a parallax (as an ``Angle``) via 
+  the ``.parallax`` attributes. [#6855]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -116,10 +116,12 @@ class Distance(u.SpecificTypeQuantity):
 
             value_msg = ('Should given only one of `value`, `z`, `distmod`, or '
                          '`parallax` in Distance constructor.')
-            if distmod is not None:
-                if value is not None:
-                    raise ValueError(value_msg)
+            n_not_none = np.sum([x is not None
+                                 for x in [value, z, distmod, parallax]])
+            if n_not_none > 1:
+                raise ValueError(value_msg)
 
+            if distmod is not None:
                 value = cls._distmod_to_pc(distmod)
                 if unit is None:
                     # if the unit is not specified, guess based on the mean of
@@ -139,11 +141,7 @@ class Distance(u.SpecificTypeQuantity):
                 copy = False
 
             elif parallax is not None:
-                if value is not None:
-                    raise ValueError(value_msg)
-
-                value = (1 / parallax).to(u.pc,
-                                          equivalencies=u.parallax()).value
+                value = parallax.to(u.pc, equivalencies=u.parallax()).value
                 unit = u.pc
 
                 # Continue on to take account of unit and other arguments
@@ -151,8 +149,9 @@ class Distance(u.SpecificTypeQuantity):
                 copy = False
 
             elif value is None:
-                raise ValueError('None of `value`, `z`, or `distmod` were '
-                                 'given to Distance constructor')
+                raise ValueError('None of `value`, `z`, `distmod`, or '
+                                 '`parallax` were given to Distance '
+                                 'constructor')
 
         # now we have arguments like for a Quantity, so let it do the work
         distance = super().__new__(

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -47,7 +47,7 @@ class Distance(u.SpecificTypeQuantity):
         The distance modulus for this distance. Note that if ``unit`` is not
         provided, a guess will be made at the unit between AU, pc, kpc, and Mpc.
     parallax : `~astropy.units.Quantity` or `~astropy.coordinates.Angle`
-        The parallax in angular units, 1/distance.
+        The parallax in angular units.
     dtype : `~numpy.dtype`, optional
         See `~astropy.units.Quantity`.
     copy : bool, optional

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -8,6 +8,7 @@ cartesian coordinates.
 import numpy as np
 
 from .. import units as u
+from .angles import Angle
 
 __all__ = ['Distance']
 
@@ -203,6 +204,11 @@ class Distance(u.SpecificTypeQuantity):
     def _distmod_to_pc(cls, dm):
         dm = u.Quantity(dm, u.mag)
         return cls(10 ** ((dm.value + 5) / 5.), u.pc, copy=False)
+
+    @property
+    def parallax(self):
+        """The parallax angle as an `~astropy.coordinates.Angle` object"""
+        return Angle(self.to(u.milliarcsecond, u.parallax()))
 
 
 def _convert_to_and_validate_length_unit(unit, allow_dimensionless=False):

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -85,7 +85,7 @@ class Distance(u.SpecificTypeQuantity):
     >>> d5 = Distance(z=0.23, cosmology=WMAP5)
     >>> d6 = Distance(distmod=24.47)
     >>> d7 = Distance(Distance(10 * u.Mpc))
-    >>> d8 = Distance(parallax=21.34*u.milliarcsecond)
+    >>> d8 = Distance(parallax=21.34*u.mas)
     """
 
     _equivalent_unit = u.m
@@ -142,19 +142,9 @@ class Distance(u.SpecificTypeQuantity):
                 if value is not None:
                     raise ValueError(value_msg)
 
-                value = cls._distmod_to_pc(distmod)
-                if unit is None:
-                    # if the unit is not specified, guess based on the mean of
-                    # the log of the distance
-                    meanlogval = np.log10(value.value).mean()
-                    if meanlogval > 6:
-                        unit = u.Mpc
-                    elif meanlogval > 3:
-                        unit = u.kpc
-                    elif meanlogval < -3:  # ~200 AU
-                        unit = u.AU
-                    else:
-                        unit = u.pc
+                value = (1 / parallax).to(u.pc,
+                                          equivalencies=u.parallax()).value
+                unit = u.pc
 
                 # Continue on to take account of unit and other arguments
                 # but a copy is already made, so no longer necessary
@@ -213,11 +203,6 @@ class Distance(u.SpecificTypeQuantity):
     @classmethod
     def _distmod_to_pc(cls, dm):
         dm = u.Quantity(dm, u.mag)
-        return cls(10 ** ((dm.value + 5) / 5.), u.pc, copy=False)
-
-    @classmethod
-    def _parallax_to_pc(cls, plx):
-        dm = u.Quantity(lpx, u.mag)
         return cls(10 ** ((dm.value + 5) / 5.), u.pc, copy=False)
 
 

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -215,8 +215,10 @@ def test_parallax():
         d = Distance(parallax=20*u.milliarcsecond, distmod=20)
 
     # array
-    d = Distance(parallax=[1, 10, 100.]*u.mas)
+    plx = [1, 10, 100.]*u.mas
+    d = Distance(parallax=plx)
     assert quantity_allclose(d.pc, [1000., 100., 10.])
+    assert quantity_allclose(plx, d.parallax)
 
 def test_distance_in_coordinates():
     """

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -11,6 +11,7 @@ import numpy as np
 from numpy import testing as npt
 
 from ... import units as u
+from ...tests.helper import quantity_allclose
 from .. import Longitude, Latitude, Distance, CartesianRepresentation
 from ..builtin_frames import ICRS, Galactic
 
@@ -201,6 +202,21 @@ def test_distmod():
     # if an array, uses the mean of the log of the distances
     assert Distance(distmod=[1, 11, 26]).unit == u.kpc
 
+
+def test_parallax():
+
+    d = Distance(parallax=1*u.arcsecond)
+    assert d.pc == 1.
+
+    with pytest.raises(ValueError):
+        d = Distance(15*u.pc, parallax=20*u.milliarcsecond)
+
+    with pytest.raises(ValueError):
+        d = Distance(parallax=20*u.milliarcsecond, distmod=20)
+
+    # array
+    d = Distance(parallax=[1, 10, 100.]*u.mas)
+    assert quantity_allclose(d.pc, [1000., 100., 10.])
 
 def test_distance_in_coordinates():
     """


### PR DESCRIPTION
This PR adds support for, e.g.,
```python
dist = coord.Distance(parallax=10*u.mas)
```
which basically just uses the `u.parallax()` equivalency to convert to a distance.

I added this mainly for completeness (since it has `z` and `distmod`). 