### PR TITLE
Possible fix for FITS regression with table keywords

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -22,6 +22,7 @@ from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
 from .verify import VerifyError, VerifyWarning
 
 from ...utils import lazyproperty, isiterable, indent
+from ...utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['Column', 'ColDefs', 'Delayed']
 
@@ -1412,12 +1413,24 @@ class ColDefs(NotifierMixin):
         _new_attributes = {'coord_type', 'coord_unit', 'coord_ref_point',
                            'coord_ref_value', 'coord_inc', 'time_ref_pos'}
 
+        copied_attributes = set()
+
         for idx, keywords in enumerate(col_keywords):
             col = self.columns[idx]
             for key, value in keywords.items():
                 if key in _new_attributes:
                     if getattr(col, key) is None:
+                        copied_attributes.add(key)
                         setattr(col, key, value)
+
+        for key in sorted(copied_attributes):
+            fits_key = ATTRIBUTE_TO_KEYWORD[key]
+            warnings.warn("The {0}n keywords are now recognized as Column "
+                          "attributes, and should be set directly on the Column "
+                          "objects in future using the {1} attribute (values "
+                          "in the supplied header "
+                          "will be ignored)".format(fits_key, key),
+                          AstropyDeprecationWarning)
 
     def _header_to_col_keywords(self, hdr, nfields, col_keywords=None):
         # go through header keywords to pick out column definition keywords

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1388,50 +1388,6 @@ class ColDefs(NotifierMixin):
                        dim=dim)
             self.columns.append(c)
 
-    def _compat_update_new_attributes_from_header(self, hdr):
-
-        # FIXME: This is a temporary method in Astropy 3.0 that is used
-        # to copy over only newly recognized column keywords to this ColDefs
-        # object - this preserves backward-compatibility with previous versions.
-
-        nfields = len(self)
-
-        # Because of the way Column._verify_keywords works in
-        # _header_to_col_keywords, we need to first build up a list of the
-        # attributes for each column.
-        col_keywords = []
-        for col in self.columns:
-            kw = {}
-            for attr in KEYWORD_ATTRIBUTES:
-                val = getattr(col, attr, None)
-                if val is not None:
-                    kw[attr] = val
-            col_keywords.append(kw)
-
-        col_keywords = self._header_to_col_keywords(hdr, nfields, col_keywords=col_keywords)
-
-        _new_attributes = {'coord_type', 'coord_unit', 'coord_ref_point',
-                           'coord_ref_value', 'coord_inc', 'time_ref_pos'}
-
-        copied_attributes = set()
-
-        for idx, keywords in enumerate(col_keywords):
-            col = self.columns[idx]
-            for key, value in keywords.items():
-                if key in _new_attributes:
-                    if getattr(col, key) is None:
-                        copied_attributes.add(key)
-                        setattr(col, key, value)
-
-        for key in sorted(copied_attributes):
-            fits_key = ATTRIBUTE_TO_KEYWORD[key]
-            warnings.warn("The {0}n keywords are now recognized as Column "
-                          "attributes, and should be set directly on the Column "
-                          "objects in future using the {1} attribute (values "
-                          "in the supplied header "
-                          "will be ignored)".format(fits_key, key),
-                          AstropyDeprecationWarning)
-
     def _header_to_col_keywords(self, hdr, nfields, col_keywords=None):
         # go through header keywords to pick out column definition keywords
         # definition dictionaries for each field

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1389,6 +1389,10 @@ class ColDefs(NotifierMixin):
 
     def _update_attributes_from_header(self, hdr):
         nfields = len(self)
+
+        # Because of the way Column._verify_keywords works in
+        # _header_to_col_keywords, we need to first build up a list of the
+        # attributes for each column.
         col_keywords = []
         for col in self.columns:
             kw = {}
@@ -1397,7 +1401,11 @@ class ColDefs(NotifierMixin):
                 if val is not None:
                     kw[attr] = val
             col_keywords.append(kw)
+
         col_keywords = self._header_to_col_keywords(hdr, nfields, col_keywords=col_keywords)
+
+        # NOTE: this is where we could restrict ourselves to the new attributes
+        # in 3.0 if we want to fully preserve backward-compatibility
         for idx, keywords in enumerate(col_keywords):
             col = self.columns[idx]
             for key, value in keywords.items():

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1387,7 +1387,12 @@ class ColDefs(NotifierMixin):
                        dim=dim)
             self.columns.append(c)
 
-    def _update_attributes_from_header(self, hdr):
+    def _compat_update_new_attributes_from_header(self, hdr):
+
+        # FIXME: This is a temporary method in Astropy 3.0 that is used
+        # to copy over only newly recognized column keywords to this ColDefs
+        # object - this preserves backward-compatibility with previous versions.
+
         nfields = len(self)
 
         # Because of the way Column._verify_keywords works in
@@ -1404,12 +1409,15 @@ class ColDefs(NotifierMixin):
 
         col_keywords = self._header_to_col_keywords(hdr, nfields, col_keywords=col_keywords)
 
-        # NOTE: this is where we could restrict ourselves to the new attributes
-        # in 3.0 if we want to fully preserve backward-compatibility
+        _new_attributes = {'coord_type', 'coord_unit', 'coord_ref_point',
+                           'coord_ref_value', 'coord_inc', 'time_ref_pos'}
+
         for idx, keywords in enumerate(col_keywords):
             col = self.columns[idx]
             for key, value in keywords.items():
-                setattr(col, key, value)
+                if key in _new_attributes:
+                    if getattr(col, key) is None:
+                        setattr(col, key, value)
 
     def _header_to_col_keywords(self, hdr, nfields, col_keywords=None):
         # go through header keywords to pick out column definition keywords

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -124,7 +124,8 @@ class _TableLikeHDU(_ValidHDU):
         """
 
         coldefs = cls._columns_type(columns)
-        coldefs._update_attributes_from_header(header)
+        if header is not None:
+            coldefs._update_attributes_from_header(header)
         data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
                                      character_as_bytes=character_as_bytes)
         hdu = cls(data=data, header=header, character_as_bytes=character_as_bytes, **kwargs)

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -95,7 +95,7 @@ class _TableLikeHDU(_ValidHDU):
             rows.
 
         header : `Header`
-            An optional `Header` object to instantiate the new HDU yet.  Header
+            An optional `Header` object to instantiate the new HDU yet. Header
             keywords specifically related to defining the table structure (such
             as the "TXXXn" keywords like TTYPEn) will be overridden by the
             supplied column definitions, but all other informational and data
@@ -124,8 +124,15 @@ class _TableLikeHDU(_ValidHDU):
         """
 
         coldefs = cls._columns_type(columns)
+
+        # In Astropy 3.0, additional keywords are recognized as having a special
+        # meaning and considered 'Column' attributes. For backward-compatibility,
+        # we need to copy these from the Header to the columns otherwise they
+        # will be dropped and will be missing from both the header and the
+        # resulting columns.
         if header is not None:
-            coldefs._update_attributes_from_header(header)
+            coldefs._compat_update_new_attributes_from_header(header)
+
         data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
                                      character_as_bytes=character_as_bytes)
         hdu = cls(data=data, header=header, character_as_bytes=character_as_bytes, **kwargs)

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -124,6 +124,7 @@ class _TableLikeHDU(_ValidHDU):
         """
 
         coldefs = cls._columns_type(columns)
+        coldefs._update_attributes_from_header(header)
         data = FITS_rec.from_columns(coldefs, nrows=nrows, fill=fill,
                                      character_as_bytes=character_as_bytes)
         hdu = cls(data=data, header=header, character_as_bytes=character_as_bytes, **kwargs)


### PR DESCRIPTION
I'm not too familiar with the FITS code base, but I was intrigued by https://github.com/astropy/astropy/issues/7145 so here's a possible fix, though if we agree on it it would need to be cleaned up and have tests etc. But since this is still new to me, feel free to close this.

I started from @stscirij's example, shortened:

```python
import astropy
from astropy.io import fits
import numpy as np

def create_column_descriptions():
    col = []
    col.append(fits.Column(name="TIME", format="1E", unit="s"))
    col.append(fits.Column(name="RAWX", format="1I", unit="pixel"))
    cd = fits.ColDefs(col)

    return cd

def create_header():
    hdr = fits.Header()
    hdr['RA'] = (1.581250000000E+00, 'RA of reference aperture center ')
    hdr['DEC'] = (2.020277777778E+01, 'Declination of reference aperture center')
    hdr['TCTYP2'] = ('RA---TAN', 'axis type for dimension 1')
    hdr['TCRVL2'] = (-999.0, 'sky coordinates of 1st axis')

    return hdr

columns = create_column_descriptions()
header = create_header()

print("Header and columns before:")
print(header)
print(columns)

hdu = fits.BinTableHDU.from_columns(columns, header)

print("Header and columns after:")
print(hdu.header)
print(hdu.columns)
```

With Astropy master this gives:

```
Header and columns before:
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TCTYP2  = 'RA---TAN'           / axis type for dimension 1                      
TCRVL2  =               -999.0 / sky coordinates of 1st axis                    
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'
)
Header and columns after:
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                    
NAXIS1  =                    6 / length of dimension 1                          
NAXIS2  =                    0 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                        
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TTYPE1  = 'TIME    '                                                            
TFORM1  = '1E      '                                                           
TUNIT1  = 's       '                                                            
TTYPE2  = 'RAWX    '                                                            
TFORM2  = '1I      '                                                            
TUNIT2  = 'pixel   '                                                            
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'
)
```

Technically speaking, this is what the docstring of ``Header`` says it does:

```
            Header
            keywords specifically related to defining the table structure (such
            as the "TXXXn" keywords like TTYPEn) will be overridden by the
            supplied column definitions, but all other informational and data
            model-specific keywords are kept.
```

However, there are three possible meanings in my view for ``from_columns(columns, header)`` from a user point of view:

1. Any column keywords in Header are ignored even the corresponding attributes are missing from ``columns``

2. Any column keywords present in Header should override attributes in ``columns``

3. Any column keywords present in Header for which the corresponding attribute in ``columns`` is ``None`` should be passed to ``columns``.

The current behavior is 1), and this breaks compatibility because more keywords are now recognized as column keywords.

Arguably, the docstring above could be interpreted as option 3) as well.

The present PR implements 3 with a twist: it copies over keywords that are in the header to the Column object **only** if this is one of the new keywords added in 3.0 and only if the Column doesn't already have that attribute set. With this, here is the result:

```
Header and columns after:
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                    6 / length of dimension 1                          
NAXIS2  =                    0 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                         
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TTYPE1  = 'TIME    '                                                            
TFORM1  = '1E      '                                                            
TUNIT1  = 's       '                                                            
TTYPE2  = 'RAWX    '                                                            
TFORM2  = '1I      '                                                            
TUNIT2  = 'pixel   '                                                            
TCTYP2  = 'RA---TAN'                                                            
TCRVL2  =               -999.0                                                  
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'; coord_type = 'RA---TAN'; coord_ref_value = -999.0
)
```

I personally think this makes more sense than the current behavior.

Note that this can still break API in more subtle ways - for instance if a column is removed, then the matching TCTYP will be removed whereas it wasn't beforehand.

In future we could then move to having a keyword argument to better control the behavior between options 1, 2, and 3?

cc @saimn @eteq @stscirij @aaryapatil 

EDIT: edited multiple times as I've edited this PR