### PR TITLE
Enable velocities in SkyOffsetFrame classes

### DIFF
--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -61,54 +61,13 @@ def make_skyoffset_cls(framecls):
             # This has to be done because FrameMeta will set these attributes
             # to the defaults from BaseCoordinateFrame when it creates the base
             # SkyOffsetFrame class initially.
-            members['_frame_specific_representation_info'] = framecls._frame_specific_representation_info
             members['_default_representation'] = framecls._default_representation
             members['_default_differential'] = framecls._default_differential
 
             newname = name[:-5] if name.endswith('Frame') else name
             newname += framecls.__name__
 
-            res = super().__new__(cls, newname, bases, members)
-
-            # now go through all the component names and make any spherical names be "lon" and "lat"
-            # instead of e.g. "ra" and "dec"
-
-            lists_done = []
-            for cls_, component_list in res._frame_specific_representation_info.items():
-                if cls_ in (r.SphericalRepresentation,
-                            r.UnitSphericalRepresentation):
-                    gotlatlon = []
-                    for i, comp in enumerate(component_list):
-                        if component_list in lists_done:
-                            # we need this because sometimes the component_
-                            # list's are the exact *same* object for both
-                            # spherical and unitspherical.  So looping then makes
-                            # the change *twice*.  This hack bypasses that.
-                            continue
-
-                        if comp.reprname in ('lon', 'lat'):
-                            dct = namedtuple_asdict(comp)
-                            # this forces the component names to be 'lat' and
-                            # 'lon' regardless of what the actual base frame
-                            # might use
-                            dct['framename'] = comp.reprname
-                            component_list[i] = type(comp)(**dct)
-                            gotlatlon.append(comp.reprname)
-
-                    if 'lon' not in gotlatlon:
-                        rmlon = RepresentationMapping('lon', 'lon', 'recommended')
-                        component_list.insert(0, rmlon)
-
-                    if 'lat' not in gotlatlon:
-                        rmlat = RepresentationMapping('lat', 'lat', 'recommended')
-                        component_list.insert(0, rmlat)
-
-                    # TODO: we could support proper motions / velocities in sky
-                    # offset frames.
-
-                    lists_done.append(component_list)
-
-            return res
+            return super().__new__(cls, newname, bases, members)
 
     # We need this to handle the intermediate metaclass correctly, otherwise we could
     # just subclass SkyOffsetFrame.
@@ -220,7 +179,3 @@ class SkyOffsetFrame(BaseCoordinateFrame):
                              'data.')
         if self.has_data and hasattr(self.data, 'lon'):
             self.data.lon.wrap_angle = 180*u.deg
-        if (self.origin is not None and getattr(self.origin.data, 'differentials', None) or
-           (self.has_data and getattr(self.data, 'differentials', None))):
-            raise NotImplementedError('SkyOffsetFrame currently does not '
-                                      'support velocities.')

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -290,18 +290,12 @@ def test_skyoffset_lonwrap():
     assert sc.lon < 180 * u.deg
 
 
-def test_skyoffset_velerr():
-    # TODO: remove this when the SkyOffsetFrame's support velocities
-    origin = ICRS(45*u.deg, 45*u.deg)
-    originwvel = ICRS(45*u.deg, 45*u.deg, radial_velocity=1*u.km/u.s)
+def test_skyoffset_velocity():
+    c = ICRS(ra=170.9*u.deg, dec=-78.4*u.deg,
+             pm_ra_cosdec=74.4134*u.mas/u.yr,
+             pm_dec=-93.2342*u.mas/u.yr)
+    skyoffset_frame = SkyOffsetFrame(origin=c)
+    c_skyoffset = c.transform_to(skyoffset_frame)
 
-    SkyOffsetFrame(origin=origin)
-    with pytest.raises(NotImplementedError):
-        SkyOffsetFrame(origin=originwvel)
-    SkyOffsetFrame(origin.data, origin=origin)
-    with pytest.raises(NotImplementedError):
-        SkyOffsetFrame(originwvel.data, origin=origin)
-    with pytest.raises(NotImplementedError):
-        SkyOffsetFrame(origin.data, origin=originwvel)
-    with pytest.raises(NotImplementedError):
-        SkyOffsetFrame(originwvel.data, origin=originwvel)
+    assert_allclose(c_skyoffset.pm_lon_coslat, c.pm_ra_cosdec)
+    assert_allclose(c_skyoffset.pm_lat, c.pm_dec)


### PR DESCRIPTION
I just tried to use `SkyOffsetFrame` to transform some coordinates with associated proper motions and got hit with a `NotImplementedError` - we forgot to fix this for v3.0, or make an issue...oops!

Here's a quick attempt at enabling this. I think it actually works out of the box (by removing the `raise` we added for v2.0), but to get the velocity component names to appear correctly I (controversially) removed a large section of code that appears unnecessary, but @eteq probably had a reason for it. That code replaces the frame specific names for lon/lat with lon and lat. But why not just revert back to the baseframe defaults? That is what removing the logic below does.