### PR TITLE
remove extra pytest section and fix links in 3.0 what's new

### DIFF
--- a/docs/whatsnew/3.0.rst
+++ b/docs/whatsnew/3.0.rst
@@ -22,8 +22,8 @@ In particular, this release includes:
 * :ref:`whatsnew-3.0-fits-time-support`
 * :ref:`whatsnew-3.0-fits-performance`
 * :ref:`whatsnew-3.0-kuiper-functions`
-* :ref:`whatsnew-3.0-pytest-plugins`
 * :ref:`whatsnew-3.0-python3`
+* :ref:`whatsnew-3.0-pytest-plugins`
 
 
 
@@ -77,12 +77,6 @@ Kuiper functions added to ``astropy.stats``
 ===========================================
 
 
-.. _whatsnew-3.0-pytest-plugins:
-
-Astropy pytest plugins moved to external packages
-=================================================
-
-
 .. _whatsnew-3.0-python3:
 
 Supporting only Python 3
@@ -101,7 +95,9 @@ API, please see the :ref:`changelog`.
 Renamed/removed functionality
 =============================
 
-pytest plugins
+.. _whatsnew-3.0-pytest-plugins:
+
+pytest plugins moved to external packages
 **************
 
 The following ``pytest`` plugins were previously provided as part of the

--- a/docs/whatsnew/3.0.rst
+++ b/docs/whatsnew/3.0.rst
@@ -98,7 +98,7 @@ Renamed/removed functionality
 .. _whatsnew-3.0-pytest-plugins:
 
 pytest plugins moved to external packages
-**************
+*****************************************
 
 The following ``pytest`` plugins were previously provided as part of the
 Astropy core package but have now been moved to separate packages:


### PR DESCRIPTION
As pointed out in https://github.com/astropy/astropy/pull/7061#discussion_r161050900, the section headings from #7061 included some duplication of the pytest discussion.  This PR fixes that. 