### PR TITLE
Automatically name frame attributes for velocity components from differentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,11 @@ astropy.coordinates
 - SkyCoord objects now support storing and tranforming differentials - i.e.,
   both radial velocities and proper motions. [#6944]
 
+- All frame classes now automatically get sensible representation mappings for
+  velocity components. For example, ``d_x``, ``d_y``, ``d_z`` are all
+  automatically mapped to frame component namse ``v_x``, ``v_y``, ``v_z``.
+  [#6856]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -197,36 +197,33 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         sph_component_map = {m.reprname: m.framename
                              for m in repr_info[r.SphericalRepresentation]}
 
-        if r.SphericalCosLatDifferential not in repr_info:
-            repr_info[r.SphericalCosLatDifferential] = [
-                RepresentationMapping(
-                    'd_lon_coslat',
-                    'pm_{lon}_cos{lat}'.format(**sph_component_map),
-                    u.mas/u.yr),
-                RepresentationMapping('d_lat',
-                                      'pm_{lat}'.format(**sph_component_map),
-                                      u.mas/u.yr),
-                RepresentationMapping('d_distance', 'radial_velocity',
-                                      u.km/u.s)
-            ]
+        repr_info.setdefault(r.SphericalCosLatDifferential, [
+            RepresentationMapping(
+                'd_lon_coslat',
+                'pm_{lon}_cos{lat}'.format(**sph_component_map),
+                u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
 
-        if r.SphericalDifferential not in repr_info:
-            repr_info[r.SphericalDifferential] = [
-                RepresentationMapping('d_lon',
-                                      'pm_{lon}'.format(**sph_component_map),
-                                      u.mas/u.yr),
-                RepresentationMapping('d_lat',
-                                      'pm_{lat}'.format(**sph_component_map),
-                                      u.mas/u.yr),
-                RepresentationMapping('d_distance', 'radial_velocity',
-                                      u.km/u.s)
-            ]
+        repr_info.setdefault(r.SphericalDifferential, [
+            RepresentationMapping('d_lon',
+                                  'pm_{lon}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_lat',
+                                  'pm_{lat}'.format(**sph_component_map),
+                                  u.mas/u.yr),
+            RepresentationMapping('d_distance', 'radial_velocity',
+                                  u.km/u.s)
+        ])
 
-        if r.CartesianDifferential not in repr_info:
-            repr_info[r.CartesianDifferential] = [
-                RepresentationMapping('d_x', 'v_x', u.km/u.s),
-                RepresentationMapping('d_y', 'v_y', u.km/u.s),
-                RepresentationMapping('d_z', 'v_z', u.km/u.s)]
+        repr_info.setdefault(r.CartesianDifferential, [
+            RepresentationMapping('d_x', 'v_x', u.km/u.s),
+            RepresentationMapping('d_y', 'v_y', u.km/u.s),
+            RepresentationMapping('d_z', 'v_z', u.km/u.s)])
 
         # Unit* classes should follow the same naming conventions
         repr_info.setdefault(r.UnitSphericalRepresentation,

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -165,7 +165,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
             if (not found_repr_info and
                     '_frame_specific_representation_info' in m):
                 # create a copy of the dict so we don't mess with the contents
-                repr_info = dict(m['_frame_specific_representation_info'])
+                repr_info = m['_frame_specific_representation_info'].copy()
                 found_repr_info = True
 
             if found_default_repr and found_default_diff and found_repr_info:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -164,7 +164,8 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
 
             if (not found_repr_info and
                     '_frame_specific_representation_info' in m):
-                repr_info = m['_frame_specific_representation_info']
+                # create a copy of the dict so we don't mess with the contents
+                repr_info = dict(m['_frame_specific_representation_info'])
                 found_repr_info = True
 
             if found_default_repr and found_default_diff and found_repr_info:
@@ -186,8 +187,8 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
             if isinstance(cls_or_name, str):
                 # TODO: this provides a layer of backwards compatibility in
                 # case the key is a string, but now we want explicit classes.
-                repr_info[_get_repr_cls(cls_or_name)] = repr_info[cls_or_name]
-                del repr_info[cls_or_name]
+                cls = _get_repr_cls(cls_or_name)
+                repr_info[cls] = repr_info.pop(cls_or_name)
 
         # The default spherical names are 'lon' and 'lat'
         repr_info.setdefault(r.SphericalRepresentation,

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -180,14 +180,15 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         #   * v_{x,y,z} for d_{x,y,z} for CartesianDifferential
         # where {lon} and {lat} are the names of the angular components
         if repr_info is None:
-            repr_info = dict()
+            repr_info = {}
 
-        if r.SphericalRepresentation in repr_info:
-            sph_component_map = {m.reprname: m.framename
-                                 for m in repr_info[r.SphericalRepresentation]}
+        # The default spherical names are 'lon' and 'lat'
+        repr_info.setdefault(r.SphericalRepresentation,
+                             [RepresentationMapping('lon', 'lon'),
+                              RepresentationMapping('lat', 'lat')])
 
-        else:
-            sph_component_map = {'lat': 'lat', 'lon': 'lon'}
+        sph_component_map = {m.reprname: m.framename
+                             for m in repr_info[r.SphericalRepresentation]}
 
         if r.SphericalCosLatDifferential not in repr_info:
             repr_info[r.SphericalCosLatDifferential] = [
@@ -221,17 +222,14 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
                 RepresentationMapping('d_z', 'v_z', u.km/u.s)]
 
         # Unit* classes should follow the same naming conventions
-        if r.SphericalRepresentation in repr_info:
-            repr_info.setdefault(r.UnitSphericalRepresentation,
-                                 repr_info[r.SphericalRepresentation])
+        repr_info.setdefault(r.UnitSphericalRepresentation,
+                             repr_info[r.SphericalRepresentation])
 
-        if r.SphericalCosLatDifferential in repr_info:
-            repr_info.setdefault(r.UnitSphericalCosLatDifferential,
-                                 repr_info[r.SphericalCosLatDifferential])
+        repr_info.setdefault(r.UnitSphericalCosLatDifferential,
+                             repr_info[r.SphericalCosLatDifferential])
 
-        if r.SphericalDifferential in repr_info:
-            repr_info.setdefault(r.UnitSphericalDifferential,
-                                 repr_info[r.SphericalDifferential])
+        repr_info.setdefault(r.UnitSphericalDifferential,
+                             repr_info[r.SphericalDifferential])
 
         # Make read-only properties for the frame class attributes that should
         # be read-only to make them immutable after creation.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -175,11 +175,16 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
                 'Could not find all expected BaseCoordinateFrame class '
                 'attributes.  Are you mis-using FrameMeta?')
 
-        # Unless overridden, velocity name defaults are:
-        #   * pm_{lon}_cos{lat} for SphericalCosLatDifferential
-        #   * radial_velocity for any d_distance, including RadialDifferential
-        #   * v_{x,y,z} for d_{x,y,z} for CartesianDifferential
-        # where {lon} and {lat} are the names of the angular components
+        # Unless overridden via `frame_specific_representation_info`, velocity
+        # name defaults are (see also docstring for BaseCoordinateFrame):
+        #   * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for
+        #     `SphericalCosLatDifferential` proper motion components
+        #   * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper
+        #     motion components
+        #   * ``radial_velocity`` for any `d_distance` component
+        #   * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
+        # where `{lon}` and `{lat}` are the frame names of the angular
+        # components.
         if repr_info is None:
             repr_info = {}
 
@@ -316,6 +321,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         `~astropy.coordinates.RepresentationMapping` objects that tell what
         names and default units should be used on this frame for the components
         of that representation.
+
+    Unless overridden via `frame_specific_representation_info`, velocity name
+    defaults are:
+
+      * ``pm_{lon}_cos{lat}``, ``pm_{lat}`` for `SphericalCosLatDifferential`
+        proper motion components
+      * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper motion
+        components
+      * ``radial_velocity`` for any `d_distance` component
+      * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
+
+    where `{lon}` and `{lat}` are the frame names of the angular components.
 
     Parameters
     ----------

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -182,6 +182,13 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if repr_info is None:
             repr_info = {}
 
+        for cls_or_name in repr_info.keys():
+            if isinstance(cls_or_name, str):
+                # TODO: this provides a layer of backwards compatibility in
+                # case the key is a string, but now we want explicit classes.
+                repr_info[_get_repr_cls(cls_or_name)] = repr_info[cls_or_name]
+                del repr_info[cls_or_name]
+
         # The default spherical names are 'lon' and 'lat'
         repr_info.setdefault(r.SphericalRepresentation,
                              [RepresentationMapping('lon', 'lon'),
@@ -647,11 +654,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 repr_attrs[repr_diff_cls]['units'].append(rec_unit)
 
         for repr_diff_cls, mappings in cls._frame_specific_representation_info.items():
-
-            if isinstance(repr_diff_cls, str):
-                # TODO: this provides a layer of backwards compatibility in
-                # case the key is a string, but now we want explicit classes.
-                repr_diff_cls = _get_repr_cls(repr_diff_cls)
 
             # take the 'names' and 'units' tuples from repr_attrs,
             # and then use the RepresentationMapping objects

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -183,24 +183,20 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
             repr_info = dict()
 
         if r.SphericalRepresentation in repr_info:
-            sph_mappings = repr_info[r.SphericalRepresentation]
-            component_map = dict([(m.reprname, m.framename)
-                                  for m in sph_mappings])
+            sph_component_map = {m.reprname: m.framename
+                                 for m in repr_info[r.SphericalRepresentation]}
 
         else:
-            component_map = dict()
-
-        component_map.setdefault('lon', 'lon')
-        component_map.setdefault('lat', 'lat')
+            sph_component_map = {'lat': 'lat', 'lon': 'lon'}
 
         if r.SphericalCosLatDifferential not in repr_info:
             repr_info[r.SphericalCosLatDifferential] = [
                 RepresentationMapping(
                     'd_lon_coslat',
-                    'pm_{lon}_cos{lat}'.format(**component_map),
+                    'pm_{lon}_cos{lat}'.format(**sph_component_map),
                     u.mas/u.yr),
                 RepresentationMapping('d_lat',
-                                      'pm_{lat}'.format(**component_map),
+                                      'pm_{lat}'.format(**sph_component_map),
                                       u.mas/u.yr),
                 RepresentationMapping('d_distance', 'radial_velocity',
                                       u.km/u.s)
@@ -209,10 +205,10 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if r.SphericalDifferential not in repr_info:
             repr_info[r.SphericalDifferential] = [
                 RepresentationMapping('d_lon',
-                                      'pm_{lon}'.format(**component_map),
+                                      'pm_{lon}'.format(**sph_component_map),
                                       u.mas/u.yr),
                 RepresentationMapping('d_lat',
-                                      'pm_{lat}'.format(**component_map),
+                                      'pm_{lat}'.format(**sph_component_map),
                                       u.mas/u.yr),
                 RepresentationMapping('d_distance', 'radial_velocity',
                                       u.km/u.s)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -227,6 +227,9 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
             RepresentationMapping('d_z', 'v_z', u.km/u.s)])
 
         # Unit* classes should follow the same naming conventions
+        # TODO: this adds some unnecessary mappings for the Unit classes, so
+        # this could be cleaned up, but in practice doesn't seem to have any
+        # negative side effects
         repr_info.setdefault(r.UnitSphericalRepresentation,
                              repr_info[r.SphericalRepresentation])
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -329,10 +329,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         proper motion components
       * ``pm_{lon}``, ``pm_{lat}`` for `SphericalDifferential` proper motion
         components
-      * ``radial_velocity`` for any `d_distance` component
+      * ``radial_velocity`` for any ``d_distance`` component
       * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
 
-    where `{lon}` and `{lat}` are the frame names of the angular components.
+    where ``{lon}`` and ``{lat}`` are the frame names of the angular components.
 
     Parameters
     ----------

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -100,29 +100,8 @@ class AltAz(BaseCoordinateFrame):
         r.SphericalRepresentation: [
             RepresentationMapping('lon', 'az'),
             RepresentationMapping('lat', 'alt')
-        ],
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_az_cosalt', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_alt', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_az', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_alt', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s)
-        ],
-        r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s),
-        ],
+        ]
     }
-    frame_specific_representation_info[r.UnitSphericalRepresentation] = \
-        frame_specific_representation_info[r.SphericalRepresentation]
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
 from .. import representation as r
 from ..baseframe import BaseCoordinateFrame, RepresentationMapping
 
@@ -58,29 +57,8 @@ class BaseRADecFrame(BaseCoordinateFrame):
         r.SphericalRepresentation: [
             RepresentationMapping('lon', 'ra'),
             RepresentationMapping('lat', 'dec')
-        ],
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_ra_cosdec', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_dec', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s)
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_ra', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_dec', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s)
-        ],
-        r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s)
-        ],
+        ]
     }
-    frame_specific_representation_info[r.UnitSphericalRepresentation] = \
-        frame_specific_representation_info[r.SphericalRepresentation]
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -63,29 +63,6 @@ class BaseEclipticFrame(BaseCoordinateFrame):
     {params}
     """
 
-    frame_specific_representation_info = {
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_lon_coslat', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_lat', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_lon', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_lat', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
-        r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s),
-        ],
-    }
-
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
-
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -79,24 +79,8 @@ class Galactic(BaseCoordinateFrame):
             RepresentationMapping('d_x', 'U', u.km/u.s),
             RepresentationMapping('d_y', 'V', u.km/u.s),
             RepresentationMapping('d_z', 'W', u.km/u.s)
-        ],
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_l_cosb', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_b', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_l', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_b', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
         ]
     }
-    frame_specific_representation_info[r.UnitSphericalRepresentation] = \
-        frame_specific_representation_info[r.SphericalRepresentation]
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -168,13 +168,6 @@ class Galactocentric(BaseCoordinateFrame):
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
 
     """
-    frame_specific_representation_info = {
-        r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s),
-        ],
-    }
 
     default_representation = r.CartesianRepresentation
     default_differential = r.CartesianDifferential

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -153,29 +153,8 @@ class GalacticLSR(BaseCoordinateFrame):
         r.SphericalRepresentation: [
             RepresentationMapping('lon', 'l'),
             RepresentationMapping('lat', 'b')
-        ],
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_l_cosb', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_b', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s)
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_l', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_b', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s)
-        ],
-        r.CartesianDifferential: [
-            RepresentationMapping('d_x', 'v_x', u.km/u.s),
-            RepresentationMapping('d_y', 'v_y', u.km/u.s),
-            RepresentationMapping('d_z', 'v_z', u.km/u.s)
-        ],
+        ]
     }
-    frame_specific_representation_info[r.UnitSphericalRepresentation] = \
-        frame_specific_representation_info[r.SphericalRepresentation]
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -59,28 +59,12 @@ class Supergalactic(BaseCoordinateFrame):
             RepresentationMapping('y', 'sgy'),
             RepresentationMapping('z', 'sgz')
         ],
-        r.SphericalCosLatDifferential: [
-            RepresentationMapping('d_lon_coslat', 'pm_sgl_cossgb', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_sgb', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
-        r.SphericalDifferential: [
-            RepresentationMapping('d_lon', 'pm_sgl', u.mas/u.yr),
-            RepresentationMapping('d_lat', 'pm_sgb', u.mas/u.yr),
-            RepresentationMapping('d_distance', 'radial_velocity', u.km/u.s),
-        ],
         r.CartesianDifferential: [
             RepresentationMapping('d_x', 'v_x', u.km/u.s),
             RepresentationMapping('d_y', 'v_y', u.km/u.s),
             RepresentationMapping('d_z', 'v_z', u.km/u.s)
         ],
     }
-    frame_specific_representation_info[r.UnitSphericalRepresentation] = \
-        frame_specific_representation_info[r.SphericalRepresentation]
-    frame_specific_representation_info[r.UnitSphericalCosLatDifferential] = \
-        frame_specific_representation_info[r.SphericalCosLatDifferential]
-    frame_specific_representation_info[r.UnitSphericalDifferential] = \
-        frame_specific_representation_info[r.SphericalDifferential]
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -323,6 +323,36 @@ def test_representation_info():
     assert allclose(i2.howfar, 1000*u.pc)
     assert i2.howfar.unit == u.kpc
 
+    # Test that the differential kwargs get overridden
+    class NewICRS3(ICRS):
+        frame_specific_representation_info = {
+            r.SphericalCosLatDifferential: [
+                RepresentationMapping('d_lon_coslat', 'pm_ang1', u.hourangle/u.century),
+                RepresentationMapping('d_lat', 'pm_ang2'),
+                RepresentationMapping('d_distance', 'vlos', u.kpc/u.Myr)]
+        }
+
+    i3 = NewICRS3(lon=10*u.degree, lat=-12*u.deg, distance=1000*u.pc,
+                  pm_ang1=1*u.mas/u.yr, pm_ang2=2*u.mas/u.yr,
+                  vlos=100*u.km/u.s)
+    assert allclose(i3.pm_ang1, 1*u.mas/u.yr)
+    assert i3.pm_ang1.unit == u.hourangle/u.century
+    assert allclose(i3.pm_ang2, 2*u.mas/u.yr)
+    assert allclose(i3.vlos, 100*u.km/u.s)
+    assert i3.vlos.unit == u.kpc/u.Myr
+
+    # Test that setting RadialDifferential alone works
+    class NewICRS4(ICRS):
+        frame_specific_representation_info = {
+            r.RadialDifferential: [
+                RepresentationMapping('d_distance', 'vlos', u.kpc/u.Myr)]
+        }
+
+    i4 = NewICRS4(lon=10*u.degree, lat=-12*u.deg, distance=1000*u.pc,
+                  vlos=100*u.km/u.s)
+    assert allclose(i4.vlos, 100*u.km/u.s)
+    assert i4.vlos.unit == u.kpc/u.Myr
+
 
 def test_realizing():
     from ..builtin_frames import ICRS, FK5

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -327,7 +327,7 @@ def test_representation_info():
     class NewICRS3(ICRS):
         frame_specific_representation_info = {
             r.SphericalCosLatDifferential: [
-                RepresentationMapping('d_lon_coslat', 'pm_ang1', u.hourangle/u.century),
+                RepresentationMapping('d_lon_coslat', 'pm_ang1', u.hourangle/u.year),
                 RepresentationMapping('d_lat', 'pm_ang2'),
                 RepresentationMapping('d_distance', 'vlos', u.kpc/u.Myr)]
         }
@@ -336,22 +336,10 @@ def test_representation_info():
                   pm_ang1=1*u.mas/u.yr, pm_ang2=2*u.mas/u.yr,
                   vlos=100*u.km/u.s)
     assert allclose(i3.pm_ang1, 1*u.mas/u.yr)
-    assert i3.pm_ang1.unit == u.hourangle/u.century
+    assert i3.pm_ang1.unit == u.hourangle/u.year
     assert allclose(i3.pm_ang2, 2*u.mas/u.yr)
     assert allclose(i3.vlos, 100*u.km/u.s)
     assert i3.vlos.unit == u.kpc/u.Myr
-
-    # Test that setting RadialDifferential alone works
-    class NewICRS4(ICRS):
-        frame_specific_representation_info = {
-            r.RadialDifferential: [
-                RepresentationMapping('d_distance', 'vlos', u.kpc/u.Myr)]
-        }
-
-    i4 = NewICRS4(lon=10*u.degree, lat=-12*u.deg, distance=1000*u.pc,
-                  vlos=100*u.km/u.s)
-    assert allclose(i4.vlos, 100*u.km/u.s)
-    assert i4.vlos.unit == u.kpc/u.Myr
 
 
 def test_realizing():


### PR DESCRIPTION
fixes #6434

This implements some magic in the `Frame` metaclass to automatically add mappings from the frame classes to the underlying representation/differential objects. The automatic mappings can still be overridden by explicitly defining `RepresentationMapping`'s in a `Frame` class. 

Unless overridden, the velocity name defaults are:
* `pm_{lon}_cos{lat}, pm_{lat}` -> `d_lon_coslat, d_lat` for `SphericalCosLatDifferential`
* `radial_velocity` -> `d_distance` for any differential with `d_distance`
* `v_{x,y,z}` -> `d_{x,y,z}` for `CartesianDifferential`

This PR still needs some explicit testing of the details, like checking that overriding the default names works, but this is implicitly checked by the tests of, e.g., the `Galactic` velocity components.

The new logic in the metaclass should make it easier to subclass, and means I can delete a lot of boilerplate code in specific frame class definitions (deletions > additions, woohoo!)