### PR TITLE
Change way slicing of recarray is done to help numpy 1.9

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -450,7 +450,7 @@ astropy.io.fits
 ^^^^^^^^^^^^^^^
 
 - Fix a minor bug where ``FITS_rec`` instances can not be indexed with tuples
-  and other sequences that end up with a scalar. [#6955]
+  and other sequences that end up with a scalar. [#6955, #6966]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -489,7 +489,7 @@ class FITS_rec(np.recarray):
         # circular reference fix/hack in FITS_rec.field() won't preserve
         # the slice.
         out = self.view(np.recarray)[key]
-        if type(out) is np.record:
+        if type(out) is not np.recarray:
             # Oops, we got a single element rather than a view. In that case,
             # return a Record, which has no __getstate__ and is more efficient.
             return self._record_type(self, key)


### PR DESCRIPTION
Tentative fix for numpy 1.9 for the 2.0.3 branch; probably somewhat more logical than my original anyway, so good to go in master too. I think this can be merged if tests on 2.0.3 pass with it.