### PR TITLE
Allow custom root directory for config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@
 New Features
 ------------
 
+- The config and cache directories and the name of the config file are now
+  customizable. This allows affiliated packages to put their configuration
+  files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
+
+
 astropy.config
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@
 New Features
 ------------
 
+astropy.config
+^^^^^^^^^^^^^^
+
 - The config and cache directories and the name of the config file are now
   customizable. This allows affiliated packages to put their configuration
   files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
@@ -11,6 +14,9 @@ New Features
 
 astropy.config
 ^^^^^^^^^^^^^^
+- The config and cache directories and the name of the config file are now
+  customizable. This allows affiliated packages to put their configuration
+  files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^
@@ -129,6 +135,8 @@ astropy.table
 
 - Improved exception handling and error messages when column ``format``
   attribute is incorrect for the column type. [#6385]
+
+- ``astropy.constants``
 
 - Allow to pass ``htmldict`` option to the jsviewer writer. [#6551]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,14 +9,7 @@ astropy.config
 
 - The config and cache directories and the name of the config file are now
   customizable. This allows affiliated packages to put their configuration
-  files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
-
-
-astropy.config
-^^^^^^^^^^^^^^
-- The config and cache directories and the name of the config file are now
-  customizable. This allows affiliated packages to put their configuration
-  files in locations other than ``CONFIG_DIR/.astropy/``. [#5828]
+  files in locations other than ``CONFIG_DIR/.astropy/``. [#6985]
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^
@@ -135,8 +128,6 @@ astropy.table
 
 - Improved exception handling and error messages when column ``format``
   attribute is incorrect for the column type. [#6385]
-
-- ``astropy.constants``
 
 - Allow to pass ``htmldict`` option to the jsviewer writer. [#6551]
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -526,7 +526,7 @@ def get_config(packageormod=None, reload=False):
                 if _override_config_file is not None:
                     cfgfn = _override_config_file
                 else:
-                    cfgfn = path.join(get_config_dir(), rootname + '.cfg')
+                    cfgfn = path.join(get_config_dir(rootname), rootname + '.cfg')
                 cobj = configobj.ConfigObj(cfgfn, interpolation=False)
             except OSError as e:
                 msg = ('Configuration defaults will be used due to ')
@@ -690,7 +690,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir(pkg), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)
     else:
         needs_template = False

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -424,7 +424,8 @@ class ConfigItem(metaclass=InheritDocstrings):
                 warn(
                     "Config parameter '{0}' {1} of the file '{2}' "
                     "is deprecated. Use '{3}' {4} instead.".format(
-                        name, section_name(module), get_config_filename(filename, rootname=self.rootname),
+                        name, section_name(module), get_config_filename(filename,
+                                                                        rootname=self.rootname),
                         self.name, section_name(new_module)),
                     AstropyDeprecationWarning)
                 options.append((sec[name], module, name))
@@ -438,7 +439,8 @@ class ConfigItem(metaclass=InheritDocstrings):
             warn(
                 "Config parameter '{0}' {1} of the file '{2}' is "
                 "given by more than one alias ({3}). Using the first.".format(
-                    self.name, section_name(sec), get_config_filename(filename, rootname=self.rootname),
+                    self.name, section_name(sec), get_config_filename(filename,
+                                                                      rootname=self.rootname),
                     ', '.join([
                         '.'.join(x[1:3]) for x in options if x[1] is not None])),
                 AstropyDeprecationWarning)
@@ -540,7 +542,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         if _autopkg:
             rootname = pkgname
         else:
-            rootname = 'astropy' # so we don't break affiliated packages
+            rootname = 'astropy'  # so we don't break affiliated packages
 
     cobj = _cfgobjs.get(pkgname, None)
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -472,7 +472,7 @@ def get_config_filename(packageormod=None, rootname=None):
     Get the filename of the config file associated with the given
     package or module.
     """
-    cfg = get_config(packageormod, rootname=None)
+    cfg = get_config(packageormod, rootname=rootname)
     while cfg.parent is not cfg:
         cfg = cfg.parent
     return cfg.filename

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -473,7 +473,7 @@ def get_config_filename(packageormod=None):
 _override_config_file = None
 
 
-def get_config(packageormod=None, reload=False):
+def get_config(packageormod=None, reload=False, rootname='astropy'):
     """ Gets the configuration object or section associated with a particular
     package or module.
 
@@ -510,10 +510,10 @@ def get_config(packageormod=None, reload=False):
             packageormod = packageormod.__name__
 
     packageormodspl = packageormod.split('.')
-    rootname = packageormodspl[0]
+    pkgname = packageormodspl[0]
     secname = '.'.join(packageormodspl[1:])
 
-    cobj = _cfgobjs.get(rootname, None)
+    cobj = _cfgobjs.get(pkgname, None)
 
     if cobj is None or reload:
         if _ASTROPY_SETUP_:
@@ -526,7 +526,7 @@ def get_config(packageormod=None, reload=False):
                 if _override_config_file is not None:
                     cfgfn = _override_config_file
                 else:
-                    cfgfn = path.join(get_config_dir(rootname), rootname + '.cfg')
+                    cfgfn = path.join(get_config_dir(rootname), pkgname + '.cfg')
                 cobj = configobj.ConfigObj(cfgfn, interpolation=False)
             except OSError as e:
                 msg = ('Configuration defaults will be used due to ')
@@ -539,7 +539,7 @@ def get_config(packageormod=None, reload=False):
                 # function won't see it unless the module is reloaded
                 cobj = configobj.ConfigObj(interpolation=False)
 
-        _cfgobjs[rootname] = cobj
+        _cfgobjs[pkgname] = cobj
 
     if secname:  # not the root package
         if secname not in cobj:

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -549,7 +549,7 @@ def get_config(packageormod=None, reload=False, rootname='astropy'):
         return cobj
 
 
-def reload_config(packageormod=None):
+def reload_config(packageormod=None, rootname='astropy'):
     """ Reloads configuration settings from a configuration file for the root
     package of the requested package/module.
 
@@ -564,7 +564,7 @@ def reload_config(packageormod=None):
     packageormod : str or None
         The package or module name - see `get_config` for details.
     """
-    sec = get_config(packageormod, True)
+    sec = get_config(packageormod, True, rootname=rootname)
     # look for the section that is its own parent - that's the base object
     while sec.parent is not sec:
         sec = sec.parent
@@ -663,7 +663,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
         # system, so just return.
         return False
 
-    cfgfn = get_config(pkg).filename
+    cfgfn = get_config(pkg, rootname='astropy').filename
 
     with open(default_cfgfn, 'rt', encoding='latin-1') as fr:
         template_content = fr.read()
@@ -690,7 +690,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(pkg), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir('astropy'), '{0}.{1}.cfg'.format(pkg, version))
         needs_template = not path.exists(template_path)
     else:
         needs_template = False

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -93,11 +93,6 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
         conf = Conf()
     """
 
-    rootname = 'astropy'
-    """
-    Rootname sets the base path for all config files.
-    """
-
     def set_temp(self, attr, value):
         """
         Temporarily set a configuration value.

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -506,6 +506,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         If ``packageormod`` is `None`, but the package this item is created
         from cannot be determined.
     """
+
     if packageormod is None:
         packageormod = find_current_module(2)
         if packageormod is None:
@@ -528,7 +529,7 @@ def get_config(packageormod=None, reload=False, rootname=None):
         if _autopkg:
             rootname = pkgname
         else:
-            rootname = 'astropy'
+            rootname = 'astropy' # so we don't break affiliated packages
 
     cobj = _cfgobjs.get(pkgname, None)
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -193,7 +193,7 @@ class ConfigItem(metaclass=InheritDocstrings):
         element (e.g. 'astropy' if this is 'astropy.config.configuration')
         will be used to determine the name of the configuration file, while
         the remaining items determine the section. If None, the package will be
-        inferred from the package within whiich this object's initializer is
+        inferred from the package within which this object's initializer is
         called.
 
     aliases : str, or list of str, optional

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -71,7 +71,7 @@ def _find_home():
             homedir = os.environ['HOME']
         else:
             raise OSError('Could not find a home directory to search for '
-                          'astropy config dir - are you on an unspported '
+                          'astropy config dir - are you on an unsupported '
                           'platform?')
     return homedir
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -76,9 +76,9 @@ def _find_home():
     return homedir
 
 
-def get_config_dir(create=True):
+def get_config_dir(pkgname, create=True):
     """
-    Determines the Astropy configuration directory name and creates the
+    Determines the package configuration directory name and creates the
     directory if it doesn't exist.
 
     This directory is typically ``$HOME/.astropy/config``, but if the
@@ -88,6 +88,7 @@ def get_config_dir(create=True):
 
     Returns
     -------
+    pkgname : TODO
     configdir : str
         The absolute path to the configuration directory.
 
@@ -99,7 +100,7 @@ def get_config_dir(create=True):
     # If using set_temp_config, that overrides all
     if set_temp_config._temp_path is not None:
         xch = set_temp_config._temp_path
-        config_path = os.path.join(xch, 'astropy')
+        config_path = os.path.join(xch, pkgname)
         if not os.path.exists(config_path):
             os.mkdir(config_path)
         return os.path.abspath(config_path)
@@ -108,16 +109,16 @@ def get_config_dir(create=True):
     xch = os.environ.get('XDG_CONFIG_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, 'astropy')
+        xchpth = os.path.join(xch, pkgname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
-    return os.path.abspath(_find_or_create_astropy_dir('config', linkto))
+    return os.path.abspath(_find_or_create_root_dir('config', linkto, pkgname))
 
 
-def get_cache_dir():
+def get_cache_dir(pkgname):
     """
     Determines the Astropy cache directory name and creates the directory if it
     doesn't exist.
@@ -129,6 +130,7 @@ def get_cache_dir():
 
     Returns
     -------
+    pkgname : TODO
     cachedir : str
         The absolute path to the cache directory.
 
@@ -140,7 +142,7 @@ def get_cache_dir():
     # If using set_temp_cache, that overrides all
     if set_temp_cache._temp_path is not None:
         xch = set_temp_cache._temp_path
-        cache_path = os.path.join(xch, 'astropy')
+        cache_path = os.path.join(xch, pkgname)
         if not os.path.exists(cache_path):
             os.mkdir(cache_path)
         return os.path.abspath(cache_path)
@@ -149,14 +151,14 @@ def get_cache_dir():
     xch = os.environ.get('XDG_CACHE_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, 'astropy')
+        xchpth = os.path.join(xch, pkgname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
 
-    return os.path.abspath(_find_or_create_astropy_dir('cache', linkto))
+    return os.path.abspath(_find_or_create_root_dir('cache', linkto, pkgname))
 
 
 class _SetTempPath:
@@ -173,7 +175,7 @@ class _SetTempPath:
 
     def __enter__(self):
         self.__class__._temp_path = self._path
-        return self._default_path_getter()
+        return self._default_path_getter('astropy')
 
     def __exit__(self, *args):
         self.__class__._temp_path = self._prev_path
@@ -269,9 +271,9 @@ class set_temp_cache(_SetTempPath):
     _default_path_getter = staticmethod(get_cache_dir)
 
 
-def _find_or_create_astropy_dir(dirnm, linkto):
-    innerdir = os.path.join(_find_home(), '.astropy')
-    maindir = os.path.join(_find_home(), '.astropy', dirnm)
+def _find_or_create_root_dir(dirnm, linkto, pkgname='astropy'):
+    innerdir = os.path.join(_find_home(), '.{}'.format(pkgname))
+    maindir = os.path.join(_find_home(), '.{}'.format(pkgname), dirnm)
 
     if not os.path.exists(maindir):
         # first create .astropy dir if needed
@@ -282,8 +284,8 @@ def _find_or_create_astropy_dir(dirnm, linkto):
                 if not os.path.isdir(innerdir):
                     raise
         elif not os.path.isdir(innerdir):
-            msg = 'Intended Astropy directory {0} is actually a file.'
-            raise OSError(msg.format(innerdir))
+            msg = 'Intended {0} {1} directory {1} is actually a file.'
+            raise OSError(msg.format(pkgname, dirnm, maindir))
 
         try:
             os.mkdir(maindir)
@@ -297,7 +299,7 @@ def _find_or_create_astropy_dir(dirnm, linkto):
             os.symlink(maindir, linkto)
 
     elif not os.path.isdir(maindir):
-        msg = 'Intended Astropy {0} directory {1} is actually a file.'
-        raise OSError(msg.format(dirnm, maindir))
+        msg = 'Intended {0} {1} directory {1} is actually a file.'
+        raise OSError(msg.format(pkgname, dirnm, maindir))
 
     return os.path.abspath(maindir)

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -76,7 +76,7 @@ def _find_home():
     return homedir
 
 
-def get_config_dir(pkgname, create=True):
+def get_config_dir(rootname, create=True):
     """
     Determines the package configuration directory name and creates the
     directory if it doesn't exist.
@@ -86,9 +86,18 @@ def get_config_dir(pkgname, create=True):
     ``$XDG_CONFIG_HOME/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
+    Parameters
+    ----------
+    rootname : str
+        Name of the root configuration directory. For example, if
+        ``rootname = 'pkgname'``, the configuration directory will be
+        ``<home>/.pkgname/``.
+
+    create : bool, optional
+        Create the path if it doesn't exist.
+
     Returns
     -------
-    pkgname : TODO
     configdir : str
         The absolute path to the configuration directory.
 
@@ -100,7 +109,7 @@ def get_config_dir(pkgname, create=True):
     # If using set_temp_config, that overrides all
     if set_temp_config._temp_path is not None:
         xch = set_temp_config._temp_path
-        config_path = os.path.join(xch, pkgname)
+        config_path = os.path.join(xch, rootname)
         if not os.path.exists(config_path):
             os.mkdir(config_path)
         return os.path.abspath(config_path)
@@ -109,16 +118,16 @@ def get_config_dir(pkgname, create=True):
     xch = os.environ.get('XDG_CONFIG_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, pkgname)
+        xchpth = os.path.join(xch, rootname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
-    return os.path.abspath(_find_or_create_root_dir('config', linkto, pkgname))
+    return os.path.abspath(_find_or_create_root_dir('config', linkto, rootname))
 
 
-def get_cache_dir(pkgname):
+def get_cache_dir(rootname):
     """
     Determines the Astropy cache directory name and creates the directory if it
     doesn't exist.
@@ -128,9 +137,15 @@ def get_cache_dir(pkgname):
     ``$XDG_CACHE_HOME/astropy`` directory exists, it will be that directory.
     If neither exists, the former will be created and symlinked to the latter.
 
+    Parameters
+    ----------
+    rootname : str
+        Name of the root cache directory. For example, if
+        ``rootname = 'pkgname'``, the cache directory will be
+        ``<cache>/.pkgname/``.
+
     Returns
     -------
-    pkgname : TODO
     cachedir : str
         The absolute path to the cache directory.
 
@@ -142,7 +157,7 @@ def get_cache_dir(pkgname):
     # If using set_temp_cache, that overrides all
     if set_temp_cache._temp_path is not None:
         xch = set_temp_cache._temp_path
-        cache_path = os.path.join(xch, pkgname)
+        cache_path = os.path.join(xch, rootname)
         if not os.path.exists(cache_path):
             os.mkdir(cache_path)
         return os.path.abspath(cache_path)
@@ -151,14 +166,14 @@ def get_cache_dir(pkgname):
     xch = os.environ.get('XDG_CACHE_HOME')
 
     if xch is not None and os.path.exists(xch):
-        xchpth = os.path.join(xch, pkgname)
+        xchpth = os.path.join(xch, rootname)
         if not os.path.islink(xchpth):
             if os.path.exists(xchpth):
                 return os.path.abspath(xchpth)
             else:
                 linkto = xchpth
 
-    return os.path.abspath(_find_or_create_root_dir('cache', linkto, pkgname))
+    return os.path.abspath(_find_or_create_root_dir('cache', linkto, rootname))
 
 
 class _SetTempPath:

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -20,6 +20,9 @@ def test_paths():
     assert 'astropy' in paths.get_config_dir('astropy')
     assert 'astropy' in paths.get_cache_dir('astropy')
 
+    assert 'testpkg' in paths.get_config_dir('testpkg')
+    assert 'testpkg' in paths.get_cache_dir('testpkg')
+
 
 def test_set_temp_config(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
@@ -83,6 +86,10 @@ def test_config_file():
     assert cfgsec.parent.filename.endswith('astropy.cfg')
 
     reload_config('astropy')
+
+    # try with a different package name, still inside astropy config dir:
+    testcfg = get_config('testpkg', rootname='astropy')
+    assert testcfg.filename.endswith('testpkg.cfg')
 
 
 def test_configitem():

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -88,7 +88,7 @@ def test_config_file():
     # try with a different package name, still inside astropy config dir:
     testcfg = get_config('testpkg', rootname='astropy')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.astropy' in parts
+    assert '.astropy' in parts or 'astropy' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
@@ -96,21 +96,21 @@ def test_config_file():
     #   default to astropy):
     testcfg = get_config('testpkg')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.astropy' in parts
+    assert '.astropy' in parts or 'astropy' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
     # try with a different package name, specified root name:
     testcfg = get_config('testpkg', rootname='testpkg')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert '.testpkg' in parts
+    assert '.testpkg' in parts or 'testpkg' in  parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
     # try with a subpackage with specified root name:
     testcfg_sec = get_config('testpkg.somemodule', rootname='testpkg')
     parts = os.path.normpath(testcfg_sec.parent.filename).split(os.sep)
-    assert '.testpkg' in parts
+    assert '.testpkg' in parts or 'testpkg' in  parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -17,31 +17,31 @@ from ...utils.exceptions import AstropyDeprecationWarning
 
 
 def test_paths():
-    assert 'astropy' in paths.get_config_dir()
-    assert 'astropy' in paths.get_cache_dir()
+    assert 'astropy' in paths.get_config_dir('astropy')
+    assert 'astropy' in paths.get_cache_dir('astropy')
 
 
 def test_set_temp_config(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
 
-    orig_config_dir = paths.get_config_dir()
+    orig_config_dir = paths.get_config_dir('astropy')
     temp_config_dir = str(tmpdir.mkdir('config'))
     temp_astropy_config = os.path.join(temp_config_dir, 'astropy')
 
     # Test decorator mode
     @paths.set_temp_config(temp_config_dir)
     def test_func():
-        assert paths.get_config_dir() == temp_astropy_config
+        assert paths.get_config_dir('astropy') == temp_astropy_config
 
         # Test temporary restoration of original default
         with paths.set_temp_config() as d:
-            assert d == orig_config_dir == paths.get_config_dir()
+            assert d == orig_config_dir == paths.get_config_dir('astropy')
 
     test_func()
 
     # Test context manager mode (with cleanup)
     with paths.set_temp_config(temp_config_dir, delete=True):
-        assert paths.get_config_dir() == temp_astropy_config
+        assert paths.get_config_dir('astropy') == temp_astropy_config
 
     assert not os.path.exists(temp_config_dir)
 
@@ -49,24 +49,24 @@ def test_set_temp_config(tmpdir, monkeypatch):
 def test_set_temp_cache(tmpdir, monkeypatch):
     monkeypatch.setattr(paths.set_temp_cache, '_temp_path', None)
 
-    orig_cache_dir = paths.get_cache_dir()
+    orig_cache_dir = paths.get_cache_dir('astropy')
     temp_cache_dir = str(tmpdir.mkdir('cache'))
     temp_astropy_cache = os.path.join(temp_cache_dir, 'astropy')
 
     # Test decorator mode
     @paths.set_temp_cache(temp_cache_dir)
     def test_func():
-        assert paths.get_cache_dir() == temp_astropy_cache
+        assert paths.get_cache_dir('astropy') == temp_astropy_cache
 
         # Test temporary restoration of original default
         with paths.set_temp_cache() as d:
-            assert d == orig_cache_dir == paths.get_cache_dir()
+            assert d == orig_cache_dir == paths.get_cache_dir('astropy')
 
     test_func()
 
     # Test context manager mode (with cleanup)
     with paths.set_temp_cache(temp_cache_dir, delete=True):
-        assert paths.get_cache_dir() == temp_astropy_cache
+        assert paths.get_cache_dir('astropy') == temp_astropy_cache
 
     assert not os.path.exists(temp_cache_dir)
 
@@ -190,18 +190,18 @@ def test_config_noastropy_fallback(monkeypatch):
     monkeypatch.delenv(str('XDG_CONFIG_HOME'))
     monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
 
-    # make sure the _find_or_create_astropy_dir function fails as though the
+    # make sure the _find_or_create_root_dir function fails as though the
     # astropy dir could not be accessed
-    def osraiser(dirnm, linkto):
+    def osraiser(dirnm, linkto, pkgname=None):
         raise OSError
-    monkeypatch.setattr(paths, '_find_or_create_astropy_dir', osraiser)
+    monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
 
     # also have to make sure the stored configuration objects are cleared
     monkeypatch.setattr(configuration, '_cfgobjs', {})
 
     with pytest.raises(OSError):
         # make sure the config dir search fails
-        paths.get_config_dir()
+        paths.get_config_dir('astropy')
 
     # now run the basic tests, and make sure the warning about no astropy
     # is present

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -88,7 +88,7 @@ def test_config_file():
     # try with a different package name, still inside astropy config dir:
     testcfg = get_config('testpkg', rootname='astropy')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert 'astropy' in parts[-2]
+    assert '.astropy' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
@@ -96,21 +96,21 @@ def test_config_file():
     #   default to astropy):
     testcfg = get_config('testpkg')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert 'astropy' in parts[-2]
+    assert '.astropy' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
     # try with a different package name, specified root name:
     testcfg = get_config('testpkg', rootname='testpkg')
     parts = os.path.normpath(testcfg.filename).split(os.sep)
-    assert 'testpkg' in parts[-2]
+    assert '.testpkg' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 
     # try with a subpackage with specified root name:
     testcfg_sec = get_config('testpkg.somemodule', rootname='testpkg')
     parts = os.path.normpath(testcfg_sec.parent.filename).split(os.sep)
-    assert 'testpkg' in parts[-2]
+    assert '.testpkg' in parts
     assert parts[-1] == 'testpkg.cfg'
     configuration._cfgobjs['testpkg'] = None # HACK
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -85,12 +85,36 @@ def test_config_file():
     assert cfgsec.name == 'config'
     assert cfgsec.parent.filename.endswith('astropy.cfg')
 
-    reload_config('astropy')
-
     # try with a different package name, still inside astropy config dir:
     testcfg = get_config('testpkg', rootname='astropy')
-    assert testcfg.filename.endswith('testpkg.cfg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'astropy' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
 
+    # try with a different package name, no specified root name (should
+    #   default to astropy):
+    testcfg = get_config('testpkg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'astropy' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    # try with a different package name, specified root name:
+    testcfg = get_config('testpkg', rootname='testpkg')
+    parts = os.path.normpath(testcfg.filename).split(os.sep)
+    assert 'testpkg' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    # try with a subpackage with specified root name:
+    testcfg_sec = get_config('testpkg.somemodule', rootname='testpkg')
+    parts = os.path.normpath(testcfg_sec.parent.filename).split(os.sep)
+    assert 'testpkg' in parts[-2]
+    assert parts[-1] == 'testpkg.cfg'
+    configuration._cfgobjs['testpkg'] = None # HACK
+
+    reload_config('astropy')
 
 def test_configitem():
 

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -491,7 +491,7 @@ class AstropyLogger(Logger):
             try:
                 if log_file_path == '' or testing_mode:
                     log_file_path = os.path.join(
-                        _config.get_config_dir(), "astropy.log")
+                        _config.get_config_dir('astropy'), "astropy.log")
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -944,7 +944,7 @@ def check_free_space_in_dir(path, size):
                 path, human_file_size(size)))
 
 
-def download_file(remote_url, cache=False, show_progress=True, timeout=None):
+def download_file(remote_url, cache=False, show_progress=True, timeout=None, pkgname='astropy'):
     """
     Accepts a URL, downloads and optionally caches the result
     returning the filename, with a name determined by the file's MD5
@@ -967,6 +967,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
         The timeout, in seconds.  Otherwise, use
         `astropy.utils.data.Conf.remote_timeout`.
 
+    pkgname : TODO
+
     Returns
     -------
     local_path : str
@@ -987,7 +989,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     if cache:
         try:
-            dldir, urlmapfn = _get_download_cache_locs()
+            dldir, urlmapfn = _get_download_cache_locs(pkgname)
         except OSError as e:
             msg = 'Remote data cache could not be accessed due to '
             estr = '' if len(e.args) < 1 else (': ' + str(e))
@@ -1082,7 +1084,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
     return local_path
 
 
-def is_url_in_cache(url_key):
+def is_url_in_cache(url_key, pkgname='astropy'):
     """
     Check if a download from ``url_key`` is in the cache.
 
@@ -1098,7 +1100,7 @@ def is_url_in_cache(url_key):
     """
     # The code below is modified from astropy.utils.data.download_file()
     try:
-        dldir, urlmapfn = _get_download_cache_locs()
+        dldir, urlmapfn = _get_download_cache_locs(pkgname)
     except OSError as e:
         msg = 'Remote data cache could not be accessed due to '
         estr = '' if len(e.args) < 1 else (': ' + str(e))
@@ -1112,10 +1114,10 @@ def is_url_in_cache(url_key):
 
 
 def _do_download_files_in_parallel(args):
-    return download_file(*args)
+    return download_file(*args, show_progress=False)
 
 
-def download_files_in_parallel(urls, cache=True, show_progress=True,
+def download_files_in_parallel(urls, cache=False, show_progress=True,
                                timeout=None):
     """
     Downloads multiple files in parallel from the given URLs.  Blocks until
@@ -1168,6 +1170,10 @@ def download_files_in_parallel(urls, cache=True, show_progress=True,
     else:
         progress = io.BytesIO()
 
+    if timeout is None:
+        # use configfile default
+        timeout = REMOTE_TIMEOUT()
+
     # Combine duplicate URLs
     combined_urls = list(set(urls))
     combined_paths = ProgressBar.map(
@@ -1198,7 +1204,7 @@ def _deltemps():
                 os.remove(fn)
 
 
-def clear_download_cache(hashorurl=None):
+def clear_download_cache(hashorurl=None, pkgname='astropy'):
     """ Clears the data file cache by deleting the local file(s).
 
     Parameters
@@ -1210,14 +1216,14 @@ def clear_download_cache(hashorurl=None):
     """
 
     try:
-        dldir, urlmapfn = _get_download_cache_locs()
+        dldir, urlmapfn = _get_download_cache_locs(pkgname)
     except OSError as e:
         msg = 'Not clearing data cache - cache inacessable due to '
         estr = '' if len(e.args) < 1 else (': ' + str(e))
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
         return
 
-    _acquire_download_cache_lock()
+    _acquire_download_cache_lock(pkgname)
     try:
         if hashorurl is None:
             # dldir includes both the download files and the urlmapfn.  This structure
@@ -1252,10 +1258,10 @@ def clear_download_cache(hashorurl=None):
     finally:
         # the lock will be gone if rmtree was used above, but release otherwise
         if os.path.exists(os.path.join(dldir, 'lock')):
-            _release_download_cache_lock()
+            _release_download_cache_lock(pkgname)
 
 
-def _get_download_cache_locs():
+def _get_download_cache_locs(pkgname='astropy'):
     """ Finds the path to the data cache directory and makes them if
     they don't exist.
 
@@ -1274,7 +1280,7 @@ def _get_download_cache_locs():
     # do whatever it wants with the filename.  Filename munging can and does happen
     # in practice).
     py_version = 'py' + str(sys.version_info.major)
-    datadir = os.path.join(get_cache_dir(), 'download', py_version)
+    datadir = os.path.join(get_cache_dir(pkgname), 'download', py_version)
     shelveloc = os.path.join(datadir, 'urlmap')
 
     if not os.path.exists(datadir):
@@ -1296,13 +1302,13 @@ def _get_download_cache_locs():
 
 # the cache directory must be locked before any writes are performed.  Same for
 # the hash shelve, so this should be used for both.
-def _acquire_download_cache_lock():
+def _acquire_download_cache_lock(pkgname='astropy'):
     """
     Uses the lock directory method.  This is good because `mkdir` is
     atomic at the system call level, so it's thread-safe.
     """
 
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+    lockdir = os.path.join(_get_download_cache_locs(pkgname)[0], 'lock')
     for i in range(conf.download_cache_lock_attempts):
         try:
             os.mkdir(lockdir)
@@ -1320,8 +1326,8 @@ def _acquire_download_cache_lock():
     raise RuntimeError(msg.format(lockdir))
 
 
-def _release_download_cache_lock():
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+def _release_download_cache_lock(pkgname='astropy'):
+    lockdir = os.path.join(_get_download_cache_locs(pkgname)[0], 'lock')
 
     if os.path.isdir(lockdir):
         # if the pid file is present, be sure to remove it

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -967,7 +967,10 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None, pkg
         The timeout, in seconds.  Otherwise, use
         `astropy.utils.data.Conf.remote_timeout`.
 
-    pkgname : TODO
+    pkgname : `str`, optional
+        The package name to use to locate the download cache. i.e. for
+        ``pkgname='astropy'`` the default cache location is
+        ``~/.astropy/cache``.
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1114,10 +1114,10 @@ def is_url_in_cache(url_key, pkgname='astropy'):
 
 
 def _do_download_files_in_parallel(args):
-    return download_file(*args, show_progress=False)
+    return download_file(*args)
 
 
-def download_files_in_parallel(urls, cache=False, show_progress=True,
+def download_files_in_parallel(urls, cache=True, show_progress=True,
                                timeout=None):
     """
     Downloads multiple files in parallel from the given URLs.  Blocks until
@@ -1169,10 +1169,6 @@ def download_files_in_parallel(urls, cache=False, show_progress=True,
         progress = sys.stdout
     else:
         progress = io.BytesIO()
-
-    if timeout is None:
-        # use configfile default
-        timeout = REMOTE_TIMEOUT()
 
     # Combine duplicate URLs
     combined_urls = list(set(urls))

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -282,7 +282,7 @@ def test_data_noastropy_fallback(monkeypatch):
     from ...config import paths
 
     # needed for testing the *real* lock at the end
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
+    lockdir = os.path.join(_get_download_cache_locs('astropy')[0], 'lock')
 
     # better yet, set the configuration to make sure the temp files are deleted
     data.conf.delete_temporary_downloads_at_exit = True
@@ -298,13 +298,13 @@ def test_data_noastropy_fallback(monkeypatch):
 
     # make sure the _find_or_create_astropy_dir function fails as though the
     # astropy dir could not be accessed
-    def osraiser(dirnm, linkto):
+    def osraiser(dirnm, linkto, pkgname=None):
         raise OSError
-    monkeypatch.setattr(paths, '_find_or_create_astropy_dir', osraiser)
+    monkeypatch.setattr(paths, '_find_or_create_root_dir', osraiser)
 
     with pytest.raises(OSError):
         # make sure the config dir search fails
-        paths.get_cache_dir()
+        paths.get_cache_dir('astropy')
 
     # first try with cache
     with catch_warnings(CacheMissingWarning) as w:


### PR DESCRIPTION
This is an adoption of #5828 because I think I have more reason to want it than @adrn.

I have rebased this for 3.0+ (so it's Python 3 only now) and I have also opened astropy/package-template#290 which demonstrates the changes needed to use this in the template. Also I have used this successfully in DKISTDC/dkist#3 to prove it works.

@eteq opinions?

EDIT: Fix #5779 , close #5828