### PR TITLE
change sites file encoding to be explicitly UTF-8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -486,8 +486,8 @@ astropy.coordinates
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
 
-- As noted above, the frame class attributes ``representation`` and 
-  ``differential_cls`` are being replaced by ``representation_type`` and 
+- As noted above, the frame class attributes ``representation`` and
+  ``differential_cls`` are being replaced by ``representation_type`` and
   ``differential_type``. In the next version, using ``representation`` will raise
   a deprecation warning. [#6873]
 
@@ -749,6 +749,10 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- The ``sites.json`` file is now parsed explicitly with a UTF-8 encoding. This
+  means that future revisions to the file with unicode observatory names can
+  be done without breaking the site registry parser.  [#7082]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -126,10 +126,12 @@ def get_downloaded_sites(jsonurl=None):
     Load observatory database from data.astropy.org and parse into a SiteRegistry
     """
 
+    # we explicitly set the encoding because the default is to leave it set by
+    # the users' locale, which may fail if it's not matched to the sites.json
     if jsonurl is None:
-        content = get_pkg_data_contents('coordinates/sites.json')
+        content = get_pkg_data_contents('coordinates/sites.json', encoding='UTF-8')
     else:
-        content = get_file_contents(jsonurl)
+        content = get_file_contents(jsonurl, encoding='UTF-8')
 
     jsondb = json.loads(content)
     return SiteRegistry.from_json(jsondb)


### PR DESCRIPTION
This fixes #7081 by forcing the parsing assumed for the sites.json file to be UTF-8.  Apparently this isn't true by default on all locales, and that's why the problem was intermittent/hard-to-reproduce.

There's a secondary problem that changing the sites file now means that older versions don't work where they did before... But that's a "problem" with the `astropy-data` repo itself, so will discuss further in astropy/astropy-data#36  .  I think this fix itself is fairly uncontroversial.