### PR TITLE
add `bel` and `Bell` aliases to logarithmic `dex` unit

### DIFF
--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -18,7 +18,7 @@ _ns = globals()
 # These calls are what core.def_unit would do, but we need to use the callable
 # unit versions.  The actual function unit classes get added in logarithmic.
 
-dex = IrreducibleFunctionUnit(['dex'], namespace=_ns,
+dex = IrreducibleFunctionUnit(['dex', 'bel', 'Bell'], namespace=_ns,
                               doc="Dex: Base 10 logarithmic unit")
 
 dB = RegularFunctionUnit(['dB', 'decibel'], 0.1 * dex, namespace=_ns,


### PR DESCRIPTION
A `decibel` is a tenth of a `bel`. Perhaps the former should instead be made by allowing SI prefixes on `dex`/`bel`.