### PR TITLE
Make barycentric vcorr-related methods public

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,12 +159,6 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- ``EarthLocation`` now has a method to compute the  gravitational redshift due
-  due to solar system bodies.  [#6861, #6935]
-
-- ``EarthLocation`` now has a ``get_gcrs`` convenience method to get the
-  location in GCRS coordinates.  [#6861, #6935]
-
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -277,6 +271,12 @@ astropy.coordinates
 - The frame classes (and ``SkyCoord``) now give more useful error messages when
   incorrect attribute names are given.  Instead of using the representation
   attribute names, they use the frame attribute names. [#7106]
+
+- ``EarthLocation`` now has a method to compute the  gravitational redshift due
+  due to solar system bodies.  [#6861, #6935]
+
+- ``EarthLocation`` now has a ``get_gcrs`` convenience method to get the
+  location in GCRS coordinates.  [#6861, #6935]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,6 +159,12 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- ``EarthLocation`` now has a method to compute the  gravitational redshift due
+  due to solar system bodies.  [#6861, #6935]
+
+- ``EarthLocation`` now has a ``get_gcrs`` convenience method to get the
+  location in GCRS coordinates.  [#6861, #6935]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -603,7 +603,7 @@ class EarthLocation(u.Quantity):
                                      for the location of this object at the
                                      default ``obstime``.""")
 
-    def _get_gcrs(self, obstime):
+    def get_gcrs(self, obstime):
         """GCRS position with velocity at ``obstime`` as a GCRS coordinate.
 
         Parameters
@@ -645,12 +645,12 @@ class EarthLocation(u.Quantity):
             The GCRS velocity of the object
         """
         # GCRS position
-        gcrs_data = self._get_gcrs(obstime).data
+        gcrs_data = self.get_gcrs(obstime).data
         obsgeopos = gcrs_data.without_differentials()
         obsgeovel = gcrs_data.differentials['s'].to_cartesian()
         return obsgeopos, obsgeovel
 
-    def _gravitational_redshift(self, obstime):
+    def gravitational_redshift(self, obstime):
         """Return the gravitational redshift at this EarthLocation.
 
         Calculates the gravitational redshift, of order 3 m/s, due to the Sun,

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -650,16 +650,22 @@ class EarthLocation(u.Quantity):
         obsgeovel = gcrs_data.differentials['s'].to_cartesian()
         return obsgeopos, obsgeovel
 
-    def gravitational_redshift(self, obstime):
+    def gravitational_redshift(self, obstime,
+                               bodies=('sun', 'jupiter', 'moon', 'earth')):
         """Return the gravitational redshift at this EarthLocation.
 
-        Calculates the gravitational redshift, of order 3 m/s, due to the Sun,
-        Jupiter, the Moon, and the Earth itself.
+        Calculates the gravitational redshift, of order 3 m/s, due to the
+        requested solar system bodies.
 
         Parameters
         ----------
         obstime : `~astropy.time.Time`
             The ``obstime`` to calculate the redshift at.
+
+        bodies : list
+            The bodies to include in the redshift calculation.  List elements
+            should be any body name `get_body_barycentric` accepts.  Defaults to
+            Jupiter, the Sun, the Moon, and Earth Itself.
 
         Returns
         --------
@@ -668,10 +674,10 @@ class EarthLocation(u.Quantity):
         """
         # needs to be here to avoid circular imports
         from .solar_system import get_body_barycentric
-        names = ('sun', 'jupiter', 'moon', 'earth')
+
         GM_moon = consts.G * 7.34767309e22*u.kg
         masses = (consts.GM_sun, consts.GM_jup, GM_moon, consts.GM_earth)
-        positions = [get_body_barycentric(name, obstime) for name in names]
+        positions = [get_body_barycentric(name, obstime) for name in bodies]
         # Calculate distances to objects other than earth.
         distances = [(pos - positions[-1]).norm() for pos in positions[:-1]]
         # Append distance from Earth's center for Earth's contribution.

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -694,8 +694,13 @@ class EarthLocation(u.Quantity):
         for body in bodies:
             if body not in GMs:
                 raise ValueError("body {} does not have a mass!".format(body))
-            if GMs[body].unit.is_equivalent(u.kg):
+            if GMs[body].unit.is_equivalent(consts.GM_earth):
+                pass  # all good
+            elif GMs[body].unit.is_equivalent(u.kg):
                 GMs[body] = consts.G * GMs[body]
+            else:
+                raise u.UnitsError('"masses" argument values must be masses or '
+                                   'gravitational parameters')
 
         positions = [get_body_barycentric(name, obstime) for name in bodies]
         # Calculate distances to objects other than earth.

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -685,8 +685,10 @@ class EarthLocation(u.Quantity):
         from .solar_system import get_body_barycentric
 
         bodies = list(bodies)
-        if 'earth' not in bodies:
-            bodies.append('earth')
+        # Ensure earth is included and last in the list.
+        if 'earth' in bodies:
+            bodies.remove('earth')
+        bodies.append('earth')
         _masses = {'sun': consts.GM_sun,
                    'jupiter': consts.GM_jup,
                    'moon': consts.G * 7.34767309e22*u.kg,

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1574,7 +1574,7 @@ class SkyCoord(ShapedLikeNDArray):
         if kind == 'barycentric':
             beta_obs = (v_origin_to_earth + gcrs_v) / speed_of_light
             gamma_obs = 1 / np.sqrt(1 - beta_obs.norm()**2)
-            gr = location._gravitational_redshift(obstime)
+            gr = location.gravitational_redshift(obstime)
             # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
             # neglecting Shapiro delay and effects of the star's own motion
             zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light) - 1

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -343,20 +343,20 @@ def test_gravitational_redshift():
 
     # check mass adjustments
     # if Jupiter and the moon are ignored, effect should be off by ~ .5 mm/s
-    masses = [constants.G*constants.M_sun,
-              0*constants.G*u.kg,
-              0*constants.G*u.kg,
-              constants.G*constants.M_earth]
+    masses = {'sun': constants.G*constants.M_sun,
+              'jupiter': 0*constants.G*u.kg,
+              'moon': 0*constants.G*u.kg,
+              'earth': constants.G*constants.M_earth}
     d_moonjup = np.abs(someloc.gravitational_redshift(sometime, masses=masses) - zg0)
     assert d_moonjup < 1*u.mm/u.s
     assert d_moonjup > .1*u.mm/u.s
 
     # if the earth is also ignored, effect should be off by ~ 20 cm/s
-    masses[3] *= 0
+    masses['earth'] *= 0
     d_moonjupearth = np.abs(someloc.gravitational_redshift(sometime, masses=masses) - zg0)
     assert d_moonjupearth < 1*u.m/u.s
     assert d_moonjupearth > 10*u.cm/u.s
 
     # if all masses are ignored, should be 0
-    masses[0] *= 0
+    masses['sun'] *= 0
     assert someloc.gravitational_redshift(sometime, masses=masses) == 0

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -348,6 +348,9 @@ def test_gravitational_redshift():
     # Check that simply not including the bodies gives the same result.
     assert zg_moonjup == someloc.gravitational_redshift(sometime,
                                                         bodies=('sun',))
+    # And that earth can be given, even not as last argument
+    assert zg_moonjup == someloc.gravitational_redshift(
+        sometime, bodies=('earth', 'sun',))
 
     # If the earth is also ignored, effect should be off by ~ 20 cm/s
     # This also tests the conversion of kg to gravitational units.

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -360,3 +360,10 @@ def test_gravitational_redshift():
     # if all masses are ignored, should be 0
     masses['sun'] *= 0
     assert someloc.gravitational_redshift(sometime, masses=masses) == 0
+
+    with pytest.raises(u.UnitsError):
+        masses = {'sun': constants.G*constants.M_sun,
+                  'jupiter': constants.G*constants.M_jup,
+                  'moon': 1*u.km,  # wrong units!
+                  'earth': constants.G*constants.M_earth}
+        someloc.gravitational_redshift(sometime, masses=masses)


### PR DESCRIPTION
This makes some small changes relative to #6861, making public some of the functionality added there for internal use.  This is mainly done here because #6861 was a bugfix, so shouldn't introduce new features - hence why this is milestoned 3.0 vs the 2.0.3 if #6861.  (It also makes a minor change in functionality, making it possible to include other solar system bodies beyond the default set). See https://github.com/astropy/astropy/pull/6861#pullrequestreview-81565400 for a bit more context.
