### PR TITLE
Enable velocities in SkyCoord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,9 @@ astropy.coordinates
   a ``CartesianDifferential``, the 2D proper motion as a ``Quantity``, and the
   radial or line-of-sight velocity as a ``Quantity``. [#6869]
 
+- SkyCoord objects now support storing and tranforming differentials - i.e.,
+  both radial velocities and proper motions. [#6944]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -301,6 +304,10 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- Frame objects now use the default differential even if the representation is
+  explicitly provided as long as the representation provided is the same type as
+  the default representation. [#6944]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -66,7 +66,7 @@ def _get_diff_cls(value):
     Return a valid differential class from ``value`` or raise exception.
 
     As originally created, this is only used in the SkyCoord initializer, so if
-    that is refactored, this function my no longer be necessary. 
+    that is refactored, this function my no longer be necessary.
     """
 
     if value in r.DIFFERENTIAL_CLASSES:
@@ -302,7 +302,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 differential_cls = {'s': differential_cls}
 
             elif differential_cls is None:
-                differential_cls = {'s': 'base'} # see set_representation_cls()
+                if representation == self.default_representation:
+                    differential_cls = {'s': self.default_differential}
+                else:
+                    differential_cls = {'s': 'base'}  # see set_representation_cls()
 
             self.set_representation_cls(representation, **differential_cls)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -61,6 +61,24 @@ def _get_repr_cls(value):
     return value
 
 
+def _get_diff_cls(value):
+    """
+    Return a valid differential class from ``value`` or raise exception.
+
+    As originally created, this is only used in the SkyCoord initializer, so if
+    that is refactored, this function my no longer be necessary. 
+    """
+
+    if value in r.DIFFERENTIAL_CLASSES:
+        value = r.DIFFERENTIAL_CLASSES[value]
+    elif (not isinstance(value, type) or
+          not issubclass(value, r.BaseDifferential)):
+        raise ValueError(
+            'Differential is {0!r} but must be a BaseDifferential class '
+            'or one of the string aliases {1}'.format(
+                value, list(r.DIFFERENTIAL_CLASSES)))
+    return value
+
 def _get_repr_classes(base, **differentials):
     """Get valid representation and differential classes.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -198,8 +198,8 @@ class SkyCoord(ShapedLikeNDArray):
             Cartesian coordinates values for the Galactic frame.
         radial_velocity : `~astropy.units.Quantity`, optional
             The component of the velocity along the line-of-sight (i.e., the
-            radial direction). Should have velocity units.
-        pm_dec, pm_ra_cosdec : `~astropy.units.Quantity`, optional
+            radial direction), in velocity units.
+        pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity`, optional
             Proper motion components, in angle per time units.
     """
 
@@ -1648,13 +1648,13 @@ def _get_frame(args, kwargs):
                                  "new frame='{1}'.  Instead transform the coordinate."
                                  .format(coord_frame_cls.__name__, frame_cls.__name__))
 
-    frameclskwargs = {}
+    frame_cls_kwargs = {}
     if 'representation' in kwargs:
-        frameclskwargs['representation'] = _get_repr_cls(kwargs['representation'])
+        frame_cls_kwargs['representation'] = _get_repr_cls(kwargs['representation'])
     if 'differential_cls' in kwargs:
-        frameclskwargs['differential_cls'] = _get_diff_cls(kwargs['differential_cls'])
+        frame_cls_kwargs['differential_cls'] = _get_diff_cls(kwargs['differential_cls'])
 
-    return frame_cls(**frameclskwargs)
+    return frame_cls(**frame_cls_kwargs)
 
 
 def _get_representation_component_units(args, kwargs):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1747,7 +1747,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             del frame_attr_names[nameidx]
             del repr_attr_classes[nameidx]
 
-        if coords.data.differentials:
+        if coords.data.differentials and 's' in coords.data.differentials:
             orig_vel = coords.data.differentials['s']
             vel = coords.data.represent_as(frame.representation, frame.get_representation_cls('s')).differentials['s']
             for frname, reprname in frame.get_representation_component_names('s').items():
@@ -1768,7 +1768,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 valid_kwargs[attr] = value
 
     elif isinstance(coords, BaseRepresentation):
-        if coords.differentials:
+        if coords.differentials and 's' in coords.differentials:
             diffs = frame.get_representation_cls('s')
             data = coords.represent_as(frame.representation, diffs)
             values = [getattr(data, repr_attr_name) for repr_attr_name in repr_attr_names]

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1193,7 +1193,12 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .funcs import get_constellation
 
-        return get_constellation(self, short_name, constellation_list)
+        # drop the velocities - not needed for a pure-position application
+        extra_frameattrs = {nm: getattr(self, nm)
+                            for nm in self._extra_frameattr_names}
+        novel = SkyCoord(self.realize_frame(self.data.without_differentials()),
+                         **extra_frameattrs)
+        return get_constellation(novel, short_name, constellation_list)
 
     # WCS pixel to/from sky conversions
     def to_pixel(self, wcs, origin=0, mode='all'):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -146,6 +146,13 @@ class SkyCoord(ShapedLikeNDArray):
 
       >>> c = SkyCoord([ICRS(ra=1*u.deg, dec=2*u.deg), ICRS(ra=3*u.deg, dec=4*u.deg)])
 
+    Velocity components (proper motions or radial velocities) can also be
+    provided in a similar manner::
+
+      >>> c = SkyCoord(ra=1*u.deg, dec=2*u.deg, radial_velocity=10*u.km/u.s)
+
+      >>> c = SkyCoord(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=2*u.mas/u.yr, pm_dec=1*u.mas/u.yr)
+
     As shown, the frame can be a `~astropy.coordinates.BaseCoordinateFrame`
     class or the corresponding string alias.  The frame classes that are built in
     to astropy are `ICRS`, `FK5`, `FK4`, `FK4NoETerms`, and `Galactic`.
@@ -189,6 +196,11 @@ class SkyCoord(ShapedLikeNDArray):
             Cartesian coordinates values
         u, v, w : float or `~astropy.units.Quantity`, optional
             Cartesian coordinates values for the Galactic frame.
+        radial_velocity : `~astropy.units.Quantity`, optional
+            The component of the velocity along the line-of-sight (i.e., the
+            radial direction). Should have velocity units.
+       pm_dec, pm_ra_cosdec : `~astropy.units.Quantity`, optional
+            Proper motion components, in angle per time units.
     """
 
     # Declare that SkyCoord can be used as a Table column by defining the

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -199,7 +199,7 @@ class SkyCoord(ShapedLikeNDArray):
         radial_velocity : `~astropy.units.Quantity`, optional
             The component of the velocity along the line-of-sight (i.e., the
             radial direction). Should have velocity units.
-       pm_dec, pm_ra_cosdec : `~astropy.units.Quantity`, optional
+        pm_dec, pm_ra_cosdec : `~astropy.units.Quantity`, optional
             Proper motion components, in angle per time units.
     """
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1735,8 +1735,6 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 repr_attr_names.append(reprname)
                 repr_attr_classes.append(vel.attr_classes[reprname])
 
-
-
         for attr in frame_transform_graph.frame_attributes:
             value = getattr(coords, attr, None)
             use_value = (isinstance(coords, SkyCoord)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1745,8 +1745,20 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 valid_kwargs[attr] = value
 
     elif isinstance(coords, BaseRepresentation):
-        data = coords.represent_as(frame.representation)
-        values = [getattr(data, repr_attr_name) for repr_attr_name in repr_attr_names]
+        if coords.differentials:
+            diffs = frame.get_representation_cls('s')
+            data = coords.represent_as(frame.representation, diffs)
+            values = [getattr(data, repr_attr_name) for repr_attr_name in repr_attr_names]
+            for frname, reprname in frame.get_representation_component_names('s').items():
+                values.append(getattr(data.differentials['s'], reprname))
+                units.append(None)
+                frame_attr_names.append(frname)
+                repr_attr_names.append(reprname)
+                repr_attr_classes.append(data.differentials['s'].attr_classes[reprname])
+
+        else:
+            data = coords.represent_as(frame.representation)
+            values = [getattr(data, repr_attr_name) for repr_attr_name in repr_attr_names]
 
     elif (isinstance(coords, np.ndarray) and coords.dtype.kind in 'if'
           and coords.ndim == 2 and coords.shape[1] <= 3):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -188,10 +188,15 @@ class SkyCoord(ShapedLikeNDArray):
             RA and Dec for frames where ``ra`` and ``dec`` are keys in the
             frame's ``representation_component_names``, including `ICRS`,
             `FK5`, `FK4`, and `FK4NoETerms`.
+        pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity`, optional
+            Proper motion components, in angle per time units.
         l, b : valid `~astropy.coordinates.Angle` initializer, optional
             Galactic ``l`` and ``b`` for for frames where ``l`` and ``b`` are
             keys in the frame's ``representation_component_names``, including
             the `Galactic` frame.
+        pm_l_cosb, pm_b : `~astropy.units.Quantity`, optional
+            Proper motion components in the `Galactic` frame, in angle per time
+            units.
         x, y, z : float or `~astropy.units.Quantity`, optional
             Cartesian coordinates values
         u, v, w : float or `~astropy.units.Quantity`, optional
@@ -199,8 +204,6 @@ class SkyCoord(ShapedLikeNDArray):
         radial_velocity : `~astropy.units.Quantity`, optional
             The component of the velocity along the line-of-sight (i.e., the
             radial direction), in velocity units.
-        pm_ra_cosdec, pm_dec  : `~astropy.units.Quantity`, optional
-            Proper motion components, in angle per time units.
     """
 
     # Declare that SkyCoord can be used as a Table column by defining the

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1208,12 +1208,17 @@ class SkyCoord(ShapedLikeNDArray):
         """
         from .funcs import get_constellation
 
-        # drop the velocities - not needed for a pure-position application
+        # because of issue #7028, the conversion to a PrecessedGeocentric
+        # system fails in some cases.  Work around is to  drop the velocities.
+        # they are not needed here since only position infromation is used
         extra_frameattrs = {nm: getattr(self, nm)
                             for nm in self._extra_frameattr_names}
         novel = SkyCoord(self.realize_frame(self.data.without_differentials()),
                          **extra_frameattrs)
         return get_constellation(novel, short_name, constellation_list)
+
+        # the simpler version below can be used when gh-issue #7028 is resolved
+        #return get_constellation(self, short_name, constellation_list)
 
     # WCS pixel to/from sky conversions
     def to_pixel(self, wcs, origin=0, mode='all'):

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -117,11 +117,14 @@ def test_separation(sc, sc2):
     sc.separation(sc2)
 
 
-def test_accesors(sc, scmany):
+def test_accessors(sc, scmany):
     sc.data.differentials['s']
     sc.spherical
     sc.galactic
+
     scmany[0]
+    scmany.spherical
+    scmany.galactic
 
 
 def test_transforms(sc):

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -108,7 +108,7 @@ def sc2():
                 pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
 @pytest.fixture(scope="module")
 def scmany():
-  return SkyCoord(ICRS(ra=[1]*100*u.deg, dec=[2]*100*u.deg,
+    return SkyCoord(ICRS(ra=[1]*100*u.deg, dec=[2]*100*u.deg,
                      pm_ra_cosdec=np.random.randn(100)*u.mas/u.yr,
                      pm_dec=np.random.randn(100)*u.mas/u.yr,))
 

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+Tests for putting velocity differentials into SkyCoord objects.
+"""
+
+import pytest
+
+import numpy as np
+
+from ... import units as u
+from ...tests.helper import assert_quantity_allclose
+from .. import (SkyCoord, ICRS, SphericalRepresentation, SphericalDifferential,
+                SphericalCosLatDifferential, Galactic, PrecessedGeocentric)
+
+
+def test_creation_frameobjs():
+    i = ICRS(1*u.deg, 2*u.deg, pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr)
+    sc = SkyCoord(i)
+
+    for attrnm in ['ra', 'dec', 'pm_ra_cosdec', 'pm_dec']:
+        assert_quantity_allclose(getattr(i, attrnm), getattr(sc, attrnm))
+
+    sc_nod = SkyCoord(ICRS(1*u.deg, 2*u.deg))
+
+    for attrnm in ['ra', 'dec']:
+        assert_quantity_allclose(getattr(sc, attrnm), getattr(sc_nod, attrnm))
+
+
+def test_creation_attrs():
+    sc1 = SkyCoord(1*u.deg, 2*u.deg,
+                   pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
+                   frame='fk5')
+    assert_quantity_allclose(sc1.ra, 1*u.deg)
+    assert_quantity_allclose(sc1.dec, 2*u.deg)
+    assert_quantity_allclose(sc1.pm_ra_cosdec, .2*u.arcsec/u.kyr)
+    assert_quantity_allclose(sc1.pm_dec, .1*u.arcsec/u.kyr)
+
+    sc2 = SkyCoord(1*u.deg, 2*u.deg,
+                   pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
+                   differential_cls=SphericalDifferential)
+    assert_quantity_allclose(sc2.ra, 1*u.deg)
+    assert_quantity_allclose(sc2.dec, 2*u.deg)
+    assert_quantity_allclose(sc2.pm_ra, .2*u.arcsec/u.kyr)
+    assert_quantity_allclose(sc2.pm_dec, .1*u.arcsec/u.kyr)
+
+    sc3 = SkyCoord('1:2:3 4:5:6',
+                   pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
+                   unit=(u.hour, u.deg))
+
+    assert_quantity_allclose(sc3.ra, 1*u.hourangle + 2*u.arcmin*15 + 3*u.arcsec*15)
+    assert_quantity_allclose(sc3.dec, 4*u.deg + 5*u.arcmin + 6*u.arcsec)
+    # might as well check with sillier units?
+    assert_quantity_allclose(sc3.pm_ra_cosdec, 1.2776637006616473e-07 * u.arcmin / u.fortnight)
+    assert_quantity_allclose(sc3.pm_dec, 6.388318503308237e-08 * u.arcmin / u.fortnight)
+
+@pytest.mark.xfail  #TODO: FIX
+def test_creation_copy():
+    i = ICRS(1*u.deg, 2*u.deg, pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr)
+    sc = SkyCoord(i)
+    sc_cpy = SkyCoord(sc)
+
+    for attrnm in ['ra', 'dec', 'pm_ra_cosdec', 'pm_dec']:
+        assert_quantity_allclose(getattr(sc, attrnm), getattr(sc_cpy, attrnm))
+
+    sc2 = SkyCoord(1*u.deg, 2*u.deg,
+                   pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
+                   differential_cls=SphericalDifferential)
+
+    sc2_cpy = SkyCoord(sc2)
+    for attrnm in ['ra', 'dec', 'pm_ra', 'pm_dec']:
+        assert_quantity_allclose(getattr(sc2, attrnm), getattr(sc2_cpy, attrnm))
+
+    sc2_newdiff = SkyCoord(sc2, differential_cls=SphericalCosLatDifferential)
+    reprepr = sc2.represent_as(SphericalRepresentation, SphericalCosLatDifferential)
+    assert_quantity_allclose(sc2_newdiff.pm_ra_cosdec, reprepr.d_lon_coslat)
+
+
+@pytest.mark.xfail  #TODO: FIX
+def test_useful_error_missing():
+    sc_nod = SkyCoord(ICRS(1*u.deg, 2*u.deg))
+    try:
+        sc_nod.l
+    except AttributeError as e:
+        # this is double-checking the *normal* behavior
+        msg_l = e.args[0]
+
+    try:
+        sc_nod.pm_dec
+    except AttributeError as e:
+        msg_pm_dec = e.args[0]
+
+    assert "has no attribute" in msg_l
+    assert "has no attribute" in msg_pm_dec
+
+
+# ----------------------Operations on SkyCoords w/ velocities-------------------
+
+# define some fixtires to get baseline coordinates to try operations with
+@pytest.fixture(scope="module")
+def sc():
+    return SkyCoord(1*u.deg, 2*u.deg,
+                  pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
+@pytest.fixture(scope="module")
+def sc2():
+    return SkyCoord(1*u.deg, 2*u.deg,
+                pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
+@pytest.fixture(scope="module")
+def scmany():
+  return SkyCoord(ICRS(ra=[1]*100*u.deg, dec=[2]*100*u.deg,
+                     pm_ra_cosdec=np.random.randn(100)*u.mas/u.yr,
+                     pm_dec=np.random.randn(100)*u.mas/u.yr,))
+
+
+def test_separation(sc, sc2):
+    sc.separation(sc2)
+
+
+def test_accesors(sc, scmany):
+    sc.data.differentials['s']
+    sc.spherical
+    sc.galactic
+    scmany[0]
+
+
+def test_transforms(sc):
+    trans = sc.transform_to('galactic')
+    assert isinstance(trans.frame, Galactic)
+
+
+def test_matching(sc, scmany):
+    # just check that it works and yields something
+    idx, d2d, d3d = sc.match_to_catalog_sky(scmany)
+
+
+def test_position_angle(sc, sc2):
+    sc.position_angle(sc2)
+
+
+@pytest.mark.xfail  #TODO: FIX
+def test_constellations(sc):
+    const = sc.get_constellation()
+    assert const == 'Pisces'
+
+
+@pytest.mark.xfail  #TODO: FIX
+def test_skyoffset_frame(sc):
+    sc.skyoffset_frame()

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -150,13 +150,18 @@ def test_separation(sc, sc2):
 
 def test_accessors(sc, scmany):
     sc.data.differentials['s']
-    sc.spherical
-    sc.galactic
+    sph = sc.spherical
+    gal = sc.galactic
+
+    assert isinstance(sph, SphericalRepresentation)
+    assert gal.data.differentials is not None
 
     scmany[0]
-    scmany.spherical
-    scmany.galactic
+    sph = scmany.spherical
+    gal = scmany.galactic
 
+    assert isinstance(sph, SphericalRepresentation)
+    assert gal.data.differentials is not None
 
 def test_transforms(sc):
     trans = sc.transform_to('galactic')

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -153,6 +153,11 @@ def test_accessors(sc, scmany):
     sph = sc.spherical
     gal = sc.galactic
 
+    if (sc.data.get_name().startswith('unit') and not
+        sc.data.differentials['s'].get_name().startswith('unit')):
+        pytest.xfail('.velocity fails if there is an RV but not distance')
+    sc.velocity
+
     assert isinstance(sph, SphericalRepresentation)
     assert gal.data.differentials is not None
 

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -82,7 +82,8 @@ def test_creation_copy_rediff():
 
     sc_newdiff = SkyCoord(sc, differential_cls=SphericalCosLatDifferential)
     reprepr = sc.represent_as(SphericalRepresentation, SphericalCosLatDifferential)
-    assert_quantity_allclose(sc_newdiff.pm_ra_cosdec, reprepr.d_lon_coslat)
+    assert_quantity_allclose(sc_newdiff.pm_ra_cosdec,
+                             reprepr.differentials['s'].d_lon_coslat)
 
 
 def test_creation_cartesian():

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -62,7 +62,7 @@ def test_creation_attrs():
     assert_quantity_allclose(sc3.pm_dec, 6.388318503308237e-08 * u.arcmin / u.fortnight)
 
 
-def test_creation_copy():
+def test_creation_copy_basic():
     i = ICRS(1*u.deg, 2*u.deg, pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr)
     sc = SkyCoord(i)
     sc_cpy = SkyCoord(sc)
@@ -70,17 +70,19 @@ def test_creation_copy():
     for attrnm in ['ra', 'dec', 'pm_ra_cosdec', 'pm_dec']:
         assert_quantity_allclose(getattr(sc, attrnm), getattr(sc_cpy, attrnm))
 
-    sc2 = SkyCoord(1*u.deg, 2*u.deg,
-                   pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
-                   differential_cls=SphericalDifferential)
 
-    sc2_cpy = SkyCoord(sc2)
+def test_creation_copy_rediff():
+    sc = SkyCoord(1*u.deg, 2*u.deg,
+                  pm_ra=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr,
+                  differential_cls=SphericalDifferential)
+
+    sc_cpy = SkyCoord(sc)
     for attrnm in ['ra', 'dec', 'pm_ra', 'pm_dec']:
-        assert_quantity_allclose(getattr(sc2, attrnm), getattr(sc2_cpy, attrnm))
+        assert_quantity_allclose(getattr(sc, attrnm), getattr(sc_cpy, attrnm))
 
-    sc2_newdiff = SkyCoord(sc2, differential_cls=SphericalCosLatDifferential)
-    reprepr = sc2.represent_as(SphericalRepresentation, SphericalCosLatDifferential)
-    assert_quantity_allclose(sc2_newdiff.pm_ra_cosdec, reprepr.d_lon_coslat)
+    sc_newdiff = SkyCoord(sc, differential_cls=SphericalCosLatDifferential)
+    reprepr = sc.represent_as(SphericalRepresentation, SphericalCosLatDifferential)
+    assert_quantity_allclose(sc_newdiff.pm_ra_cosdec, reprepr.d_lon_coslat)
 
 
 def test_creation_cartesian():

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -133,19 +133,19 @@ def sc(request):
     return SkyCoord(*args, **kwargs)
 
 @pytest.fixture(scope="module")
-def sc2():
-    return SkyCoord(1*u.deg, 2*u.deg,
-                pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
-
-@pytest.fixture(scope="module")
 def scmany():
     return SkyCoord(ICRS(ra=[1]*100*u.deg, dec=[2]*100*u.deg,
                      pm_ra_cosdec=np.random.randn(100)*u.mas/u.yr,
                      pm_dec=np.random.randn(100)*u.mas/u.yr,))
 
+@pytest.fixture(scope="module")
+def sc_for_sep():
+    return SkyCoord(1*u.deg, 2*u.deg,
+                    pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
 
-def test_separation(sc, sc2):
-    sc.separation(sc2)
+
+def test_separation(sc, sc_for_sep):
+    sc.separation(sc_for_sep)
 
 
 def test_accessors(sc, scmany):
@@ -155,6 +155,7 @@ def test_accessors(sc, scmany):
 
     if (sc.data.get_name().startswith('unit') and not
         sc.data.differentials['s'].get_name().startswith('unit')):
+        # this xfail can be eliminated when issue #7028 is resolved
         pytest.xfail('.velocity fails if there is an RV but not distance')
     sc.velocity
 
@@ -187,8 +188,8 @@ def test_matching(sc, scmany):
     idx, d2d, d3d = sc.match_to_catalog_sky(scmany)
 
 
-def test_position_angle(sc, sc2):
-    sc.position_angle(sc2)
+def test_position_angle(sc, sc_for_sep):
+    sc.position_angle(sc_for_sep)
 
 
 def test_constellations(sc):

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -96,7 +96,6 @@ def test_creation_cartesian():
     assert_quantity_allclose(c.pm_ra_cosdec, sdif.d_lon_coslat)
 
 
-@pytest.mark.xfail  #TODO: FIX
 def test_useful_error_missing():
     sc_nod = SkyCoord(ICRS(1*u.deg, 2*u.deg))
     try:
@@ -107,11 +106,11 @@ def test_useful_error_missing():
 
     try:
         sc_nod.pm_dec
-    except AttributeError as e:
+    except Exception as e:
         msg_pm_dec = e.args[0]
 
     assert "has no attribute" in msg_l
-    assert "has no attribute" in msg_pm_dec
+    assert "has no associated differentials" in msg_pm_dec
 
 
 # ----------------------Operations on SkyCoords w/ velocities-------------------

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -163,6 +163,14 @@ def test_transforms(sc):
     assert isinstance(trans.frame, Galactic)
 
 
+@pytest.mark.xfail
+def test_transforms_diff(sc):
+    # note that arguably this *should* fail for the no-distance cases: 3D
+    # information is necessary to truly solve this, hence the xfail
+    trans = sc.transform_to(PrecessedGeocentric(equinox='B1975'))
+    assert isinstance(trans.frame, PrecessedGeocentric)
+
+
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching(sc, scmany):
     # just check that it works and yields something
@@ -173,12 +181,14 @@ def test_position_angle(sc, sc2):
     sc.position_angle(sc2)
 
 
-@pytest.mark.xfail  #TODO: FIX
 def test_constellations(sc):
     const = sc.get_constellation()
     assert const == 'Pisces'
 
 
-@pytest.mark.xfail  #TODO: FIX
+# at the time of this writing, sky offset frames don't support velocities
+# TODO: make them actually work
+@pytest.mark.xfail
 def test_skyoffset_frame(sc):
+
     sc.skyoffset_frame()

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -14,6 +14,11 @@ from ...tests.helper import assert_quantity_allclose
 from .. import (SkyCoord, ICRS, SphericalRepresentation, SphericalDifferential,
                 SphericalCosLatDifferential, Galactic, PrecessedGeocentric)
 
+try:
+    import scipy
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
 
 def test_creation_frameobjs():
     i = ICRS(1*u.deg, 2*u.deg, pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr)
@@ -132,6 +137,7 @@ def test_transforms(sc):
     assert isinstance(trans.frame, Galactic)
 
 
+@pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching(sc, scmany):
     # just check that it works and yields something
     idx, d2d, d3d = sc.match_to_catalog_sky(scmany)

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -291,10 +291,21 @@ high-level |skycoord| method - see :ref:`astropy-coordinates-rv-corrs`)::
 Velocities (Proper Motions and Radial Velocities)
 -------------------------------------------------
 
-New in Astropy v2.0, the :doc:`coordinate frame classes <frames>` can now store
-and transform velocities along with positional coordinate information. This
-is not available from the |skycoord| class as this new functionality is
-experimental, but is accessible  for more information see the :doc:`velocities` page.
+In addition to positional coordinates, `~astropy.coordinates` supports storing
+and transforming velocities.  These are available both via the lower-level
+:doc:`coordinate frame classes <frames>`, (new in v3.0) via  |skycoord|
+objects::
+
+    >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)
+    >>> sc  # doctest: +SKIP
+    <SkyCoord (ICRS): (ra, dec) in deg
+        ( 1.,  2.)
+     (radial_velocity) in km / s
+        ( 20.,)>
+
+.. the SKIP above in the ``sc`` line is because numpy has a subtly different output in versions < 12 - the trailing comma is missing.  If a NPY_LT_1_12 comes in to being this can switch to that.  But don't forget to *also* change this in the velocities.rst file
+
+For more details on velocity support (and limitations), see the :doc:`velocities` page.
 
 .. _astropy-coordinates-overview:
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -293,7 +293,7 @@ Velocities (Proper Motions and Radial Velocities)
 
 In addition to positional coordinates, `~astropy.coordinates` supports storing
 and transforming velocities.  These are available both via the lower-level
-:doc:`coordinate frame classes <frames>`, (new in v3.0) via  |skycoord|
+:doc:`coordinate frame classes <frames>`, and (new in v3.0) via  |skycoord|
 objects::
 
     >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -24,7 +24,7 @@ created as::
     >>> sc.radial_velocity  # doctest: +FLOAT_CMP
     <Quantity 20.0 km / s>
 
-.. the SKIP above in the ``sc`` line is because numpy has a subtly different output in versions < 12 - the trailing comma is missing.  If a NPY_LT_1_12 comes in to being this can switch to that
+.. the SKIP above in the ``sc`` line is because numpy has a subtly different output in versions < 12 - the trailing comma is missing.  If a NPY_LT_1_12 comes in to being this can switch to that.  But don't forget to *also* change this in the coordinates/index.rst file
 
 |skycoord| objects created in this manner follow all the same transformation
 rules, and will correctly update their velocities when transformed to other

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -9,7 +9,7 @@ Using velocities with ``SkyCoord``
 ==================================
 
 The easiest way of getting a coordinate object with velocities is to use the
-|skycoord| interface.  For example, a |skycoord| tp represent a star with a
+|skycoord| interface.  For example, a |skycoord| to represent a star with a
 measured radial velocity but unknown proper motion and distance could be
 created as::
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -5,19 +5,50 @@
 Working with velocities in Astropy coordinates
 **********************************************
 
-.. warning::
-    Velocities support, new in Astropy v2.0, is an experimental feature and is
-    subject to change based on user feedback.  While we do not expect major API
-    changes, the possibility exists based on the precedent of earlier changes
-    in the ``coordinates`` subpackage based on user feedback from previous
-    versions of Astropy.
+Using velocities with ``SkyCoord``
+==================================
+
+The easiest way of getting a coordinate object with velocities is to use the
+|skycoord| interface.  For example, a |skycoord| tp represent a star with a
+measured radial velocity but unknown proper motion and distance could be
+created as::
+
+    >>> from astropy.coordinates import SkyCoord
+    >>> import astropy.units as u
+    >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)
+    >>> sc  # doctest: +FLOAT_CMP
+    <SkyCoord (ICRS): (ra, dec) in deg
+        ( 1.,  2.)
+     (radial_velocity) in km / s
+        ( 20.,)>
+    >>> sc.radial_velocity  # doctest: +FLOAT_CMP
+    <Quantity 20.0 km / s>
+
+|skycoord| objects created in this manner follow all the same transformation
+rules, and will correctly update their velocities when transformed to other
+frames.  For example, to determine proper motions in Galactic coordinates for
+a star with proper motions measured in ICRS::
+
+    >>> sc = SkyCoord(1*u.deg, 2*u.deg, pm_ra_cosdec=.2*u.mas/u.yr, pm_dec=.1*u.mas/u.yr)
+    >>> sc.galactic  # doctest: +FLOAT_CMP
+    <SkyCoord (Galactic): (l, b) in deg
+      ( 99.63785528, -58.70969293)
+    (pm_l_cosb, pm_b) in mas / yr
+      ( 0.22240398,  0.02316181)>
+
+For more details on valid operations and limitations of velocity support in
+`astropy.coordinates` (particularly the :ref:`current accuracy limitations
+<astropy-coordinate-finite-difference-velocities>` ), see the more detailed
+discussions below of velocity support in the lower-level frame objects.  All
+these same rules apply for |skycoord| objects, as they are built directly on top
+of the frame classes' velocity functionality detailed here.
 
 .. _astropy-coordinate-custom-frame-with-velocities:
 
 Creating frame objects with velocity data
 =========================================
 
-The coordinate frame classes now support storing and transforming velocity data
+The coordinate frame classes support storing and transforming velocity data
 (along side the positional coordinate data). Similar to the positional data ---
 that use the ``Representation`` classes to abstract away the particular
 representation and allow re-representing from, e.g., Cartesian to Spherical
@@ -36,7 +67,6 @@ term. For example, the proper motion components for the ``ICRS`` frame are
 (``pm_ra_cosdec``, ``pm_dec``)::
 
     >>> from astropy.coordinates import ICRS
-    >>> import astropy.units as u
     >>> ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
     ...      pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr)  # doctest: +FLOAT_CMP
     <ICRS Coordinate: (ra, dec) in deg
@@ -198,6 +228,8 @@ for example, `~astropy.coordinates.ICRS` to `~astropy.coordinates.LSR`::
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
         (-24.51315607, -2.67935501, 27.07339176)>
 
+.. _astropy-coordinate-finite-difference-velocities:
+
 Finite Difference Transformations
 ---------------------------------
 
@@ -299,15 +331,6 @@ a particular direction changes dramatically over the course of one year).
 
 Future versions of Astropy will improve on this algorithm to make the results
 more numerically stable and practical for use in these (not unusual) use cases.
-
-
-``SkyCoord`` support for Velocities
-===================================
-
-|skycoord| currently does *not* support velocities as of Astropy v2.0.  This is
-an intentional choice, allowing the "power-user" community to provide feedback
-on the API and functionality in the frame-level classes before it is adopted in
-|skycoord| (currently planned for the next Astropy version, v3.0).
 
 .. _astropy-coordinates-rv-corrs:
 

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -16,13 +16,15 @@ created as::
     >>> from astropy.coordinates import SkyCoord
     >>> import astropy.units as u
     >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)
-    >>> sc  # doctest: +FLOAT_CMP
+    >>> sc  # doctest: +SKIP
     <SkyCoord (ICRS): (ra, dec) in deg
         ( 1.,  2.)
      (radial_velocity) in km / s
         ( 20.,)>
     >>> sc.radial_velocity  # doctest: +FLOAT_CMP
     <Quantity 20.0 km / s>
+
+.. the SKIP above in the ``sc`` line is because numpy has a subtly different output in versions < 12 - the trailing comma is missing.  If a NPY_LT_1_12 comes in to being this can switch to that
 
 |skycoord| objects created in this manner follow all the same transformation
 rules, and will correctly update their velocities when transformed to other


### PR DESCRIPTION
This PR fixes #6559 and thereby achieves the goal planned from  v2.0 of adding the proper motion and radial velocity support in `coordinates` that was added in v2.0 to work with `SkyCoord` objects.  Basically it all works the way you'd expect following the already established paradigm that the "real work" is done in the frame classes and `SkyCoord` provides a veneer to make it easier to create these objects.  So with that in mind I've also removed the warning at the top of the velocities docs that say "this is experimental".  I think that's fair because once it's in `SkyCoord` it's basically "ready for prime time".

For now (and arguably *for ever*), there's no clever parsing done on the velocity components.  Unlike the spatial components (e.g. ra/dec), there are no clear conventions for how to represent these.  So keywords are required. That simplified the documentation as it's basically all just referencing the frame class machinery for creation/etc syntax.

One tricky bit that was required to get this working: in v2.0 doing ``SomeFrame(representation=SphericalRepresentation,...)`` would make it so that the default differential was *ignored*, leading to some confusing behavior (e.g. you couldn't create frame objects using the default differential component names even if the representation matched the default representation).  The fix is straightforward (5cb4156), but @adrn may want to look at that to make sure that it doesn't violate the idea of that frame creation pathway as originally intended.

Thanks to @adrn and @mhvk for help and brainstorming on making this work.  One question for both of you: are there any important test cases you think I might be missing based on our discussion of all the possible creation scenarios?