### PR TITLE
WIP: Make it possible to run tests without pytest-astropy

### DIFF
--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -10,6 +10,13 @@ from textwrap import dedent
 
 import pytest
 
+try:
+    import pytest_doctestplus
+except ImportError:
+    PYTEST_DOCTESTPLUS_INSTALLED = False
+else:
+    PYTEST_DOCTESTPLUS_INSTALLED = True
+
 # test helper.run_tests function
 from ... import test as run_tests
 
@@ -38,6 +45,7 @@ def test_unicode_literal_conversion():
     assert isinstance('ångström', str)
 
 
+@pytest.mark.skipif('not PYTEST_DOCTESTPLUS_INSTALLED')
 def test_doctest_float_replacement(tmpdir):
     test1 = dedent("""
         This will demonstrate a doctest that fails due to a few extra decimal

--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,9 @@ setup_requires = [min_numpy_version]
 # Make sure to have the packages needed for building astropy, but do not require them
 # when installing from an sdist as the c files are included there.
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
-    setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
+    setup_requires.extend(['cython>=0.21', 'jinja2>=2.7', 'pytest-astropy'])
 
-install_requires = [min_numpy_version]
+install_requires = [min_numpy_version, 'pytest>=3.1']
 
 extras_require = {
     'test': ['pytest-astropy']


### PR DESCRIPTION
Following a discussion on slack regarding the fact that running tests can now give an error related to pytest-astropy not being present, I just wanted to propose the changes here. These are:

* Make it possible to run astropy.test() and python setup.py test without any plugins installed. This has the effect of running all the remote tests by default and won't run the docs and docstrings, though the docs/ tests wouldn't run anyway when doing astropy.test() on a user install.

* Add pytest back as an install dependency (as was the case in 2.0.x)

* Add pytest-astropy as an install dependency for the developer version of astropy

The net effect of this is the following:

* For users who run astropy.test(), the only 'downside' is that remote tests would be run by default in the absence of plugins. The absence of doctestplus doesn't matter I think because the docs/ directory is not installed (is there a way to re-enable just plain docstring testing?). I don't think it's a big deal to run the remote tests by default, it's only really a problem in CI. If we do think it's a problem it would be trivial to simply skip those tests if pytest_remotedata is not installed.

* For developers, running e.g. ``python setup.py develop`` or ``python setup.py install`` will automatically install pytest-astropy. It would be nice if python setup.py test did too but I recall @drdavella saying something about ``tests_requires`` not working.

We can still follow up with Continuum to see how they would feel about packaging pytest-doctestplus and pytest-remotedata, but at least with the PR here, things will be only a little different from before.

@eteq @drdavella @Cadair @pllim @bsipocz - what do you think?

