### PR TITLE
Add mention about model_set_axis=False in Model's docstring

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -522,7 +522,8 @@ class Model(metaclass=_ModelMeta):
         of an input array may be taken as this "model set axis".  This accepts
         negative integers as well--for example use ``model_set_axis=-1`` if the
         last (most rapidly changing) axis should be associated with the model
-        sets.
+        sets. Also, ``model_set_axis=False`` can be used to tell that a given
+        input should be used to evaluate all the models in the model set.
 
     fixed : dict, optional
         Dictionary ``{parameter_name: bool}`` setting the fixed constraint


### PR DESCRIPTION
Following #7142, use of `model_set_axis=False` is mentioned only in the *Model sets* section, it can be useful to have this in the docstring too.