### PR TITLE
Fix use of tests_require

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,9 +16,10 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python3 -c 'import sys; print(sys.maxsize)'
 
-# The doctestplus plugin in Astropy doesn't work correctly with pytest>=3.2, so
-# we install an older version here
-easy_install-3.5 pytest pytest-astropy pytest-xdist
+# We install pytest-astropy explicitly here because the auto-installation
+# of dependencies does not work when using the --parallel option (sub-
+# processes don't see the temporarily installed dependencies)
+easy_install-3.5 pytest-astropy pytest-xdist
 
 PYTHONHASHSEED=42 python3 setup.py test --parallel=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         - ASDF_GIT='git+git://github.com/spacetelescope/asdf.git#egg=asdf'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach'
-        - PIP_DEPENDENCIES='pytest-astropy'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
@@ -79,7 +78,7 @@ matrix:
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='pytest-astropy jplephem' EVENT_TYPE='cron'
+               PIP_DEPENDENCIES='jplephem' EVENT_TYPE='cron'
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -87,7 +86,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='pytest-astropy sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
+               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
                LC_CTYPE=C LC_ALL=C LANG=C
 
         # Try all python versions and Numpy versions. Since we can assume that
@@ -100,6 +99,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
                INSTALL_CMD='python setup.py build_ext --inplace'
+               PIP_DEPENDENCIES='pytest-astropy'
                TEST_CMD='pytest --open-files --doctest-rst'
           script:
             - $INSTALL_CMD
@@ -110,7 +110,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="pytest-astropy jplephem pytest-mpl $ASDF_GIT"
+               PIP_DEPENDENCIES="jplephem pytest-mpl $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.11
                MATPLOTLIB_VERSION=1.5
@@ -129,7 +129,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="pytest-astropy cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
+               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,9 @@ astropy.tests
   a temporary directory instead of copying the build. This allows
   entry points to work correctly. [#6890]
 
+- The tests_require setting in setup.py now works properly when running
+  'python setup.py test'
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,7 +105,7 @@ astropy.tests
   entry points to work correctly. [#6890]
 
 - The tests_require setting in setup.py now works properly when running
-  'python setup.py test'
+  'python setup.py test'. [#6892]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
         CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 jinja2 pyyaml matplotlib scikit-image pytz"
-        PIP_DEPENDENCIES: "pytest-astropy objgraph"
+        PIP_DEPENDENCIES: "objgraph"
 
     matrix:
         - PYTHON_VERSION: "3.6"
@@ -36,4 +36,3 @@ build: false
 
 test_script:
     - "%CMD_IN_ENV% python setup.py test"
-

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -190,7 +190,7 @@ class TestRunnerBase:
 
             # Add each egg to sys.path individually
             for egg in glob.glob(os.path.join('.eggs', '*.egg')):
-                sys.path.append(egg)
+                sys.path.insert(0, egg)
 
             # We now need to force reload pkg_resources in case any pytest
             # plugins were added above, so that their entry points are picked up

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -2,11 +2,13 @@
 
 import inspect
 import os
+import glob
 import copy
 import shlex
 import sys
 import tempfile
 import warnings
+import importlib
 from collections import OrderedDict
 from importlib.util import find_spec
 
@@ -178,7 +180,24 @@ class TestRunnerBase:
         """
 
     def run_tests(self, **kwargs):
-        if not _has_test_dependencies(): # pragma: no cover
+
+        # The following option will include eggs inside a .eggs folder in
+        # sys.path when running the tests. This is possible so that when
+        # runnning python setup.py test, test dependencies installed via e.g.
+        # tests_requires are available here. This is not an advertised option
+        # since it is only for internal use
+        if kwargs.pop('add_local_eggs_to_path', False):
+
+            # Add each egg to sys.path individually
+            for egg in glob.glob(os.path.join('.eggs', '*.egg')):
+                sys.path.append(egg)
+
+            # We now need to force reload pkg_resources in case any pytest
+            # plugins were added above, so that their entry points are picked up
+            import pkg_resources
+            importlib.reload(pkg_resources)
+
+        if not _has_test_dependencies():  # pragma: no cover
             msg = "Test dependencies are missing. You should install the 'pytest-astropy' package."
             raise RuntimeError(msg)
 

--- a/setup.py
+++ b/setup.py
@@ -109,5 +109,6 @@ setup(name=NAME,
       zip_safe=False,
       entry_points=entry_points,
       python_requires='>=' + astropy.__minimum_python_version__,
+      tests_require=['pytest-astropy'],
       **package_info
 )


### PR DESCRIPTION
This builds on https://github.com/astropy/astropy/pull/6890 - basically the issue is that dependencies in ``tests_require`` get installed in ``.eggs`` in the repository, but this isn't seen by the subprocess. So this copies over the ``.eggs`` directory then tells the test subprocess to include the eggs inside ``.eggs`` in ``sys.path``. With this, ``python setup.py test`` now auto-installs pytest-astropy, which will hopefully make @eteq happy ;)

(this doesn't address the issue of what happens when users try and run the tests directly with astropy.test(), but that is discussed in https://github.com/astropy/astropy/pull/6860 - one step at a time!)

This includes commits from https://github.com/astropy/astropy/pull/6890 and should be rebased once that PR is merged. To see the new changes, just look at the individual commits ignoring the three first ones.