### PR TITLE
Update travis script to use master branch of ASDF for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ env:
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        # Build against branch in fork until it has been merged into asdf
-        - ASDF_GIT='git+git://github.com/drdavella/asdf.git@astropy-transition#egg=asdf'
+        # Build against github source until asdf-2.0 has been released
+        - ASDF_GIT='git+git://github.com/spacetelescope/asdf.git#egg=asdf'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach'
         - PIP_DEPENDENCIES='pytest-astropy'


### PR DESCRIPTION
Now that changes related to ASDF tags have been integrated in both ASDF and Astropy, we can update the travis script to point to ASDF's `master` branch instead of an unmerged feature branch.

When `asdf-2.0` is released, we can update it to be a conda dependency.