### PR TITLE
We need to test with pytest >3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,7 @@ matrix:
         - os: linux
           stage: Initial tests
           env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
+               PYTEST_VERSION='>3.2'
           compiler: clang
 
         # Pinning conda version temporarily to 4.3.21, as some anaconda


### PR DESCRIPTION
This testing was accidentally removed in https://github.com/astropy/astropy/commit/5250d134305a77aaf302100c338fabe6bb39d727#diff-354f30a63fb0907d4ad57269548329e3, we should keep it around until https://github.com/astropy/ci-helpers/pull/257 is merged.