### PR TITLE
Minor update to release section [docs only]

### DIFF
--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -615,7 +615,8 @@ by ``CHANGES.md`` in the instructions.
    all pass, you can proceed on.
 
 #. If you did the previous step, do ``git clean -fxd`` again to remove anything
-   you made there. Then you can upload to PyPI via ``twine``::
+   you made there.  Run ``python setup.py build sdist --format=gztar`` to
+   create the files for upload.  Then you can upload to PyPI via ``twine``::
 
         twine upload dist/*
 

--- a/docs/development/affiliated-packages.rst
+++ b/docs/development/affiliated-packages.rst
@@ -528,7 +528,7 @@ by ``CHANGES.md`` in the instructions.
    and update the release date, which should currently be set to
    ``unreleased``, to the current date in ``yyyy-mm-dd`` format.
 
-#. Update the version number in ``setup.py`` to the version you're about to
+#. Update the version number in ``setup.cfg`` to the version you're about to
    release, without the ``.dev`` suffix (e.g. ``0.1``).
 
 #. Run ``git clean -fxd`` to remove any untracked files (WARNING: this will
@@ -562,9 +562,9 @@ by ``CHANGES.md`` in the instructions.
 
         git clean -fxd
 
-#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
+#. Add the changes to ``CHANGES.rst`` and ``setup.cfg``::
 
-        git add CHANGES.rst setup.py
+        git add CHANGES.rst setup.cfg
 
    and commit with message::
 
@@ -574,7 +574,7 @@ by ``CHANGES.md`` in the instructions.
 
         git tag v<version>
 
-#. Change ``VERSION`` in ``setup.py`` to next version number, but with a
+#. Change ``VERSION`` in ``setup.cfg`` to next version number, but with a
    ``.dev`` suffix at the end (e.g. ``0.2.dev``). Add a new section to
    ``CHANGES.rst`` for next version, with a single entry ``No changes yet``, e.g.::
 
@@ -583,9 +583,9 @@ by ``CHANGES.md`` in the instructions.
 
        - No changes yet
 
-#. Add the changes to ``CHANGES.rst`` and ``setup.py``::
+#. Add the changes to ``CHANGES.rst`` and ``setup.cfg``::
 
-        git add CHANGES.rst setup.py
+        git add CHANGES.rst setup.cfg
 
    and commit with message::
 


### PR DESCRIPTION
I followed the existing instructions to do an initial release of a package that uses the affiliated package template (great stuff!).  I found that the twine command (step 13) for upload to pypi failed as the dist directory was removed.  This pull request adds in the command needed to create the dist directory for upload.  In addition, the pull request changes the instructions to point to setup.cfg instead of setup.py for version number changes as this is where the version number is kept.

But I may have misunderstood the instructions.  I'm looking forward to hearing what others think.