### PR TITLE
Update copyright years and ReST formatting of licenses

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2011-2017, Astropy Developers
+Copyright (c) 2011-2018, Astropy Developers
 
 All rights reserved.
 

--- a/licenses/AURA_LICENSE.rst
+++ b/licenses/AURA_LICENSE.rst
@@ -3,17 +3,15 @@ Copyright (C) 2005 Association of Universities for Research in Astronomy (AURA)
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    3. The name of AURA and its representatives may not be used to
-      endorse or promote products derived from this software without
-      specific prior written permission.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+3. The name of AURA and its representatives may not be used to
+   endorse or promote products derived from this software without
+   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/licenses/CONFIGOBJ_LICENSE.rst
+++ b/licenses/CONFIGOBJ_LICENSE.rst
@@ -6,18 +6,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Michael Foord nor the name of Voidspace
-      may be used to endorse or promote products derived from this
-      software without specific prior written permission.
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+* Neither the name of Michael Foord nor the name of Voidspace
+  may be used to endorse or promote products derived from this
+  software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/licenses/CONFIGOBJ_LICENSE.rst
+++ b/licenses/CONFIGOBJ_LICENSE.rst
@@ -1,5 +1,7 @@
 Copyright (c) 2003-2010, Michael Foord
+
 All rights reserved.
+
 E-mail : fuzzyman AT voidspace DOT org DOT uk
 
 Redistribution and use in source and binary forms, with or without

--- a/licenses/DATATABLES_LICENSE.rst
+++ b/licenses/DATATABLES_LICENSE.rst
@@ -5,16 +5,14 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-Redistributions of source code must retain the above copyright notice,
-this list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-Neither the name of Allan Jardine nor SpryMedia may be used to endorse
-or promote products derived from this software without specific prior
-written permission.
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Allan Jardine nor SpryMedia may be used to endorse
+  or promote products derived from this software without specific prior
+  written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY
 EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/licenses/ERFA.rst
+++ b/licenses/ERFA.rst
@@ -28,14 +28,12 @@ TERMS AND CONDITIONS
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1 Redistributions of source code must retain the above copyright
+1. Redistributions of source code must retain the above copyright
    notice, this list of conditions and the following disclaimer.
-
-2 Redistributions in binary form must reproduce the above copyright
+2. Redistributions in binary form must reproduce the above copyright
    notice, this list of conditions and the following disclaimer in the
    documentation and/or other materials provided with the distribution.
-
-3 Neither the name of the Standards Of Fundamental Astronomy Board, the
+3. Neither the name of the Standards Of Fundamental Astronomy Board, the
    International Astronomical Union nor the names of its contributors
    may be used to endorse or promote products derived from this software
    without specific prior written permission.

--- a/licenses/EXPAT_LICENSE.rst
+++ b/licenses/EXPAT_LICENSE.rst
@@ -1,5 +1,5 @@
-Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd
-                               and Clark Cooper
+Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd and Clark Cooper
+			       
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006 Expat maintainers.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/licenses/FUTURES_LICENSE.rst
+++ b/licenses/FUTURES_LICENSE.rst
@@ -3,11 +3,11 @@ Copyright 2009 Brian Quinlan. All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-   1. Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-   2. Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY BRIAN QUINLAN "AS IS" AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/licenses/JQUERY_LICENSE.rst
+++ b/licenses/JQUERY_LICENSE.rst
@@ -1,4 +1,5 @@
 Copyright 2014 jQuery Foundation and other contributors
+
 http://jquery.com/
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/licenses/NUMPY_LICENSE.rst
+++ b/licenses/NUMPY_LICENSE.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2005-2011, NumPy Developers.
+Copyright (c) 2005-2018, NumPy Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/licenses/NUMPY_LICENSE.rst
+++ b/licenses/NUMPY_LICENSE.rst
@@ -5,17 +5,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-    * Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-       copyright notice, this list of conditions and the following
-       disclaimer in the documentation and/or other materials provided
-       with the distribution.
-
-    * Neither the name of the NumPy Developers nor the names of any
-       contributors may be used to endorse or promote products derived
-       from this software without specific prior written permission.
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+* Neither the name of the NumPy Developers nor the names of any
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT

--- a/licenses/PLY_LICENSE.rst
+++ b/licenses/PLY_LICENSE.rst
@@ -1,7 +1,7 @@
-PLY (Python Lex-Yacc)                   Version 3.6
+PLY (Python Lex-Yacc) Version 3.6
 
-Copyright (C) 2001-2015,
-David M. Beazley (Dabeaz LLC)
+Copyright (C) 2001-2015, David M. Beazley (Dabeaz LLC)
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/licenses/PYFITS.rst
+++ b/licenses/PYFITS.rst
@@ -3,17 +3,15 @@ Copyright (C) 2014 Association of Universities for Research in Astronomy (AURA)
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright
-       notice, this list of conditions and the following disclaimer.
-
-    2. Redistributions in binary form must reproduce the above
-       copyright notice, this list of conditions and the following
-       disclaimer in the documentation and/or other materials provided
-       with the distribution.
-
-    3. The name of AURA and its representatives may not be used to
-       endorse or promote products derived from this software without
-       specific prior written permission.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above
+   copyright notice, this list of conditions and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+3. The name of AURA and its representatives may not be used to
+   endorse or promote products derived from this software without
+   specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY AURA ``AS IS'' AND ANY EXPRESS OR IMPLIED
 WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF

--- a/licenses/PYTEST_LICENSE.rst
+++ b/licenses/PYTEST_LICENSE.rst
@@ -1,18 +1,19 @@
+Copyright (c) 2004-2018 Holger Krekel and others
 
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/SPHINXEXT_LICENSES.rst
+++ b/licenses/SPHINXEXT_LICENSES.rst
@@ -1,4 +1,4 @@
-This file details liceses for some of the files in astropy/sphinx/ext
+This file details licenses for some of the files in astropy/sphinx/ext
 that are adapted from other projects:
 
 
@@ -6,12 +6,12 @@ that are adapted from other projects:
 License 1
 =========
 
-    The files
-    - numpydoc.py
-    - docscrape.py
-    - docscrape_sphinx.py
-    - phantom_import.py
-    have the following license:
+The files
+- numpydoc.py
+- docscrape.py
+- docscrape_sphinx.py
+- phantom_import.py
+have the following license:
 
 Copyright (C) 2008 Stefan van der Walt <stefan@mentat.za.net>, Pauli Virtanen <pav@iki.fi>
 
@@ -19,12 +19,12 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
- 1. Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the
-    distribution.
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS" AND ANY EXPRESS OR
 IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -42,11 +42,11 @@ POSSIBILITY OF SUCH DAMAGE.
 License 2
 =========
 
-    The files
-    - compiler_unparse.py
-    - comment_eater.py
-    - traitsdoc.py
-    have the following license:
+The files
+- compiler_unparse.py
+- comment_eater.py
+- traitsdoc.py
+have the following license:
 
 This software is OSI Certified Open Source Software.
 OSI Certified is a certification mark of the Open Source Initiative.
@@ -57,14 +57,14 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
- * Neither the name of Enthought, Inc. nor the names of its contributors may
-   be used to endorse or promote products derived from this software without
-   specific prior written permission.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+* Neither the name of Enthought, Inc. nor the names of its contributors may
+  be used to endorse or promote products derived from this software without
+  specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -76,5 +76,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-

--- a/licenses/SYMPY.rst
+++ b/licenses/SYMPY.rst
@@ -1,18 +1,18 @@
-Copyright (c) 2006-2014 SymPy Development Team
+Copyright (c) 2006-2018 SymPy Development Team
 
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-  a. Redistributions of source code must retain the above copyright notice,
-     this list of conditions and the following disclaimer.
-  b. Redistributions in binary form must reproduce the above copyright
-     notice, this list of conditions and the following disclaimer in the
-     documentation and/or other materials provided with the distribution.
-  c. Neither the name of SymPy nor the names of its contributors
-     may be used to endorse or promote products derived from this software
-     without specific prior written permission.
+a. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+b. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+c. Neither the name of SymPy nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"

--- a/licenses/WCSLIB_LICENSE.md
+++ b/licenses/WCSLIB_LICENSE.md
@@ -1,11 +1,9 @@
-=================================
-GNU LESSER GENERAL PUBLIC LICENSE
-=================================
------------------------
-Version 3, 29 June 2007
------------------------
+### GNU LESSER GENERAL PUBLIC LICENSE
 
-Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc.
+<https://fsf.org/>
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.
@@ -14,8 +12,7 @@ This version of the GNU Lesser General Public License incorporates the
 terms and conditions of version 3 of the GNU General Public License,
 supplemented by the additional permissions listed below.
 
-0. Additional Definitions.
-==========================
+#### 0. Additional Definitions.
 
 As used herein, "this License" refers to version 3 of the GNU Lesser
 General Public License, and the "GNU GPL" refers to version 3 of the
@@ -30,7 +27,7 @@ Defining a subclass of a class defined by the Library is deemed a mode
 of using an interface provided by the Library.
 
 A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
+Application with the Library. The particular version of the Library
 with which the Combined Work was made is also called the "Linked
 Version".
 
@@ -44,14 +41,12 @@ object code and/or source code for the Application, including any data
 and utility programs needed for reproducing the Combined Work from the
 Application, but excluding the System Libraries of the Combined Work.
 
-1. Exception to Section 3 of the GNU GPL.
-=========================================
+#### 1. Exception to Section 3 of the GNU GPL.
 
 You may convey a covered work under sections 3 and 4 of this License
 without being bound by section 3 of the GNU GPL.
 
-2. Conveying Modified Versions.
-===============================
+#### 2. Conveying Modified Versions.
 
 If you modify a copy of the Library, and, in your modifications, a
 facility refers to a function or data to be supplied by an Application
@@ -59,79 +54,71 @@ that uses the facility (other than as an argument passed when the
 facility is invoked), then you may convey a copy of the modified
 version:
 
-* **a)** under this License, provided that you make a good faith effort to
-  ensure that, in the event an Application does not supply the
-  function or data, the facility still operates, and performs whatever
-  part of its purpose remains meaningful, or
+-   a) under this License, provided that you make a good faith effort
+    to ensure that, in the event an Application does not supply the
+    function or data, the facility still operates, and performs
+    whatever part of its purpose remains meaningful, or
+-   b) under the GNU GPL, with none of the additional permissions of
+    this License applicable to that copy.
 
-* **b)** under the GNU GPL, with none of the additional permissions of
-  this License applicable to that copy.
-
-3. Object Code Incorporating Material from Library Header Files.
-================================================================
+#### 3. Object Code Incorporating Material from Library Header Files.
 
 The object code form of an Application may incorporate material from a
-header file that is part of the Library.  You may convey such object
+header file that is part of the Library. You may convey such object
 code under terms of your choice, provided that, if the incorporated
 material is not limited to numerical parameters, data structure
 layouts and accessors, or small macros, inline functions and templates
 (ten or fewer lines in length), you do both of the following:
 
-* **a)** Give prominent notice with each copy of the object code that the
-  Library is used in it and that the Library and its use are covered
-  by this License.
+-   a) Give prominent notice with each copy of the object code that
+    the Library is used in it and that the Library and its use are
+    covered by this License.
+-   b) Accompany the object code with a copy of the GNU GPL and this
+    license document.
 
-* **b)** Accompany the object code with a copy of the GNU GPL and this
-  license document.
-
-4. Combined Works.
-==================
+#### 4. Combined Works.
 
 You may convey a Combined Work under terms of your choice that, taken
 together, effectively do not restrict modification of the portions of
 the Library contained in the Combined Work and reverse engineering for
 debugging such modifications, if you also do each of the following:
 
-* **a)** Give prominent notice with each copy of the Combined Work that
-  the Library is used in it and that the Library and its use are
-  covered by this License.
+-   a) Give prominent notice with each copy of the Combined Work that
+    the Library is used in it and that the Library and its use are
+    covered by this License.
+-   b) Accompany the Combined Work with a copy of the GNU GPL and this
+    license document.
+-   c) For a Combined Work that displays copyright notices during
+    execution, include the copyright notice for the Library among
+    these notices, as well as a reference directing the user to the
+    copies of the GNU GPL and this license document.
+-   d) Do one of the following:
+    -   0) Convey the Minimal Corresponding Source under the terms of
+        this License, and the Corresponding Application Code in a form
+        suitable for, and under terms that permit, the user to
+        recombine or relink the Application with a modified version of
+        the Linked Version to produce a modified Combined Work, in the
+        manner specified by section 6 of the GNU GPL for conveying
+        Corresponding Source.
+    -   1) Use a suitable shared library mechanism for linking with
+        the Library. A suitable mechanism is one that (a) uses at run
+        time a copy of the Library already present on the user's
+        computer system, and (b) will operate properly with a modified
+        version of the Library that is interface-compatible with the
+        Linked Version.
+-   e) Provide Installation Information, but only if you would
+    otherwise be required to provide such information under section 6
+    of the GNU GPL, and only to the extent that such information is
+    necessary to install and execute a modified version of the
+    Combined Work produced by recombining or relinking the Application
+    with a modified version of the Linked Version. (If you use option
+    4d0, the Installation Information must accompany the Minimal
+    Corresponding Source and Corresponding Application Code. If you
+    use option 4d1, you must provide the Installation Information in
+    the manner specified by section 6 of the GNU GPL for conveying
+    Corresponding Source.)
 
-* **b)** Accompany the Combined Work with a copy of the GNU GPL and this
-  license document.
-
-* **c)** For a Combined Work that displays copyright notices during
-  execution, include the copyright notice for the Library among these
-  notices, as well as a reference directing the user to the copies of
-  the GNU GPL and this license document.
-
-* **d)** Do one of the following:
-
-  - **0)** Convey the Minimal Corresponding Source under the terms of this
-    License, and the Corresponding Application Code in a form suitable
-    for, and under terms that permit, the user to recombine or relink
-    the Application with a modified version of the Linked Version to
-    produce a modified Combined Work, in the manner specified by
-    section 6 of the GNU GPL for conveying Corresponding Source.
-    
-  - **1)** Use a suitable shared library mechanism for linking with the
-    Library.  A suitable mechanism is one that **(a)** uses at run time a
-    copy of the Library already present on the user's computer system,
-    and **(b)** will operate properly with a modified version of the
-    Library that is interface-compatible with the Linked Version.
-
-* **e)** Provide Installation Information, but only if you would otherwise
-  be required to provide such information under section 6 of the GNU
-  GPL, and only to the extent that such information is necessary to
-  install and execute a modified version of the Combined Work produced
-  by recombining or relinking the Application with a modified version
-  of the Linked Version. (If you use option 4d0, the Installation
-  Information must accompany the Minimal Corresponding Source and
-  Corresponding Application Code. If you use option 4d1, you must
-  provide the Installation Information in the manner specified by
-  section 6 of the GNU GPL for conveying Corresponding Source.)
-
-5. Combined Libraries.
-======================
+#### 5. Combined Libraries.
 
 You may place library facilities that are a work based on the Library
 side by side in a single library together with other library
@@ -139,16 +126,14 @@ facilities that are not Applications and are not covered by this
 License, and convey such a combined library under terms of your
 choice, if you do both of the following:
 
-* **a)** Accompany the combined library with a copy of the same work based
-  on the Library, uncombined with any other library facilities,
-  conveyed under the terms of this License.
+-   a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities, conveyed under the terms of this License.
+-   b) Give prominent notice with the combined library that part of it
+    is a work based on the Library, and explaining where to find the
+    accompanying uncombined form of the same work.
 
-* **b)** Give prominent notice with the combined library that part of it
-  is a work based on the Library, and explaining where to find the
-  accompanying uncombined form of the same work.
-
-6. Revised Versions of the GNU Lesser General Public License.
-=============================================================
+#### 6. Revised Versions of the GNU Lesser General Public License.
 
 The Free Software Foundation may publish revised and/or new versions
 of the GNU Lesser General Public License from time to time. Such new

--- a/licenses/WCSLIB_LICENSE.rst
+++ b/licenses/WCSLIB_LICENSE.rst
@@ -8,7 +8,8 @@ Everyone is permitted to copy and distribute verbatim copies of this license doc
 This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
 
 0. Additional Definitions.
-
+==========================
+   
 As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
 
 "The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
@@ -22,17 +23,20 @@ The "Minimal Corresponding Source" for a Combined Work means the Corresponding S
 The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
 
 1. Exception to Section 3 of the GNU GPL.
-
+=========================================
+   
 You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
 
 2. Conveying Modified Versions.
-
+===============================
+   
 If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
 a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
 b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
 
 3. Object Code Incorporating Material from Library Header Files.
-
+================================================================
+   
 The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
 
 a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
@@ -40,7 +44,8 @@ a) Give prominent notice with each copy of the object code that the Library is u
 b) Accompany the object code with a copy of the GNU GPL and this license document.
 
 4. Combined Works.
-
+==================
+   
 You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
 
 a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
@@ -58,7 +63,8 @@ d) Do one of the following:
 e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
 
 5. Combined Libraries.
-
+======================
+   
 You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
 
 a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
@@ -66,7 +72,8 @@ a) Accompany the combined library with a copy of the same work based on the Libr
 b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
 
 6. Revised Versions of the GNU Lesser General Public License.
-
+=============================================================
+   
 The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
 
 Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.

--- a/licenses/WCSLIB_LICENSE.rst
+++ b/licenses/WCSLIB_LICENSE.rst
@@ -1,81 +1,172 @@
+=================================
 GNU LESSER GENERAL PUBLIC LICENSE
+=================================
+-----------------------
 Version 3, 29 June 2007
+-----------------------
 
 Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
-Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
 
-This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+This version of the GNU Lesser General Public License incorporates the
+terms and conditions of version 3 of the GNU General Public License,
+supplemented by the additional permissions listed below.
 
 0. Additional Definitions.
 ==========================
-   
-As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
 
-"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the
+GNU General Public License.
 
-An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library.  Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+"The Library" refers to a covered work governed by this License, other
+than an Application or a Combined Work as defined below.
 
-A "Combined Work" is a work produced by combining or linking an Application with the Library.  The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
 
-The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
 
-The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
 
 1. Exception to Section 3 of the GNU GPL.
 =========================================
-   
-You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
 
 2. Conveying Modified Versions.
 ===============================
-   
-If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
-a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
-b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+* **a)** under this License, provided that you make a good faith effort to
+  ensure that, in the event an Application does not supply the
+  function or data, the facility still operates, and performs whatever
+  part of its purpose remains meaningful, or
+
+* **b)** under the GNU GPL, with none of the additional permissions of
+  this License applicable to that copy.
 
 3. Object Code Incorporating Material from Library Header Files.
 ================================================================
-   
-The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
 
-a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+The object code form of an Application may incorporate material from a
+header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
 
-b) Accompany the object code with a copy of the GNU GPL and this license document.
+* **a)** Give prominent notice with each copy of the object code that the
+  Library is used in it and that the Library and its use are covered
+  by this License.
+
+* **b)** Accompany the object code with a copy of the GNU GPL and this
+  license document.
 
 4. Combined Works.
 ==================
-   
-You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
 
-a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+You may convey a Combined Work under terms of your choice that, taken
+together, effectively do not restrict modification of the portions of
+the Library contained in the Combined Work and reverse engineering for
+debugging such modifications, if you also do each of the following:
 
-b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+* **a)** Give prominent notice with each copy of the Combined Work that
+  the Library is used in it and that the Library and its use are
+  covered by this License.
 
-c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+* **b)** Accompany the Combined Work with a copy of the GNU GPL and this
+  license document.
 
-d) Do one of the following:
+* **c)** For a Combined Work that displays copyright notices during
+  execution, include the copyright notice for the Library among these
+  notices, as well as a reference directing the user to the copies of
+  the GNU GPL and this license document.
 
-0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+* **d)** Do one of the following:
 
-1) Use a suitable shared library mechanism for linking with the Library.  A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+  - **0)** Convey the Minimal Corresponding Source under the terms of this
+    License, and the Corresponding Application Code in a form suitable
+    for, and under terms that permit, the user to recombine or relink
+    the Application with a modified version of the Linked Version to
+    produce a modified Combined Work, in the manner specified by
+    section 6 of the GNU GPL for conveying Corresponding Source.
+    
+  - **1)** Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that **(a)** uses at run time a
+    copy of the Library already present on the user's computer system,
+    and **(b)** will operate properly with a modified version of the
+    Library that is interface-compatible with the Linked Version.
 
-e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+* **e)** Provide Installation Information, but only if you would otherwise
+  be required to provide such information under section 6 of the GNU
+  GPL, and only to the extent that such information is necessary to
+  install and execute a modified version of the Combined Work produced
+  by recombining or relinking the Application with a modified version
+  of the Linked Version. (If you use option 4d0, the Installation
+  Information must accompany the Minimal Corresponding Source and
+  Corresponding Application Code. If you use option 4d1, you must
+  provide the Installation Information in the manner specified by
+  section 6 of the GNU GPL for conveying Corresponding Source.)
 
 5. Combined Libraries.
 ======================
-   
-You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
 
-a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+You may place library facilities that are a work based on the Library
+side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
 
-b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+* **a)** Accompany the combined library with a copy of the same work based
+  on the Library, uncombined with any other library facilities,
+  conveyed under the terms of this License.
+
+* **b)** Give prominent notice with the combined library that part of it
+  is a work based on the Library, and explaining where to find the
+  accompanying uncombined form of the same work.
 
 6. Revised Versions of the GNU Lesser General Public License.
 =============================================================
-   
-The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
 
-Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
 
-If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.
+Each version is given a distinguishing version number. If the Library
+as you received it specifies that a certain numbered version of the
+GNU Lesser General Public License "or any later version" applies to
+it, you have the option of following the terms and conditions either
+of that published version or of any later version published by the
+Free Software Foundation. If the Library as you received it does not
+specify a version number of the GNU Lesser General Public License, you
+may choose any version of the GNU Lesser General Public License ever
+published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/licenses/WCSLIB_LICENSE.rst
+++ b/licenses/WCSLIB_LICENSE.rst
@@ -1,165 +1,74 @@
-		   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
 
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
 
-  0. Additional Definitions.
+0. Additional Definitions.
 
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
 
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
 
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library.  Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
 
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
+A "Combined Work" is a work produced by combining or linking an Application with the Library.  The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
 
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
 
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
 
-  1. Exception to Section 3 of the GNU GPL.
+1. Exception to Section 3 of the GNU GPL.
 
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
 
-  2. Conveying Modified Versions.
+2. Conveying Modified Versions.
 
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
 
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
+3. Object Code Incorporating Material from Library Header Files.
 
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
+The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
 
-  3. Object Code Incorporating Material from Library Header Files.
+a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
 
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
+b) Accompany the object code with a copy of the GNU GPL and this license document.
 
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
+4. Combined Works.
 
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
 
-  4. Combined Works.
+a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
 
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
+b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
 
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
+c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
 
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
+d) Do one of the following:
 
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
+0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
 
-   d) Do one of the following:
+1) Use a suitable shared library mechanism for linking with the Library.  A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
 
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
+e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
 
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
+5. Combined Libraries.
 
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
 
-  5. Combined Libraries.
+a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
 
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
+b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
 
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
+6. Revised Versions of the GNU Lesser General Public License.
 
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
 
-  6. Revised Versions of the GNU Lesser General Public License.
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
 
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.


### PR DESCRIPTION
This pull request makes the following changes:
 - Updates the end copyright year in Astropy's license file to 2018
 - Updates the end copyright years in the NumPy, SymPy, and pytest licenses to 2018
 - Changes the reStructuredText (ReST) formatting for several external licenses where indentations were treated as quotations when they shouldn't have been (but without changing the text of the licenses, except as described above)

I did not update the end copyright years for any other licenses yet since I do not know if development has continued, but we could update any other licenses as well.  I'd like to check WCSLIB's licenses in particular to make sure everything is consistent between the different directories.

[skip ci]