### PR TITLE
Fix order of u,v,w in SkyCoord docstring

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -186,7 +186,7 @@ class SkyCoord(ShapedLikeNDArray):
             the `Galactic` frame.
         x, y, z : float or `~astropy.units.Quantity`, optional
             Cartesian coordinates values
-        w, u, v : float or `~astropy.units.Quantity`, optional
+        u, v, w : float or `~astropy.units.Quantity`, optional
             Cartesian coordinates values for the Galactic frame.
     """
 


### PR DESCRIPTION
Here's a tiny typo I just noticed. To be parallel to `x,y,z` above, the reference to galactic cartesian components should be `u,v,w`.