### PR TITLE
Fix :Tables with columns of strings can't be written to hdf5 with python 3 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,11 @@ astropy.io.misc
 
 - Added support for saving models with units to the asdf format. [#7237]
 
+- Added a new ``character_as_bytes`` keyword to the HDF5 Table reading
+  function to control whether byte string columns in the HDF5 file
+  are left as bytes or converted to unicode.  The default is to read
+  as bytes (``character_as_bytes=True``). [#7024]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -388,6 +393,10 @@ astropy.io.misc
   enabled the data mask will now be written as an additional column and the
   masked columns will round-trip correctly. [#7481]
 
+- Fixed a bug where writing to HDF5 failed for for tables with columns of
+  unicode strings.  Now those columns are first encoded to UTF-8 and
+  written as byte strings. [#7024]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -496,11 +505,6 @@ astropy.io.fits
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
-
-- Fix Tables with columns of strings can't be written to Hdf5 file with Python3
-  If the table columns have data in form of string then a new table is made
-  from the original table with columns of strings replaced by columns of bytes.
-  The new table can now be written in Hdf5 file.[#7024]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -497,6 +497,11 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Fix Tables with columns of strings can't be written to Hdf5 file with Python3
+  If the table columns have data in form of string then a new table is made
+  from the original table with columns of strings replaced by columns of bytes.
+  The new table can now be written in Hdf5 file.[#7024]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -235,13 +235,13 @@ def convert_dtype(table, character_as_bytes, copy=False):
             table = temp
         try:
             table.convert_unicode_to_bytestring()
-        except UnicodeEncodeError:
+        except (UnicodeEncodeError, AttributeError):
             for column_name in colnames:
                 table.replace_column(column_name, np.char.encode(table.columns[column_name], "utf-8"))
     elif character_as_bytes is False:
         try:
             table.convert_bytestring_to_unicode()
-        except UnicodeDecodeError:
+        except (UnicodeDecodeError, AttributeError):
             colnames = [name for name in table.colnames if table.columns[name].info.dtype.kind == 'S']
             for column_name in colnames:
                 table.replace_column(column_name, np.char.decode(table.columns[column_name], "utf-8"))
@@ -337,10 +337,10 @@ def write_table_hdf5(table, output, path=None, compression=False,
             del output_group[name]
         else:
             raise OSError("Table {0} already exists".format(path))
-    #Table with native py3 strings can't be wriiten in hdf5 so
+    #Table with native py3 strings can't be written in hdf5 so
     #to write such a table a copy of table is made containg columns as
     #bytestrings.Now this copy of the table can be written in hdf5.
-    table = convert_dtype(table,character_as_bytes=True,copy=True)
+    table = convert_dtype(table, character_as_bytes=True, copy=True)
     # Encode any mixin columns as plain columns + appropriate metadata
     table = _encode_mixins(table)
     # Warn if information will be lost when serialize_meta=False.  This is

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -569,29 +569,37 @@ def test_read_h5py_objects(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY')
-def test_write_to_Hdf5(tmpdir):
+def test_write_to_hdf5(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
+
     t = Table()
     t['p'] = ['a', 'b', 'c']
     t['q'] = [ 1, 2, 3 ]
     t['r'] = [b'a', b'b', b'c']
     t['s'] = ["\u2119", "\u01b4", "\u2602"]
     t.write(test_file, path='the_table', overwrite=True)
-    t1 = Table.read(test_file, path='the_table')
+    t1 = Table.read(test_file, path='the_table', character_as_bytes=False)
+    assert np.all(t1['p'] == ['a', 'b', 'c'])
+    assert np.all(t1['q'] == [1, 2, 3])
+    assert np.all(t1['r'] == ['a', 'b', 'c'])
+    assert np.all(t1['s'] == ["\u2119", "\u01b4", "\u2602"])
+    assert np.all(t1['p'].info.dtype.kind == "U")
+    assert np.all(t1['q'].info.dtype.kind == "i")
+    assert np.all(t1['r'].info.dtype.kind == "U")
+    assert np.all(t1['s'].info.dtype.kind == "U")
+
     f = h5py.File(test_file)
     t2 = Table.read(f, path='the_table')
-    assert np.all(t['p'] == ['a', 'b', 'c'])
-    assert np.all(t['q'] == [ 1, 2 , 3 ])
-    assert np.all(t['r'] == [b'a', b'b', b'c'])
-    assert np.all(t['s'] == ["\u2119", "\u01b4", "\u2602"])
-    assert np.all(t1['p'] == ['a', 'b', 'c'])
-    assert np.all(t1['q'] == [ 1, 2, 3])
-    assert np.all(t1['r'] == [b'a', b'b', b'c'])
-    assert np.all(t1['s'] == ["\u2119", "\u01b4", "\u2602"])
     assert np.all(t2['p'] == ['a', 'b', 'c'])
-    assert np.all(t2['q'] == [ 1, 2, 3 ])
+    assert np.all(t2['q'] == [1, 2, 3])
     assert np.all(t2['r'] == [b'a', b'b', b'c'])
     assert np.all(t2['s'] == ["\u2119", "\u01b4", "\u2602"])
+
+    t3 = Table.read(test_file, path='the_table', character_as_bytes=True)
+    assert np.all(t3['p'].info.dtype.kind == "S")
+    assert np.all(t3['q'].info.dtype.kind == "i")
+    assert np.all(t3['r'].info.dtype.kind == "S")
+    assert np.all(t3['s'].info.dtype.kind == "S")
 
 
 def assert_objects_equal(obj1, obj2, attrs, compare_class=True):

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -568,6 +568,28 @@ def test_read_h5py_objects(tmpdir):
     f.close()         # don't raise an error in 'test --open-files'
 
 
+@pytest.mark.skipif('not HAS_H5PY')
+def test_write_to_Hdf5(tmpdir):
+    test_file = str(tmpdir.join('test.hdf5'))
+    t1 = Table()
+    t1['x']=['a', 'b', 'c']
+    t1['y']=[ 1, 2, 3 ]
+    t1['z']=[b'a', b'b', b'c']
+    t1.write(test_file, path='the_table', overwrite=True)
+    f = h5py.File(test_file)
+    t2 = Table.read(f, path='the_table')
+    t = Table.read(test_file, path='the_table')
+    assert np.all(t1['x'] == ['a', 'b', 'c'])
+    assert np.all(t1['y'] == [ 1, 2 , 3 ])
+    assert np.all(t1['z'] == [b'a', b'b', b'c'])
+    assert np.all(t['x'] == ['a', 'b', 'c'])
+    assert np.all(t['y'] == [ 1 ,2 ,3])
+    assert np.all(t['z'] == [b'a', b'b', b'c'])
+    assert np.all(t2['x'] == ['a', 'b', 'c'])
+    assert np.all(t2['y'] == [ 1, 2 , 3 ])
+    assert np.all(t2['z'] == [b'a', b'b', b'c'])
+
+
 def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
     if compare_class:
         assert obj1.__class__ is obj2.__class__

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -571,23 +571,27 @@ def test_read_h5py_objects(tmpdir):
 @pytest.mark.skipif('not HAS_H5PY')
 def test_write_to_Hdf5(tmpdir):
     test_file = str(tmpdir.join('test.hdf5'))
-    t1 = Table()
-    t1['x']=['a', 'b', 'c']
-    t1['y']=[ 1, 2, 3 ]
-    t1['z']=[b'a', b'b', b'c']
-    t1.write(test_file, path='the_table', overwrite=True)
+    t = Table()
+    t['p'] = ['a', 'b', 'c']
+    t['q'] = [ 1, 2, 3 ]
+    t['r'] = [b'a', b'b', b'c']
+    t['s'] = ["\u2119", "\u01b4", "\u2602"]
+    t.write(test_file, path='the_table', overwrite=True)
+    t1 = Table.read(test_file, path='the_table')
     f = h5py.File(test_file)
     t2 = Table.read(f, path='the_table')
-    t = Table.read(test_file, path='the_table')
-    assert np.all(t1['x'] == ['a', 'b', 'c'])
-    assert np.all(t1['y'] == [ 1, 2 , 3 ])
-    assert np.all(t1['z'] == [b'a', b'b', b'c'])
-    assert np.all(t['x'] == ['a', 'b', 'c'])
-    assert np.all(t['y'] == [ 1 ,2 ,3])
-    assert np.all(t['z'] == [b'a', b'b', b'c'])
-    assert np.all(t2['x'] == ['a', 'b', 'c'])
-    assert np.all(t2['y'] == [ 1, 2 , 3 ])
-    assert np.all(t2['z'] == [b'a', b'b', b'c'])
+    assert np.all(t['p'] == ['a', 'b', 'c'])
+    assert np.all(t['q'] == [ 1, 2 , 3 ])
+    assert np.all(t['r'] == [b'a', b'b', b'c'])
+    assert np.all(t['s'] == ["\u2119", "\u01b4", "\u2602"])
+    assert np.all(t1['p'] == ['a', 'b', 'c'])
+    assert np.all(t1['q'] == [ 1, 2, 3])
+    assert np.all(t1['r'] == [b'a', b'b', b'c'])
+    assert np.all(t1['s'] == ["\u2119", "\u01b4", "\u2602"])
+    assert np.all(t2['p'] == ['a', 'b', 'c'])
+    assert np.all(t2['q'] == [ 1, 2, 3 ])
+    assert np.all(t2['r'] == [b'a', b'b', b'c'])
+    assert np.all(t2['s'] == ["\u2119", "\u01b4", "\u2602"])
 
 
 def assert_objects_equal(obj1, obj2, attrs, compare_class=True):


### PR DESCRIPTION
This fix will allow the Tables with native py3 strings to be written to hdf5. Table columns are converted to bytes for I/O if they are in string format so that the table can be written to hdf5 format.

EDIT: Fix #5286.