### PR TITLE
Don't allow adding new frames to transform graph if their attributes conflict with component names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,9 +28,6 @@ astropy.coordinates
   properties that provide shorthands to the full-space Cartesian velocity as
   a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
   radial or line-of-sight velocity as a ``Quantity``. [#6869]
-- Coordinate frame classes now can't be added to the frame transform graph if
-  they have frame attribute names that conflict with any component names.
-  [#6871]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
@@ -238,6 +235,11 @@ astropy.coordinates
 - Deprecated ``recommended_units`` for representations. These were used to
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
+
+- Coordinate frame classes now can't be added to the frame transform graph if
+  they have frame attribute names that conflict with any component names. This
+  is so ``SkyCoord`` can uniquely identify and distinguish frame attributes from
+  frame components. [#6871]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -350,6 +350,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Coordinate frame classes now raise a warning when they are added to the frame
+  transform graph if they have frame attribute names that conflict with any
+  component names. [#6871]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ astropy.coordinates
   properties that provide shorthands to the full-space Cartesian velocity as
   a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
   radial or line-of-sight velocity as a ``Quantity``. [#6869]
+- Coordinate frame classes now can't be added to the frame transform graph if
+  they have frame attribute names that conflict with any component names.
+  [#6871]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -430,3 +430,23 @@ def test_function_transform_with_differentials():
         t2 = t3.transform_to(TCoo2)
         assert len(w) == 1
         assert 'they have been dropped' in str(w[0].message)
+
+
+def test_frame_override_component_with_attribute():
+    """
+    It was previously possible to define a frame with an attribute with the
+    same name as a component. We don't want to allow this!
+    """
+    from ..baseframe import BaseCoordinateFrame
+    from ..attributes import Attribute
+
+    class BorkedFrame(BaseCoordinateFrame):
+        ra = Attribute(default=150)
+
+    with pytest.raises(ValueError) as exc:
+        @frame_transform_graph.transform(t.FunctionTransform, BorkedFrame, TCoo2)
+        def trans(coo1, f):
+            pass
+
+    assert ('BorkedFrame' in exc.value.args[0] and
+            "{'ra'}" in exc.value.args[0])

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -442,11 +442,15 @@ def test_frame_override_component_with_attribute():
 
     class BorkedFrame(BaseCoordinateFrame):
         ra = Attribute(default=150)
+        dec = Attribute(default=150)
 
+    def trans_func(coo1, f):
+        pass
+
+    trans = t.FunctionTransform(trans_func, BorkedFrame, ICRS)
     with pytest.raises(ValueError) as exc:
-        @frame_transform_graph.transform(t.FunctionTransform, BorkedFrame, TCoo2)
-        def trans(coo1, f):
-            pass
+        trans.register(frame_transform_graph)
 
     assert ('BorkedFrame' in exc.value.args[0] and
-            "{'ra'}" in exc.value.args[0])
+            "'ra'" in exc.value.args[0] and
+            "'dec'" in exc.value.args[0])

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -85,6 +85,23 @@ class TransformGraph:
 
         return self._cached_frame_attributes
 
+    @property
+    def frame_component_names(self):
+        """
+        A `set` of all component names every defined within any frame class in
+        this `TransformGraph`.
+        """
+        if self._cached_component_names is None:
+            self._cached_component_names = set()
+
+            for frame_cls in self.frame_set:
+                rep_info = frame_cls._frame_specific_representation_info
+                for mappings in rep_info.values():
+                    for rep_map in mappings:
+                        self._cached_component_names.update([rep_map.framename])
+
+        return self._cached_component_names
+
     def invalidate_cache(self):
         """
         Invalidates the cache that stores optimizations for traversing the
@@ -95,6 +112,7 @@ class TransformGraph:
         self._cached_names_dct = None
         self._cached_frame_set = None
         self._cached_frame_attributes = None
+        self._cached_component_names = None
         self._shortestpaths = {}
         self._composite_cache = {}
 


### PR DESCRIPTION
See #6870 for a description of the problem.

This solves the problem by checking whether a new frame class added to the transform graph has invalid attribute names. 