### PR TITLE
change branching instructions to use master instead of HEAD local branch

### DIFF
--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -177,7 +177,7 @@ packages that use the full bugfix/maintenance branch approach.)
 
    * build and upload the Astropy wheels;
    * make and upload the Astropy source release.
-   
+
 
 #. For the wheel build / upload, follow the `wheel builder README`_
    instructions again.  Edit the ``.travis.yml`` and ``appveyor.yml`` files
@@ -202,7 +202,7 @@ packages that use the full bugfix/maintenance branch approach.)
       $ python setup.py build sdist
       $ gpg --detach-sign -a dist/astropy-<version>.tar.gz
       $ twine upload dist/astropy-<version>*
-      
+
 #. Go to https://pypi.python.org/pypi?:action=pkg_edit&name=astropy
    and ensure that only the most recent releases in each actively maintained
    release line are *not* marked hidden.  For example, if v1.2.2 was
@@ -314,10 +314,10 @@ soon-to-be-released version can focus on bug fixes and documentation updates.
 
 The procedure for this is straightforward:
 
-#. Make sure you're on master, and updated to the latest version from github::
+#. Update your local master branch to use to the latest version from github::
 
       $ git fetch upstream
-      $ git checkout upstream/master
+      $ git checkout -B master upstream/master
 
 #. Create a new branch from master at the point you want the feature freeze to
    occur::
@@ -361,7 +361,7 @@ The procedure for this is straightforward:
 #. Push all of these changes up to github::
 
       $ git push upstream v<version>.x:v<version>.x
-      $ git push upstream HEAD:master
+      $ git push upstream master:master
 
    .. note::
 


### PR DESCRIPTION
This is a minor perturbation on the "branching" instructions to use the local master branch instead of HEAD.

My justification is based on the branching I just did, where it was useful to pop back and forth between master and the just-made v3.0.x branch to check some things.  That's more awkward if you're using a detached head.

cc @astrofrog and @bsipocz because I *think* maybe it was like this before but one of you swapped it back for some reason?