### PR TITLE
fits2bitmap updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -548,8 +548,11 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Fixed the vertical orientation of the output bitmap image to match that
-  of the FITS image. [#6844]
+- Fixed the vertical orientation of the ``fits2bitmap`` output bitmap
+  image to match that of the FITS image. [#6844, #6969]
+
+- Added a workaround for a bug in matplotlib so that the ``fits2bitmap``
+  script generates the correct output file type. [#6969]
 
 astropy.vo
 ^^^^^^^^^^

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
+
+from ..mpl_normalize import simple_norm
 from ... import log
 from ...io.fits import getdata
-from ..mpl_normalize import simple_norm
 
 
 def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
@@ -90,6 +91,10 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
             out_fn = os.path.splitext(out_fn)[0]
         out_fn += '.png'
 
+    # need to explicitly define the output format due to a bug in
+    # matplotlib (<= 2.1), otherwise the format will always be PNG
+    out_format = os.path.splitext(out_fn)[1][1:]
+
     if cmap not in cm.datad:
         log.critical('{0} is not a valid matplotlib colormap name.'
                      .format(cmap))
@@ -100,7 +105,8 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
                        min_percent=min_percent, max_percent=max_percent,
                        percent=percent)
 
-    mimg.imsave(out_fn, norm(image), cmap=cmap, origin='lower')
+    mimg.imsave(out_fn, norm(image), cmap=cmap, origin='lower',
+                format=out_format)
     log.info('Saved file to {0}.'.format(out_fn))
 
 

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import os
+from distutils.version import LooseVersion
 
 from ..mpl_normalize import simple_norm
 from ... import log
@@ -66,6 +67,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
         The matplotlib color map name.  The default is 'Greys_r'.
     """
 
+    import matplotlib
     import matplotlib.cm as cm
     import matplotlib.image as mimg
 
@@ -94,6 +96,12 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
     # need to explicitly define the output format due to a bug in
     # matplotlib (<= 2.1), otherwise the format will always be PNG
     out_format = os.path.splitext(out_fn)[1][1:]
+
+    # workaround for matplotlib 2.0.0 bug where png images are inverted
+    # (mpl-#7656)
+    if (out_format.lower() == 'png' and
+            LooseVersion(matplotlib.__version__) == LooseVersion('2.0.0')):
+        image = image[::-1]
 
     if cmap not in cm.datad:
         log.critical('{0} is not a valid matplotlib colormap name.'

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -61,11 +61,13 @@ class TestFits2Bitmap:
         """
 
         filename = tmpdir.join(self.filename).strpath
+        out_filename = 'fits2bitmap_test.png'
+        out_filename = tmpdir.join(out_filename).strpath
         data = np.zeros((32, 32))
         data[0:16, :] = 1.
         fits.writeto(filename, data)
-        main([filename, '-e', '0'])
+        main([filename, '-e', '0', '-o', out_filename])
 
-        img = mpimg.imread(filename.replace('.fits', '.png'))
-        assert img[0, 0, 0] == 0.
-        assert img[31, 31, 0] == 1.
+        img = mpimg.imread(out_filename)
+        assert img[0, 0, 0] == 0
+        assert img[31, 31, 0] == 1


### PR DESCRIPTION
This PR addresses #6960, which is due to a bug `matplotlib <= 2.0.0`.

The test failure reported in #6960 with `mpl 2.0.0` is due to a `mpl` bug where `imsave` was ignoring the `origin` option for PNG files (https://github.com/matplotlib/matplotlib/issues/7656).  This bug was fixed in `mpl 2.0.1`.  This PR merely fixes the **test** to use JPG instead of PNG files so that it passes with older versions of `mpl`.

When using `mpl <= 2.0.0` the output from the `fits2bitmap` script will continue to be (incorrectly) flipped for PNG output.  We can't really fix this without putting a bunch of `mpl` code in `extern`, which I don't want to do.

While investigating this issue, I also discovered another bug in `mpl` where `imsave` always uses the PNG output format if the `format` keyword is None.  I'm submitting a PR to `mpl` fix this bug.  This PR includes a workaround for that issue by explicitly setting the output file format (which is needed to fix the above test).