### PR TITLE
Use Docker images on CircleCI to do image tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,10 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+          command: |
+            pip3 install coveralls
+            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            coveralls || true
   image-tests-mpl202:
     docker:
       - image: astropy/image-tests-py35-mpl202:1.0
@@ -27,7 +30,10 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
+          command: |
+            pip3 install coveralls
+            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            coveralls || true
   image-tests-mpl212:
     docker:
       - image: astropy/image-tests-py35-mpl212:1.0
@@ -35,7 +41,10 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
+          command: |
+            pip3 install coveralls
+            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            coveralls || true
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build:
+  32bit:
     docker:
       - image: quay.io/pypa/manylinux1_i686
     steps:
@@ -12,3 +12,37 @@ jobs:
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4
+  image-tests-mpl15:
+    docker:
+      - image: astrofrog/pytest-mpl-15:1.0
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+  image-tests-mpl20:
+    docker:
+      - image: astrofrog/pytest-mpl-20:1.0
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: python3 setup.py test -P visualization --remote-data=astropy  -a "--mpl"
+  image-tests-mpl21:
+    docker:
+      - image: astrofrog/pytest-mpl-21:1.0
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: python3 setup.py test -P visualization --remote-data=astropy  -a "--mpl"
+
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - 32bit
+      - image-tests-mpl15
+      - image-tests-mpl20
+      - image-tests-mpl21

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,25 +12,25 @@ jobs:
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4
-  image-tests-mpl15:
+  image-tests-mpl153:
     docker:
-      - image: astrofrog/pytest-mpl-15:1.0
+      - image: astrofrog/image-tests-py35-mpl153:1.0
     steps:
       - checkout
       - run:
           name: Run tests
           command: python3 setup.py test -P visualization --remote-data=any -a "--mpl"
-  image-tests-mpl20:
+  image-tests-mpl202:
     docker:
-      - image: astrofrog/pytest-mpl-20:1.0
+      - image: astrofrog/image-tests-py35-mpl202:1.0
     steps:
       - checkout
       - run:
           name: Run tests
           command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
-  image-tests-mpl21:
+  image-tests-mpl212:
     docker:
-      - image: astrofrog/pytest-mpl-21:1.0
+      - image: astrofrog/image-tests-py35-mpl212:1.0
     steps:
       - checkout
       - run:
@@ -43,6 +43,6 @@ workflows:
   build_and_test:
     jobs:
       - 32bit
-      - image-tests-mpl15
-      - image-tests-mpl20
-      - image-tests-mpl21
+      - image-tests-mpl153
+      - image-tests-mpl202
+      - image-tests-mpl212

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=any -a "--mpl"
   image-tests-mpl20:
     docker:
       - image: astrofrog/pytest-mpl-20:1.0
@@ -27,7 +27,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy  -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
   image-tests-mpl21:
     docker:
       - image: astrofrog/pytest-mpl-21:1.0
@@ -35,7 +35,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy  -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: Run tests
           command: |
             pip3 install coveralls
-            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
             coveralls || true
   image-tests-mpl202:
     docker:
@@ -32,7 +32,7 @@ jobs:
           name: Run tests
           command: |
             pip3 install coveralls
-            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
             coveralls || true
   image-tests-mpl212:
     docker:
@@ -43,7 +43,7 @@ jobs:
           name: Run tests
           command: |
             pip3 install coveralls
-            python3 setup.py test -P visualization --remote-data=any -a "--mpl"
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
             coveralls || true
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4
   image-tests-mpl153:
     docker:
-      - image: astrofrog/image-tests-py35-mpl153:1.0
+      - image: astropy/image-tests-py35-mpl153:1.0
     steps:
       - checkout
       - run:
@@ -22,7 +22,7 @@ jobs:
           command: python3 setup.py test -P visualization --remote-data=any -a "--mpl"
   image-tests-mpl202:
     docker:
-      - image: astrofrog/image-tests-py35-mpl202:1.0
+      - image: astropy/image-tests-py35-mpl202:1.0
     steps:
       - checkout
       - run:
@@ -30,7 +30,7 @@ jobs:
           command: python3 setup.py test -P visualization --remote-data=any  -a "--mpl"
   image-tests-mpl212:
     docker:
-      - image: astrofrog/image-tests-py35-mpl212:1.0
+      - image: astropy/image-tests-py35-mpl212:1.0
     steps:
       - checkout
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time. Since we test the latest Numpy as part of the builds with all
         # optional dependencies below, we can focus on older builds here.
-        # Numpy 1.11 is tested below in the image tests, 1.12 in the Initial stage test.
+        # Numpy 1.11 is tested below, 1.12 in the Initial stage test.
         # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.10
@@ -111,9 +111,8 @@ matrix:
             - $TEST_CMD
 
         # Now try with all optional dependencies.
-        # We also test the two latest matplotlib versions for the image tests.
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy -a "--mpl"'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="jplephem pytest-mpl $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
@@ -133,7 +132,7 @@ matrix:
         # packages are installed from pip.
         # TODO: remove the pinning once the issue is solved upstream.
         - os: linux
-          env: SETUP_CMD='test --coverage --remote-data=astropy -a "--mpl"'
+          env: SETUP_CMD='test --coverage --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C

--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="jplephem pytest-mpl $ASDF_GIT"
+               PIP_DEPENDENCIES="jplephem $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                NUMPY_VERSION=1.11
                MATPLOTLIB_VERSION=1.5
@@ -134,7 +134,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem pytest-mpl bintrees $ASDF_GIT"
+               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem bintrees $ASDF_GIT"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0 NUMPY_VERSION=1.13

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -508,9 +508,9 @@ def test_2d_model():
     p2 = models.Polynomial2D(1, c0_0=1, c1_0=1.2, c0_1=3.2)
     z = p2(x, y)
     m = fitter(p2, x, y, z + 2 * n, weights=None)
-    utils.assert_allclose(m.parameters, p2.parameters, rtol=1e-1)
+    utils.assert_allclose(m.parameters, p2.parameters, rtol=1.5e-1)
     m = fitter(p2, x, y, z + 2 * n, weights=w)
-    utils.assert_allclose(m.parameters, p2.parameters, rtol=1e-1)
+    utils.assert_allclose(m.parameters, p2.parameters, rtol=1.5e-1)
     # Polynomial2D, col_fit_deriv=False, fixed constraint
     p2.c1_0.fixed = True
     m = fitter(p2, x, y, z + 2 * n, weights=w)

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -7,7 +7,7 @@ MPL_VERSION = matplotlib.__version__
 
 ROOT = "http://{server}/testing/astropy/2018-02-01T23:31:45.013149/{mpl_version}/"
 
-IMAGE_REFERENCE_DIR = ROOT.format(server='astropy.github.io/astropy-data', mpl_version=MPL_VERSION[:3] + '.x')
+IMAGE_REFERENCE_DIR = ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x')
 
 
 def ignore_matplotlibrc(func):

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -1,16 +1,13 @@
-from distutils.version import LooseVersion
-
 import matplotlib
 from matplotlib import pyplot as plt
 
 from ..utils.decorators import wraps
 
-MPL_VERSION = LooseVersion(matplotlib.__version__)
+MPL_VERSION = matplotlib.__version__
 
-ROOT = "http://{server}/testing/astropy/2017-07-12T14:12:26.217559/{mpl_version}/"
+ROOT = "http://{server}/testing/astropy/2018-02-01T23:31:45.013149/{mpl_version}/"
 
-IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version='1.5.x') + ',' +
-                       ROOT.format(server='www.astropy.org/astropy-data', mpl_version='1.5.x'))
+IMAGE_REFERENCE_DIR = ROOT.format(server='astrofrog.github.io/astropy-data', mpl_version=MPL_VERSION[:3] + '.x')
 
 
 def ignore_matplotlibrc(func):

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -7,7 +7,7 @@ MPL_VERSION = matplotlib.__version__
 
 ROOT = "http://{server}/testing/astropy/2018-02-01T23:31:45.013149/{mpl_version}/"
 
-IMAGE_REFERENCE_DIR = ROOT.format(server='astrofrog.github.io/astropy-data', mpl_version=MPL_VERSION[:3] + '.x')
+IMAGE_REFERENCE_DIR = ROOT.format(server='astropy.github.io/astropy-data', mpl_version=MPL_VERSION[:3] + '.x')
 
 
 def ignore_matplotlibrc(func):

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -39,7 +39,7 @@ class TestFrame(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='custom_frame.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_custom_frame(self):
 
         wcs = WCS(self.msx_header)
@@ -81,7 +81,7 @@ class TestFrame(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_rectangular.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_update_clip_path_rectangular(self, tmpdir):
 
         fig = plt.figure()
@@ -105,7 +105,7 @@ class TestFrame(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_nonrectangular.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_update_clip_path_nonrectangular(self, tmpdir):
 
         fig = plt.figure()
@@ -130,7 +130,7 @@ class TestFrame(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='update_clip_path_change_wcs.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_update_clip_path_change_wcs(self, tmpdir):
 
         # When WCS is changed, a new frame is created, so we need to make sure

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -48,7 +48,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='image_plot.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_image_plot(self):
         # Test for plotting image and also setting values of ticks
         fig = plt.figure(figsize=(6, 6))
@@ -61,7 +61,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='contour_overlay.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_contour_overlay(self):
         # Test for overlaying contours on images
         hdu_msx = datasets.fetch_msx_hdu()
@@ -87,7 +87,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='overlay_features_image.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_overlay_features_image(self):
 
         # Test for overlaying grid, changing format of ticks, setting spacing
@@ -126,7 +126,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='curvlinear_grid_patches_image.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_curvilinear_grid_patches_image(self):
 
         # Overlay curvilinear grid and patches on image
@@ -160,7 +160,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='cube_slice_image.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_cube_slice_image(self):
 
         # Test for cube slicing
@@ -188,7 +188,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='cube_slice_image_lonlat.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_cube_slice_image_lonlat(self):
 
         # Test for cube slicing. Here we test with longitude and latitude since
@@ -208,7 +208,8 @@ class TestBasic(BaseImageTests):
         return fig
 
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, tolerance=1.5)
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
     def test_plot_coord(self):
         fig = plt.figure(figsize=(6, 6))
         ax = fig.add_axes([0.15, 0.15, 0.8, 0.8],
@@ -223,7 +224,8 @@ class TestBasic(BaseImageTests):
         return fig
 
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, tolerance=1.5)
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
     def test_plot_line(self):
         fig = plt.figure(figsize=(6, 6))
         ax = fig.add_axes([0.15, 0.15, 0.8, 0.8],
@@ -240,7 +242,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='changed_axis_units.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_changed_axis_units(self):
         # Test to see if changing the units of axis works
         fig = plt.figure()
@@ -260,7 +262,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='minor_ticks_image.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_minor_ticks(self):
         # Test for drawing minor ticks
         fig = plt.figure()
@@ -281,7 +283,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='ticks_labels.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_ticks_labels(self):
         fig = plt.figure(figsize=(6, 6))
         ax = WCSAxes(fig, [0.1, 0.1, 0.7, 0.7], wcs=None)
@@ -311,7 +313,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='rcparams.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_rcparams(self):
         # Test default style (matplotlib.rcParams) for ticks and gridlines
         with rc_context({
@@ -335,7 +337,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='tick_angles.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_tick_angles(self):
         # Test that tick marks point in the correct direction, even when the
         # axes limits extend only over a few FITS pixels. Addresses #45, #46.
@@ -358,7 +360,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='tick_angles_non_square_axes.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_tick_angles_non_square_axes(self):
         # Test that tick marks point in the correct direction, even when the
         # axes limits extend only over a few FITS pixels, and the axes are
@@ -382,7 +384,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='set_coord_type.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_set_coord_type(self):
         # Test for setting coord_type
         fig = plt.figure(figsize=(3, 3))
@@ -402,7 +404,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='test_ticks_regression_1.png',
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_ticks_regression(self):
         # Regression test for a bug that caused ticks aligned exactly with a
         # sampled frame point to not appear. This also checks that tick labels
@@ -428,7 +430,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='test_axislabels_regression.png',
                                    savefig_kwargs={'bbox_inches': 'tight'},
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_axislabels_regression(self):
         # Regression test for a bug that meant that if tick labels were made
         # invisible with ``set_visible(False)``, they were still added to the
@@ -446,7 +448,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    savefig_kwargs={'bbox_inches': 'tight'},
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_noncelestial_angular(self, tmpdir):
         # Regression test for a bug that meant that when passing a WCS that had
         # angular axes and using set_coord_type to set the coordinates to
@@ -483,7 +485,7 @@ class TestBasic(BaseImageTests):
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    savefig_kwargs={'bbox_inches': 'tight'},
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_patches_distortion(self, tmpdir):
 
         # Check how patches get distorted (and make sure that scatter markers
@@ -527,7 +529,7 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   tolerance=1.5)
+                                   tolerance=0, style={})
     def test_elliptical_frame(self):
 
         # Regression test for a bug (astropy/astropy#6063) that caused labels to

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -57,7 +57,9 @@ class LonLatToDistance(CurvedTransform):
 class TestTransformCoordMeta(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='coords_overlay.png', tolerance=1.5)
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   filename='coords_overlay.png',
+                                   tolerance=0, style={})
     def test_coords_overlay(self):
 
         # Set up a simple WCS that maps pixels to non-projected distances
@@ -105,7 +107,9 @@ class TestTransformCoordMeta(BaseImageTests):
         return fig
 
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='coords_overlay_auto_coord_meta.png', tolerance=1.5)
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   filename='coords_overlay_auto_coord_meta.png',
+                                   tolerance=0, style={})
     def test_coords_overlay_auto_coord_meta(self):
 
         fig = plt.figure(figsize=(4, 4))
@@ -128,7 +132,9 @@ class TestTransformCoordMeta(BaseImageTests):
         return fig
 
     @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR, filename='direct_init.png', tolerance=1.5)
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   filename='direct_init.png',
+                                   tolerance=0, style={})
     def test_direct_init(self):
 
         s = DistanceToLonLat(R=6378.273)

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -696,10 +696,11 @@ However, note that the output can be very sensitive to the version of Matplotlib
 as well as all its dependencies (e.g. freetype), so we recommend running the
 image tests inside a `Docker <https://www.docker.com/>`__ container which has a
 frozen set of package versions (Docker containers can be thought of as mini
-virtual machines). We have made a set of Docker container images that can be
-used for this. Once you have installed Docker, to run the Astropy tests with the
-image comparison inside a Docker container, make sure you are inside the Astropy
-repository (or the repository of the package you are testing) then do::
+virtual machines). We have made a `set of Docker container images
+<https://hub.docker.com/u/astropy/>`__ that can be used for this. Once you have
+installed Docker, to run the Astropy tests with the image comparison inside a
+Docker container, make sure you are inside the Astropy repository (or the
+repository of the package you are testing) then do::
 
     docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl153:1.0 /bin/bash
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -680,6 +680,9 @@ block::
 Image tests with pytest-mpl
 ===========================
 
+Running image tests
+-------------------
+
 We make use of the `pytest-mpl <https://pypi.python.org/pypi/pytest-mpl>`_
 plugin to create tests where we can compare the output of plotting commands
 with reference files (this is used for instance in
@@ -688,6 +691,28 @@ with reference files (this is used for instance in
 To run the Astropy tests with the image comparison, use::
 
     python setup.py test -a "--mpl" --remote-data
+
+However, note that the output can be very sensitive to the version of Matplotlib
+as well as all its dependencies (e.g. freetype), so we recommend running the
+image tests inside a docker container which has a frozen set of package versions.
+To run the Astropy tests with the image comparison inside a docker container,
+make sure you are inside the Astropy repository then do::
+
+    docker run -it -v ${PWD}:/astropy_repo astrofrog/pytest-mpl-15:1.0 /bin/bash
+
+You should then see a bash prompt that looks like::
+
+    root@8173d2494b0b:/#
+
+Once this appears, you can then run the tests as above::
+
+    cd astropy_repo
+    python3 setup.py test -a "--mpl" --remote-data
+
+The available containers are ...
+
+Writing image tests
+-------------------
 
 The `README.rst <https://github.com/astrofrog/pytest-mpl/blob/master/README.rst>`__
 for the plugin contains information on writing tests with this plugin. The only
@@ -703,13 +728,28 @@ to the repository size, we instead store them on the http://data.astropy.org
 site. The downside is that it is a little more complicated to create or
 re-generate reference files, but we describe the process here.
 
-Once you have a test for which you want to (re-)generate reference images,
-run the tests with the ``--mpl-generate-path`` argument, e.g::
+Generating reference images
+---------------------------
 
-    python setup.py test -a "--mpl --mpl-generate-path=reference_tmp" --remote-data
+Once you have a test for which you want to (re-)generate reference images,
+start up one of the Docker containers using e.g.::
+
+    docker run -it -v ${PWD}:/astropy_repo astrofrog/pytest-mpl-15:1.0 /bin/bash
+
+then run the tests inside with the ``--mpl-generate-path`` argument, e.g::
+
+    cd astropy_repo
+    python3 setup.py test -a "--mpl --mpl-generate-path=reference_tmp" --remote-data
 
 This will create a ``reference_tmp`` folder and put the generated reference
-images inside it.
+images inside it - the folder will be available in the repository outside of
+the docker container.
+
+Make sure you generate images for the different supported Matplotlib versions
+using the available containers.
+
+Uploading the reference images
+------------------------------
 
 Next, we need to add these images to the http://data.astropy.org server. To do
 this, open a pull request to `this <https://github.com/astropy/astropy-data>`_

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -684,8 +684,8 @@ Running image tests
 -------------------
 
 We make use of the `pytest-mpl <https://pypi.python.org/pypi/pytest-mpl>`_
-plugin to create tests where we can compare the output of plotting commands
-with reference files (this is used for instance in
+plugin to write tests where we can compare the output of plotting commands
+with reference files on a pixel-by-pixel basis (this is used for instance in
 :ref:`astropy.visualization.wcsaxes <wcsaxes>`).
 
 To run the Astropy tests with the image comparison, use::
@@ -694,22 +694,33 @@ To run the Astropy tests with the image comparison, use::
 
 However, note that the output can be very sensitive to the version of Matplotlib
 as well as all its dependencies (e.g. freetype), so we recommend running the
-image tests inside a docker container which has a frozen set of package versions.
-To run the Astropy tests with the image comparison inside a docker container,
-make sure you are inside the Astropy repository then do::
+image tests inside a `Docker <https://www.docker.com/>`_ container which has a
+frozen set of package versions (Docker containers can be thought of as mini
+virtual machines). We have made a set of Docker container images that can be
+used for this. Once you have installed Docker, to run the Astropy tests with the
+image comparison inside a Docker container, make sure you are inside the Astropy
+repository (or the repository of the package you are testing) then do::
 
-    docker run -it -v ${PWD}:/astropy_repo astrofrog/pytest-mpl-15:1.0 /bin/bash
+    docker run -it -v ${PWD}:/repo astrofrog/image-tests-py35-mpl153:1.0 /bin/bash
 
-You should then see a bash prompt that looks like::
+This will start up a bash prompt in the Docker container, and you should see
+something like::
 
     root@8173d2494b0b:/#
 
-Once this appears, you can then run the tests as above::
+You can now go to the ``/repo`` directory, which is the same folder as
+your local version of the repository you are testing::
 
-    cd astropy_repo
+    cd /repo
+
+You can then run the tests as above::
+
     python3 setup.py test -a "--mpl" --remote-data
 
-The available containers are ...
+Type ``exit`` to exit the container.
+
+You can find the names of the available Docker images on the `Docker Hub
+<https://hub.docker.com/r/astrofrog/>`_.
 
 Writing image tests
 -------------------
@@ -734,16 +745,16 @@ Generating reference images
 Once you have a test for which you want to (re-)generate reference images,
 start up one of the Docker containers using e.g.::
 
-    docker run -it -v ${PWD}:/astropy_repo astrofrog/pytest-mpl-15:1.0 /bin/bash
+  docker run -it -v ${PWD}:/repo astrofrog/image-tests-py35-mpl153:1.0 /bin/bash
 
-then run the tests inside with the ``--mpl-generate-path`` argument, e.g::
+then run the tests inside ``/repo`` with the ``--mpl-generate-path`` argument, e.g::
 
-    cd astropy_repo
+    cd repo
     python3 setup.py test -a "--mpl --mpl-generate-path=reference_tmp" --remote-data
 
 This will create a ``reference_tmp`` folder and put the generated reference
 images inside it - the folder will be available in the repository outside of
-the docker container.
+the Docker container. Type ``exit`` to exit the container.
 
 Make sure you generate images for the different supported Matplotlib versions
 using the available containers.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -694,7 +694,7 @@ To run the Astropy tests with the image comparison, use::
 
 However, note that the output can be very sensitive to the version of Matplotlib
 as well as all its dependencies (e.g. freetype), so we recommend running the
-image tests inside a `Docker <https://www.docker.com/>`_ container which has a
+image tests inside a `Docker <https://www.docker.com/>`__ container which has a
 frozen set of package versions (Docker containers can be thought of as mini
 virtual machines). We have made a set of Docker container images that can be
 used for this. Once you have installed Docker, to run the Astropy tests with the
@@ -1021,7 +1021,7 @@ Reproducing failing 32-bit builds
 =================================
 
 If you want to run your tests in the same 32-bit Python environment that
-CircleCI uses, start off by installing `Docker <https://www.docker.com>`_ if you
+CircleCI uses, start off by installing `Docker <https://www.docker.com>`__ if you
 don't already have it installed. Docker can be installed on a variety of
 different operating systems.
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -701,7 +701,7 @@ used for this. Once you have installed Docker, to run the Astropy tests with the
 image comparison inside a Docker container, make sure you are inside the Astropy
 repository (or the repository of the package you are testing) then do::
 
-    docker run -it -v ${PWD}:/repo astrofrog/image-tests-py35-mpl153:1.0 /bin/bash
+    docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl153:1.0 /bin/bash
 
 This will start up a bash prompt in the Docker container, and you should see
 something like::
@@ -720,12 +720,12 @@ You can then run the tests as above::
 Type ``exit`` to exit the container.
 
 You can find the names of the available Docker images on the `Docker Hub
-<https://hub.docker.com/r/astrofrog/>`_.
+<https://hub.docker.com/r/astropy/>`_.
 
 Writing image tests
 -------------------
 
-The `README.rst <https://github.com/astrofrog/pytest-mpl/blob/master/README.rst>`__
+The `README.rst <https://github.com/astropy/pytest-mpl/blob/master/README.rst>`__
 for the plugin contains information on writing tests with this plugin. The only
 key addition compared to those instructions is that you should set
 ``baseline_dir``::
@@ -745,7 +745,7 @@ Generating reference images
 Once you have a test for which you want to (re-)generate reference images,
 start up one of the Docker containers using e.g.::
 
-  docker run -it -v ${PWD}:/repo astrofrog/image-tests-py35-mpl153:1.0 /bin/bash
+  docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl153:1.0 /bin/bash
 
 then run the tests inside ``/repo`` with the ``--mpl-generate-path`` argument, e.g::
 

--- a/docs/visualization/wcsaxes/slicing_datacubes.rst
+++ b/docs/visualization/wcsaxes/slicing_datacubes.rst
@@ -14,7 +14,7 @@ Like the example introduced in :ref:`initialization`, we will read in the
 data using `astropy.io.fits
 <http://docs.astropy.org/en/stable/io/fits/index.html>`_ and parse the WCS
 information. The original FITS file can be downloaded from `here
-<http://astrofrog.github.io/wcsaxes-datasets/L1448_13CO.fits>`_.
+<http://astropy.github.io/wcsaxes-datasets/L1448_13CO.fits>`_.
 
 .. plot::
    :context: reset


### PR DESCRIPTION
### Background

In **astropy.visualization** we have a number of tests which use [pytest-mpl](https://github.com/matplotlib/pytest-mpl) to do pixel-by-pixel comparisons of matplotlib plots with reference images (e.g. to check the output of WCSAxes). These tests are of course sensitive to the Matplotlib version, but also non-Python dependencies such as freetype (and even Numpy in some rare cases). We currently run the image tests on Travis, and rely on conda to keep the versions of dependencies frozen. However, this doesn't really work well because sometimes there are changes that occur because of new conda builds of the same package versions, and even with the same versions, the results are often operating-system dependent. Such differences mean we have to increase the tolerance on the tests, and risk missing real differences.

### Docker to the rescue 🐳 

In this pull request I am proposing to get around this issue by making a set of officially sanctioned docker images, one for each Matplotlib version, which will be a 'frozen' environment that can be used to run tests and generate reference images. These images can then be used on CircleCI to run the tests, and can also be used by any developer locally who wants to generate reference images. Having a reproducible environment then means we can push the tolerance for the tests down to 0, meaning that we will be sensitive to any real change in output.

Note that these images can be used for other projects too, not just the core astropy package, and I plan to advertise this method and the images we use in the pytest-mpl docs.

### Impact on users

None!

### Impact on developers

The only developers this will have an impact on are ones that actually need to run the image tests and/or generate new reference images, which is to say, very few. I have updated the developer documentation to give clear instructions on how to use Docker to run the tests and generate reference images. The process is actually quite simple once Docker is installed.

I've also documented how the docker images are produced [here](https://github.com/astrofrog/astropy-docker/tree/image-tests/image-tests)

### Impact on continuous integration

The image tests will now no longer run on Travis, which means fewer issues when changing e.g. Matplotlib/Numpy versions in future. This PR modifies the CircleCI configuration to add three new jobs - at the moment I've made it so that it will actually only run the tests in ``astropy.visualization`` since this is where the image tests are. These run in <3 minutes each, and CircleCI is quick to start up, so this will have no impact on the wait times for CI

### Next steps

At the moment, the docker images are under my user, as are the new reference images. **Before this is merged I need to put the reference images in astropy/astropy-data and the docker images in the astropy organization**

@lpsinger  - since I think you are the only person other than me who has made reference images and used the previous infrastructure, could you let me know your thoughts on this?