### PR TITLE
Favor recursive cloning with git [docs only]

### DIFF
--- a/docs/development/workflow/additional_git_topics.rst
+++ b/docs/development/workflow/additional_git_topics.rst
@@ -58,7 +58,7 @@ collaborator:
 
 Now all those people can do::
 
-    git clone git@githhub.com:your-user-name/astropy.git
+    git clone --recursive git@githhub.com:your-user-name/astropy.git
 
 Remember that links starting with ``git@`` use the ssh protocol and are
 read-write; links starting with ``git://`` are read-only.

--- a/docs/development/workflow/get_devel_version.rst
+++ b/docs/development/workflow/get_devel_version.rst
@@ -129,9 +129,9 @@ of `Astropy`_ in a directory called ``astropy``; which form you use depends
 on what kind of authentication you set up in the previous step::
 
     # Use this form if you setup SSH keys...
-    $ git clone git@github.com:your-user-name/astropy.git
+    $ git clone --recursive git@github.com:your-user-name/astropy.git
     # ...otherwise use this form:
-    $ git clone https://github.com/your-user-name/astropy.git
+    $ git clone --recursive https://github.com/your-user-name/astropy.git
 
 If there is an error at this stage it is probably an error in setting up
 authentication.

--- a/docs/development/workflow/patches.rst
+++ b/docs/development/workflow/patches.rst
@@ -17,7 +17,7 @@ If you haven't already configured git::
 Then, the workflow is the following::
 
    # Get the repository if you don't have it
-   git clone git://github.com/astropy/astropy.git
+   git clone --recursive git://github.com/astropy/astropy.git
 
    # Make a branch for your patching
    cd astropy
@@ -58,7 +58,7 @@ In detail
 #. If you don't already have one, clone a copy of the
    Astropy_ repository::
 
-      git clone git://github.com/astropy/astropy.git
+      git clone --recursive git://github.com/astropy/astropy.git
       cd astropy
 
 #. Make a 'feature branch'. This will be where you work on your bug fix. It's

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -207,7 +207,7 @@ Development repository
 The latest development version of Astropy can be cloned from github
 using this command::
 
-   git clone git://github.com/astropy/astropy.git
+   git clone --recursive git://github.com/astropy/astropy.git
 
 .. note::
 


### PR DESCRIPTION
Refers to https://github.com/astropy/astropy/issues/4685

**Note:** `docs/development/astropy-package-template.rst` provides step-by-step instructions for creating an Astropy package from scratch, so therefore I did not touch the `git clone` command.

However, `astropy-helpers` is already a submodule of `astropy/package-template`. Adding `--recursive` to the initial clone command would allow you to drop next section involving `git submodule add`. 

Then again, is it really necessary to run `git submodule add` after cloning without recursive if it's already part of `astropy/package-template`? Should this be fixed?