### PR TITLE
Ensure Time can read byte arrays with items of unequal length.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -329,7 +329,8 @@ astropy.time
 
 - Initialization of ``Time`` instances with bytes or arrays with dtype ``S``
   will now automatically attempt to decode as ASCII. This ensures ``Column``
-  instances with ASCII strings stored with dtype ``S`` can be used. [#6823]
+  instances with ASCII strings stored with dtype ``S`` can be used.
+  [#6823, #6903]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -737,8 +737,10 @@ class TimeString(TimeUnique):
         # Select subformats based on current self.in_subfmt
         subfmts = self._select_subfmts(self.in_subfmt)
         # Be liberal in what we accept: convert bytes to ascii.
+        # Here .item() is needed for arrays with entries of unequal length,
+        # to strip trailing 0 bytes.
         to_string = (str if val1.dtype.kind == 'U' else
-                     lambda x: str(x, encoding='ascii'))
+                     lambda x: str(x.item(), encoding='ascii'))
         iterator = np.nditer([val1, None, None, None, None, None, None],
                              op_dtypes=[val1.dtype] + 5*[np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
@@ -1062,7 +1064,7 @@ class TimeEpochDateString(TimeString):
         epoch_prefix = self.epoch_prefix
         # Be liberal in what we accept: convert bytes to ascii.
         to_string = (str if val1.dtype.kind == 'U' else
-                     lambda x: str(x, encoding='ascii'))
+                     lambda x: str(x.item(), encoding='ascii'))
         iterator = np.nditer([val1, None], op_dtypes=[val1.dtype, np.double])
         for val, years in iterator:
             try:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1152,6 +1152,9 @@ def test_string_valued_columns():
     tutf32 = Time(Column(['B1950']))
     tbytes = Time(Column([b'B1950']))
     assert tutf32 == tbytes
+    # Regression tests for arrays with entries with unequal length. gh-6903.
+    times = Column([b'2012-01-01', b'2012-01-01T00:00:00'])
+    assert np.all(Time(times) == Time(['2012-01-01', '2012-01-01T00:00:00']))
 
 
 def test_bytes_input():


### PR DESCRIPTION
Before this PR, this broke because the two byte strings were of unequal length:
```
Time([b'2012-01-01', b'2012-01-01T00:00:00']) 
```