### PR TITLE
Added LOCAL time scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,8 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
+- Added the ability to use ``local`` as time scale in ``Time`` and
+  ``TimeDelta``. [#6487]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,9 @@ astropy.time
 
 - Added support for missing values (masking) to the ``Time`` class. [#6028]
 
+- Added supper for a 'local' time scale (for free-running clocks, etc.),
+  and round-tripping to the corresponding FITS time scale. [#7122]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -338,15 +338,12 @@ class TestFitsTime(FitsTestCase):
         bhdu = fits.BinTableHDU.from_columns([c])
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
 
-        with catch_warnings() as w:
-            tm = table_types.read(self.temp('time.fits'), astropy_native=True)
-            assert len(w) == 1
-            assert 'FITS recognized time scale value "LOCAL"' in str(w[0].message)
+        tm = table_types.read(self.temp('time.fits'), astropy_native=True)
 
         assert isinstance(tm['local_time'], Time)
         assert tm['local_time'].format == 'mjd'
-        # Default scale is UTC
-        assert tm['local_time'].scale == 'utc'
+        
+        assert tm['local_time'].scale == 'local'
         assert (tm['local_time'].value == local_time).all()
 
     @pytest.mark.parametrize('table_types', (Table, QTable))

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -342,7 +342,7 @@ class TestFitsTime(FitsTestCase):
 
         assert isinstance(tm['local_time'], Time)
         assert tm['local_time'].format == 'mjd'
-        
+
         assert tm['local_time'].scale == 'local'
         assert (tm['local_time'].value == local_time).all()
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -135,7 +135,7 @@ def test_io_time_write_fits(tmpdir, table_types):
     (metadata scale, location).
     """
     t = table_types([[1,2], ['string', 'column']])
-    for scale in time.TIME_SCALES:
+    for scale in time.STANDARD_TIME_SCALES:
         t['a'+scale] = time.Time([[1,2],[3,4]], format='cxcsec', scale=scale,
                                   location=EarthLocation(-2446354,
                                   4237210, 4077985, unit='m'))
@@ -149,7 +149,7 @@ def test_io_time_write_fits(tmpdir, table_types):
     t.write(filename, format='fits', overwrite=True)
     tm = table_types.read(filename, format='fits', astropy_native=True)
 
-    for scale in time.TIME_SCALES:
+    for scale in time.STANDARD_TIME_SCALES:
         for ab in ('a', 'b'):
             name = ab + scale
 
@@ -176,7 +176,7 @@ def test_io_time_write_fits(tmpdir, table_types):
         assert (tm[name] == t[name]).all()
 
     # Test for conversion of time data to its value, as defined by its format
-    for scale in time.TIME_SCALES:
+    for scale in time.STANDARD_TIME_SCALES:
         for ab in ('a', 'b'):
             name = ab + scale
             t[name].info.serialize_method['fits'] = 'formatted_value'
@@ -184,7 +184,7 @@ def test_io_time_write_fits(tmpdir, table_types):
     t.write(filename, format='fits', overwrite=True)
     tm = table_types.read(filename, format='fits')
 
-    for scale in time.TIME_SCALES:
+    for scale in time.STANDARD_TIME_SCALES:
         for ab in ('a', 'b'):
             name = ab + scale
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -199,6 +199,9 @@ def test_io_time_write_fits_local(tmpdir, table_types):
     Validation of the output is done. Test that io.fits writes a table
     containing Time mixin columns that can be partially round-tripped
     (metadata scale, location).
+    This test is only done for Time mixin columns with local timescale
+    and since it can't be converted to standard timescales, this test
+    is done seperately from the standard one.
     """
     t = table_types([[1,2], ['string', 'column']])
     scale = 'local'

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1480,20 +1480,25 @@ class Time(ShapedLikeNDArray):
                 if other.scale not in (out.scale, None):
                     other = getattr(other, out.scale)
             else:
-                if other.scale is not None and self.scale not in TIME_TYPES[other.scale]:
-                    raise TypeError("Cannot subtract Time and TimeDelta instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
+                if other.scale is None:
+                    out._set_scale('tai')
                 else:
-                    out._set_scale(other.scale if other.scale is not None else 'tai')
+                    if self.scale not in TIME_TYPES[other.scale]:
+                        raise TypeError("Cannot subtract Time and TimeDelta instances "
+                                        "with scales '{0}' and '{1}'"
+                                        .format(self.scale, other.scale))
+                    out._set_scale(other.scale)
             # remove attributes that are invalidated by changing time
             for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
                 if hasattr(out, attr):
                     delattr(out, attr)
 
         else:  # T - T
-
             # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
-            if(other.scale not in self.SCALES):
-                raise TypeError("Cannot subtract Time instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
+            if other.scale not in self.SCALES:
+                raise TypeError("Cannot subtract Time instances "
+                                "with scales '{0}' and '{1}'"
+                                .format(self.scale, other.scale))
             self_time = (self._time if self.scale in TIME_DELTA_SCALES
                          else self.tai._time)
             # set up TimeDelta, subtraction to be done shortly
@@ -1536,11 +1541,14 @@ class Time(ShapedLikeNDArray):
             if other.scale not in (out.scale, None):
                 other = getattr(other, out.scale)
         else:
-            if other.scale is not None and self.scale not in TIME_TYPES[other.scale]:
-                raise TypeError("Cannot add Time and TimeDelta instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
+            if other.scale is None:
+                    out._set_scale('tai')
             else:
-                out._set_scale(other.scale if other.scale is not None
-                               else 'tai')
+                if self.scale not in TIME_TYPES[other.scale]:
+                    raise TypeError("Cannot add Time and TimeDelta instances "
+                                    "with scales '{0}' and '{1}'"
+                                    .format(self.scale, other.scale))
+                out._set_scale(other.scale)
         # remove attributes that are invalidated by changing time
         for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
             if hasattr(out, attr):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1041,7 +1041,7 @@ class Time(ShapedLikeNDArray):
                              tm.in_subfmt, tm.out_subfmt,
                              from_jd=True)
         tm._format = new_format
-
+        tm.SCALES = self.SCALES
         return tm
 
     def __copy__(self):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -33,7 +33,10 @@ __all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'TIME_DELTA_SCALES',
            'ScaleValueError', 'OperandTypeError', 'TimeInfo']
 
 
-TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
+STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
+LOCAL_SCALES = ('local',)
+TIME_TYPES = dict((scale, scales) for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales)
+TIME_SCALES = TIME_TYPES.keys()
 MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
               ('tai', 'tcg'): ('tt',),
               ('tai', 'ut1'): ('utc',),
@@ -55,7 +58,7 @@ BARYCENTRIC_SCALES = ('tcb', 'tdb')
 ROTATIONAL_SCALES = ('ut1',)
 TIME_DELTA_TYPES = dict((scale, scales)
                         for scales in (GEOCENTRIC_SCALES, BARYCENTRIC_SCALES,
-                                       ROTATIONAL_SCALES) for scale in scales)
+                                       ROTATIONAL_SCALES, LOCAL_SCALES) for scale in scales)
 TIME_DELTA_SCALES = TIME_DELTA_TYPES.keys()
 # For time scale changes, we need L_G and L_B, which are stored in erfam.h as
 #   /* L_G = 1 - d(TT)/d(TCG) */
@@ -272,12 +275,13 @@ class Time(ShapedLikeNDArray):
                 self._time.in_subfmt = in_subfmt
             if out_subfmt is not None:
                 self._time.out_subfmt = out_subfmt
-
+            self.SCALES = TIME_TYPES[self.scale]
             if scale is not None:
                 self._set_scale(scale)
         else:
             self._init_from_vals(val, val2, format, scale, copy,
                                  precision, in_subfmt, out_subfmt)
+            self.SCALES = TIME_TYPES[self.scale]
 
         if self.location is not None and (self.location.size > 1 and
                                           self.location.shape != self.shape):
@@ -1476,14 +1480,21 @@ class Time(ShapedLikeNDArray):
                 if other.scale not in (out.scale, None):
                     other = getattr(other, out.scale)
             else:
-                out._set_scale(other.scale if other.scale is not None
-                               else 'tai')
+                if other.scale is not None and self.scale not in TIME_TYPES[other.scale]:
+                    raise TypeError("Cannot subtract Time and TimeDelta instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
+                else:
+                    out._set_scale(other.scale if other.scale is not None else 'tai')
             # remove attributes that are invalidated by changing time
             for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
                 if hasattr(out, attr):
                     delattr(out, attr)
 
         else:  # T - T
+
+            # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
+            if(self.scale is not None and self.scale not in other.SCALES or
+               other.scale is not None and other.scale not in self.SCALES):
+                raise TypeError("Cannot subtract Time instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
             self_time = (self._time if self.scale in TIME_DELTA_SCALES
                          else self.tai._time)
             # set up TimeDelta, subtraction to be done shortly
@@ -1526,8 +1537,11 @@ class Time(ShapedLikeNDArray):
             if other.scale not in (out.scale, None):
                 other = getattr(other, out.scale)
         else:
-            out._set_scale(other.scale if other.scale is not None else 'tai')
-
+            if other.scale is not None and self.scale not in TIME_TYPES[other.scale]:
+                raise TypeError("Cannot add Time and TimeDelta instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
+            else:
+                out._set_scale(other.scale if other.scale is not None
+                               else 'tai')
         # remove attributes that are invalidated by changing time
         for attr in ('_delta_ut1_utc', '_delta_tdb_tt'):
             if hasattr(out, attr):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -29,14 +29,14 @@ from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
 from .formats import TimeFromEpoch  # pylint: disable=W0611
 
 
-__all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'TIME_DELTA_SCALES',
+__all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
            'ScaleValueError', 'OperandTypeError', 'TimeInfo']
 
 
 STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
 LOCAL_SCALES = ('local',)
 TIME_TYPES = dict((scale, scales) for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales)
-TIME_SCALES = TIME_TYPES.keys()
+TIME_SCALES = STANDARD_TIME_SCALES + LOCAL_SCALES
 MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
               ('tai', 'tcg'): ('tt',),
               ('tai', 'ut1'): ('utc',),
@@ -59,7 +59,7 @@ ROTATIONAL_SCALES = ('ut1',)
 TIME_DELTA_TYPES = dict((scale, scales)
                         for scales in (GEOCENTRIC_SCALES, BARYCENTRIC_SCALES,
                                        ROTATIONAL_SCALES, LOCAL_SCALES) for scale in scales)
-TIME_DELTA_SCALES = TIME_DELTA_TYPES.keys()
+TIME_DELTA_SCALES = GEOCENTRIC_SCALES + BARYCENTRIC_SCALES + ROTATIONAL_SCALES + LOCAL_SCALES
 # For time scale changes, we need L_G and L_B, which are stored in erfam.h as
 #   /* L_G = 1 - d(TT)/d(TCG) */
 #   define ERFA_ELG (6.969290134e-10)
@@ -1492,8 +1492,7 @@ class Time(ShapedLikeNDArray):
         else:  # T - T
 
             # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
-            if(self.scale is not None and self.scale not in other.SCALES or
-               other.scale is not None and other.scale not in self.SCALES):
+            if(other.scale not in self.SCALES):
                 raise TypeError("Cannot subtract Time instances with scales '{0}' and '{1}'".format(self.scale, other.scale))
             self_time = (self._time if self.scale in TIME_DELTA_SCALES
                          else self.tai._time)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -420,7 +420,14 @@ class TimeFromEpoch(TimeFormat):
         if self.scale != self.epoch_scale:
             if parent is None:
                 raise ValueError('cannot compute value without parent Time object')
-            tm = getattr(parent, self.epoch_scale)
+            try:
+                tm = getattr(parent, self.epoch_scale)
+            except Exception as err:
+                raise ScaleValueError("Cannot convert from '{0}' epoch scale '{1}'"
+                                  "to specified scale '{2}', got error:\n{3}"
+                                  .format(self.name, self.epoch_scale,
+                                          self.scale, err))
+
             jd1, jd2 = tm._time.jd1, tm._time.jd2
         else:
             jd1, jd2 = self.jd1, self.jd2

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -424,9 +424,9 @@ class TimeFromEpoch(TimeFormat):
                 tm = getattr(parent, self.epoch_scale)
             except Exception as err:
                 raise ScaleValueError("Cannot convert from '{0}' epoch scale '{1}'"
-                                  "to specified scale '{2}', got error:\n{3}"
-                                  .format(self.name, self.epoch_scale,
-                                          self.scale, err))
+                                      "to specified scale '{2}', got error:\n{3}"
+                                      .format(self.name, self.epoch_scale,
+                                              self.scale, err))
 
             jd1, jd2 = tm._time.jd1, tm._time.jd2
         else:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -7,6 +7,7 @@ import datetime
 from copy import deepcopy
 
 import numpy as np
+from numpy.testing import assert_allclose
 
 from ...tests.helper import catch_warnings, pytest
 from ...utils import isiterable
@@ -362,15 +363,15 @@ class TestBasic():
         ScalevalueError
         """
         t = Time('2006-01-15 21:24:37.5', scale='local')
-        assert t.jd == 2453751.3921006946
-        assert t.mjd == 53750.892100694444
-        assert t.decimalyear == 2006.0408002758752
+        assert_allclose(t.jd, 2453751.3921006946, atol=0.001/3600./24., rtol=0.)
+        assert_allclose(t.mjd, 53750.892100694444, atol=0.001/3600./24., rtol=0.)
+        assert_allclose(t.decimalyear, 2006.0408002758752, atol=0.001/3600./24./365., rtol=0.)
         assert t.datetime == datetime.datetime(2006, 1, 15, 21, 24, 37, 500000)
         assert t.isot == '2006-01-15T21:24:37.500'
         assert t.yday == '2006:015:21:24:37.500'
         assert t.fits == '2006-01-15T21:24:37.500(LOCAL)'
-        assert t.byear == 2006.04217888831
-        assert t.jyear == 2006.0407723496082
+        assert_allclose(t.byear, 2006.04217888831, atol=0.001/3600./24./365., rtol=0.)
+        assert_allclose(t.jyear, 2006.0407723496082, atol=0.001/3600./24./365., rtol=0.)
         assert t.byear_str == 'B2006.042'
         assert t.jyear_str == 'J2006.041'
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from ...tests.helper import catch_warnings, pytest
 from ...utils import isiterable
-from .. import Time, ScaleValueError, TIME_SCALES, TimeString, TimezoneInfo
+from .. import Time, ScaleValueError, STANDARD_TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation
 from ... import units as u
 from ... import _erfa as erfa
@@ -316,10 +316,10 @@ class TestBasic():
         except reversibility [#2074]"""
         lat = 19.48125
         lon = -155.933222
-        for scale1 in TIME_SCALES:
+        for scale1 in STANDARD_TIME_SCALES:
             t1 = Time('2006-01-15 21:24:37.5', format='iso', scale=scale1,
                       location=(lon, lat))
-            for scale2 in TIME_SCALES:
+            for scale2 in STANDARD_TIME_SCALES:
                 t2 = getattr(t1, scale2)
                 t21 = getattr(t2, scale1)
                 assert allclose_jd(t21.jd, t1.jd)

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -269,7 +269,8 @@ class TestTimeDeltaScales():
             TimeDelta([0., 1., 10.], format='sec', scale='utc')
 
     @pytest.mark.parametrize(('scale1', 'scale2'),
-                             list(itertools.product(STANDARD_TIME_SCALES, STANDARD_TIME_SCALES)))
+                             list(itertools.product(STANDARD_TIME_SCALES,
+                                                    STANDARD_TIME_SCALES)))
     def test_standard_scales_for_time_minus_time(self, scale1, scale2):
         """T(X) - T2(Y)  -- does T(X) - T2(Y).X and return dT(X)
         and T(X) +/- dT(Y)  -- does (in essence) (T(X).Y +/- dT(Y)).X
@@ -299,39 +300,36 @@ class TestTimeDeltaScales():
         assert allclose_jd(t2_recover.jd, t2.jd)
 
     def test_local_scales_for_time_minus_time(self):
-        """T(X) - T2(Y)  -- does T(X) - T2(Y).X and return dT(X)
-        and T(X) +/- dT(Y)  -- does (in essence) (T(X).Y +/- dT(Y)).X
+        """ T1(local) - T2(local) should return dT(local)
+        T1(local) +/- dT(local) or T1(local) +/- Quantity(time-like) should
+        also return T(local)
 
-        I.e., time differences of two times should have the scale of the
-        first time.
+        I.e. Tests that time differences of two local scale times should
+        return delta time with local timescale. Furthermore, checks that
+        arithmetic of T(local) with dT(None) or time-like quantity does work.
 
-        Also tests that subtracting two time scales, one of which is
-        different from local time scale should raise TypeError.
+        Also tests that subtracting two Time objects, one having local time
+        scale and other having standard time scale should raise TypeError.
         """
-        scale1 = 'local'
-        scale2 = 'local'
-        t1 = self.t[scale1]
-        t2 = Time('2010-01-01', scale=scale2)
+        t1 = self.t['local']
+        t2 = Time('2010-01-01', scale='local')
         dt = t1 - t2
-        assert dt.scale == scale1
+        assert dt.scale == 'local'
 
-        # now check with delta time; also check reversibility
-        t1_recover_t2_scale = t2 + dt
-        assert t1_recover_t2_scale.scale == scale2
-        t1_recover = getattr(t1_recover_t2_scale, scale1)
+        # now check with delta time
+        t1_recover = t2 + dt
+        assert t1_recover.scale == 'local'
         assert allclose_jd(t1_recover.jd, t1.jd)
-        t2_recover_t1_scale = t1 - dt
-        assert t2_recover_t1_scale.scale == scale1
-        t2_recover = getattr(t2_recover_t1_scale, scale2)
-        assert allclose_jd(t2_recover.jd, t2.jd)
+        # check that dT(None) can be subtracted from T(local)
         dt2 = TimeDelta([10.], format='sec', scale=None)
         t3 = t2 - dt2
         assert t3.scale == t2.scale
+        # check that time quantity can be subtracted from T(local)
         q = 10 * u.s
         assert (t2 - q).value == (t2 - dt2).value
-        for scale3 in STANDARD_TIME_SCALES:
-            t1 = self.t[scale1]
-            t2 = self.t[scale3]
+        for scale in STANDARD_TIME_SCALES:
+            t1 = self.t['local']
+            t2 = self.t[scale]
             with pytest.raises(TypeError):
                 dt = t1 - t2
             with pytest.raises(TypeError):
@@ -401,6 +399,10 @@ class TestTimeDeltaScales():
 
         # local time scale
         dt_local = self.dt['local']
+        dt6 = dt_local - dt_local[-1]
+        assert dt6.scale == 'local'
+        assert dt6[-1].sec == 0.
+
         for scale in 'utc', 'tai', 'tt', 'tcg', 'tcb', 'tdb', 'ut1':
             with pytest.raises(TypeError):
                 dt_local - self.dt[scale]

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -7,7 +7,7 @@ import operator
 import pytest
 
 from .. import (Time, TimeDelta, OperandTypeError, ScaleValueError,
-                TIME_SCALES, TIME_DELTA_SCALES)
+                TIME_SCALES, STANDARD_TIME_SCALES, TIME_DELTA_SCALES)
 from ... import units as u
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
@@ -268,7 +268,7 @@ class TestTimeDeltaScales():
             TimeDelta([0., 1., 10.], format='sec', scale='utc')
 
     @pytest.mark.parametrize(('scale1', 'scale2'),
-                             list(itertools.product(TIME_SCALES, TIME_SCALES)))
+                             list(itertools.product(STANDARD_TIME_SCALES, STANDARD_TIME_SCALES)))
     def test_scales_for_time_minus_time(self, scale1, scale2):
         """T(X) - T2(Y)  -- does T(X) - T2(Y).X and return dT(X)
         and T(X) +/- dT(Y)  -- does (in essence) (T(X).Y +/- dT(Y)).X

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -305,10 +305,8 @@ class TestTimeDeltaScales():
         I.e., time differences of two times should have the scale of the
         first time.
 
-        There are no local timescales for which this does not work.
-
         Also tests that subtracting two time scales, one of which is
-        from different local time scale should raise TypeError.
+        different from local time scale should raise TypeError.
         """
         scale1 = 'local'
         scale2 = 'local'
@@ -326,11 +324,18 @@ class TestTimeDeltaScales():
         assert t2_recover_t1_scale.scale == scale1
         t2_recover = getattr(t2_recover_t1_scale, scale2)
         assert allclose_jd(t2_recover.jd, t2.jd)
+        dt2 = TimeDelta([10.], format='sec', scale=None)
+        t3 = t2 - dt2
+        assert t3.scale == t2.scale
+        q = 10 * u.s
+        assert (t2 - q).value == (t2 - dt2).value
         for scale3 in STANDARD_TIME_SCALES:
             t1 = self.t[scale1]
             t2 = self.t[scale3]
             with pytest.raises(TypeError):
                 dt = t1 - t2
+            with pytest.raises(TypeError):
+                t3 = t2 - dt
 
     def test_scales_for_delta_minus_delta(self):
         """dT(X) +/- dT2(Y) -- Add/substract JDs for dT(X) and dT(Y).X

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -327,13 +327,21 @@ class TestTimeDeltaScales():
         # check that time quantity can be subtracted from T(local)
         q = 10 * u.s
         assert (t2 - q).value == (t2 - dt2).value
+        # Check that one cannot subtract/add times with a standard scale
+        # from a local one (or vice versa)
+        t1 = self.t['local']
         for scale in STANDARD_TIME_SCALES:
-            t1 = self.t['local']
             t2 = self.t[scale]
             with pytest.raises(TypeError):
-                dt = t1 - t2
+                t1 - t2
             with pytest.raises(TypeError):
-                t3 = t2 - dt
+                t2 - t1
+            with pytest.raises(TypeError):
+                t2 - dt
+            with pytest.raises(TypeError):
+                t2 + dt
+            with pytest.raises(TypeError):
+                dt + t2
 
     def test_scales_for_delta_minus_delta(self):
         """dT(X) +/- dT2(Y) -- Add/substract JDs for dT(X) and dT(Y).X

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -274,7 +274,7 @@ both" [#]_. See also [#]_ and [#]_.
 ::
 
   >>> Time.SCALES
-  ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
+  ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc', 'local')
 
 ====== =================================
 Scale        Description

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -179,8 +179,8 @@ yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:0
 ===========  =================================================  ==============================
 
 .. note:: The :class:`~astropy.time.TimeFITS` format allows for most
-   but not all of the the FITS standard [#]_. Not implemented (yet) is
-   support for a ``LOCAL`` timescale. Furthermore, FITS supports some deprecated
+   but not all of the the FITS standard [#]_. It also supports the
+   ``LOCAL`` timescale. Furthermore, FITS supports some deprecated
    names for timescales; these are translated to the formal names upon
    initialization.  Furthermore, any specific realization information,
    such as ``UT(NIST)`` is stored only as long as the time scale is not changed.
@@ -286,12 +286,17 @@ tdb    Barycentric Dynamical Time  (TDB)
 tt     Terrestrial Time            (TT)
 ut1    Universal Time              (UT1)
 utc    Coordinated Universal Time  (UTC)
+local  Local Time Scale            (LOCAL)
 ====== =================================
-
+  
 .. [#] Wikipedia `time standard <https://en.wikipedia.org/wiki/Time_standard>`_ article
 .. [#] SOFA Time Scale and Calendar Tools
        `(PDF) <http://www.iausofa.org/sofa_ts_c.pdf>`_
 .. [#] `<http://www.ucolick.org/~sla/leapsecs/timescales.html>`_
+
+.. note:: ``local`` TimeScale is a scale that cannot be converted to/from any
+   other scale and to which only TimeDelta with ``None`` type scale could be
+   added or subtracted.
 
 The system of transformation between supported time scales is shown in the
 figure below.  Further details are provided in the `Convert time scale`_ section.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -178,12 +178,12 @@ unix         :class:`~astropy.time.TimeUnix`                    946684800.0
 yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:00.000
 ===========  =================================================  ==============================
 
-.. note:: The :class:`~astropy.time.TimeFITS` format allows for most
-   but not all of the the FITS standard [#]_. It also supports the
-   ``LOCAL`` timescale. Furthermore, FITS supports some deprecated
-   names for timescales; these are translated to the formal names upon
-   initialization.  Furthermore, any specific realization information,
-   such as ``UT(NIST)`` is stored only as long as the time scale is not changed.
+.. note:: The :class:`~astropy.time.TimeFITS` format implements most
+   of the FITS standard [#]_, including support for the ``LOCAL`` timescale.
+   Note, though, that FITS supports some deprecated names for timescales;
+   these are translated to the formal names upon initialization.  Furthermore,
+   any specific realization information, such as ``UT(NIST)`` is stored only as
+   long as the time scale is not changed.
 .. [#] `Rots et al. 2015, A&A 574:A36 <http://adsabs.harvard.edu/abs/2015A%26A...574A..36R>`_
 
 Changing format
@@ -283,23 +283,25 @@ tai    International Atomic Time   (TAI)
 tcb    Barycentric Coordinate Time (TCB)
 tcg    Geocentric Coordinate Time  (TCG)
 tdb    Barycentric Dynamical Time  (TDB)
-tt     Terrestrial Time            (TT)
+tt     Terrestrial Time             (TT)
 ut1    Universal Time              (UT1)
 utc    Coordinated Universal Time  (UTC)
-local  Local Time Scale            (LOCAL)
+local  Local Time Scale          (LOCAL)
 ====== =================================
-  
+
 .. [#] Wikipedia `time standard <https://en.wikipedia.org/wiki/Time_standard>`_ article
 .. [#] SOFA Time Scale and Calendar Tools
        `(PDF) <http://www.iausofa.org/sofa_ts_c.pdf>`_
 .. [#] `<http://www.ucolick.org/~sla/leapsecs/timescales.html>`_
 
-.. note:: ``local`` TimeScale is a scale that cannot be converted to/from any
-   other scale and to which only TimeDelta with ``None`` type scale could be
-   added or subtracted.
+.. note:: The ``local`` time scale is meant for free-running clocks or simulation times,
+  i.e., to represent a time without properly defined scale. This means it cannot be converted
+  to any other time scale, and arithmetic is possible only with |Time| instances with scale
+  ``local`` and with |TimeDelta| instances with scale ``local`` or `None`.
 
-The system of transformation between supported time scales is shown in the
-figure below.  Further details are provided in the `Convert time scale`_ section.
+The system of transformation between supported time scales (i.e., all but ``local``)
+is shown in the figure below.
+Further details are provided in the `Convert time scale`_ section.
 
 .. image:: time_scale_conversion.png
 


### PR DESCRIPTION
issue #6487 
Added the ability to use `local` time scale for `Time` and `TimeDelta`.  Operations that are valid now

Subtracting two `Time` instances of 'local' or `None` type.
Subtracting/Adding `Time` and `TimeDelta` instances of `local` or `None` type.
`local` type  `Time` or `TimeDelta` can only be converted to/from `local` type, all other types are invalid.

Also made changes to existing tests, because not all transformations between `Time` are valid now.
