### PR TITLE
Add lomb scargle false alarm probabilities to 3.0 what's new

### DIFF
--- a/docs/whatsnew/3.0.rst
+++ b/docs/whatsnew/3.0.rst
@@ -163,6 +163,12 @@ Numpy byte arrays (Numpy type 'S'), which uses less memory.
 Kuiper functions added to ``astropy.stats``
 ===========================================
 
+.. _whatsnew-3.0-lomb-scargle-false-alarm:
+
+False alarm probabilities in ``astropy.stats.LombScargle``
+==========================================================
+
+:class:`~astropy.stats.LombScargle` now supports estimation of false alarm probabilities, using the :meth:`~astropy.stats.LombScargle.false_alarm_probability` and :meth:`~astropy.stats.LombScargle.false_alarm_level` methods. Supported approaches to false alarm estimation include a common heuristic based on an estimated number of independent frequencies (``method='naive'``), a more careful approach based on extreme value statistics (``method='baluev'``; first explored by Baluev (2007)), and a more accurate (but computationally intensive) approach based on bootstrap resampling (``method='bootstrap'``). These methods are implemented for all of the available periodogram normalizations. Further explanation and examples are available in :ref:`stats-lombscargle`.
 
 .. _whatsnew-3.0-python3:
 

--- a/docs/whatsnew/3.0.rst
+++ b/docs/whatsnew/3.0.rst
@@ -22,7 +22,7 @@ In particular, this release includes:
 * :ref:`whatsnew-3.0-hdf5-mixins`
 * :ref:`whatsnew-3.0-fits-time-support`
 * :ref:`whatsnew-3.0-fits-performance`
-* :ref:`whatsnew-3.0-kuiper-functions`
+* :ref:`whatsnew-3.0-lomb-scargle-false-alarm`
 * :ref:`whatsnew-3.0-python3`
 * :ref:`whatsnew-3.0-pytest-plugins`
 
@@ -158,17 +158,22 @@ or not to use memory mapping when reading the table, and ``fits.open`` supports
 a new keyword argument ``character_as_bytes`` to return character columns as
 Numpy byte arrays (Numpy type 'S'), which uses less memory.
 
-.. _whatsnew-3.0-kuiper-functions:
-
-Kuiper functions added to ``astropy.stats``
-===========================================
-
 .. _whatsnew-3.0-lomb-scargle-false-alarm:
 
 False alarm probabilities in ``astropy.stats.LombScargle``
 ==========================================================
 
-:class:`~astropy.stats.LombScargle` now supports estimation of false alarm probabilities, using the :meth:`~astropy.stats.LombScargle.false_alarm_probability` and :meth:`~astropy.stats.LombScargle.false_alarm_level` methods. Supported approaches to false alarm estimation include a common heuristic based on an estimated number of independent frequencies (``method='naive'``), a more careful approach based on extreme value statistics (``method='baluev'``; first explored by Baluev (2007)), and a more accurate (but computationally intensive) approach based on bootstrap resampling (``method='bootstrap'``). These methods are implemented for all of the available periodogram normalizations. Further explanation and examples are available in :ref:`stats-lombscargle`.
+:class:`~astropy.stats.LombScargle` now supports estimation of false alarm
+probabilities, using the
+:meth:`~astropy.stats.LombScargle.false_alarm_probability` and
+:meth:`~astropy.stats.LombScargle.false_alarm_level` methods. Supported
+approaches to false alarm estimation include a common heuristic based on an
+estimated number of independent frequencies (``method='naive'``), a more careful
+approach based on extreme value statistics (``method='baluev'``; first explored
+by Baluev (2007)), and a more accurate (but computationally intensive) approach
+based on bootstrap resampling (``method='bootstrap'``). These methods are
+implemented for all of the available periodogram normalizations. Further
+explanation and examples are available in :ref:`stats-lombscargle`.
 
 .. _whatsnew-3.0-python3:
 


### PR DESCRIPTION
The content was generated by @jakevdp (in the first commit, which I set to have him be the author). This is replacing the Kuiper section, which some slack discussion judged to be less "what's new-y" than this.