### PR TITLE
Ensure FITS_rec can be indexed with a tuple even if it returns a scalar.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -446,6 +446,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix a minor bug where ``FITS_rec`` instances can not be indexed with tuples
+  and other sequences that end up with a scalar. [#6955]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -484,40 +484,37 @@ class FITS_rec(np.recarray):
 
         if isinstance(key, str):
             return self.field(key)
-        elif isinstance(key, (slice, np.ndarray, tuple, list)):
-            # Have to view as a recarray then back as a FITS_rec, otherwise the
-            # circular reference fix/hack in FITS_rec.field() won't preserve
-            # the slice
-            subtype = type(self)
-            out = self.view(np.recarray).__getitem__(key).view(subtype)
-            out._coldefs = ColDefs(self._coldefs)
-            arrays = []
-            out._converted = {}
-            for idx, name in enumerate(self._coldefs.names):
-                #
-                # Store the new arrays for the _coldefs object
-                #
-                arrays.append(self._coldefs._arrays[idx][key])
 
-                # Ensure that the sliced FITS_rec will view the same scaled
-                # columns as the original; this is one of the few cases where
-                # it is not necessary to use _cache_field()
-                if name in self._converted:
-                    dummy = self._converted[name]
-                    field = np.ndarray.__getitem__(dummy, key)
-                    out._converted[name] = field
+        # Have to view as a recarray then back as a FITS_rec, otherwise the
+        # circular reference fix/hack in FITS_rec.field() won't preserve
+        # the slice.
+        out = self.view(np.recarray)[key]
+        if type(out) is np.record:
+            # Oops, we got a single element rather than a view. In that case,
+            # return a Record, which has no __getstate__ and is more efficient.
+            return self._record_type(self, key)
 
-            out._coldefs._arrays = arrays
-            return out
+        # We got a view; change it back to our class, and add stuff
+        out = out.view(type(self))
+        out._coldefs = ColDefs(self._coldefs)
+        arrays = []
+        out._converted = {}
+        for idx, name in enumerate(self._coldefs.names):
+            #
+            # Store the new arrays for the _coldefs object
+            #
+            arrays.append(self._coldefs._arrays[idx][key])
 
-        # if not a slice, do this because Record has no __getstate__.
-        # also more efficient.
-        else:
-            if isinstance(key, int) and key >= len(self):
-                raise IndexError("Index out of bounds")
+            # Ensure that the sliced FITS_rec will view the same scaled
+            # columns as the original; this is one of the few cases where
+            # it is not necessary to use _cache_field()
+            if name in self._converted:
+                dummy = self._converted[name]
+                field = np.ndarray.__getitem__(dummy, key)
+                out._converted[name] = field
 
-            newrecord = self._record_type(self, key)
-            return newrecord
+        out._coldefs._arrays = arrays
+        return out
 
     def __setitem__(self, key, value):
         if self._coldefs is None:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3062,3 +3062,15 @@ def test_table_to_hdu():
 
     assert hdu.header['FOO'] == 'bar'
     assert hdu.header['TEST'] == 1
+
+
+def test_regression_scalar_indexing():
+    # Indexing a FITS_rec with a tuple that returns a scalar record
+    # should work
+    x = np.array([(1.0, 2), (3.0, 4)],
+                 dtype=[('x', float), ('y', int)]).view(fits.FITS_rec)
+    x1a = x[1]
+    # this should succeed.
+    x1b = x[(1,)]
+    # FITS_record does not define __eq__; so test elements.
+    assert all(a == b for a, b in zip(x1a, x1b))


### PR DESCRIPTION
While investigating numpy-dev failures, I noticed one of them was caused by indexing a `FITS_rec` instance with a tuple of the form `(number,)`, i.e., one that just returns a scalar. This causes a failure (see below) because the `__getitem__` code assumes any tuple key will return a view on the original array (another example of why one should not LBYL but rather EAFP...). This fixes the problem, though scalar lookup will now become somewhat more expensive (probably, a real fix would be to deal with the reference issues that force one to go through the current hoops).

```
import numpy as np
from astropy.io.fits import FITS_rec
x = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', float), ('y', int)]).view(FITS_rec)
x[1,]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-aacf971fccce> in <module>()
      2 from astropy.io.fits import FITS_rec
      3 x = np.array([(1.0, 2), (3.0, 4)], dtype=[('x', float), ('y', int)]).view(FITS_rec)
----> 4 x[1,]

/usr/lib/python3/dist-packages/astropy/io/fits/fitsrec.py in __getitem__(self, key)
    490             subtype = type(self)
    491             out = self.view(np.recarray).__getitem__(key).view(subtype)
--> 492             out._coldefs = ColDefs(self._coldefs)
    493             arrays = []
    494             out._converted = {}

/usr/lib/python3/dist-packages/numpy/core/records.py in __setattr__(self, attr, val)
    265             else:
    266                 raise AttributeError("'record' object has no "
--> 267                         "attribute '%s'" % attr)
    268 
    269     def __getitem__(self, indx):

AttributeError: 'record' object has no attribute '_coldefs'
```