### PR TITLE
Ensure that tests run even if IPython emits deprecation warnings.

### DIFF
--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -130,6 +130,7 @@ _modules_to_ignore_on_import = set([
     'scipy',
     'pygments',
     'ipykernel',
+    'IPython',   # deprecation warnings for async and await
     'setuptools'])
 _warnings_to_ignore_entire_module = set([])
 _warnings_to_ignore_by_pyver = {


### PR DESCRIPTION
EDIT: fixes #6965 