### PR TITLE
Use setuptools entry point to install ASDF extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,10 @@ entry_points['console_scripts'] = [
     'volint = astropy.io.votable.volint:main',
     'wcslint = astropy.wcs.wcslint:main',
 ]
+# Register ASDF extensions
+entry_points['asdf_extensions'] = [
+    'astropy = astropy.io.misc.asdf.extension:AstropyAsdfExtension'
+]
 
 min_numpy_version = 'numpy>=' + astropy.__minimum_numpy_version__
 setup_requires = [min_numpy_version]


### PR DESCRIPTION
ASDF now allows extension classes to be installed using setuptools entry points. This updates Astropy to install its own ASDF extensions using entry points.

When testing against ASDF, it is now necessary for Astropy to be installed (in develop mode) before the tests run so that the entry points are available at runtime.