### PR TITLE
Add ability to create a custom coordinate transformation graph

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The new function :func:`~.coordinates.make_transform_graph_docs` can
+  be used to create a docstring graph from a custom
+  `~.coordinates.TransformGraph` object. [#7135]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,8 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- The new function :func:`~.coordinates.make_transform_graph_docs` can
-  be used to create a docstring graph from a custom
-  `~.coordinates.TransformGraph` object. [#7135]
+- The new function ``make_transform_graph_docs`` can be used to create a
+  docstring graph from a custom ``TransformGraph`` object. [#7135]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -59,23 +59,26 @@ __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'BaseEclipticFrame', 'BaseRADecFrame']
 
 
-def _make_transform_graph_docs():
+def _make_transform_graph_docs(transform_graph=None):
     """
     Generates a string for use with the coordinate package's docstring
-    to show the available transforms and coordinate systems
+    to show the available transforms and coordinate systems.
     """
+    if transform_graph is None:
+        from ..baseframe import frame_transform_graph
+        transform_graph = frame_transform_graph
+
     import inspect
     from textwrap import dedent
-    from ..baseframe import BaseCoordinateFrame, frame_transform_graph
+    from ..baseframe import BaseCoordinateFrame
 
     isclass = inspect.isclass
-    coosys = [item for item in globals().values()
-              if isclass(item) and issubclass(item, BaseCoordinateFrame)]
+    coosys = [transform_graph.lookup_name(item) for item in transform_graph.get_names()]
 
     # currently, all of the priorities are set to 1, so we don't need to show
     #   then in the transform graph.
-    graphstr = frame_transform_graph.to_dot_graph(addnodes=coosys,
-                                                  priorities=False)
+    graphstr = transform_graph.to_dot_graph(addnodes=coosys,
+                                            priorities=False)
 
     docstr = """
     The diagram below shows all of the coordinate systems built into the

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -50,30 +50,31 @@ from . import cirs_observed_transforms
 from . import intermediate_rotation_transforms
 from . import ecliptic_transforms
 
-# we define an __all__ because otherwise the transformation modules get included
+from ..baseframe import frame_transform_graph
+
+# we define an __all__ because otherwise the transformation modules
+# get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS', 'HCRS',
            'PrecessedGeocentric', 'GeocentricTrueEcliptic',
            'BarycentricTrueEcliptic', 'HeliocentricTrueEcliptic',
            'SkyOffsetFrame', 'GalacticLSR', 'LSR',
-           'BaseEclipticFrame', 'BaseRADecFrame']
+           'BaseEclipticFrame', 'BaseRADecFrame', 'make_transform_graph_docs']
 
 
-def _make_transform_graph_docs(transform_graph=None):
+def make_transform_graph_docs(transform_graph):
     """
-    Generates a string for use with the coordinate package's docstring
-    to show the available transforms and coordinate systems.
-    """
-    if transform_graph is None:
-        from ..baseframe import frame_transform_graph
-        transform_graph = frame_transform_graph
+    Generates a string that can be used in other docstrings to include a
+    transformation graph, showing the available transforms and
+    coordinate systems.
 
-    import inspect
+    Parameters
+    ----------
+    transform_graph : `~.coordinates.TransformGraph`
+    """
     from textwrap import dedent
-    from ..baseframe import BaseCoordinateFrame
-
-    isclass = inspect.isclass
-    coosys = [transform_graph.lookup_name(item) for item in transform_graph.get_names()]
+    coosys = [transform_graph.lookup_name(item) for
+              item in transform_graph.get_names()]
 
     # currently, all of the priorities are set to 1, so we don't need to show
     #   then in the transform graph.
@@ -126,4 +127,4 @@ def _make_transform_graph_docs(transform_graph=None):
     return docstr
 
 
-_transform_graph_docs = _make_transform_graph_docs()
+_transform_graph_docs = make_transform_graph_docs(frame_transform_graph)

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -71,6 +71,12 @@ def make_transform_graph_docs(transform_graph):
     Parameters
     ----------
     transform_graph : `~.coordinates.TransformGraph`
+
+    Returns
+    -------
+    docstring : str
+        A string that can be added to the end of a docstring to show the
+        transform graph.
     """
     from textwrap import dedent
     coosys = [transform_graph.lookup_name(item) for


### PR DESCRIPTION
Currently the `_make_transform_graph_docs` method generates a transform graph based on the `TransformGraph` object that is stored as a module variable in `astropy.coordinates.baseframe`. This PR allows a transformation graph to be created using any `TransformGraph` object, and not just the one in `astropy.coordinates.baseframe`.

The motivation for this is I want to use the astropy coordinates ecosystem to define coordinate transformations, but I don't want to use any of the astropy frames (yet!), so I don't want them showing up in my transformation graph.

In the long run it would be really nice if astropy could have some sort of "transformation registry", that could hold multiple user supplied `TransformGraph` objects, instead of the single one that is in `astropy.coordinates.baseframe`.