### PR TITLE
Add thermodynamic temperature equivalency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,9 @@ astropy.units
 
 - Add complex numbers support for ``Quantity._repr_latex_``. [#7676]
 
+- Add ``thermodynamic_temperature`` equivalency to convert between
+  Jy/beam and "thermodynamic temperature" for cosmology. [#7054]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -561,12 +561,12 @@ def beam_angular_area(beam_area):
 def thermodynamic_temperature(disp, T_cmb=None):
     r"""Defines the conversion between Jy/beam and "thermodynamic temperature",
     :math:`T_{CMB}`, in Kelvins.  The thermodynamic temperature is a unit very
-    commonly used in cosmology.  See, e.g., "Planck 2013 results. IX. HFI spectral response"
-    (Planck Collaboration 2013) eqn 8 (available on `arXiv <https://arxiv.org/abs/1303.5070>`__).
+    commonly used in cosmology. See eqn 8 in [1]
 
-    :math:`T_{CMB} \equiv B_\nu / \left(2 k \nu^2 / c^2  f(\nu) \right)`
+    :math:`K_{CMB} \equiv I_\nu / \left(2 k \nu^2 / c^2  f(\nu) \right)`
 
-    with :math:`f(\nu) = \frac{ x^2 e^x}{(e^x - 1 )^2}` where :math:`x = h \nu / k T`
+    with :math:`f(\nu) = \frac{ x^2 e^x}{(e^x - 1 )^2}`
+    where :math:`x = h \nu / k T`
 
     Parameters
     ----------
@@ -581,6 +581,10 @@ def thermodynamic_temperature(disp, T_cmb=None):
     For broad band receivers, this conversion do not hold
     as it highly depends on the frequency
 
+    References
+    ----------
+    .. [1] Planck 2013 results. IX. HFI spectral response
+       https://arxiv.org/abs/1303.5070
 
     Examples
     --------

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -541,6 +541,7 @@ def brightness_temperature(frequency, beam_area=None):
 
         return [(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr)]
 
+
 def beam_angular_area(beam_area):
     """
     Convert between the ``beam`` unit, which is commonly used to express the area
@@ -557,6 +558,7 @@ def beam_angular_area(beam_area):
             (astrophys.beam**-1, Unit(beam_area)**-1),
             (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),
            ]
+
 
 def thermodynamic_temperature(frequency, T_cmb=None):
     r"""Defines the conversion between Jy/beam and "thermodynamic temperature",
@@ -606,7 +608,7 @@ def thermodynamic_temperature(frequency, T_cmb=None):
 
     def f(nu, T_cmb=T_cmb):
         x = _si.h * nu / _si.k_B / T_cmb
-        return x**2 * np.exp(x) / (np.exp(x) - 1)**2
+        return x**2 * np.exp(x) / np.expm1(x)**2
 
     def convert_Jy_to_K(x_jybm):
         factor = (f(nu) * 2 * _si.k_B * si.K * nu**2 / _si.c**2).to_value(astrophys.Jy)

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -558,7 +558,7 @@ def beam_angular_area(beam_area):
             (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),
            ]
 
-def thermodynamic_temperature(disp, T_cmb=None):
+def thermodynamic_temperature(frequency, T_cmb=None):
     r"""Defines the conversion between Jy/beam and "thermodynamic temperature",
     :math:`T_{CMB}`, in Kelvins.  The thermodynamic temperature is a unit very
     commonly used in cosmology. See eqn 8 in [1]
@@ -570,7 +570,7 @@ def thermodynamic_temperature(disp, T_cmb=None):
 
     Parameters
     ----------
-    disp : `~astropy.units.Quantity` with spectral units
+    frequency : `~astropy.units.Quantity` with spectral units
         The observed `spectral` equivalent `~astropy.units.Unit` (e.g.,
         frequency or wavelength)
     T_cmb :  `~astropy.units.Quantity` with temperature units (default Planck15 value)
@@ -598,7 +598,7 @@ def thermodynamic_temperature(disp, T_cmb=None):
         379.93172115555564
 
     """
-    nu = disp.to(si.GHz, spectral())
+    nu = frequency.to(si.GHz, spectral())
 
     if T_cmb is None:
         from ..cosmology import Planck15

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -558,7 +558,7 @@ def beam_angular_area(beam_area):
             (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),
            ]
 
-def thermodynamic_temperature(disp, T_cmb=2.7255*si.K):
+def thermodynamic_temperature(disp, T_cmb=None):
     r"""Defines the conversion between Jy/beam and "thermodynamic temperature",
     :math:`T_{CMB}`, in Kelvins.  The thermodynamic temperature is a unit very
     commonly used in cosmology.  See, e.g., "Planck 2013 results. IX. HFI spectral response"
@@ -573,7 +573,7 @@ def thermodynamic_temperature(disp, T_cmb=2.7255*si.K):
     disp : `~astropy.units.Quantity` with spectral units
         The observed `spectral` equivalent `~astropy.units.Unit` (e.g.,
         frequency or wavelength)
-    T_cmb :  `~astropy.units.Quantity` with temperature units (default to 2.7255 K)
+    T_cmb :  `~astropy.units.Quantity` with temperature units (default Planck15 value)
         The CMB temperature at z=0
 
     Notes
@@ -595,6 +595,10 @@ def thermodynamic_temperature(disp, T_cmb=2.7255*si.K):
 
     """
     nu = disp.to(si.GHz, spectral())
+
+    if T_cmb is None:
+        from ..cosmology import Planck15
+        T_cmb = Planck15.Tcmb0
 
     def f(nu, T_cmb=T_cmb):
         x = _si.h * nu / _si.k_B / T_cmb

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -592,12 +592,11 @@ def thermodynamic_temperature(frequency, T_cmb=None):
     --------
     Planck HFI 143 GHz::
 
-        >>> import numpy as np
         >>> from astropy import units as u
-        >>> freq = 143*u.GHz
+        >>> freq = 143 * u.GHz
         >>> equiv = u.thermodynamic_temperature(freq)
-        >>> u.K.to(u.MJy/u.sr, equivalencies=equiv)  # doctest: +FLOAT_CMP
-        379.93172115555564
+        >>> (1. * u.mK).to(u.MJy / u.sr, equivalencies=equiv)  # doctest: +FLOAT_CMP
+        <Quantity 0.37993172 MJy / sr>
 
     """
     nu = frequency.to(si.GHz, spectral())

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -610,11 +610,11 @@ def thermodynamic_temperature(disp, T_cmb=None):
 
     def convert_Jy_to_K(x_jybm):
         factor = (f(nu) * 2 * _si.k_B * si.K * nu**2 / _si.c**2).to_value(astrophys.Jy)
-        return (x_jybm / factor)
+        return x_jybm / factor
 
     def convert_K_to_Jy(x_K):
         factor = (astrophys.Jy / (f(nu) * 2 * _si.k_B * nu**2 / _si.c**2)).to_value(si.K)
-        return (x_K / factor)
+        return x_K / factor
 
     return [(astrophys.Jy/si.sr, si.K, convert_Jy_to_K, convert_K_to_Jy)]
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -585,6 +585,17 @@ def test_thermodynamic_temperature():
             u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu)))
 
 
+def test_thermodynamic_temperature_w_tcmb():
+    nu = 143 * u.GHz
+    tb = 0.0026320518775281975 * u.K
+    np.testing.assert_almost_equal(
+        tb.value, (1 * u.MJy/u.sr).to_value(
+            u.K, equivalencies=u.thermodynamic_temperature(nu, T_cmb=2.7255 * u.K)))
+    np.testing.assert_almost_equal(
+        1.0, tb.to_value(
+            u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu, T_cmb=2.7255 * u.K)))
+
+
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         phase = u.Quantity(1., u.cycle)

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -574,6 +574,17 @@ def test_beam():
     np.testing.assert_almost_equal(flux_density.value, 13.5425483146382)
 
 
+def test_thermodynamic_temperature():
+    nu = 143 * u.GHz
+    tb = 0.0026320518775281975 * u.K
+    np.testing.assert_almost_equal(
+        tb.value, (1 * u.MJy/u.sr).to_value(
+            u.K, equivalencies=u.thermodynamic_temperature(nu)))
+    np.testing.assert_almost_equal(
+        1.0, tb.to_value(
+            u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu)))
+
+
 def test_equivalency_context():
     with u.set_enabled_equivalencies(u.dimensionless_angles()):
         phase = u.Quantity(1., u.cycle)

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -291,6 +291,18 @@ observations at high-energy, be it for solar or X-ray astronomy. Example::
     >>> t_k.to(u.eV, equivalencies=u.temperature_energy())  # doctest: +FLOAT_CMP
     <Quantity 86.17332384960955 eV>
 
+Thermodynamic Temperature Equivalency
+-------------------------------------
+
+This equivalency allows conversion between Jy/beam and "thermodynamic
+temperature", :math:`T_{CMB}`, in Kelvins. Example::
+
+    >>> import astropy.units as u
+    >>> nu = 143 * u.GHz
+    >>> t_k = 0.0026320518775281975 * u.K
+    >>> t_k.to(u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu))  # doctest: +FLOAT_CMP
+    <Quantity 1. MJy / sr>
+
 
 Molar Mass AMU Equivalency
 --------------------------

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -294,7 +294,8 @@ observations at high-energy, be it for solar or X-ray astronomy. Example::
 Thermodynamic Temperature Equivalency
 -------------------------------------
 
-This equivalency allows conversion between Jy/beam and "thermodynamic
+This :func:`~astropy.units.equivalencies.thermodynamic_temperature`
+equivalency allows conversion between Jy/beam and "thermodynamic
 temperature", :math:`T_{CMB}`, in Kelvins. Example::
 
     >>> import astropy.units as u


### PR DESCRIPTION
This PR add the thermodynamic temperature equivalency, also called `T_CMB`, often used in CMB studies.

Despite the brightness_temperature equivalency, this one is between `K` and any brightness unit, e.g. `MJy / sr`.