### PR TITLE
Add a showtable script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,7 @@ astropy.table
   as ``astropy.time.Time`` Table columns. [#6442]
 
 - Allowed to remove table rows through the ``__delitem__`` method. [#5839]
+
 - Added a new ``showtable`` command-line script to view binary tables. [#6859]
 
 astropy.tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,7 +113,8 @@ astropy.table
 
 - Allowed to remove table rows through the ``__delitem__`` method. [#5839]
 
-- Added a new ``showtable`` command-line script to view binary tables. [#6859]
+- Added a new ``showtable`` command-line script to view binary or ASCII table
+  files. [#6859]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,7 @@ astropy.table
   as ``astropy.time.Time`` Table columns. [#6442]
 
 - Allowed to remove table rows through the ``__delitem__`` method. [#5839]
+- Added a new ``showtable`` command-line script to view binary tables. [#6859]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -45,7 +45,7 @@ from astropy.table import Table
 from astropy import log
 
 
-def showtable(filename, **kwargs):
+def showtable(filename, args):
     """
     Read a table and print to the standard output.
 
@@ -55,10 +55,11 @@ def showtable(filename, **kwargs):
         The path to a FITS file.
 
     """
-    # print(kwargs)
+    print(args)
     try:
         table = Table.read(filename)
-        table.pprint(**kwargs)
+        table.pprint(max_lines=args.max_lines, max_width=args.max_width,
+                     show_unit=not args.hide_unit, show_dtype=args.show_dtype)
     except IOError as e:
         log.error(str(e))
 
@@ -66,30 +67,23 @@ def showtable(filename, **kwargs):
 def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=('Print tables from ASCII, FITS, HDF5, VOTABLE file(s).'))
     parser.add_argument('--max-lines', type=int,
                         help='Maximum number of lines in table output.')
     parser.add_argument('--max-width', type=int,
                         help='Maximum character width of output.')
-    parser.add_argument('--show-name', default=True,
-                        help='Include a header row for column names.')
-    parser.add_argument('--show-unit',
-                        help='Include a header row for unit.  Default is to '
-                        'show a row for units only if one or more columns')
-    parser.add_argument('--show-dtype', default=False,
+    parser.add_argument('--hide-unit', action='store_true',
+                        help='Hide the header row for unit (which is shown '
+                        'only if one or more columns has a unit).')
+    parser.add_argument('--show-dtype', action='store_true',
                         help='Include a header row for column dtypes.')
     parser.add_argument('filename', nargs='+',
                         help='Path to one or more FITS files.')
 
-    # TODO: fix bool args
     # TODO: add `read` kwargs (to choose format, hdu, etc.)
-
     args = parser.parse_args(args)
-    args = vars(args)
-    filenames = args.pop('filename')
 
-    for idx, filename in enumerate(filenames):
+    for idx, filename in enumerate(args.filename):
         if idx > 0:
             print()
-        showtable(filename, **args)
+        showtable(filename, args)

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -70,40 +70,35 @@ def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
         description=('Print tables from ASCII, FITS, HDF5, VOTable file(s).'))
+    addarg = parser.add_argument
 
     # pprint arguments
-    parser.add_argument('--max-lines', type=int,
-                        help='Maximum number of lines in table output.')
-    parser.add_argument('--max-width', type=int,
-                        help='Maximum character width of output.')
-    parser.add_argument('--hide-unit', action='store_true',
-                        help='Hide the header row for unit (which is shown '
-                        'only if one or more columns has a unit).')
-    parser.add_argument('--show-dtype', action='store_true',
-                        help='Include a header row for column dtypes.')
+    addarg('--max-lines', type=int,
+           help='Maximum number of lines in table output.')
+    addarg('--max-width', type=int,
+           help='Maximum character width of output.')
+    addarg('--hide-unit', action='store_true',
+           help='Hide the header row for unit (which is shown '
+           'only if one or more columns has a unit).')
+    addarg('--show-dtype', action='store_true',
+           help='Include a header row for column dtypes.')
 
     # ASCII-specific arguments
     # FIXME: add more args ? (delimiter, guess ?)
-    parser.add_argument('--format',
-                        help='Input table format (only for ASCII files).')
+    addarg('--format', help='Input table format (only for ASCII files).')
 
     # FITS-specific arguments
-    parser.add_argument('--hdu',
-                        help='Name of the HDU to show (only for FITS files).')
+    addarg('--hdu', help='Name of the HDU to show (only for FITS files).')
 
     # HDF5-specific arguments
-    parser.add_argument('--path',
-                        help='The path from which to read the table (only '
-                        'for HDF5 files).')
+    addarg('--path', help='The path from which to read the table (only '
+           'for HDF5 files).')
 
     # VOTable-specific arguments
-    parser.add_argument('--table_id', help='The table to read in (only '
-                        'for VOTable files).')
+    addarg('--table_id', help='The table to read in (only for VOTable files).')
 
-    parser.add_argument('filename', nargs='+',
-                        help='Path to one or more files.')
+    addarg('filename', nargs='+', help='Path to one or more files.')
 
-    # TODO: add `read` kwargs (to choose format, hdu, etc.)
     args = parser.parse_args(args)
 
     for idx, filename in enumerate(args.filename):

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -57,10 +57,13 @@ def showtable(filename, args):
         The path to a FITS file.
 
     """
-    read_kwargs = {k: v for k, v in vars(args).items()
-                   if k in ('hdu', 'format', 'table_id') and v is not None}
+    # these parameters are passed to Table.read if they are specified in the
+    # command-line
+    read_kwargs = ('hdu', 'format', 'table_id', 'delimiter')
+    kwargs = {k: v for k, v in vars(args).items()
+              if k in read_kwargs and v is not None}
     try:
-        table = Table.read(filename, **read_kwargs)
+        table = Table.read(filename, **kwargs)
         formatter = table.more if args.more else table.pprint
         formatter(max_lines=args.max_lines, max_width=args.max_width,
                   show_unit=not args.hide_unit, show_dtype=args.show_dtype)
@@ -97,8 +100,9 @@ def main(args=None):
            help='Include a header row for column dtypes.')
 
     # ASCII-specific arguments
-    # FIXME: add more args ? (delimiter, guess ?)
     addarg('--format', help='Input table format (only for ASCII files).')
+    addarg('--delimiter',
+           help='Column delimiter string (only for ASCII files).')
 
     # FITS-specific arguments
     addarg('--hdu', help='Name of the HDU to show (only for FITS files).')

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 ``showtable`` is a command-line script based on astropy.io and astropy.table
-for printing ASCII, FITS, HDF5(?) or VOTABLE files(s) to the standard output.
+for printing ASCII, FITS, HDF5(?) or VOTable files(s) to the standard output.
 
 Example usage of ``showtable``:
 
@@ -56,8 +56,10 @@ def showtable(filename, args):
 
     """
     print(args)
+    read_kwargs = {k: v for k, v in vars(args).items()
+                   if k in ('hdu', 'format', 'table_id') and k is not None}
     try:
-        table = Table.read(filename)
+        table = Table.read(filename, **read_kwargs)
         table.pprint(max_lines=args.max_lines, max_width=args.max_width,
                      show_unit=not args.hide_unit, show_dtype=args.show_dtype)
     except IOError as e:
@@ -67,7 +69,9 @@ def showtable(filename, args):
 def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
-        description=('Print tables from ASCII, FITS, HDF5, VOTABLE file(s).'))
+        description=('Print tables from ASCII, FITS, HDF5, VOTable file(s).'))
+
+    # pprint arguments
     parser.add_argument('--max-lines', type=int,
                         help='Maximum number of lines in table output.')
     parser.add_argument('--max-width', type=int,
@@ -77,8 +81,27 @@ def main(args=None):
                         'only if one or more columns has a unit).')
     parser.add_argument('--show-dtype', action='store_true',
                         help='Include a header row for column dtypes.')
+
+    # ASCII-specific arguments
+    # FIXME: add more args ? (delimiter, guess ?)
+    parser.add_argument('--format',
+                        help='Input table format (only for ASCII files).')
+
+    # FITS-specific arguments
+    parser.add_argument('--hdu',
+                        help='Name of the HDU to show (only for FITS files).')
+
+    # HDF5-specific arguments
+    parser.add_argument('--path',
+                        help='The path from which to read the table (only '
+                        'for HDF5 files).')
+
+    # VOTable-specific arguments
+    parser.add_argument('--table_id', help='The table to read in (only '
+                        'for VOTable files).')
+
     parser.add_argument('filename', nargs='+',
-                        help='Path to one or more FITS files.')
+                        help='Path to one or more files.')
 
     # TODO: add `read` kwargs (to choose format, hdu, etc.)
     args = parser.parse_args(args)

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -43,6 +43,7 @@ Example usage of ``showtable``:
 """
 
 import argparse
+import textwrap
 import warnings
 from astropy import log
 from astropy.table import Table
@@ -89,52 +90,61 @@ def showtable(filename, args):
 def main(args=None):
     """The main function called by the `showtable` script."""
     parser = argparse.ArgumentParser(
-        description=(
-            'Print tables from ASCII, FITS, HDF5, VOTable file(s).'
-            'The default behavior is make the table output fit onto a single '
-            'screen page.  For a long and wide table this will mean cutting '
-            'out inner rows and columns.  To print **all** the rows or columns'
-            ' use ``--max-lines=-1`` or ``max-width=-1``, respectively.'
-        ))
+        description=textwrap.dedent("""
+            Print tables from ASCII, FITS, HDF5, VOTable file(s).  The tables
+            are read with 'astropy.table.Table.read' and are printed with
+            'astropy.table.Table.pprint'. The default behavior is to make the
+            table output fit onto a single screen page.  For a long and wide
+            table this will mean cutting out inner rows and columns.  To print
+            **all** the rows or columns use ``--max-lines=-1`` or
+            ``max-width=-1``, respectively.
+        """))
 
     addarg = parser.add_argument
+    addarg('filename', nargs='+', help='path to one or more files')
 
     addarg('--more', action='store_true',
-           help='Use the pager mode from Table.more.')
+           help='use the pager mode from Table.more')
     addarg('--info', action='store_true',
-           help='Show information about the table columns.')
+           help='show information about the table columns')
     addarg('--stats', action='store_true',
-           help='Show statistics about the table columns.')
+           help='show statistics about the table columns')
 
     # pprint arguments
+    pprint_args = parser.add_argument_group('pprint arguments')
+    addarg = pprint_args.add_argument
     addarg('--max-lines', type=int,
-           help='Maximum number of lines in table output (default=screen '
-           'length, -1 for no limit).')
+           help='maximum number of lines in table output (default=screen '
+           'length, -1 for no limit)')
     addarg('--max-width', type=int,
-           help='Maximum width in table output (default=screen width, '
-           '-1 for no limit).')
+           help='maximum width in table output (default=screen width, '
+           '-1 for no limit)')
     addarg('--hide-unit', action='store_true',
-           help='Hide the header row for unit (which is shown '
-           'only if one or more columns has a unit).')
+           help='hide the header row for unit (which is shown '
+           'only if one or more columns has a unit)')
     addarg('--show-dtype', action='store_true',
-           help='Include a header row for column dtypes.')
+           help='include a header row for column dtypes')
 
     # ASCII-specific arguments
-    addarg('--format', help='Input table format (only for ASCII files).')
-    addarg('--delimiter',
-           help='Column delimiter string (only for ASCII files).')
+    ascii_args = parser.add_argument_group('ASCII arguments')
+    addarg = ascii_args.add_argument
+    addarg('--format', help='input table format')
+    addarg('--delimiter', help='column delimiter string')
 
     # FITS-specific arguments
-    addarg('--hdu', help='Name of the HDU to show (only for FITS files).')
+    fits_args = parser.add_argument_group('FITS arguments')
+    addarg = fits_args.add_argument
+    addarg('--hdu', help='name of the HDU to show')
 
     # HDF5-specific arguments
-    addarg('--path', help='The path from which to read the table (only '
-           'for HDF5 files).')
+    hdf5_args = parser.add_argument_group('HDF5 arguments')
+    addarg = hdf5_args.add_argument
+    addarg('--path', help='the path from which to read the table')
 
     # VOTable-specific arguments
-    addarg('--table_id', help='The table to read in (only for VOTable files).')
-
-    addarg('filename', nargs='+', help='Path to one or more files.')
+    votable_args = parser.add_argument_group('VOTable arguments')
+    addarg = votable_args.add_argument
+    addarg('--table-id', help='the table to read in')
 
     args = parser.parse_args(args)
 

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -10,7 +10,7 @@ Example usage of ``showtable``:
 
     $ showtable astropy/io/fits/tests/data/table.fits
 
-    target V_mag
+     target V_mag
     ------- -----
     NGC1001  11.1
     NGC1002  12.3

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -15,7 +15,7 @@ Example usage of ``showtable``:
     NGC1002  12.3
     NGC1003  15.2
 
-3. ASCII::
+2. ASCII::
 
     $ showtable astropy/io/ascii/tests/t/simple_csv.csv
 
@@ -26,15 +26,16 @@ Example usage of ``showtable``:
 
 3. XML::
 
-    $ showtable astropy/io/votable/tests/data/names.xml
-               col1             col2     col3    col4     col5   ... col13 col14 col15 col16 col17
-               ---              deg      deg     deg      deg    ...  mag   mag   mag   mag   ---
-    ------------------------- -------- ------- -------- -------- ... ----- ----- ----- ----- -----
-    SSTGLMC G000.0000+00.1611   0.0000  0.1611 266.2480 -28.8521 ...  9.13  8.17    --    --    AA
+    $ showtable astropy/io/votable/tests/data/names.xml --max-width 70
+
+               col1             col2     col3  ... col15 col16 col17
+               ---              deg      deg   ...  mag   mag   ---
+    ------------------------- -------- ------- ... ----- ----- -----
+    SSTGLMC G000.0000+00.1611   0.0000  0.1611 ...    --    --    AA
 
 
 
-2. Print a summary of HDUs of all the FITS files in the current directory::
+4. Print a summary of HDUs of all the FITS files in the current directory::
 
     $ showtable *.fits
 
@@ -57,7 +58,7 @@ def showtable(filename, args):
     """
     print(args)
     read_kwargs = {k: v for k, v in vars(args).items()
-                   if k in ('hdu', 'format', 'table_id') and k is not None}
+                   if k in ('hdu', 'format', 'table_id') and v is not None}
     try:
         table = Table.read(filename, **read_kwargs)
         table.pprint(max_lines=args.max_lines, max_width=args.max_width,

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -71,16 +71,25 @@ def showtable(filename, args):
 def main(args=None):
     """The main function called by the `showtable` script."""
     parser = argparse.ArgumentParser(
-        description=('Print tables from ASCII, FITS, HDF5, VOTable file(s).'))
+        description=(
+            'Print tables from ASCII, FITS, HDF5, VOTable file(s).'
+            'The default behavior is make the table output fit onto a single '
+            'screen page.  For a long and wide table this will mean cutting '
+            'out inner rows and columns.  To print **all** the rows or columns'
+            ' use ``--max-lines=-1`` or ``max-width=-1``, respectively.'
+        ))
+
     addarg = parser.add_argument
 
     # pprint arguments
     addarg('--more', action='store_true',
            help='Use the pager mode from Table.more.')
     addarg('--max-lines', type=int,
-           help='Maximum number of lines in table output.')
+           help='Maximum number of lines in table output (default=screen '
+           'length, -1 for no limit).')
     addarg('--max-width', type=int,
-           help='Maximum character width of output.')
+           help='Maximum width in table output (default=screen width, '
+           '-1 for no limit).')
     addarg('--hide-unit', action='store_true',
            help='Hide the header row for unit (which is shown '
            'only if one or more columns has a unit).')

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -1,0 +1,60 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+
+``showtable`` is a command-line script based on astropy.io and astropy.table
+for printing ASCII, FITS, HDF5(?) or VOTABLE files(s) to the standard output.
+
+Example usage of ``showtable``:
+
+1. Print a summary of the HDUs in a FITS file::
+
+    $ showtable filename.fits
+
+    Filename: filename.fits
+    No.    Name         Type      Cards   Dimensions   Format
+    0    PRIMARY     PrimaryHDU     138   ()
+    1    SCI         ImageHDU        61   (800, 800)   int16
+    2    SCI         ImageHDU        61   (800, 800)   int16
+    3    SCI         ImageHDU        61   (800, 800)   int16
+    4    SCI         ImageHDU        61   (800, 800)   int16
+
+2. Print a summary of HDUs of all the FITS files in the current directory::
+
+    $ fitsinfo *.fits
+"""
+
+import argparse
+from astropy.table import Table
+from astropy import log
+
+
+def showtable(filename, **kwargs):
+    """
+    Print a summary of the HDUs in a FITS file.
+
+    Parameters
+    ----------
+    filename : str
+        The path to a FITS file.
+    """
+
+    try:
+        table = Table.read(filename)
+        table.pprint(**kwargs)
+    except IOError as e:
+        log.error(str(e))
+
+
+def main(args=None):
+    """The main function called by the `fitsinfo` script."""
+    parser = argparse.ArgumentParser(
+        description=('Print tables from ASCII, FITS, HDF5, VOTABLE file(s).'))
+    parser.add_argument(
+        'filename', nargs='+',
+        help='Path to one or more FITS files. Wildcards are supported.')
+    args = parser.parse_args(args)
+
+    for idx, filename in enumerate(args.filename):
+        if idx > 0:
+            print()
+        showtable(filename)

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-
 ``showtable`` is a command-line script based on astropy.io and astropy.table
 for printing ASCII, FITS, HDF5(?) or VOTABLE files(s) to the standard output.
 
@@ -8,19 +7,37 @@ Example usage of ``showtable``:
 
 1. Print a summary of the HDUs in a FITS file::
 
-    $ showtable filename.fits
+    $ showtable astropy/io/fits/tests/data/table.fits
 
-    Filename: filename.fits
-    No.    Name         Type      Cards   Dimensions   Format
-    0    PRIMARY     PrimaryHDU     138   ()
-    1    SCI         ImageHDU        61   (800, 800)   int16
-    2    SCI         ImageHDU        61   (800, 800)   int16
-    3    SCI         ImageHDU        61   (800, 800)   int16
-    4    SCI         ImageHDU        61   (800, 800)   int16
+    target V_mag
+    ------- -----
+    NGC1001  11.1
+    NGC1002  12.3
+    NGC1003  15.2
+
+3. ASCII::
+
+    $ showtable astropy/io/ascii/tests/t/simple_csv.csv
+
+     a   b   c
+    --- --- ---
+      1   2   3
+      4   5   6
+
+3. XML::
+
+    $ showtable astropy/io/votable/tests/data/names.xml
+               col1             col2     col3    col4     col5   ... col13 col14 col15 col16 col17
+               ---              deg      deg     deg      deg    ...  mag   mag   mag   mag   ---
+    ------------------------- -------- ------- -------- -------- ... ----- ----- ----- ----- -----
+    SSTGLMC G000.0000+00.1611   0.0000  0.1611 266.2480 -28.8521 ...  9.13  8.17    --    --    AA
+
+
 
 2. Print a summary of HDUs of all the FITS files in the current directory::
 
-    $ fitsinfo *.fits
+    $ showtable *.fits
+
 """
 
 import argparse
@@ -30,14 +47,15 @@ from astropy import log
 
 def showtable(filename, **kwargs):
     """
-    Print a summary of the HDUs in a FITS file.
+    Read a table and print to the standard output.
 
     Parameters
     ----------
     filename : str
         The path to a FITS file.
-    """
 
+    """
+    # print(kwargs)
     try:
         table = Table.read(filename)
         table.pprint(**kwargs)
@@ -48,13 +66,30 @@ def showtable(filename, **kwargs):
 def main(args=None):
     """The main function called by the `fitsinfo` script."""
     parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=('Print tables from ASCII, FITS, HDF5, VOTABLE file(s).'))
-    parser.add_argument(
-        'filename', nargs='+',
-        help='Path to one or more FITS files. Wildcards are supported.')
-    args = parser.parse_args(args)
+    parser.add_argument('--max-lines', type=int,
+                        help='Maximum number of lines in table output.')
+    parser.add_argument('--max-width', type=int,
+                        help='Maximum character width of output.')
+    parser.add_argument('--show-name', default=True,
+                        help='Include a header row for column names.')
+    parser.add_argument('--show-unit',
+                        help='Include a header row for unit.  Default is to '
+                        'show a row for units only if one or more columns')
+    parser.add_argument('--show-dtype', default=False,
+                        help='Include a header row for column dtypes.')
+    parser.add_argument('filename', nargs='+',
+                        help='Path to one or more FITS files.')
 
-    for idx, filename in enumerate(args.filename):
+    # TODO: fix bool args
+    # TODO: add `read` kwargs (to choose format, hdu, etc.)
+
+    args = parser.parse_args(args)
+    args = vars(args)
+    filenames = args.pop('filename')
+
+    for idx, filename in enumerate(filenames):
         if idx > 0:
             print()
-        showtable(filename)
+        showtable(filename, **args)

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -61,8 +61,9 @@ def showtable(filename, args):
                    if k in ('hdu', 'format', 'table_id') and v is not None}
     try:
         table = Table.read(filename, **read_kwargs)
-        table.pprint(max_lines=args.max_lines, max_width=args.max_width,
-                     show_unit=not args.hide_unit, show_dtype=args.show_dtype)
+        formatter = table.more if args.more else table.pprint
+        formatter(max_lines=args.max_lines, max_width=args.max_width,
+                  show_unit=not args.hide_unit, show_dtype=args.show_dtype)
     except IOError as e:
         log.error(str(e))
 
@@ -74,6 +75,8 @@ def main(args=None):
     addarg = parser.add_argument
 
     # pprint arguments
+    addarg('--more', action='store_true',
+           help='Use the pager mode from Table.more.')
     addarg('--max-lines', type=int,
            help='Maximum number of lines in table output.')
     addarg('--max-width', type=int,

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -1,11 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-``showtable`` is a command-line script based on astropy.io and astropy.table
-for printing ASCII, FITS, HDF5(?) or VOTable files(s) to the standard output.
+``showtable`` is a command-line script based on ``astropy.io`` and
+``astropy.table`` for printing ASCII, FITS, HDF5 or VOTable files(s) to the
+standard output.
 
 Example usage of ``showtable``:
 
-1. Print a summary of the HDUs in a FITS file::
+1. FITS::
 
     $ showtable astropy/io/fits/tests/data/table.fits
 
@@ -35,7 +36,7 @@ Example usage of ``showtable``:
 
 
 
-4. Print a summary of HDUs of all the FITS files in the current directory::
+4. Print all the FITS tables in the current directory::
 
     $ showtable *.fits
 

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -76,13 +76,14 @@ def showtable(filename, args):
     try:
         table = Table.read(filename, **kwargs)
         if args.info:
-            print(table.info)
+            table.info('attributes')
         elif args.stats:
             table.info('stats')
         else:
             formatter = table.more if args.more else table.pprint
             formatter(max_lines=args.max_lines, max_width=args.max_width,
-                      show_unit=not args.hide_unit, show_dtype=args.show_dtype)
+                      show_unit=(False if args.hide_unit else None),
+                      show_dtype=args.show_dtype)
     except IOError as e:
         log.error(str(e))
 
@@ -97,12 +98,16 @@ def main(args=None):
             table output fit onto a single screen page.  For a long and wide
             table this will mean cutting out inner rows and columns.  To print
             **all** the rows or columns use ``--max-lines=-1`` or
-            ``max-width=-1``, respectively.
+            ``max-width=-1``, respectively. The complete list of supported
+            formats can be found at
+            http://astropy.readthedocs.io/en/latest/io/unified.html#built-in-table-readers-writers
         """))
 
     addarg = parser.add_argument
     addarg('filename', nargs='+', help='path to one or more files')
 
+    addarg('--format', help='input table format, should be specified if it '
+           'cannot be automatically detected')
     addarg('--more', action='store_true',
            help='use the pager mode from Table.more')
     addarg('--info', action='store_true',
@@ -128,7 +133,6 @@ def main(args=None):
     # ASCII-specific arguments
     ascii_args = parser.add_argument_group('ASCII arguments')
     addarg = ascii_args.add_argument
-    addarg('--format', help='input table format')
     addarg('--delimiter', help='column delimiter string')
 
     # FITS-specific arguments

--- a/astropy/table/scripts/showtable.py
+++ b/astropy/table/scripts/showtable.py
@@ -56,7 +56,6 @@ def showtable(filename, args):
         The path to a FITS file.
 
     """
-    print(args)
     read_kwargs = {k: v for k, v in vars(args).items()
                    if k in ('hdu', 'format', 'table_id') and v is not None}
     try:
@@ -68,7 +67,7 @@ def showtable(filename, args):
 
 
 def main(args=None):
-    """The main function called by the `fitsinfo` script."""
+    """The main function called by the `showtable` script."""
     parser = argparse.ArgumentParser(
         description=('Print tables from ASCII, FITS, HDF5, VOTable file(s).'))
     addarg = parser.add_argument

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from ..scripts import showtable
@@ -103,4 +101,56 @@ def test_votable(capsys):
         '             XXXX          XXXX ...       -- .. --',
         '                                ...       -- .. --',
         '                                ...       -- .. --',
+    ]
+
+
+def test_max_lines(capsys):
+    showtable.main([os.path.join(ASCII_ROOT, 't/cds2.dat'),
+                    '--format', 'ascii.cds', '--max-lines', '7',
+                    '--max-width', '30'])
+    out, err = capsys.readouterr()
+    assert out.splitlines() == [
+        '      SST       ... Note',
+        '                ...     ',
+        '--------------- ... ----',
+        '041314.1+281910 ...   --',
+        '            ... ...  ...',
+        '044427.1+251216 ...   --',
+        '044642.6+245903 ...   --',
+        'Length = 215 rows',
+    ]
+
+
+def test_show_dtype(capsys):
+    showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'),
+                    '--show-dtype'])
+    out, err = capsys.readouterr()
+    assert out.splitlines() == [
+        ' target  V_mag ',
+        ' str20  float32',
+        '------- -------',
+        'NGC1001    11.1',
+        'NGC1002    12.3',
+        'NGC1003    15.2',
+    ]
+
+
+def test_hide_unit(capsys):
+    showtable.main([os.path.join(ASCII_ROOT, 't/cds.dat'),
+                    '--format', 'ascii.cds'])
+    out, err = capsys.readouterr()
+    assert out.splitlines() == [
+        'Index RAh RAm  RAs  DE- DEd  DEm    DEs   Match Class  AK Fit ',
+        '       h  min   s       deg arcmin arcsec             mag     ',
+        '----- --- --- ----- --- --- ------ ------ ----- ----- --- ----',
+        '    1   3  28 39.09   +  31      6    1.9    --    I*  -- 1.35',
+    ]
+
+    showtable.main([os.path.join(ASCII_ROOT, 't/cds.dat'),
+                    '--format', 'ascii.cds', '--hide-unit'])
+    out, err = capsys.readouterr()
+    assert out.splitlines() == [
+        'Index RAh RAm  RAs  DE- DEd DEm DEs Match Class  AK Fit ',
+        '----- --- --- ----- --- --- --- --- ----- ----- --- ----',
+        '    1   3  28 39.09   +  31   6 1.9    --    I*  -- 1.35',
     ]

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -21,7 +21,7 @@ def test_info(capsys):
     assert out.splitlines() == ['<Table length=3>',
                                 ' name   dtype ',
                                 '------ -------',
-                                'target   str20',
+                                'target bytes20',
                                 ' V_mag float32']
 
 
@@ -127,7 +127,7 @@ def test_show_dtype(capsys):
     out, err = capsys.readouterr()
     assert out.splitlines() == [
         ' target  V_mag ',
-        ' str20  float32',
+        'bytes20 float32',
         '------- -------',
         'NGC1001    11.1',
         'NGC1002    12.3',

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -20,22 +20,22 @@ def test_missing_file(capsys):
 def test_info(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--info'])
     out, err = capsys.readouterr()
-    assert out == ('<Table length=3>\n'
-                   ' name   dtype \n'
-                   '------ -------\n'
-                   'target   str20\n'
-                   ' V_mag float32\n'
-                   '\n')
+    assert out == ('<Table length=3>{0}'
+                   ' name   dtype {0}'
+                   '------ -------{0}'
+                   'target   str20{0}'
+                   ' V_mag float32{0}'
+                   '\n').format(os.linesep)
 
 
 def test_stats(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--stats'])
     out, err = capsys.readouterr()
-    assert out == ('<Table length=3>\n'
-                   ' name    mean    std   min  max \n'
-                   '------ ------- ------- ---- ----\n'
-                   'target      --      --   --   --\n'
-                   ' V_mag 12.8667 1.72111 11.1 15.2\n')
+    assert out == ('<Table length=3>{0}'
+                   ' name    mean    std   min  max {0}'
+                   '------ ------- ------- ---- ----{0}'
+                   'target      --      --   --   --{0}'
+                   ' V_mag 12.8667 1.72111 11.1 15.2{0}').format(os.linesep)
 
 
 def test_fits(capsys):

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -20,12 +20,11 @@ def test_missing_file(capsys):
 def test_info(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--info'])
     out, err = capsys.readouterr()
-    assert out == ('<Table length=3>{0}'
-                   ' name   dtype {0}'
-                   '------ -------{0}'
-                   'target   str20{0}'
-                   ' V_mag float32{0}'
-                   '\n').format(os.linesep)
+    assert out.splitlines() == ['<Table length=3>',
+                                ' name   dtype ',
+                                '------ -------',
+                                'target   str20',
+                                ' V_mag float32']
 
 
 def test_stats(capsys):
@@ -41,12 +40,11 @@ def test_stats(capsys):
 def test_fits(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits')])
     out, err = capsys.readouterr()
-    assert out == (' target V_mag\n'
-                   '             \n'
-                   '------- -----\n'
-                   'NGC1001  11.1\n'
-                   'NGC1002  12.3\n'
-                   'NGC1003  15.2\n')
+    assert out.splitlines() == [' target V_mag',
+                                '------- -----',
+                                'NGC1001  11.1',
+                                'NGC1002  12.3',
+                                'NGC1003  15.2']
 
 
 def test_fits_hdu(capsys):
@@ -64,49 +62,45 @@ def test_fits_hdu(capsys):
 def test_csv(capsys):
     showtable.main([os.path.join(ASCII_ROOT, 't/simple_csv.csv')])
     out, err = capsys.readouterr()
-    assert out == (' a   b   c \n'
-                   '           \n'
-                   '--- --- ---\n'
-                   '  1   2   3\n'
-                   '  4   5   6\n')
+    assert out.splitlines() == [' a   b   c ',
+                                '--- --- ---',
+                                '  1   2   3',
+                                '  4   5   6']
 
 
 def test_ascii_format(capsys):
     showtable.main([os.path.join(ASCII_ROOT, 't/commented_header.dat'),
                     '--format', 'ascii.commented_header'])
     out, err = capsys.readouterr()
-    assert out == (' a   b   c \n'
-                   '           \n'
-                   '--- --- ---\n'
-                   '  1   2   3\n'
-                   '  4   5   6\n')
+    assert out.splitlines() == [' a   b   c ',
+                                '--- --- ---',
+                                '  1   2   3',
+                                '  4   5   6']
 
 
 def test_ascii_delimiter(capsys):
     showtable.main([os.path.join(ASCII_ROOT, 't/simple2.txt'),
                     '--format', 'ascii', '--delimiter', '|'])
     out, err = capsys.readouterr()
-    assert out == (
-        "obsid redshift  X    Y      object   rad \n"
-        "                                         \n"
-        "----- -------- ---- ---- ----------- ----\n"
-        " 3102     0.32 4167 4085 Q1250+568-A  9.0\n"
-        " 3102     0.32 4706 3916 Q1250+568-B 14.0\n"
-        "  877     0.22 4378 3892 'Source 82' 12.5\n"
-    )
+    assert out.splitlines() == [
+        "obsid redshift  X    Y      object   rad ",
+        "----- -------- ---- ---- ----------- ----",
+        " 3102     0.32 4167 4085 Q1250+568-A  9.0",
+        " 3102     0.32 4706 3916 Q1250+568-B 14.0",
+        "  877     0.22 4378 3892 'Source 82' 12.5",
+    ]
 
 
 def test_votable(capsys):
     showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
                     '--table-id', 'main_table', '--max-width', '50'])
     out, err = capsys.readouterr()
-    assert out == (
-        '   string_test    string_test_2 ... bitarray2 [16]\n'
-        '                                ...               \n'
-        '----------------- ------------- ... --------------\n'
-        '    String & test    Fixed stri ...  True .. False\n'
-        'String &amp; test    0123456789 ...       -- .. --\n'
-        '             XXXX          XXXX ...       -- .. --\n'
-        '                                ...       -- .. --\n'
-        '                                ...       -- .. --\n'
-    )
+    assert out.splitlines() == [
+        '   string_test    string_test_2 ... bitarray2 [16]',
+        '----------------- ------------- ... --------------',
+        '    String & test    Fixed stri ...  True .. False',
+        'String &amp; test    0123456789 ...       -- .. --',
+        '             XXXX          XXXX ...       -- .. --',
+        '                                ...       -- .. --',
+        '                                ...       -- .. --',
+    ]

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -17,6 +17,27 @@ def test_missing_file(capsys):
                           "'foobar.fits'")
 
 
+def test_info(capsys):
+    showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--info'])
+    out, err = capsys.readouterr()
+    assert out == ('<Table length=3>\n'
+                   ' name   dtype \n'
+                   '------ -------\n'
+                   'target   str20\n'
+                   ' V_mag float32\n'
+                   '\n')
+
+
+def test_stats(capsys):
+    showtable.main([os.path.join(FITS_ROOT, 'data/table.fits'), '--stats'])
+    out, err = capsys.readouterr()
+    assert out == ('<Table length=3>\n'
+                   ' name    mean    std   min  max \n'
+                   '------ ------- ------- ---- ----\n'
+                   'target      --      --   --   --\n'
+                   ' V_mag 12.8667 1.72111 11.1 15.2\n')
+
+
 def test_fits(capsys):
     showtable.main([os.path.join(FITS_ROOT, 'data/table.fits')])
     out, err = capsys.readouterr()

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+from ..scripts import showtable
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
+ASCII_ROOT = os.path.join(ROOT, '..', '..', 'io', 'ascii', 'tests')
+FITS_ROOT = os.path.join(ROOT, '..', '..', 'io', 'fits', 'tests')
+
+
+def test_missing_file(capsys):
+    showtable.main(['foobar.fits'])
+    out, err = capsys.readouterr()
+    assert err.startswith("ERROR: [Errno 2] No such file or directory: "
+                          "'foobar.fits'")
+
+
+def test_fits(capsys):
+    showtable.main([os.path.join(FITS_ROOT, 'data/table.fits')])
+    out, err = capsys.readouterr()
+    assert out == (' target V_mag\n'
+                   '             \n'
+                   '------- -----\n'
+                   'NGC1001  11.1\n'
+                   'NGC1002  12.3\n'
+                   'NGC1003  15.2\n')
+
+
+def test_fits_hdu(capsys):
+    showtable.main([os.path.join(FITS_ROOT, 'data/zerowidth.fits'),
+                    '--hdu', 'AIPS OF'])
+    out, err = capsys.readouterr()
+    assert out.startswith(
+        '  TIME   SOURCE ID ANTENNA NO. SUBARRAY FREQ ID ANT FLAG STATUS 1\n'
+        '  DAYS                                                           \n'
+        '-------- --------- ----------- -------- ------- -------- --------\n'
+        '0.144387         1          10        1       1        4        4\n'
+    )
+
+
+def test_csv(capsys):
+    showtable.main([os.path.join(ASCII_ROOT, 't/simple_csv.csv')])
+    out, err = capsys.readouterr()
+    assert out == (' a   b   c \n'
+                   '           \n'
+                   '--- --- ---\n'
+                   '  1   2   3\n'
+                   '  4   5   6\n')
+
+
+def test_ascii_format(capsys):
+    showtable.main([os.path.join(ASCII_ROOT, 't/commented_header.dat'),
+                    '--format', 'ascii.commented_header'])
+    out, err = capsys.readouterr()
+    assert out == (' a   b   c \n'
+                   '           \n'
+                   '--- --- ---\n'
+                   '  1   2   3\n'
+                   '  4   5   6\n')

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -98,7 +98,7 @@ def test_ascii_delimiter(capsys):
 
 def test_votable(capsys):
     showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
-                    '--table_id', 'main_table', '--max-width', '50'])
+                    '--table-id', 'main_table', '--max-width', '50'])
     out, err = capsys.readouterr()
     assert out == (
         '   string_test    string_test_2 ... bitarray2 [16]\n'

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -61,6 +61,20 @@ def test_ascii_format(capsys):
                    '  4   5   6\n')
 
 
+def test_ascii_delimiter(capsys):
+    showtable.main([os.path.join(ASCII_ROOT, 't/simple2.txt'),
+                    '--format', 'ascii', '--delimiter', '|'])
+    out, err = capsys.readouterr()
+    assert out == (
+        "obsid redshift  X    Y      object   rad \n"
+        "                                         \n"
+        "----- -------- ---- ---- ----------- ----\n"
+        " 3102     0.32 4167 4085 Q1250+568-A  9.0\n"
+        " 3102     0.32 4706 3916 Q1250+568-B 14.0\n"
+        "  877     0.22 4378 3892 'Source 82' 12.5\n"
+    )
+
+
 def test_votable(capsys):
     showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
                     '--table_id', 'main_table', '--max-width', '50'])

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -7,6 +7,7 @@ from ..scripts import showtable
 ROOT = os.path.abspath(os.path.dirname(__file__))
 ASCII_ROOT = os.path.join(ROOT, '..', '..', 'io', 'ascii', 'tests')
 FITS_ROOT = os.path.join(ROOT, '..', '..', 'io', 'fits', 'tests')
+VOTABLE_ROOT = os.path.join(ROOT, '..', '..', 'io', 'votable', 'tests')
 
 
 def test_missing_file(capsys):
@@ -58,3 +59,19 @@ def test_ascii_format(capsys):
                    '--- --- ---\n'
                    '  1   2   3\n'
                    '  4   5   6\n')
+
+
+def test_votable(capsys):
+    showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
+                    '--table_id', 'main_table', '--max-width', '50'])
+    out, err = capsys.readouterr()
+    assert out == (
+        '   string_test    string_test_2 ... bitarray2 [16]\n'
+        '                                ...               \n'
+        '----------------- ------------- ... --------------\n'
+        '    String & test    Fixed stri ...  True .. False\n'
+        'String &amp; test    0123456789 ...       -- .. --\n'
+        '             XXXX          XXXX ...       -- .. --\n'
+        '                                ...       -- .. --\n'
+        '                                ...       -- .. --\n'
+    )

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -72,6 +72,9 @@ content of tables for the formats supported by the unified I/O interface::
     NGC1002  12.3
     NGC1003  15.2
 
+To get full documentation on the usage and available options do ``showtable
+--help``.
+
 
 .. _built_in_readers_writers:
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -58,6 +58,21 @@ Any additional arguments specified will depend on the format.  For examples of t
 section `Built-in table readers/writers`_.  This section also provides the full list of
 choices for the ``format`` argument.
 
+Command-line utility
+--------------------
+
+For convenience, the command-line tool ``showtable`` can be used to print the
+content of tables for the formats supported by the unified I/O interface::
+
+    $ showtable astropy/io/fits/tests/data/table.fits
+
+     target V_mag
+    ------- -----
+    NGC1001  11.1
+    NGC1002  12.3
+    NGC1003  15.2
+
+
 .. _built_in_readers_writers:
 
 Built-in table readers/writers

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ entry_points['console_scripts'] = [
     'fitsheader = astropy.io.fits.scripts.fitsheader:main',
     'fitsinfo = astropy.io.fits.scripts.fitsinfo:main',
     'samp_hub = astropy.samp.hub_script:hub_script',
+    'showtable = astropy.table.scripts.showtable:main',
     'volint = astropy.io.votable.volint:main',
     'wcslint = astropy.wcs.wcslint:main',
 ]


### PR DESCRIPTION
Closes #3022. I often miss such a script and there was an agreement in #3022. Basically it is just a wrapper around `Table.read` and `Table.pprint` so it supports printing ascii, fits, votable and hdf5. I also added options specific to each format (see the script help below), suggestions welcome if you think some option is missing.
```
❯ showtable --help
usage: showtable [-h] [--max-lines MAX_LINES] [--max-width MAX_WIDTH]
                 [--hide-unit] [--show-dtype] [--format FORMAT] [--hdu HDU]
                 [--path PATH] [--table_id TABLE_ID]
                 filename [filename ...]

Print tables from ASCII, FITS, HDF5, VOTable file(s).

positional arguments:
  filename              Path to one or more files.

optional arguments:
  -h, --help            show this help message and exit
  --max-lines MAX_LINES
                        Maximum number of lines in table output.
  --max-width MAX_WIDTH
                        Maximum character width of output.
  --hide-unit           Hide the header row for unit (which is shown only if
                        one or more columns has a unit).
  --show-dtype          Include a header row for column dtypes.
  --format FORMAT       Input table format (only for ASCII files).
  --hdu HDU             Name of the HDU to show (only for FITS files).
  --path PATH           The path from which to read the table (only for HDF5
                        files).
  --table_id TABLE_ID   The table to read in (only for VOTable files).
```