### PR TITLE
Make CoC wording a bit more declarative

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-Please read the [Astropy Project Code of Conduct](http://www.astropy.org/code_of_conduct.html).
+We ask that all Astropy community members abide by the [Astropy Project Code of Conduct](http://www.astropy.org/code_of_conduct.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-We ask that all Astropy community members abide by the [Astropy Project Code of Conduct](http://www.astropy.org/code_of_conduct.html).
+All Astropy community members are expected to abide by the [Astropy Project Code of Conduct](http://www.astropy.org/code_of_conduct.html).


### PR DESCRIPTION
This is a minor change to the wording of the `CODE_OF_CONDUCT.md` file to be a bit more declarative - it currently asks members to "please read" the CoC, but I think it might be better to say explicitly that "they should abide by it".

cc @kelle