### PR TITLE
Update sky_coordinate.py

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -833,6 +833,13 @@ class SkyCoord(ShapedLikeNDArray):
         lonargs.update(kwargs)
         latargs.update(kwargs)
 
+        if style == 'hmsdms' :  # for hmsdms, want to adjust precision of RA to be one more than 
+                                # that or dec, because hours are 15 * cos(dec) bigger than degrees.
+            # default case; precision = 0 for both
+            if not latargs.has_key('precision') : lonargs['precision'] = 1
+            else :
+               lonargs['precision'] = latargs['precision'] + 1
+
         if np.isscalar(sph_coord.lon.value):
             coord_string = (sph_coord.lon.to_string(**lonargs)
                             + " " +


### PR DESCRIPTION
When a SkyCoord is output in 'hmsdms' format, the right ascension units are15*cos(dec) larger than the dec units.  To get roughly the same precision in the two axes, one should quote one more digit in the RA seconds than in the dec seconds.  The proposed change accomplishes this.   It should close my own issue #6158.

Edit: Fix #6158