### PR TITLE
Update docker image for CircleCI to include git by default

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -5,7 +5,7 @@ docker info
 cat << EOF | docker run -i \
                         -v ${PWD}:/astropy_src \
                         -a stdin -a stdout -a stderr \
-                        astropy/astropy-py35-32bit-test-env:1.9 \
+                        astropy/astropy-py35-32bit-test-env:1.10 \
                         bash || exit $?
 
 cd /astropy_src
@@ -19,9 +19,6 @@ python3 -c 'import sys; print(sys.maxsize)'
 # The doctestplus plugin in Astropy doesn't work correctly with pytest>=3.2, so
 # we install an older version here
 easy_install-3.5 pytest pytest-astropy pytest-xdist
-
-# Install git
-apt-get install -y git
 
 PYTHONHASHSEED=42 python3 setup.py test --parallel=4
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
 
 dependencies:
   override:
-    - docker pull astropy/astropy-py35-32bit-test-env:1.9
+    - docker pull astropy/astropy-py35-32bit-test-env:1.10
 
 test:
   override:


### PR DESCRIPTION
This also makes sure that the apt-get mirror list is up to date (I saw some issues in a couple of recent CircleCI builds)