### PR TITLE
 Fix for--Tables with columns of strings can't be written to hdf5 with python 3 

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3,7 +3,6 @@ from .index import TableIndices, TableLoc, TableILoc
 
 import re
 import sys
-import os
 from collections import OrderedDict, Mapping
 import warnings
 from copy import deepcopy
@@ -2534,11 +2533,16 @@ class Table:
         The arguments and keywords (other than ``format``) provided to this function are
         passed through to the underlying data reader (e.g. `~astropy.io.ascii.write`).
         """
+        #Columns written in native py3 format are first converted to bytes so as to be written in hdf5 format.
         if isinstance(args[0],str):
             if(args[0].endswith(('.hdf5', '.h5'))):
-                for col in self.colnames:
-                    if str(self.columns[col].dtype)[1]=='U':
-                        self.replace_column(col, np.core.defchararray.encode((self.columns[col]).astype(str)))
+                for column in self.colnames:
+                    if str(self.columns[column].dtype)[1]=='U':
+                        self.replace_column(column, np.core.defchararray.encode(self.columns[column]))
+        """
+         self.replace_column(column, np.core.defchararray.encode(self.columns[column]),replaces the column
+         written in natine py3 format to bytes.
+        """
         io_registry.write(self, *args, **kwargs)
 
     def copy(self, copy_data=True):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3,6 +3,7 @@ from .index import TableIndices, TableLoc, TableILoc
 
 import re
 import sys
+import os
 from collections import OrderedDict, Mapping
 import warnings
 from copy import deepcopy
@@ -2533,6 +2534,9 @@ class Table:
         The arguments and keywords (other than ``format``) provided to this function are
         passed through to the underlying data reader (e.g. `~astropy.io.ascii.write`).
         """
+        if((ext=='.h5'or ext=='.hdf5')and kwargs['overwrite']):
+            for col in self.colnames:
+                self.replace_column(col, np.core.defchararray.encode((self.columns[col])))
         io_registry.write(self, *args, **kwargs)
 
     def copy(self, copy_data=True):


### PR DESCRIPTION
This fix will allow the Tables with native py3 strings  to be written to hdf5.`np.core.defchararray.encode()` is used to convert py3strings to bytes for I/O (as was suggested to fix this issue) which can be then converted to hdf5 format.

EDIT: Fix #5286.