### PR TITLE
Fix behavior of scaled columns in binary table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -477,6 +477,8 @@ astropy.io.fits
 - When datafile is missing, fits.tabledump uses input file name to build
   output file name. Fixed how it gets input file name from HDUList. [#6976]
 
+- Fix in-place updates to scaled columns. [#6956]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -963,6 +963,10 @@ class FITS_rec(np.recarray):
                         field = test_overflow
                 else:
                     field += bzero
+
+            # mark the column as scaled
+            column._physical_values = True
+
         elif _bool and field.dtype != bool:
             field = np.equal(field, ord('T'))
         elif _str:

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -314,45 +314,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 if isinstance(data, self._data_type):
                     self.data = data
                 else:
-                    # Just doing a view on the input data screws up unsigned
-                    # columns, so treat those more carefully.
-                    # TODO: I need to read this code a little more closely
-                    # again, but I think it can be simplified quite a bit with
-                    # the use of some appropriate utility functions
-                    update_coldefs = {}
-                    if 'u' in [data.dtype[k].kind for k in data.dtype.names]:
-                        self._uint = True
-                        bzeros = {2: np.uint16(2**15), 4: np.uint32(2**31),
-                                  8: np.uint64(2**63)}
-
-                        new_dtype = [
-                            (k, data.dtype[k].kind.replace('u', 'i') +
-                            str(data.dtype[k].itemsize))
-                            for k in data.dtype.names]
-
-                        new_data = np.zeros(data.shape, dtype=new_dtype)
-
-                        for k in data.dtype.fields:
-                            dtype = data.dtype[k]
-                            if dtype.kind == 'u':
-                                new_data[k] = data[k] - bzeros[dtype.itemsize]
-                                update_coldefs[k] = bzeros[dtype.itemsize]
-                            else:
-                                new_data[k] = data[k]
-                        self.data = new_data.view(self._data_type)
-                        # Uck...
-                        self.data._uint = True
-                    else:
-                        self.data = data.view(self._data_type)
-                    for k in update_coldefs:
-                        indx = _get_index(self.data.names, k)
-                        self.data._coldefs[indx].bzero = update_coldefs[k]
-                        # This is so bad that we have to update this in
-                        # duplicate...
-                        self.data._coldefs.bzeros[indx] = update_coldefs[k]
-                        # More uck...
-                        self.data._coldefs[indx]._physical_values = False
-                        self.data._coldefs[indx]._pseudo_unsigned_ints = True
+                    self.data = self._data_type.from_columns(data)
 
                 # TODO: Too much of the code in this class uses header keywords
                 # in making calculations related to the data size.  This is

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2545,7 +2545,7 @@ class TestTableFunctions(FitsTestCase):
             assert np.all(hdu.data['A'] == data)
 
             # Test updating the unsigned int data
-            hdu.data['A'] = 99
+            hdu.data['A'][0] = 99
             hdu.writeto(self.temp('test2.fits'))
 
         with fits.open(self.temp('test2.fits'), uint=True) as hdul:


### PR DESCRIPTION
Fix #6887.

Once a column with a tscale or tzero keyword is scaled, it was not marked as such. So if the column was modified and then saved, the old (unscaled) values when saved instead.

It seems that all what was missing was to put the `_physical_values` flag to True. 

While looking at old issues I found #4709 which is very similar, so I included these 2 commits. Sadly it is not enough to fix  #3921 (I still do not understand everything there :roll_eyes: )

Note: There is no 2.0.4 section in the changelog yet, so I used 2.0.3 for now.