### PR TITLE
Fix use of frombuffer which made array read-only

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -859,10 +859,12 @@ class TestFileFunctions(FitsTestCase):
         gf = self._make_gzip_file()
         with fits.open(gf, mode='update') as h:
             h[0].header['EXPFLAG'] = 'ABNORMAL'
+            h[1].data[0, 0] = 1
         with fits.open(gf) as h:
             # Just to make sur ethe update worked; if updates work
             # normal writes should work too...
             assert h[0].header['EXPFLAG'] == 'ABNORMAL'
+            assert h[1].data[0, 0] == 1
 
     def test_write_read_gzip_file(self):
         """

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -582,7 +582,11 @@ def _array_from_file(infile, dtype, count):
         # their underlying file object, instead of the decompressed bytes
         read_size = np.dtype(dtype).itemsize * count
         s = infile.read(read_size)
-        return np.frombuffer(s, dtype=dtype, count=count)
+        array = np.frombuffer(s, dtype=dtype, count=count)
+        # copy is needed because np.frombuffer returns a read-only view of the
+        # underlying buffer
+        array = array.copy()
+        return array
 
 
 _OSX_WRITE_LIMIT = (2 ** 32) - 1


### PR DESCRIPTION
Fix #6862.

#6785 replaced `np.fromstring` with `np.frombuffer` but the latter returns a read-only view of the binary buffer. So copying the array is needed to get a writeable array.

From what I can understand from the numpy code, `np.fromstring` was doing the copy internally. This seems true also when doing a quick test to compare the two functions, `np.frombuffer` does not allocate memory.