### PR TITLE
Allow lists of quantities to be converted in Matplotlib unit converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ astropy.utils
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
+- Lists of units are now converted in the Matplotlib unit converter. This means
+  that for Matplotlib versions later than 2.2, more plotting functions now work
+  with units (e.g. errorbar). [#7037]
 
 astropy.wcs
 ^^^^^^^^^^^
@@ -945,9 +948,6 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Explicilty default to origin='lower' in WCSAxes. [#7331]
-- Lists of units are converted in the Matplotlib unit converter. This means
-  more plotting functions now work with units (e.g. errorbar).
-  [#7037]
 
 - Fixed a bug that caused the position of the tick values in decimal mode
   to be incorrectly determined. [#7332]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -945,6 +945,9 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Explicilty default to origin='lower' in WCSAxes. [#7331]
+- Lists of units are converted in the Matplotlib unit converter. This means
+  more plotting functions now work with units (e.g. errorbar).
+  [#7037]
 
 - Fixed a bug that caused the position of the tick values in decimal mode
   to be incorrectly determined. [#7332]

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -39,6 +39,7 @@ def test_units():
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_units_errbarr():
+    pytest.importorskip("matplotlib", minversion="2.2")
     plt.figure()
 
     with quantity_support():

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -38,6 +38,24 @@ def test_units():
 
 
 @pytest.mark.skipif('not HAS_PLT')
+def test_units_errbarr():
+    plt.figure()
+
+    with quantity_support():
+        x = [1, 2, 3] * u.s
+        y = [1, 2, 3] * u.m
+        yerr = [3, 2, 1] * u.cm
+
+        fig, ax = plt.subplots()
+        ax.errorbar(x, y, yerr=yerr)
+
+        assert ax.xaxis.get_units() == u.s
+        assert ax.yaxis.get_units() == u.m
+
+    plt.clf()
+
+
+@pytest.mark.skipif('not HAS_PLT')
 def test_incompatible_units():
     plt.figure()
 

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -80,6 +80,8 @@ def quantity_support(format='latex_inline'):
         def convert(val, unit, axis):
             if isinstance(val, u.Quantity):
                 return val.to_value(unit)
+            elif isinstance(val, list):
+                return [v.to_value(unit) for v in val]
             else:
                 return val
 


### PR DESCRIPTION
Quite a lot of the unit support built into Matplotlib, and quite a lot of the internals, works on lists of unit-like object. This lets a list of quantities be converted fine using the Matplotlib unit converters in Astropy.

As an example, this change makes vlines and hlines work in Matplotlib:

```python
from astropy.visualization import quantity_support
import astropy.units as u
import matplotlib.pyplot as plt

quantity_support()
x = 0.5 * u.m

fig, ax = plt.subplots()
ax.axhline(x)
plt.show()
```
