### PR TITLE
Remove use of the "universal newline mode" with 'U'

### DIFF
--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -173,7 +173,7 @@ def test_configitem_options(tmpdir):
     f = tmpdir.join('astropy.cfg')
     with open(f.strpath, 'wb') as fd:
         apycfg.write(fd)
-    with open(f.strpath, 'rU', encoding='utf-8') as fd:
+    with open(f.strpath, 'r', encoding='utf-8') as fd:
         lns = [x.strip() for x in f.readlines()]
 
     assert 'tstnmo = op2' in lns


### PR DESCRIPTION
Related to #6902 (Python 3.7 compatibility).

Using `mode='U'` is deprecated and raises a DeprecationWarning
with Python 3.7. Also on Python 3 this mode is activated by default.

I wonder if it should be backported for 2.0 as I think it is also the default behavior on Python 2.7, and it would allow to keep the 2.0.x branch compatible with Python 3.7.