### PR TITLE
Use weak references in modeling

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1569,7 +1569,6 @@ class Model(metaclass=_ModelMeta):
             self = self.__new__(self, *dummy_args)
         else:
             needs_initialization = False
-            self = self.copy()
 
         aliases = dict(zip(self.param_names, param_names))
         # This is basically an alternative _initialize_constraints
@@ -1593,7 +1592,6 @@ class Model(metaclass=_ModelMeta):
 
         if needs_initialization:
             self.__init__(*dummy_args)
-
         return self
 
     def _initialize_constraints(self, kwargs):
@@ -2377,7 +2375,7 @@ class _CompoundModelMeta(_ModelMeta):
             '__module__': str(modname)})
 
         new_cls = mcls(name, (_CompoundModel,), members)
-        print(new_cls[1].mean._model)
+
         if isinstance(left, Model) and isinstance(right, Model):
             # Both models used in the operator were already instantiated models,
             # not model *classes*.  As such it's not particularly useful to return
@@ -2385,7 +2383,6 @@ class _CompoundModelMeta(_ModelMeta):
             ### This is where the weeak reference dies.
             instance = new_cls()
 
-            print('instance', instance[1].mean._model)
             # Workaround for https://github.com/astropy/astropy/issues/3542
             # TODO: Any effort to restructure the tree-like data structure for
             # compound models should try to obviate this workaround--if
@@ -2491,7 +2488,6 @@ class _CompoundModelMeta(_ModelMeta):
         # type objects
         if cls._submodels is not None:
             return cls._submodels
-
         submodels = [c.value for c in cls._tree.traverse_postorder()
                      if c.isleaf]
         cls._submodels = submodels
@@ -2768,7 +2764,6 @@ class _CompoundModel(Model, metaclass=_CompoundModelMeta):
     def __getitem__(self, index):
         index = self.__class__._normalize_index(index)
         model = self.__class__[index]
-
         if isinstance(index, slice):
             param_names = model.param_names
         else:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2377,13 +2377,15 @@ class _CompoundModelMeta(_ModelMeta):
             '__module__': str(modname)})
 
         new_cls = mcls(name, (_CompoundModel,), members)
-
+        print(new_cls[1].mean._model)
         if isinstance(left, Model) and isinstance(right, Model):
             # Both models used in the operator were already instantiated models,
             # not model *classes*.  As such it's not particularly useful to return
             # the class itself, but to instead produce a new instance:
+            ### This is where the weeak reference dies.
             instance = new_cls()
 
+            print('instance', instance[1].mean._model)
             # Workaround for https://github.com/astropy/astropy/issues/3542
             # TODO: Any effort to restructure the tree-like data structure for
             # compound models should try to obviate this workaround--if

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -309,11 +309,11 @@ class Parameter(OrderedDescriptor):
     def __len__(self):
         if self._model is None:
             raise TypeError('Parameter definitions do not have a length.')
-        return len(self._model)
+        return len(self._model())
 
     def __getitem__(self, key):
         value = self.value
-        if len(self._model) == 1:
+        if len(self._model()) == 1:
             # Wrap the value in a list so that getitem can work for sensible
             # indices like [0] and [-1]
             value = [value]
@@ -323,7 +323,7 @@ class Parameter(OrderedDescriptor):
         # Get the existing value and check whether it even makes sense to
         # apply this index
         oldvalue = self.value
-        n_models = len(self._model)
+        n_models = len(self._model())
 
         # if n_models == 1:
         #    # Convert the single-dimension value to a list to allow some slices
@@ -701,7 +701,7 @@ class Parameter(OrderedDescriptor):
             # the name "validator"
             def validator(self, value):
                 if self._validator is not None:
-                    return self._validator(self._model, value)
+                    return self._validator(self._model(), value)
 
             return types.MethodType(validator, self)
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -347,7 +347,7 @@ class Parameter(OrderedDescriptor):
 
     def __repr__(self):
         args = "'{0}'".format(self._name)
-        if self._model is None:
+        if self._model is None or self._model() is None:
             if self._default is not None:
                 args += ', default={0}'.format(self._default)
         else:

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -720,23 +720,21 @@ class _ConstraintsTestB(Model):
         return mean
 
 
-@pytest.mark.parametrize('model',
-        [Gaussian1D(bounds={'stddev': (0, 0.3)}, fixed={'mean': True}) +
-            Gaussian1D(fixed={'mean': True}),
-         (_ConstraintsTestA + _ConstraintsTestB)()])
-def test_inherit_constraints(model):
+def test_inherit_constraints():
     """
     Various tests for copying of constraint values between compound models and
     their members.
 
-    There are two versions of this test: One where a compound model is created
+    Th eoriginal test had two versions: One where a compound model is created
     from two model instances, and another where a compound model is created
     from two model classes that have default constraints set on some of their
-    parameters.
+    parameters. The second version was removed in #6946 as it is not intended
+    to be supported any more.
 
     Regression test for https://github.com/astropy/astropy/issues/3481
     """
-
+    model = Gaussian1D(bounds={'stddev': (0, 0.3)}, fixed={'mean': True}) + \
+            Gaussian1D(fixed={'mean': True})
     # We have to copy the model before modifying it, otherwise the test fails
     # if it is run twice in a row, because the state of the model instance
     # would be preserved from one run to the next.


### PR DESCRIPTION
This is an attempt to make `Parameter._model` a weak reference with the goal to reduce memory usage. The circular references Model --> Parameter --> Model do not allow memory to be cleaned.
Implementing `Parameter._model` as a weakref helps and memory is now released. 

This PR stops support for inheriting constraints in compound models when the submodels are classes (not instances of models) and removes a test for this.