### PR TITLE
Make sure local matplotlibrc files are ignored for WCSAxes tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1005,6 +1005,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed test failures for ``astropy.visualization.wcsaxes`` which were due to
+  local matplotlibrc files being taken into account. [#7132]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -1,6 +1,9 @@
 from distutils.version import LooseVersion
 
 import matplotlib
+from matplotlib import pyplot as plt
+
+from ..utils.decorators import wraps
 
 MPL_VERSION = LooseVersion(matplotlib.__version__)
 
@@ -8,3 +11,13 @@ ROOT = "http://{server}/testing/astropy/2017-07-12T14:12:26.217559/{mpl_version}
 
 IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version='1.5.x') + ',' +
                        ROOT.format(server='www.astropy.org/astropy-data', mpl_version='1.5.x'))
+
+
+def ignore_matplotlibrc(func):
+    # This is a decorator for tests that use matplotlib but not pytest-mpl
+    # (which already handles rcParams)
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with plt.style.context({}, after_reset=True):
+            return func(*args, **kwargs)
+    return wrapper

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -1,13 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..core import WCSAxes
-from .... import units as u
-import matplotlib.pyplot as plt
 
 from unittest.mock import patch
 
 import pytest
+import matplotlib.pyplot as plt
+
+from ..core import WCSAxes
+from .... import units as u
+from ....tests.image_tests import ignore_matplotlibrc
 
 
+@ignore_matplotlibrc
 def test_getaxislabel():
 
     fig = plt.figure()
@@ -40,10 +43,12 @@ def assert_label_draw(ax, x_label, y_label):
     assert pos2.call_count == y_label
 
 
+@ignore_matplotlibrc
 def test_label_visibility_rules_default(ax):
     assert_label_draw(ax, True, True)
 
 
+@ignore_matplotlibrc
 def test_label_visibility_rules_label(ax):
 
     ax.coords[0].set_ticklabel_visible(False)
@@ -52,6 +57,7 @@ def test_label_visibility_rules_label(ax):
     assert_label_draw(ax, False, False)
 
 
+@ignore_matplotlibrc
 def test_label_visibility_rules_ticks(ax):
 
     ax.coords[0].set_axislabel_visibility_rule('ticks')
@@ -63,6 +69,7 @@ def test_label_visibility_rules_ticks(ax):
     assert_label_draw(ax, True, False)
 
 
+@ignore_matplotlibrc
 def test_label_visibility_rules_always(ax):
 
     ax.coords[0].set_axislabel_visibility_rule('always')

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -6,12 +6,14 @@ from matplotlib.backend_bases import KeyEvent
 from ....wcs import WCS
 from ....coordinates import FK5
 from ....time import Time
+from ....tests.image_tests import ignore_matplotlibrc
 
 from .test_images import BaseImageTests
 
 
 class TestDisplayWorldCoordinate(BaseImageTests):
 
+    @ignore_matplotlibrc
     def test_overlay_coords(self, tmpdir):
         wcs = WCS(self.msx_header)
 
@@ -92,6 +94,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         assert string_world5 == '267.652 -28\xb046\'23" (world, overlay 3)'
 
+    @ignore_matplotlibrc
     def test_cube_coords(self, tmpdir):
         wcs = WCS(self.cube_header)
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -12,11 +12,15 @@ from ....wcs import WCS
 from ....io import fits
 from ....coordinates import SkyCoord
 from ....tests.helper import catch_warnings
+from ....tests.image_tests import ignore_matplotlibrc
 
 from ..core import WCSAxes
 from ..utils import get_coord_meta
 
+DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
+
+@ignore_matplotlibrc
 def test_grid_regression():
     # Regression test for a bug that meant that if the rc parameter
     # axes.grid was set to True, WCSAxes would crash upon initalization.
@@ -25,6 +29,7 @@ def test_grid_regression():
     WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
 
 
+@ignore_matplotlibrc
 def test_format_coord_regression(tmpdir):
     # Regression test for a bug that meant that if format_coord was called by
     # Matplotlib before the axes were drawn, an error occurred.
@@ -58,6 +63,7 @@ COORDSYS= 'icrs    '
 """, sep='\n')
 
 
+@ignore_matplotlibrc
 def test_no_numpy_warnings(tmpdir):
 
     # Make sure that no warnings are raised if some pixels are outside WCS
@@ -77,6 +83,7 @@ def test_no_numpy_warnings(tmpdir):
     assert len(ws) == 0
 
 
+@ignore_matplotlibrc
 def test_invalid_frame_overlay():
 
     # Make sure a nice error is returned if a frame doesn't exist
@@ -90,14 +97,15 @@ def test_invalid_frame_overlay():
     assert exc.value.args[0] == 'Unknown frame: banana'
 
 
+@ignore_matplotlibrc
 def test_plot_coord_transform():
 
-    twoMASS_k_header = os.path.join(os.path.abspath(os.path.join(os.path.dirname(__file__), 'data')), '2MASS_k_header')
+    twoMASS_k_header = os.path.join(DATA, '2MASS_k_header')
     twoMASS_k_header = fits.Header.fromtextfile(twoMASS_k_header)
     fig = plt.figure(figsize=(6, 6))
     ax = fig.add_axes([0.15, 0.15, 0.8, 0.8],
-                        projection=WCS(twoMASS_k_header),
-                        aspect='equal')
+                      projection=WCS(twoMASS_k_header),
+                      aspect='equal')
     ax.set_xlim(-0.5, 720.5)
     ax.set_ylim(-0.5, 720.5)
 
@@ -106,6 +114,7 @@ def test_plot_coord_transform():
         ax.plot_coord(c, 'o', transform=ax.get_transform('galactic'))
 
 
+@ignore_matplotlibrc
 def test_set_label_properties():
 
     # Regression test to make sure that arguments passed to
@@ -148,6 +157,7 @@ CRPIX3  =                241.0
 """, sep='\n')
 
 
+@ignore_matplotlibrc
 def test_slicing_warnings(tmpdir):
 
     # Regression test to make sure that no warnings are emitted by the tick
@@ -164,7 +174,7 @@ def test_slicing_warnings(tmpdir):
 
     with warnings.catch_warnings(record=True) as warning_lines:
         warnings.resetwarnings()
-        ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+        plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
         plt.savefig(tmpdir.join('test.png').strpath)
 
     # For easy debugging if there are indeed warnings
@@ -179,7 +189,7 @@ def test_slicing_warnings(tmpdir):
 
     with warnings.catch_warnings(record=True) as warning_lines:
         warnings.resetwarnings()
-        ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
+        plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 2))
         plt.savefig(tmpdir.join('test.png').strpath)
 
     # For easy debugging if there are indeed warnings


### PR DESCRIPTION
In particular those that don't use pytest-mpl but use Matplotlib (pytest-mpl already ignores local matplotlibrc files)

@pllim - this will fix four of the issues you were seeing with RC2:

Fixes https://github.com/astropy/astropy/issues/6309
Fixes https://github.com/astropy/astropy/issues/7130

@bsipocz - I'm milestoning this as 2.0.4 as it should be backported to 2.0.x but if we can get this in 3.0 that would be great (I'll leave it up to you)