### PR TITLE
Deprecate "recommended_units" for representations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -229,6 +229,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Deprecated ``recommended_units`` for representations. These were used to
+  ensure that any angle was presented in degrees in sky coordinates and
+  frames. This is more logically done in the frame itself. [#6858]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -25,7 +25,7 @@ from ..utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
                      check_broadcast)
 from .transformations import TransformGraph
 from . import representation as r
-
+from .angles import Angle
 from .attributes import Attribute
 
 # Import old names for Attributes so we don't break backwards-compatibility
@@ -560,9 +560,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
                               list(r.DIFFERENTIAL_CLASSES.values())):
             repr_attrs[repr_diff_cls] = {'names': [], 'units': []}
-            for c in repr_diff_cls.attr_classes.keys():
+            for c, c_cls in repr_diff_cls.attr_classes.items():
                 repr_attrs[repr_diff_cls]['names'].append(c)
-                rec_unit = repr_diff_cls.recommended_units.get(c, None)
+                rec_unit = repr_diff_cls.recommended_units.get(
+                    c, u.deg if issubclass(c_cls, Angle) else None)
                 repr_attrs[repr_diff_cls]['units'].append(rec_unit)
 
         for repr_diff_cls, mappings in cls._frame_specific_representation_info.items():

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -562,7 +562,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             repr_attrs[repr_diff_cls] = {'names': [], 'units': []}
             for c, c_cls in repr_diff_cls.attr_classes.items():
                 repr_attrs[repr_diff_cls]['names'].append(c)
-                rec_unit = repr_diff_cls.recommended_units.get(
+                # TODO: when "recommended_units" is removed, just directly use
+                # the default part here.
+                rec_unit = repr_diff_cls._recommended_units.get(
                     c, u.deg if issubclass(c_cls, Angle) else None)
                 repr_attrs[repr_diff_cls]['units'].append(rec_unit)
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -10,6 +10,7 @@ import functools
 import operator
 from collections import OrderedDict
 import inspect
+import warnings
 
 import numpy as np
 import astropy.units as u
@@ -18,6 +19,8 @@ from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from ..utils import ShapedLikeNDArray, classproperty
 
+from ..utils import deprecated_attribute
+from ..utils.exceptions import AstropyDeprecationWarning
 from ..utils.misc import InheritDocstrings
 from ..utils.compat import NUMPY_LT_1_12, NUMPY_LT_1_14
 
@@ -37,6 +40,16 @@ __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
 # classes get registered automatically.
 REPRESENTATION_CLASSES = {}
 DIFFERENTIAL_CLASSES = {}
+
+
+# recommended_units deprecation message; if the attribute is removed later,
+# also remove its use in BaseFrame._get_representation_info.
+_recommended_units_deprecation = """
+The 'recommended_units' attribute is deprecated since 3.0 and may be removed
+in a future version. Its main use, of representing angles in degrees in frames,
+is now done automatically in frames. Further overrides are discouraged but can
+be done using a frame's ``frame_specific_representation_info``.
+"""
 
 
 def _array2string(values, prefix=''):
@@ -420,6 +433,13 @@ class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
             raise NotImplementedError('Representations must have an '
                                       '"attr_classes" class attribute.')
 
+        if 'recommended_units' in dct:
+            warnings.warn(_recommended_units_deprecation,
+                          AstropyDeprecationWarning)
+            # Ensure we don't override the property that warns about the
+            # deprecation, but that the value remains the same.
+            dct.setdefault('_recommended_units', dct.pop('recommended_units'))
+
         repr_name = cls.get_name()
 
         if repr_name in REPRESENTATION_CLASSES:
@@ -467,14 +487,11 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     that want to define a smarter transformation path can overload the
     ``represent_as`` method. If one wants to use an associated differential
     class, one should also define ``unit_vectors`` and ``scale_factors``
-    methods (see those methods for details). Finally, classes can also define a
-    ``recommended_units`` dictionary, which maps component names to the units
-    they are best presented to users in (this is used only in representations
-    of coordinates, and may be overridden by frame classes; by default, frames
-    present angles in degrees).
+    methods (see those methods for details).
     """
 
-    recommended_units = {}  # subclasses can override
+    recommended_units = deprecated_attribute('recommended_units', since='3.0')
+    _recommended_units = {}
 
     def __init__(self, *args, differentials=None, **kwargs):
         # Handle any differentials passed in.
@@ -1928,6 +1945,13 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
             cls.attr_classes = OrderedDict([('d_' + c, u.Quantity)
                                             for c in base_attr_classes])
 
+        if 'recommended_units' in dct:
+            warnings.warn(_recommended_units_deprecation,
+                          AstropyDeprecationWarning)
+            # Ensure we don't override the property that warns about the
+            # deprecation, but that the value remains the same.
+            dct.setdefault('_recommended_units', dct.pop('recommended_units'))
+
         repr_name = cls.get_name()
         if repr_name in DIFFERENTIAL_CLASSES:
             raise ValueError("Differential class {0} already defined"
@@ -1971,7 +1995,8 @@ class BaseDifferential(BaseRepresentationOrDifferential,
     those, and a default ``__init__`` for initialization.
     """
 
-    recommended_units = {}  # subclasses can override
+    recommended_units = deprecated_attribute('recommended_units', since='3.0')
+    _recommended_units = {}
 
     @classmethod
     def _check_base(cls, base):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -470,7 +470,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     methods (see those methods for details). Finally, classes can also define a
     ``recommended_units`` dictionary, which maps component names to the units
     they are best presented to users in (this is used only in representations
-    of coordinates, and may be overridden by frame classes).
+    of coordinates, and may be overridden by frame classes; by default, frames
+    present angles in degrees).
     """
 
     recommended_units = {}  # subclasses can override
@@ -1240,7 +1241,6 @@ class UnitSphericalRepresentation(BaseRepresentation):
 
     attr_classes = OrderedDict([('lon', Longitude),
                                 ('lat', Latitude)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
 
     @classproperty
     def _dimensional_representation(cls):
@@ -1529,7 +1529,6 @@ class SphericalRepresentation(BaseRepresentation):
     attr_classes = OrderedDict([('lon', Longitude),
                                 ('lat', Latitude),
                                 ('distance', u.Quantity)])
-    recommended_units = {'lon': u.deg, 'lat': u.deg}
     _unit_representation = UnitSphericalRepresentation
 
     def __init__(self, lon, lat, distance, differentials=None, copy=True):
@@ -1682,7 +1681,6 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
     attr_classes = OrderedDict([('phi', Angle),
                                 ('theta', Angle),
                                 ('r', u.Quantity)])
-    recommended_units = {'phi': u.deg, 'theta': u.deg}
 
     def __init__(self, phi, theta, r, differentials=None, copy=True):
         super().__init__(phi, theta, r, copy=copy, differentials=differentials)
@@ -1838,7 +1836,6 @@ class CylindricalRepresentation(BaseRepresentation):
     attr_classes = OrderedDict([('rho', u.Quantity),
                                 ('phi', Angle),
                                 ('z', u.Quantity)])
-    recommended_units = {'phi': u.deg}
 
     def __init__(self, rho, phi, z, differentials=None, copy=True):
         super().__init__(rho, phi, z, copy=copy, differentials=differentials)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -10,9 +10,10 @@ from numpy.testing import assert_allclose
 
 from ... import units as u
 from ...tests.helper import (assert_quantity_allclose as
-                             assert_allclose_quantity)
+                             assert_allclose_quantity, catch_warnings)
 from ...utils import isiterable
 from ...utils.compat import NUMPY_LT_1_14
+from ...utils.exceptions import AstropyDeprecationWarning
 from ..angles import Longitude, Latitude, Angle
 from ..distances import Distance
 from ..representation import (REPRESENTATION_CLASSES,
@@ -1360,3 +1361,16 @@ def test_to_cartesian():
     cart = sr.to_cartesian()
     assert cart.get_name() == 'cartesian'
     assert not cart.differentials
+
+
+def test_recommended_units_deprecation():
+    sr = SphericalRepresentation(lat=1*u.deg, lon=2*u.deg, distance=10*u.m)
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        sr.recommended_units
+    assert 'recommended_units' in str(w[0].message)
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        class MyClass(SphericalRepresentation):
+            attr_classes = SphericalRepresentation.attr_classes
+            recommended_units = {}
+    assert 'recommended_units' in str(w[0].message)

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -510,14 +510,6 @@ must be defined:
   comp3, copy=True)``, and use ``super`` to call the base representation
   initializer.
 
-* ``recommended_units`` dictionary (optional):
-
-  Maps component names to the recommended unit to convert the values of that
-  component to if the representation is part of a coordinate frame.  Can be
-  ``None`` to indicate there is no preferred unit.  If this dictionary is not
-  defined (or a component is missing), by default angular components
-  will be converted to degrees, while others are not converted.
-
 Once you do this, you will then automatically be able to call ``represent_as``
 to convert other representations to/from your representation class.  Your
 representation will also be available for use in |skycoord| and all frame
@@ -561,9 +553,6 @@ In pseudo-code, this means that a class will look like::
         attr_classes = OrderedDict([('comp1', ComponentClass1),
                                      ('comp2', ComponentClass2),
                                      ('comp3', ComponentClass3)])
-
-        # recommended_units is optional
-        recommended_units = {'comp1': u.unit1, 'comp2': u.unit2, 'comp3': u.unit3}
 
 	# __init__ is optional
         def __init__(self, comp1, comp2, comp3, copy=True):

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -514,9 +514,9 @@ must be defined:
 
   Maps component names to the recommended unit to convert the values of that
   component to if the representation is part of a coordinate frame.  Can be
-  ``None`` (or missing) to indicate there is no preferred unit.  If this
-  dictionary is not defined, no conversion of components to particular units
-  will occur.
+  ``None`` to indicate there is no preferred unit.  If this dictionary is not
+  defined (or a component is missing), by default angular components
+  will be converted to degrees, while others are not converted.
 
 Once you do this, you will then automatically be able to call ``represent_as``
 to convert other representations to/from your representation class.  Your


### PR DESCRIPTION
`recommended_units` of representations were used to ensure that any angles are presented in degrees in sky coordinates and frames. It is strange to have classes define an attribute that they do not use at all, and, more generally, it seems more logical to do this in frames itself (which already allow overriding units for specific representations). Still, this PR has two commits, one that replaces the actual definitions of `recommended_units` with a default of degree for angles, and a second that deprecates the attribute. 
