### PR TITLE
Alternative fix for auto-installing test dependencies

### DIFF
--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,9 +16,7 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python3 -c 'import sys; print(sys.maxsize)'
 
-# The doctestplus plugin in Astropy doesn't work correctly with pytest>=3.2, so
-# we install an older version here
-easy_install-3.5 pytest pytest-astropy pytest-xdist
+easy_install-3.5 pytest-xdist
 
 PYTHONHASHSEED=42 python3 setup.py test --parallel=4
 

--- a/.run_docker_tests.sh
+++ b/.run_docker_tests.sh
@@ -16,7 +16,11 @@ uname -m
 echo "Output of sys.maxsize in Python:"
 python3 -c 'import sys; print(sys.maxsize)'
 
-easy_install-3.5 pytest-xdist
+
+# We install pytest-astropy explicitly here because the auto-installation
+# of dependencies does not work when using the --parallel option (sub-
+# processes don't see the temporarily installed dependencies)
+easy_install-3.5 pytest-astropy pytest-xdist
 
 PYTHONHASHSEED=42 python3 setup.py test --parallel=4
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         - ASDF_GIT='git+git://github.com/spacetelescope/asdf.git#egg=asdf'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach'
-        - PIP_DEPENDENCIES='pytest-astropy'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
@@ -79,7 +78,7 @@ matrix:
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='pytest-astropy jplephem' EVENT_TYPE='cron'
+               PIP_DEPENDENCIES='jplephem' EVENT_TYPE='cron'
 
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time. The sphinx build also has some additional
@@ -87,7 +86,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='pytest-astropy sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
+               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
                LC_CTYPE=C LC_ALL=C LANG=C
 
         # Try all python versions and Numpy versions. Since we can assume that
@@ -110,7 +109,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="pytest-astropy jplephem pytest-mpl $ASDF_GIT"
+               PIP_DEPENDENCIES="jplephem pytest-mpl $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.11
                MATPLOTLIB_VERSION=1.5
@@ -129,7 +128,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="pytest-astropy cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
+               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
         CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 jinja2 pyyaml matplotlib scikit-image pytz"
-        PIP_DEPENDENCIES: "pytest-astropy objgraph"
+        PIP_DEPENDENCIES: "objgraph"
 
     matrix:
         - PYTHON_VERSION: "3.6"

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -155,12 +155,6 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         """
         Run the tests!
         """
-        # Install the runtime and test dependencies.
-        if self.distribution.install_requires:
-            self.distribution.fetch_build_eggs(
-                self.distribution.install_requires)
-        if self.distribution.tests_require:
-            self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
         # Ensure there is a doc path
         if self.docs_path is None:

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -1,7 +1,9 @@
 """Implements the Astropy TestRunner which is a thin wrapper around py.test."""
 
 import inspect
+import importlib
 import os
+import glob
 import copy
 import shlex
 import sys
@@ -180,6 +182,40 @@ class TestRunnerBase:
         """
 
     def run_tests(self, **kwargs):
+
+        # We need to install the dependencies for the 'test' entry in
+        # extras_require. We start off by finding the
+        # pkg_resources.EggInfoDistribution object which contains information
+        # about the dependencies
+        import pkg_resources
+        pk_dist = pkg_resources.get_distribution(__name__.split('.')[0])
+        requirements = [str(r) for r in pk_dist.requires(extras=('test',))]
+
+        # We now need to make a setuptools.Distribution instance to install
+        # the requirements. We install eggs to a .eggs folder inside a temporary
+        # folder and add these to sys.path.
+        from setuptools import Distribution
+        st_dist = Distribution()
+
+        start_dir = os.path.abspath('.')
+        tmp = tempfile.mkdtemp()
+        try:
+            os.chdir(tmp)
+            st_dist.fetch_build_eggs(requirements)
+        finally:
+            os.chdir(start_dir)
+
+        egg_dir = os.path.join(tmp, '.eggs')
+
+        # Add each egg to sys.path individually
+        for egg in glob.glob(os.path.join(egg_dir, '*.egg')):
+            sys.path.insert(0, egg)
+
+        # We now need to force reload pkg_resources in case any pytest
+        # plugins were added above, so that their entry points are picked up
+        import pkg_resources
+        importlib.reload(pkg_resources)
+
         if not _has_test_dependencies(): # pragma: no cover
             msg = "Test dependencies are missing. You should install the 'pytest-astropy' package."
             raise RuntimeError(msg)

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -185,7 +185,9 @@ class TestRunnerBase:
 
         if not _has_test_dependencies():  # pragma: no cover
 
-            print("Some test dependencies are missing - we will now attempt to install them")
+            print("Some test dependencies are missing - we will now "
+                  "attempt to install them to a temporary directory "
+                  "for the duration of the tests")
 
             # We need to install the dependencies for the 'test' entry in
             # extras_require. We start off by finding the


### PR DESCRIPTION
I was down in a 🐰 hole and while I was there I realized that there is an alternative to #6892, which tries to solve the problem of auto-installing test dependencies. The PR here installs tests dependencies, if missing, *inside* astropy.test() so that it also works for users running tests on an installed version of Astropy.

Note that this doesn't install the dependencies permanently, only to a temporary directory for the duration of the tests. Note also #that this uses the ``extras_requires['test']`` rather than tests_require because I can't find how to access the latter in an installed version.

Now I do feel this method is more hacky than #6892, so I would prefer that we just merge #6892 and then consider whether we think this would work. There are two things that should be checked here - what happens for packages where the module name differs from the package name? (e.g. ``spectral_cube`` and ``spectral-cube``). And will information on the extras_require be available in conda and other installation methods?

Here's what a user would see if they don't have the test dependencies installed:

```
Some test dependencies are missing - we will now attempt to install them to a temporary directory for the duration of the tests
warning: install_lib: 'build/lib' does not exist -- no Python modules to install


Installed /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs/pytest_astropy-0.1.0-py3.6.egg
Searching for pytest-remotedata
Reading https://pypi.python.org/simple/pytest-remotedata/
Downloading https://pypi.python.org/packages/a2/ea/b180cae6678270c9b223b9deafeedeb5344a8b813d5af6d38bdd76066cd0/pytest-remotedata-0.2.0.tar.gz#md5=963ee4151c16d2dd2679bcd97fc324ff
Best match: pytest-remotedata 0.2.0
Processing pytest-remotedata-0.2.0.tar.gz
Writing /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/easy_install-o_zchmyw/pytest-remotedata-0.2.0/setup.cfg
Running pytest-remotedata-0.2.0/setup.py -q bdist_egg --dist-dir /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/easy_install-o_zchmyw/pytest-remotedata-0.2.0/egg-dist-tmp-0h54t2xh
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '*.o' found anywhere in distribution
creating /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs/pytest_remotedata-0.2.0-py3.6.egg
Extracting pytest_remotedata-0.2.0-py3.6.egg to /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs

Installed /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs/pytest_remotedata-0.2.0-py3.6.egg
Searching for pytest-doctestplus
Reading https://pypi.python.org/simple/pytest-doctestplus/
Downloading https://pypi.python.org/packages/b8/83/7d8d8210224da74232429b41d3b767cd8de2b5d6bbd415ab39346b66c80b/pytest-doctestplus-0.1.1.tar.gz#md5=84d47cb2e48efc5e11a786ba95a493d6
Best match: pytest-doctestplus 0.1.1
Processing pytest-doctestplus-0.1.1.tar.gz
Writing /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/easy_install-ef59ntjd/pytest-doctestplus-0.1.1/setup.cfg
Running pytest-doctestplus-0.1.1/setup.py -q bdist_egg --dist-dir /var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/easy_install-ef59ntjd/pytest-doctestplus-0.1.1/egg-dist-tmp-zxb9raq0
warning: no previously-included files matching '*.pyc' found anywhere in distribution
warning: no previously-included files matching '*.o' found anywhere in distribution
creating /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs/pytest_doctestplus-0.1.1-py3.6.egg
Extracting pytest_doctestplus-0.1.1-py3.6.egg to /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs

Installed /private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/tmpiakxw9et/.eggs/pytest_doctestplus-0.1.1-py3.6.egg
/Users/tom/miniconda3/envs/dev/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
/Users/tom/miniconda3/envs/dev/lib/python3.6/importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
  return f(*args, **kwds)
================================================================= test session starts =================================================================
platform darwin -- Python 3.6.3, pytest-3.1.0, py-1.4.34, pluggy-0.4.0

etc.
```


