### PR TITLE
Support Time in table hstack, vstack and join

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -619,6 +619,8 @@ astropy.table
 - Enable tab-completion for column names with IPython 5 and later. [#7071]
 
 - Allow getting and setting a table Row using multiple column names. [#7107]
+- Added support for full use of ``Time`` mixin column for join, hstack, and
+  vstack table operations. [#6888]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Added support for full use of ``Time`` mixin column for join, hstack, and
+  vstack table operations. [#6888]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -619,8 +622,6 @@ astropy.table
 - Enable tab-completion for column names with IPython 5 and later. [#7071]
 
 - Allow getting and setting a table Row using multiple column names. [#7107]
-- Added support for full use of ``Time`` mixin column for join, hstack, and
-  vstack table operations. [#6888]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -163,6 +163,13 @@ class ArrayWrapper:
     def __len__(self):
         return len(self.data)
 
+    def __eq__(self, other):
+        """Minimal equality testing, mostly for mixin unit tests"""
+        if isinstance(other, ArrayWrapper):
+            return self.data == other.data
+        else:
+            return self.data == other
+
     @property
     def dtype(self):
         return self.data.dtype

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -514,7 +514,7 @@ class TestJoin():
             assert np.all(out['m1'].mask == [False, False, True, False])
             assert np.all(out['m2'].mask == [False, True, False, False])
         else:
-            # Otherwise make sure it fails with the right excpetion message
+            # Otherwise make sure it fails with the right exception message
             for join_type in ('outer', 'left', 'right'):
                 with pytest.raises(NotImplementedError) as err:
                     table.join(t1, t2, join_type='outer')

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -174,16 +174,18 @@ class TimeInfo(MixinInfo):
 
     def new_like(self, cols, length, metadata_conflicts='warn', name=None):
         """
-        Return a new Time instance which is consistent with the
-        input ``cols`` and has ``length`` rows.
+        Return a new Time instance which is consistent with the input Time objects
+        ``cols`` and has ``length`` rows.
 
-        This is intended for creating an empty column object whose elements can
-        be set in-place for table operations like join or vstack.
+        This is intended for creating an empty Time instance whose elements can
+        be set in-place for table operations like join or vstack.  It checks
+        that the input locations and attributes are consistent.  This is used
+        when a Time object is used as a mixin column in an astropy Table.
 
         Parameters
         ----------
         cols : list
-            List of input columns
+            List of input columns (Time objects)
         length : int
             Length of the output column object
         metadata_conflicts : str ('warn'|'error'|'silent')

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -204,7 +204,8 @@ does not handle mixin column types like |Quantity| or |SkyCoord|.
 
 **Masking**
 
-Mixin columns do not support masking, but there is limited support for use of
+Mixin columns do not generally support masking (with the exception of |Time|),
+but there is limited support for use of
 mixins within a masked table.  In this case a ``mask`` attribute is assigned to
 the mixin column object.  This ``mask`` is a special object that is a boolean
 array of ``False`` corresponding to the mixin data shape.  The ``mask`` looks
@@ -226,7 +227,8 @@ that contain mixin columns:
    * - :ref:`grouped-operations`
      - Not implemented yet, but no fundamental limitation
    * - :ref:`stack-vertically`
-     - Available for `~astropy.units.Quantity` and any other mixin classes that provide an
+     - Available for `~astropy.units.Quantity` subclasses, |Time|
+       and any other mixin classes that provide a
        `new_like() method`_ in the ``info`` descriptor.
    * - :ref:`stack-horizontally`
      - Works if output mixin column supports masking or if no masking is required


### PR DESCRIPTION
This PR adds support for Time objects to be used in table operations hstack, vstack and join.  It builds off the support for setting and masking in #6028.

The only substantive code change is in the `new_like` method to create a new empty `Time` object based on a list of input `Time` objects.