### PR TITLE
Use broadcast_to from compat for Numpy 1.9

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -628,7 +628,7 @@ class EarthLocation(u.Quantity):
         # Assume the observatory itself is fixed on the ground.
         # We do a direct assignment rather than an update to avoid validation
         # and creation of a new object.
-        zeros = np.broadcast_to(0. * u.km / u.s, (3,) + itrs.shape, subok=True)
+        zeros = broadcast_to(0. * u.km / u.s, (3,) + itrs.shape, subok=True)
         itrs.data.differentials['s'] = CartesianDifferential(zeros)
         return itrs.transform_to(GCRS(obstime=obstime))
 


### PR DESCRIPTION
`np.broadcast_to` is new in Numpy 1.10.

xref #6918