### PR TITLE
Fix non-deterministic test failure

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -673,10 +673,12 @@ class TestFileFunctions(FitsTestCase):
                             with fits.open(urlobj, mode=mode) as fits_handle:
                                 assert len(fits_handle) == 1
 
-            except urllib.error.HTTPError:
+            except (urllib.error.HTTPError, urllib.error.URLError):
                 continue
             else:
                 break
+        else:
+            raise Exception("Could not download file")
 
     def test_open_gzipped(self):
         gzip_file = self._make_gzip_file()


### PR DESCRIPTION
One of the tests in FITS is still seeing timeout errors:

https://travis-ci.org/astropy/astropy/jobs/306059257

I think this is because the exception can be URLError but we were only catching HTTPError so the mirror was never used.