### PR TITLE
Add a way to update the position of a source given its proper motion, radial velocity and a new time or time difference

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,13 +29,16 @@ astropy.coordinates
   a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
   radial or line-of-sight velocity as a ``Quantity``. [#6869]
 
-- SkyCoord objects now support storing and tranforming differentials - i.e.,
+- ``SkyCoord`` objects now support storing and tranforming differentials - i.e.,
   both radial velocities and proper motions. [#6944]
 
 - All frame classes now automatically get sensible representation mappings for
   velocity components. For example, ``d_x``, ``d_y``, ``d_z`` are all
   automatically mapped to frame component namse ``v_x``, ``v_y``, ``v_z``.
   [#6856]
+
+- ``SkyCoord`` objects now support updating the position of a source given its
+  space motion and a new time or time difference. [#6872]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -553,30 +553,30 @@ class SkyCoord(ShapedLikeNDArray):
         icrs.set_representation_cls(s=SphericalDifferential)
 
         try:
-            plx = icrs.distance.to(u.arcsecond, u.parallax()).value
+            plx = icrs.distance.to_value(u.arcsecond, u.parallax())
         except u.UnitConversionError: # No distance: set to 0 by starpm convention
             plx = 0.
 
         try:
-            rv = icrs.radial_velocity.to(u.km/u.s).value
+            rv = icrs.radial_velocity.to_value(u.km/u.s)
         except u.UnitConversionError: # No RV
             rv = 0.
 
         # proper motion in RA should not include the cos(dec) term, see the
         # erfa function eraStarpv, comment (4).
         starpm = erfa.starpm(icrs.ra.radian, icrs.dec.radian,
-                             icrs.pm_ra.to(u.radian/u.yr).value,
-                             icrs.pm_dec.to(u.radian/u.yr).value,
+                             icrs.pm_ra.to_value(u.radian/u.yr),
+                             icrs.pm_dec.to_value(u.radian/u.yr),
                              plx, rv,
                              2400000.5, t1.tdb.mjd,
                              2400000.5, t2.tdb.mjd)
 
-        icrs2 = ICRS(ra=starpm[0] * u.radian,
-                     dec=starpm[1] * u.radian,
-                     pm_ra=starpm[2] * u.radian/u.yr,
-                     pm_dec=starpm[3] * u.radian/u.yr,
-                     distance=Distance(parallax=starpm[4] * u.arcsec),
-                     radial_velocity=starpm[5] * u.km/u.s,
+        icrs2 = ICRS(ra=u.Quantity(starpm[0], u.radian, copy=False),
+                     dec=u.Quantity(starpm[1], u.radian, copy=False),
+                     pm_ra=u.Quantity(starpm[2], u.radian/u.yr, copy=False),
+                     pm_dec=u.Quantity(starpm[3], u.radian/u.yr, copy=False),
+                     distance=Distance(parallax=starpm[4] * u.arcsec, copy=False),
+                     radial_velocity=u.Quantity(starpm[5], u.km/u.s, copy=False),
                      differential_cls=SphericalDifferential)
 
         # Update the obstime of the returned SkyCoord, and need to carry along

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -610,8 +610,10 @@ class SkyCoord(ShapedLikeNDArray):
 
         # Update the obstime of the returned SkyCoord, and need to carry along
         # the frame attributes
-        return self.__class__(icrs2.transform_to(self.frame),
-                              obstime=new_obstime, frame=self.frame)
+        frattrs = {attrnm: getattr(self, attrnm)
+                   for attrnm in self._extra_frameattr_names}
+        frattrs['obstime'] = new_obstime
+        return self.__class__(icrs2, **frattrs).transform_to(self.frame)
 
     def __getattr__(self, attr):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -496,8 +496,7 @@ class SkyCoord(ShapedLikeNDArray):
             frame_kwargs.pop(attr)
         return self.__class__(new_coord, **frame_kwargs)
 
-    @u.quantity_input(dt=(u.year, None))
-    def move_to(self, new_obstime=None, dt=None):
+    def apply_space_motion(self, new_obstime=None, dt=None):
         """
         Update the position of the source represented by this coordinate object
         to a new specified time using the velocity and assuming linear motion.
@@ -508,8 +507,8 @@ class SkyCoord(ShapedLikeNDArray):
         ----------
         new_obstime : `~astropy.time.Time`, optional
             The time at which to evolve the position to.
-        dt : `~astropy.units.Quantity`, optional
-            A time to evolve as a `Quantity` object.
+        dt : `~astropy.units.Quantity`, `~astropy.time.TimeDelta`, optional
+            An amount of time to evolve the position of the source.
         """
 
         if (new_obstime is None and dt is None or

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -532,6 +532,9 @@ class SkyCoord(ShapedLikeNDArray):
                                       "https://github.com/astropy/astropy")
 
         if new_obstime is not None and self.obstime is None:
+            # If no obstime is already on this object, raise an error if a new
+            # obstime is passed: we need to know the time / epoch at which the
+            # the position / velocity were measured initially
             raise ValueError('This object has no associated `obstime`. '
                              'apply_space_motion() must receive a time '
                              'difference, `dt`, and not a new obstime.')
@@ -543,8 +546,6 @@ class SkyCoord(ShapedLikeNDArray):
             t1 = Time('J2000')
 
         if dt is None:
-            # If no obstime already on this object, raise error: we need to know
-            # the time / epoch at which the the position/velocity were measured
             dt = new_obstime - self.obstime
         t2 = t1 + dt
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -509,12 +509,14 @@ class SkyCoord(ShapedLikeNDArray):
         attribute of this coordinate.  Note that this method currently does not
         support evolving coordinates where the *frame* has an ``obstime`` frame
         attribute, so the ``obstime`` is only used for storing the before and
-        after times, not actually as an attribute of the frame.
+        after times, not actually as an attribute of the frame. Alternatively,
+        if ``dt`` is given, an ``obstime`` need not be provided at all.
 
         Parameters
         ----------
         new_obstime : `~astropy.time.Time`, optional
-            The time at which to evolve the position to.
+            The time at which to evolve the position to. Requires that the
+            ``obstime`` attribute be present on this frame.
         dt : `~astropy.units.Quantity`, `~astropy.time.TimeDelta`, optional
             An amount of time to evolve the position of the source. Cannot be
             given at the same time as ``new_obstime``.
@@ -523,7 +525,8 @@ class SkyCoord(ShapedLikeNDArray):
         -------
         new_coord : `SkyCoord`
             A new coordinate object with the evolved location of this coordinate
-            at the new time.
+            at the new time.  ``obstime`` will be set on this object to the new
+            time only if ``self`` also has ``obstime``.
         """
 
         if (new_obstime is None and dt is None or

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -500,17 +500,30 @@ class SkyCoord(ShapedLikeNDArray):
 
     def apply_space_motion(self, new_obstime=None, dt=None):
         """
-        Update the position of the source represented by this coordinate object
-        to a new specified time using the velocity and assuming linear motion.
+        Compute the position of the source represented by this coordinate object
+        to a new time using the velocities stored in this object and assuming
+        linear space motion (including relativistic corrections). This is
+        sometimes referred to as an "epoch transformation."
 
-        This is sometimes referred to as an "epoch transformation."
+        The initial time before the evolution is taken from the ``obstime``
+        attribute of this coordinate.  Note that this method currently does not
+        support evolving coordinates where the *frame* has an ``obstime`` frame
+        attribute, so the ``obstime`` is only used for storing the before and
+        after times, not actually as an attribute of the frame.
 
         Parameters
         ----------
         new_obstime : `~astropy.time.Time`, optional
             The time at which to evolve the position to.
         dt : `~astropy.units.Quantity`, `~astropy.time.TimeDelta`, optional
-            An amount of time to evolve the position of the source.
+            An amount of time to evolve the position of the source. Cannot be
+            given at the same time as ``new_obstime``.
+
+        Returns
+        -------
+        new_coord : `SkyCoord`
+            A new coordinate object with the evolved location of this coordinate
+            at the new time.
         """
 
         if (new_obstime is None and dt is None or

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -531,15 +531,16 @@ class SkyCoord(ShapedLikeNDArray):
                                       "issue on github:\n"
                                       "https://github.com/astropy/astropy")
 
+        if new_obstime is not None and self.obstime is None:
+            raise ValueError('This object has no associated `obstime`. '
+                             'apply_space_motion() must receive a time '
+                             'difference, `dt`, and not a new obstime.')
+
         t1 = self.obstime
         if t1 is None:
-            # Arbitrary choice: if the current SkyCoord object has no obstime,
+            # MAGIC NUMBER: if the current SkyCoord object has no obstime,
             # assume J2000 to do the dt offset.
             t1 = Time('J2000')
-            if new_obstime is not None:
-                raise ValueError('This object has no associated `obstime`. '
-                                 'apply_space_motion() must receive a time '
-                                 'difference, `dt`, and not a new obstime.')
 
         if dt is None:
             # If no obstime already on this object, raise error: we need to know

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -566,7 +566,9 @@ class SkyCoord(ShapedLikeNDArray):
 
         # Update the obstime of the returned SkyCoord, and need to carry along
         # the frame attributes
-        return self.__class__(icrs2.transform_to(self.frame),
+        # TODO: HACK for now is passing in .data because the SkyCoord init dies
+        # if a frame with a SphericalDifferential is passed in.
+        return self.__class__(icrs2.transform_to(self.frame).data,
                               obstime=new_obstime)
 
     def __getattr__(self, attr):

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1385,8 +1385,8 @@ def test_extra_attributes():
 
 
 def test_apply_space_motion():
-    t1 = Time('2015-01-01T00:00')
-    t2 = Time('2025-01-01T00:00')
+    t1 = Time('2005-01-01T00:00')
+    t2 = Time('2015-01-01T00:00')
 
     # Check a very simple case first:
     frame = ICRS(ra=10.*u.deg, dec=0*u.deg,
@@ -1394,9 +1394,17 @@ def test_apply_space_motion():
                  pm_ra_cosdec=0.1*u.deg/u.yr,
                  pm_dec=0*u.mas/u.yr,
                  radial_velocity=0*u.km/u.s)
+
+    # Cases that should work (just testing input for now):
     c1 = SkyCoord(frame, obstime=t1)
-    c2 = c1.apply_space_motion(new_obstime=t2)
-    c3 = c1.apply_space_motion(dt=10*u.year)
+    c1.apply_space_motion(new_obstime=t2)
+    c1.apply_space_motion(dt=10*u.year)
+
+    c2 = SkyCoord(frame)
+    c2.apply_space_motion(dt=10*u.year)
+
+    with pytest.raises(ValueError):
+        c1.apply_space_motion(new_obstime=t2)
 
     # TODO: we need to actually check something here...remember trigonometry,
     # though - the source moves on a straight line, so the above won't move by

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1382,3 +1382,29 @@ def test_extra_attributes():
     # Finally, check that we can delete such attributes.
     del sc3.obstime
     assert sc3.obstime is None
+
+
+def test_evolve_to():
+    t1 = Time('2015-01-01T00:00')
+    t2 = Time('2025-01-01T00:00')
+
+    # Check a very simple case first:
+    # frame = ICRS(ra=10.*u.deg, dec=0*u.deg,
+    #              distance=10.*u.pc,
+    #              pm_ra_cosdec=0.1*u.deg/u.yr,
+    #              pm_dec=0*u.mas/u.yr,
+    #              radial_velocity=0*u.km/u.s)
+    # c1 = SkyCoord(frame, obstime=t1)
+    # c2 = c1.evolve_to(t2)
+
+    # print(c2.separation(c1))
+    # assert quantity_allclose(c2.separation(c1), 1*u.arcsec)
+
+    frame = ICRS(ra=10.*u.deg, dec=0*u.deg,
+                 pm_ra_cosdec=0.1*u.deg/u.yr,
+                 pm_dec=0*u.mas/u.yr,
+                 radial_velocity=100*u.km/u.s)
+    c1 = SkyCoord(frame, obstime=t1)
+    c2 = c1.evolve_to(t2)
+
+    print(c2.separation(c1))

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1395,7 +1395,8 @@ def test_apply_space_motion():
                  distance=10.*u.pc,
                  pm_ra_cosdec=0.1*u.deg/u.yr,
                  pm_dec=0*u.mas/u.yr,
-                 radial_velocity=0*u.km/u.s)
+                 radial_velocity=0*u.km/u.s,
+                 pressure=101*u.kPa)
 
     # Cases that should work (just testing input for now):
     c1 = SkyCoord(frame, obstime=t1)
@@ -1408,6 +1409,9 @@ def test_apply_space_motion():
     assert_allclose(applied1.pm_ra, applied2.pm_ra)
     assert_allclose(applied1.dec, applied2.dec)
     assert_allclose(applied1.distance, applied2.distance)
+
+    # ensure any frame attributes that were there before get passed through
+    assert applied1.pressure == c1.pressure
 
     # there were 2 leap seconds between 2000 and 2010, so the difference in
     # the two forms of time evolution should be ~2 sec

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1395,11 +1395,10 @@ def test_apply_space_motion():
                  distance=10.*u.pc,
                  pm_ra_cosdec=0.1*u.deg/u.yr,
                  pm_dec=0*u.mas/u.yr,
-                 radial_velocity=0*u.km/u.s,
-                 pressure=101*u.kPa)
+                 radial_velocity=0*u.km/u.s)
 
     # Cases that should work (just testing input for now):
-    c1 = SkyCoord(frame, obstime=t1)
+    c1 = SkyCoord(frame, obstime=t1, pressure=101*u.kPa)
     applied1 = c1.apply_space_motion(new_obstime=t2)
     applied2 = c1.apply_space_motion(dt=12*u.year)
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1384,27 +1384,20 @@ def test_extra_attributes():
     assert sc3.obstime is None
 
 
-def test_evolve_to():
+def test_move_to():
     t1 = Time('2015-01-01T00:00')
     t2 = Time('2025-01-01T00:00')
 
     # Check a very simple case first:
-    # frame = ICRS(ra=10.*u.deg, dec=0*u.deg,
-    #              distance=10.*u.pc,
-    #              pm_ra_cosdec=0.1*u.deg/u.yr,
-    #              pm_dec=0*u.mas/u.yr,
-    #              radial_velocity=0*u.km/u.s)
-    # c1 = SkyCoord(frame, obstime=t1)
-    # c2 = c1.evolve_to(t2)
-
-    # print(c2.separation(c1))
-    # assert quantity_allclose(c2.separation(c1), 1*u.arcsec)
-
     frame = ICRS(ra=10.*u.deg, dec=0*u.deg,
+                 distance=10.*u.pc,
                  pm_ra_cosdec=0.1*u.deg/u.yr,
                  pm_dec=0*u.mas/u.yr,
-                 radial_velocity=100*u.km/u.s)
+                 radial_velocity=0*u.km/u.s)
     c1 = SkyCoord(frame, obstime=t1)
-    c2 = c1.evolve_to(t2)
+    c2 = c1.move_to(new_obstime=t2)
+    c3 = c1.move_to(dt=10*u.year)
 
-    print(c2.separation(c1))
+    # TODO: we need to actually check something here...remember trigonometry,
+    # though - the source moves on a straight line, so the above won't move by
+    # 1 deg

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1384,7 +1384,7 @@ def test_extra_attributes():
     assert sc3.obstime is None
 
 
-def test_move_to():
+def test_apply_space_motion():
     t1 = Time('2015-01-01T00:00')
     t2 = Time('2025-01-01T00:00')
 
@@ -1395,8 +1395,8 @@ def test_move_to():
                  pm_dec=0*u.mas/u.yr,
                  radial_velocity=0*u.km/u.s)
     c1 = SkyCoord(frame, obstime=t1)
-    c2 = c1.move_to(new_obstime=t2)
-    c3 = c1.move_to(dt=10*u.year)
+    c2 = c1.apply_space_motion(new_obstime=t2)
+    c3 = c1.apply_space_motion(dt=10*u.year)
 
     # TODO: we need to actually check something here...remember trigonometry,
     # though - the source moves on a straight line, so the above won't move by

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1404,7 +1404,7 @@ def test_apply_space_motion():
     c2.apply_space_motion(dt=10*u.year)
 
     with pytest.raises(ValueError):
-        c1.apply_space_motion(new_obstime=t2)
+        c2.apply_space_motion(new_obstime=t2)
 
     # TODO: we need to actually check something here...remember trigonometry,
     # though - the source moves on a straight line, so the above won't move by

--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -38,3 +38,6 @@ Or, we can specify the new time to evaluate the position at::
 If the |SkyCoord| object has no specified radial velocity (RV), the RV is
 assumed to be 0. The new position of the source is determined assuming the
 source moves in a straight line with constant velocity in an inertial frame.
+There are no plans to support more complex evolution (e.g. non-inertial
+frames or more complex evolution), as that is out of scope for the Astropy core
+(although it may well be in-scope for a variety of affiliated packages).

--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -24,16 +24,22 @@ and the desired time::
 
     >>> c.apply_space_motion(dt=10. * u.year) # doctest: +FLOAT_CMP
     <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
-        ( 10.00013356,  44.999675,  99.99999994)>
+        ( 10.00013356,  44.999675,  99.99999994)
+     (pm_l_cosb, pm_b, radial_velocity) in (mas / yr, mas / yr, km / s)
+        ( 33.99980714, -117.00005604,  0.00034117)>
     >>> c.apply_space_motion(dt=-10. * u.year) # doctest: +FLOAT_CMP
     <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
-        ( 9.99986643,  45.000325,  100.00000006)>
+        ( 9.99986643,  45.000325,  100.00000006)
+     (pm_l_cosb, pm_b, radial_velocity) in (mas / yr, mas / yr, km / s)
+        ( 34.00019286, -116.99994395, -0.00034117)>
 
 Or, we can specify the new time to evaluate the position at::
 
     >>> c.apply_space_motion(new_obstime=Time('2017-12-18 01:12:07.3')) # doctest: +FLOAT_CMP
     <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
-        ( 10.00038732,  44.99905754,  99.99999985)>
+        ( 10.00038732,  44.99905754,  99.99999985)
+     (pm_l_cosb, pm_b, radial_velocity) in (mas / yr, mas / yr, km / s)
+        ( 33.99944073, -117.00016248,  0.00098937)>
 
 If the |SkyCoord| object has no specified radial velocity (RV), the RV is
 assumed to be 0. The new position of the source is determined assuming the

--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -1,0 +1,40 @@
+.. include:: references.txt
+
+.. _astropy-coordinates-apply-space-motion:
+
+Accounting for space motion
+***************************
+
+The |SkyCoord| object supports updating the position of a source given its space
+motion and a time or time difference to evaluate the new position at. This is
+done using the :meth:`~astropy.coordinates.apply_space_motion` method. As an
+example, first we'll create a |SkyCoord| object with a specified ``obstime``::
+
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>> from astropy.coordinates import SkyCoord
+    >>> c = SkyCoord(l=10*u.degree, b=45*u.degree, distance=100*u.pc,
+    ...              pm_l_cosb=34*u.mas/u.yr, pm_b=-117*u.mas/u.yr,
+    ...              frame='galactic',
+    ...              obstime=Time('1988-12-18 05:11:23.5'))
+
+We can now find the position at some other time, taking the space motion into
+account. We can either specify the time difference between the observation time
+and the desired time::
+
+    >>> c.apply_space_motion(dt=10. * u.year) # doctest: +FLOAT_CMP
+    <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
+        ( 10.00013356,  44.999675,  99.99999994)>
+    >>> c.apply_space_motion(dt=-10. * u.year) # doctest: +FLOAT_CMP
+    <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
+        ( 9.99986643,  45.000325,  100.00000006)>
+
+Or, we can specify the new time to evaluate the position at::
+
+    >>> c.apply_space_motion(new_obstime=Time('2017-12-18 01:12:07.3')) # doctest: +FLOAT_CMP
+    <SkyCoord (Galactic): (l, b, distance) in (deg, deg, pc)
+        ( 10.00038732,  44.99905754,  99.99999985)>
+
+If the |SkyCoord| object has no specified radial velocity (RV), the RV is
+assumed to be 0. The new position of the source is determined assuming the
+source moves in a straight line with constant velocity in an inertial frame.

--- a/docs/coordinates/apply_space_motion.rst
+++ b/docs/coordinates/apply_space_motion.rst
@@ -7,8 +7,9 @@ Accounting for space motion
 
 The |SkyCoord| object supports updating the position of a source given its space
 motion and a time or time difference to evaluate the new position at. This is
-done using the :meth:`~astropy.coordinates.apply_space_motion` method. As an
-example, first we'll create a |SkyCoord| object with a specified ``obstime``::
+done using the :meth:`~astropy.coordinates.SkyCoord.apply_space_motion` method.
+As an example, first we'll create a |SkyCoord| object with a specified
+``obstime``::
 
     >>> import astropy.units as u
     >>> from astropy.time import Time

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -369,6 +369,7 @@ listed below.
    representations
    frames
    velocities
+   apply_space_motion
    galactocentric
    remote_methods
    definitions

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -942,6 +942,8 @@ the available docstrings below:
 - `~astropy.coordinates.SkyCoord.position_angle`,
 - `~astropy.coordinates.SkyCoord.separation`,
 - `~astropy.coordinates.SkyCoord.separation_3d`
+- `~astropy.coordinates.SkyCoord.apply_space_motion`
 
 Addition information and examples can be found in the section on
-:ref:`astropy-coordinates-separations-matching`.
+:ref:`astropy-coordinates-separations-matching` and
+:ref:`astropy-coordinates-apply-space-motion`.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -389,8 +389,8 @@ new |SkyCoord| object in the requested frame::
 Other attributes you should recognize are ``distance``, ``equinox``,
 ``obstime``, ``shape``.
 
-Digger deeper
--------------
+Digging deeper
+--------------
 *[Casual users can skip this section]*
 
 After transforming to Galactic the longitude and latitude values are now


### PR DESCRIPTION
This implements what is sometimes called an "epoch transformation": you observe a source on some date, but if it has a large proper motion, it will have moved when going back to observe it later. This currently assumes that the motion is linear, and that if a velocity component is not specified, that it is 0 (this is a hard assumption, so we need to be up front about this in the documentation!).

Note that this requires `SkyCoord` to support velocity data, so this includes a commit by @eteq who is working on making that possible. This probably has to wait until his PR is merged to write good tests, but creating this just to get discussion started and so I remember the branch exists :) 

This needs:
* [x] Real tests
* [x] Documentation
* [x] Need to preserve the frame attributes in the new method...
* [x] An audit of the method name (we originally thought of `evolve_to`, but think that's not quite right). @mhvk settled on `move_to`, but I'm not quite sold on that either...
* [x] Changelog entry

cc @eteq @mhvk