### PR TITLE
Enable tab-completion for column names on Table and Row in IPython

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Enable tab-completion for column names with IPython 5 and later. [#7071]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Enable tab-completion for ``FITS_rec`` column names and ``Header`` keywords
+  with IPython 5 and later. [#7071]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -549,6 +549,9 @@ class FITS_rec(np.recarray):
             raise TypeError('Assignment requires a FITS_record, tuple, or '
                             'list as input.')
 
+    def _ipython_key_completions_(self):
+        return self.names
+
     def copy(self, order='C'):
         """
         The Numpy documentation lies; `numpy.ndarray.copy` is not equivalent to

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -269,6 +269,9 @@ class Header:
         self.extend(other)
         return self
 
+    def _ipython_key_completions_(self):
+        return self.__iter__()
+
     @property
     def cards(self):
         """

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -43,6 +43,9 @@ class Row:
     def __setitem__(self, item, val):
         self._table.columns[item][self._index] = val
 
+    def _ipython_key_completions_(self):
+        return self.colnames
+
     def __eq__(self, other):
         if self._table.masked:
             # Sent bug report to numpy-discussion group on 2012-Oct-21, subject:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1379,6 +1379,9 @@ class Table:
         else:
             raise IndexError('illegal key or index value')
 
+    def _ipython_key_completions_(self):
+        return self.colnames
+
     def field(self, item):
         """Return column[item] for recarray compatibility."""
         return self.columns[item]

--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -30,3 +30,6 @@ exclude_lines =
 
    # Ignore branches that don't pertain to this version of Python
    pragma: py{ignore_python_version}
+
+   # Don't complain about IPython completion helper
+   def _ipython_key_completions_


### PR DESCRIPTION
With IPython 5 or later, it's possible to define custom completions for dict-like objects, so this adds that feature for Table and Row. Note that of course it's possible to pass an integer to a table to slice it, and this does not prevent that. It just adds column names to possible completions when pressing tab after typing e.g. ``t['a<tab>``.

@saimn @MSeifert04 - maybe this could be done for Header and FITS_rec too?

EDIT: testing procedure:
```
>>> from astropy.table import Table
>>> t = Table([[1], [2]], names=('aaaa', 'bbbb'))
```
Typing ``t['aa`` and pressing ``<tab>`` should complete the column name.
And similarly for `fits.Header`:
```
>>> from astropy.io import fits
>>> hdr = fits.Header({'aaaa': 1, 'bbbb':2})
```
Then type ``hdr['AA`` and press ``<tab>``.