### PR TITLE
Deprecate Astropy matplotlib plot style

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -275,6 +275,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- The Astropy matplotlib plot style has been deprecated. It will continue to
+  work in future but is no longer documented. [#6991]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -1,18 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This module contains dictionaries that can be used to set a matplotlib
-plotting style.  It is mostly here to allow a consistent plotting style
-in tutorials, but can be used to prepare any matplotlib figure.
-"""
+
+# This module contains dictionaries that can be used to set a matplotlib
+# plotting style. It is no longer documented/recommended as of Astropy v3.0
+# but is kept here for backward-compatibility.
 
 from ..utils import minversion
+
 # This returns False if matplotlib cannot be imported
 MATPLOTLIB_GE_1_5 = minversion('matplotlib', '1.5')
 
-
-__all__ = ['astropy_mpl_style_1', 'astropy_mpl_style',
-           'astropy_mpl_docs_style']
-
+__all__ = ['astropy_mpl_style_1', 'astropy_mpl_style']
 
 # Version 1 astropy plotting style for matplotlib
 astropy_mpl_style_1 = {
@@ -87,27 +84,3 @@ else:
 
 astropy_mpl_style = astropy_mpl_style_1
 """The most recent version of the astropy plotting style."""
-
-astropy_mpl_docs_style = astropy_mpl_style_1.copy()
-"""The plotting style used in the astropy documentation."""
-
-color_cycle_docs = [
-    '#E24A33',   # orange
-    '#348ABD',   # blue
-    '#467821',   # green
-    '#A60628',   # red
-    '#7A68A6',   # purple
-    '#CF4457',   # pink
-    '#188487'    # turquoise
-]
-
-if MATPLOTLIB_GE_1_5:
-    astropy_mpl_docs_style['axes.prop_cycle'] = cycler('color',
-                                                       color_cycle_docs)
-else:
-    astropy_mpl_docs_style['axes.color_cycle'] = color_cycle_docs
-
-astropy_mpl_docs_style['axes.grid'] = False
-astropy_mpl_docs_style['figure.figsize'] = (6, 6)
-astropy_mpl_docs_style['savefig.facecolor'] = 'none'
-astropy_mpl_docs_style['savefig.bbox'] = 'tight'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,9 +49,13 @@ from astropy_helpers.sphinx.conf import *
 
 import astropy
 
-# Use the astropy style when building docs
-from astropy import visualization
-plot_rcparams = visualization.astropy_mpl_docs_style
+plot_rcparams = {}
+plot_rcparams['figure.figsize'] = (6, 6)
+plot_rcparams['savefig.facecolor'] = 'none'
+plot_rcparams['savefig.bbox'] = 'tight'
+plot_rcparams['axes.labelsize'] = 'large'
+plot_rcparams['figure.subplot.hspace'] = 0.5
+
 plot_apply_rcparams = True
 plot_html_show_source_link = False
 plot_formats = ['png', 'svg', 'pdf']

--- a/docs/visualization/index.rst
+++ b/docs/visualization/index.rst
@@ -24,69 +24,6 @@ Using `astropy.visualization`
    histogram.rst
    lupton_rgb.rst
 
-Astropy matplotlib style
-=========================
-
-The visualization package contains two dictionaries that can be used to
-set the Matplotlib plotting style:
-
-.. data:: astropy_mpl_style
-
-    Improves some settings over the matplotlib default style.
-
-.. data:: astropy_mpl_docs_style
-
-    Matplotlib style used by the Astropy documentation.
-
-To apply the custom style on top of your existing matplotlib style,
-perform the following:
-
-Using matplotlib version >= 1.5:
-
-.. NOTE:  skip this doctest because the travis-ci py2.7 test uses
-.. matplotlib 1.4.3, which does not support "axes.axisbelow"
-
-.. doctest-skip::
-
-    >>> import matplotlib.pyplot as plt
-    >>> from astropy.visualization import astropy_mpl_style
-    >>> plt.style.use(astropy_mpl_style)
-
-For older versions of matplotlib:
-
-.. doctest-requires:: matplotlib
-
-    >>> import matplotlib as mpl
-    >>> from astropy.visualization import astropy_mpl_style
-    >>> mpl.rcParams.update(astropy_mpl_style)
-
-Note that these styles are applied *on top* your existing matplotlib
-style.  If you want an exactly reproducible plot (i.e. if you want the
-plot to come out exactly the same independent of the user
-configuration), you should reset the matplotlib settings to the
-defaults *before* applying the astropy style.
-
-Using matplotlib version >= 1.5:
-
-.. NOTE:  skip this doctest because the travis-ci py2.7 test uses
-.. matplotlib 1.4.3, which does not support "axes.axisbelow"
-
-.. doctest-skip::
-
-    >>> import matplotlib.pyplot as plt
-    >>> from astropy.visualization import astropy_mpl_style
-    >>> plt.style.use('default')
-    >>> plt.style.use(astropy_mpl_style)
-
-For older versions of matplotlib:
-
-.. doctest-requires:: matplotlib
-
-    >>> import matplotlib as mpl
-    >>> from astropy.visualization import astropy_mpl_style
-    >>> mpl.rcdefaults()
-    >>> mpl.rcParams.update(astropy_mpl_style)
-
 .. _fits2bitmap:
 
 Scripts
@@ -100,8 +37,6 @@ more about the available options and how to use it, type::
 
 Reference/API
 =============
-
-.. automodapi:: astropy.visualization.mpl_style
 
 .. automodapi:: astropy.visualization
 


### PR DESCRIPTION
This may be controversial, but I'd like to suggest that we deprecate/remove the Astropy Matplotlib plot style. This was developed back when the Matplotlib defaults weren't great, but with Matplotlib 2.0 (which has been out for a little while now) the default Matplotlib style is actually nicer than the Astropy one. So this PR does the following:

* Update ``astropy_mpl_style`` to an empty dictionary to just use the default Matplotlib style
* Leaves ``astropy_mpl_style_1`` as-is for people who liked the old style for a deprecation period
* Removes any mention of it in the docs - note that interestingly it never showed up in the API docs anyway
* Removes ``astropy_mpl_docs_style`` which I couldn't find any repo using apart from astropy

Now we can still do some customizations for the docs, but these can just live in ``conf.py`` - I've added a few. If we think this should be accessible to e.g. affiliated packages then this should probably go in astropy-helpers (or sphinx-astropy if we create that one day) and doesn't really belong in the actual core package. 

What do people think?

**Before**

<img width="625" alt="screen shot 2017-12-15 at 12 47 08" src="https://user-images.githubusercontent.com/314716/34042951-d8c1d150-e196-11e7-9207-c8dbdaa3df43.png">

**After**

<img width="709" alt="screen shot 2017-12-15 at 12 58 28" src="https://user-images.githubusercontent.com/314716/34043164-b888f6c4-e197-11e7-821f-f7fceef344d7.png">
