### PR TITLE
Fix bug in FITS column meta serialization: ignored without mixins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -254,6 +254,10 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix bug of dropping table column meta (format, description, meta) when writing a table
+  to FITS using Table.write().  Since #6912 this should be written if it would be lost.
+  [#7147]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -581,3 +581,21 @@ def test_error_for_mixins_but_no_yaml(tmpdir):
     with pytest.raises(TypeError) as err:
         t.write(filename)
     assert "cannot write type SkyCoord column 'col0' to FITS without PyYAML" in str(err)
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_info_attributes_with_no_mixins(tmpdir):
+    """Even if there are no mixin columns, if there is metadata that would be lost it still
+    gets serialized
+    """
+    filename = str(tmpdir.join('test.fits'))
+    t = Table([[1.0, 2.0]])
+    t['col0'].description = 'hello' * 40
+    t['col0'].format = '%8.4f'
+    t['col0'].meta['a'] = {'b': 'c'}
+    t.write(filename, overwrite=True)
+
+    t2 = Table.read(filename)
+    assert t2['col0'].description == 'hello' * 40
+    assert t2['col0'].format == '%8.4f'
+    assert t2['col0'].meta['a'] == {'b': 'c'}


### PR DESCRIPTION
The new machinery to serialize mixins along with column meta is being by-passed for a pure-columns (no mixins) table.

However, the intent (in #6912) was to use this machinery if there is any column meta (`format`, `description`, or `meta`) that would be lost.  This PR fixes that.

This might address #6806, but takes an end-run around `TDISP`.