### PR TITLE
Respect proper z-order for WCSAxes ticks, tick labels, and grids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -931,6 +931,11 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Matplotlib axes have the ``axisbelow`` property to control the z-order of
+  ticks, tick labels, and grid lines. WCSAxes will now respect this property.
+  This is useful for drawing scale bars or inset boxes, which should have a
+  z-order that places them above all ticks and gridlines. [#7098]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -60,6 +60,33 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=1.5)
+    @pytest.mark.parametrize('axisbelow', [True, False, 'line'])
+    def test_axisbelow(self, axisbelow):
+        # Test that tick marks, labels, and gridlines are drawn with the
+        # correct zorder controlled by the axisbelow property.
+        fig = plt.figure(figsize=(6, 6))
+        ax = fig.add_axes([0.1, 0.1, 0.8, 0.8], projection=WCS(self.msx_header), aspect='equal')
+        ax.set_axisbelow(axisbelow)
+        ax.set_xlim(-0.5, 148.5)
+        ax.set_ylim(-0.5, 148.5)
+        ax.coords[0].set_ticks([-0.30, 0., 0.20] * u.degree, size=5, width=1)
+        ax.grid()
+
+        # Add an image (default zorder=0).
+        ax.imshow(np.zeros((64, 64)))
+
+        # Add a patch (default zorder=1).
+        r = Rectangle((30., 50.), 60., 50., facecolor='green', edgecolor='red')
+        ax.add_patch(r)
+
+        # Add a line (default zorder=2).
+        ax.plot([32, 128], [32, 128], linewidth=10)
+
+        return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='contour_overlay.png',
                                    tolerance=0, style={})
     def test_contour_overlay(self):


### PR DESCRIPTION
Matplotlib axes have the `axisbelow` property to control the z-order of ticks, tick labels, and grid lines. WCSAxes will now respect this property. This is useful for drawing scale bars or inset boxes, which should have a z-order that places them above all ticks and gridlines.

(The implementation is a bit of a hack, because unlike normal Matplotlib axes, the ticks, tick labels, and grid lines in WCSAxes are not actually implemented as artists and so don't actually have a zorder property.)