### PR TITLE
remove block to letting groupy_by work on mixins

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2638,9 +2638,6 @@ class Table:
         out : `Table`
             New table with groups set
         """
-        if self.has_mixin_columns:
-            raise NotImplementedError('group_by not available for tables with mixin columns')
-
         return groups.table_group_by(self, keys)
 
     def to_pandas(self):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -480,9 +480,11 @@ def test_grouping():
     Test grouping with mixin columns.  Raises not yet implemented error.
     """
     t = QTable(MIXIN_COLS)
-    t['index'] = ['a', 'b', 'b', 'c']
-    with pytest.raises(NotImplementedError):
-        t.group_by('index')
+    t['index'] = ['a', 'b', 'c', 'b']
+    grped = t.group_by('index')
+    assert np.all(grped['index'] == ['a', 'b', 'b', 'c'])
+    assert np.all(grped['quantity'] == [0, 1, 3, 2]*u.m)
+    assert np.all(grped['skycoord'] == [0, 1, 3, 2]*u.deg)
 
 
 def test_conversion_qtable_table():


### PR DESCRIPTION
@taldcroft or @mhvk can correct me (and immediately close this PR) if I'm crazy here (or if Travis reveals it's failing), but it looks to me like `group_by` now works on all the relevant mixin classes I see.  I wonder if this got fixed implicitly somewhere and the `NotImplementedError` is just now wrong?