### PR TITLE
Serialize all astropy core objects to HDF5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,15 +72,20 @@ astropy.io.fits
   keyword argument - if set to `True`, then when string columns are accessed,
   byte columns will be returned, which can provide significantly improved
   performance. [#6920]
+
 - Added support for writing and reading back a table which has "mixin columns"
   such as ``SkyCoord`` or ``EarthLocation`` with no loss of information. [#6912]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
-  - When writing to HDF5 files, the serialized metadata are now saved in a new
-    dataset, instead of the HDF5 dataset attributes. This allows for metadata of
-    any dimensions. [#6304]
+- When writing to HDF5 files, the serialized metadata are now saved in a new
+  dataset, instead of the HDF5 dataset attributes. This allows for metadata of
+  any dimensions. [#6304]
+
+- Added support in HDF5 for writing and reading back a table which has "mixin
+  columns" such as ``SkyCoord`` or ``EarthLocation`` with no loss of
+  information. [#7007]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -12,7 +12,7 @@ from ...table import Table, serialize, meta, Column, MaskedColumn
 from ...table.table import has_info_class
 from ...time import Time
 from ...utils.exceptions import AstropyUserWarning
-from ...utils.data_info import MixinInfo
+from ...utils.data_info import MixinInfo, serialize_context_as
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES
 from .convenience import table_to_hdu
@@ -312,8 +312,10 @@ def _encode_mixins(tbl):
     # meta data which is extracted with meta.get_yaml_from_table.  This ignores
     # Time-subclass columns and leave them in the table so that the downstream
     # FITS Time handling does the right thing.
-    encode_tbl = serialize._represent_mixins_as_columns(
-        tbl, exclude_classes=(Time,))
+
+    with serialize_context_as('fits'):
+        encode_tbl = serialize._represent_mixins_as_columns(
+            tbl, exclude_classes=(Time,))
     if encode_tbl is tbl:
         return tbl
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -293,7 +293,7 @@ def _encode_mixins(tbl):
                     col.__class__ not in (u.Quantity, Time)):
                 raise TypeError('cannot write type {} column {!r} '
                                 'to FITS without PyYAML installed.'
-                                .format(col.info.name, col.__class__.__name__))
+                                .format(col.__class__.__name__, col.info.name))
         else:
             # Warn if information will be lost.  This is hardcoded to the set
             # difference between column info attributes and what FITS can store

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -291,8 +291,8 @@ def _encode_mixins(tbl):
         for col in tbl.itercols():
             if (has_info_class(col, MixinInfo) and
                     col.__class__ not in (u.Quantity, Time)):
-                raise TypeError('cannot write type {} column {!r} '
-                                'to FITS without PyYAML installed.'
+                raise TypeError("cannot write type {} column '{}' "
+                                "to FITS without PyYAML installed."
                                 .format(col.__class__.__name__, col.info.name))
         else:
             # Warn if information will be lost.  This is hardcoded to the set
@@ -300,12 +300,13 @@ def _encode_mixins(tbl):
             # natively (name, dtype, unit).  See _get_col_attributes() in
             # table/meta.py for where this comes from.
             for col in tbl.itercols():
-                for attr in ('format', 'description', 'meta'):
-                    if getattr(col.info, attr, None) not in (None, {}):
-                        warnings.warn("table contains column(s) with defined 'format',"
-                                      " 'description', or 'meta' info attributes. These"
-                                      " will be dropped unless you install PyYAML.",
-                                      AstropyUserWarning)
+                if any(getattr(col.info, attr, None) not in (None, {})
+                       for attr in ('format', 'description', 'meta')):
+                    warnings.warn("table contains column(s) with defined 'format',"
+                                  " 'description', or 'meta' info attributes. These"
+                                  " will be dropped unless you install PyYAML.",
+                                  AstropyUserWarning)
+                    break
             return tbl
 
     # Convert the table to one with no mixins, only Column objects.  This adds

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -572,3 +572,12 @@ def test_warn_for_dropped_info_attributes(tmpdir):
     assert len(warns) == 1
     assert str(warns[0].message).startswith(
         "table contains column(s) with defined 'format'")
+
+
+@pytest.mark.skipif('HAS_YAML')
+def test_error_for_mixins_but_no_yaml(tmpdir):
+    filename = str(tmpdir.join('test.fits'))
+    t = Table([mixin_cols['sc']])
+    with pytest.raises(TypeError) as err:
+        t.write(filename)
+    assert "cannot write type SkyCoord column 'col0' to FITS without PyYAML" in str(err)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -189,7 +189,7 @@ def _encode_mixins(tbl):
     from ...table import serialize
     from ...table.table import has_info_class
     from ... import units as u
-    from ...utils.data_info import MixinInfo
+    from ...utils.data_info import MixinInfo, serialize_context_as
 
     # If PyYAML is not available then check to see if there are any mixin cols
     # that *require* YAML serialization.  FITS already has support for Time,
@@ -210,7 +210,9 @@ def _encode_mixins(tbl):
 
     # Convert the table to one with no mixins, only Column objects.  This adds
     # meta data which is extracted with meta.get_yaml_from_table.
-    encode_tbl = serialize._represent_mixins_as_columns(tbl)
+
+    with serialize_context_as('hdf5'):
+        encode_tbl = serialize._represent_mixins_as_columns(tbl)
     if encode_tbl is tbl:
         return tbl
 

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -352,7 +352,10 @@ def write_table_hdf5(table, output, path=None, compression=False,
                                         data=header_encoded)
 
     else:
-        # Write the meta-data to the file
+        # Write the Table meta dict key:value pairs to the file as HDF5
+        # attributes.  This works only for a limited set of scalar data types
+        # like numbers, strings, etc., but not any complex types.  This path
+        # also ignores column meta like unit or format.
         for key in table.meta:
             val = table.meta[key]
             try:

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -192,29 +192,24 @@ def _encode_mixins(tbl):
     from ...utils.data_info import MixinInfo, serialize_context_as
 
     # If PyYAML is not available then check to see if there are any mixin cols
-    # that *require* YAML serialization.  FITS already has support for Time,
+    # that *require* YAML serialization.  HDF5 already has support for
     # Quantity, so if those are the only mixins the proceed without doing the
     # YAML bit, for backward compatibility (i.e. not requiring YAML to write
-    # Time or Quantity).  In this case other mixin column meta (e.g.
-    # description or meta) will be silently dropped, consistent with astropy <=
-    # 2.0 behavior.
+    # Quantity).
     try:
         import yaml
     except ImportError:
         for col in tbl.itercols():
             if (has_info_class(col, MixinInfo) and
                     col.__class__ is not u.Quantity):
-                raise TypeError('cannot write type {} column {!r} '
-                                'to HDF5 without PyYAML installed.'
+                raise TypeError("cannot write type {} column '{}' "
+                                "to HDF5 without PyYAML installed."
                                 .format(col.__class__.__name__, col.info.name))
 
     # Convert the table to one with no mixins, only Column objects.  This adds
     # meta data which is extracted with meta.get_yaml_from_table.
-
     with serialize_context_as('hdf5'):
         encode_tbl = serialize._represent_mixins_as_columns(tbl)
-    if encode_tbl is tbl:
-        return tbl
 
     return encode_tbl
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -692,7 +692,7 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
                         'scc.x', 'scc.y', 'scc.z',
                         'scd.ra', 'scd.dec', 'scd.distance',
                         'scd.obstime.jd1', 'scd.obstime.jd2',
-                        'tm',  # serialize_method is formatted_value
+                        'tm.jd1', 'tm.jd2',
                         ]
 
     t = table_cls([mixin_cols[name] for name in names], names=names)
@@ -710,8 +710,9 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
     assert t.colnames == t2.colnames
 
     # Read directly via hdf5 and confirm column names
-    # hdus = hdf5.open(filename)
-    # assert hdus[1].columns.names == serialized_names
+    h5 = h5py.File(filename, 'r')
+    assert list(h5['root'].dtype.names) == serialized_names
+    h5.close()
 
 
 @pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -593,8 +593,8 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
 
         assert np.all(a1 == a2)
 
-# Testing FITS table read/write with mixins.  This is mostly
-# copied from ECSV mixin testing.
+# Testing HDF5 table read/write with mixins.  This is mostly
+# copied from FITS mixin testing.
 
 el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
 el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -5,7 +5,13 @@ import pytest
 import numpy as np
 
 from ....tests.helper import catch_warnings
-from ....table import Table, Column
+from ....table import Table, QTable, NdarrayMixin, Column
+
+from .... import units as u
+
+from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from ....time import Time, TimeDelta
+from ....units.quantity import QuantityInfo
 
 try:
     import h5py
@@ -520,6 +526,20 @@ def test_skip_meta(tmpdir):
         "Attribute `f` of type {0} cannot be written to HDF5 files - skipping".format(type(t1.meta['f'])))
 
 
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+def test_fail_meta_serialize(tmpdir):
+
+    test_file = str(tmpdir.join('test.hdf5'))
+
+    t1 = Table()
+    t1.add_column(Column(name='a', data=[1, 2, 3]))
+    t1.meta['f'] = str
+
+    with pytest.raises(Exception) as err:
+        t1.write(test_file, path='the_table', serialize_meta=True)
+    assert "cannot represent an object: <class 'str'>" in str(err)
+
+
 @pytest.mark.skipif('not HAS_H5PY')
 def test_read_h5py_objects(tmpdir):
 
@@ -545,3 +565,204 @@ def test_read_h5py_objects(tmpdir):
     assert np.all(t4['a'] == [1, 2, 3])
 
     f.close()         # don't raise an error in 'test --open-files'
+
+
+def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
+    if compare_class:
+        assert obj1.__class__ is obj2.__class__
+
+    info_attrs = ['info.name', 'info.format', 'info.unit', 'info.description', 'info.meta']
+    for attr in attrs + info_attrs:
+        a1 = obj1
+        a2 = obj2
+        for subattr in attr.split('.'):
+            try:
+                a1 = getattr(a1, subattr)
+                a2 = getattr(a2, subattr)
+            except AttributeError:
+                a1 = a1[subattr]
+                a2 = a2[subattr]
+
+        # Mixin info.meta can None instead of empty OrderedDict(), #6720 would
+        # fix this.
+        if attr == 'info.meta':
+            if a1 is None:
+                a1 = {}
+            if a2 is None:
+                a2 = {}
+
+        assert np.all(a1 == a2)
+
+# Testing FITS table read/write with mixins.  This is mostly
+# copied from ECSV mixin testing.
+
+el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
+el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
+              obstime='J1990.5')
+scc = sc.copy()
+scc.representation = 'cartesian'
+tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
+
+
+mixin_cols = {
+    'tm': tm,
+    'dt': TimeDelta([1, 2] * u.day),
+    'sc': sc,
+    'scc': scc,
+    'scd': SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
+                    obstime=['J1990.5', 'J1991.5']),
+    'q': [1, 2] * u.m,
+    'lat': Latitude([1, 2] * u.deg),
+    'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
+    'ang': Angle([1, 2] * u.deg),
+    'el2': el2,
+}
+
+time_attrs = ['value', 'shape', 'format', 'scale', 'location']
+compare_attrs = {
+    'c1': ['data'],
+    'c2': ['data'],
+    'tm': time_attrs,
+    'dt': ['shape', 'value', 'format', 'scale'],
+    'sc': ['ra', 'dec', 'representation', 'frame.name'],
+    'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
+    'q': ['value', 'unit'],
+    'lon': ['value', 'unit', 'wrap_angle'],
+    'lat': ['value', 'unit'],
+    'ang': ['value', 'unit'],
+    'el2': ['x', 'y', 'z', 'ellipsoid'],
+    'nd': ['x', 'y', 'z'],
+}
+
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+def test_hdf5_mixins_qtable_to_table(tmpdir):
+    """Test writing as QTable and reading as Table.  Ensure correct classes
+    come out.
+    """
+    filename = str(tmpdir.join('test_simple.hdf5'))
+
+    names = sorted(mixin_cols)
+
+    t = QTable([mixin_cols[name] for name in names], names=names)
+    t.write(filename, format='hdf5', path='root', serialize_meta=True)
+    t2 = Table.read(filename, format='hdf5', path='root')
+
+    assert t.colnames == t2.colnames
+
+    for name, col in t.columns.items():
+        col2 = t2[name]
+
+        # Special-case Time, which does not yet support round-tripping
+        # the format.
+        if isinstance(col2, Time):
+            col2.format = col.format
+
+        attrs = compare_attrs[name]
+        compare_class = True
+
+        if isinstance(col.info, QuantityInfo):
+            # Downgrade Quantity to Column + unit
+            assert type(col2) is Column
+            # Class-specific attributes like `value` or `wrap_angle` are lost.
+            attrs = ['unit']
+            compare_class = False
+            # Compare data values here (assert_objects_equal doesn't know how in this case)
+            assert np.all(col.value == col2)
+
+        assert_objects_equal(col, col2, attrs, compare_class)
+
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+@pytest.mark.parametrize('table_cls', (Table, QTable))
+def test_hdf5_mixins_as_one(table_cls, tmpdir):
+    """Test write/read all cols at once and validate intermediate column names"""
+    filename = str(tmpdir.join('test_simple.hdf5'))
+    names = sorted(mixin_cols)
+
+    serialized_names = ['ang',
+                        'dt.jd1', 'dt.jd2',
+                        'el2.x', 'el2.y', 'el2.z',
+                        'lat',
+                        'lon',
+                        'q',
+                        'sc.ra', 'sc.dec',
+                        'scc.x', 'scc.y', 'scc.z',
+                        'scd.ra', 'scd.dec', 'scd.distance',
+                        'scd.obstime.jd1', 'scd.obstime.jd2',
+                        'tm',  # serialize_method is formatted_value
+                        ]
+
+    t = table_cls([mixin_cols[name] for name in names], names=names)
+    t.meta['C'] = 'spam'
+    t.meta['comments'] = ['this', 'is', 'a', 'comment']
+    t.meta['history'] = ['first', 'second', 'third']
+
+    t.write(filename, format="hdf5", path='root', serialize_meta=True)
+
+    t2 = table_cls.read(filename, format='hdf5', path='root')
+    assert t2.meta['C'] == 'spam'
+    assert t2.meta['comments'] == ['this', 'is', 'a', 'comment']
+    assert t2.meta['history'] == ['first', 'second', 'third']
+
+    assert t.colnames == t2.colnames
+
+    # Read directly via hdf5 and confirm column names
+    # hdus = hdf5.open(filename)
+    # assert hdus[1].columns.names == serialized_names
+
+
+@pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')
+@pytest.mark.parametrize('name_col', list(mixin_cols.items()))
+@pytest.mark.parametrize('table_cls', (Table, QTable))
+def test_hdf5_mixins_per_column(table_cls, name_col, tmpdir):
+    """Test write/read one col at a time and do detailed validation"""
+    filename = str(tmpdir.join('test_simple.hdf5'))
+    name, col = name_col
+
+    c = [1.0, 2.0]
+    t = table_cls([c, col, c], names=['c1', name, 'c2'])
+    t[name].info.description = 'my description'
+    t[name].info.meta = {'list': list(range(50)), 'dict': {'a': 'b' * 200}}
+
+    if not t.has_mixin_columns:
+        pytest.skip('column is not a mixin (e.g. Quantity subclass in Table)')
+
+    if isinstance(t[name], NdarrayMixin):
+        pytest.xfail('NdarrayMixin not supported')
+
+    t.write(filename, format="hdf5", path='root', serialize_meta=True)
+    t2 = table_cls.read(filename, format='hdf5', path='root')
+
+    assert t.colnames == t2.colnames
+
+    for colname in t.colnames:
+        assert_objects_equal(t[colname], t2[colname], compare_attrs[colname])
+
+    # Special case to make sure Column type doesn't leak into Time class data
+    if name.startswith('tm'):
+        assert t2[name]._time.jd1.__class__ is np.ndarray
+        assert t2[name]._time.jd2.__class__ is np.ndarray
+
+
+@pytest.mark.skipif('HAS_YAML or not HAS_H5PY')
+def test_warn_for_dropped_info_attributes(tmpdir):
+    filename = str(tmpdir.join('test.hdf5'))
+    t = Table([[1, 2]])
+    t['col0'].info.description = 'hello'
+    with catch_warnings() as warns:
+        t.write(filename, path='root', serialize_meta=False)
+    assert len(warns) == 1
+    assert str(warns[0].message).startswith(
+        "table contains column(s) with defined 'unit'")
+
+
+@pytest.mark.skipif('HAS_YAML or not HAS_H5PY')
+def test_error_for_mixins_but_no_yaml(tmpdir):
+    filename = str(tmpdir.join('test.hdf5'))
+    t = Table([mixin_cols['sc']])
+    with pytest.raises(TypeError) as err:
+        t.write(filename, path='root', serialize_meta=True)
+    assert "cannot write type SkyCoord column 'col0' to HDF5 without PyYAML" in str(err)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -109,7 +109,7 @@ def test_io_ascii_write():
             t.write(out, format=fmt['Format'])
 
 
-def test_io_quantity_write(tmpdir):
+def test_votable_quantity_write(tmpdir):
     """
     Test that table with Quantity mixin column can be round-tripped by
     io.votable.  Note that FITS and HDF5 mixin support are tested (much more
@@ -192,7 +192,7 @@ def test_io_time_write_fits(tmpdir, table_types):
             assert (tm[name] == t[name].value).all()
 
 
-def test_io_write_fail(mixin_cols):
+def test_votable_mixin_write_fail(mixin_cols):
     """
     Test that table with mixin columns (excluding Quantity) cannot be written by
     io.votable.

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -111,28 +111,19 @@ def test_io_ascii_write():
 
 def test_io_quantity_write(tmpdir):
     """
-    Test that table with Quantity mixin column can be written by io.fits and
-    io.votable but not by io.misc.hdf5. Validation of the output is done.
-    Test that io.fits writes a table containing Quantity mixin columns that can
-    be round-tripped (metadata unit).
+    Test that table with Quantity mixin column can be round-tripped by
+    io.votable.  Note that FITS and HDF5 mixin support are tested (much more
+    thoroughly) in their respective subpackage tests
+    (io/fits/tests/test_connect.py and io/misc/tests/test_hdf5.py).
     """
     t = QTable()
     t['a'] = u.Quantity([1, 2, 4], unit='Angstrom')
 
     filename = str(tmpdir.join('table-tmp'))
-
-    # Show that FITS and VOTable formats succeed
-    for fmt in ('fits', 'votable'):
-        t.write(filename, format=fmt, overwrite=True)
-        qt = QTable.read(filename, format=fmt)
-        assert isinstance(qt['a'], u.Quantity)
-        assert qt['a'].unit == 'Angstrom'
-
-    # Show that HDF5 format fails
-    if HAS_H5PY:
-        with pytest.raises(ValueError) as err:
-            t.write(filename, format='hdf5', overwrite=True)
-        assert 'cannot write table with mixin column(s)' in str(err.value)
+    t.write(filename, format='votable', overwrite=True)
+    qt = QTable.read(filename, format='votable')
+    assert isinstance(qt['a'], u.Quantity)
+    assert qt['a'].unit == 'Angstrom'
 
 
 @pytest.mark.parametrize('table_types', (Table, QTable))
@@ -204,8 +195,7 @@ def test_io_time_write_fits(tmpdir, table_types):
 def test_io_write_fail(mixin_cols):
     """
     Test that table with mixin columns (excluding Quantity) cannot be written by
-    io.votable, io.fits and io.misc.hdf5. Also test that table with Time mixin
-    columns cannot be written by io.votable and io.misc.hdf5.
+    io.votable.
     """
     t = QTable(mixin_cols)
     # Only do this test if there are unsupported column types (i.e. anything besides
@@ -214,13 +204,11 @@ def test_io_write_fail(mixin_cols):
 
     if not unsupported_cols:
         pytest.skip("no unsupported column types")
-    for fmt in ('votable', 'hdf5'):
-        if fmt == 'hdf5' and not HAS_H5PY:
-            continue
-        out = StringIO()
-        with pytest.raises(ValueError) as err:
-            t.write(out, format=fmt)
-        assert 'cannot write table with mixin column(s)' in str(err.value)
+
+    out = StringIO()
+    with pytest.raises(ValueError) as err:
+        t.write(out, format='votable')
+    assert 'cannot write table with mixin column(s)' in str(err.value)
 
 
 def test_join(table_types):

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -658,7 +658,7 @@ have defined values for any of the above-listed column attributes, these
 metadata will *not* be stored and a warning will be issued.
 
 serialize_meta
-""""""""""""""
+~~~~~~~~~~~~~~
 To enable storing all table and column metadata to the HDF5 file, call
 the ``write()`` method with ``serialize_meta=True``.  This will store metadata
 in a separate HDF5 dataset, contained in the same file, which is named
@@ -672,7 +672,7 @@ HDF5 tables that contain :ref:`mixin_columns` such as `~astropy.time.Time` or
 `~astropy.coordinates.SkyCoord` columns.
 
 compatibility_mode
-""""""""""""""""""
+~~~~~~~~~~~~~~~~~~
 
 The way metadata are saved in the HDF5 dataset has changed in astropy 3.0.
 Previously the metadata were serialized with YAML and this was stored as an

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -455,7 +455,7 @@ and the time coordinate column ``time`` as ``[1, 2]`` will give::
 
 By default, FITS table columns will be read as standard `~astropy.table.Column`
 objects without taking the FITS time standard into consideration.
-n
+
 * String time column in ISO-8601 Datetime format
 
 FITS uses a subset of ISO-8601 (which in itself does not imply a particular time scale)

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -273,15 +273,10 @@ Astropy native objects (mixin columns)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is possible to store not only standard `~astropy.table.Column` objects to a
-FITS table HDU, but also the following Astropy native objects
-(:ref:`mixin_columns`) within a `~astropy.table.Table` or `~astropy.table.QTable`:
-
-- `astropy.time.Time`
-- `astropy.units.Quantity`
-
-Other mixin columns such as `~astropy.coordinates.SkyCoord` or
-`~astropy.coordinates.EarthLocation` are not currently supported due to reasons
-including extensive metadata and no precise mapping to the FITS standard.
+FITS table HDU, but also any Astropy native objects
+(:ref:`mixin_columns`) within a `~astropy.table.Table` or
+`~astropy.table.QTable`.  This includes `~astropy.time.Time`,
+`~astropy.units.Quantity`, `~astropy.coordinates.SkyCoord`, and many others.
 
 In general a mixin column may contain multiple data components as well as
 object attributes beyond the standard Column attributes like ``format`` or
@@ -460,7 +455,7 @@ and the time coordinate column ``time`` as ``[1, 2]`` will give::
 
 By default, FITS table columns will be read as standard `~astropy.table.Column`
 objects without taking the FITS time standard into consideration.
-
+n
 * String time column in ISO-8601 Datetime format
 
 FITS uses a subset of ISO-8601 (which in itself does not imply a particular time scale)
@@ -642,24 +637,60 @@ overwriting existing files. To overwrite only a single table within an HDF5
 file that has multiple datasets, use *both* the ``overwrite=True`` and
 ``append=True`` arguments.
 
-If the metadata of the table cannot be written directly to the HDF5 file
-(e.g. dictionaries), or if you want to preserve the units and description
-of tables and columns, use ``serialize_meta=True``::
-
-    >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True)
-
-The way serialized meta are saved in the HDF5 dataset have changed in Astropy 3.0.
-Files in the old format are still read correctly. If for some reason the user wants to *write*
-in the old format, they will specify the (deprecated) ``compatibility_mode`` keyword
-
-    >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True, compatibility_mode=True)
-
 Finally, when writing to HDF5 files, the ``compression=`` argument can be
 used to ensure that the data is compressed on disk::
 
     >>> t.write('new_file.hdf5', path='updated_data', compression=True)
 
+Metadata and mixin columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Astropy tables can contain metadata, both in the table ``meta`` attribute
+(which is an ordered dictionary of arbitrary key/value pairs), and within the
+columns, which each have attributes ``unit``, ``format``, ``description``,
+and ``meta``.
+
+By default, when writing a table to HDF5 the code will attempt to store each
+key/value pair within the table ``meta`` as HDF5 attributes of the table
+dataset.  This will fail of the values within ``meta`` are not objects that can
+be stored as HDF5 attributes.  In addition, if the table columns being stored
+have defined values for any of the above-listed column attributes, these
+metadata will *not* be stored and a warning will be issued.
+
+serialize_meta
+""""""""""""""
+To enable storing all table and column metadata to the HDF5 file, call
+the ``write()`` method with ``serialize_meta=True``.  This will store metadata
+in a separate HDF5 dataset, contained in the same file, which is named
+``<path>.__table_column_meta__``.  Here ``path`` is the argument provided in
+the call to ``write()``::
+
+    >>> t.write('observations.hdf5', path='data', serialize_meta=True)
+
+As of astropy 3.0, by specifying ``serialize_meta=True`` one can also store to
+HDF5 tables that contain :ref:`mixin_columns` such as `~astropy.time.Time` or
+`~astropy.coordinates.SkyCoord` columns.
+
+compatibility_mode
+""""""""""""""""""
+
+The way metadata are saved in the HDF5 dataset has changed in astropy 3.0.
+Previously the metadata were serialized with YAML and this was stored as an
+HDF5 attribute.  This process was subject to a fixed limit on the size of an
+attribute.  Starting with 3.0 the YAML-serialized metadata are stored as a
+separate dataset as described above, with no size limit.
+
+Files using the old convention are automatically recognized and will always be read
+correctly.
+
+If for some reason the user needs to *write* in the old format, they should
+specify the deprecated ``compatibility_mode`` keyword::
+
+    >>> t.write('observations.hdf5', path='updated_data', serialize_meta=True,
+    ...         compatibility_mode=True)
+
+.. warning:: The ``compatibility_mode`` keyword will be removed in a future
+   version of astropy so your code should be changed.
 
 .. _table_io_jsviewer:
 


### PR DESCRIPTION
This is pretty much #6912 but for HDF5.  It is a bit simpler for HDF5 because there are no complications with keywords and splitting the YAML into COMMENT cards, etc.  On the flip side the whole `serialize_meta` business is a bit annoying.

Overall this is very much like the FITS implementation and testing, thus am requesting review from @mhvk.

One small point is that in doing this I noticed a trivial bug in the FITS implementation (Exception message has args flipped), so I fixed that and added a test both for HDF5 and FITS.  I also noticed some FITS docs in the `unified.rst` that were not updated so I fixed that as well.  Sorry for the leakage but this is faster and saves CI time.

Closes #6977.