### PR TITLE
Remove useless file open_file_detection.txt

### DIFF
--- a/astropy/tests/setup_package.py
+++ b/astropy/tests/setup_package.py
@@ -4,4 +4,4 @@
 def get_package_data():
     return {
         'astropy.tests': ['coveragerc'],
-        'astropy.tests.tests': ['data/open_file_detection.txt']}
+    }

--- a/astropy/tests/tests/data/open_file_detection.txt
+++ b/astropy/tests/tests/data/open_file_detection.txt
@@ -1,1 +1,0 @@
-CONTENTS


### PR DESCRIPTION
This file is useless since the openfiles plugin was moved to a separate
repository, and removed in 5ae6ad50d5dff095e41b458adf3a0fbf21e0333d

The pytest plugins have been backported I think, hence the milestone, but feel free to change it @bsipocz ;)
