### PR TITLE
Added new attributes to the frame classes for easier access to velocity data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,12 @@ astropy.coordinates
   initializer, and supports retrieving a parallax (as an ``Angle``) via
   the ``.parallax`` attributes. [#6855]
 
+- The coordinate frame classes (subclasses of ``BaseCoordinateFrame``) now
+  always have ``.velocity``, ``.proper_motion``, and ``.radial_velocity``
+  properties that provide shorthands to the full-space Cartesian velocity as
+  a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
+  radial or line-of-sigh velocity as a ``Quantity``. [#6869]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ astropy.coordinates
   always have ``.velocity``, ``.proper_motion``, and ``.radial_velocity``
   properties that provide shorthands to the full-space Cartesian velocity as
   a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
-  radial or line-of-sigh velocity as a ``Quantity``. [#6869]
+  radial or line-of-sight velocity as a ``Quantity``. [#6869]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1388,11 +1388,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     @property
     def proper_motion(self):
         """
-        Shorthand for the two-dimensional proper motion as a `Quantity` object
-        with angular velocity units. In the returned `Quantity`, ``axis=0`` is
-        the longitude/latitude dimension so that ``.proper_motion[0]`` is the
-        longitudinal proper motion and ``.proper_motion[1]`` is latitudinal.
-        The longitudinal proper motion already includes the cos(latitude) term.
+        Shorthand for the two-dimensional proper motion as a
+        `~astropy.units.Quantity` object with angular velocity units. In the
+        returned `~astropy.units.Quantity`, ``axis=0`` is the longitude/latitude
+        dimension so that ``.proper_motion[0]`` is the longitudinal proper
+        motion and ``.proper_motion[1]`` is latitudinal. The longitudinal proper
+        motion already includes the cos(latitude) term.
         """
         if 's' not in self.data.differentials:
             raise ValueError('Frame has no associated velocity (Differential) '
@@ -1408,8 +1409,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     @property
     def radial_velocity(self):
         """
-        Shorthand for the radial or line-of-sight velocity as a `Quantity`
-        object.
+        Shorthand for the radial or line-of-sight velocity as a
+        `~astropy.units.Quantity` object.
         """
         if 's' not in self.data.differentials:
             raise ValueError('Frame has no associated velocity (Differential) '

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1369,8 +1369,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     @property
     def velocity(self):
         """
-        Shorthand for the Cartesian velocity as a `CartesianDifferential`
-        object.
+        Shorthand for retrieving the Cartesian space-motion as a
+        `CartesianDifferential` object. This is equivalent to calling
+        ``frame.cartesian.differentials['s']``.
         """
         if 's' not in self.data.differentials:
             raise ValueError('Frame has no associated velocity (Differential) '
@@ -1380,9 +1381,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             v = self.cartesian.differentials['s']
         except Exception as e:
             raise ValueError('Could not retrieve a Cartesian velocity. Your '
-                             'frame data must include all six of sky positions,'
-                             ' distance, proper motions, and radial velocity '
-                             'for this to work.')
+                             'frame must include velocity information for this '
+                             'to work.')
         return v
 
     @property

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1371,7 +1371,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         Shorthand for retrieving the Cartesian space-motion as a
         `CartesianDifferential` object. This is equivalent to calling
-        ``frame.cartesian.differentials['s']``.
+        ``self.cartesian.differentials['s']``.
         """
         if 's' not in self.data.differentials:
             raise ValueError('Frame has no associated velocity (Differential) '

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1405,6 +1405,19 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return np.stack((pm_lon.value,
                          pm_lat.to(pm_lon.unit).value), axis=0) * pm_lon.unit
 
+    @property
+    def radial_velocity(self):
+        """
+        Shorthand for the radial or line-of-sight velocity as a `Quantity`
+        object.
+        """
+        if 's' not in self.data.differentials:
+            raise ValueError('Frame has no associated velocity (Differential) '
+                             'data information.')
+
+        sph = self.represent_as('spherical', in_frame_units=True)
+        return sph.differentials['s'].d_distance
+
 
 class GenericFrame(BaseCoordinateFrame):
     """

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -3,6 +3,7 @@
 
 
 import pytest
+import numpy as np
 
 from ... import units as u
 from ..builtin_frames import ICRS, Galactic, Galactocentric
@@ -219,3 +220,38 @@ def test_slicing_preserves_differential():
 
     for name in icrs.get_representation_component_names('s').keys():
         assert getattr(icrs, name) == getattr(icrs2, name)[0]
+
+
+def test_shorthand_attributes():
+    # Check that attribute access works
+
+    # for array data:
+    n = 4
+    icrs1 = ICRS(ra=np.random.uniform(0, 360, n)*u.deg,
+                 dec=np.random.uniform(-90, 90, n)*u.deg,
+                 distance=100*u.pc,
+                 pm_ra_cosdec=np.random.normal(0, 100, n)*u.mas/u.yr,
+                 pm_dec=np.random.normal(0, 100, n)*u.mas/u.yr,
+                 radial_velocity=np.random.normal(0, 100, n)*u.km/u.s)
+    v = icrs1.velocity
+    pm = icrs1.proper_motion
+    assert quantity_allclose(pm[0], icrs1.pm_ra_cosdec)
+    assert quantity_allclose(pm[1], icrs1.pm_dec)
+
+    # for scalar data:
+    icrs2 = ICRS(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
+                 pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
+                 radial_velocity=105.7*u.km/u.s)
+    v = icrs2.velocity
+    pm = icrs2.proper_motion
+    assert quantity_allclose(pm[0], icrs2.pm_ra_cosdec)
+    assert quantity_allclose(pm[1], icrs2.pm_dec)
+
+    # check that it fails where we expect:
+
+    # no distance
+    icrs3 = ICRS(ra=37.4*u.deg, dec=-55.8*u.deg,
+                 pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
+                 radial_velocity=105.7*u.km/u.s)
+    with pytest.raises(ValueError):
+        icrs3.velocity

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -250,8 +250,20 @@ def test_shorthand_attributes():
     # check that it fails where we expect:
 
     # no distance
+    rv = 105.7*u.km/u.s
     icrs3 = ICRS(ra=37.4*u.deg, dec=-55.8*u.deg,
                  pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
-                 radial_velocity=105.7*u.km/u.s)
+                 radial_velocity=rv)
     with pytest.raises(ValueError):
         icrs3.velocity
+
+    icrs3.set_representation_cls('cartesian')
+    assert hasattr(icrs3, 'radial_velocity')
+    assert quantity_allclose(icrs3.radial_velocity, rv)
+
+    icrs4 = ICRS(x=30*u.pc, y=20*u.pc, z=11*u.pc,
+                 v_x=10*u.km/u.s, v_y=10*u.km/u.s, v_z=10*u.km/u.s,
+                 representation=r.CartesianRepresentation,
+                 differential_cls=r.CartesianDifferential)
+    icrs4.radial_velocity
+

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -266,4 +266,3 @@ def test_shorthand_attributes():
                  representation=r.CartesianRepresentation,
                  differential_cls=r.CartesianDifferential)
     icrs4.radial_velocity
-

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -14,6 +14,8 @@ from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates import ICRS
 from astropy.coordinates.baseframe import RepresentationMapping
 
+from .. import representation as r
+
 import astropy.units as u
 
 import astropy.coordinates
@@ -54,23 +56,23 @@ def test_unit_representation_subclass():
 
         _unit_representation = UnitSphericalWrap180Representation
 
-    class myframe(ICRS):
+    class MyFrame(ICRS):
         default_representation = SphericalWrap180Representation
         frame_specific_representation_info = {
-            'spherical': [RepresentationMapping('lon', 'ra'),
-                          RepresentationMapping('lat', 'dec')]
+            'spherical': [
+                RepresentationMapping('lon', 'ra'),
+                RepresentationMapping('lat', 'dec')]
         }
-        frame_specific_representation_info['unitspherical'] = \
         frame_specific_representation_info['unitsphericalwrap180'] = \
-        frame_specific_representation_info['sphericalwrap180'] = \
+            frame_specific_representation_info['sphericalwrap180'] = \
             frame_specific_representation_info['spherical']
 
     @frame_transform_graph.transform(FunctionTransform,
-                                     myframe, astropy.coordinates.ICRS)
+                                     MyFrame, astropy.coordinates.ICRS)
     def myframe_to_icrs(myframe_coo, icrs):
         return icrs.realize_frame(myframe_coo._data)
 
-    f = myframe(10*u.deg, 10*u.deg)
+    f = MyFrame(10*u.deg, 10*u.deg)
     assert isinstance(f._data, UnitSphericalWrap180Representation)
     assert isinstance(f.ra, Longitude180)
 
@@ -78,6 +80,6 @@ def test_unit_representation_subclass():
     assert isinstance(g, astropy.coordinates.ICRS)
     assert isinstance(g._data, UnitSphericalWrap180Representation)
 
-    frame_transform_graph.remove_transform(myframe,
+    frame_transform_graph.remove_transform(MyFrame,
                                            astropy.coordinates.ICRS,
                                            None)

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -125,7 +125,7 @@ There are also shorthands for retrieving a single `Quantity` object that
 contains the two-dimensional proper motion data, and for retrieving the radial
 (line-of-sight) velocity::
 
-    >>> icrs.proper_motion
+    >>> icrs.proper_motion # doctest: +SKIP
     [  4.8  -15.16] mas / yr
     >>> icrs.radial_velocity
     23.42 km / s

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -121,9 +121,9 @@ Cartesian velocity can be accessed with::
     <CartesianDifferential (d_x, d_y, d_z) in km / s
         ( 23.03160789,  7.44794505,  11.34587732)>
 
-There are also shorthands for retrieving a single `Quantity` object that
-contains the two-dimensional proper motion data, and for retrieving the radial
-(line-of-sight) velocity::
+There are also shorthands for retrieving a single `~astropy.units.Quantity`
+object that contains the two-dimensional proper motion data, and for retrieving
+the radial (line-of-sight) velocity::
 
     >>> icrs.proper_motion # doctest: +FLOAT_CMP
     <Quantity [  4.8 ,-15.16] mas / yr>

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -125,10 +125,10 @@ There are also shorthands for retrieving a single `Quantity` object that
 contains the two-dimensional proper motion data, and for retrieving the radial
 (line-of-sight) velocity::
 
-    >>> icrs.proper_motion # doctest: +SKIP
-    [  4.8  -15.16] mas / yr
-    >>> icrs.radial_velocity
-    23.42 km / s
+    >>> icrs.proper_motion # doctest: +FLOAT_CMP
+    <Quantity [  4.8 ,-15.16] mas / yr>
+    >>> icrs.radial_velocity # doctest: +FLOAT_CMP
+    <Quantity 23.42 km / s>
 
 .. _astropy-coordinate-transform-with-velocities:
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -108,6 +108,28 @@ position and velocity components. For other frames, these are just ``x,y,z`` and
      (v_x, v_y, v_z) in km / s
         (31., -10., 75.)>
 
+For any frame with velocity data with any representation, there are also
+shorthands that provide easier access to the underlying velocity data in
+commonly-needed formats. With any frame object with 3D velocity data, the 3D
+Cartesian velocity can be accessed with::
+
+    >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
+    ...             distance=171*u.pc,
+    ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
+    ...             radial_velocity=23.42*u.km/u.s)
+    >>> icrs.velocity # doctest: +FLOAT_CMP
+    <CartesianDifferential (d_x, d_y, d_z) in km / s
+        ( 23.03160789,  7.44794505,  11.34587732)>
+
+There are also shorthands for retrieving a single `Quantity` object that
+contains the two-dimensional proper motion data, and for retrieving the radial
+(line-of-sight) velocity::
+
+    >>> icrs.proper_motion
+    [  4.8  -15.16] mas / yr
+    >>> icrs.radial_velocity
+    23.42 km / s
+
 .. _astropy-coordinate-transform-with-velocities:
 
 Transforming frames with velocities


### PR DESCRIPTION
This adds three new attributes to the frame classes to provide access to the cartesian velocity data (`frame.velocity` is equivalent to `frame.cartesian.data.differentials['s']`), the 2D proper motion data (rather than the two components separately via `frame.pm_...`, `frame.pm_...`), and the radial velocity.

Fixes #6854