### PR TITLE
Add ASDF tag implementation and schema for ICRSCoord

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         # Build against github source until asdf-2.0 has been released
-        - ASDF_GIT='git+git://github.com/spacetelescope/asdf.git#egg=asdf'
+        - ASDF_GIT='git+git://github.com/drdavella/asdf.git@relocate-icrs-coord#egg=asdf'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach'
         - SETUP_XVFB=True

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ astropy.io.misc
 
 - Add implementations of astropy-specific ASDF tag types. [#6790]
 
+- Add ASDF tag and schema for ICRSCoord. [#6904]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -3,8 +3,9 @@
 
 import os
 
-from asdf.extension import BuiltinExtension
+from asdf.extension import AsdfExtension, BuiltinExtension
 from asdf.resolver import Resolver, DEFAULT_URL_MAPPING
+from asdf.util import filepath_to_url
 
 # Make sure that all tag implementations are imported by the time we create
 # the extension class so that _astropy_asdf_types is populated correctly. We
@@ -20,10 +21,41 @@ from .tags.transform.projections import *
 from .tags.transform.tabular import *
 from .tags.unit.quantity import *
 from .tags.unit.unit import *
-from .types import _astropy_asdf_types
+from .types import _astropy_types, _astropy_asdf_types
 
 
-__all__ = ['AstropyAsdfExtension']
+__all__ = ['AstropyExtension', 'AstropyAsdfExtension']
+
+
+ASTROPY_SCHEMA_URI_BASE = 'http://astropy.org/schemas/'
+SCHEMA_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'schemas'))
+ASTROPY_URL_MAPPING = [
+    (ASTROPY_SCHEMA_URI_BASE,
+     filepath_to_url(
+         os.path.join(SCHEMA_PATH, 'astropy.org')) +
+         '/{url_suffix}.yaml'),
+    ('tag:astropy.org:astropy/',
+     filepath_to_url(
+         os.path.join(SCHEMA_PATH, 'astropy.org')) +
+         '/astropy/{url_suffix}.yaml')]
+
+
+# This extension is used to register custom types that have both tags and
+# schemas defined by Astropy.
+class AstropyExtension(AsdfExtension):
+    @property
+    def types(self):
+        return _astropy_types
+
+    @property
+    def tag_mapping(self):
+        return [('tag:astropy.org:astropy',
+                 ASTROPY_SCHEMA_URI_BASE + 'astropy{tag_suffix}')]
+
+    @property
+    def url_mapping(self):
+        return ASTROPY_URL_MAPPING
 
 
 # This extension is used to register custom tag types that have schemas defined

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -11,6 +11,7 @@ from asdf.util import filepath_to_url
 # the extension class so that _astropy_asdf_types is populated correctly. We
 # could do this using __init__ files, except it causes pytest import errors in
 # the case that asdf is not installed.
+from .tags.coords.coords import *
 from .tags.fits.fits import *
 from .tags.table.table import *
 from .tags.time.time import *

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -35,11 +35,7 @@ ASTROPY_URL_MAPPING = [
     (ASTROPY_SCHEMA_URI_BASE,
      filepath_to_url(
          os.path.join(SCHEMA_PATH, 'astropy.org')) +
-         '/{url_suffix}.yaml'),
-    ('tag:astropy.org:astropy/',
-     filepath_to_url(
-         os.path.join(SCHEMA_PATH, 'astropy.org')) +
-         '/astropy/{url_suffix}.yaml')]
+         '/{url_suffix}.yaml')]
 
 
 # This extension is used to register custom types that have both tags and

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/coords/icrs_coord-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/coords/icrs_coord-1.0.0.yaml
@@ -1,0 +1,42 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/coords/icrs_coord-1.0.0"
+tag: "tag:astropy.org:astropy/coords/icrs_coord-1.0.0"
+
+title: |
+  Represents an ICRS coordinate object from astropy
+
+description:
+  This object represents the right ascension (RA) and declination of an ICRS
+  coordinate or frame. The ICRS class contains additional fields that may be
+  useful to add here in the future.
+
+type: object
+properties:
+  ra:
+    type: object
+    description: |
+      A longitude representing the right ascension of the ICRS coordinate
+    properties:
+      value:
+        type: number
+      unit:
+        $ref: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+        default: deg
+      wrap_angle:
+        $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+        default: "360 deg"
+  dec:
+    type: object
+    description: |
+      A latitude representing the declination of the ICRS coordinate
+    properties:
+      value:
+        type: number
+      unit:
+        $ref: "tag:stsci.edu:asdf/unit/unit-1.0.0"
+        default: deg
+
+required: [ra, dec]
+...

--- a/astropy/io/misc/asdf/tags/coords/__init__.py
+++ b/astropy/io/misc/asdf/tags/coords/__init__.py
@@ -1,0 +1,2 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/coords/coords.py
+++ b/astropy/io/misc/asdf/tags/coords/coords.py
@@ -22,8 +22,8 @@ class ICRSCoordType(AstropyType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-        angle = QuantityType.from_tree(node['ra']['wrap_angle'], ctx)
-        wrap_angle = Angle(angle.value, unit=angle.unit)
+        angle = Angle(QuantityType.from_tree(node['ra']['wrap_angle'], ctx))
+        wrap_angle = Angle(angle)
         ra = Longitude(
             node['ra']['value'],
             unit=node['ra']['unit'],
@@ -36,9 +36,7 @@ class ICRSCoordType(AstropyType):
     def to_tree(cls, frame, ctx):
         node = {}
 
-        wrap_angle = Quantity(
-            frame.ra.wrap_angle.value,
-            unit=frame.ra.wrap_angle.unit)
+        wrap_angle = Quantity(frame.ra.wrap_angle)
         node['ra'] = {
             'value': frame.ra.value,
             'unit': frame.ra.unit.to_string(),

--- a/astropy/io/misc/asdf/tags/coords/coords.py
+++ b/astropy/io/misc/asdf/tags/coords/coords.py
@@ -5,6 +5,7 @@ from asdf.yamlutil import custom_tree_to_tagged_tree
 
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
+from astropy.tests.helper import assert_quantity_allclose
 
 from ...types import AstropyType
 from ..unit.quantity import QuantityType
@@ -52,4 +53,7 @@ class ICRSCoordType(AstropyType):
 
     @classmethod
     def assert_equal(cls, old, new):
-        assert new.ra == old.ra and new.dec == old.dec
+        assert isinstance(old, ICRS)
+        assert isinstance(new, ICRS)
+        assert_quantity_allclose(new.ra, old.ra)
+        assert_quantity_allclose(new.dec, old.dec)

--- a/astropy/io/misc/asdf/tags/coords/coords.py
+++ b/astropy/io/misc/asdf/tags/coords/coords.py
@@ -1,0 +1,55 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from asdf.yamlutil import custom_tree_to_tagged_tree
+
+from astropy.units import Quantity
+from astropy.coordinates import ICRS, Longitude, Latitude, Angle
+
+from ...types import AstropyType
+from ..unit.quantity import QuantityType
+
+
+__all__ = ['ICRSCoordType']
+
+
+class ICRSCoordType(AstropyType):
+    name = "coords/icrs_coord"
+    types = ['astropy.coordinates.ICRS']
+    requires = ['astropy']
+    version = "1.0.0"
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        angle = QuantityType.from_tree(node['ra']['wrap_angle'], ctx)
+        wrap_angle = Angle(angle.value, unit=angle.unit)
+        ra = Longitude(
+            node['ra']['value'],
+            unit=node['ra']['unit'],
+            wrap_angle=wrap_angle)
+        dec = Latitude(node['dec']['value'], unit=node['dec']['unit'])
+
+        return ICRS(ra=ra, dec=dec)
+
+    @classmethod
+    def to_tree(cls, frame, ctx):
+        node = {}
+
+        wrap_angle = Quantity(
+            frame.ra.wrap_angle.value,
+            unit=frame.ra.wrap_angle.unit)
+        node['ra'] = {
+            'value': frame.ra.value,
+            'unit': frame.ra.unit.to_string(),
+            'wrap_angle': custom_tree_to_tagged_tree(wrap_angle, ctx)
+        }
+        node['dec'] = {
+            'value': frame.dec.value,
+            'unit': frame.dec.unit.to_string()
+        }
+
+        return node
+
+    @classmethod
+    def assert_equal(cls, old, new):
+        assert new.ra == old.ra and new.dec == old.dec

--- a/astropy/io/misc/asdf/tags/coords/tests/test_coords.py
+++ b/astropy/io/misc/asdf/tags/coords/tests/test_coords.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+import pytest
+
+asdf = pytest.importorskip('asdf')
+from asdf.tests.helpers import assert_roundtrip_tree
+
+from astropy import units
+from astropy.coordinates import ICRS, Longitude, Latitude, Angle
+
+from ....extension import AstropyExtension
+
+
+def test_icrs_basic(tmpdir):
+    wrap_angle = Angle(1.5, unit=units.rad)
+    ra = Longitude(25, unit=units.deg, wrap_angle=wrap_angle)
+    dec = Latitude(45, unit=units.deg)
+
+    tree = {'coord': ICRS(ra=ra, dec=dec)}
+
+    assert_roundtrip_tree(tree, tmpdir, extensions=AstropyExtension())
+
+
+@pytest.mark.xfail(
+    reason="Compound ICRS coordinates have not been implemented for ASDF yet")
+def test_icrs_compound(tmpdir):
+
+    icrs = ICRS(ra=[0, 1, 2]*units.deg, dec=[3, 4, 5]*units.deg)
+
+    tree = {'coord': icrs}
+
+    assert_roundtrip_tree(tree, tmpdir, extensions=AstropyExtension())

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -33,11 +33,11 @@ class AstropyTypeMeta(ExtensionTypeMeta):
 @six.add_metaclass(AstropyTypeMeta)
 class AstropyType(CustomType):
     """
-    This class represents types that have schemas that are defined by Astropy.
-    standard, but have tags that are implemented within astropy.
+    This class represents types that have schemas and tags that are defined by
+    Astropy.
 
-    IMPORTANT: This parent class should **not** be used for types that also
-    have schemas that are defined by astropy.
+    IMPORTANT: This parent class should **not** be used for types that have
+    schemas that are defined by the ASDF standard.
     """
     organization = 'astropy.org'
     standard = 'astropy'

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -6,9 +6,10 @@ import six
 from asdf.asdftypes import CustomType, ExtensionTypeMeta
 
 
-__all__ = ['AstropyAsdfType']
+__all__ = ['AstropyType', 'AstropyAsdfType']
 
 
+_astropy_types = set()
 _astropy_asdf_types = set()
 
 
@@ -21,10 +22,25 @@ class AstropyTypeMeta(ExtensionTypeMeta):
         cls = super(AstropyTypeMeta, mcls).__new__(mcls, name, bases, attrs)
         # Classes using this metaclass are automatically added to the list of
         # astropy extensions
-        if cls.organization == 'stsci.edu' and cls.standard == 'asdf':
+        if cls.organization == 'astropy.org' and cls.standard == 'astropy':
+            _astropy_types.add(cls)
+        elif cls.organization == 'stsci.edu' and cls.standard == 'asdf':
             _astropy_asdf_types.add(cls)
 
         return cls
+
+
+@six.add_metaclass(AstropyTypeMeta)
+class AstropyType(CustomType):
+    """
+    This class represents types that have schemas that are defined by Astropy.
+    standard, but have tags that are implemented within astropy.
+
+    IMPORTANT: This parent class should **not** be used for types that also
+    have schemas that are defined by astropy.
+    """
+    organization = 'astropy.org'
+    standard = 'astropy'
 
 
 @six.add_metaclass(AstropyTypeMeta)

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ entry_points['console_scripts'] = [
 ]
 # Register ASDF extensions
 entry_points['asdf_extensions'] = [
-    'astropy = astropy.io.misc.asdf.extension:AstropyAsdfExtension'
+    'astropy = astropy.io.misc.asdf.extension:AstropyExtension',
+    'astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension',
 ]
 
 min_numpy_version = 'numpy>=' + astropy.__minimum_numpy_version__


### PR DESCRIPTION
This was previously in ASDF, but is being moved to Astropy since it serializes an Astropy type. This is the first ASDF tag that also introduces a schema to Astropy.

This PR temporarily builds against a feature branch in ASDF (https://github.com/spacetelescope/asdf/pull/401). This change to the travis script should be reverted before merging.

