### PR TITLE
WIP: Support masked arrays in LinearLSQFitter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,7 +104,7 @@ astropy.modeling
 - A ``deepcopy()`` method was added to models. [#6515]
 
 - Added units support to ``AffineTransformation``. [#6853]
-- Added ``is_separable`` function to modeling totest the
+
 - Added ``is_separable`` function to modeling to test the
   separability of a model. [#6746]
 
@@ -501,6 +501,9 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+
+- Support masked array values in ``LinearLSQFitter`` (instead of silently
+  ignorning the mask). [#6927]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -347,6 +347,37 @@ function in which the resulting mean (variance) is the sum of the means
     plt.plot(x, g2(x), 'k-')
     plt.plot(x, g3(x), 'k-')
 
+.. _modeling-getting-started-masked-data:
+
+Fitting masked data
+-------------------
+
+.. versionadded:: 2.0.4
+
+When `astropy.modeling.fitting.LinearLSQFitter` is provided with the dependent
+co-ordinate values as a `numpy.ma.MaskedArray`, it ignores any masked values
+when performing the fit::
+
+    >>> p_init = models.Polynomial1D(degree=1)
+    >>> x = np.arange(10)
+    >>> y = np.ma.masked_array(2*x+1, mask=np.zeros_like(x))
+    >>> y[7] = 100.       # simulate spurious value
+    >>> y.mask[7] = True
+    >>> fitter = fitting.LinearLSQFitter()
+    >>> p = fitter(p_init, x, y)
+    >>> print('Fit intercept={:.3f}, slope={:.3f}'.format(p.c0.value, p.c1.value))  # doctest: +FLOAT_CMP
+    Fit intercept=1.000, slope=2.000
+
+At present, the non-linear fitters do not distinguish between good and bad
+values in this way.
+
+Note that model set fitting is currently about an order of magnitude slower in
+the presence of masked values, because the matrix equation has to be solved for
+each model separately, on their respective co-ordinate grids. This is still an
+order of magnitude faster than fitting separate model instances, however.
+Supplying a `numpy.ma.MaskedArray` without any bad (``True``) mask values
+produces the normal, faster behaviour.
+
 .. _modeling-using:
 
 Using `astropy.modeling`


### PR DESCRIPTION
Candidate solution for #4824 & #6819 for linear fitting. Currently this adds support for masked arrays in `modeling.fitting.LinearLSQFitter`.
