### PR TITLE
Fix:Unicode decode error when trying to read in CSV table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,6 +256,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fix a unicode decode error when reading a table with non-ASCII characters.
+  The fast C reader cannot handle unicode so the code now uses the pure-Python
+  reader in this case. [#7103]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1378,3 +1378,12 @@ def test_read_chunks_table_changes():
     # This also confirms that the dtypes are exactly the same, i.e.
     # the string itemsizes are the same.
     assert np.all(t1 == t2)
+
+
+def test_read_non_ascii():
+    """Test that pure-Python reader is used in case the file contains non-ASCII characters
+    in it.
+    """
+    table = Table.read(['col1, col2', '\u2119, \u01b4', '1, 2'], format='csv')
+    assert np.all(table['col1'] == ['\u2119', '1'])
+    assert np.all(table['col2'] == ['\u01b4', '2'])

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -369,7 +369,7 @@ def read(table, guess=None, **kwargs):
                 _read_trace.append({'kwargs': fast_kwargs,
                                     'Reader': fast_reader_rdr.__class__,
                                     'status': 'Success with fast reader (no guessing)'})
-            except (core.ParameterError, cparser.CParserError) as err:
+            except (core.ParameterError, cparser.CParserError, UnicodeEncodeError) as err:
                 # special testing value to avoid falling back on the slow reader
                 if fast_reader['enable'] == 'force':
                     raise core.InconsistentTableError(


### PR DESCRIPTION
The pure-Python reader is used in case the file contains non-ASCII characters in it.

Fixes #7047