### PR TITLE
Analytic age and lookback time calculations for FlatLambdaCDM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ are now 20x faster by using the hypergeometric function solution
 for this special case.  [#7087]
 
 Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
-are now 1000x faster by using analytic solutions instead of integrating.
+are now 1000x faster by using analytic solutions instead of integrating. [#7117]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
 are now 20x faster by using the hypergeometric function solution
 for this special case.  [#7087]
 
+Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
+are now 1000x faster by using analytic solutions instead of integrating.
+
 astropy.extern
 ^^^^^^^^^^^^^^
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1051,7 +1051,42 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         --------
         z_at_value : Find the redshift corresponding to a lookback time.
         """
+        return self._lookback_time(z)
 
+    def _lookback_time(self, z):
+        """ Lookback time in Gyr to redshift ``z``.
+
+        The lookback time is the difference between the age of the
+        Universe now and the age at redshift ``z``.
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          Lookback time in Gyr to each input redshift.
+        """
+        return self._integral_lookback_time(z)
+
+    def _integral_lookback_time(self, z):
+        """ Lookback time in Gyr to redshift ``z``.
+
+        The lookback time is the difference between the age of the
+        Universe now and the age at redshift ``z``.
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          Lookback time in Gyr to each input redshift.
+        """
         from scipy.integrate import quad
         f = lambda red: quad(self._lookback_time_integrand_scalar, 0, red)[0]
         return self._hubble_time * vectorize_if_needed(f, z)
@@ -1091,6 +1126,23 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         See Also
         --------
         z_at_value : Find the redshift corresponding to an age.
+        """
+        return self._age(z)
+
+    def _age(self, z):
+        """ Age of the universe in Gyr at redshift ``z``.
+
+        This internal function exists to be re-defined for optimizations.
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          The age of the universe in Gyr at each input redshift.
         """
         return self._integral_age(z)
 
@@ -1788,18 +1840,18 @@ class FlatLambdaCDM(LambdaCDM):
             if self._Om0 == 0:
                 self._comoving_distance_z1z2 = \
                     self._dS_comoving_distance_z1z2
-                self.age = self._dS_age
-                self.lookback_time = self._dS_lookback_time
+                self._age = self._dS_age
+                self._lookback_time = self._dS_lookback_time
             elif self._Om0 == 1:
                 self._comoving_distance_z1z2 = \
                     self._EdS_comoving_distance_z1z2
-                self.age = self._EdS_age
-                self.lookback_time = self._EdS_lookback_time
+                self._age = self._EdS_age
+                self._lookback_time = self._EdS_lookback_time
             else:
                 self._comoving_distance_z1z2 = \
                     self._hypergeometric_comoving_distance_z1z2
-                self.age = self._analytic_age
-                self.lookback_time = self._analytic_lookback_time
+                self._age = self._analytic_age
+                self._lookback_time = self._analytic_lookback_time
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1092,7 +1092,27 @@ class FLRW(Cosmology, metaclass=ABCMeta):
         --------
         z_at_value : Find the redshift corresponding to an age.
         """
+        return self._integral_age(z)
 
+    def _integral_age(self, z):
+        """ Age of the universe in Gyr at redshift ``z``.
+
+        Calculated using explicit integration.
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          The age of the universe in Gyr at each input redshift.
+
+        See Also
+        --------
+        z_at_value : Find the redshift corresponding to an age.
+        """
         from scipy.integrate import quad
         f = lambda red: quad(self._lookback_time_integrand_scalar,
                              red, np.inf)[0]

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -2032,10 +2032,6 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           Lookback time in Gyr to each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to a lookback time.
         """
         if isiterable(z):
             z = np.asarray(z)
@@ -2061,10 +2057,6 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           Lookback time in Gyr to each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to a lookback time.
         """
         return self._analytic_age(0) - self._analytic_age(z)
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -3182,19 +3182,24 @@ def vectorize_if_needed(func, *x):
 
 
 def inf_like(x):
-    """Return the shape of x with value infinity.
+    """Return the shape of x with value infinity and dtype='float'.
 
     Preserves 'shape' for both array and scalar inputs.
+    But always returns a float array, even if x is of integer type.
 
-    >>> inf_like(0.)
+    >>> inf_like(0.)  # float scalar
     inf
-    >>> inf_like([0., 1., 2., 3.])
-    array([ inf,  inf,  inf,  inf])
+    >>> inf_like(1)  # integer scalar should give float output
+    inf
+    >>> inf_like([0., 1., 2., 3.])  # float list
+    array([inf, inf, inf, inf])
+    >>> inf_like([0, 1, 2, 3])  # integer list should give float output
+    array([inf, inf, inf, inf])
     """
     if np.isscalar(x):
         return np.inf
     else:
-        return np.full_like(x, np.inf)
+        return np.full_like(x, np.inf, dtype='float')
 
 
 # Pre-defined cosmologies. This loops over the parameter sets in the

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -3186,9 +3186,9 @@ def inf_like(x):
 
     Preserves 'shape' for both array and scalar inputs.
 
-    >>> np.inf * inf_like(0.)
+    >>> inf_like(0.)
     inf
-    >>> np.inf * inf_like([0., 1., 2., 3.])
+    >>> inf_like([0., 1., 2., 3.])
     array([ inf,  inf,  inf,  inf])
     """
     if np.isscalar(x):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1935,10 +1935,6 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           The age of the universe in Gyr at each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to an age.
         """
         if isiterable(z):
             z = np.asarray(z)
@@ -1963,10 +1959,6 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           The age of the universe in Gyr at each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to an age.
         """
         if isiterable(z):
             z = np.asarray(z)
@@ -1990,18 +1982,16 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           The age of the universe in Gyr at each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to an age.
         """
         if isiterable(z):
             z = np.asarray(z)
 
         # Use np.sqrt, np.arcsinh instead of math.sqrt, math.asinh
         # to handle properly the complex numbers for 1 - Om0 < 0
-        prefactor = (2./3) * self._hubble_time / np.lib.scimath.sqrt(1-self._Om0)
-        arg = np.arcsinh(np.lib.scimath.sqrt((1/self._Om0 - 1 + 0j) / (1+z)**3))
+        prefactor = (2./3) * self._hubble_time / \
+            np.lib.scimath.sqrt(1 - self._Om0)
+        arg = np.arcsinh(np.lib.scimath.sqrt((1 / self._Om0 - 1 + 0j) /
+                                             (1 + z)**3))
         return (prefactor * arg).real
 
     def _EdS_lookback_time(self, z):
@@ -2023,13 +2013,7 @@ class FlatLambdaCDM(LambdaCDM):
         -------
         t : `~astropy.units.Quantity`
           Lookback time in Gyr to each input redshift.
-
-        See Also
-        --------
-        z_at_value : Find the redshift corresponding to a lookback time.
         """
-        # Writing out the equation again isn't clearly faster
-        # than two calls to age so we stick with the calls to minimize code.
         return self._EdS_age(0) - self._EdS_age(z)
 
     def _dS_lookback_time(self, z):
@@ -2086,8 +2070,6 @@ class FlatLambdaCDM(LambdaCDM):
         --------
         z_at_value : Find the redshift corresponding to a lookback time.
         """
-        # Writing out the equation again isn't clearly faster
-        # than two calls to age so we stick with the calls to minimize code.
         return self._analytic_age(0) - self._analytic_age(z)
 
     def efunc(self, z):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1998,8 +1998,11 @@ class FlatLambdaCDM(LambdaCDM):
         if isiterable(z):
             z = np.asarray(z)
 
-        prefactor = (2/3) * self._hubble_time / sqrt(1-self._Om0)
-        return prefactor * np.arcsinh(np.sqrt((1/self._Om0 - 1) / (1+z)**3))
+        # Use np.sqrt, np.arcsinh instead of math.sqrt, math.asinh
+        # to handle properly the complex numbers for 1 - Om0 < 0
+        prefactor = (2./3) * self._hubble_time / np.lib.scimath.sqrt(1-self._Om0)
+        arg = np.arcsinh(np.lib.scimath.sqrt((1/self._Om0 - 1 + 0j) / (1+z)**3))
+        return (prefactor * arg).real
 
     def _EdS_lookback_time(self, z):
         """ Lookback time in Gyr to redshift ``z``.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1936,11 +1936,7 @@ class FlatLambdaCDM(LambdaCDM):
         t : `~astropy.units.Quantity`
           The age of the universe in Gyr at each input redshift.
         """
-        if isiterable(z):
-            z = np.asarray(z)
-
-        # Add the Hubble time * z to get the right units in the right shape
-        return np.inf + self._hubble_time * z
+        return self._hubble_time * inf_like(z)
 
     def _EdS_age(self, z):
         """ Age of the universe in Gyr at redshift ``z``.
@@ -3139,6 +3135,22 @@ def vectorize_if_needed(func, *x):
         return np.vectorize(func)(*x)
     else:
         return func(*x)
+
+
+def inf_like(x):
+    """Return the shape of x with value infinity.
+
+    Preserves 'shape' for both array and scalar inputs.
+
+    >>> np.inf * inf_like(0.)
+    inf
+    >>> np.inf * inf_like([0., 1., 2., 3.])
+    array([ inf,  inf,  inf,  inf])
+    """
+    if np.isscalar(x):
+        return np.inf
+    else:
+        return np.full_like(x, np.inf)
 
 
 # Pre-defined cosmologies. This loops over the parameter sets in the

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1118,6 +1118,24 @@ def test_comoving_distance_z1z2():
                     results)
 
 @pytest.mark.skipif('not HAS_SCIPY')
+def test_age_in_special_cosmologies():
+    """Check that age in de Sitter and Einstein-de Sitter Universes work.
+
+    Some analytic solutions fail at these critical points.
+    """
+    c_dS = core.FlatLambdaCDM(100, 0, Tcmb0=0)
+    assert allclose(c_dS.age(z=0), np.inf * u.Gyr)
+    assert allclose(c_dS.age(z=1), np.inf * u.Gyr)
+    assert allclose(c_dS.lookback_time(z=0), 0 * u.Gyr)
+    assert allclose(c_dS.lookback_time(z=1), 6.777539216261741 * u.Gyr)
+
+    c_EdS = core.FlatLambdaCDM(100, 1, Tcmb0=0)
+    assert allclose(c_EdS.age(z=0), 6.518614811154189 * u.Gyr)
+    assert allclose(c_EdS.age(z=1), 2.3046783684542738 * u.Gyr)
+    assert allclose(c_EdS.lookback_time(z=0), 0 * u.Gyr)
+    assert allclose(c_EdS.lookback_time(z=1), 4.213936442699092 * u.Gyr)
+
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_distance_in_special_cosmologies():
     """Check that de Sitter and Einstein-de Sitter Universes both work.
 


### PR DESCRIPTION
In a FlatLambdaCDM Universe, the age and lookback time calculations have purely analytic forms.

This PR implements those for a speed-up of ~100x over the explicit integration.  It adds the general analytic form and also special cases for de Sitter and Einstein - de Sitter cosmologies.

This PR also adds tests for these cases.  Note that the previous age result for a `FlatLambdaCDM(100, 0)` de Sitter cosmology was wrong.  It would trigger a warning from the integration and give an answer of ~400 Gyr, instead of the formal answer of infinity.