### PR TITLE
Cast input data as np.float64 in biweight functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -448,6 +448,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed an issue where the biweight statistics functions would
+  sometimes cause runtime underflow/overflow errors for float32 input
+  arrays. [#6905]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -90,7 +90,7 @@ def biweight_location(data, c=6.0, M=None, axis=None):
     -0.0175741540445
     """
 
-    data = np.asanyarray(data)
+    data = np.asanyarray(data).astype(np.float64)
 
     if M is None:
         M = np.median(data, axis=axis)
@@ -324,7 +324,7 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
     0.97362869104
     """
 
-    data = np.asanyarray(data)
+    data = np.asanyarray(data).astype(np.float64)
 
     if M is None:
         M = np.median(data, axis=axis)
@@ -510,7 +510,7 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
     [ 0.90820237  3.13091961]
     """
 
-    data = np.asanyarray(data)
+    data = np.asanyarray(data).astype(np.float64)
 
     # ensure data is 2D
     if data.ndim == 1:

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -9,6 +9,7 @@ from numpy.testing.utils import assert_allclose
 from ..biweight import (biweight_location, biweight_scale,
                         biweight_midvariance, biweight_midcovariance,
                         biweight_midcorrelation)
+from ...tests.helper import catch_warnings
 from ...utils.misc import NumpyRNGContext
 
 
@@ -246,3 +247,18 @@ def test_biweight_midcorrelation_inputs():
     with pytest.raises(ValueError) as e:
         biweight_midcorrelation(a2, a3)
         assert 'x and y must have the same shape.' in str(e.value)
+
+
+def test_biweight_32bit_runtime_warnings():
+    """Regression test for #6905."""
+    with NumpyRNGContext(12345):
+        data = np.random.random(100).astype(np.float32)
+        data[50] = 30000.
+
+        with catch_warnings(RuntimeWarning) as warning_lines:
+            biweight_scale(data)
+            assert len(warning_lines) == 0
+
+        with catch_warnings(RuntimeWarning) as warning_lines:
+            biweight_midvariance(data)
+            assert len(warning_lines) == 0


### PR DESCRIPTION
I often see floating underflows/overflows in the biweight stat functions when using float32 arrays.  This PR casts the input arrays as float64, which prevents the runtime warnings.

This is more a fix than a feature, so I set the milestone as 2.0.3 -- feel free to change.  Also, is a changelog necessary for this small change?