### PR TITLE
Promote MplQuantityConverter to a public object

### DIFF
--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -3,8 +3,77 @@
 
 import numpy as np
 
+from matplotlib import units
+from matplotlib import ticker
+
+from .. import units as u
 
 __doctest_skip__ = ['quantity_support']
+
+
+def rad_fn(x, pos=None):
+    """Represent a value in radians as a multiple of pi.
+    """
+    n = int((x / np.pi) * 2.0 + 0.25)
+    if n == 0:
+        return '0'
+    elif n == 1:
+        return 'π/2'
+    elif n == 2:
+        return 'π'
+    elif n % 2 == 0:
+        return '{0}π'.format(n / 2)
+    else:
+        return '{0}π/2'.format(n)
+
+
+class MplQuantityConverter(units.ConversionInterface):
+    """`ConversionInterface` with support for Astropy units
+    """
+    def __init__(self, format='latex_inline'):
+        if u.Quantity not in units.registry:
+            units.registry[u.Quantity] = self
+            self._remove = True
+        else:
+            self._remove = False
+        self.format = format
+
+    def axisinfo(self, unit, axis):
+        if unit == u.radian:
+            return units.AxisInfo(
+                majloc=ticker.MultipleLocator(base=np.pi/2),
+                majfmt=ticker.FuncFormatter(rad_fn),
+                label=unit.to_string(),
+            )
+        elif unit == u.degree:
+            return units.AxisInfo(
+                majloc=ticker.AutoLocator(),
+                majfmt=ticker.FormatStrFormatter('%i°'),
+                label=unit.to_string(),
+            )
+        elif unit is not None:
+            return units.AxisInfo(label=unit.to_string(self.format))
+        return None
+
+    @staticmethod
+    def convert(val, unit, axis):
+        if isinstance(val, u.Quantity):
+            return val.to_value(unit)
+        else:
+            return val
+
+    @staticmethod
+    def default_units(x, axis):
+        if hasattr(x, 'unit'):
+            return x.unit
+        return None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, tb):
+        if self._remove:
+            del units.registry[u.Quantity]
 
 
 def quantity_support(format='latex_inline'):
@@ -32,68 +101,4 @@ def quantity_support(format='latex_inline'):
         provided, defaults to ``latex_inline``.
 
     """
-    from .. import units as u
-
-    from matplotlib import units
-    from matplotlib import ticker
-
-    def rad_fn(x, pos=None):
-        n = int((x / np.pi) * 2.0 + 0.25)
-        if n == 0:
-            return '0'
-        elif n == 1:
-            return 'π/2'
-        elif n == 2:
-            return 'π'
-        elif n % 2 == 0:
-            return '{0}π'.format(n / 2)
-        else:
-            return '{0}π/2'.format(n)
-
-    class MplQuantityConverter(units.ConversionInterface):
-        def __init__(self):
-            if u.Quantity not in units.registry:
-                units.registry[u.Quantity] = self
-                self._remove = True
-            else:
-                self._remove = False
-
-        @staticmethod
-        def axisinfo(unit, axis):
-            if unit == u.radian:
-                return units.AxisInfo(
-                    majloc=ticker.MultipleLocator(base=np.pi/2),
-                    majfmt=ticker.FuncFormatter(rad_fn),
-                    label=unit.to_string(),
-                )
-            elif unit == u.degree:
-                return units.AxisInfo(
-                    majloc=ticker.AutoLocator(),
-                    majfmt=ticker.FormatStrFormatter('%i°'),
-                    label=unit.to_string(),
-                )
-            elif unit is not None:
-                return units.AxisInfo(label=unit.to_string(format))
-            return None
-
-        @staticmethod
-        def convert(val, unit, axis):
-            if isinstance(val, u.Quantity):
-                return val.to_value(unit)
-            else:
-                return val
-
-        @staticmethod
-        def default_units(x, axis):
-            if hasattr(x, 'unit'):
-                return x.unit
-            return None
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, type, value, tb):
-            if self._remove:
-                del units.registry[u.Quantity]
-
     return MplQuantityConverter()


### PR DESCRIPTION
This PR promotes the contents of `astropy.visualization.units.quantity_support()` to module-level objects, so that they are independently referenceable. The motivation is mainly to allow customisation of the `MplQuantityConverter` via sub-classing.