### PR TITLE
Use sphinx-astropy to build the docs

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - pip:
     - "git+https://github.com/sphinx-gallery/sphinx-gallery.git"
     - jplephem
+    - sphinx-astropy

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_docs -w'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
+               PIP_DEPENDENCIES='sphinx-astropy jplephem pillow'
                LC_CTYPE=C LC_ALL=C LANG=C
 
         # Try all python versions and Numpy versions. Since we can assume that

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -248,8 +248,8 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
-
+- The documentation build now uses the Sphinx configuration from sphinx-astropy
+  rather than from astropy-helpers. [#7139]
 
 3.0.2 (unreleased)
 ==================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,27 +27,15 @@
 
 from datetime import datetime
 import os
-ON_RTD = os.environ.get('READTHEDOCS') == 'True'
-ON_TRAVIS = os.environ.get('TRAVIS') == 'true'
-
-try:
-    import astropy_helpers
-except ImportError:
-    # Building from inside the docs/ directory?
-    import os
-    import sys
-    if os.path.basename(os.getcwd()) == 'docs':
-        a_h_path = os.path.abspath(os.path.join('..', 'astropy_helpers'))
-        if os.path.isdir(a_h_path):
-            sys.path.insert(1, a_h_path)
-
-    # If that doesn't work trying to import from astropy_helpers below will
-    # still blow up
-
-# Load all of the global Astropy configuration
-from astropy_helpers.sphinx.conf import *
+import sys
 
 import astropy
+
+try:
+    from sphinx_astropy.conf.v1 import *  # noqa
+except ImportError:
+    print('ERROR: the documentation requires the sphinx-astropy package to be installed')
+    sys.exit(1)
 
 plot_rcparams = {}
 plot_rcparams['figure.figsize'] = (6, 6)
@@ -192,7 +180,7 @@ man_pages = [('index', project.lower(), project + u' Documentation',
 
 # -- Options for the edit_on_github extension ----------------------------------------
 
-extensions += ['astropy_helpers.sphinx.ext.edit_on_github']
+extensions += ['sphinx_astropy.ext.edit_on_github']
 
 # Don't import the module as "version" or it will override the
 # "version" configuration parameter

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -4,22 +4,19 @@
 Writing Documentation
 *********************
 
-High-quality, consistent documentation for astronomy code is one of
-the major goals of the Astropy Project.  Hence, we describe our
-documentation procedures and rules here.  For the astropy core
-project we try to keep to these as closely as possible, while the
-standards for affiliated packages are somewhat looser.
-(These procedures and guidelines are still recommended for affiliated
-packages, as they encourage useful documentation, a characteristic
-often lacking in professional astronomy software.)
-
+High-quality, consistent documentation for astronomy code is one of the major
+goals of the Astropy Project.  Hence, we describe our documentation procedures
+and rules here.  For the astropy core project we try to keep to these as closely
+as possible, while the standards for affiliated packages are somewhat looser.
+(These procedures and guidelines are still recommended for affiliated packages,
+as they encourage useful documentation, a characteristic often lacking in
+professional astronomy software.)
 
 Building the Documentation from source
 ======================================
 
 For information about building the documentation from source, see
 the :ref:`builddocs` section in the installation instructions.
-
 
 Astropy Documentation Rules and Guidelines
 ==========================================
@@ -59,80 +56,60 @@ The details of the docstring format are described on a separate page:
 Sphinx Documentation Themes
 ===========================
 
-A custom Sphinx HTML theme is included in the `astropy-helpers`_ package.
-This allows the
-theme to be used by both Astropy and affiliated packages. This is done by
-setting the theme in the global Astropy sphinx configuration, which is imported
-in the sphinx configuration of both Astropy and affiliated packages.
-
-Using a different theme for ``astropy`` or affiliated packages
---------------------------------------------------------------
+An Astropy-branded Sphinx HTML theme is included in the astropy-sphinx-theme_
+package. This allows the theme to be used by both Astropy and affiliated
+packages. This is done by setting the theme in the global Astropy sphinx
+configuration in sphinx-astropy_, which is imported in the sphinx
+configuration of both Astropy and affiliated packages.
 
 A different theme can be used by overriding a few sphinx
 configuration variables set in the global configuration.
 
-* To use a different theme, set ``'html_theme'`` to the name of a desired
+* To use a different theme, set ``html_theme`` to the name of a desired
   builtin Sphinx theme or a custom theme in ``package-name/docs/conf.py``
   (where ``'package-name'`` is "astropy" or the name of the affiliated
   package).
 
 * To use a custom theme, additionally: place the theme in
   ``package-name/docs/_themes`` and add ``'_themes'`` to the
-  ``'html_theme_path'`` variable. See the Sphinx_ documentation for more
+  ``html_theme_path`` variable. See the Sphinx_ documentation for more
   details on theming.
-
-Adding more custom themes to astropy
-------------------------------------
-
-Additional custom themes can be included in the astropy source tree by
-placing them in the directory ``astropy/astropy/sphinx/themes``, and
-editing ``astropy/astropy/sphinx/setup_package.py`` to include the theme
-(so that it is installed).
-
-
 
 Sphinx extensions
 =================
 
-Astropy-helpers includes a number of sphinx extensions (some via the
-`sphinx-automodapi`_ package) that are used in Astropy and its affiliated
-packages to facilitate easily documenting code in a homogeneous and readable
-way. The two main extensions are `~sphinx_automodapi.automodapi` for
-generating module documentation and `~sphinx_automodapi.automodsumm` for
-generating tables of module objects. Please see their documentation about
-usage.
+The documentation build process for Astropy uses a number of sphinx extensions
+which are all installed automatically when installing sphinx-astropy_. These
+facilitate easily documenting code in a homogeneous and readable way.
 
+The main extensions used are:
 
-edit_on_github Extension
-------------------------
+* sphinx-automodapi_ - an extension
+  that makes it easy to automatically generate API documentation.
 
-.. automodule:: astropy_helpers.sphinx.ext.edit_on_github
+* sphinx-gallery_ - an
+  extension to generate example galleries
 
+* numpydoc_ - an extension to parse
+  docstrings in NumpyDoc format
 
-numpydoc Extension
-------------------
-This extension (and some related extensions) are a port of the
-`numpydoc <https://pypi.python.org/pypi/numpydoc/0.3.1>`_ extension
-written by the NumPy_ and SciPy_, projects, with some tweaks for
-Astropy.  Its main purposes is to reprocess docstrings from code into
-a form sphinx understands. Generally, there's no need to interact with
-it directly, as docstrings following the :doc:`docrules` will be
-processed automatically.
+In addition, the sphinx-astropy_ includes a few small extensions:
 
+* ``sphinx_astropy.ext.edit_on_github`` - an extension to add 'Edit on GitHub'
+  links to documentation pages.
 
-Other Extensions
-----------------
+* ``sphinx_astropy.ext.changelog_links`` - an extension to add links to
+  pull requests when rendering the changelog.
 
-``astropy_helpers.sphinx.ext`` and `sphinx-automodapi`_ includes a few other
-extensions that are primarily helpers for the other extensions or
-workarounds for undesired behavior.  Their APIs are not included here
-because we may change them in the future.
-
+* ``sphinx_astropy.ext.doctest`` - an extension that makes it possible to
+  add metadata about doctests inside ``.rst`` files
 
 .. _NumPy: http://www.numpy.org/
 .. _numpydoc: https://pypi.python.org/pypi/numpydoc/0.3.1
 .. _Matplotlib: http://matplotlib.org/
 .. _SciPy: https://www.scipy.org/
 .. _Sphinx: http://sphinx.pocoo.org
-.. _astropy-helpers: https://github.com/astropy/astropy-helpers
 .. _sphinx-automodapi: https://github.com/astropy/sphinx-automodapi
+.. _astropy-sphinx-theme: https://github.com/astropy/astropy-sphinx-theme
+.. _sphinx-astropy: https://github.com/astropy/sphinx-astropy
+.. _sphinx-gallery: https://sphinx-gallery.readthedocs.io

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -56,10 +56,10 @@ The details of the docstring format are described on a separate page:
 Sphinx Documentation Themes
 ===========================
 
-An Astropy-branded Sphinx HTML theme is included in the astropy-sphinx-theme_
+An Astropy Project Sphinx HTML theme is included in the astropy-sphinx-theme_
 package. This allows the theme to be used by both Astropy and affiliated
-packages. This is done by setting the theme in the global Astropy sphinx
-configuration in sphinx-astropy_, which is imported in the sphinx
+packages. The theme is activated by setting the theme in the global Astropy
+sphinx configuration in sphinx-astropy_, which is imported in the sphinx
 configuration of both Astropy and affiliated packages.
 
 A different theme can be used by overriding a few sphinx
@@ -104,6 +104,14 @@ In addition, the sphinx-astropy_ includes a few small extensions:
 * ``sphinx_astropy.ext.doctest`` - an extension that makes it possible to
   add metadata about doctests inside ``.rst`` files
 
+Note that packages that make use of astropy-helpers_ have access to the::
+
+    python setup.py build_docs
+
+command. Provided that Sphinx is installed, the above command will temporarily
+install sphinx-astropy_ and all its dependencies automatically.
+
+.. _astropy-helpers: https://github.com/astropy/astropy-helpers
 .. _NumPy: http://www.numpy.org/
 .. _numpydoc: https://pypi.python.org/pypi/numpydoc/0.3.1
 .. _Matplotlib: http://matplotlib.org/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -345,6 +345,8 @@ packages:
 
     - `Sphinx <http://sphinx.pocoo.org>`_ (and its dependencies) 1.0 or later
 
+    - `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ 1.0 or later
+
     - `Graphviz <http://www.graphviz.org>`_
 
     - `Astropy-helpers <https://github.com/astropy/astropy-helpers>`_ (Astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -340,31 +340,44 @@ Building documentation
     the latest (and archive) versions of astropy's documentation should
     be available at `docs.astropy.org <http://docs.astropy.org>`_ .
 
+Dependencies
+^^^^^^^^^^^^
+
 Building the documentation requires the Astropy source code and some additional
-packages:
+packages. The easiest way to install all the required dependencies is to install
+the `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ package,
+either with pip::
 
-    - `Sphinx <http://sphinx.pocoo.org>`_ (and its dependencies) 1.0 or later
+    pip install sphinx-astropy
 
-    - `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ 1.0 or later
+or with conda::
 
-    - `Graphviz <http://www.graphviz.org>`_
+    conda install -c astropy sphinx-astropy
 
-    - `Astropy-helpers <https://github.com/astropy/astropy-helpers>`_ (Astropy
-      and most affiliated packages include this as a submodule in the source
-      repository, so it does not need to be installed separately.)
+In addition to providing configuration common to packages in the Astropy
+ecosystem, this package also serves as a way to automatically get the main
+dependencies, including:
 
-    - `Pillow <http://python-pillow.org/>`_
+* `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
+  the documentation.
+* `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
+  the default 'bootstrap' theme use by Astropy and a number of affilited
+  packages.
+* `sphinx-automodapi <http://sphinx-automodapi.readthedocs.io>`_ - an extension
+  that makes it easy to automatically generate API documentation.
+* `sphinx-gallery <https://sphinx-gallery.readthedocs.io/en/latest/>`_ - an
+  extension to generate example galleries
+* `numpydoc <https://numpydoc.readthedocs.io>`_ - an extension to parse
+  docstrings in NumpyDoc format
 
-    - (optional) `sphinx-gallery <http://sphinx-gallery.readthedocs.io/>`_
+In addition, if you want inheritance graphs to be generated, you will need to
+make sure that `Graphviz <http://www.graphviz.org>`_ is installed. If you
+install sphinx-astropy with conda, graphviz will automatically get installed,
+but if you use pip, you will need to install Graphviz separately as it isn't
+a Python package.
 
-.. note::
-
-    If sphinx-gallery is not installed, you will see many Sphinx warnings
-    building the documentation, e.g.::
-
-        .../docs/coordinates/frames.rst:278: WARNING: undefined label:
-            sphx_glr_generated_examples_coordinates_plot_sgr-coordinate-frame.py
-            (if the link has no caption the label must precede a section header)
+Building
+^^^^^^^^
 
 There are two ways to build the Astropy documentation. The most straightforward
 way is to execute the command (from the astropy source directory)::
@@ -389,6 +402,29 @@ Alternatively, you can do::
 
 And the documentation will be generated in the same location, but using the
 *installed* version of Astropy.
+
+Reporting issues/requesting features
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As mentioned above, building the documentation depends on a number of sphinx
+extensions and other packages. Since it isn't necessarily straightforward to
+know which package is causing issues or would need to have a new feature
+implemented, you can simply open an issue in the `core astropy package issue
+tracker <https://github.com/astropy/astropy/issues>`_. However, if you wish you
+can also open issues in the repositories for some of the dependencies:
+
+* For requests/issues related to the appearance of the docs (e.g. related to
+  the CSS), you can open an issue in the `astropy-sphinx-theme issue tracker
+  <https://github.com/astropy/astropy-sphinx-theme/issues>`_.
+
+* For requests/issues related to the auto-generated API docs which appear to
+  be general issues rather than an issue with a specific docstring, you can use
+  the `sphinx-automodapi issue tracker
+  <https://github.com/astropy/sphinx-automodapi/issues>`_.
+
+* For issues related to the default configuration (e.g which extensions are
+  enabled by default), you can use the `sphinx-astropy issue tracker
+  <https://github.com/astropy/sphinx-astropy/issues>`_.
 
 .. _sourcebuildtest:
 

--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -4,3 +4,4 @@ scipy
 pillow
 sphinx-gallery
 jplephem
+sphinx-astropy

--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -2,6 +2,5 @@
 matplotlib
 scipy
 pillow
-sphinx-gallery
 jplephem
 sphinx-astropy


### PR DESCRIPTION
This is a companion PR to https://github.com/astropy/astropy-helpers/pull/368, which splits out the sphinx-related functionality from astropy-helpers to a dedicated [sphinx-astropy](https://github.com/astropy/sphinx-astropy) package.

If ``sphinx-astropy`` is not installed a clear error message is given:

```
skipping 'astropy/convolution/boundary_wrap.c' Cython extension (up-to-date)
skipping 'astropy/stats/lombscargle/implementations/cython_impl.c' Cython extension (up-to-date)
Running Sphinx v1.6.6
ERROR: the documentation requires the sphinx-astropy package to be installed

Configuration error:
The configuration file (or one of the modules it imports) called sys.exit()
Sphinx Documentation subprocess failed with return code 1
```