### PR TITLE
Increase tolerance for fitting test result

### DIFF
--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -514,6 +514,6 @@ def test_2d_model():
     # Polynomial2D, col_fit_deriv=False, fixed constraint
     p2.c1_0.fixed = True
     m = fitter(p2, x, y, z + 2 * n, weights=w)
-    utils.assert_allclose(m.parameters, p2.parameters, rtol=1e-1)
+    utils.assert_allclose(m.parameters, p2.parameters, rtol=1.5e-1)
     m = fitter(p2, x, y, z + 2 * n, weights=None)
-    utils.assert_allclose(m.parameters, p2.parameters, rtol=1e-1)
+    utils.assert_allclose(m.parameters, p2.parameters, rtol=1.5e-1)


### PR DESCRIPTION
On CircleCI, where the tests run in parallel, this specific test occasionally failed because the tolerance wasn't quite large enough.