### PR TITLE
FlatLambdaCDM hypergeometric function solution, de Sitter, and Einstein-de Sitter for no radiation case

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
 Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
-are now 20x faster by using the incomplete elliptic integral solution
+are now 20x faster by using the hypergeometric function solution
 for this special case.  [#7087]
 
 astropy.extern

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
+are now 20x faster by using the incomplete elliptic integral solution
+for this special case.
+
 astropy.extern
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
+are now 20x faster by using the incomplete elliptic integral solution
+for this special case.  [#7087]
+
 astropy.extern
 ^^^^^^^^^^^^^^
 
@@ -161,10 +165,6 @@ astropy.coordinates
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
-
-Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
-are now 20x faster by using the incomplete elliptic integral solution
-for this special case.
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1843,41 +1843,6 @@ class FlatLambdaCDM(LambdaCDM):
         prefactor = 2 * self._hubble_distance
         return prefactor * ((1+z1)**(-1./2) - (1+z2)**(-1./2))
 
-    def _elliptic_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at
-        redshifts z1 and z2.
-
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
-
-        For Omega_radiation = 0 the comoving distance can be directly calculated
-        as an elliptic integral.
-        Equation here taken from
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
-
-        Parameters
-        ----------
-        z1, z2 : array-like, shape (N,)
-          Input redshifts.  Must be 1D or scalar.
-
-        Returns
-        -------
-        d : `~astropy.units.Quantity`
-          Comoving distance in Mpc between each input redshift.
-        """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
-
-        s = ((1 - self._Om0) / self._Om0) ** (1./3)
-        prefactor = self._hubble_distance / np.sqrt(s * self._Om0)
-        return prefactor * (self._T_legendre(s / (1 + z1)) -
-                            self._T_legendre(s / (1 + z2)))
-
     def _hypergeometric_comoving_distance_z1z2(self, z1, z2):
         """ Comoving line-of-sight distance in Mpc between objects at
         redshifts z1 and z2.
@@ -1913,23 +1878,6 @@ class FlatLambdaCDM(LambdaCDM):
         prefactor = self._hubble_distance / np.sqrt(s * self._Om0)
         return prefactor * (self._T_hypergeometric(s / (1 + z1)) -
                             self._T_hypergeometric(s / (1 + z2)))
-
-    def _T_legendre(self, x):
-        """ Compute T_legendre(x) using Legendre elliptical integrals of the first kind.
-
-        T(x) = 3^{-\\frac{1}{4}}
-               F\\left(arccos\\left(\\frac{1+(1-\\sqrt{3}x}{1+(1+\\sqrt{3})x}\\right),
-                      \\cos\\frac{\\pi}{12}\\right)
-        where
-        F(phi, m) = int_0^phi {1/sqrt(1 - m \\sin^2{t})} dt
-        """
-
-        from scipy.special import ellipkinc
-        # math.sqrt is several times faster than np.sqrt for scalars
-        phi = np.arccos((1 + (1 - sqrt(3)) * x) /
-                        (1 + (1 + sqrt(3)) * x))
-        m = 0.9330127018922193  # cos(pi/12)**2 == 1/2 + sqrt(3)/4
-        return 3**(-1./4) * ellipkinc(phi, m)
 
     def _T_hypergeometric(self, x):
         """ Compute T_hypergeometric(x) using Gauss Hypergeometric function 2F1

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1761,9 +1761,10 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
-            # Call out Om0=1 (Einstein-de Sitter) and Om0=0 (de Sitter)
-            # special cases. These are a bit faster, but also necessary because
-            # the elliptic integral formulation is not valid for these cases.
+            # Call out Om0=1 (Einstein-de Sitter) and Om0=0 (de Sitter) cases.
+            # The dS case is required because the hypergeometric case
+            #    for Omega_M=0 would lead to an infinity in its argument.
+            # The EdS case is three times faster than the hypergeometric.
             if self._Om0 == 0:
                 self._comoving_distance_z1z2 = \
                     self._dS_comoving_distance_z1z2

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1744,15 +1744,17 @@ class FlatLambdaCDM(LambdaCDM):
             # Call out Om0=1 (Einstein-de Sitter) and Om0=0 (de Sitter)
             # special cases. These are a bit faster, but also necessary because
             # the elliptic integral formulation is not valid for these cases.
-            if self._Om0 == 1:
-                self._comoving_distance_z1z2 = \
-                    self._EdS_comoving_distance_z1z2
-            elif self._Om0 == 0:
+            if self._Om0 == 0:
                 self._comoving_distance_z1z2 = \
                     self._dS_comoving_distance_z1z2
-            else:
+            elif (0 < self.Om0) and (self._Om0 < 1):
                 self._comoving_distance_z1z2 = \
                     self._elliptic_comoving_distance_z1z2
+            elif self._Om0 == 1:
+                self._comoving_distance_z1z2 = \
+                    self._EdS_comoving_distance_z1z2
+            else:
+                pass
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1741,7 +1741,15 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
-            self._comoving_distance_z1z2 = self._elliptic_comoving_distance_z1z2
+            if self._Om0 == 1:
+                self._comoving_distance_z1z2 = \
+                    self._EdS_comoving_distance_z1z2
+            elif self._Om0 == 0:
+                self._comoving_distance_z1z2 = \
+                    self._dS_comoving_distance_z1z2
+            else:
+                self._comoving_distance_z1z2 = \
+                    self._elliptic_comoving_distance_z1z2
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
@@ -1752,6 +1760,65 @@ class FlatLambdaCDM(LambdaCDM):
                                            self._Ogamma0, self._neff_per_nu,
                                            self._nmasslessnu,
                                            self._nu_y_list)
+
+    def _dS_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at redshifts
+        z1 and z2 in a flat, Omega_Lambda=1 cosmology (de Sitter).
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        The de Sitter case has an analytic solution.
+
+        Parameters
+        ----------
+        z1, z2 : array-like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        return self._hubble_distance * (z2 - z1)
+
+    def _EdS_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at redshifts
+        z1 and z2 in a flat, Omega_M=1 cosmology (Einstein - de Sitter).
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        For OM=1, Omega_rad=0 the comoving distance has an analytic solution.
+
+        Parameters
+        ----------
+        z1, z2 : array-like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        prefactor = 2 * self._hubble_distance
+        return prefactor * ((1+z1)**(-1./2) - (1+z2)**(-1./2))
 
     def _elliptic_comoving_distance_z1z2(self, z1, z2):
         """ Comoving line-of-sight distance in Mpc between objects at

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1783,9 +1783,10 @@ class FlatLambdaCDM(LambdaCDM):
                 msg = "z1 and z2 have different shapes"
                 raise ValueError(msg)
 
-        s = ((1-self._Om0)/self._Om0) ** (1/3)
-        prefactor = self._hubble_distance / sqrt(s*self._Om0)
-        return prefactor * (self._T_legendre(s/(1+z1)) - self._T_legendre(s/(1+z2)))
+        s = ((1 - self._Om0) / self._Om0) ** (1./3)
+        prefactor = self._hubble_distance / sqrt(s * self._Om0)
+        return prefactor * (self._T_legendre(s / (1 + z1)) -
+                            self._T_legendre(s / (1 + z2)))
 
     def _T_legendre(self, x):
         """ Compute T_legendre(x) using Legendre elliptical integrals of the first kind.
@@ -1798,14 +1799,11 @@ class FlatLambdaCDM(LambdaCDM):
         """
 
         from scipy.special import ellipkinc
-        F = ellipkinc
         # math.sqrt is several times faster than np.sqrt for scalars
-        phi = np.arccos((1 + (1-sqrt(3))*x) /
-                        (1 + (1+sqrt(3))*x))
-        k = np.cos(np.pi/12)
-        m = k*k  # np.cos(np.pi/12)**2 == 1/2 + math.sqrt(3)/4
-        # ellipkinc expects m=k*k as its second argument.
-        return 3**(-1./4) * F(phi, m)
+        phi = np.arccos((1 + (1 - sqrt(3)) * x) /
+                        (1 + (1 + sqrt(3)) * x))
+        m = 0.9330127018922193  # cos(pi/12)**2 == 1/2 + sqrt(3)/4
+        return 3**(-1./4) * ellipkinc(phi, m)
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -28,7 +28,7 @@ __all__ = ["FLRW", "LambdaCDM", "FlatLambdaCDM", "wCDM", "FlatwCDM",
            "Flatw0waCDM", "w0waCDM", "wpwaCDM", "w0wzCDM",
            "default_cosmology"] + parameters.available
 
-__doctest_requires__ = {'*': ['scipy.integrate']}
+__doctest_requires__ = {'*': ['scipy.integrate', 'scipy.special']}
 
 # Notes about speeding up integrals:
 # ---------------------------------

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1798,6 +1798,13 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             """Calculate comoving distance using incomplete elliptic integration
             """
+            if isiterable(z1):
+                z1 = np.asarray(z1)
+                z2 = np.asarray(z2)
+                if z1.shape != z2.shape:
+                    msg = "In _comoving_distance_z1z2: z1 and z2 have different lengths"
+                    raise ValueError(msg)
+
             s = ((1-self._Om0)/self._Om0) ** (1/3)
             prefactor = self._hubble_distance / sqrt(s*self._Om0)
             return prefactor * (T_legendre(s/(1+z1)) - T_legendre(s/(1+z2)))

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1741,6 +1741,9 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
+            # Call out Om0=1 (Einstein-de Sitter) and Om0=0 (de Sitter)
+            # special cases. These are a bit faster, but also necessary because
+            # the elliptic integral formulation is not valid for these cases.
             if self._Om0 == 1:
                 self._comoving_distance_z1z2 = \
                     self._EdS_comoving_distance_z1z2

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1747,14 +1747,12 @@ class FlatLambdaCDM(LambdaCDM):
             if self._Om0 == 0:
                 self._comoving_distance_z1z2 = \
                     self._dS_comoving_distance_z1z2
-            elif (0 < self.Om0) and (self._Om0 < 1):
-                self._comoving_distance_z1z2 = \
-                    self._elliptic_comoving_distance_z1z2
             elif self._Om0 == 1:
                 self._comoving_distance_z1z2 = \
                     self._EdS_comoving_distance_z1z2
             else:
-                pass
+                self._comoving_distance_z1z2 = \
+                    self._hypergeometric_comoving_distance_z1z2
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1763,6 +1763,12 @@ class FlatLambdaCDM(LambdaCDM):
 
         For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
         the comoving distance can be directly calculated as an elliptic integral.
+        See
+            Feige, 1992, Astron. Nachr., 313, 139.
+            Eisenstein, 1997, arXiv:9709054v2
+            Mészáros & Řípai 2013, A&A, 556, A13.
+        and a useful summary in
+            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
 
         Parameters
         ----------

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1741,6 +1741,7 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
+            self._comoving_distance_z1z2 = self._elliptic_comoving_distance_z1z2
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
@@ -1752,7 +1753,7 @@ class FlatLambdaCDM(LambdaCDM):
                                            self._nmasslessnu,
                                            self._nu_y_list)
 
-    def _comoving_distance_z1z2(self, z1, z2):
+    def _elliptic_comoving_distance_z1z2(self, z1, z2):
         """ Comoving line-of-sight distance in Mpc between objects at
         redshifts z1 and z2.
 
@@ -1762,7 +1763,6 @@ class FlatLambdaCDM(LambdaCDM):
 
         For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
         the comoving distance can be directly calculated as an elliptic integral.
-        We thus override the FLRW._comoving_distance_z1z2 here to provide a wrapper to catch this case.
 
         Parameters
         ----------
@@ -1774,45 +1774,36 @@ class FlatLambdaCDM(LambdaCDM):
         d : `~astropy.units.Quantity`
           Comoving distance in Mpc between each input redshift.
         """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "In _comoving_distance_z1z2: z1 and z2 have different lengths"
+                raise ValueError(msg)
 
-        def T_legendre(x):
-            """ Compute T(x) using Legendre elliptical integrals of the first kind.
+        s = ((1-self._Om0)/self._Om0) ** (1/3)
+        prefactor = self._hubble_distance / sqrt(s*self._Om0)
+        return prefactor * (self._T_legendre(s/(1+z1)) - self._T_legendre(s/(1+z2)))
 
-            T(x) = 3^{-\\frac{1}{4}}
-                   F\\left(arccos\\left(\\frac{1+(1-\\sqrt{3}x}{1+(1+\\sqrt{3})x}\\right),
-                          \\cos\\frac{\\pi}{12}\\right)
-            where
-            F(phi, m) = int_0^phi {1/sqrt(1 - m \\sin^2{t})} dt
-            """
+    def _T_legendre(self, x):
+        """ Compute T(x) using Legendre elliptical integrals of the first kind.
 
-            from scipy.special import ellipkinc
-            F = ellipkinc
-            # math.sqrt is several times faster than np.sqrt for scalars
-            phi = np.arccos((1 + (1-sqrt(3))*x) /
-                            (1 + (1+sqrt(3))*x))
-            k = np.cos(np.pi/12)
-            m = k*k  # np.cos(np.pi/12)**2 == 1/2 + math.sqrt(3)/4
-            # ellipkinc expects m=k*k as its second argument.
-            return 3**(-1./4) * F(phi, m)
+        T(x) = 3^{-\\frac{1}{4}}
+               F\\left(arccos\\left(\\frac{1+(1-\\sqrt{3}x}{1+(1+\\sqrt{3})x}\\right),
+                      \\cos\\frac{\\pi}{12}\\right)
+        where
+        F(phi, m) = int_0^phi {1/sqrt(1 - m \\sin^2{t})} dt
+        """
 
-        if self._Tcmb0.value == 0:
-            """Calculate comoving distance using incomplete elliptic integration
-            """
-            if isiterable(z1):
-                z1 = np.asarray(z1)
-                z2 = np.asarray(z2)
-                if z1.shape != z2.shape:
-                    msg = "In _comoving_distance_z1z2: z1 and z2 have different lengths"
-                    raise ValueError(msg)
-
-            s = ((1-self._Om0)/self._Om0) ** (1/3)
-            prefactor = self._hubble_distance / sqrt(s*self._Om0)
-            return prefactor * (T_legendre(s/(1+z1)) - T_legendre(s/(1+z2)))
-
-        from scipy.integrate import quad
-        f = lambda z1, z2: quad(self._inv_efunc_scalar, z1, z2,
-                             args=self._inv_efunc_scalar_args)[0]
-        return self._hubble_distance * vectorize_if_needed(f, z1, z2)
+        from scipy.special import ellipkinc
+        F = ellipkinc
+        # math.sqrt is several times faster than np.sqrt for scalars
+        phi = np.arccos((1 + (1-sqrt(3))*x) /
+                        (1 + (1+sqrt(3))*x))
+        k = np.cos(np.pi/12)
+        m = k*k  # np.cos(np.pi/12)**2 == 1/2 + math.sqrt(3)/4
+        # ellipkinc expects m=k*k as its second argument.
+        return 3**(-1./4) * F(phi, m)
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1761,13 +1761,9 @@ class FlatLambdaCDM(LambdaCDM):
         objects remains constant with time for objects in the Hubble
         flow.
 
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the comoving distance can be directly calculated as an elliptic integral.
-        See
-            Feige, 1992, Astron. Nachr., 313, 139.
-            Eisenstein, 1997, arXiv:9709054v2
-            Mészáros & Řípai 2013, A&A, 556, A13.
-        and a useful summary in
+        For Omega_radiation = 0 the comoving distance can be directly calculated
+        as an elliptic integral.
+        Equation here taken from
             Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
 
         Parameters
@@ -1784,7 +1780,7 @@ class FlatLambdaCDM(LambdaCDM):
             z1 = np.asarray(z1)
             z2 = np.asarray(z2)
             if z1.shape != z2.shape:
-                msg = "In _comoving_distance_z1z2: z1 and z2 have different lengths"
+                msg = "z1 and z2 have different shapes"
                 raise ValueError(msg)
 
         s = ((1-self._Om0)/self._Om0) ** (1/3)
@@ -1792,7 +1788,7 @@ class FlatLambdaCDM(LambdaCDM):
         return prefactor * (self._T_legendre(s/(1+z1)) - self._T_legendre(s/(1+z2)))
 
     def _T_legendre(self, x):
-        """ Compute T(x) using Legendre elliptical integrals of the first kind.
+        """ Compute T_legendre(x) using Legendre elliptical integrals of the first kind.
 
         T(x) = 3^{-\\frac{1}{4}}
                F\\left(arccos\\left(\\frac{1+(1-\\sqrt{3}x}{1+(1+\\sqrt{3})x}\\right),

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1153,6 +1153,26 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         d : `~astropy.units.Quantity`
           Comoving distance in Mpc between each input redshift.
         """
+        return self._integral_comoving_distance_z1z2(z1, z2)
+
+    def _integral_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        Parameters
+        ----------
+        z1, z2 : array-like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
 
         from scipy.integrate import quad
         f = lambda z1, z2: quad(self._inv_efunc_scalar, z1, z2,

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1117,6 +1117,19 @@ def test_comoving_distance_z1z2():
     assert allclose(tcos._comoving_distance_z1z2(z1, z2),
                     results)
 
+@pytest.mark.skipif('not HAS_SCIPY')
+def test_distance_in_special_cosmologies():
+    """Check that de Sitter and Einstein-de Sitter Universes both work.
+
+    Some analytic solutions fail at these critical points.
+    """
+    c_dS = core.FlatLambdaCDM(100, 0, Tcmb0=0)
+    assert allclose(c_dS.comoving_distance(z=0), 0 * u.Mpc)
+    assert allclose(c_dS.comoving_distance(z=1), 2997.92458 * u.Mpc)
+
+    c_EdS = core.FlatLambdaCDM(100, 1, Tcmb0=0)
+    assert allclose(c_EdS.comoving_distance(z=0), 0 * u.Mpc)
+    assert allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_comoving_transverse_distance_z1z2():

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1150,6 +1150,24 @@ def test_comoving_transverse_distance_z1z2():
     assert allclose(tcos._comoving_distance_z1z2(z1, z2),
                     tcos._comoving_transverse_distance_z1z2(z1, z2))
 
+    # Test Flat Universe with Omega_M > 1.  Rarely used, but perfectly valid.
+    tcos = core.FlatLambdaCDM(100, 1.5, Tcmb0=0.0)
+    results = (2202.72682564,
+               1559.51679971,
+               -643.21002593,
+               1408.36365679,
+                 85.09286258) * u.Mpc
+
+    assert allclose(tcos._comoving_transverse_distance_z1z2(z1, z2),
+                    results)
+
+    # In a flat universe comoving distance and comoving transverse
+    # distance are identical
+    z1 = 0, 0, 2, 0.5, 1
+    z2 = 2, 1, 1, 2.5, 1.1
+
+    assert allclose(tcos._comoving_distance_z1z2(z1, z2),
+                    tcos._comoving_transverse_distance_z1z2(z1, z2))
     # Test non-flat cases to avoid simply testing
     # comoving_distance_z1z2. Test array, array case.
     tcos = core.LambdaCDM(100, 0.3, 0.5, Tcmb0=0.0)


### PR DESCRIPTION
For a Flat LambdaCDM cosmology with no radiation (and no relativistic species), the comoving distance is expressible as an incomplete elliptic integral.  This pull request implements this to make a ~20x speedup in calculating distances.

This pull request makes FlatLambdaCDM set the comoving distance calculation to use the incomplete elliptic integral solution in the __init__ for the case of `Tcmb0=0`.  The speed-up is a factor of ~20x.  It depends on the number of redshifts being calculated simultaneously.  In more detail, my testing found that it was ~(1.2, 20, 100) times faster for n=(1, 200, 2000) redshifts

No new tests are required.  The existing ones already test both the `Tcmb0=0` and `Tcmb!=0` cases and this present change still passes those test.

