### PR TITLE
Adding numpy 1.13 testing to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES NUMPY_VERSION=1.12
+          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PYTEST_VERSION='>3.2'
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
@@ -138,13 +138,18 @@ matrix:
                PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=2.0
+               MATPLOTLIB_VERSION=2.0 NUMPY_VERSION=1.13
                EVENT_TYPE='push pull_request cron'
                CONDA_VERSION=4.3.21
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux
           env: NUMPY_VERSION=prerelease
+               EVENT_TYPE='push pull_request cron'
+
+        # Try older numpy versions
+        - os: linux
+          env: NUMPY_VERSION=1.12
                EVENT_TYPE='push pull_request cron'
 
         # Do a PEP8/pyflakes test with flake8


### PR DESCRIPTION
and a bit of reshuffle as np 1.14 cannot be installed with the old conda packaging, and the mpl packaging with the new conda version is still failing on travis while locally is fine