### PR TITLE
Fix 7069

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -697,6 +697,21 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         inferred), use the ``set_represenation_cls`` method.
         """)
 
+    @property
+    def differential_type(self):
+        """
+        The differential used for this frame's data.
+
+        This will be a subclass from `~astropy.coordinates.BaseRepresentation`.
+        For simultaneous setting of representation and differentials, see the
+        ``set_represenation_cls`` method.
+        """
+        return self.get_representation_cls('s')
+    @differential_type.setter
+    def differential_type(self, value):
+        self.set_representation_cls(s=value)
+
+
     # TODO: deprecate these?
     @property
     def representation(self):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -202,7 +202,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if repr_info is None:
             repr_info = {}
 
-        for cls_or_name in repr_info.keys():
+        for cls_or_name in tuple(repr_info.keys()):
             if isinstance(cls_or_name, str):
                 # TODO: this provides a layer of backwards compatibility in
                 # case the key is a string, but now we want explicit classes.

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -2071,13 +2071,13 @@ def _get_representation_attrs(frame, units, kwargs):
     # also check the differentials.  They aren't included in the units keyword,
     # so we only look for the names.
 
-    # TODO: change _representation['s'] to `differential_type` when that exists
-    differential_type = frame._representation['s'].attr_classes
-    for frame_name, repr_name in frame.get_representation_component_names('s').items():
-        diff_attr_class = differential_type[repr_name]
-        value = kwargs.pop(frame_name, None)
-        if value is not None:
-            valid_kwargs[frame_name] = diff_attr_class(value)
+    differential_type = frame.get_representation_cls('s')
+    if differential_type is not None:
+        for frame_name, repr_name in frame.get_representation_component_names('s').items():
+            diff_attr_class = differential_type.attr_classes[repr_name]
+            value = kwargs.pop(frame_name, None)
+            if value is not None:
+                valid_kwargs[frame_name] = diff_attr_class(value)
 
     return valid_kwargs
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -2071,7 +2071,7 @@ def _get_representation_attrs(frame, units, kwargs):
     # also check the differentials.  They aren't included in the units keyword,
     # so we only look for the names.
 
-    differential_type = frame.get_representation_cls('s')
+    differential_type = frame.differential_type
     if differential_type is not None:
         for frame_name, repr_name in frame.get_representation_component_names('s').items():
             diff_attr_class = differential_type.attr_classes[repr_name]

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1786,8 +1786,12 @@ def _get_frame(args, kwargs):
             coord_frame_obj = arg.frame
         if coord_frame_obj is not None:
             coord_frame_cls = coord_frame_obj.__class__
-            kwargs.setdefault('differential_type',
-                              coord_frame_obj.get_representation_cls('s'))
+            frame_diff = coord_frame_obj.get_representation_cls('s')
+            if frame_diff is not None:
+                # we do this check because otherwise if there's no default
+                # differential (i.e. it is None), the code below chokes. but
+                # None still gets through if the user *requests* it
+                kwargs.setdefault('differential_type', frame_diff)
 
         if coord_frame_cls is not None:
             if not frame_specified_explicitly:

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -20,7 +20,7 @@ from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             SphericalRepresentation, CartesianRepresentation,
                             UnitSphericalRepresentation, AltAz,
                             BaseCoordinateFrame, Attribute,
-                            frame_transform_graph)
+                            frame_transform_graph, RepresentationMapping)
 from ...coordinates import Latitude, EarthLocation
 from ...time import Time
 from ...utils import minversion, isiterable
@@ -1434,3 +1434,21 @@ def test_apply_space_motion():
 
     with pytest.raises(ValueError):
         c2.apply_space_motion(new_obstime=t2)
+
+
+def test_custom_frame_skycoord():
+    # also regression check for the case from #7069
+
+    class BlahBleeBlopFrame(BaseCoordinateFrame):
+        default_representation = SphericalRepresentation
+        # without a differential, SkyCoord creation fails
+        # default_differential = SphericalDifferential
+
+        _frame_specific_representation_info = {
+            'spherical': [
+                RepresentationMapping('lon', 'lon', 'recommended'),
+                RepresentationMapping('lat', 'lat', 'recommended'),
+                RepresentationMapping('distance', 'radius', 'recommended')
+            ]
+        }
+    SkyCoord(lat=1*u.deg, lon=2*u.deg, frame=BlahBleeBlopFrame)


### PR DESCRIPTION
This is a patch to allow Sunpy's coordinate machinery to work again following the various v3.0 coordinates-related changes. That is, it fixes #7069.

I ran the tests against sunpy master and they seemed to be working *but* I would appreciate it if @Cadair or @nabobalis could double-check my results before we merge this.