### PR TITLE
Use ASDF schema tester plugin if ASDF is installed

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -4,8 +4,14 @@ This file contains pytest configuration settings that are astropy-specific
 (i.e.  those that would not necessarily be shared by affiliated packages
 making use of astropy's test runner).
 """
+from importlib.util import find_spec
+
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
+
+if find_spec('asdf') is not None:
+    pytest_plugins = ['asdf.tests.schema_tester']
+
 
 enable_deprecations_as_exceptions(
     include_astropy_deprecations=False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true
 addopts = -p no:warnings
+asdf_schema_root = astropy/io/misc/asdf/schemas
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
When ASDF is installed, using this plugin will allow any ASDF schemas that are provided by Astropy to be validated. Any examples within those schemas will also be tested.