### PR TITLE
Switch "representation" to "representation_type" in coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,11 @@ astropy.coordinates
 - ``SkyCoord`` objects now support updating the position of a source given its
   space motion and a new time or time difference. [#6872]
 
+- The frame classes now accept a representation class or differential class, or
+  string names for either, through the keyword arguments ``representation_type``
+  and ``differential_type`` instead of ``representation`` and
+  ``differential_cls``. [#6873]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -258,10 +263,9 @@ astropy.coordinates
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
 
-- The frame classes now accept a representation class or differential class, or
-  string names for either, through the keyword arguments ``representation_type``
-  and ``differential_type`` instead of ``representation`` and
-  ``differential_cls``. In the next version, using ``representation`` will raise
+- As noted above, the frame class attributes ``representation`` and 
+  ``differential_cls`` are being replaced by ``representation_type`` and 
+  ``differential_type``. In the next version, using ``representation`` will raise
   a deprecation warning. [#6873]
 
 - Coordinate frame classes now can't be added to the frame transform graph if

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,7 @@ astropy.coordinates
 - Deprecated ``recommended_units`` for representations. These were used to
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
+
 - The frame classes now accept a representation class or differential class, or
   string names for either, through the keyword arguments ``representation_type``
   and ``differential_type`` instead of ``representation`` and

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,11 @@ astropy.coordinates
 - Deprecated ``recommended_units`` for representations. These were used to
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
+- The frame classes now accept a representation class or differential class, or
+  string names for either, through the keyword arguments ``representation_type``
+  and ``differential_type`` instead of ``representation`` and
+  ``differential_cls``. In the next version, using ``representation`` will raise
+  a deprecation warning. [#6873]
 
 - Coordinate frame classes now can't be added to the frame transform graph if
   they have frame attribute names that conflict with any component names. This

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -399,7 +399,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # This is here for backwards compatibility. It should be possible
         # to use either the kwarg representation_type, or representation.
         # TODO: In future versions, we will raise a deprecation warning here:
+        # if 'representation' in kwargs:
+        #     representation_type = kwargs.pop('representation')
+        if representation_type is not None:
+            kwargs['representation_type'] = representation_type
         _normalize_representation_type(kwargs)
+        representation_type = kwargs.pop('representation_type', representation_type)
+
         if representation_type is not None or differential_type is not None:
 
             if representation_type is None:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -336,12 +336,15 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     Parameters
     ----------
-    representation_type : `BaseRepresentation` or None
-        A representation class or ``None`` to have no data (or use the other
-        arguments)
+    data : `BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the
+        coordinate component arguments, see below).
     *args, **kwargs
         Coordinate components, with names that depend on the subclass.
-    differential_type : `BaseDifferential`, dict, optional
+    representation_type : `BaseRepresentation` subclass, str, optional
+        A representation class or ``None`` to have no data (or use the other
+        arguments)
+    differential_type : `BaseDifferential` subclass, str, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
@@ -369,9 +372,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                  differential_type=None, **kwargs):
         self._attr_names_with_defaults = []
 
-        # TODO: we should be able to deal with an instance, not just a
-        # class or string for representation and differential_type.
-
         # TODO: this is here for backwards compatibility. It should be possible
         # to use either the kwarg representation_type, or representation.
         # In future versions, we will raise a deprecation warning here:
@@ -387,6 +387,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 # TODO: assumes the differential class is for the velocity
                 # differential
                 differential_type = {'s': differential_type}
+
+            elif isinstance(differential_type, str):
+                # TODO: assumes the differential class is for the velocity
+                # differential
+                diff_cls = r.DIFFERENTIAL_CLASSES[differential_type]
+                differential_type = {'s': diff_cls}
 
             elif differential_type is None:
                 if representation == self.default_representation:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -482,7 +482,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             # Now we handle the Differential data:
             # Get any differential data passed in to the frame initializer
             # using keyword or positional arguments for the component names
-            differential_type = self.get_representation_cls('s')
+            differential_cls = self.get_representation_cls('s')
             diff_component_names = self.get_representation_component_names('s')
             diff_kwargs = {}
             for nmkw, nmrep in diff_component_names.items():
@@ -493,14 +493,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     diff_kwargs[nmrep] = kwargs.pop(nmkw)
 
             if diff_kwargs:
-                if (hasattr(differential_type, '_unit_differential') and
+                if (hasattr(differential_cls, '_unit_differential') and
                         'd_distance' not in diff_kwargs):
-                    differential_type = differential_type._unit_differential
+                    differential_cls = differential_cls._unit_differential
 
                 elif len(diff_kwargs) == 1 and 'd_distance' in diff_kwargs:
-                    differential_type = r.RadialDifferential
+                    differential_cls = r.RadialDifferential
 
-                differential_data = differential_type(copy=copy, **diff_kwargs)
+                differential_data = differential_cls(copy=copy, **diff_kwargs)
 
         if len(args) > 0:
             raise TypeError(
@@ -971,27 +971,27 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         representation_cls = repr_classes['base']
         # We only keep velocity information
         if 's' in self.data.differentials:
-            differential_type = repr_classes['s']
+            differential_cls = repr_classes['s']
         elif s is None or s == 'base':
-            differential_type = None
+            differential_cls = None
         else:
             raise TypeError('Frame data has no associated differentials '
                             '(i.e. the frame has no velocity data) - '
                             'represent_as() only accepts a new '
                             'representation.')
 
-        if differential_type:
+        if differential_cls:
             cache_key = (representation_cls.__name__,
-                         differential_type.__name__, in_frame_units)
+                         differential_cls.__name__, in_frame_units)
         else:
             cache_key = (representation_cls.__name__, in_frame_units)
 
         cached_repr = self.cache['representation'].get(cache_key)
         if not cached_repr:
-            if differential_type:
+            if differential_cls:
                 # TODO NOTE: only supports a single differential
                 data = self.data.represent_as(representation_cls,
-                                              differential_type)
+                                              differential_cls)
                 diff = data.differentials['s']  # TODO: assumes velocity
             else:
                 data = self.data.represent_as(representation_cls)
@@ -1007,13 +1007,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                         datakwargs[comp] = datakwargs[comp].to(new_attr_unit)
                 data = data.__class__(copy=False, **datakwargs)
 
-            if differential_type:
+            if differential_cls:
                 # the original differential
                 data_diff = self.data.differentials['s']
 
                 # If the new differential is known to this frame and has a
                 # defined set of names and units, then use that.
-                new_attrs = self.representation_info.get(differential_type)
+                new_attrs = self.representation_info.get(differential_cls)
                 if new_attrs and in_frame_units:
                     diffkwargs = dict((comp, getattr(diff, comp))
                                       for comp in diff.components)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -18,7 +18,7 @@ import numpy as np
 
 # Project
 from ..utils.compat.misc import override__dir__
-from ..utils.decorators import lazyproperty
+from ..utils.decorators import lazyproperty, format_doc
 from ..utils.exceptions import AstropyWarning
 from .. import units as u
 from ..utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
@@ -294,6 +294,37 @@ class RepresentationMapping(_RepresentationMappingBase):
         return super().__new__(cls, reprname, framename, defaultunit)
 
 
+base_doc = """{__doc__}
+    Parameters
+    ----------
+    data : `BaseRepresentation` subclass instance
+        A representation object or ``None`` to have no data (or use the
+        coordinate component arguments, see below).
+    {components}
+    representation_type : `BaseRepresentation` subclass, str, optional
+        A representation class or string name of a representation class. This
+        sets the expected input representation class, thereby changing the
+        expected keyword arguments for the data passed in. For example, passing
+        ``representation_type='cartesian'`` will make the classes expect
+        position data with cartesian names, i.e. ``x, y, z`` in most cases.
+    differential_type : `BaseDifferential` subclass, str, dict, optional
+        A differential class or dictionary of differential classes (currently
+        only a velocity differential with key 's' is supported). This sets the
+        expected input differential class, thereby changing the expected keyword
+        arguments of the data passed in. For example, passing
+        ``differential_type='cartesian'`` will make the classes expect velocity
+        data with the argument names ``v_x, v_y, v_z``.
+    copy : bool, optional
+        If `True` (default), make copies of the input coordinate arrays.
+        Can only be passed in as a keyword argument.
+    {footer}
+"""
+
+_components = """
+    *args, **kwargs
+        Coordinate components, with names that depend on the subclass.
+"""
+@format_doc(base_doc, components=_components, footer="")
 class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     """
     The base class for coordinate frames.
@@ -333,27 +364,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
       * ``v_{x,y,z}`` for `CartesianDifferential` velocity components
 
     where ``{lon}`` and ``{lat}`` are the frame names of the angular components.
-
-    Parameters
-    ----------
-    data : `BaseRepresentation` subclass instance
-        A representation object or ``None`` to have no data (or use the
-        coordinate component arguments, see below).
-    *args, **kwargs
-        Coordinate components, with names that depend on the subclass.
-    representation_type : `BaseRepresentation` subclass, str, optional
-        A representation class or ``None`` to have no data (or use the other
-        arguments)
-    differential_type : `BaseDifferential` subclass, str, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
     """
 
     default_representation = None

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -399,8 +399,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # This is here for backwards compatibility. It should be possible
         # to use either the kwarg representation_type, or representation.
         # TODO: In future versions, we will raise a deprecation warning here:
-        # if 'representation' in kwargs:
-        #     representation_type = kwargs.pop('representation')
         if representation_type is not None:
             kwargs['representation_type'] = representation_type
         _normalize_representation_type(kwargs)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -375,7 +375,14 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # TODO: this is here for backwards compatibility. It should be possible
         # to use either the kwarg representation_type, or representation.
         # In future versions, we will raise a deprecation warning here:
-        representation_type = kwargs.pop('representation', representation_type)
+        if 'representation' in kwargs:
+            if representation_type is not None:
+                raise ValueError("Both `representation` and "
+                                 "`representation_type` were passed to a frame "
+                                 "initializer. Please use only "
+                                 "`representation_type` (`representation` is "
+                                 "now pending deprecation).")
+            representation_type = kwargs.pop('representation')
 
         if representation_type is not None or differential_type is not None:
 

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -4,31 +4,18 @@
 import numpy as np
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 from ..attributes import (Attribute, TimeAttribute,
                           QuantityAttribute, EarthLocationAttribute)
 
+__all__ = ['AltAz']
+
+
 _90DEG = 90*u.deg
 
-
-class AltAz(BaseCoordinateFrame):
-    """
-    A coordinate or frame in the Altitude-Azimuth system (Horizontal
-    coordinates).  Azimuth is oriented East of North (i.e., N=0, E=90 degrees).
-
-    This frame is assumed to *include* refraction effects if the ``pressure``
-    frame attribute is non-zero.
-
-    The frame attributes are listed under **Other Parameters**, which are
-    necessary for transforming from AltAz to some other system.
-
-    Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other
-        keywords)
-
+doc_components = """
     az : `Angle`, optional, must be keyword
         The Azimuth for this object (``alt`` must also be given and
         ``representation`` must be None).
@@ -45,20 +32,9 @@ class AltAz(BaseCoordinateFrame):
         The proper motion in altitude for this object (``pm_az_cosalt`` must
         also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
-        The radial velocity of this object.
+        The radial velocity of this object."""
 
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
-
+doc_footer = """
     Other parameters
     ----------------
     obstime : `~astropy.time.Time`
@@ -93,7 +69,19 @@ class AltAz(BaseCoordinateFrame):
     results.  For much better numerical stability, leaving the ``pressure`` at
     ``0`` (the default), disabling the refraction correction (yielding
     "topocentric" horizontal coordinates).
+    """
 
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
+class AltAz(BaseCoordinateFrame):
+    """
+    A coordinate or frame in the Altitude-Azimuth system (Horizontal
+    coordinates).  Azimuth is oriented East of North (i.e., N=0, E=90 degrees).
+
+    This frame is assumed to *include* refraction effects if the ``pressure``
+    frame attribute is non-zero.
+
+    The frame attributes are listed under **Other Parameters**, which are
+    necessary for transforming from AltAz to some other system.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -51,12 +51,12 @@ class AltAz(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 
     Other parameters

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ...utils.decorators import format_doc
 from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 
 __all__ = ['BaseRADecFrame']
 
-_base_radec_docstring = """Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or ``None`` to have no data (or use the other
-        keywords below).
 
+doc_components = """
     ra : `Angle`, optional, must be keyword
         The RA for this object (``dec`` must also be given and ``representation``
         must be None).
@@ -30,28 +27,14 @@ _base_radec_docstring = """Parameters
         also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
         The radial velocity of this object.
-
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 
-
+@format_doc(base_doc, components=doc_components, footer="")
 class BaseRADecFrame(BaseCoordinateFrame):
     """
     A base class that defines default representation info for frames that
     represent longitude and latitude as Right Ascension and Declination
     following typical "equatorial" conventions.
-
-    {params}
     """
     frame_specific_representation_info = {
         r.SphericalRepresentation: [
@@ -62,7 +45,3 @@ class BaseRADecFrame(BaseCoordinateFrame):
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
-
-
-BaseRADecFrame.__doc__ = BaseRADecFrame.__doc__.format(
-    params=_base_radec_docstring)

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -35,12 +35,12 @@ _base_radec_docstring = """Parameters
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -1,31 +1,33 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ...utils.decorators import format_doc
 from ..attributes import TimeAttribute
-
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from ..baseframe import base_doc
+from .baseradec import doc_components, BaseRADecFrame
 from .utils import DEFAULT_OBSTIME
 
+__all__ = ['CIRS']
 
-class CIRS(BaseRADecFrame):
-    """
-    A coordinate or frame in the Celestial Intermediate Reference System (CIRS).
 
-    The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
+doc_footer = """
     Other parameters
     ----------------
     obstime : `~astropy.time.Time`
         The time at which the observation is taken.  Used for determining the
         position of the Earth and its precession.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
+class CIRS(BaseRADecFrame):
+    """
+    A coordinate or frame in the Celestial Intermediate Reference System (CIRS).
+
+    The frame attributes are listed under **Other Parameters**.
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
 
-
-CIRS.__doc__ = CIRS.__doc__.format(params=_base_radec_docstring)
 
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like GCRS)

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -130,4 +130,3 @@ class HeliocentricTrueEcliptic(BaseEclipticFrame):
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -2,25 +2,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 from ..attributes import TimeAttribute
 from .utils import EQUINOX_J2000, DEFAULT_OBSTIME
 
 __all__ = ['GeocentricTrueEcliptic', 'BarycentricTrueEcliptic',
            'HeliocentricTrueEcliptic', 'BaseEclipticFrame']
 
-_base_ecliptic_docstring = """.. warning::
-        In the current version of astropy, the ecliptic frames do not yet have
-        stringent accuracy tests.  We recommend you test to "known-good" cases
-        to ensure this frames are what you are looking for. (and then ideally
-        you would contribute these tests to Astropy!)
 
-    Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other keywords)
-
+doc_components_ecl = """
     lon : `Angle`, optional, must be keyword
         The ecliptic longitude for this object (``lat`` must also be given and
         ``representation`` must be None).
@@ -40,37 +32,38 @@ _base_ecliptic_docstring = """.. warning::
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The distance for this object from the {0}.
         (``representation`` must be None).
-
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 
-
+@format_doc(base_doc,
+            components=doc_components_ecl.format('specified location'),
+            footer="")
 class BaseEclipticFrame(BaseCoordinateFrame):
     """
     A base class for frames that have names and conventions like that of
     ecliptic frames.
 
-    {params}
+    .. warning::
+            In the current version of astropy, the ecliptic frames do not yet have
+            stringent accuracy tests.  We recommend you test to "known-good" cases
+            to ensure this frames are what you are looking for. (and then ideally
+            you would contribute these tests to Astropy!)
     """
 
     default_representation = r.SphericalRepresentation
     default_differential = r.SphericalCosLatDifferential
 
 
-BaseEclipticFrame.__doc__ = BaseEclipticFrame.__doc__.format(
-    params=_base_ecliptic_docstring)
+doc_footer_geo = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth (necessary for transformation to
+        non-geocentric systems).
+"""
 
-
+@format_doc(base_doc, components=doc_components_ecl.format('geocenter'),
+            footer=doc_footer_geo)
 class GeocentricTrueEcliptic(BaseEclipticFrame):
     """
     Geocentric ecliptic coordinates.  These origin of the coordinates are the
@@ -83,24 +76,20 @@ class GeocentricTrueEcliptic(BaseEclipticFrame):
     to/from e.g. ICRS.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The date to assume for this frame.  Determines the location of the
-        x-axis and the location of the Earth (necessary for transformation to
-        non-geocentric systems).
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
 
 
-GeocentricTrueEcliptic.__doc__ = GeocentricTrueEcliptic.__doc__.format(
-    params=_base_ecliptic_docstring.format("geocenter"))
-
-
+doc_footer_bary = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth and Sun.
+"""
+@format_doc(base_doc, components=doc_components_ecl.format("barycenter"),
+            footer=doc_footer_bary)
 class BarycentricTrueEcliptic(BaseEclipticFrame):
     """
     Barycentric ecliptic coordinates.  These origin of the coordinates are the
@@ -110,23 +99,20 @@ class BarycentricTrueEcliptic(BaseEclipticFrame):
     ecliptic for that date.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The date to assume for this frame.  Determines the location of the
-        x-axis and the location of the Earth and Sun.
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
 
 
-BarycentricTrueEcliptic.__doc__ = BarycentricTrueEcliptic.__doc__.format(
-    params=_base_ecliptic_docstring.format("sun's center"))
-
-
+doc_footer_helio = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The date to assume for this frame.  Determines the location of the
+        x-axis and the location of the Earth and Sun.
+"""
+@format_doc(base_doc, components=doc_components_ecl.format("sun's center"),
+            footer=doc_footer_helio)
 class HeliocentricTrueEcliptic(BaseEclipticFrame):
     """
     Heliocentric ecliptic coordinates.  These origin of the coordinates are the
@@ -139,16 +125,9 @@ class HeliocentricTrueEcliptic(BaseEclipticFrame):
 
     {params}
 
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The date to assume for this frame.  Determines the location of the
-        x-axis and the location of the Earth and Sun.
+
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
 
-
-HeliocentricTrueEcliptic.__doc__ = HeliocentricTrueEcliptic.__doc__.format(
-    params=_base_ecliptic_docstring.format("sun's center"))

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -45,12 +45,12 @@ _base_ecliptic_docstring = """.. warning::
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 """
 

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -4,7 +4,8 @@
 import numpy as np
 
 from ... import units as u
-from ..baseframe import frame_transform_graph
+from ...utils.decorators import format_doc
+from ..baseframe import frame_transform_graph, base_doc
 from ..attributes import TimeAttribute
 from ..transformations import (FunctionTransformWithFiniteDifference,
                                FunctionTransform, DynamicMatrixTransform)
@@ -13,9 +14,21 @@ from ..representation import (CartesianRepresentation,
 from .. import earth_orientation as earth
 
 from .utils import EQUINOX_B1950
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from .baseradec import doc_components, BaseRADecFrame
+
+__all__ = ['FK4', 'FK4NoETerms']
 
 
+doc_footer_fk4 = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The equinox of this frame.
+    obstime : `~astropy.time.Time`
+        The time this frame was observed.  If ``None``, will be the same as
+        ``equinox``.
+"""
+@format_doc(base_doc, components=doc_components, footer=doc_footer_fk4)
 class FK4(BaseRADecFrame):
     """
     A coordinate or frame in the FK4 system.
@@ -24,23 +37,11 @@ class FK4(BaseRADecFrame):
     this frame is the Solar System Barycenter, *not* the Earth geocenter.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The equinox of this frame.
-    obstime : `~astropy.time.Time`
-        The time this frame was observed.  If ``None``, will be the same as
-        ``equinox``.
     """
 
     equinox = TimeAttribute(default=EQUINOX_B1950)
     obstime = TimeAttribute(default=None, secondary_attribute='equinox')
 
-
-FK4.__doc__ = FK4.__doc__.format(params=_base_radec_docstring)
 
 # the "self" transform
 
@@ -54,22 +55,13 @@ def fk4_to_fk4(fk4coord1, fk4frame2):
     return fnoe_w_eqx2.transform_to(fk4frame2)
 
 
+@format_doc(base_doc, components=doc_components, footer=doc_footer_fk4)
 class FK4NoETerms(BaseRADecFrame):
     """
     A coordinate or frame in the FK4 system, but with the E-terms of aberration
     removed.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The equinox of this frame.
-    obstime : `~astropy.time.Time`
-        The time this frame was observed.  If ``None``, will be the same as
-        ``equinox``.
     """
 
     equinox = TimeAttribute(default=EQUINOX_B1950)
@@ -95,8 +87,6 @@ class FK4NoETerms(BaseRADecFrame):
         """
         return earth._precession_matrix_besselian(oldequinox.byear, newequinox.byear)
 
-
-FK4NoETerms.__doc__ = FK4NoETerms.__doc__.format(params=_base_radec_docstring)
 
 # the "self" transform
 

--- a/astropy/coordinates/builtin_frames/fk5.py
+++ b/astropy/coordinates/builtin_frames/fk5.py
@@ -1,15 +1,26 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..baseframe import frame_transform_graph
+from ...utils.decorators import format_doc
+from ..baseframe import frame_transform_graph, base_doc
 from ..attributes import TimeAttribute
 from ..transformations import DynamicMatrixTransform
 from .. import earth_orientation as earth
 
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from .baseradec import BaseRADecFrame, doc_components
 from .utils import EQUINOX_J2000
 
+__all__ = ['FK5']
 
+
+doc_footer = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The equinox of this frame.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
 class FK5(BaseRADecFrame):
     """
     A coordinate or frame in the FK5 system.
@@ -18,13 +29,6 @@ class FK5(BaseRADecFrame):
     this frame is the Solar System Barycenter, *not* the Earth geocenter.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The equinox of this frame.
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
@@ -49,8 +53,6 @@ class FK5(BaseRADecFrame):
         """
         return earth.precession_matrix_Capitaine(oldequinox, newequinox)
 
-
-FK5.__doc__ = FK5.__doc__.format(params=_base_radec_docstring)
 
 # This is the "self-transform".  Defined at module level because the decorator
 #  needs a reference to the FK5 class

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -50,12 +50,12 @@ class Galactic(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 
     Notes

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -2,32 +2,19 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from ..angles import Angle
 from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 
 # these are needed for defining the NGP
 from .fk5 import FK5
 from .fk4 import FK4NoETerms
 
+__all__ = ['Galactic']
 
-class Galactic(BaseCoordinateFrame):
-    """
-    A coordinate or frame in the Galactic coordinate system.
 
-    This frame is used in a variety of Galactic contexts because it has as its
-    x-y plane the plane of the Milky Way.  The positive x direction (i.e., the
-    l=0, b=0 direction) points to the center of the Milky Way and the z-axis
-    points toward the North Galactic Pole (following the IAU's 1958 definition
-    [1]_). However, unlike the `~astropy.coordinates.Galactocentric` frame, the
-    *origin* of this frame in 3D space is the solar system barycenter, not
-    the center of the Milky Way.
-
-    Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other keywords)
-
+doc_components = """
     l : `Angle`, optional, must be keyword
         The Galactic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
@@ -45,24 +32,28 @@ class Galactic(BaseCoordinateFrame):
         must also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
         The radial velocity of this object.
+"""
 
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
-
+doc_footer = """
     Notes
     -----
     .. [1] Blaauw, A.; Gum, C. S.; Pawsey, J. L.; Westerhout, G. (1960), "The
        new I.A.U. system of galactic coordinates (1958 revision),"
        `MNRAS, Vol 121, pp.123 <http://adsabs.harvard.edu/abs/1960MNRAS.121..123B>`_.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
+class Galactic(BaseCoordinateFrame):
+    """
+    A coordinate or frame in the Galactic coordinate system.
+
+    This frame is used in a variety of Galactic contexts because it has as its
+    x-y plane the plane of the Milky Way.  The positive x direction (i.e., the
+    l=0, b=0 direction) points to the center of the Milky Way and the z-axis
+    points toward the North Galactic Pole (following the IAU's 1958 definition
+    [1]_). However, unlike the `~astropy.coordinates.Galactocentric` frame, the
+    *origin* of this frame in 3D space is the solar system barycenter, not
+    the center of the Milky Way.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -6,12 +6,13 @@ import warnings
 import numpy as np
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from ...utils.exceptions import AstropyDeprecationWarning
 from ..angles import Angle
 from ..matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 from .. import representation as r
 from ..baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                         RepresentationMapping)
+                         RepresentationMapping, base_doc)
 from ..attributes import (Attribute, CoordinateAttribute,
                           QuantityAttribute,
                           DifferentialAttribute)
@@ -20,61 +21,16 @@ from ..errors import ConvertError
 
 from .icrs import ICRS
 
+__all__ = ['Galactocentric']
+
+
 # Measured by minimizing the difference between a plane of coordinates along
 #   l=0, b=[-90,90] and the Galactocentric x-z plane
 # This is not used directly, but accessed via `get_roll0`.  We define it here to
 # prevent having to create new Angle objects every time `get_roll0` is called.
 _ROLL0 = Angle(58.5986320306*u.degree)
 
-
-class Galactocentric(BaseCoordinateFrame):
-    r"""
-    A coordinate or frame in the Galactocentric system. This frame
-    requires specifying the Sun-Galactic center distance, and optionally
-    the height of the Sun above the Galactic midplane.
-
-    The position of the Sun is assumed to be on the x axis of the final,
-    right-handed system. That is, the x axis points from the position of
-    the Sun projected to the Galactic midplane to the Galactic center --
-    roughly towards :math:`(l,b) = (0^\circ,0^\circ)`. For the default
-    transformation (:math:`{\rm roll}=0^\circ`), the y axis points roughly
-    towards Galactic longitude :math:`l=90^\circ`, and the z axis points
-    roughly towards the North Galactic Pole (:math:`b=90^\circ`).
-
-    The default position of the Galactic Center in ICRS coordinates is
-    taken from Reid et al. 2004,
-    http://adsabs.harvard.edu/abs/2004ApJ...616..872R.
-
-    .. math::
-
-        {\rm RA} = 17:45:37.224~{\rm hr}\\
-        {\rm Dec} = -28:56:10.23~{\rm deg}
-
-    The default distance to the Galactic Center is 8.3 kpc, e.g.,
-    Gillessen et al. (2009),
-    https://ui.adsabs.harvard.edu/#abs/2009ApJ...692.1075G/abstract
-
-    The default height of the Sun above the Galactic midplane is taken to
-    be 27 pc, as measured by Chen et al. (2001),
-    https://ui.adsabs.harvard.edu/#abs/2001ApJ...553..184C/abstract
-
-    The default solar motion relative to the Galactic center is taken from a
-    combination of Schönrich et al. (2010) [for the peculiar velocity] and
-    Bovy (2015) [for the circular velocity at the solar radius],
-    https://ui.adsabs.harvard.edu/#abs/2010MNRAS.403.1829S/abstract
-    https://ui.adsabs.harvard.edu/#abs/2015ApJS..216...29B/abstract
-
-    For a more detailed look at the math behind this transformation, see
-    the document :ref:`coordinates-galactocentric`.
-
-    The frame attributes are listed under **Other Parameters**.
-
-    Parameters
-    ----------
-    representation : `~astropy.coordinates.representation.BaseRepresentation` or None
-        A representation object or None to have no data (or use the other
-        keywords)
-
+doc_components = """
     x : `~astropy.units.Quantity`, optional
         Cartesian, Galactocentric :math:`x` position component.
     y : `~astropy.units.Quantity`, optional
@@ -88,19 +44,9 @@ class Galactocentric(BaseCoordinateFrame):
         Cartesian, Galactocentric :math:`v_y` velocity component.
     v_z : `~astropy.units.Quantity`, optional
         Cartesian, Galactocentric :math:`v_z` velocity component.
+"""
 
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
-
+doc_footer = """
     Other parameters
     ----------------
     galcen_coord : `ICRS`, optional, must be keyword
@@ -166,7 +112,50 @@ class Galactocentric(BaseCoordinateFrame):
         <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
             [(  86.2585249 ,  28.85773187,  2.75625475e-05),
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
+"""
 
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
+class Galactocentric(BaseCoordinateFrame):
+    r"""
+    A coordinate or frame in the Galactocentric system. This frame
+    requires specifying the Sun-Galactic center distance, and optionally
+    the height of the Sun above the Galactic midplane.
+
+    The position of the Sun is assumed to be on the x axis of the final,
+    right-handed system. That is, the x axis points from the position of
+    the Sun projected to the Galactic midplane to the Galactic center --
+    roughly towards :math:`(l,b) = (0^\circ,0^\circ)`. For the default
+    transformation (:math:`{\rm roll}=0^\circ`), the y axis points roughly
+    towards Galactic longitude :math:`l=90^\circ`, and the z axis points
+    roughly towards the North Galactic Pole (:math:`b=90^\circ`).
+
+    The default position of the Galactic Center in ICRS coordinates is
+    taken from Reid et al. 2004,
+    http://adsabs.harvard.edu/abs/2004ApJ...616..872R.
+
+    .. math::
+
+        {\rm RA} = 17:45:37.224~{\rm hr}\\
+        {\rm Dec} = -28:56:10.23~{\rm deg}
+
+    The default distance to the Galactic Center is 8.3 kpc, e.g.,
+    Gillessen et al. (2009),
+    https://ui.adsabs.harvard.edu/#abs/2009ApJ...692.1075G/abstract
+
+    The default height of the Sun above the Galactic midplane is taken to
+    be 27 pc, as measured by Chen et al. (2001),
+    https://ui.adsabs.harvard.edu/#abs/2001ApJ...553..184C/abstract
+
+    The default solar motion relative to the Galactic center is taken from a
+    combination of Schönrich et al. (2010) [for the peculiar velocity] and
+    Bovy (2015) [for the circular velocity at the solar radius],
+    https://ui.adsabs.harvard.edu/#abs/2010MNRAS.403.1829S/abstract
+    https://ui.adsabs.harvard.edu/#abs/2015ApJS..216...29B/abstract
+
+    For a more detailed look at the math behind this transformation, see
+    the document :ref:`coordinates-galactocentric`.
+
+    The frame attributes are listed under **Other Parameters**.
     """
 
     default_representation = r.CartesianRepresentation

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -93,12 +93,12 @@ class Galactocentric(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 
     Other parameters

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -2,31 +2,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from ..attributes import (TimeAttribute,
                           CartesianRepresentationAttribute)
 from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from ..baseframe import base_doc
+from .baseradec import BaseRADecFrame, doc_components
+
+__all__ = ['GCRS', 'PrecessedGeocentric']
 
 
-class GCRS(BaseRADecFrame):
-    """
-    A coordinate or frame in the Geocentric Celestial Reference System (GCRS).
-
-    GCRS is distinct form ICRS mainly in that it is relative to the Earth's
-    center-of-mass rather than the solar system Barycenter.  That means this
-    frame includes the effects of aberration (unlike ICRS). For more background
-    on the GCRS, see the references provided in the
-    :ref:`astropy-coordinates-seealso` section of the documentation. (Of
-    particular note is Section 1.2 of
-    `USNO Circular 179 <http://aa.usno.navy.mil/publications/docs/Circular_179.php>`_)
-
-    This frame also includes frames that are defined *relative* to the Earth,
-    but that are offset (in both position and velocity) from the Earth.
-
-    The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
+doc_footer_gcrs = """
     Other parameters
     ----------------
     obstime : `~astropy.time.Time`
@@ -44,6 +30,25 @@ class GCRS(BaseRADecFrame):
         `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
         i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
         units.  Defaults to [0, 0, 0], meaning "true" GCRS.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer_gcrs)
+class GCRS(BaseRADecFrame):
+    """
+    A coordinate or frame in the Geocentric Celestial Reference System (GCRS).
+
+    GCRS is distinct form ICRS mainly in that it is relative to the Earth's
+    center-of-mass rather than the solar system Barycenter.  That means this
+    frame includes the effects of aberration (unlike ICRS). For more background
+    on the GCRS, see the references provided in the
+    :ref:`astropy-coordinates-seealso` section of the documentation. (Of
+    particular note is Section 1.2 of
+    `USNO Circular 179 <http://aa.usno.navy.mil/publications/docs/Circular_179.php>`_)
+
+    This frame also includes frames that are defined *relative* to the Earth,
+    but that are offset (in both position and velocity) from the Earth.
+
+    The frame attributes are listed under **Other Parameters**.
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
@@ -53,12 +58,33 @@ class GCRS(BaseRADecFrame):
                                                  unit=u.m/u.s)
 
 
-GCRS.__doc__ = GCRS.__doc__.format(params=_base_radec_docstring)
-
 # The "self-transform" is defined in icrs_cirs_transformations.py, because in
 # the current implementation it goes through ICRS (like CIRS)
 
 
+doc_footer_prec_geo = """
+    Other parameters
+    ----------------
+    equinox : `~astropy.time.Time`
+        The (mean) equinox to precess the coordinates to.
+    obstime : `~astropy.time.Time`
+        The time at which the observation is taken.  Used for determining the
+        position of the Earth.
+    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
+        The position of the observer relative to the center-of-mass of the
+        Earth, oriented the same as BCRS/ICRS. Either [0, 0, 0],
+        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
+        i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
+        Defaults to [0, 0, 0], meaning "true" Geocentric.
+    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
+        The velocity of the observer relative to the center-of-mass of the
+        Earth, oriented the same as BCRS/ICRS. Either 0,
+        `~astropy.coordinates.CartesianRepresentation`, or proper input for one,
+        i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity
+        units. Defaults to [0, 0, 0], meaning "true" Geocentric.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer_prec_geo)
 class PrecessedGeocentric(BaseRADecFrame):
     """
     A coordinate frame defined in a similar manner as GCRS, but precessed to a
@@ -68,33 +94,9 @@ class PrecessedGeocentric(BaseRADecFrame):
     orientation.
 
     The frame attributes are listed under **Other Parameters**
-
-    {params}
-
-    Other parameters
-    ----------------
-    equinox : `~astropy.time.Time`
-        The (mean) equinox to precess the coordinates to.
-    obstime : `~astropy.time.Time`
-        The time at which the observation is taken.  Used for determining the
-        position of the Earth.
-    obsgeoloc : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The position of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS. Either [0, 0, 0], `~astropy.coordinates.CartesianRepresentation`,
-        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and length units.
-        Defaults to [0, 0, 0], meaning "true" Geocentric.
-    obsgeovel : `~astropy.coordinates.CartesianRepresentation`, `~astropy.units.Quantity`
-        The velocity of the observer relative to the center-of-mass of the Earth,
-        oriented the same as BCRS/ICRS. Either 0, `~astropy.coordinates.CartesianRepresentation`,
-        or proper input for one, i.e., a `~astropy.units.Quantity` with shape (3, ...) and velocity units.
-        Defaults to [0, 0, 0], meaning "true" Geocentric.
     """
 
     equinox = TimeAttribute(default=EQUINOX_J2000)
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
     obsgeoloc = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m)
     obsgeovel = CartesianRepresentationAttribute(default=[0, 0, 0], unit=u.m/u.s)
-
-
-PrecessedGeocentric.__doc__ = PrecessedGeocentric.__doc__.format(
-    params=_base_radec_docstring)

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -1,11 +1,24 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ...utils.decorators import format_doc
 from ..attributes import TimeAttribute
 from .utils import DEFAULT_OBSTIME
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from ..baseframe import base_doc
+from .baseradec import BaseRADecFrame, doc_components
+
+__all__ = ['HCRS']
 
 
+doc_footer = """
+    Other parameters
+    ----------------
+    obstime : `~astropy.time.Time`
+        The time at which the observation is taken.  Used for determining the
+        position of the Sun.
+"""
+
+@format_doc(base_doc, components=doc_components, footer=doc_footer)
 class HCRS(BaseRADecFrame):
     """
     A coordinate or frame in a Heliocentric system, with axes aligned to ICRS.
@@ -24,19 +37,8 @@ class HCRS(BaseRADecFrame):
     the documentation.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    obstime : `~astropy.time.Time`
-        The time at which the observation is taken.  Used for determining the
-        position of the Sun.
     """
 
     obstime = TimeAttribute(default=DEFAULT_OBSTIME)
-
-
-HCRS.__doc__ = HCRS.__doc__.format(params=_base_radec_docstring)
 
 # Transformations are defined in icrs_circ_transforms.py

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from ...utils.decorators import format_doc
+from ..baseframe import base_doc
+from .baseradec import BaseRADecFrame, doc_components
+
+__all__ = ['ICRS']
 
 
+@format_doc(base_doc, components=doc_components, footer="")
 class ICRS(BaseRADecFrame):
     """
     A coordinate or frame in the ICRS system.
@@ -16,9 +21,4 @@ class ICRS(BaseRADecFrame):
     For more background on the ICRS and related coordinate transformations, see the
     references provided in the  :ref:`astropy-coordinates-seealso` section of the
     documentation.
-
-    {params}
     """
-
-
-ICRS.__doc__ = ICRS.__doc__.format(params=_base_radec_docstring)

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from ...utils.decorators import format_doc
 from ..representation import CartesianRepresentation, CartesianDifferential
-from ..baseframe import BaseCoordinateFrame
+from ..baseframe import BaseCoordinateFrame, base_doc
 from ..attributes import TimeAttribute
 from .utils import DEFAULT_OBSTIME
 
+__all__ = ['ITRS']
 
+
+@format_doc(base_doc, components="", footer="")
 class ITRS(BaseCoordinateFrame):
     """
     A coordinate or frame in the International Terrestrial Reference System

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -2,14 +2,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from ...time import Time
 from .. import representation as r
 from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
-                         frame_transform_graph)
+                         frame_transform_graph, base_doc)
 from ..transformations import AffineTransform
 from ..attributes import DifferentialAttribute
 
-from .baseradec import _base_radec_docstring, BaseRADecFrame
+from .baseradec import BaseRADecFrame, doc_components as doc_components_radec
 from .icrs import ICRS
 from .galactic import Galactic
 
@@ -21,6 +22,15 @@ v_bary_Schoenrich2010 = r.CartesianDifferential([11.1, 12.24, 7.25]*u.km/u.s)
 __all__ = ['LSR', 'GalacticLSR']
 
 
+doc_footer_lsr = """
+    Other parameters
+    ----------------
+    v_bary : `~astropy.coordinates.representation.CartesianDifferential`
+        The velocity of the solar system barycenter with respect to the LSR, in
+        Galactic cartesian velocity components.
+"""
+
+@format_doc(base_doc, components=doc_components_radec, footer=doc_footer_lsr)
 class LSR(BaseRADecFrame):
     r"""A coordinate or frame in the Local Standard of Rest (LSR).
 
@@ -43,23 +53,11 @@ class LSR(BaseRADecFrame):
     velocity of the solar system barycenter with respect to the LSR.
 
     The frame attributes are listed under **Other Parameters**.
-
-    {params}
-
-    Other parameters
-    ----------------
-    v_bary : `~astropy.coordinates.representation.CartesianDifferential`
-        The velocity of the solar system barycenter with respect to the LSR, in
-        Galactic cartesian velocity components.
-
     """
 
     # frame attributes:
     v_bary = DifferentialAttribute(default=v_bary_Schoenrich2010,
                                    allowed_classes=[r.CartesianDifferential])
-
-
-LSR.__doc__ = LSR.__doc__.format(params=_base_radec_docstring)
 
 
 @frame_transform_graph.transform(AffineTransform, ICRS, LSR)
@@ -81,7 +79,28 @@ def lsr_to_icrs(lsr_coord, icrs_frame):
 
 # ------------------------------------------------------------------------------
 
+doc_components_gal = """
+    l : `Angle`, optional, must be keyword
+        The Galactic longitude for this object (``b`` must also be given and
+        ``representation`` must be None).
+    b : `Angle`, optional, must be keyword
+        The Galactic latitude for this object (``l`` must also be given and
+        ``representation`` must be None).
+    distance : `~astropy.units.Quantity`, optional, must be keyword
+        The Distance for this object along the line-of-sight.
+        (``representation`` must be None).
 
+    pm_l_cosb : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The proper motion in Galactic longitude (including the ``cos(b)`` term)
+        for this object (``pm_b`` must also be given).
+    pm_b : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The proper motion in Galactic latitude for this object (``pm_l_cosb``
+        must also be given).
+    radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The radial velocity of this object.
+"""
+
+@format_doc(base_doc, components=doc_components_gal, footer=doc_footer_lsr)
 class GalacticLSR(BaseCoordinateFrame):
     r"""A coordinate or frame in the Local Standard of Rest (LSR), axis-aligned
     to the `Galactic` frame.
@@ -105,48 +124,6 @@ class GalacticLSR(BaseCoordinateFrame):
     velocity of the solar system barycenter with respect to the LSR.
 
     The frame attributes are listed under **Other Parameters**.
-
-    Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other keywords)
-
-    l : `Angle`, optional, must be keyword
-        The Galactic longitude for this object (``b`` must also be given and
-        ``representation`` must be None).
-    b : `Angle`, optional, must be keyword
-        The Galactic latitude for this object (``l`` must also be given and
-        ``representation`` must be None).
-    distance : `~astropy.units.Quantity`, optional, must be keyword
-        The Distance for this object along the line-of-sight.
-        (``representation`` must be None).
-
-    pm_l_cosb : :class:`~astropy.units.Quantity`, optional, must be keyword
-        The proper motion in Galactic longitude (including the ``cos(b)`` term)
-        for this object (``pm_b`` must also be given).
-    pm_b : :class:`~astropy.units.Quantity`, optional, must be keyword
-        The proper motion in Galactic latitude for this object (``pm_l_cosb``
-        must also be given).
-    radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
-        The radial velocity of this object.
-
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
-
-    Other parameters
-    ----------------
-    v_bary : `~astropy.coordinates.representation.CartesianDifferential`
-        The velocity of the solar system barycenter with respect to the LSR, in
-        Galactic cartesian velocity components.
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -134,12 +134,12 @@ class GalacticLSR(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
 
     Other parameters

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -40,12 +40,12 @@ class Supergalactic(BaseCoordinateFrame):
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.
 
-    differential_cls : `BaseDifferential`, dict, optional
+    differential_type : `BaseDifferential`, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets
         the expected input differential class, thereby changing the expected
         keyword arguments of the data passed in. For example, passing
-        ``differential_cls=CartesianDifferential`` will make the classes
+        ``differential_type=CartesianDifferential`` will make the classes
         expect velocity data with the argument names ``v_x, v_y, v_z``.
     """
 

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -2,22 +2,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from ... import units as u
+from ...utils.decorators import format_doc
 from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping
+from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 from .galactic import Galactic
 
+__all__ = ['Supergalactic']
 
-class Supergalactic(BaseCoordinateFrame):
-    """
-    Supergalactic Coordinates
-    (see Lahav et al. 2000, <http://adsabs.harvard.edu/abs/2000MNRAS.312..166L>,
-    and references therein).
 
-    Parameters
-    ----------
-    representation : `BaseRepresentation` or None
-        A representation object or None to have no data (or use the other keywords)
-
+doc_components = """
     sgl : `Angle`, optional, must be keyword
         The supergalactic longitude for this object (``sgb`` must also be given and
         ``representation`` must be None).
@@ -35,18 +28,14 @@ class Supergalactic(BaseCoordinateFrame):
         also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword
         The radial velocity of this object.
+"""
 
-    copy : bool, optional
-        If `True` (default), make copies of the input coordinate arrays.
-        Can only be passed in as a keyword argument.
-
-    differential_type : `BaseDifferential`, dict, optional
-        A differential class or dictionary of differential classes (currently
-        only a velocity differential with key 's' is supported). This sets
-        the expected input differential class, thereby changing the expected
-        keyword arguments of the data passed in. For example, passing
-        ``differential_type=CartesianDifferential`` will make the classes
-        expect velocity data with the argument names ``v_x, v_y, v_z``.
+@format_doc(base_doc, components=doc_components, footer="")
+class Supergalactic(BaseCoordinateFrame):
+    """
+    Supergalactic Coordinates
+    (see Lahav et al. 2000, <http://adsabs.harvard.edu/abs/2000MNRAS.312..166L>,
+    and references therein).
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -632,7 +632,7 @@ class SkyCoord(ShapedLikeNDArray):
                      pm_dec=u.Quantity(starpm[3], u.radian/u.yr, copy=False),
                      distance=Distance(parallax=starpm[4] * u.arcsec, copy=False),
                      radial_velocity=u.Quantity(starpm[5], u.km/u.s, copy=False),
-                     differential_cls=SphericalDifferential)
+                     differential_type=SphericalDifferential)
 
         # Update the obstime of the returned SkyCoord, and need to carry along
         # the frame attributes
@@ -1786,7 +1786,7 @@ def _get_frame(args, kwargs):
             coord_frame_obj = arg.frame
         if coord_frame_obj is not None:
             coord_frame_cls = coord_frame_obj.__class__
-            kwargs.setdefault('differential_cls',
+            kwargs.setdefault('differential_type',
                               coord_frame_obj.get_representation_cls('s'))
 
         if coord_frame_cls is not None:

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -957,3 +957,33 @@ def test_representation_with_multiple_differentials():
     # check warning is raised for a scalar
     with pytest.raises(ValueError):
         ICRS(rep)
+
+
+def test_representation_arg_backwards_compatibility():
+    # TODO: this test can be removed when the `representation` argument is
+    # removed from the BaseCoordinateFrame initializer.
+    from ..builtin_frames import ICRS
+
+    c1 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+              representation_type=r.CartesianRepresentation)
+
+    c2 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+              representation=r.CartesianRepresentation)
+
+    c3 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+              representation='cartesian')
+
+    assert c1.x == c2.x
+    assert c1.y == c2.y
+    assert c1.z == c2.z
+
+    assert c1.x == c3.x
+    assert c1.y == c3.y
+    assert c1.z == c3.z
+
+    assert c1.representation == c1.representation_type
+
+    with pytest.raises(ValueError):
+        ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+             representation='cartesian',
+             representation_type='cartesian')

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -168,7 +168,7 @@ def test_frame_affinetransform(kwargs, expect_success):
         with pytest.raises(ConvertError):
             icrs.transform_to(Galactocentric)
 
-def test_differential_cls_arg():
+def test_differential_type_arg():
     """
     Test passing in an explicit differential class to the initializer or
     changing the differential class via set_representation_cls
@@ -177,12 +177,12 @@ def test_differential_cls_arg():
 
     icrs = ICRS(ra=1*u.deg, dec=60*u.deg,
                 pm_ra=10*u.mas/u.yr, pm_dec=-11*u.mas/u.yr,
-                differential_cls=r.UnitSphericalDifferential)
+                differential_type=r.UnitSphericalDifferential)
     assert icrs.pm_ra == 10*u.mas/u.yr
 
     icrs = ICRS(ra=1*u.deg, dec=60*u.deg,
                 pm_ra=10*u.mas/u.yr, pm_dec=-11*u.mas/u.yr,
-                differential_cls={'s': r.UnitSphericalDifferential})
+                differential_type={'s': r.UnitSphericalDifferential})
     assert icrs.pm_ra == 10*u.mas/u.yr
 
     icrs = ICRS(ra=1*u.deg, dec=60*u.deg,
@@ -194,13 +194,13 @@ def test_differential_cls_arg():
     with pytest.raises(TypeError):
         ICRS(ra=1*u.deg, dec=60*u.deg,
              v_x=1*u.km/u.s, v_y=-2*u.km/u.s, v_z=-2*u.km/u.s,
-             differential_cls=r.CartesianDifferential)
+             differential_type=r.CartesianDifferential)
 
     # specify both
     icrs = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
                 v_x=1*u.km/u.s, v_y=2*u.km/u.s, v_z=3*u.km/u.s,
                 representation=r.CartesianRepresentation,
-                differential_cls=r.CartesianDifferential)
+                differential_type=r.CartesianDifferential)
     assert icrs.x == 1*u.pc
     assert icrs.y == 2*u.pc
     assert icrs.z == 3*u.pc

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -73,7 +73,7 @@ def test_all_arg_options(kwargs):
     repr_gal = repr(gal)
 
     for k in kwargs:
-        if '_type' in k:
+        if k == 'differential_type':
             continue
         getattr(icrs, k)
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -47,7 +47,20 @@ all_kwargs = [
          pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr),
     dict(ra=37.4*u.deg, dec=-55.8*u.deg, distance=150*u.pc,
          pm_ra_cosdec=-21.2*u.mas/u.yr, pm_dec=17.1*u.mas/u.yr,
-         radial_velocity=105.7*u.km/u.s)
+         radial_velocity=105.7*u.km/u.s),
+    # Now test other representation/differential types:
+    dict(x=100.*u.pc, y=200*u.pc, z=300*u.pc,
+         representation_type='cartesian'),
+    dict(x=100.*u.pc, y=200*u.pc, z=300*u.pc,
+         representation_type=r.CartesianRepresentation),
+    dict(x=100.*u.pc, y=200*u.pc, z=300*u.pc,
+         v_x=100.*u.km/u.s, v_y=200*u.km/u.s, v_z=300*u.km/u.s,
+         representation_type=r.CartesianRepresentation,
+         differential_type=r.CartesianDifferential),
+    dict(x=100.*u.pc, y=200*u.pc, z=300*u.pc,
+         v_x=100.*u.km/u.s, v_y=200*u.km/u.s, v_z=300*u.km/u.s,
+         representation_type=r.CartesianRepresentation,
+         differential_type='cartesian'),
 ]
 
 @pytest.mark.parametrize('kwargs', all_kwargs)
@@ -60,6 +73,8 @@ def test_all_arg_options(kwargs):
     repr_gal = repr(gal)
 
     for k in kwargs:
+        if '_type' in k:
+            continue
         getattr(icrs, k)
 
     if 'pm_ra_cosdec' in kwargs: # should have both
@@ -263,6 +278,6 @@ def test_shorthand_attributes():
 
     icrs4 = ICRS(x=30*u.pc, y=20*u.pc, z=11*u.pc,
                  v_x=10*u.km/u.s, v_y=10*u.km/u.s, v_z=10*u.km/u.s,
-                 representation=r.CartesianRepresentation,
-                 differential_cls=r.CartesianDifferential)
+                 representation_type=r.CartesianRepresentation,
+                 differential_type=r.CartesianDifferential)
     icrs4.radial_velocity

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -45,7 +45,7 @@ def test_creation_attrs():
 
     sc2 = SkyCoord(1*u.deg, 2*u.deg,
                    pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
-                   differential_cls=SphericalDifferential)
+                   differential_type=SphericalDifferential)
     assert_quantity_allclose(sc2.ra, 1*u.deg)
     assert_quantity_allclose(sc2.dec, 2*u.deg)
     assert_quantity_allclose(sc2.pm_ra, .2*u.arcsec/u.kyr)
@@ -74,13 +74,13 @@ def test_creation_copy_basic():
 def test_creation_copy_rediff():
     sc = SkyCoord(1*u.deg, 2*u.deg,
                   pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
-                  differential_cls=SphericalDifferential)
+                  differential_type=SphericalDifferential)
 
     sc_cpy = SkyCoord(sc)
     for attrnm in ['ra', 'dec', 'pm_ra', 'pm_dec']:
         assert_quantity_allclose(getattr(sc, attrnm), getattr(sc_cpy, attrnm))
 
-    sc_newdiff = SkyCoord(sc, differential_cls=SphericalCosLatDifferential)
+    sc_newdiff = SkyCoord(sc, differential_type=SphericalCosLatDifferential)
     reprepr = sc.represent_as(SphericalRepresentation, SphericalCosLatDifferential)
     assert_quantity_allclose(sc_newdiff.pm_ra_cosdec,
                              reprepr.differentials['s'].d_lon_coslat)

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -97,7 +97,7 @@ These same attributes can be used to access the data in the frames, as
     >>> coo.ra.to(u.hourangle)  # doctest: +FLOAT_CMP
     <Longitude 0.07333333 hourangle>
 
-You can use the ``representation`` attribute in conjunction
+You can use the ``representation_type`` attribute in conjunction
 with the ``representation_component_names`` attribute to figure out what
 keywords are accepted by a particular class object.  The former will be the
 representation class the system is expressed in (e.g.,
@@ -118,13 +118,26 @@ One can get the data in a different representation if needed::
     <CartesianRepresentation (x, y, z) [dimensionless]
          (0.99923861, 0.01744177, 0.0348995)>
 
+.. note::
+
+    In previous versions of Astropy, both the frame attribute and the argument
+    to frame classes that are now named ``representation_type`` used to be
+    simply ``representation``. The name of this attribute/argument is confusing
+    as it points to the representation *class*, not the object containing the
+    underlying frame data (this is accessed via the frame attribute ``.data``).
+    To clarify, we have renamed ``representation`` to ``representation_type``.
+    In this version 3.0, we have only changed the references to this attribute
+    in the documentation. In the next major version, we will issue a deprecation
+    warning. In two major versions, we will remove the ``.representation``
+    attribute and ``representation=`` argument.
+
 The representation of the coordinate object can also be changed directly, as
 shown below.  This actually does *nothing* to the object internal data which
 stores the coordinate values, but it changes the external view of that data in
 two ways: (1) the object prints itself in accord with the new representation,
 and (2) the available attributes change to match those of the new
 representation (e.g. from ``ra, dec, distance`` to ``x, y, z``).  Setting the
-``representation`` thus changes a *property* of the object (how it appears)
+``representation_type`` thus changes a *property* of the object (how it appears)
 without changing the intrinsic object itself which represents a point in 3d
 space.::
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -107,7 +107,7 @@ class::
 
     >>> import astropy.units as u
     >>> icrs = ICRS(1*u.deg, 2*u.deg)
-    >>> icrs.representation
+    >>> icrs.representation_type
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
     >>> icrs.representation_component_names
     OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
@@ -129,7 +129,7 @@ without changing the intrinsic object itself which represents a point in 3d
 space.::
 
     >>> from astropy.coordinates import CartesianRepresentation
-    >>> icrs.representation = CartesianRepresentation
+    >>> icrs.representation_type = CartesianRepresentation
     >>> icrs  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (x, y, z) [dimensionless]
         (0.99923861, 0.01744177, 0.0348995)>
@@ -140,7 +140,7 @@ The representation can also be set at the time of creating a coordinate
 and affects the set of keywords used to supply the coordinate data.  For
 example to create a coordinate with cartesian data do::
 
-    >>> ICRS(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc, representation=CartesianRepresentation)  #  doctest: +FLOAT_CMP
+    >>> ICRS(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc, representation_type='cartesian')  #  doctest: +FLOAT_CMP
     <ICRS Coordinate: (x, y, z) in kpc
         (1., 2., 3.)>
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -168,14 +168,14 @@ representation such as cartesian or cylindrical.  This can be done by setting
 the ``representation`` for either |skycoord| objects or low-level frame
 coordinate objects::
 
-    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
+    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (x, y, z) in kpc
         (1., 2., 3.)>
     >>> c.x, c.y, c.z  # doctest: +FLOAT_CMP
     (<Quantity 1. kpc>, <Quantity 2. kpc>, <Quantity 3. kpc>)
 
-    >>> c.representation = 'cylindrical'
+    >>> c.representation_type = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
         (2.23606798, 63.43494882, 3.)>

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -404,7 +404,7 @@ lies in some less-obvious attributes::
   >>> sc_gal.representation_component_units
   OrderedDict([('l', Unit("deg")), ('b', Unit("deg"))])
 
-  >>> sc_gal.representation
+  >>> sc_gal.representation_type
   <class 'astropy.coordinates.representation.SphericalRepresentation'>
 
 Together these tell the object that ``l`` and ``b`` are the longitude and
@@ -533,7 +533,7 @@ by extrapolating the previous documentation for spherical representations.
 Initialization just requires setting the ``representation`` keyword and
 supplying the corresponding components for that representation::
 
-    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
+    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (x, y, z) in kpc
         (1., 2., 3.)>
@@ -542,34 +542,34 @@ supplying the corresponding components for that representation::
 
 Other variations include::
 
-    >>> SkyCoord(1, 2*u.deg, 3, representation='cylindrical')  # doctest: +FLOAT_CMP
+    >>> SkyCoord(1, 2*u.deg, 3, representation_type='cylindrical')  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
         (1., 2., 3.)>
 
-    >>> SkyCoord(rho=1*u.km, phi=2*u.deg, z=3*u.m, representation='cylindrical')  # doctest: +FLOAT_CMP
+    >>> SkyCoord(rho=1*u.km, phi=2*u.deg, z=3*u.m, representation_type='cylindrical')  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
         (1., 2., 3.)>
 
-    >>> SkyCoord(rho=1, phi=2, z=3, unit=(u.km, u.deg, u.m), representation='cylindrical')  # doctest: +FLOAT_CMP
+    >>> SkyCoord(rho=1, phi=2, z=3, unit=(u.km, u.deg, u.m), representation_type='cylindrical')  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (km, deg, m)
         (1., 2., 3.)>
 
-    >>> SkyCoord(1, 2, 3, unit=(None, u.deg, None), representation='cylindrical')  # doctest: +FLOAT_CMP
+    >>> SkyCoord(1, 2, 3, unit=(None, u.deg, None), representation_type='cylindrical')  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (, deg, )
         (1., 2., 3.)>
 
 In general terms, the allowed syntax is as follows::
 
-  SkyCoord(COORD, [FRAME | frame=FRAME], [unit=UNIT], [representation=REPRESENTATION],
+  SkyCoord(COORD, [FRAME | frame=FRAME], [unit=UNIT], [representation_type=REPRESENTATION],
            keyword_args ...)
   SkyCoord(COMP1, COMP2, [COMP3], [FRAME | frame=FRAME], [unit=UNIT],
-           [representation=REPRESENTATION], keyword_args ...)
+           [representation_type=REPRESENTATION], keyword_args ...)
   SkyCoord([FRAME | frame=FRAME], <comp1_name>=COMP1, <comp2_name>=COMP2,
-           <comp3_name>=COMP3, [representation=REPRESENTATION], [unit=UNIT],
+           <comp3_name>=COMP3, [representation_type=REPRESENTATION], [unit=UNIT],
            keyword_args ...)
 
 In this case the ``keyword_args`` now includes the element
-``representation=REPRESENTATION``.  In the above description, elements in all
+``representation_type=REPRESENTATION``.  In the above description, elements in all
 capital letters (e.g. ``FRAME``) describes a user input of that element type.
 Elements in square brackets are optional.
 
@@ -676,7 +676,7 @@ names for that frame to the component name on the representation class::
 
     >>> import astropy.units as u
     >>> icrs = ICRS(1*u.deg, 2*u.deg)
-    >>> icrs.representation
+    >>> icrs.representation_type
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
     >>> icrs.representation_component_names
     OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
@@ -698,12 +698,12 @@ appears) without changing the intrinsic object itself which represents a point
 in 3d space.
 ::
 
-    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation='cartesian')
+    >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (x, y, z) in kpc
         (1., 2., 3.)>
 
-    >>> c.representation = 'cylindrical'
+    >>> c.representation_type = 'cylindrical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (rho, phi, z) in (kpc, deg, kpc)
         (2.23606798, 63.43494882, 3.)>
@@ -714,12 +714,12 @@ in 3d space.
     ...
     AttributeError: 'SkyCoord' object has no attribute 'x'
 
-    >>> c.representation = 'spherical'
+    >>> c.representation_type = 'spherical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
         (63.43494882, 53.3007748, 3.74165739)>
 
-    >>> c.representation = 'unitspherical'
+    >>> c.representation_type = 'unitspherical'
     >>> c  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
         (63.43494882, 53.3007748)>
@@ -727,18 +727,18 @@ in 3d space.
 You can also use any representation class to set the representation::
 
     >>> from astropy.coordinates import CartesianRepresentation
-    >>> c.representation = CartesianRepresentation
+    >>> c.representation_type = CartesianRepresentation
 
 Note that if all you want is a particular representation without changing the
 state of the |SkyCoord| object, you should instead use the
 ``astropy.coordinates.SkyCoord.represent_as()`` method::
 
-    >>> c.representation = 'spherical'
+    >>> c.representation_type = 'spherical'
     >>> cart = c.represent_as(CartesianRepresentation)
     >>> cart  # doctest: +FLOAT_CMP
     <CartesianRepresentation (x, y, z) in kpc
         (1., 2., 3.)>
-    >>> c.representation
+    >>> c.representation_type
     <class 'astropy.coordinates.representation.SphericalRepresentation'>
 
 
@@ -867,7 +867,7 @@ We now generate random data for visualisation using
 As next step, those coordinates are transformed into an astropy.coordinates
 |SkyCoord| object.
 
-    >>> c_gal = SkyCoord(galaxy, representation='cartesian', frame='galactic')
+    >>> c_gal = SkyCoord(galaxy, representation_type='cartesian', frame='galactic')
     >>> c_gal_icrs = c_gal.icrs
 
 Again, as in the last example, we need to convert the coordinates in radians
@@ -913,7 +913,7 @@ We use the same plotting setup as in the last example:
 
     # As next step, those coordinates are transformed into an astropy.coordinates
     # astropy.coordinates.SkyCoord object.
-    c_gal = SkyCoord(galaxy, representation='cartesian', frame='galactic')
+    c_gal = SkyCoord(galaxy, representation_type='cartesian', frame='galactic')
     c_gal_icrs = c_gal.icrs
 
     # Again, as in the last example, we need to convert the coordinates in radians

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -106,7 +106,7 @@ changed by specifying the `~astropy.coordinates.SphericalDifferential` class
     >>> from astropy.coordinates import SphericalDifferential
     >>> Galactic(l=11.23*u.degree, b=58.13*u.degree,
     ...          pm_l=21.34*u.mas/u.yr, pm_b=-55.89*u.mas/u.yr,
-    ...          differential_cls=SphericalDifferential)  # doctest: +FLOAT_CMP
+    ...          differential_type=SphericalDifferential)  # doctest: +FLOAT_CMP
     <Galactic Coordinate: (l, b) in deg
         (11.23, 58.13)
      (pm_l, pm_b) in mas / yr
@@ -120,8 +120,8 @@ specify all coordinate and velocity components in Cartesian::
     ...                                  CartesianDifferential)
     >>> Galactic(u=103*u.pc, v=-11*u.pc, w=93.*u.pc,
     ...          U=31*u.km/u.s, V=-10*u.km/u.s, W=75*u.km/u.s,
-    ...          representation=CartesianRepresentation,
-    ...          differential_cls=CartesianDifferential)  # doctest: +FLOAT_CMP
+    ...          representation_type=CartesianRepresentation,
+    ...          differential_type=CartesianDifferential)  # doctest: +FLOAT_CMP
     <Galactic Coordinate: (u, v, w) in pc
         (103., -11., 93.)
      (U, V, W) in km / s
@@ -133,8 +133,8 @@ position and velocity components. For other frames, these are just ``x,y,z`` and
 
     >>> ICRS(x=103*u.pc, y=-11*u.pc, z=93.*u.pc,
     ...      v_x=31*u.km/u.s, v_y=-10*u.km/u.s, v_z=75*u.km/u.s,
-    ...      representation=CartesianRepresentation,
-    ...      differential_cls=CartesianDifferential)  # doctest: +FLOAT_CMP
+    ...      representation_type=CartesianRepresentation,
+    ...      differential_type=CartesianDifferential)  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (x, y, z) in pc
         (103., -11., 93.)
      (v_x, v_y, v_z) in km / s


### PR DESCRIPTION
The context is: the frame classes and `SkyCoord` accept a `representation=` keyword and have a `.representation` attribute (and similar for `differential`), but these are the *class*, not the underlying representation object (that is `.data`). This has confused me, @eteq, and at least a few users, so we have a long term plan of deprecating and removing these attributes in favor of `representation_type` and `differential_type`. 

This is something we discussed in the lead up to v2.0 and then recently at the coordination meeting. 

This still needs:
* [x] Documentation updates
* [x] Updates to the tests: right now I left the tests (for `representation` at least) just to make sure that they still pass with the new attribute name / keyword.
* [x] At least one check that this doesn't break things in the wild (@cadair checking this with Sunpy would be great!)
* [x] TODO comments over each line that will be deprecated in the future

This fixes #6591 