### PR TITLE
Skycoord baseframe method speedup

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,6 +236,11 @@ astropy.coordinates
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
 
+- Slicing and reshaping of ``SkyCoord`` and coordinate frames no longer passes
+  the new object through ``__init__``, but directly sets atttributes on a new
+  instance. This speeds up those methods by an order of magnitude, but means
+  that any customization done in ``__init__`` is by-passed. [#6941]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -636,8 +636,24 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     representation_component_units = property(get_representation_component_units)
 
     def _replicate(self, data, copy=False, **kwargs):
-        # This is to provide a slightly nicer error message if the user tries to
-        # use frame_obj.representation instead of frame_obj.data to get the
+        """Base for replicating a frame, with possibly different attributes.
+
+        Produces a new instance of the frame using the attributes of the old
+        frame (unless overridden) and with the data given.
+
+        Parameters
+        ----------
+        data : `~astropy.coordinates.BaseRepresentation` or `None`
+            Data to use in the new frame instance.  If `None`, it will be
+            a data-less frame.
+        copy : bool, optional
+            Whether data and the attributes on the old frame should be copied
+            (default), or passed on by reference.
+        **kwargs
+            Any attributes that should be overridden.
+        """
+        # This is to provide a slightly nicer error message if the user tries
+        # to use frame_obj.representation instead of frame_obj.data to get the
         # underlying representation object [e.g., #2890]
         if inspect.isclass(data):
             raise TypeError('Class passed as data instead of a representation '

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -267,8 +267,11 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         else:
             apply_method = operator.methodcaller(method, *args, **kwargs)
 
-        return self.__class__(*[apply_method(getattr(self, component))
-                                for component in self.components], copy=False)
+        new = super().__new__(self.__class__)
+        for component in self.components:
+            setattr(new, '_' + component,
+                    apply_method(getattr(self, component)))
+        return new
 
     @property
     def shape(self):


### PR DESCRIPTION
This builds on #5598 and #6940 to speed up item access in `SkyCoord` by a factor of almost 50. The main change is for `_apply` to create a new instance itself, and fill it as appropriate, i.e., to avoid the extremely long and slow parsing and error checking in the `__init__` methods of `BaseRepresentation`, `BaseFrame`, and `SkyCoordinate`. To me, this is a rather striking lesson in the dangers of trying to be overly generous in what to accept; this would not have been a problem if the various ways of initialization all had their own class methods.

What I am still very unsure about, however, is whether the current approach, of just doing `__new__` in `_apply` and fill the object, is the best one. It does mean that if people do something important in `__init__` in a subclass, that now gets skipped. Indeed, you'll see I already have to copy over some cached information from `self`... Furthermore, I had to make `BaseFrame.realize_frame` go through a new `_replicate` method to ensure I wouldn't get hit by a regression test for SunPy that changes the default representation in `__init__`; #6236.  While this is much cleaner, it does make one wonder about other possible regressions.

As an alternative to just replicating the actual stuff `__init__` does, one could imagine passing on an argument to `__init__` that states all arguments are OK and default (say, `copy=None`) or perhaps making a new class method `from_vetted_data` or so.  Suggestions most welcome!

EDIT: I do think this can and arguably should be done by rewriting `__init__` such that it is fast for simple & correct data. In a way, this PR should be seen as showing what is possible, not necessarily as what I would like merged. But we definitely should not merge *any* speed-ups that work by caching before we actually have gone over these classes properly and removed the obvious bottlenecks.

```
c = SkyCoord(np.arange(30.)*u.deg, np.arange(30.)*u.deg)
%timeit c[1:2]
# 2.0.2: 100 loops, best of 3: 2.94 ms per loop
# this PR: 10000 loops, best of 3: 59.1 µs per loop
```