### PR TITLE
Fixed trivial typo in docstring for Quantity.__quantity_subclass__

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -697,7 +697,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         -------
         tuple :
             - `Quantity` subclass
-            - bool: True is subclasses of the given class are ok
+            - bool: True if subclasses of the given class are ok
         """
         return Quantity, True
 


### PR DESCRIPTION
This fixes (what I think is) a trivial typo in the docstring for `Quantity.__quantity_subclass__`:

`'True is'` -> `'True if'`

Every little helps (unless the original was correct and I just can't read properly).