### PR TITLE
Speed up writing of FITS tables with string columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ astropy.io.fits
 
 - The ``table_to_hdu`` function and the ``BinTableHDU.from_columns`` and
   ``FITS_rec.from_columns`` methods now include a ``character_as_bytes``
-   keyword argument - if set to `True`, then when string columns are accessed,
+  keyword argument - if set to `True`, then when string columns are accessed,
   byte columns will be returned, which can provide significantly improved
   performance. [#6920]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,9 @@ astropy.io.fits
   in particular for cases where the tables contain one or more string columns
   and when done through ``Table.read``. [#6821]
 
+- The performance for writing tables from ``Table.write`` has now been
+  significantly improved for tables containing one or more string columns. [#6920]
+
 - The ``Table.read`` now supports a ``memmap=`` keyword argument to control
   whether or not to use  memory mapping when reading the table. [#6821]
 
@@ -55,6 +58,12 @@ astropy.io.fits
   are returned as Numpy byte arrays (Numpy type S) while when set to `False`,
   the same columns are decoded to Unicode strings (Numpy type U) which uses more
   memory. [#6821]
+
+- The ``table_to_hdu`` function and the ``BinTableHDU.from_columns`` and
+  ``FITS_rec.from_columns`` methods now include a ``character_as_bytes``
+   keyword argument - if set to `True`, then when string columns are accessed,
+  byte columns will be returned, which can provide significantly improved
+  performance. [#6920]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -222,7 +222,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
     return t
 
 
-def write_table_fits(input, output, overwrite=False, character_as_bytes=True):
+def write_table_fits(input, output, overwrite=False):
     """
     Write a Table object to a FITS file
 
@@ -236,7 +236,7 @@ def write_table_fits(input, output, overwrite=False, character_as_bytes=True):
         Whether to overwrite any existing file without warning.
     """
 
-    table_hdu = table_to_hdu(input, character_as_bytes=character_as_bytes)
+    table_hdu = table_to_hdu(input, character_as_bytes=True)
 
     # Check if output file already exists
     if isinstance(output, str) and os.path.exists(output):

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -222,7 +222,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
     return t
 
 
-def write_table_fits(input, output, overwrite=False):
+def write_table_fits(input, output, overwrite=False, character_as_bytes=True):
     """
     Write a Table object to a FITS file
 
@@ -236,7 +236,7 @@ def write_table_fits(input, output, overwrite=False):
         Whether to overwrite any existing file without warning.
     """
 
-    table_hdu = table_to_hdu(input)
+    table_hdu = table_to_hdu(input, character_as_bytes=character_as_bytes)
 
     # Check if output file already exists
     if isinstance(output, str) and os.path.exists(output):

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -474,7 +474,7 @@ def table_to_hdu(table):
 
         # TODO: it might be better to construct the FITS table directly from
         # the Table columns, rather than go via a structured array.
-        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=True)
         for col in table_hdu.columns:
             # Binary FITS tables support TNULL *only* for integer data columns
             # TODO: Determine a schema for handling non-integer masked columns
@@ -491,7 +491,7 @@ def table_to_hdu(table):
 
             col.null = fill_value.astype(table[col.name].dtype)
     else:
-        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=True)
 
     # Set units for output HDU
     for col in table_hdu.columns:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -423,7 +423,7 @@ def writeto(filename, data, header=None, output_verify='exception',
                 checksum=checksum)
 
 
-def table_to_hdu(table):
+def table_to_hdu(table, character_as_bytes=False):
     """
     Convert an `~astropy.table.Table` object to a FITS
     `~astropy.io.fits.BinTableHDU`.
@@ -491,7 +491,7 @@ def table_to_hdu(table):
 
             col.null = fill_value.astype(table[col.name].dtype)
     else:
-        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=True)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=character_as_bytes)
 
     # Set units for output HDU
     for col in table_hdu.columns:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -432,6 +432,10 @@ def table_to_hdu(table, character_as_bytes=False):
     ----------
     table : astropy.table.Table
         The table to convert.
+    character_as_bytes : bool
+        Whether to return bytes for string columns when accessed from the HDU.
+        By default this is `False` and (unicode) strings are returned, but for
+        large tables this may use up a lot of memory.
 
     Returns
     -------

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1292,17 +1292,17 @@ def _rstrip_inplace(array):
     """
 
     # The following implementation uses a 1D view of the buffer (via ravel())
-    # converts it to a 2D array of unsigned 8-bit integers. Trailing spaces
-    # (which are represented as 32 are then converted to null characters,
-    # represented as zeros). The loop over j is to avoid creating too large
-    # temporary arrays in memory.
+    # converts it to a 2D array of unsigned integers. Trailing spaces (which are
+    # represented as 32 are then converted to null characters, represented as
+    # zeros). The loop over j is to avoid creating too large temporary arrays in
+    # memory.
 
     dt = array.dtype
 
     if dt.kind not in 'SU':
         raise TypeError("This function can only be used on string arrays")
 
-    dt_int = "{0}{1}u{2}".format(dt.itemsize, dt.byteorder, 1 if dt.kind == 'S' else 4)
+    dt_int = "{0}{1}u{2}".format(dt.itemsize // dt.alignment, dt.byteorder, dt.alignment)
     b = np.array(array, copy=False).ravel().view(dt_int)
     for j in range(0, b.shape[0], 10000):
         c = b[j:j + 10000]

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1295,7 +1295,7 @@ def _rstrip_inplace(array):
     # the right length. Trailing spaces (which are represented as 32) are then
     # converted to null characters (represented as zeros). To avoid creating
     # large temporary mask arrays, we loop over chunks (attempting to do that
-    # on a 1-D version of the array; large memomry may still be needed in the
+    # on a 1-D version of the array; large memory may still be needed in the
     # unlikely case that a string array has small first dimension and cannot
     # be represented as a contiguous 1-D array in memory).
 
@@ -1303,18 +1303,18 @@ def _rstrip_inplace(array):
 
     if dt.kind not in 'SU':
         raise TypeError("This function can only be used on string arrays")
+    # View the array as appropriate integers. The last dimension will
+    # equal the number of characters in each string.
     bpc = 1 if dt.kind == 'S' else 4
-    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, dt.bpc)
+    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
     b = np.array(array, copy=False).view(dt_int)
     # For optimal speed, work in chunks of the internal ufunc buffer size.
     bufsize = np.getbufsize()
-    # Attempt to make it a 1-D array so that the chunks have known size.
-    # We cannot use ravel, since that will copy for non-contiguous arrays.
-    # and we need a view of the input array. The code will work on non-1D
-    # arrays, although the chunks will now be larger.
-    if b.ndim > 1:
+    # Attempt to have the strings as a 1-D array to give the chunk known size.
+    # Note: the code will work if this fails; the chunks will just be larger.
+    if b.ndim > 2:
         try:
-            b.shape = -1
+            b.shape = -1, b.shape[-1]
         except AttributeError:
             pass
     for j in range(0, b.shape[0], bufsize):

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1307,7 +1307,10 @@ def _rstrip_inplace(array):
     # equal the number of characters in each string.
     bpc = 1 if dt.kind == 'S' else 4
     dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
-    b = np.array(array, copy=False).view(dt_int)
+    if isinstance(array, np.chararray):
+        b = np.array(array, copy=False).view(dt_int)
+    else:
+        b = array.view(dt_int)
     # For optimal speed, work in chunks of the internal ufunc buffer size.
     bufsize = np.getbufsize()
     # Attempt to have the strings as a 1-D array to give the chunk known size.

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1307,10 +1307,7 @@ def _rstrip_inplace(array):
     # equal the number of characters in each string.
     bpc = 1 if dt.kind == 'S' else 4
     dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
-    if isinstance(array, np.chararray):
-        b = np.array(array, copy=False).view(dt_int)
-    else:
-        b = array.view(dt_int)
+    b = array.view(dt_int, np.ndarray)
     # For optimal speed, work in chunks of the internal ufunc buffer size.
     bufsize = np.getbufsize()
     # Attempt to have the strings as a 1-D array to give the chunk known size.

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -267,7 +267,7 @@ class FITS_rec(np.recarray):
         self._uint = False
 
     @classmethod
-    def from_columns(cls, columns, nrows=0, fill=False):
+    def from_columns(cls, columns, nrows=0, fill=False, character_as_bytes=False):
         """
         Given a `ColDefs` object of unknown origin, initialize a new `FITS_rec`
         object.
@@ -329,6 +329,7 @@ class FITS_rec(np.recarray):
         raw_data = np.empty(columns.dtype.itemsize * nrows, dtype=np.uint8)
         raw_data.fill(ord(columns._padding_byte))
         data = np.recarray(nrows, dtype=columns.dtype, buf=raw_data).view(cls)
+        data._character_as_bytes = character_as_bytes
 
         # Make sure the data is a listener for changes to the columns
         columns._add_listener(data)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -15,7 +15,7 @@ from numpy import char as chararray
 from .column import (ASCIITNULL, FITS2NUMPY, ASCII2NUMPY, ASCII2STR, ColDefs,
                      _AsciiColDefs, _FormatX, _FormatP, _VLF, _get_index,
                      _wrapx, _unwrapx, _makep, Delayed)
-from .util import decode_ascii, encode_ascii
+from .util import decode_ascii, encode_ascii, _rstrip_inplace
 from ...utils import lazyproperty
 
 
@@ -1282,52 +1282,6 @@ def _get_recarray_field(array, key):
             not isinstance(field, chararray.chararray)):
         field = field.view(chararray.chararray)
     return field
-
-
-def _rstrip_inplace(array):
-    """
-    Performs an in-place rstrip operation on string arrays. This is necessary
-    since the built-in `np.char.rstrip` in Numpy does not perform an in-place
-    calculation.
-    """
-
-    # The following implementation convert the string to unsigned integers of
-    # the right length. Trailing spaces (which are represented as 32) are then
-    # converted to null characters (represented as zeros). To avoid creating
-    # large temporary mask arrays, we loop over chunks (attempting to do that
-    # on a 1-D version of the array; large memory may still be needed in the
-    # unlikely case that a string array has small first dimension and cannot
-    # be represented as a contiguous 1-D array in memory).
-
-    dt = array.dtype
-
-    if dt.kind not in 'SU':
-        raise TypeError("This function can only be used on string arrays")
-    # View the array as appropriate integers. The last dimension will
-    # equal the number of characters in each string.
-    bpc = 1 if dt.kind == 'S' else 4
-    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
-    b = array.view(dt_int, np.ndarray)
-    # For optimal speed, work in chunks of the internal ufunc buffer size.
-    bufsize = np.getbufsize()
-    # Attempt to have the strings as a 1-D array to give the chunk known size.
-    # Note: the code will work if this fails; the chunks will just be larger.
-    if b.ndim > 2:
-        try:
-            b.shape = -1, b.shape[-1]
-        except AttributeError:
-            pass
-    for j in range(0, b.shape[0], bufsize):
-        c = b[j:j + bufsize]
-        # mask which will tell whether we're in a sequence of trailing spaces.
-        mask = np.ones(c.shape[:-1], dtype=bool)
-        # loop over the characters in the strings, in reverse order.
-        for i in range(-1, -c.shape[-1], -1):
-            mask &= c[..., i] == 32
-            c[..., i][mask] = 0
-            mask = c[..., i] == 0
-
-    return array
 
 
 class _UnicodeArrayEncodeError(UnicodeEncodeError):

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1291,22 +1291,37 @@ def _rstrip_inplace(array):
     calculation.
     """
 
-    # The following implementation uses a 1D view of the buffer (via ravel())
-    # converts it to a 2D array of unsigned integers. Trailing spaces (which are
-    # represented as 32 are then converted to null characters, represented as
-    # zeros). The loop over j is to avoid creating too large temporary arrays in
-    # memory.
+    # The following implementation convert the string to unsigned integers of
+    # the right length. Trailing spaces (which are represented as 32) are then
+    # converted to null characters (represented as zeros). To avoid creating
+    # large temporary mask arrays, we loop over chunks (attempting to do that
+    # on a 1-D version of the array; large memomry may still be needed in the
+    # unlikely case that a string array has small first dimension and cannot
+    # be represented as a contiguous 1-D array in memory).
 
     dt = array.dtype
 
     if dt.kind not in 'SU':
         raise TypeError("This function can only be used on string arrays")
-
-    dt_int = "{0}{1}u{2}".format(dt.itemsize // dt.alignment, dt.byteorder, dt.alignment)
-    b = np.array(array, copy=False).ravel().view(dt_int)
-    for j in range(0, b.shape[0], 10000):
-        c = b[j:j + 10000]
+    bpc = 1 if dt.kind == 'S' else 4
+    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, dt.bpc)
+    b = np.array(array, copy=False).view(dt_int)
+    # For optimal speed, work in chunks of the internal ufunc buffer size.
+    bufsize = np.getbufsize()
+    # Attempt to make it a 1-D array so that the chunks have known size.
+    # We cannot use ravel, since that will copy for non-contiguous arrays.
+    # and we need a view of the input array. The code will work on non-1D
+    # arrays, although the chunks will now be larger.
+    if b.ndim > 1:
+        try:
+            b.shape = -1
+        except AttributeError:
+            pass
+    for j in range(0, b.shape[0], bufsize):
+        c = b[j:j + bufsize]
+        # mask which will tell whether we're in a sequence of trailing spaces.
         mask = np.ones(c.shape[:-1], dtype=bool)
+        # loop over the characters in the strings, in reverse order.
         for i in range(-1, -c.shape[-1], -1):
             mask &= c[..., i] == 32
             c[..., i][mask] = 0

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -71,7 +71,7 @@ class _TableLikeHDU(_ValidHDU):
 
     @classmethod
     def from_columns(cls, columns, header=None, nrows=0, fill=False,
-                     **kwargs):
+                     character_as_bytes=False, **kwargs):
         """
         Given either a `ColDefs` object, a sequence of `Column` objects,
         or another table HDU or table data (a `FITS_rec` or multi-field
@@ -111,6 +111,12 @@ class _TableLikeHDU(_ValidHDU):
             copy the data from input, undefined cells will still be filled with
             zeros/blanks.
 
+        character_as_bytes : bool
+            Whether to represent string columns using byte arrays. By default
+            this is `False` and byte arrays are represented as unicode arrays.
+            Setting this to `True` is much more memory-efficient if unicode
+            arrays are not needed.
+
         Notes
         -----
 
@@ -119,7 +125,8 @@ class _TableLikeHDU(_ValidHDU):
         """
 
         coldefs = cls._columns_type(columns)
-        data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill)
+        data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
+                                     character_as_bytes=character_as_bytes)
         hdu = cls(data=data, header=header, **kwargs)
         coldefs._add_listener(hdu)
         return hdu

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -112,10 +112,9 @@ class _TableLikeHDU(_ValidHDU):
             zeros/blanks.
 
         character_as_bytes : bool
-            Whether to represent string columns using byte arrays. By default
-            this is `False` and byte arrays are represented as unicode arrays.
-            Setting this to `True` is much more memory-efficient if unicode
-            arrays are not needed.
+            Whether to return bytes for string columns when accessed from the
+            HDU. By default this is `False` and (unicode) strings are returned,
+            but for large tables this may use up a lot of memory.
 
         Notes
         -----
@@ -127,7 +126,7 @@ class _TableLikeHDU(_ValidHDU):
         coldefs = cls._columns_type(columns)
         data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
                                      character_as_bytes=character_as_bytes)
-        hdu = cls(data=data, header=header, **kwargs)
+        hdu = cls(data=data, header=header, character_as_bytes=character_as_bytes, **kwargs)
         coldefs._add_listener(hdu)
         return hdu
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -873,3 +873,53 @@ def get_testdata_filepath(filename):
     """
     return data.get_pkg_data_filename(
         'io/fits/tests/data/{}'.format(filename), 'astropy')
+
+
+def _rstrip_inplace(array):
+    """
+    Performs an in-place rstrip operation on string arrays. This is necessary
+    since the built-in `np.char.rstrip` in Numpy does not perform an in-place
+    calculation.
+    """
+
+    # The following implementation convert the string to unsigned integers of
+    # the right length. Trailing spaces (which are represented as 32) are then
+    # converted to null characters (represented as zeros). To avoid creating
+    # large temporary mask arrays, we loop over chunks (attempting to do that
+    # on a 1-D version of the array; large memory may still be needed in the
+    # unlikely case that a string array has small first dimension and cannot
+    # be represented as a contiguous 1-D array in memory).
+
+    dt = array.dtype
+
+    if dt.kind not in 'SU':
+        raise TypeError("This function can only be used on string arrays")
+    # View the array as appropriate integers. The last dimension will
+    # equal the number of characters in each string.
+    bpc = 1 if dt.kind == 'S' else 4
+    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
+    b = array.view(dt_int, np.ndarray)
+    # For optimal speed, work in chunks of the internal ufunc buffer size.
+    bufsize = np.getbufsize()
+    # Attempt to have the strings as a 1-D array to give the chunk known size.
+    # Note: the code will work if this fails; the chunks will just be larger.
+    if b.ndim > 2:
+        try:
+            b.shape = -1, b.shape[-1]
+        except AttributeError:  # can occur for non-contiguous arrays
+            pass
+    for j in range(0, b.shape[0], bufsize):
+        c = b[j:j + bufsize]
+        # Mask which will tell whether we're in a sequence of trailing spaces.
+        mask = np.ones(c.shape[:-1], dtype=bool)
+        # Loop over the characters in the strings, in reverse order. We process
+        # the i-th character of all strings in the chunk at the same time. If
+        # the character is 32, this corresponds to a space, and we then change
+        # this to 0. We then construct a new mask to find rows where the
+        # i-th character is 0 (null) and the i-1-th is 32 (space) and repeat.
+        for i in range(-1, -c.shape[-1], -1):
+            mask &= c[..., i] == 32
+            c[..., i][mask] = 0
+            mask = c[..., i] == 0
+
+    return array


### PR DESCRIPTION
This is a follow-up to #6821 and speeds up specifically writing tables with string columns.

At the moment, if a table contains a string column, that string column is first decoded by io.fits to a unicode array (if not already the case) before getting re-encoded to a byte array. This means that if the original column was a byte string column (which one could get after reading in a FITS file with Table.read), there is an unnecessary conversion to unicode and back. Furthermore, there was previously a Python loop over all string elements to remove trailing whitespace. This PR uses the ``character_as_bytes`` functionality developed in #6821 to avoid the conversion to unicode in the case a byte string array is passed, and also includes a significantly sped up ``_rstrip_replace`` provided by @mhvk in https://github.com/astropy/astropy/issues/6906.

@mhvk - I feel bad including your code without assigning the commit to you, so if you want the credit, feel free to edit this PR and change the existing commit to be under your user!

Test code:

```python
import numpy as np
from astropy.table import Table

N = 10_000_000

t = Table()
t['floats1'] = np.random.random(N)
t['ints1'] = np.random.randint(0, 100, N)
t['strings'] = b'some strings'

t.write('test_write.fits', overwrite=True)
```

The table initialization takes 1.5s, and the writing of the table itself takes 22.1s before this PR and 2.1s after, giving a speedup of a factor of 10x, and the peak memory usage goes down by a factor of ~2.5x:

![perf](https://user-images.githubusercontent.com/314716/33481186-53b06654-d68b-11e7-98e9-2189c376cb05.png)

(the 'speed up ``_rstrip_replace``' curve also includes ``character_as_bytes``)

If I set ``t['strings']`` to a unicode column instead of bytes column:

```
t['strings'] = 'some strings'
```

Things are also faster with this PR:

![perf_u](https://user-images.githubusercontent.com/314716/33481456-778a4ad0-d68c-11e7-8c63-c1d811747864.png)

(the 'speed up ``_rstrip_replace``' curve also includes ``character_as_bytes``)

In both cases writing a table still seems to double the memory used by the table, but I'm not sure if we can avoid that. One use case I'd like to test is whether if I have a larger-than-memory table I can read it in with memory mapping, modify a cell, and write it out again without using much memory.

Now we might want to consider whether to put some of the optimizations lower down in io.fits - for instance if doing ``BinTableHDU.from_columns`` with a byte array, it will be converted to unicode internally then back to bytes as mentioned above. Check this out:

```python
import numpy as np
from astropy.io.fits import BinTableHDU
x = np.repeat(b'a', 100_000_000)
array = np.array(x, dtype=[('col', 'S1')])
hdu = BinTableHDU.from_columns(array)
print(hdu.dtype)
````

This takes almost a minute and 2.2Gb of memory:

![hdu_false](https://user-images.githubusercontent.com/314716/33481918-8a96fb1c-d68e-11e7-95d9-b97731d4a288.png)

The output for the dtype is ``(numpy.record, [('col', 'S1')])``. If I call it with:

```python
hdu = BinTableHDU.from_columns(array, character_as_bytes=True)
```

it takes 2 seconds and 350Mb of memory:

![hdu_true](https://user-images.githubusercontent.com/314716/33481916-87f89a50-d68e-11e7-8a3a-b9d7b55f749b.png)

And produces the exact same output. So maybe ``BinTableHDU.from_columns`` shouldn't even have a ``character_as_bytes`` option and it should always default to ``True``. But I need to think about the implications about this some more and would value input from FITS experts (e.g. @saimn @MSeifert04).