### PR TITLE
Precise barycentric radial velocity corrections.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -378,6 +378,8 @@ astropy.coordinates
   yield the correct type of frame, and works at all for non-equatorial frames.
   [#6612]
 
+- Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6697]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -506,8 +508,6 @@ astropy.coordinates
 
 - Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
   coordinate objects from being written out to ECSV files. [#6448]
-
-- Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6697]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -507,7 +507,7 @@ astropy.coordinates
 - Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
   coordinate objects from being written out to ECSV files. [#6448]
 
-- Improved accuracy of velocity calculation in ```EarthLocation.get_gcrs_posvel```. [#6679]
+- Improved accuracy of velocity calculation in ```EarthLocation.get_gcrs_posvel```. [#6697]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -378,7 +378,7 @@ astropy.coordinates
   yield the correct type of frame, and works at all for non-equatorial frames.
   [#6612]
 
-- Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6697]
+- Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6699]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -507,6 +507,8 @@ astropy.coordinates
 - Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
   coordinate objects from being written out to ECSV files. [#6448]
 
+- Improved accuracy of velocity calculation in ```EarthLocation.get_gcrs_posvel```. [#6679]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -507,7 +507,7 @@ astropy.coordinates
 - Fixed a bug that was preventing ``SkyCoord`` objects made from lists of other
   coordinate objects from being written out to ECSV files. [#6448]
 
-- Improved accuracy of velocity calculation in ```EarthLocation.get_gcrs_posvel```. [#6697]
+- Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6697]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -380,6 +380,8 @@ astropy.coordinates
 
 - Improved accuracy of velocity calculation in ``EarthLocation.get_gcrs_posvel``. [#6699]
 
+- Improved accuracy of radial velocity corrections in ``SkyCoord.radial_velocity_correction```. [#6861]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -603,7 +603,7 @@ class EarthLocation(u.Quantity):
                                      for the location of this object at the
                                      default ``obstime``.""")
 
-    def get_gcrs(self, obstime):
+    def _get_gcrs(self, obstime):
         """GCRS position with velocity at ``obstime`` as a GCRS coordinate.
 
         Parameters
@@ -645,12 +645,12 @@ class EarthLocation(u.Quantity):
             The GCRS velocity of the object
         """
         # GCRS position
-        gcrs_data = self.get_gcrs(obstime).data
+        gcrs_data = self._get_gcrs(obstime).data
         obsgeopos = gcrs_data.without_differentials()
         obsgeovel = gcrs_data.differentials['s'].to_cartesian()
         return obsgeopos, obsgeovel
 
-    def gravitational_redshift(self, obstime):
+    def _gravitational_redshift(self, obstime):
         """Return the gravitational redshift at this EarthLocation.
 
         Calculates the gravitational redshift, of order 3 m/s, due to the Sun,

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -14,7 +14,7 @@ from ..units.quantity import QuantityInfoBase
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.compat.numpycompat import NUMPY_LT_1_12
 from .angles import Longitude, Latitude
-from .matrix_utilities import matrix_transpose, matmul
+from .matrix_utilities import matrix_transpose
 from .representation import CartesianRepresentation
 from .errors import UnknownSiteException
 from ..utils import data, deprecated

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -15,7 +15,6 @@ from ..units.quantity import QuantityInfoBase
 from ..utils.exceptions import AstropyUserWarning
 from ..utils.compat.numpycompat import NUMPY_LT_1_12
 from .angles import Longitude, Latitude
-from .matrix_utilities import matrix_transpose
 from .representation import CartesianRepresentation, CartesianDifferential
 from .errors import UnknownSiteException
 from ..utils import data, deprecated

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -669,8 +669,9 @@ class EarthLocation(u.Quantity):
                      zip(masses, distances)]
         # now Earth's contribution
         distance = CartesianRepresentation(self.geocentric).norm()
-        redshifts.append(-consts.G*consts.M_earth/consts.c/distance)
-        return u.Quantity(redshifts).sum().to(u.m/u.s)
+        gravitational_redshift = (u.Quantity(redshifts).sum()
+                                  - consts.G*consts.M_earth/consts.c/distance)
+        return gravitational_redshift
 
     @property
     def x(self):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1386,7 +1386,7 @@ class SkyCoord(ShapedLikeNDArray):
         if kind == 'barycentric':
             beta_obs = (v_origin_to_earth + gcrs_v) / speed_of_light
             gamma_obs = 1 / np.sqrt(1 - beta_obs.norm()**2)
-            gr = location.gravitational_redshift(obstime)
+            gr = location._gravitational_redshift(obstime)
             # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
             # neglecting Shapiro delay and effects of the star's own motion
             zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light) - 1

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1370,13 +1370,19 @@ class SkyCoord(ShapedLikeNDArray):
             icrs_cart = self.cartesian
             targcart = (icrs_cart - obs_icrs_cart).represent_as(UnitSphericalRepresentation).to_cartesian()
 
-        beta_obs = (v_origin_to_earth + gcrs_v) / speed_of_light
-        gamma_obs = 1 / np.sqrt(1 - beta_obs.norm()**2)
-        gr = location.gravitational_redshift(obstime)
-        # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
-        # neglectic Shapiro delay and effects of the star's own motion
-        zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light) - 1
-        return zb * speed_of_light
+        if kind == 'barycentric':
+            beta_obs = (v_origin_to_earth + gcrs_v) / speed_of_light
+            gamma_obs = 1 / np.sqrt(1 - beta_obs.norm()**2)
+            gr = location.gravitational_redshift(obstime)
+            # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
+            # neglectic Shapiro delay and effects of the star's own motion
+            zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light) - 1
+            return zb * speed_of_light
+        else:
+            # do a simpler correction ignoring time dilation and gravitational redshift
+            # this is adequate since Heliocentric corrections shouldn't be used if
+            # cm/s precision is required.
+            return targcart.dot(v_origin_to_earth + gcrs_v)
 
     # Table interactions
     @classmethod

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -577,3 +577,18 @@ def test_regression_6597_2():
     sc1 = SkyCoord([c1, c2])
 
     assert sc1.frame.name == frame.name
+
+
+def test_regression_6697():
+    """
+    Test for regression of a bug in get_gcrs_posvel that introduced errors at the 1m/s level.
+
+    Comparison data is derived from calculation in PINT
+    https://github.com/nanograv/PINT/blob/master/pint/erfautils.py
+    """
+    pint_vels = CartesianRepresentation(*(348.63632871, -212.31704928, -0.60154936), unit=u.m/u.s)
+    location = EarthLocation(*(5327448.9957829, -1718665.73869569,  3051566.90295403), unit=u.m)
+    t = Time(2458036.161966612, format='jd', scale='utc')
+    obsgeopos, obsgeovel = location.get_gcrs_posvel(t)
+    delta = (obsgeovel-pint_vels).norm()
+    assert delta < 1*u.cm/u.s

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -233,7 +233,7 @@ def test_barycorr():
                                                       location=test_input_loc,
                                                       kind='barycentric')
 
-    assert_quantity_allclose(bvcs_astropy, barycorr_bvcs, atol=5*u.m/u.s)
+    assert_quantity_allclose(bvcs_astropy, barycorr_bvcs, atol=10*u.mm/u.s)
     return bvcs_astropy, barycorr_bvcs  # for interactively examination
 
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -312,10 +312,10 @@ radial velocity to determine the final heliocentric radial velocity::
     >>> sc = SkyCoord(ra=4.88375*u.deg, dec=35.0436389*u.deg)
     >>> barycorr = sc.radial_velocity_correction(obstime=Time('2016-6-4'), location=keck)
     >>> barycorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
-    <Quantity 20.07369368 km / s>
+    <Quantity 20.074064687695454 km / s>
     >>> heliocorr = sc.radial_velocity_correction('heliocentric', obstime=Time('2016-6-4'), location=keck)
     >>> heliocorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
-    <Quantity 20.071123 km / s>
+    <Quantity 20.071494016308176 km / s>
 
 Note that there are a few different ways to specify the options for the
 correction (e.g., the location, observation time, etc).  See the

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -302,9 +302,9 @@ details).
 
 An example of this is below.  It demonstrates how to compute this correction if
 observing some object at a known RA and Dec from the Keck observatory at a
-particular time.  If one is only interested in accuracies of around
-3 m/s, the computed correction would then be added to any observed
-radial velocity to determine the final heliocentric radial velocity::
+particular time.  If a precision of around 3 m/s is sufficient, the computed 
+correction can then be added to any observed radial velocity to determine 
+the final heliocentric radial velocity::
 
     >>> from astropy.time import Time
     >>> from astropy.coordinates import SkyCoord, EarthLocation
@@ -342,7 +342,7 @@ be used for high precision work.
 
 Other considerations necessary for radial velocity corrections at the cm/s level are outlined
 in `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_. Most important
-is that the barycentric correct is, strictly speaking, *multiplicative*, so that one should apply it
+is that the barycentric correction is, strictly speaking, *multiplicative*, so that one should apply it
 as
 
 .. math::
@@ -359,5 +359,5 @@ the Wright & Eastmann (2014) paper to a level of 10 mm/s for a source at infinit
 the Shapiro delay, nor any effect related to the finite distance or proper motion of the source.
 The Shapiro delay is unlikely to be important unless you seek mm/s precision, but the effects of the
 source's parallax and proper motion can be important at the cm/s level. These effects are likely to be
-added to future versions of Astropy, but in the meantime
+added to future versions of Astropy along with velocity support for |skycoord|, but in the meantime
 see `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -302,7 +302,8 @@ details).
 
 An example of this is below.  It demonstrates how to compute this correction if
 observing some object at a known RA and Dec from the Keck observatory at a
-particular time.  The computed correction would then be added to any observed
+particular time.  If one is only interested in accuracies of around
+3 m/s, the computed correction would then be added to any observed
 radial velocity to determine the final heliocentric radial velocity::
 
     >>> from astropy.time import Time
@@ -321,3 +322,42 @@ Note that there are a few different ways to specify the options for the
 correction (e.g., the location, observation time, etc).  See the
 `~astropy.coordinates.SkyCoord.radial_velocity_correction` docs for more
 information.
+
+Precision of `~astropy.coordinates.SkyCoord.radial_velocity_correction`
+------------------------------------------------------------------------
+
+The correction computed by `~astropy.coordinates.SkyCoord.radial_velocity_correction`
+can be added to any observed radial velocity to provide a correction that is accurate
+to a level of approximately 3 m/s. If you need more precise corrections, there are a number
+of subtleties you must be aware of.
+
+The first is that one should always use a barycentric correction, as the barycenter is a fixed
+point where gravity is constant. Since the heliocentre does not satisfy these conditions, corrections
+to the heliocentre are only suitable for low precision work. As a result, and
+to increase speed, the heliocentric correction in
+`~astropy.coordinates.SkyCoord.radial_velocity_correction` does not include effects such as the
+gravitational redshift due to the potential at the Earth's surface. For these reasons, the
+barycentric correction in `~astropy.coordinates.SkyCoord.radial_velocity_correction` should always
+be used for high precision work.
+
+Other considerations necessary for radial velocity corrections at the cm/s level are outlined
+in `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_. Most important
+is that the barycentric correct is, strictly speaking, *multiplicative*, so that one should apply it
+as
+
+.. math::
+
+    v_t = v_m + v_b + \frac{v_b v_m}{c},
+
+where :math:`v_t` is the true radial velocity,  :math:`v_m` is the measured radial velocity and :math:`v_b`
+is the barycentric correction returned by `~astropy.coordinates.SkyCoord.radial_velocity_correction`.
+Failure to apply the barycentric correction in this way leads to errors of order 3 m/s.
+
+The barycentric correction in `~astropy.coordinates.SkyCoord.radial_velocity_correction` is consistent
+with the `IDL implementation <http://astroutils.astronomy.ohio-state.edu/exofast/barycorr.html>`_ of
+the Wright & Eastmann (2014) paper to a level of 10 mm/s for a source at infinite distance. We do not include
+the Shapiro delay, nor any effect related to the finite distance or proper motion of the source.
+The Shapiro delay is unlikely to be important unless you seek mm/s precision, but the effects of the
+source's parallax and proper motion can be important at the cm/s level. These effects are likely to be
+added to future versions of Astropy, but in the meantime
+see `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -302,8 +302,8 @@ details).
 
 An example of this is below.  It demonstrates how to compute this correction if
 observing some object at a known RA and Dec from the Keck observatory at a
-particular time.  If a precision of around 3 m/s is sufficient, the computed 
-correction can then be added to any observed radial velocity to determine 
+particular time.  If a precision of around 3 m/s is sufficient, the computed
+correction can then be added to any observed radial velocity to determine
 the final heliocentric radial velocity::
 
     >>> from astropy.time import Time
@@ -313,10 +313,10 @@ the final heliocentric radial velocity::
     >>> sc = SkyCoord(ra=4.88375*u.deg, dec=35.0436389*u.deg)
     >>> barycorr = sc.radial_velocity_correction(obstime=Time('2016-6-4'), location=keck)
     >>> barycorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
-    <Quantity 20.074064687695454 km / s>
+    <Quantity 20.077135 km / s>
     >>> heliocorr = sc.radial_velocity_correction('heliocentric', obstime=Time('2016-6-4'), location=keck)
     >>> heliocorr.to(u.km/u.s)  # doctest: +FLOAT_CMP
-    <Quantity 20.071494016308176 km / s>
+    <Quantity 20.070039 km / s>
 
 Note that there are a few different ways to specify the options for the
 correction (e.g., the location, observation time, etc).  See the


### PR DESCRIPTION
This PR builds on the improvements to ```EarthLocation.get_gcrs_posvel``` in #6699, to offer radial velocity corrections compatible with [Wright & Eastman (2014)](http://adsabs.harvard.edu/abs/2014PASP..126..838W) to 10 mm/s (for sources at infinite distance).

Prior to this PR, radial velocity corrections between astropy and WE14 differed by several metres/second. This is due to ignoring the gravitational redshift at the observatory and a slight bug in ```SkyCoord.radial_velocity_correction```. This PR fixes both of these issues to give much more accurate radial velocity corrections. The plot before shows the situation before (top) and after (below). The yellow star marks the position of the Sun.
![barycentric_deltas](https://user-images.githubusercontent.com/4570807/32886317-391b4798-cab8-11e7-8ff5-a628137acd29.png)

As discussed in [5752](https://github.com/astropy/astropy/pull/5752#issuecomment-309268570) improvements to the precision of these corrections should probably be thought of as bug fixes.

The only remaining physics to include is that caused by the proper motion and parallax of the source, but I propose only including those terms once velocity support is added to ```SkyCoord```.

This PR fixes #6697 and also fixes #6680, subject to the precision required by that user.