### PR TITLE
Fix get and set of table Row when using multiple column names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -478,6 +478,7 @@ astropy.table
 - Allow updating of table by indices through the property ``astropy.table.Table.loc``. [#6831]
 
 - Enable tab-completion for column names with IPython 5 and later. [#7071]
+- Allow getting and setting a table Row using multiple column names. [#7107]
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -677,6 +678,13 @@ astropy.table
   unicode arrays (dtype ``U``). The ``Column`` class then ensures the
   bytes are automatically converted to string as needed. [#6821]
 
+- When getting a table row using multiple column names, if one of the
+  names is not a valid column name then a ``KeyError`` exception is
+  now raised (previously ``ValueError``).  When setting a table row,
+  if the right hand side is not a sequence with the correct length
+  then a ``ValueError`` is now raised (previously in certain cases
+  a ``TypeError`` was raised). [#7107]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -778,6 +786,12 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fix getting a table row when using multiple column names (for example
+  ``t[3]['a', 'b', 'c']``).  Also fix a problem when setting an entire row:
+  if setting one of the right-hand side values failed this could result in
+  a partial update of the referenced parent table before the exception is
+  raised. [#7107]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -38,10 +38,20 @@ class Row:
                              .format(index, len(table)))
 
     def __getitem__(self, item):
-        return self._table.columns[item][self._index]
+        if self._table._is_list_or_tuple_of_str(item):
+            cols = [self._table[name] for name in item]
+            out = self._table.__class__(cols, copy=False)[self._index]
+
+        else:
+            out = self._table.columns[item][self._index]
+
+        return out
 
     def __setitem__(self, item, val):
-        self._table.columns[item][self._index] = val
+        if self._table._is_list_or_tuple_of_str(item):
+            self._table._set_row(self._index, colnames=item, vals=val)
+        else:
+            self._table.columns[item][self._index] = val
 
     def _ipython_key_completions_(self):
         return self.colnames

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -220,13 +220,13 @@ class TestTableItems(BaseTestItems):
         """Selecting a column that doesn't exist fails"""
         self.t = table_data.Table(table_data.COLS)
 
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(KeyError) as err:
             self.t[['xxxx']]
-        assert 'Slice name(s) xxxx not valid column name(s)' in str(err)
+        assert "KeyError: 'xxxx'" in str(err)
 
-        with pytest.raises(ValueError) as err:
+        with pytest.raises(KeyError) as err:
             self.t[['xxxx', 'yyyy']]
-        assert 'Slice name(s) xxxx, yyyy not valid column name(s)' in str(err)
+        assert "KeyError: 'xxxx'" in str(err)
 
     def test_np_where(self, table_data):
         """Select rows using output of np.where"""

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from ... import table
 from ...table import Row
+from ... import units as u
 from .conftest import MaskedTable
 
 
@@ -200,3 +201,81 @@ class TestRow():
         for ibad in (-5, -4, 3, 4):
             with pytest.raises(IndexError):
                 self.t[ibad]
+
+
+def test_row_tuple_column_slice():
+    """
+    Test getting and setting a row using a tuple or list of column names
+    """
+    t = table.QTable([[1, 2, 3] * u.m,
+                      [10., 20., 30.],
+                      [100., 200., 300.],
+                      ['x', 'y', 'z']], names=['a', 'b', 'c', 'd'])
+    # Get a row for index=1
+    r1 = t[1]
+    # Column slice with tuple of col names
+    r1_abc = r1['a', 'b', 'c']  # Row object for these cols
+    r1_abc_repr = ['<Row index=1>',
+                   '   a       b       c   ',
+                   '   m                   ',
+                   'float64 float64 float64',
+                   '------- ------- -------',
+                   '    2.0    20.0   200.0']
+    assert repr(r1_abc).splitlines() == r1_abc_repr
+
+    # Column slice with list of col names
+    r1_abc = r1[['a', 'b', 'c']]
+    assert repr(r1_abc).splitlines() == r1_abc_repr
+
+    # Make sure setting on a tuple or slice updates parent table and row
+    r1['c'] = 1000
+    r1['a', 'b'] = 1000 * u.cm, 100.
+    assert r1['a'] == 10 * u.m
+    assert r1['b'] == 100
+    assert t['a'][1] == 10 * u.m
+    assert t['b'][1] == 100.
+    assert t['c'][1] == 1000
+
+    # Same but using a list of column names instead of tuple
+    r1[['a', 'b']] = 2000 * u.cm, 200.
+    assert r1['a'] == 20 * u.m
+    assert r1['b'] == 200
+    assert t['a'][1] == 20 * u.m
+    assert t['b'][1] == 200.
+
+    # Set column slice of column slice
+    r1_abc['a', 'c'] = -1 * u.m, -10
+    assert t['a'][1] == -1 * u.m
+    assert t['b'][1] == 200.
+    assert t['c'][1] == -10.
+
+    # Bad column name
+    with pytest.raises(KeyError) as err:
+        t[1]['a', 'not_there']
+    assert "KeyError: 'not_there'" in str(err)
+
+    # Too many values
+    with pytest.raises(ValueError) as err:
+        t[1]['a', 'b'] = 1 * u.m, 2, 3
+    assert 'right hand side must be a sequence' in str(err)
+
+    # Something without a length
+    with pytest.raises(ValueError) as err:
+        t[1]['a', 'b'] = 1
+    assert 'right hand side must be a sequence' in str(err)
+
+
+def test_row_tuple_column_slice_transaction():
+    """
+    Test that setting a row that fails part way through does not
+    change the table at all.
+    """
+    t = table.QTable([[10., 20., 30.],
+                      [1, 2, 3] * u.m], names=['a', 'b'])
+    tc = t.copy()
+
+    # First one succeeds but second fails.
+    with pytest.raises(ValueError) as err:
+        t[1]['a', 'b'] = (-1, -1 * u.s)  # Bad unit
+    assert "'s' (time) and 'm' (length) are not convertible" in str(err)
+    assert t[1] == tc[1]

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -111,7 +111,7 @@ class TestSetTableColumn(SetupData):
         t = table_types.Table([self.a, self.b])
         with pytest.raises(ValueError):
             t[1] = (20, 21, 22)
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             t[1] = 0
 
     def test_set_row_fail_2(self, table_types):


### PR DESCRIPTION
Fixes #7049.

For now I milestoned this for 3.1 because there is no 3.0.1 in master CHANGES.rst.  

From a functional perspective I think this could be backported to LTS, but it is slightly a pain because I factored out a new helper method and it has now a `isinstance(.., str)` instead of `isinstance(.., six.string_types)`.