### PR TITLE
Serialize all astropy core objects to FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ astropy.io.fits
   keyword argument - if set to `True`, then when string columns are accessed,
   byte columns will be returned, which can provide significantly improved
   performance. [#6920]
+- Added support for writing and reading back a table which has "mixin columns"
+  such as ``SkyCoord`` or ``EarthLocation`` with no loss of information. [#6912]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -346,8 +346,11 @@ def test_ecsv_mixins_qtable_to_table():
         if isinstance(col.info, QuantityInfo):
             # Downgrade Quantity to Column + unit
             assert type(col2) is Column
-            attrs = ['unit']  # Other attrs are lost
+            # Class-specific attributes like `value` or `wrap_angle` are lost.
+            attrs = ['unit']
             compare_class = False
+            # Compare data values here (assert_objects_equal doesn't know how in this case)
+            assert np.allclose(col.value, col2, rtol=1e-10)
 
         assert_objects_equal(col, col2, attrs, compare_class)
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -10,7 +10,7 @@ from .. import registry as io_registry
 from ... import units as u
 from ...table import Table, serialize, meta, Column, MaskedColumn
 from ...table.table import has_info_class
-from ...time import Time, TimeDelta
+from ...time import Time
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.data_info import MixinInfo
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
@@ -280,17 +280,17 @@ def _encode_mixins(tbl):
     """
     # If PyYAML is not available then check to see if there are any mixin cols
     # that *require* YAML serialization.  FITS already has support for Time,
-    # TimeDelta, and Quantity, so if those are the only mixins the proceed
-    # without doing the YAML bit, for backward compatibility (i.e. not
-    # requiring YAML to write Time or Quantity).  In this case other mixin
-    # column meta (e.g.  description or meta) will be silently dropped,
-    # consistent with astropy <= 2.0 behavior.
+    # Quantity, so if those are the only mixins the proceed without doing the
+    # YAML bit, for backward compatibility (i.e. not requiring YAML to write
+    # Time or Quantity).  In this case other mixin column meta (e.g.
+    # description or meta) will be silently dropped, consistent with astropy <=
+    # 2.0 behavior.
     try:
         import yaml
     except ImportError:
         for col in tbl.itercols():
             if (has_info_class(col, MixinInfo) and
-                    col.__class__ not in (u.Quantity, Time, TimeDelta)):
+                    col.__class__ not in (u.Quantity, Time)):
                 raise TypeError('cannot write type {} column {!r} '
                                 'to FITS without PyYAML installed.'
                                 .format(col.info.name, col.__class__.__name__))
@@ -302,7 +302,7 @@ def _encode_mixins(tbl):
     # Time-subclass columns and leave them in the table so that the downstream
     # FITS Time handling does the right thing.
     encode_tbl = serialize._represent_mixins_as_columns(
-        tbl, exclude_classes=(Time, TimeDelta))
+        tbl, exclude_classes=(Time,))
     if encode_tbl is tbl:
         return tbl
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -9,8 +9,10 @@ from collections import OrderedDict
 from .. import registry as io_registry
 from ... import units as u
 from ...table import Table, serialize, meta, Column, MaskedColumn
+from ...table.table import has_info_class
 from ...time import Time, TimeDelta
 from ...utils.exceptions import AstropyUserWarning
+from ...utils.data_info import MixinInfo
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES
 from .convenience import table_to_hdu
@@ -276,6 +278,25 @@ def _encode_mixins(tbl):
     """Encode a Table ``tbl`` that may have mixin columns to a Table with only
     astropy Columns + appropriate meta-data to allow subsequent decoding.
     """
+    # If PyYAML is not available then check to see if there are any mixin cols
+    # that *require* YAML serialization.  FITS already has support for Time,
+    # TimeDelta, and Quantity, so if those are the only mixins the proceed
+    # without doing the YAML bit, for backward compatibility (i.e. not
+    # requiring YAML to write Time or Quantity).  In this case other mixin
+    # column meta (e.g.  description or meta) will be silently dropped,
+    # consistent with astropy <= 2.0 behavior.
+    try:
+        import yaml
+    except ImportError:
+        for col in tbl.itercols():
+            if (has_info_class(col, MixinInfo) and
+                    col.__class__ not in (u.Quantity, Time, TimeDelta)):
+                raise TypeError('cannot write type {} column {!r} '
+                                'to FITS without PyYAML installed.'
+                                .format(col.info.name, col.__class__.__name__))
+        else:
+            return tbl
+
     # Convert the table to one with no mixins, only Column objects.  This adds
     # meta data which is extracted with meta.get_yaml_from_table.  TODO: this
     # needs a new pathway to IGNORE Time-subclass columns and leave them in the

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -295,6 +295,17 @@ def _encode_mixins(tbl):
                                 'to FITS without PyYAML installed.'
                                 .format(col.info.name, col.__class__.__name__))
         else:
+            # Warn if information will be lost.  This is hardcoded to the set
+            # difference between column info attributes and what FITS can store
+            # natively (name, dtype, unit).  See _get_col_attributes() in
+            # table/meta.py for where this comes from.
+            for col in tbl.itercols():
+                for attr in ('format', 'description', 'meta'):
+                    if getattr(col.info, attr, None) not in (None, {}):
+                        warnings.warn("table contains column(s) with defined 'format',"
+                                      " 'description', or 'meta' info attributes. These"
+                                      " will be dropped unless you install PyYAML.",
+                                      AstropyUserWarning)
             return tbl
 
     # Convert the table to one with no mixins, only Column objects.  This adds

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -9,6 +9,7 @@ from collections import OrderedDict
 from .. import registry as io_registry
 from ... import units as u
 from ...table import Table, serialize, meta, Column, MaskedColumn
+from ...time import Time, TimeDelta
 from ...utils.exceptions import AstropyUserWarning
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES
@@ -273,7 +274,8 @@ def _encode_mixins(tbl):
     # meta data which is extracted with meta.get_yaml_from_table.  TODO: this
     # needs a new pathway to IGNORE Time-subclass columns and leave them in the
     # table so that the downstream FITS Time handling does the right thing.
-    encode_tbl = serialize._represent_mixins_as_columns(tbl)
+    encode_tbl = serialize._represent_mixins_as_columns(
+        tbl, exclude_classes=(Time, TimeDelta))
     if encode_tbl is tbl:
         return tbl
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -535,7 +535,7 @@ def time_to_fits(table):
         coord_meta[col.info.name]['coord_unit'] = 'd'
 
         # Time column reference position
-        if getattr(col, 'location', None) is None:
+        if getattr(col, 'location') is None:
             if location is not None:
                 warnings.warn(
                     'Time Column "{}" has no specified location, but global Time '

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -535,7 +535,7 @@ def time_to_fits(table):
         coord_meta[col.info.name]['coord_unit'] = 'd'
 
         # Time column reference position
-        if col.location is None:
+        if getattr(col, 'location', None) is None:
             if location is not None:
                 warnings.warn(
                     'Time Column "{}" has no specified location, but global Time '

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -406,10 +406,7 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
             if a2 is None:
                 a2 = {}
 
-        if isinstance(a1, np.ndarray) and a1.dtype.kind == 'f':
-            assert quantity_allclose(a1, a2, rtol=1e-10)
-        else:
-            assert np.all(a1 == a2)
+        assert np.all(a1 == a2)
 
 # Testing FITS table read/write with mixins.  This is mostly
 # copied from ECSV mixin testing.

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -492,9 +492,6 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
                         'scd.ra', 'scd.dec', 'scd.distance',
                         'scd.obstime.jd1', 'scd.obstime.jd2',
                         'tm',  # serialize_method is formatted_value
-                        # 'tm2',  # serialize_method is formatted_value
-                        # 'tm3.jd1', 'tm3.jd2',    # serialize is jd1_jd2
-                        # 'tm3.location.x', 'tm3.location.y', 'tm3.location.z'
                         ]
 
     t = table_cls([mixin_cols[name] for name in names], names=names)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -17,7 +17,7 @@ from ....tests.helper import catch_warnings
 from ....units.format.fits import UnitScaleError
 
 from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
-from ....time import Time  # , TimeDelta
+from ....time import Time, TimeDelta
 from ....tests.helper import quantity_allclose
 from ....units.quantity import QuantityInfo
 
@@ -425,7 +425,7 @@ tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
 
 mixin_cols = {
     'tm': tm,
-    # 'dt': TimeDelta([1, 2] * u.day),
+    'dt': TimeDelta([1, 2] * u.day),
     'sc': sc,
     'scc': scc,
     'scd': SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
@@ -442,7 +442,7 @@ compare_attrs = {
     'c1': ['data'],
     'c2': ['data'],
     'tm': time_attrs,
-    # 'dt': ['shape', 'value', 'format', 'scale'],
+    'dt': ['shape', 'value', 'format', 'scale'],
     'sc': ['ra', 'dec', 'representation', 'frame.name'],
     'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
     'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
@@ -498,7 +498,7 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
     names = sorted(mixin_cols)
 
     serialized_names = ['ang',
-                        # 'dt',
+                        'dt.jd1', 'dt.jd2',
                         'el2.x', 'el2.y', 'el2.z',
                         'lat',
                         'lon',

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -12,9 +12,14 @@ from .. import HDUList, PrimaryHDU, BinTableHDU
 from ... import fits
 
 from .... import units as u
-from ....table import Table, QTable
+from ....table import Table, QTable, NdarrayMixin, Column
 from ....tests.helper import catch_warnings
 from ....units.format.fits import UnitScaleError
+
+from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from ....time import Time  # , TimeDelta
+from ....tests.helper import quantity_allclose
+from ....units.quantity import QuantityInfo
 
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
@@ -369,3 +374,174 @@ def test_convert_comment_convention(tmpdir):
         ' *** Column formats ***',
         ''
     ]
+
+
+def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
+    if compare_class:
+        assert obj1.__class__ is obj2.__class__
+
+    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description']
+    for attr in attrs + info_attrs:
+        a1 = obj1
+        a2 = obj2
+        for subattr in attr.split('.'):
+            try:
+                a1 = getattr(a1, subattr)
+                a2 = getattr(a2, subattr)
+            except AttributeError:
+                a1 = a1[subattr]
+                a2 = a2[subattr]
+
+        if isinstance(a1, np.ndarray) and a1.dtype.kind == 'f':
+            assert quantity_allclose(a1, a2, rtol=1e-10)
+        else:
+            assert np.all(a1 == a2)
+
+# Testing FITS table read/write with mixins.  This is mostly
+# copied from ECSV mixin testing.
+
+el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
+el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
+              obstime='J1990.5')
+scc = sc.copy()
+scc.representation = 'cartesian'
+tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
+
+
+mixin_cols = {
+    'tm': tm,
+    # 'dt': TimeDelta([1, 2] * u.day),
+    'sc': sc,
+    'scc': scc,
+    'scd': SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
+                    obstime=['J1990.5', 'J1991.5']),
+    'q': [1, 2] * u.m,
+    'lat': Latitude([1, 2] * u.deg),
+    'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
+    'ang': Angle([1, 2] * u.deg),
+    'el2': el2,
+}
+
+time_attrs = ['value', 'shape', 'format', 'scale', 'location']
+compare_attrs = {
+    'c1': ['data'],
+    'c2': ['data'],
+    'tm': time_attrs,
+    # 'dt': ['shape', 'value', 'format', 'scale'],
+    'sc': ['ra', 'dec', 'representation', 'frame.name'],
+    'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
+    'q': ['value', 'unit'],
+    'lon': ['value', 'unit', 'wrap_angle'],
+    'lat': ['value', 'unit'],
+    'ang': ['value', 'unit'],
+    'el2': ['x', 'y', 'z', 'ellipsoid'],
+    'nd': ['x', 'y', 'z'],
+}
+
+
+def test_fits_mixins_qtable_to_table(tmpdir):
+    """Test writing as QTable and reading as Table.  Ensure correct classes
+    come out.
+    """
+    filename = str(tmpdir.join('test_simple.fits'))
+
+    names = sorted(mixin_cols)
+
+    t = QTable([mixin_cols[name] for name in names], names=names)
+    t.write(filename, format='fits')
+    t2 = Table.read(filename, format='fits', astropy_native=True)
+
+    assert t.colnames == t2.colnames
+
+    for name, col in t.columns.items():
+        col2 = t2[name]
+
+        # Special-case Time, which does not yet support round-tripping
+        # the format.
+        if isinstance(col2, Time):
+            col2.format = col.format
+
+        attrs = compare_attrs[name]
+        compare_class = True
+
+        if isinstance(col.info, QuantityInfo):
+            # Downgrade Quantity to Column + unit
+            assert type(col2) is Column
+            attrs = ['unit']  # Other attrs are lost
+            compare_class = False
+
+        assert_objects_equal(col, col2, attrs, compare_class)
+
+
+@pytest.mark.parametrize('table_cls', (Table, QTable))
+def test_fits_mixins_as_one(table_cls, tmpdir):
+    """Test write/read all cols at once and validate intermediate column names"""
+    filename = str(tmpdir.join('test_simple.fits'))
+    names = sorted(mixin_cols)
+
+    serialized_names = ['ang',
+                        # 'dt',
+                        'el2.x', 'el2.y', 'el2.z',
+                        'lat',
+                        'lon',
+                        'q',
+                        'sc.ra', 'sc.dec',
+                        'scc.x', 'scc.y', 'scc.z',
+                        'scd.ra', 'scd.dec', 'scd.distance',
+                        'scd.obstime.jd1', 'scd.obstime.jd2',
+                        'tm',  # serialize_method is formatted_value
+                        # 'tm2',  # serialize_method is formatted_value
+                        # 'tm3.jd1', 'tm3.jd2',    # serialize is jd1_jd2
+                        # 'tm3.location.x', 'tm3.location.y', 'tm3.location.z'
+                        ]
+
+    t = table_cls([mixin_cols[name] for name in names], names=names)
+    t.meta['C'] = 'spam'
+    t.meta['comments'] = ['this', 'is', 'a', 'comment']
+    t.meta['history'] = ['first', 'second', 'third']
+
+    t.write(filename, format="fits")
+
+    t2 = table_cls.read(filename, format='fits', astropy_native=True)
+    assert t2.meta['C'] == 'spam'
+    assert t2.meta['comments'] == ['this', 'is', 'a', 'comment']
+    assert t2.meta['HISTORY'] == ['first', 'second', 'third']
+
+    assert t.colnames == t2.colnames
+
+    # Read directly via fits and confirm column names
+    hdus = fits.open(filename)
+    assert hdus[1].columns.names == serialized_names
+
+
+@pytest.mark.parametrize('name_col', list(mixin_cols.items()))
+@pytest.mark.parametrize('table_cls', (Table, QTable))
+def test_fits_mixins_per_column(table_cls, name_col, tmpdir):
+    """Test write/read one col at a time and do detailed validation"""
+    filename = str(tmpdir.join('test_simple.fits'))
+    name, col = name_col
+
+    c = [1.0, 2.0]
+    t = table_cls([c, col, c], names=['c1', name, 'c2'])
+    t[name].info.description = 'description'
+
+    if not t.has_mixin_columns:
+        pytest.skip('column is not a mixin (e.g. Quantity subclass in Table)')
+
+    if isinstance(t[name], NdarrayMixin):
+        pytest.xfail('NdarrayMixin not supported')
+
+    t.write(filename, format="fits")
+    t2 = table_cls.read(filename, format='fits', astropy_native=True)
+
+    assert t.colnames == t2.colnames
+
+    for colname in t.colnames:
+        assert_objects_equal(t[colname], t2[colname], compare_attrs[colname])
+
+    # Special case to make sure Column type doesn't leak into Time class data
+    if name.startswith('tm'):
+        assert t2[name]._time.jd1.__class__ is np.ndarray
+        assert t2[name]._time.jd2.__class__ is np.ndarray

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -386,7 +386,7 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
     if compare_class:
         assert obj1.__class__ is obj2.__class__
 
-    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description']
+    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description', 'info.meta']
     for attr in attrs + info_attrs:
         a1 = obj1
         a2 = obj2
@@ -397,6 +397,14 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
             except AttributeError:
                 a1 = a1[subattr]
                 a2 = a2[subattr]
+
+        # Mixin info.meta can None instead of empty OrderedDict(), #6720 would
+        # fix this.
+        if attr == 'info.meta':
+            if a1 is None:
+                a1 = {}
+            if a2 is None:
+                a2 = {}
 
         if isinstance(a1, np.ndarray) and a1.dtype.kind == 'f':
             assert quantity_allclose(a1, a2, rtol=1e-10)
@@ -531,7 +539,8 @@ def test_fits_mixins_per_column(table_cls, name_col, tmpdir):
 
     c = [1.0, 2.0]
     t = table_cls([c, col, c], names=['c1', name, 'c2'])
-    t[name].info.description = 'description'
+    t[name].info.description = 'my description'
+    t[name].info.meta = {'list': list(range(50)), 'dict': {'a': 'b' * 200}}
 
     if not t.has_mixin_columns:
         pytest.skip('column is not a mixin (e.g. Quantity subclass in Table)')

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -481,8 +481,11 @@ def test_fits_mixins_qtable_to_table(tmpdir):
         if isinstance(col.info, QuantityInfo):
             # Downgrade Quantity to Column + unit
             assert type(col2) is Column
-            attrs = ['unit']  # Other attrs are lost
+            # Class-specific attributes like `value` or `wrap_angle` are lost.
+            attrs = ['unit']
             compare_class = False
+            # Compare data values here (assert_objects_equal doesn't know how in this case)
+            assert np.all(col.value == col2)
 
         assert_objects_equal(col, col2, attrs, compare_class)
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -560,3 +560,15 @@ def test_fits_mixins_per_column(table_cls, name_col, tmpdir):
     if name.startswith('tm'):
         assert t2[name]._time.jd1.__class__ is np.ndarray
         assert t2[name]._time.jd2.__class__ is np.ndarray
+
+
+@pytest.mark.skipif('HAS_YAML')
+def test_warn_for_dropped_info_attributes(tmpdir):
+    filename = str(tmpdir.join('test.fits'))
+    t = Table([[1, 2]])
+    t['col0'].info.description = 'hello'
+    with catch_warnings() as warns:
+        t.write(filename, overwrite=True)
+    assert len(warns) == 1
+    assert str(warns[0].message).startswith(
+        "table contains column(s) with defined 'format'")

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -21,6 +21,12 @@ from ....time import Time  # , TimeDelta
 from ....tests.helper import quantity_allclose
 from ....units.quantity import QuantityInfo
 
+try:
+    import yaml  # pylint: disable=W0611
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
 DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 
@@ -441,6 +447,7 @@ compare_attrs = {
 }
 
 
+@pytest.mark.skipif('not HAS_YAML')
 def test_fits_mixins_qtable_to_table(tmpdir):
     """Test writing as QTable and reading as Table.  Ensure correct classes
     come out.
@@ -475,6 +482,7 @@ def test_fits_mixins_qtable_to_table(tmpdir):
         assert_objects_equal(col, col2, attrs, compare_class)
 
 
+@pytest.mark.skipif('not HAS_YAML')
 @pytest.mark.parametrize('table_cls', (Table, QTable))
 def test_fits_mixins_as_one(table_cls, tmpdir):
     """Test write/read all cols at once and validate intermediate column names"""
@@ -513,6 +521,7 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
     assert hdus[1].columns.names == serialized_names
 
 
+@pytest.mark.skipif('not HAS_YAML')
 @pytest.mark.parametrize('name_col', list(mixin_cols.items()))
 @pytest.mark.parametrize('table_cls', (Table, QTable))
 def test_fits_mixins_per_column(table_cls, name_col, tmpdir):

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -184,7 +184,7 @@ def _get_col_attributes(col):
     return attrs
 
 
-def get_yaml_from_table(table, compact=False):
+def get_yaml_from_table(table):
     """
     Return lines with a YAML representation of header content from the ``table``.
 
@@ -192,8 +192,6 @@ def get_yaml_from_table(table, compact=False):
     ----------
     table : `~astropy.table.Table` object
         Table for which header content is output
-    compact : bool
-        If True then dump yaml as a single compact string, not human readable.
 
     Returns
     -------
@@ -205,10 +203,10 @@ def get_yaml_from_table(table, compact=False):
     if table.meta:
         header['meta'] = table.meta
 
-    return get_yaml_from_header(header, compact)
+    return get_yaml_from_header(header)
 
 
-def get_yaml_from_header(header, compact=False):
+def get_yaml_from_header(header):
     """
     Return lines with a YAML representation of header content from a Table.
 
@@ -224,8 +222,6 @@ def get_yaml_from_header(header, compact=False):
     ----------
     header : dict
         Table header content
-    compact : bool
-        If True then dump yaml as a single compact string, not human readable.
 
     Returns
     -------
@@ -235,7 +231,8 @@ def get_yaml_from_header(header, compact=False):
     try:
         import yaml
     except ImportError:
-        raise ImportError('`import yaml` failed, PyYAML package is required for ECSV format')
+        raise ImportError('`import yaml` failed, PyYAML package is '
+                          'required for serializing mixin columns')
 
     from ..io.misc.yaml import AstropyDumper
 
@@ -290,7 +287,7 @@ def get_yaml_from_header(header, compact=False):
     header['datatype'] = [_get_col_attributes(col) for col in header['cols']]
     del header['cols']
 
-    lines = yaml.dump(header, Dumper=TableDumper).splitlines()
+    lines = yaml.dump(header, Dumper=TableDumper, width=130).splitlines()
     return lines
 
 
@@ -300,10 +297,9 @@ class YamlParseError(Exception):
 
 def get_header_from_yaml(lines):
     """
-    Get a header dict from input ``lines`` which should be valid YAML in the
-    ECSV meta format.  This input will typically be created by
-    get_yaml_from_header.  The output is a dictionary which describes all the
-    table and column meta.
+    Get a header dict from input ``lines`` which should be valid YAML.  This
+    input will typically be created by get_yaml_from_header.  The output is a
+    dictionary which describes all the table and column meta.
 
     The get_cols() method in the io/ascii/ecsv.py file should be used as a
     guide to using the information when constructing a table using this
@@ -318,12 +314,14 @@ def get_header_from_yaml(lines):
     -------
     header : dict
         Dictionary describing table and column meta
+
     """
 
     try:
         import yaml
     except ImportError:
-        raise ImportError('`import yaml` failed, PyYAML package is required for ECSV format')
+        raise ImportError('`import yaml` failed, PyYAML package '
+                          'is required for serializing mixin columns')
 
     from ..io.misc.yaml import AstropyLoader
 

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -290,8 +290,7 @@ def get_yaml_from_header(header, compact=False):
     header['datatype'] = [_get_col_attributes(col) for col in header['cols']]
     del header['cols']
 
-    kwargs = {'width': float('inf'), 'default_flow_style': True} if compact else {}
-    lines = yaml.dump(header, Dumper=TableDumper, **kwargs).splitlines()
+    lines = yaml.dump(header, Dumper=TableDumper).splitlines()
     return lines
 
 

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -184,7 +184,7 @@ def _get_col_attributes(col):
     return attrs
 
 
-def get_yaml_from_table(table):
+def get_yaml_from_table(table, compact=False):
     """
     Return lines with a YAML representation of header content from the ``table``.
 
@@ -192,6 +192,8 @@ def get_yaml_from_table(table):
     ----------
     table : `~astropy.table.Table` object
         Table for which header content is output
+    compact : bool
+        If True then dump yaml as a single compact string, not human readable.
 
     Returns
     -------
@@ -203,10 +205,10 @@ def get_yaml_from_table(table):
     if table.meta:
         header['meta'] = table.meta
 
-    return get_yaml_from_header(header)
+    return get_yaml_from_header(header, compact)
 
 
-def get_yaml_from_header(header):
+def get_yaml_from_header(header, compact=False):
     """
     Return lines with a YAML representation of header content from a Table.
 
@@ -222,6 +224,8 @@ def get_yaml_from_header(header):
     ----------
     header : dict
         Table header content
+    compact : bool
+        If True then dump yaml as a single compact string, not human readable.
 
     Returns
     -------
@@ -286,7 +290,8 @@ def get_yaml_from_header(header):
     header['datatype'] = [_get_col_attributes(col) for col in header['cols']]
     del header['cols']
 
-    lines = yaml.dump(header, Dumper=TableDumper).splitlines()
+    kwargs = {'width': float('inf'), 'default_flow_style': True} if compact else {}
+    lines = yaml.dump(header, Dumper=TableDumper, **kwargs).splitlines()
     return lines
 
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -35,9 +35,10 @@ class SerializedColumn(dict):
 def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
                                exclude_classes=()):
     """Convert a mixin column to a plain columns or a set of mixin columns."""
-    # If not a mixin, or if an instance of the ``exclude_classes`` tuple then
-    # treat as a normal column.
-    if not has_info_class(col, MixinInfo) or isinstance(col, exclude_classes):
+    # If not a mixin, or if class in ``exclude_classes`` tuple then
+    # treat as a normal column.  Excluded sub-classes must be explicitly
+    # specified.
+    if not has_info_class(col, MixinInfo) or col.__class__ in exclude_classes:
         new_cols.append(col)
         return
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -32,9 +32,12 @@ class SerializedColumn(dict):
     pass
 
 
-def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
+def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
+                               exclude_classes=()):
     """Convert a mixin column to a plain columns or a set of mixin columns."""
-    if not has_info_class(col, MixinInfo):
+    # If not a mixin, or if an instance of the ``exclude_classes`` tuple then
+    # treat as a normal column.
+    if not has_info_class(col, MixinInfo) or isinstance(col, exclude_classes):
         new_cols.append(col)
         return
 
@@ -100,10 +103,11 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols):
     mixin_cols[name] = obj_attrs
 
 
-def _represent_mixins_as_columns(tbl):
+def _represent_mixins_as_columns(tbl, exclude_classes=()):
     """
     Convert any mixin columns to plain Column or MaskedColumn and
-    return a new table.
+    return a new table.  Exclude any mixin columns in ``exclude_classes``,
+    which must be a tuple of classes.
     """
     if not tbl.has_mixin_columns:
         return tbl
@@ -113,7 +117,8 @@ def _represent_mixins_as_columns(tbl):
     new_cols = []
 
     for col in tbl.itercols():
-        _represent_mixin_as_column(col, col.info.name, new_cols, mixin_cols)
+        _represent_mixin_as_column(col, col.info.name, new_cols, mixin_cols,
+                                   exclude_classes=exclude_classes)
 
     meta = deepcopy(tbl.meta)
     meta['__serialized_columns__'] = mixin_cols

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -211,14 +211,10 @@ def test_io_write_fail(mixin_cols):
     # Only do this test if there are unsupported column types (i.e. anything besides
     # BaseColumn and Quantity class instances).
     unsupported_cols = t.columns.not_isinstance((BaseColumn, u.Quantity))
-    # Partially supported columns (FITS)
-    fits_unsupported_cols = t.columns.not_isinstance((BaseColumn, u.Quantity, time.Time))
 
     if not unsupported_cols:
         pytest.skip("no unsupported column types")
-    for fmt in ('fits', 'votable', 'hdf5'):
-        if fmt == 'fits' and not fits_unsupported_cols:
-            pytest.skip("no unsupported column types")
+    for fmt in ('votable', 'hdf5'):
         if fmt == 'hdf5' and not HAS_H5PY:
             continue
         out = StringIO()

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -227,6 +227,13 @@ can use the convenience function
 binary table HDU and insert or append that to an existing
 :class:`~astropy.io.fits.HDUList`.
 
+As of astropy version 3.0 there is support for writing a table which contains
+:ref:`mixin_columns` such as `~astropy.time.Time` or
+`~astropy.coordinates.SkyCoord`.  This uses FITS ``COMMENT`` cards to capture
+additional information needed order to fully reconstruct the mixin columns when
+reading back from FITS.  The information is a Python `dict` structure which is
+serialized using YAML.
+
 Keywords
 ^^^^^^^^^
 

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -16,9 +16,10 @@ converted in any way but are used natively.
 
 The available built-in mixin column classes are:
 
-- |Quantity|
-- |SkyCoord|
-- |Time|
+- |Quantity| and subclasses
+- |SkyCoord| and coordinate frame classes
+- |Time| and :class:`~astropy.time.TimeDelta`
+- :class:`~astropy.coordinates.EarthLocation`
 - `~astropy.table.NdarrayMixin`
 
 As a first example we can create a table and add a time column::


### PR DESCRIPTION
This is a proof of concept for serializing all astropy core objects to FITS.  It heavily leverages the machinery used for ECSV, and the concept is pretty much identical.  HDF5 can be done in much the same way.

For writing the process is to encode a table with mixins into a table with only standard Columns + appropriate YAML-encoded metadata.  That metadata has all the information needed to fully-reconstruct the mixin columns.

The key question is how to store the YAML-encoded metadata in FITS.  This POC takes a simple approach and just puts it into FITS COMMENT cards, contained within two sentinel strings to allow being able to reliable identify such metadata in a FITS file.  This is not the only approach, but it is pretty simple and non-invasive.   See code comments for an implementation detail that required base64 encoding of the YAML.

The requirement here is that this process is minimally impacting to output FITS files.  The final implementation would be careful to cause no change to the output FITS file for a Table that has no mixin columns.  That is not currently the case in this POC.

Reading is just the reverse, and the Columns-only table + metadata are decoded into a Table with mixin columns.

This works right now:
```
In [3]: t = QTable([[1, 2] * u.m, 
                    SkyCoord([1,2], [3,4], unit='deg'), 
                    [5.0, 6.0]])
   ...: t['col0'].info.format = '.2f'
   ...: t['col1'].info.meta = {'a': 1}
   ...: t['col2'].format = '.3f'
   ...: t['col2'].description = 'interesting'
   ...: t.write('junk.fits', overwrite=True)
   ...: t2 = QTable.read('junk.fits')
   ...: t2
   ...: 
Out[3]: 
<QTable length=2>
  col0    col1    col2 
   m    deg,deg        
float64  object float64
------- ------- -------
   1.00 1.0,3.0   5.000
   2.00 2.0,4.0   6.000

In [4]: t2['col1'].info.meta
Out[4]: {'a': 1}

$ fitsheader junk.fits 
# HDU 0 in junk.fits:
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                    8 / array data type                                
NAXIS   =                    0 / number of array dimensions                     
EXTEND  =                    T                                                  

# HDU 1 in junk.fits:
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                   32 / length of dimension 1                          
NAXIS2  =                    2 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    4 / number of table fields                         
TTYPE1  = 'col0    '                                                            
TFORM1  = 'D       '                                                            
TUNIT1  = 'm       '                                                            
TTYPE2  = 'col1.ra '                                                            
TFORM2  = 'D       '                                                            
TUNIT2  = 'deg     '                                                            
TTYPE3  = 'col1.dec'                                                            
TFORM3  = 'D       '                                                            
TUNIT3  = 'deg     '                                                            
TTYPE4  = 'col2    '                                                            
TFORM4  = 'D       '                                                            
COMMENT --BEGIN-BASE64-ASTROPY-SERIALIZED-COLUMNS--                             
COMMENT e2RhdGF0eXBlOiBbe25hbWU6IGNvbDAsIHVuaXQ6IG0sIGRhdGF0eXBlOiBmbG9hdDY0LCBm
COMMENT b3JtYXQ6IC4yZn0sIHtuYW1lOiBjb2wxLnJhLCB1bml0OiBkZWcsIGRhdGF0eXBlOiBmbG9h
COMMENT dDY0fSwge25hbWU6IGNvbDEuZGVjLCB1bml0OiBkZWcsIGRhdGF0eXBlOiBmbG9hdDY0fSwg
COMMENT e25hbWU6IGNvbDIsIGRhdGF0eXBlOiBmbG9hdDY0LCBmb3JtYXQ6IC4zZiwgZGVzY3JpcHRp
COMMENT b246IGludGVyZXN0aW5nfV0sIG1ldGE6ICEhb21hcCBbe19fc2VyaWFsaXplZF9jb2x1bW5z
COMMENT X186IHtjb2wwOiB7X19jbGFzc19fOiBhc3Ryb3B5LnVuaXRzLnF1YW50aXR5LlF1YW50aXR5
COMMENT LCB2YWx1ZTogIWFzdHJvcHkudGFibGUuU2VyaWFsaXplZENvbHVtbiB7bmFtZTogY29sMH19
COMMENT LCBjb2wxOiB7X19jbGFzc19fOiBhc3Ryb3B5LmNvb3JkaW5hdGVzLnNreV9jb29yZGluYXRl
COMMENT LlNreUNvb3JkLCBfX2luZm9fXzoge21ldGE6IHthOiAxfX0sIGRlYzogIWFzdHJvcHkudGFi
COMMENT bGUuU2VyaWFsaXplZENvbHVtbiB7X19jbGFzc19fOiBhc3Ryb3B5LmNvb3JkaW5hdGVzLmFu
COMMENT Z2xlcy5MYXRpdHVkZSwgdmFsdWU6ICFhc3Ryb3B5LnRhYmxlLlNlcmlhbGl6ZWRDb2x1bW4g
COMMENT e25hbWU6IGNvbDEuZGVjfX0sIGZyYW1lOiBpY3JzLCByYTogIWFzdHJvcHkudGFibGUuU2Vy
COMMENT aWFsaXplZENvbHVtbiB7X19jbGFzc19fOiBhc3Ryb3B5LmNvb3JkaW5hdGVzLmFuZ2xlcy5M
COMMENT b25naXR1ZGUsIHZhbHVlOiAhYXN0cm9weS50YWJsZS5TZXJpYWxpemVkQ29sdW1uIHtuYW1l
COMMENT OiBjb2wxLnJhfSwgd3JhcF9hbmdsZTogIWFzdHJvcHkuY29vcmRpbmF0ZXMuQW5nbGUge3Vu
COMMENT aXQ6ICFhc3Ryb3B5LnVuaXRzLlVuaXQge3VuaXQ6IGRlZ30sIHZhbHVlOiAzNjAuMH19LCBy
COMMENT ZXByZXNlbnRhdGlvbjogc3BoZXJpY2FsfX19XX0=                                
COMMENT --END-BASE64-ASTROPY-SERIALIZED-COLUMNS--                               
```
