### PR TITLE
Remove duplicate packages from pip-requirements-dev

### DIFF
--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -3,15 +3,12 @@
 Cython>=0.21
 jinja2>=2.7
 pyyaml
-scipy
 pandas
 h5py
 beautifulsoup4
 bintrees
 bleach
-jplephem
 scikit-image
-matplotlib
 
 # below here are used only for tests
 pytest-astropy


### PR DESCRIPTION
These packages are already mentioned in `pip-requirements-doc`, which is included in `pip-requirements-dev`.