### PR TITLE
work around numpy 1.14.0 bug in einsum

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -754,6 +754,9 @@ astropy.coordinates
   means that future revisions to the file with unicode observatory names can
   be done without breaking the site registry parser.  [#7082]
 
+- Working around a bug in Numpy 1.14.0 that broke some coordinate
+  transformations. [#7105]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -202,7 +202,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if repr_info is None:
             repr_info = {}
 
-        # the tuple() call below is necessary because if it is not there, 
+        # the tuple() call below is necessary because if it is not there,
         # the iteration proceeds in a difficult-to-predict manner in the
         # case that one of the class objects hash is such that it gets
         # revisited by the iteration.  The tuple() call prevents this by
@@ -713,7 +713,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         ``set_represenation_cls`` method.
         """
         return self.get_representation_cls('s')
-      
+
     @differential_type.setter
     def differential_type(self, value):
         self.set_representation_cls(s=value)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1125,7 +1125,14 @@ class CartesianRepresentation(BaseRepresentation):
         else:
             # Matrix multiply all pmat items and coordinates, broadcasting the
             # remaining dimensions.
-            newxyz = np.einsum('...ij,j...->i...', matrix, oldxyz.value)
+            if np.__version__ == '1.14.0':
+                # there is a bug in numpy v1.14.0 (fixed in 1.14.1) that causes
+                # this einsum call to break with the default of optimize=True
+                # see https://github.com/astropy/astropy/issues/7051
+                newxyz = np.einsum('...ij,j...->i...', matrix, oldxyz.value,
+                                   optimize=False)
+            else:
+                newxyz = np.einsum('...ij,j...->i...', matrix, oldxyz.value)
 
         newxyz = u.Quantity(newxyz, oldxyz.unit, copy=False)
         # Handle differentials attached to this representation


### PR DESCRIPTION
This fixes #7051 by explicitly setting the optimize keyword of `einsum` to `False`, *only* for numpy v1.14.0 , as the underlying bug will be fixed in 1.14.1 (numpy/numpy#10371).

In passing I note that there may be a factor of ~2x speedup in 1.14.1 though, where `einsum` defaults to `optimize=True` (probably because BLAS is now used in einsum).  So 👏 there!