### PR TITLE
Improve error handling for missing pytest-astropy dependencies

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -22,7 +22,9 @@ def _has_test_dependencies(): # pragma: no cover
     # pytest-openfiles is optional, so it's not listed here.
     required = ['pytest', 'pytest_remotedata', 'pytest_doctestplus']
     for module in required:
-        if find_spec(module) is None:
+        spec = find_spec(module)
+        # Checking loader accounts for packages that were uninstalled
+        if spec is None or spec.loader is None:
             return False
 
     return True


### PR DESCRIPTION
This update allows us to handle the case where one of the required dependencies may have once been installed, but was uninstalled by `pip uninstall`. This case cannot be properly handled by importing in a try/except, so it seems like `find_spec` is still the cleanest solution.