### PR TITLE
Use ccache on Travis to speedup installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: c
 
 compiler: gcc
 
+# Cache can be cleared from the travis settings menu, see docs currently at
+# https://docs.travis-ci.com/user/caching#Clearing-Caches
 cache:
   - ccache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: c
 
 compiler: gcc
 
+cache:
+  - ccache
+
 os:
     - linux
 


### PR DESCRIPTION
This should gain a few minutes of compilation time. It is handled directly by Travis (https://docs.travis-ci.com/user/caching/#ccache-cache). The cache must first be filled, then we can run Travis again to see the gain.