### PR TITLE
Remove autosummary templates

### DIFF
--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,1 +1,0 @@
-{% extends "autosummary_core/base.rst" %}

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -1,1 +1,0 @@
-{% extends "autosummary_core/class.rst" %}

--- a/docs/_templates/autosummary/module.rst
+++ b/docs/_templates/autosummary/module.rst
@@ -1,1 +1,0 @@
-{% extends "autosummary_core/module.rst" %}


### PR DESCRIPTION
I'm not sure exactly when, but at some point these template files stopped being needed (we used to have to have these even though they only inherit from the automodapi ones). I think the docs now build fine without.

We should remove this in the package-template too.