### PR TITLE
Fix problem comparing unicode to bytes masked column (#6838)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -451,6 +451,9 @@ astropy.table
 - Fixed a problem when setting a column format to an invalid value.  This
   was supposed to revert to the previous (valid) value but was not. [#6812]
 
+- Fixed a problem when comparing a unicode masked column (on left side) to
+  a bytes masked column (on right side).
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -935,9 +935,17 @@ class Column(BaseColumn):
         """
 
         def _compare(self, other):
+            # Special case to work around #6838.  Other combinations work OK,
+            # see tests.test_column.test_unicode_sandwich_compare().  In this
+            # case just swap self and other.
+            if (isinstance(self, MaskedColumn) and self.dtype.kind == 'U' and
+                    isinstance(other, MaskedColumn) and other.dtype.kind == 'S'):
+                self, other = other, self
+
             if self.dtype.char == 'S':
                 other = self._encode_str(other)
             return getattr(self.data, oper)(other)
+
         return _compare
 
     __eq__ = _make_compare('__eq__')

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -764,3 +764,21 @@ def test_unicode_sandwich_set(Column):
     c[:] = ''
     c[:] = [uba, b'def']
     assert np.all(c == [uba, b'def'])
+
+
+@pytest.mark.parametrize('class1', [table.MaskedColumn, table.Column])
+@pytest.mark.parametrize('class2', [table.MaskedColumn, table.Column, str, list])
+def test_unicode_sandwich_compare(class1, class2):
+    """Test that comparing a bytestring Column/MaskedColumn with various
+    str (unicode) object types gives the expected result.  Tests #6838.
+    """
+    obj1 = class1([b'a', b'b'])
+    if class2 is str:
+        obj2 = 'a'
+    elif class2 is list:
+        obj2 = ['a', 'c']
+    else:
+        obj2 = class2(['a', 'c'])
+
+    assert np.all((obj1 == obj2) == [True, False])
+    assert np.all((obj2 == obj1) == [True, False])


### PR DESCRIPTION
This appears to be an upstream problem in numpy MaskedArray (see #6838 comments).  This PR improves testing and implements a narrow fix for the only case that previously failed.

Fixes #6838 
