### PR TITLE
Improve Frame/SkyCoord errors from missing components in init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -268,6 +268,10 @@ astropy.coordinates
   and ``differential_type`` instead of ``representation`` and
   ``differential_cls``. [#6873]
 
+- The frame classes (and ``SkyCoord``) now give more useful error messages when
+  incorrect attribute names are given.  Instead of using the representation
+  attribute names, they use the frame attribute names. [#7106]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -202,7 +202,7 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if repr_info is None:
             repr_info = {}
 
-        # the tuple() call below is necessary because if it is not there, 
+        # the tuple() call below is necessary because if it is not there,
         # the iteration proceeds in a difficult-to-predict manner in the
         # case that one of the class objects hash is such that it gets
         # revisited by the iteration.  The tuple() call prevents this by
@@ -486,6 +486,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     representation_data = representation_cls(copy=copy,
                                                              **repr_kwargs)
                 except TypeError as e:
+                    # this except clause is here to make the names of the
+                    # attributes more human-readable.  Without this the names
+                    # come from the representation instead of the frame's
+                    # attribute names.
                     msg = str(e)
                     names = self.get_representation_component_names()
                     for frame_name, repr_name in names.items():
@@ -520,6 +524,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     differential_data = differential_cls(copy=copy,
                                                          **diff_kwargs)
                 except TypeError as e:
+                    # this except clause is here to make the names of the
+                    # attributes more human-readable.  Without this the names
+                    # come from the representation instead of the frame's
+                    # attribute names.
                     msg = str(e)
                     names = self.get_representation_component_names('s')
                     for frame_name, repr_name in names.items():
@@ -734,7 +742,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         ``set_represenation_cls`` method.
         """
         return self.get_representation_cls('s')
-      
+
     @differential_type.setter
     def differential_type(self, value):
         self.set_representation_cls(s=value)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -482,8 +482,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                         and 'distance' not in repr_kwargs):
                     representation_cls = representation_cls._unit_representation
 
-                representation_data = representation_cls(copy=copy,
-                                                         **repr_kwargs)
+                try:
+                    representation_data = representation_cls(copy=copy,
+                                                             **repr_kwargs)
+                except TypeError as e:
+                    msg = str(e)
+                    names = self.get_representation_component_names()
+                    for frame_name, repr_name in names.items():
+                        msg = msg.replace(repr_name, frame_name)
+                    msg = msg.replace('__init__()',
+                                      '{0}()'.format(self.__class__.__name__))
+                    e.args = (msg,)
+                    raise
 
             # Now we handle the Differential data:
             # Get any differential data passed in to the frame initializer
@@ -506,7 +516,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 elif len(diff_kwargs) == 1 and 'd_distance' in diff_kwargs:
                     differential_cls = r.RadialDifferential
 
-                differential_data = differential_cls(copy=copy, **diff_kwargs)
+                try:
+                    differential_data = differential_cls(copy=copy,
+                                                         **diff_kwargs)
+                except TypeError as e:
+                    msg = str(e)
+                    names = self.get_representation_component_names('s')
+                    for frame_name, repr_name in names.items():
+                        msg = msg.replace(repr_name, frame_name)
+                    msg = msg.replace('__init__()',
+                                      '{0}()'.format(self.__class__.__name__))
+                    e.args = (msg,)
+                    raise
 
         if len(args) > 0:
             raise TypeError(

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -987,3 +987,27 @@ def test_representation_arg_backwards_compatibility():
         ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
              representation='cartesian',
              representation_type='cartesian')
+
+
+def test_missing_component_error_names():
+    """
+    This test checks that the component names are frame component names, not
+    representation or differential names, when referenced in an exception raised
+    when not passing in enough data. For example:
+
+    ICRS(ra=10*u.deg)
+
+    should state:
+
+    TypeError: __init__() missing 1 required positional argument: 'dec'
+    """
+    from ..builtin_frames import ICRS
+
+    with pytest.raises(TypeError) as e:
+        ICRS(ra=150 * u.deg)
+    assert "missing 1 required positional argument: 'dec'" in str(e)
+
+    with pytest.raises(TypeError) as e:
+        ICRS(ra=150*u.deg, dec=-11*u.deg,
+             pm_ra=100*u.mas/u.yr, pm_dec=10*u.mas/u.yr)
+    assert "pm_ra_cosdec" in str(e)

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1452,3 +1452,28 @@ def test_custom_frame_skycoord():
             ]
         }
     SkyCoord(lat=1*u.deg, lon=2*u.deg, frame=BlahBleeBlopFrame)
+
+
+def test_user_friendly_pm_error():
+    """
+    This checks that a more user-friendly error message is raised for the user
+    if they pass, e.g., pm_ra instead of pm_ra_cosdec
+    """
+
+    with pytest.raises(ValueError) as e:
+        SkyCoord(ra=150*u.deg, dec=-11*u.deg,
+                 pm_ra=100*u.mas/u.yr, pm_dec=10*u.mas/u.yr)
+    assert 'pm_ra_cosdec' in str(e.value)
+
+    with pytest.raises(ValueError) as e:
+        SkyCoord(l=150*u.deg, b=-11*u.deg,
+                 pm_l=100*u.mas/u.yr, pm_b=10*u.mas/u.yr,
+                 frame='galactic')
+    assert 'pm_l_cosb' in str(e.value)
+
+    # The special error should not turn on here:
+    with pytest.raises(ValueError) as e:
+        SkyCoord(x=1*u.pc, y=2*u.pc, z=3*u.pc,
+                 pm_ra=100*u.mas/u.yr, pm_dec=10*u.mas/u.yr,
+                 representation_type='cartesian')
+    assert 'pm_ra_cosdec' not in str(e.value)


### PR DESCRIPTION
This includes two conceptual changes:

1. In the `Frame` class initialization, the current behavior when a representation or differential component is missing is that a `TypeError` gets raised in the representation or differential class initializer. This means that the error contains the repr./diff. component names instead of the frame names for them. This is fairly confusing to the user. Example, with current master:

```python
>>> c = coord.ICRS(ra=150*u.deg)
...
TypeError: __init__() missing 1 required positional argument: 'lat'
```

This PR catches the error and does a string replace on the component names before re-raising. That mechanic might be controversial and feels a bit awkward to me, but the other option is also a little awkward for the user: we could catch and raise a new exception, but then the traceback will show both errors, e.g.:
```
...
TypeError: __init__() missing 1 required positional argument: 'lat'
...
TypeError:ICRS() missing 1 required positional argument: 'dec'
```

2. The above changes also naturally propagate to `SkyCoord` because it constructs a frame class. But I've also added a special-case error to the `SkyCoord` init for new users of the velocity machinery to try to clarify our naming choices. Some users would think `pm_ra` means `pm_ra_cosdec`, and may try to create an object like:

```python
>>> SkyCoord(ra=150*u.deg, dec=10*u.deg, pm_ra=100*u.mas/u.yr, pm_dec=-10*u.mas/u.yr)
```
With master,  this just fails with an "unrecognized argument `pm_ra`" error. In this PR, I've added a special case that adds to the error message for cases where `pm_<lon>` appears in the unrecogized kwargs list. So, for example:
```python
>>> SkyCoord(ra=150*u.deg, dec=10*u.deg, pm_ra=100*u.mas/u.yr, pm_dec=-10*u.mas/u.yr)
...
ValueError: Unrecognized keyword argument(s) 'pm_ra'

 By default, most frame classes expect the longitudinal proper motion to include the cos(latitude) term, named `pm_ra_cosdec`. Did you mean to pass in this component?
```