### PR TITLE
include additional site information in EarthLocation.info.meta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Additional information about a site loaded from the Astropy sites registry is
+  now available in ``EarthLocation.info.meta``. [#7083]
+  
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -486,8 +489,8 @@ astropy.coordinates
   ensure that any angle was presented in degrees in sky coordinates and
   frames. This is more logically done in the frame itself. [#6858]
 
-- As noted above, the frame class attributes ``representation`` and 
-  ``differential_cls`` are being replaced by ``representation_type`` and 
+- As noted above, the frame class attributes ``representation`` and
+  ``differential_cls`` are being replaced by ``representation_type`` and
   ``differential_type``. In the next version, using ``representation`` will raise
   a deprecation warning. [#6873]
 

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -102,12 +102,15 @@ class SiteRegistry(Mapping):
         reg = cls()
         for site in jsondb:
             site_info = jsondb[site]
-            location = EarthLocation.from_geodetic(site_info['longitude'] * u.Unit(site_info['longitude_unit']),
-                                                   site_info['latitude'] * u.Unit(site_info['latitude_unit']),
-                                                   site_info['elevation'] * u.Unit(site_info['elevation_unit']))
-            location.info.name = site_info['name']
+            location = EarthLocation.from_geodetic(site_info.pop('longitude') * u.Unit(site_info.pop('longitude_unit')),
+                                                   site_info.pop('latitude') * u.Unit(site_info.pop('latitude_unit')),
+                                                   site_info.pop('elevation') * u.Unit(site_info.pop('elevation_unit')))
+            location.info.name = site_info.pop('name')
+            aliases = site_info.pop('aliases')
+            location.info.meta = site_info  # whatever is left
 
-            reg.add_site([site] + site_info['aliases'], location)
+            reg.add_site([site] + aliases, location)
+
         reg._loaded_jsondb = jsondb
         return reg
 

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -166,3 +166,11 @@ def check_builtin_matches_remote(download_url=True):
             if not matches[name] and in_dl[name]:
                 print('    ', name, 'builtin:', builtin_registry[name], 'download:', dl_registry[name])
         assert False, "Builtin and download registry aren't consistent - failures printed to stdout"
+
+
+def test_meta_present():
+    reg = get_builtin_sites()
+
+    greenwich = reg['greenwich']
+    assert greenwich.info.meta['source'] == ('Ordnance Survey via '
+           'http://gpsinformation.net/main/greenwich.htm and UNESCO')


### PR DESCRIPTION
While troubleshooting #7082 I realized why never store the "extra" information from the `sites.json` file anywhere that's accessible.  Some of this is potentially useful, like the source of the info, or the timezone.  So this PR adjusts things to stuff this as a dict in `EarthLocation.info.meta`.  

Pretty straightforward and simple... *could* potentially go into 3.0 if it makes it in time for RC2, but not critical.