### PR TITLE
WIP:Addition of nocopy argument to (Bin)TableHDU.from_columns

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -121,10 +121,17 @@ class _TableLikeHDU(_ValidHDU):
         Any additional keyword arguments accepted by the HDU class's
         ``__init__`` may also be passed in as keyword arguments.
         """
-
         coldefs = cls._columns_type(columns)
-        data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
-                                     character_as_bytes=character_as_bytes)
+        if nocopy==False:
+            data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
+                                         character_as_bytes=character_as_bytes)
+        else :
+            if isinstance(columns,Column) or isinstance(columns,ColDefs) :
+                raise Exception("data has to be copied")
+            elif isinstance(columns,TableHDU) or isinstance(columns,BinTableHDU):
+                data=columns.data
+            else:
+                data=columns
         hdu = cls(data=data, header=header, character_as_bytes=character_as_bytes, **kwargs)
         coldefs._add_listener(hdu)
         return hdu

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -70,7 +70,7 @@ class _TableLikeHDU(_ValidHDU):
 
     @classmethod
     def from_columns(cls, columns, header=None, nrows=0, fill=False,
-                     character_as_bytes=False, **kwargs):
+                     character_as_bytes=False,nocopy=False, **kwargs):
         """
         Given either a `ColDefs` object, a sequence of `Column` objects,
         or another table HDU or table data (a `FITS_rec` or multi-field


### PR DESCRIPTION
 A nocopy argument would allow a table HDU to be created from an existing recarray or FITS_rec without copying the data in the array--reusing the existing array. 
Fix:#7012