### PR TITLE
Change BaseFrame.__setattr__ to be fast for private attributes.

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1239,16 +1239,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return self.__getattribute__(attr)  # Raise AttributeError.
 
     def __setattr__(self, attr, value):
-        repr_attr_names = set()
-        if hasattr(self, 'representation_info'):
-            for representation_attr in self.representation_info.values():
-                repr_attr_names.update(representation_attr['names'])
+        # Don't slow down access of private attributes!
+        if not attr.startswith('_'):
+            if hasattr(self, 'representation_info'):
+                repr_attr_names = set()
+                for representation_attr in self.representation_info.values():
+                    repr_attr_names.update(representation_attr['names'])
 
-        if attr in repr_attr_names:
-            raise AttributeError(
-                'Cannot set any frame attribute {0}'.format(attr))
-        else:
-            super().__setattr__(attr, value)
+                if attr in repr_attr_names:
+                    raise AttributeError(
+                        'Cannot set any frame attribute {0}'.format(attr))
+
+        super().__setattr__(attr, value)
 
     def separation(self, other):
         """


### PR DESCRIPTION
Add one line and get a speed-up of more than a factor 3 in slicing; not bad!

But is also shows the risk inherent in overriding `__getattr__` and `__setattr__`. Here, just to protect the user from accidentally writing an attribute with the same name as that of a representation coordinate, we slowed down things considerably.

And of course this is partially why I'm hesitant to try to paper over simple mistakes such as this by caching yet more stuff (though caching the representation names set seems an obvious next fix).

```
import astropy.units as u
from astropy.coordinates import ICRS
c = ICRS(np.arange(30.)*u.deg, np.arange(30.)*u.deg)
%timeit c[1:2]
# with current master 1000 loops, best of 3: 579 µs per loop
# with this PR: 10000 loops, best of 3: 185 µs per loop
```

