### PR TITLE
Do not use --pyargs by default in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astrop
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true
-addopts = --pyargs -p no:warnings
+addopts = -p no:warnings
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
This should fix #6884. The `--pyargs` argument was left over from an earlier iteration of the test refactoring, and is no longer necessary. Its presence does not appear to cause an issue on newer versions of python and pytest, but it does apparently cause problems on Py35.