### PR TITLE
Add new uncertainty types to nddata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -298,6 +298,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Add two new uncertainty classes, ``astropy.nddata.VarianceUncertainty`` and
+  ``astropy.nddata.InverseVariance``. [#6971]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -120,7 +120,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
                         raise UnitConversionError(
                             'Cannot convert unit of uncertainty to unit of '
                             '{0} object.'.format(class_name))
-                    value.array *= scaling
+                    value.array = value.array * scaling
                 elif not self.unit and value._unit:
                     # Raise an error if uncertainty has unit and data does not
                     raise ValueError("Cannot assign an uncertainty with unit "

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -113,15 +113,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
         if value is not None:
             if isinstance(value, NDUncertainty):
                 class_name = self.__class__.__name__
-                if self.unit and value._unit:
-                    try:
-                        scaling = (1 * value._unit).to(self.unit)
-                    except UnitsError:
-                        raise UnitConversionError(
-                            'Cannot convert unit of uncertainty to unit of '
-                            '{0} object.'.format(class_name))
-                    value.array = value.array * scaling
-                elif not self.unit and value._unit:
+                if not self.unit and value._unit:
                     # Raise an error if uncertainty has unit and data does not
                     raise ValueError("Cannot assign an uncertainty with unit "
                                      "to {0} without "

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from ...nduncertainty import (StdDevUncertainty, VarianceUncertainty,
+                              InverseVariance,
                               UnknownUncertainty,
                               IncompatibleUncertaintiesException)
 from ... import NDDataRef
@@ -523,6 +524,93 @@ def test_arithmetics_varianceuncertainty_basic_with_correlation(
     ref_uncertainty_2 = (data2 / data1)**2 * ref_common
     assert_array_almost_equal(nd4.uncertainty.array, ref_uncertainty_2)
 
+
+# Tests for correlation, covering
+# correlation between -1 and 1 with correlation term being positive / negative
+# also with one data being once positive and once completely negative
+# The point of this test is to compare the used formula to the theoretical one.
+# TODO: Maybe covering units too but I think that should work because of
+# the next tests. Also this may be reduced somehow.
+@pytest.mark.parametrize(('cor', 'uncert1', 'data2'), [
+    (-1, [1, 1, 3], [2, 2, 7]),
+    (-0.5, [1, 1, 3], [2, 2, 7]),
+    (-0.25, [1, 1, 3], [2, 2, 7]),
+    (0, [1, 1, 3], [2, 2, 7]),
+    (0.25, [1, 1, 3], [2, 2, 7]),
+    (0.5, [1, 1, 3], [2, 2, 7]),
+    (1, [1, 1, 3], [2, 2, 7]),
+    (-1, [-1, -1, -3], [2, 2, 7]),
+    (-0.5, [-1, -1, -3], [2, 2, 7]),
+    (-0.25, [-1, -1, -3], [2, 2, 7]),
+    (0, [-1, -1, -3], [2, 2, 7]),
+    (0.25, [-1, -1, -3], [2, 2, 7]),
+    (0.5, [-1, -1, -3], [2, 2, 7]),
+    (1, [-1, -1, -3], [2, 2, 7]),
+    (-1, [1, 1, 3], [-2, -3, -2]),
+    (-0.5, [1, 1, 3], [-2, -3, -2]),
+    (-0.25, [1, 1, 3], [-2, -3, -2]),
+    (0, [1, 1, 3], [-2, -3, -2]),
+    (0.25, [1, 1, 3], [-2, -3, -2]),
+    (0.5, [1, 1, 3], [-2, -3, -2]),
+    (1, [1, 1, 3], [-2, -3, -2]),
+    (-1, [-1, -1, -3], [-2, -3, -2]),
+    (-0.5, [-1, -1, -3], [-2, -3, -2]),
+    (-0.25, [-1, -1, -3], [-2, -3, -2]),
+    (0, [-1, -1, -3], [-2, -3, -2]),
+    (0.25, [-1, -1, -3], [-2, -3, -2]),
+    (0.5, [-1, -1, -3], [-2, -3, -2]),
+    (1, [-1, -1, -3], [-2, -3, -2]),
+    ])
+def test_arithmetics_inversevarianceuncertainty_basic_with_correlation(
+        cor, uncert1, data2):
+    data1 = np.array([1, 2, 3])
+    data2 = np.array(data2)
+    uncert1 = 1 / np.array(uncert1)**2
+    uncert2 = 1 / np.array([2, 2, 2])**2
+    nd1 = NDDataArithmetic(data1, uncertainty=InverseVariance(uncert1))
+    nd2 = NDDataArithmetic(data2, uncertainty=InverseVariance(uncert2))
+    nd3 = nd1.add(nd2, uncertainty_correlation=cor)
+    nd4 = nd2.add(nd1, uncertainty_correlation=cor)
+    # Inverse operation should result in the same uncertainty
+    assert_array_equal(nd3.uncertainty.array, nd4.uncertainty.array)
+    # Compare it to the theoretical uncertainty
+    ref_uncertainty = 1/ (1 / uncert1 + 1 / uncert2 +
+                       2 * cor / np.sqrt(uncert1 * uncert2))
+    assert_array_equal(nd3.uncertainty.array, ref_uncertainty)
+
+    nd3 = nd1.subtract(nd2, uncertainty_correlation=cor)
+    nd4 = nd2.subtract(nd1, uncertainty_correlation=cor)
+    # Inverse operation should result in the same uncertainty
+    assert_array_equal(nd3.uncertainty.array, nd4.uncertainty.array)
+    # Compare it to the theoretical uncertainty
+    ref_uncertainty = 1 / (1 / uncert1 + 1 / uncert2 -
+                       2 * cor / np.sqrt(uncert1 * uncert2))
+    assert_array_equal(nd3.uncertainty.array, ref_uncertainty)
+
+    # Multiplication and Division only work with almost equal array comparisons
+    # since the formula implemented and the formula used as reference are
+    # slightly different.
+    nd3 = nd1.multiply(nd2, uncertainty_correlation=cor)
+    nd4 = nd2.multiply(nd1, uncertainty_correlation=cor)
+    # Inverse operation should result in the same uncertainty
+    assert_array_almost_equal(nd3.uncertainty.array, nd4.uncertainty.array)
+    # Compare it to the theoretical uncertainty
+    ref_uncertainty = 1 / ((data1 * data2)**2 * (
+        1 / uncert1 / data1**2 + 1 / uncert2 / data2**2 +
+        (2 * cor / np.sqrt(uncert1 * uncert2) / (data1 * data2))))
+    assert_array_almost_equal(nd3.uncertainty.array, ref_uncertainty)
+
+    nd3 = nd1.divide(nd2, uncertainty_correlation=cor)
+    nd4 = nd2.divide(nd1, uncertainty_correlation=cor)
+    # Inverse operation gives a different uncertainty because of the
+    # prefactor nd1/nd2 vs nd2/nd1. Howeveare, a large chunk is the same.
+    ref_common = (
+        1 / uncert1 / data1**2 + 1 / uncert2 / data2**2 -
+        (2 * cor / np.sqrt(uncert1 * uncert2) / (data1 * data2)))
+    # Compare it to the theoretical uncertainty
+    ref_uncertainty_1 = 1 / ((data1 / data2)**2 * ref_common)
+    assert_array_almost_equal(nd3.uncertainty.array, ref_uncertainty_1)
+    ref_uncertainty_2 = 1 / ((data2 / data1)**2 * ref_common)
     assert_array_almost_equal(nd4.uncertainty.array, ref_uncertainty_2)
 
 
@@ -820,6 +908,111 @@ def test_arithmetics_varianceuncertainty_with_units(uncert1, uncert2):
     assert nd3.unit == nd3_ref.unit
     assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
     assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+
+# Covering:
+# data with unit and uncertainty with unit (but equivalent units)
+# compared against correctly scaled NDDatas
+@pytest.mark.parametrize(('uncert1', 'uncert2'), [
+    (np.array([1, 2, 3]) * u.m, None),
+    (np.array([1, 2, 3]) * u.cm, None),
+    (None, np.array([1, 2, 3]) * u.m),
+    (None, np.array([1, 2, 3]) * u.cm),
+    (np.array([1, 2, 3]), np.array([2, 3, 4])),
+    (np.array([1, 2, 3]) * u.m, np.array([2, 3, 4])),
+    (np.array([1, 2, 3]), np.array([2, 3, 4])) * u.m,
+    (np.array([1, 2, 3]) * u.m, np.array([2, 3, 4])) * u.m,
+    (np.array([1, 2, 3]) * u.cm, np.array([2, 3, 4])),
+    (np.array([1, 2, 3]), np.array([2, 3, 4])) * u.cm,
+    (np.array([1, 2, 3]) * u.cm, np.array([2, 3, 4])) * u.cm,
+    (np.array([1, 2, 3]) * u.km, np.array([2, 3, 4])) * u.cm,
+    ])
+def test_arithmetics_inversevarianceuncertainty_with_units(uncert1, uncert2):
+    # Data has same units
+    data1 = np.array([1, 2, 3]) * u.m
+    data2 = np.array([-4, 7, 0]) * u.m
+    if uncert1 is not None:
+        uncert1 = InverseVariance(1 / uncert1**2)
+        if isinstance(uncert1, Quantity):
+            uncert1_ref = uncert1.to_value(1 / data1.unit**2)
+        else:
+            uncert1_ref = uncert1
+        uncert_ref1 = InverseVariance(uncert1_ref, copy=True)
+    else:
+        uncert1 = None
+        uncert_ref1 = None
+
+    if uncert2 is not None:
+        uncert2 = InverseVariance(1 / uncert2**2)
+        if isinstance(uncert2, Quantity):
+            uncert2_ref = uncert2.to_value(1 / data2.unit**2)
+        else:
+            uncert2_ref = uncert2
+        uncert_ref2 = InverseVariance(uncert2_ref, copy=True)
+    else:
+        uncert2 = None
+        uncert_ref2 = None
+
+    nd1 = NDDataArithmetic(data1, uncertainty=uncert1)
+    nd2 = NDDataArithmetic(data2, uncertainty=uncert2)
+
+    nd1_ref = NDDataArithmetic(data1, uncertainty=uncert_ref1)
+    nd2_ref = NDDataArithmetic(data2, uncertainty=uncert_ref2)
+
+    # Let's start the tests
+    # Addition
+    nd3 = nd1.add(nd2)
+    nd3_ref = nd1_ref.add(nd2_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    nd3 = nd2.add(nd1)
+    nd3_ref = nd2_ref.add(nd1_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    # Subtraction
+    nd3 = nd1.subtract(nd2)
+    nd3_ref = nd1_ref.subtract(nd2_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    nd3 = nd2.subtract(nd1)
+    nd3_ref = nd2_ref.subtract(nd1_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    # Multiplication
+    nd3 = nd1.multiply(nd2)
+    nd3_ref = nd1_ref.multiply(nd2_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    nd3 = nd2.multiply(nd1)
+    nd3_ref = nd2_ref.multiply(nd1_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    # Division
+    nd3 = nd1.divide(nd2)
+    nd3_ref = nd1_ref.divide(nd2_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+    nd3 = nd2.divide(nd1)
+    nd3_ref = nd2_ref.divide(nd1_ref)
+    assert nd3.unit == nd3_ref.unit
+    assert nd3.uncertainty.unit == nd3_ref.uncertainty.unit
+    assert_array_equal(nd3.uncertainty.array, nd3.uncertainty.array)
+
+
 # Test abbreviation and long name for taking the first found meta, mask, wcs
 @pytest.mark.parametrize(('use_abbreviation'), ['ff', 'first_found'])
 def test_arithmetics_handle_switches(use_abbreviation):

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -395,7 +395,7 @@ def test_arithmetics_stddevuncertainty_basic_with_correlation(
     assert_array_equal(nd3.uncertainty.array, nd4.uncertainty.array)
     # Compare it to the theoretical uncertainty
     ref_uncertainty = np.sqrt(uncert1**2 + uncert2**2 +
-                              2 * cor * uncert1 * uncert2)
+                              2 * cor * np.abs(uncert1 * uncert2))
     assert_array_equal(nd3.uncertainty.array, ref_uncertainty)
 
     nd3 = nd1.subtract(nd2, uncertainty_correlation=cor)
@@ -404,7 +404,7 @@ def test_arithmetics_stddevuncertainty_basic_with_correlation(
     assert_array_equal(nd3.uncertainty.array, nd4.uncertainty.array)
     # Compare it to the theoretical uncertainty
     ref_uncertainty = np.sqrt(uncert1**2 + uncert2**2 -
-                              2 * cor * uncert1 * uncert2)
+                              2 * cor * np.abs(uncert1 * uncert2))
     assert_array_equal(nd3.uncertainty.array, ref_uncertainty)
 
     # Multiplication and Division only work with almost equal array comparisons
@@ -417,7 +417,7 @@ def test_arithmetics_stddevuncertainty_basic_with_correlation(
     # Compare it to the theoretical uncertainty
     ref_uncertainty = (np.abs(data1 * data2)) * np.sqrt(
         (uncert1 / data1)**2 + (uncert2 / data2)**2 +
-        (2 * cor * uncert1 * uncert2 / (data1 * data2)))
+        (2 * cor * np.abs(uncert1 * uncert2) / (data1 * data2)))
     assert_array_almost_equal(nd3.uncertainty.array, ref_uncertainty)
 
     nd3 = nd1.divide(nd2, uncertainty_correlation=cor)
@@ -426,11 +426,12 @@ def test_arithmetics_stddevuncertainty_basic_with_correlation(
     # Compare it to the theoretical uncertainty
     ref_uncertainty_1 = (np.abs(data1 / data2)) * np.sqrt(
         (uncert1 / data1)**2 + (uncert2 / data2)**2 -
-        (2 * cor * uncert1 * uncert2 / (data1 * data2)))
+        (2 * cor * np.abs(uncert1 * uncert2) / (data1 * data2)))
     assert_array_almost_equal(nd3.uncertainty.array, ref_uncertainty_1)
     ref_uncertainty_2 = (np.abs(data2 / data1)) * np.sqrt(
         (uncert1 / data1)**2 + (uncert2 / data2)**2 -
-        (2 * cor * uncert1 * uncert2 / (data1 * data2)))
+        (2 * cor * np.abs(uncert1 * uncert2) / (data1 * data2)))
+    assert_array_almost_equal(nd4.uncertainty.array, ref_uncertainty_2)
     assert_array_almost_equal(nd4.uncertainty.array, ref_uncertainty_2)
 
 

--- a/astropy/nddata/mixins/tests/test_ndslicing.py
+++ b/astropy/nddata/mixins/tests/test_ndslicing.py
@@ -76,7 +76,7 @@ def test_slicing_1dmask_ndslice(prop_name):
 def test_slicing_all_npndarray_1d():
     data = np.arange(10)
     mask = data > 3
-    uncertainty = np.linspace(10, 20, 10)
+    uncertainty = StdDevUncertainty(np.linspace(10, 20, 10))
     wcs = np.linspace(1, 1000, 10)
     # Just to have them too
     unit = u.s
@@ -87,7 +87,7 @@ def test_slicing_all_npndarray_1d():
     nd2 = nd[2:5]
     assert_array_equal(data[2:5], nd2.data)
     assert_array_equal(mask[2:5], nd2.mask)
-    assert_array_equal(uncertainty[2:5], nd2.uncertainty.array)
+    assert_array_equal(uncertainty[2:5].array, nd2.uncertainty.array)
     assert_array_equal(wcs[2:5], nd2.wcs)
     assert unit is nd2.unit
     assert meta == nd.meta

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -141,8 +141,8 @@ class NDUncertainty(metaclass=ABCMeta):
 
     @unit.setter
     def unit(self, value):
-        """Each subclass should interpret how it transform parent's unit into the correct Uncertainty Unit (
-        i.e. StdDev should have the same, Variance should have its square, ...
+        """Each subclass should interpret how it transform parent's unit into the correct Uncertainty Unit
+        (i.e. StdDev should have the same, Variance should have its square, ...)
         """
         if isinstance(value, NDUncertainty):
             raise NotImplemented("How to interpret the parent's unit into NDUncertainty class "

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -13,7 +13,7 @@ from ..units import Unit, Quantity
 __all__ = ['MissingDataAssociationException',
            'IncompatibleUncertaintiesException', 'NDUncertainty',
            'StdDevUncertainty', 'UnknownUncertainty',
-           'VarianceUncertainty']
+           'VarianceUncertainty', 'InverseVariance']
 
 
 class IncompatibleUncertaintiesException(Exception):
@@ -728,3 +728,116 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
         return super()._propagate_multiply_divide(other_uncert,
                                                   result_data, correlation,
                                                   divide=True)
+
+
+def _inverse(x):
+    """Just a simple inverse for use in the InverseVariance"""
+    return 1 / x
+
+
+class InverseVariance(_VariancePropagationMixin, NDUncertainty):
+    """
+    Variance deviation uncertainty assuming first order gaussian error
+    propagation.
+
+    This class implements uncertainty propagation for ``addition``,
+    ``subtraction``, ``multiplication`` and ``division`` with other instances
+    of `VarianceUncertainty`. The class can handle if the uncertainty has a
+    unit that differs from (but is convertible to) the parents `NDData` unit.
+    The unit of the resulting uncertainty will have the same unit as the
+    resulting data. Also support for correlation is possible but requires the
+    correlation as input. It cannot handle correlation determination itself.
+
+    Parameters
+    ----------
+    args, kwargs :
+        see `NDUncertainty`
+
+    Examples
+    --------
+    `StdDevUncertainty` should always be associated with an `NDData`-like
+    instance, either by creating it during initialization::
+
+        >>> from astropy.nddata import NDData, StdDevUncertainty
+        >>> ndd = NDData([1,2,3],
+        ...              uncertainty=StdDevUncertainty([0.1, 0.1, 0.1]))
+        >>> ndd.uncertainty  # doctest: +FLOAT_CMP
+        StdDevUncertainty([0.1, 0.1, 0.1])
+
+    or by setting it manually on the `NDData` instance::
+
+        >>> ndd.uncertainty = StdDevUncertainty([0.2], unit='m', copy=True)
+        >>> ndd.uncertainty  # doctest: +FLOAT_CMP
+        StdDevUncertainty([0.2])
+
+    the uncertainty ``array`` can also be set directly::
+
+        >>> ndd.uncertainty.array = 2
+        >>> ndd.uncertainty
+        StdDevUncertainty(2)
+
+    .. note::
+        The unit will not be displayed.
+    """
+    @property
+    def uncertainty_type(self):
+        """``"var"`` : `VarianceUncertainty` implements variance.
+        """
+        return 'ivar'
+
+    @property
+    def supports_correlated(self):
+        """`True` : `StdDevUncertainty` allows to propagate correlated \
+                    uncertainties.
+
+        ``correlation`` must be given, this class does not implement computing
+        it by itself.
+        """
+        return True
+
+    @property
+    def unit(self):
+        """`~astropy.units.Unit` : The unit of the uncertainty, if any.
+
+        Even though it is not enforced the unit should be convertible to the
+        ``parent_nddata`` unit. Otherwise uncertainty propagation might give
+        wrong results.
+
+        If the unit is not set the square of the unit of the parent will
+        be returned.
+        """
+        if self._unit is None:
+            if (self._parent_nddata is None or
+                    self.parent_nddata.unit is None):
+                return None
+            else:
+                return 1 / self.parent_nddata.unit**2
+        return self._unit
+
+    def _propagate_add(self, other_uncert, result_data, correlation):
+        """Not possible for unknown uncertainty types.
+        """
+        return super()._propagate_add_sub(other_uncert, result_data,
+                                          correlation, 1,
+                                          to_variance=_inverse,
+                                          from_variance=_inverse)
+
+    def _propagate_subtract(self, other_uncert, result_data, correlation):
+        return super()._propagate_add_sub(other_uncert, result_data,
+                                          correlation, -1,
+                                          to_variance=_inverse,
+                                          from_variance=_inverse)
+
+    def _propagate_multiply(self, other_uncert, result_data, correlation):
+        return super()._propagate_multiply_divide(other_uncert,
+                                                  result_data, correlation,
+                                                  divide=False,
+                                                  to_variance=_inverse,
+                                                  from_variance=_inverse)
+
+    def _propagate_divide(self, other_uncert, result_data, correlation):
+        return super()._propagate_multiply_divide(other_uncert,
+                                                  result_data, correlation,
+                                                  divide=True,
+                                                  to_variance=_inverse,
+                                                  from_variance=_inverse)

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -236,7 +236,7 @@ class NDUncertainty(metaclass=ABCMeta):
         and return the correct unit for the uncertainty given the uncertainty
         type.
         """
-        raise None
+        return None
 
     def __repr__(self):
         prefix = self.__class__.__name__ + '('
@@ -396,6 +396,12 @@ class UnknownUncertainty(NDUncertainty):
                            uncertainty type.
         """
         return 'unknown'
+
+    def _data_unit_to_uncertainty_unit(self, value):
+        """
+        No way to convert if uncertainty is unknown.
+        """
+        return None
 
     def _convert_uncertainty(self, other_uncert):
         """Raise an Exception because unknown uncertainty types cannot

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -561,7 +561,7 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
     instance, either by creating it during initialization::
 
         >>> from astropy.nddata import NDData, StdDevUncertainty
-        >>> ndd = NDData([1,2,3],
+        >>> ndd = NDData([1,2,3], unit='m',
         ...              uncertainty=StdDevUncertainty([0.1, 0.1, 0.1]))
         >>> ndd.uncertainty  # doctest: +FLOAT_CMP
         StdDevUncertainty([0.1, 0.1, 0.1])
@@ -632,7 +632,7 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
 
 class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
     """
-    Variance deviation uncertainty assuming first order gaussian error
+    Variance uncertainty assuming first order Gaussian error
     propagation.
 
     This class implements uncertainty propagation for ``addition``,
@@ -650,26 +650,30 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     Examples
     --------
-    `StdDevUncertainty` should always be associated with an `NDData`-like
+    Compare this example to that in `StdDevUncertainty`; the uncertainties
+    in the examples below are equivalent to the uncertainties in
+    `StdDevUncertainty`.
+
+    `VarianceUncertainty` should always be associated with an `NDData`-like
     instance, either by creating it during initialization::
 
-        >>> from astropy.nddata import NDData, StdDevUncertainty
-        >>> ndd = NDData([1,2,3],
-        ...              uncertainty=StdDevUncertainty([0.1, 0.1, 0.1]))
+        >>> from astropy.nddata import NDData, VarianceUncertainty
+        >>> ndd = NDData([1,2,3], unit='m',
+        ...              uncertainty=VarianceUncertainty([0.01, 0.01, 0.01]))
         >>> ndd.uncertainty  # doctest: +FLOAT_CMP
-        StdDevUncertainty([0.1, 0.1, 0.1])
+        VarianceUncertainty([0.01, 0.01, 0.01])
 
     or by setting it manually on the `NDData` instance::
 
-        >>> ndd.uncertainty = StdDevUncertainty([0.2], unit='m', copy=True)
+        >>> ndd.uncertainty = VarianceUncertainty([0.04], unit='m^2', copy=True)
         >>> ndd.uncertainty  # doctest: +FLOAT_CMP
-        StdDevUncertainty([0.2])
+        VarianceUncertainty([0.04])
 
     the uncertainty ``array`` can also be set directly::
 
-        >>> ndd.uncertainty.array = 2
+        >>> ndd.uncertainty.array = 4
         >>> ndd.uncertainty
-        StdDevUncertainty(2)
+        VarianceUncertainty(4)
 
     .. note::
         The unit will not be displayed.
@@ -682,7 +686,7 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     @property
     def supports_correlated(self):
-        """`True` : `StdDevUncertainty` allows to propagate correlated \
+        """`True` : `VarianceUncertainty` allows to propagate correlated \
                     uncertainties.
 
         ``correlation`` must be given, this class does not implement computing
@@ -710,8 +714,6 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
         return self._unit
 
     def _propagate_add(self, other_uncert, result_data, correlation):
-        """Not possible for unknown uncertainty types.
-        """
         return super()._propagate_add_sub(other_uncert, result_data,
                                           correlation, 1)
 
@@ -737,12 +739,12 @@ def _inverse(x):
 
 class InverseVariance(_VariancePropagationMixin, NDUncertainty):
     """
-    Variance deviation uncertainty assuming first order gaussian error
+    Inverse variance uncertainty assuming first order Gaussian error
     propagation.
 
     This class implements uncertainty propagation for ``addition``,
     ``subtraction``, ``multiplication`` and ``division`` with other instances
-    of `VarianceUncertainty`. The class can handle if the uncertainty has a
+    of `InverseVariance`. The class can handle if the uncertainty has a
     unit that differs from (but is convertible to) the parents `NDData` unit.
     The unit of the resulting uncertainty will have the same unit as the
     resulting data. Also support for correlation is possible but requires the
@@ -755,39 +757,43 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
 
     Examples
     --------
-    `StdDevUncertainty` should always be associated with an `NDData`-like
+    Compare this example to that in `StdDevUncertainty`; the uncertainties
+    in the examples below are equivalent to the uncertainties in
+    `StdDevUncertainty`.
+
+    `InverseVariance` should always be associated with an `NDData`-like
     instance, either by creating it during initialization::
 
-        >>> from astropy.nddata import NDData, StdDevUncertainty
-        >>> ndd = NDData([1,2,3],
-        ...              uncertainty=StdDevUncertainty([0.1, 0.1, 0.1]))
+        >>> from astropy.nddata import NDData, InverseVariance
+        >>> ndd = NDData([1,2,3], unit='m',
+        ...              uncertainty=InverseVariance([100, 100, 100]))
         >>> ndd.uncertainty  # doctest: +FLOAT_CMP
-        StdDevUncertainty([0.1, 0.1, 0.1])
+        InverseVariance([100, 100, 100])
 
     or by setting it manually on the `NDData` instance::
 
-        >>> ndd.uncertainty = StdDevUncertainty([0.2], unit='m', copy=True)
+        >>> ndd.uncertainty = InverseVariance([25], unit='1/m^2', copy=True)
         >>> ndd.uncertainty  # doctest: +FLOAT_CMP
-        StdDevUncertainty([0.2])
+        InverseVariance([25])
 
     the uncertainty ``array`` can also be set directly::
 
-        >>> ndd.uncertainty.array = 2
+        >>> ndd.uncertainty.array = 0.25
         >>> ndd.uncertainty
-        StdDevUncertainty(2)
+        InverseVariance(0.25)
 
     .. note::
         The unit will not be displayed.
     """
     @property
     def uncertainty_type(self):
-        """``"var"`` : `VarianceUncertainty` implements variance.
+        """``"ivar"`` : `InverseVariance` implements inverse variance.
         """
         return 'ivar'
 
     @property
     def supports_correlated(self):
-        """`True` : `StdDevUncertainty` allows to propagate correlated \
+        """`True` : `InverseVariance` allows to propagate correlated \
                     uncertainties.
 
         ``correlation`` must be given, this class does not implement computing
@@ -803,8 +809,8 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
         ``parent_nddata`` unit. Otherwise uncertainty propagation might give
         wrong results.
 
-        If the unit is not set the square of the unit of the parent will
-        be returned.
+        If the unit is not set, the square of the inverse of the unit of the
+        parent will be returned.
         """
         if self._unit is None:
             if (self._parent_nddata is None or
@@ -815,8 +821,6 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
         return self._unit
 
     def _propagate_add(self, other_uncert, result_data, correlation):
-        """Not possible for unknown uncertainty types.
-        """
         return super()._propagate_add_sub(other_uncert, result_data,
                                           correlation, 1,
                                           to_variance=_inverse,

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -373,8 +373,13 @@ class _VariancePropagationMixin:
     variance).
     """
     def _propagate_add_sub(self, other_uncert, result_data, correlation,
-                           add_or_subtract,
+                           subtract=False,
                            to_variance=lambda x: x, from_variance=lambda x: x):
+
+        if subtract:
+            correlation_sign = -1
+        else:
+            correlation_sign = 1
 
         if self.array is None:
             # Formula: sigma = dB
@@ -424,7 +429,7 @@ class _VariancePropagationMixin:
             # Determine the result depending on the correlation
             if isinstance(correlation, np.ndarray) or correlation != 0:
                 corr = 2 * correlation * np.sqrt(this * other)
-                result = this + other + add_or_subtract * corr
+                result = this + other + correlation_sign * corr
             else:
                 result = this + other
 
@@ -606,13 +611,13 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     def _propagate_add(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, 1,
+                                          correlation, subtract=False,
                                           to_variance=lambda x: x**2,
                                           from_variance=np.sqrt)
 
     def _propagate_subtract(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, -1,
+                                          correlation, subtract=True,
                                           to_variance=lambda x: x**2,
                                           from_variance=np.sqrt)
 
@@ -715,11 +720,11 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
 
     def _propagate_add(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, 1)
+                                          correlation, subtract=False)
 
     def _propagate_subtract(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, -1)
+                                          correlation, subtract=True)
 
     def _propagate_multiply(self, other_uncert, result_data, correlation):
         return super()._propagate_multiply_divide(other_uncert,
@@ -822,13 +827,13 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
 
     def _propagate_add(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, 1,
+                                          correlation, subtract=False,
                                           to_variance=_inverse,
                                           from_variance=_inverse)
 
     def _propagate_subtract(self, other_uncert, result_data, correlation):
         return super()._propagate_add_sub(other_uncert, result_data,
-                                          correlation, -1,
+                                          correlation, subtract=True,
                                           to_variance=_inverse,
                                           from_variance=_inverse)
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -188,8 +188,9 @@ class NDUncertainty(metaclass=ABCMeta):
             # https://github.com/astropy/astropy/pull/4799#discussion_r61236832
             value = weakref.ref(value)
         self._parent_nddata = value
-        #set uncertainty unit to that of the parent if it was not already set.
-        if self.unit is None:
+        #set uncertainty unit to that of the parent if it was not already set, unless initializing
+        # with empty parent (Value=None)
+        if value is not None and self.unit is None:
             if self.parent_nddata.unit is None:
                 #warning("No units specified")
                 self.unit = None

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -424,7 +424,11 @@ class _VariancePropagationMixin:
         else:
             correlation_sign = 1
 
+        try:
         result_unit_sq = result_data.unit ** 2
+        except AttributeError:
+            result_unit_sq = None
+
         if other_uncert.array is not None:
             # Formula: sigma**2 = dB
             if (other_uncert.unit is not None and

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -229,12 +229,14 @@ class NDUncertainty(metaclass=ABCMeta):
                                               "data".format(self.unit,
                                                             parent_unit))
 
+    @abstractmethod
     def _data_unit_to_uncertainty_unit(self, value):
         """
-        Utility method for converting a value in units of the uncertainty
-        to the same unit as the data.
+        Subclasses must override this property. It should take in a data unit
+        and return the correct unit for the uncertainty given the uncertainty
+        type.
         """
-        raise NotImplementedError("Subclasses need to implement this dang method")
+        raise None
 
     def __repr__(self):
         prefix = self.__class__.__name__ + '('

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -425,7 +425,7 @@ class _VariancePropagationMixin:
             correlation_sign = 1
 
         try:
-        result_unit_sq = result_data.unit ** 2
+            result_unit_sq = result_data.unit ** 2
         except AttributeError:
             result_unit_sq = None
 
@@ -635,6 +635,8 @@ class StdDevUncertainty(_VariancePropagationMixin, NDUncertainty):
         """
         if isinstance(value, NDDataBase):
             self._unit = value.unit
+        elif value is not None:
+            self._unit = Unit(value)
         else:
             self._unit = value
 
@@ -759,6 +761,8 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
         """
         if isinstance(value, NDDataBase):
             self._unit = value.unit**2
+        elif value is not None:
+            self._unit = Unit(value)
         else:
             self._unit = value
 
@@ -858,8 +862,9 @@ class InverseVariance(_VariancePropagationMixin, NDUncertainty):
         parent will be returned.
         """
         if isinstance(value, NDDataBase):
-            # warning("using square of the parent")
             self._unit = 1.0 / value.unit ** 2
+        elif value is not None:
+            self._unit = Unit(value)
         else:
             self._unit = value
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -754,7 +754,6 @@ class VarianceUncertainty(_VariancePropagationMixin, NDUncertainty):
         parent will be returned.
         """
         if isinstance(value, NDDataBase):
-            # warning("using square of the parent")
             self._unit = value.unit**2
         else:
             self._unit = value

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -231,7 +231,7 @@ def test_nddata_init_data_nddata():
     assert nd1.data[2, 3] != nd2.data[2, 3]
 
     # Now let's see what happens if we have all explicitly set
-    nd1 = NDData(np.array([1]), mask=False, uncertainty=10, unit=u.s,
+    nd1 = NDData(np.array([1]), mask=False, uncertainty=StdDevUncertainty(10), unit=u.s,
                  meta={'dest': 'mordor'}, wcs=10)
     nd2 = NDData(nd1)
     assert nd2.data is nd1.data
@@ -242,7 +242,7 @@ def test_nddata_init_data_nddata():
     assert nd2.meta == nd1.meta
 
     # now what happens if we overwrite them all too
-    nd3 = NDData(nd1, mask=True, uncertainty=200, unit=u.km,
+    nd3 = NDData(nd1, mask=True, uncertainty=StdDevUncertainty(200), unit=u.km,
                  meta={'observer': 'ME'}, wcs=4)
     assert nd3.data is nd1.data
     assert nd3.wcs != nd1.wcs
@@ -253,6 +253,7 @@ def test_nddata_init_data_nddata():
 
 
 def test_nddata_init_data_nddata_subclass():
+    uncert = StdDevUncertainty(3)
     # There might be some incompatible subclasses of NDData around.
     bnd = BadNDDataSubclass(False, True, 3, 2, 'gollum', 100)
     # Before changing the NDData init this would not have raised an error but
@@ -260,12 +261,12 @@ def test_nddata_init_data_nddata_subclass():
     with pytest.raises(TypeError):
         NDData(bnd)
     # but if it has no actual incompatible attributes it passes
-    bnd_good = BadNDDataSubclass(np.array([1, 2]), True, 3, 2,
+    bnd_good = BadNDDataSubclass(np.array([1, 2]), uncert, 3, 2,
                                  {'enemy': 'black knight'}, u.km)
     nd = NDData(bnd_good)
     assert nd.unit == bnd_good.unit
     assert nd.meta == bnd_good.meta
-    assert nd.uncertainty.array == bnd_good.uncertainty
+    assert nd.uncertainty == bnd_good.uncertainty
     assert nd.mask == bnd_good.mask
     assert nd.wcs == bnd_good.wcs
     assert nd.data is bnd_good.data

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -10,28 +10,11 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from ..nddata import NDData
-from ..nduncertainty import NDUncertainty, StdDevUncertainty
+from ..nduncertainty import StdDevUncertainty
 from ... import units as u
 from ...utils import NumpyRNGContext
 
-
-class FakeUncertainty(NDUncertainty):
-
-    @property
-    def uncertainty_type(self):
-        return 'fake'
-
-    def _propagate_add(self, data, final_data):
-        pass
-
-    def _propagate_subtract(self, data, final_data):
-        pass
-
-    def _propagate_multiply(self, data, final_data):
-        pass
-
-    def _propagate_divide(self, data, final_data):
-        pass
+from .test_nduncertainty import FakeUncertainty
 
 
 class FakeNumpyArray:

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -55,10 +55,18 @@ class FakeUncertainty(NDUncertainty):
     def _propagate_divide(self, data, final_data):
         pass
 
+
 # Test the fake (added also StdDevUncertainty which should behave identical)
 
 # the list of classes used for parametrization in tests below
-uncertainty_types_to_be_tested = [FakeUncertainty, StdDevUncertainty, UnknownUncertainty]
+uncertainty_types_to_be_tested = [
+    FakeUncertainty,
+    StdDevUncertainty,
+    VarianceUncertainty,
+    InverseVariance,
+    UnknownUncertainty
+]
+
 
 @pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_list(UncertClass):
@@ -244,6 +252,7 @@ def test_for_stolen_uncertainty():
     ndd2 = NDData(2, uncertainty=ndd1.uncertainty)
     # uncertainty.parent_nddata.data should be the original data!
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data
+    assert ndd2.uncertainty.parent_nddata.data == ndd2.data
 
 
 @pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
@@ -255,7 +264,6 @@ def test_quantity(UncertClass):
     fake_uncert_nounit = UncertClass([1, 2, 3])
     assert isinstance(fake_uncert_nounit.quantity, u.Quantity)
     assert fake_uncert_nounit.quantity.unit.is_equivalent(u.dimensionless_unscaled)
-    assert ndd2.uncertainty.parent_nddata.data == ndd2.data
 
 
 @pytest.mark.parametrize(('UncertClass'),

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -253,3 +253,12 @@ def test_quantity(UncertClass):
     fake_uncert_nounit = UncertClass([1, 2, 3])
     assert isinstance(fake_uncert_nounit.quantity, u.Quantity)
     assert fake_uncert_nounit.quantity.unit.is_equivalent(u.dimensionless_unscaled)
+    assert ndd2.uncertainty.parent_nddata.data == ndd2.data
+
+
+@pytest.mark.parametrize(('UncertClass'), [VarianceUncertainty, StdDevUncertainty,
+                                           InverseVariance])
+def test_setting_uncertainty_unit_results_in_unit_object(UncertClass):
+    v = UncertClass([1, 1])
+    v.unit = 'electron'
+    assert isinstance(v.unit, u.UnitBase)

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_array_equal
 
 from ..nduncertainty import (StdDevUncertainty,
                              VarianceUncertainty,
+                             InverseVariance,
                              NDUncertainty,
                              IncompatibleUncertaintiesException,
                              UnknownUncertainty)
@@ -170,6 +171,8 @@ def test_uncertainty_type():
     assert std_uncert.uncertainty_type == 'std'
     var_uncert = VarianceUncertainty([10, 2])
     assert var_uncert.uncertainty_type == 'var'
+    ivar_uncert = InverseVariance([10, 2])
+    assert ivar_uncert.uncertainty_type == 'ivar'
 
 
 def test_uncertainty_correlated():

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -43,6 +43,9 @@ class FakeUncertainty(NDUncertainty):
     def uncertainty_type(self):
         return 'fake'
 
+    def _data_unit_to_uncertainty_unit(self, value):
+        return None
+
     def _propagate_add(self, data, final_data):
         pass
 

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ..nduncertainty import (StdDevUncertainty, NDUncertainty,
+from ..nduncertainty import (StdDevUncertainty,
+                             VarianceUncertainty,
+                             NDUncertainty,
                              IncompatibleUncertaintiesException,
                              UnknownUncertainty)
 from ..nddata import NDData
@@ -168,6 +168,8 @@ def test_uncertainty_type():
     assert fake_uncert.uncertainty_type == 'fake'
     std_uncert = StdDevUncertainty([10, 2])
     assert std_uncert.uncertainty_type == 'std'
+    var_uncert = VarianceUncertainty([10, 2])
+    assert var_uncert.uncertainty_type == 'var'
 
 
 def test_uncertainty_correlated():

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -403,13 +403,11 @@ def block_reduce(data, block_size, func=np.sum):
     size_init = size_resampled * block_size
 
     # trim data if necessary
-    # todo: benchmark which method is faster, but most likely this one should be it
-
-    # for i in range(data.ndim):
-    #     if data.shape[i] != size_init[i]:
-    #         data = data.swapaxes(0, i)
-    #         data = data[:size_init[i]]
-    #         data = data.swapaxes(0, i)
+    for i in range(data.ndim):
+        if data.shape[i] != size_init[i]:
+            data = data.swapaxes(0, i)
+            data = data[:size_init[i]]
+            data = data.swapaxes(0, i)
 
     return block_reduce(data, tuple(block_size), func=func)
 

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -403,11 +403,13 @@ def block_reduce(data, block_size, func=np.sum):
     size_init = size_resampled * block_size
 
     # trim data if necessary
-    for i in range(data.ndim):
-        if data.shape[i] != size_init[i]:
-            data = data.swapaxes(0, i)
-            data = data[:size_init[i]]
-            data = data.swapaxes(0, i)
+    # todo: benchmark which method is faster, but most likely this one should be it
+
+    # for i in range(data.ndim):
+    #     if data.shape[i] != size_init[i]:
+    #         data = data.swapaxes(0, i)
+    #         data = data[:size_init[i]]
+    #         data = data.swapaxes(0, i)
 
     return block_reduce(data, tuple(block_size), func=func)
 

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -365,7 +365,7 @@ correct uncertainty of ``0``::
 which would be consistent with the equivalent operation ``ndd1 * 0``::
 
     >>> ndd1.multiply(0, propagate_uncertainties=True).uncertainty
-    StdDevUncertainty([0])
+    StdDevUncertainty([ 0.])
 
 .. warning::
     The user needs to calculate or know the appropriate value or array manually

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -364,8 +364,8 @@ correct uncertainty of ``0``::
 
 which would be consistent with the equivalent operation ``ndd1 * 0``::
 
-    >>> ndd1.multiply(0, propagate_uncertainties=True).uncertainty
-    StdDevUncertainty([ 0.])
+    >>> ndd1.multiply(0, propagate_uncertainties=True).uncertainty # doctest: +FLOAT_CMP
+    StdDevUncertainty([0.])
 
 .. warning::
     The user needs to calculate or know the appropriate value or array manually

--- a/docs/nddata/nddata.rst
+++ b/docs/nddata/nddata.rst
@@ -186,7 +186,8 @@ property is found it will be wrapped inside a
 
 The ``uncertainty_type`` should follow the `~astropy.nddata.StdDevUncertainty`
 convention that it returns a short string like ``"std"`` for an uncertainty
-given in standard deviation.
+given in standard deviation. Other examples are
+`~astropy.nddata.VarianceUncertainty` and `~astropy.nddata.InverseVariance`.
 
 Like the other properties the ``uncertainty`` can be set during
 initialization::

--- a/docs/nddata/subclassing.rst
+++ b/docs/nddata/subclassing.rst
@@ -467,6 +467,9 @@ systematic uncertainties::
     ...     def uncertainty_type(self):
     ...         return 'systematic'
     ...
+    ...     def _data_unit_to_uncertainty_unit(self, value):
+    ...         return None
+    ...
     ...     def _propagate_add(self, other_uncert, *args, **kwargs):
     ...         return None
     ...


### PR DESCRIPTION
This PR:

+ Refactors propagation of uncertainties into two methods (instead of the current 4) and rewrites propagation in terms of variance, with optional arguments to transform the input uncertainty to/from variance.
+ Adds a class `VarianceUncertainty`.
+ Adds a class `InverseVariance`.
+ Adds tests for the new classes and makes minor updates to the tests for `StdDevUncertainty`.

It is the first step towards implementing a revised NDData (see https://github.com/astropy/astropy-APEs/pull/14) but is useful, I think, independent of that APE.

Ping @crawfordsm @bjweiner (and hoping @MSeifert04  will review 😀 )
