### PR TITLE
Speed up LambdaCDM distance calculations using elliptic integrals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,7 +39,8 @@ astropy.cosmology
   are now 1000x faster by using analytic solutions instead of integrating.
   [#7117]
 Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
-are now 20x faster by using elliptic integrals and hypergeometric functions.
+are now 20x faster by using elliptic integrals for non-flat cases
+and hypergeometric functions for flat cases.  [#7155]
 
 Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
 are now 1000x faster by using analytic solutions instead of integrating. [#7117]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+- Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
+  are now 20x faster by using elliptic integrals for non-flat cases
+  [#7155]
+
 - Distance calculations with ``FlatLambaCDM`` with no radiation (T_CMB0=0)
   are now 20x faster by using the hypergeometric function solution
   for this special case. [#7087]
@@ -38,12 +42,6 @@ astropy.cosmology
 - Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
   are now 1000x faster by using analytic solutions instead of integrating.
   [#7117]
-Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
-are now 20x faster by using elliptic integrals for non-flat cases
-and hypergeometric functions for flat cases.  [#7155]
-
-Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
-are now 1000x faster by using analytic solutions instead of integrating. [#7117]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,11 @@ astropy.cosmology
 - Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
   are now 1000x faster by using analytic solutions instead of integrating.
   [#7117]
+Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
+are now 20x faster by using elliptic integrals and hypergeometric functions.
+
+Age calculations with ``FlatLambdaCDM`` with no radiation (Tcmb0=0)
+are now 1000x faster by using analytic solutions instead of integrating. [#7117]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1749,18 +1749,18 @@ class LambdaCDM(FLRW):
         if self._Om0 == 0 or self._Ode0 == 0 or self._Ok0 == 0:
             return self._integral_comoving_distance_z1z2(z1, z2)
 
-        b = -(27./2) * self._Om0**2 * self._Ode0 / self._Ok0**3
+        b = -(27. / 2) * self._Om0**2 * self._Ode0 / self._Ok0**3
         kappa = b / abs(b)
         if (b < 0) or (2 < b):
             def phi_z(Om0, Ok0, kappa, y1, A, z):
-                return np.arccos(((1+z)*Om0/abs(Ok0) + kappa*y1 - A) /
-                                 ((1+z)*Om0/abs(Ok0) + kappa*y1 + A))
+                return np.arccos(((1 + z) * Om0 / abs(Ok0) + kappa * y1 - A) /
+                                 ((1 + z) * Om0 / abs(Ok0) + kappa * y1 + A))
 
-            v_k = pow(kappa * (b-1) + sqrt(b*(b-2)), 1./3)
-            y1 = (-1 + kappa*(v_k + 1/v_k))/3
-            A = sqrt(y1*(3*y1+2))
-            g = 1/sqrt(A)
-            k2 = (2*A+kappa*(1+3*y1))/(4*A)
+            v_k = pow(kappa * (b - 1) + sqrt(b * (b - 2)), 1. / 3)
+            y1 = (-1 + kappa * (v_k + 1 / v_k)) / 3
+            A = sqrt(y1 * (3 * y1 + 2))
+            g = 1 / sqrt(A)
+            k2 = (2 * A + kappa * (1 + 3 * y1)) / (4 * A)
 
             phi_z1 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z1)
             phi_z2 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z2)
@@ -1769,15 +1769,15 @@ class LambdaCDM(FLRW):
         elif (0 < b) and (b < 2) and self._Om0 > self.Ol0:
             def phi_z(Om0, Ok0, kappa, y1, A, z):
                 return np.arcsin(np.sqrt((y1 - y2) /
-                                         (1+z) * Om0 / abs(Ok0) + y1))
+                                         (1 + z) * Om0 / abs(Ok0) + y1))
 
-            yb = cos(acos(1-b)/3)
-            yc = sqrt(3) * sin(acos(1-b)/3)
-            y1 = (1./3) * (-1 + yb + yc)
-            y2 = (1./3) * (-1 - 2 * yb)
-            y3 = (1./3) * (-1 + yb - yc)
-            g = 2/sqrt(y1-y2)
-            k2 = (y1-y3)/(y1-y2)
+            yb = cos(acos(1 - b) / 3)
+            yc = sqrt(3) * sin(acos(1 - b) / 3)
+            y1 = (1. / 3) * (-1 + yb + yc)
+            y2 = (1. / 3) * (-1 - 2 * yb)
+            y3 = (1. / 3) * (-1 + yb - yc)
+            g = 2 / sqrt(y1 - y2)
+            k2 = (y1 - y3) / (y1 - y2)
             phi_z1 = phi_z(self._Om0, self._Ok0, y1, y2, z1)
             phi_z2 = phi_z(self._Om0, self._Ok0, y1, y2, z2)
         else:

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1738,7 +1738,9 @@ class LambdaCDM(FLRW):
         from scipy.special import ellipkinc
         if isiterable(z1):
             z1 = np.asarray(z1)
+        if isiterable(z2):
             z2 = np.asarray(z2)
+        if isiterable(z1) and isiterable(z2):
             if z1.shape != z2.shape:
                 msg = "z1 and z2 have different shapes"
                 raise ValueError(msg)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1750,7 +1750,7 @@ class LambdaCDM(FLRW):
         b = -(27./2) * self._Om0**2 * self._Ode0 / self._Ok0**3
         kappa = b / abs(b)
         if (b < 0) or (2 < b):
-            def phi_z(Om0, Ol0, Ok0, kappa, y1, A, z):
+            def phi_z(Om0, Ok0, kappa, y1, A, z):
                 return np.arccos(((1+z)*Om0/abs(Ok0) + kappa*y1 - A) /
                                  ((1+z)*Om0/abs(Ok0) + kappa*y1 + A))
 
@@ -1760,12 +1760,12 @@ class LambdaCDM(FLRW):
             g = 1/sqrt(A)
             k2 = (2*A+kappa*(1+3*y1))/(4*A)
 
-            phi_z1 = phi_z(self._Om0, self._Ode0, self._Ok0, kappa, y1, A, z1)
-            phi_z2 = phi_z(self._Om0, self._Ode0, self._Ok0, kappa, y1, A, z2)
+            phi_z1 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z1)
+            phi_z2 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z2)
         # Get lower-right 0<b<2 solution in Om, Ol plane.
         # Fot the upper-left 0<b<2 solution the Big Bang didn't happen.
         elif (0 < b) and (b < 2) and self._Om0 > self.Ol0:
-            def phi_z(Om0, Ol0, Ok0, kappa, y1, A, z):
+            def phi_z(Om0, Ok0, kappa, y1, A, z):
                 return np.arcsin(np.sqrt((y1 - y2) /
                                          (1+z) * Om0 / abs(Ok0) + y1))
 
@@ -1776,8 +1776,8 @@ class LambdaCDM(FLRW):
             y3 = (1./3) * (-1 + ya - yc)
             g = 2/sqrt(y1-y2)
             k2 = (y1-y3)/(y1-y2)
-            phi_z1 = phi_z(self._Om0, self._Ode0, self._Ok0, y1, y2, z1)
-            phi_z2 = phi_z(self._Om0, self._Ode0, self._Ok0, y1, y2, z2)
+            phi_z1 = phi_z(self._Om0, self._Ok0, y1, y2, z1)
+            phi_z2 = phi_z(self._Om0, self._Ok0, y1, y2, z2)
         else:
             return self._integral_comoving_distance_z1z2(z1, z2)
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1743,7 +1743,9 @@ class LambdaCDM(FLRW):
                 msg = "z1 and z2 have different shapes"
                 raise ValueError(msg)
 
-        if self._Om0 == 0 or self._Ode0 == 0:
+        # The analytic solution is not valid for any of Om0, Ode0, Ok0 == 0.
+        # Use the explicit inmtegral solution for these cases.
+        if self._Om0 == 0 or self._Ode0 == 0 or self._Ok0 == 0:
             return self._integral_comoving_distance_z1z2(z1, z2)
 
         prefactor = self._hubble_distance / np.lib.scimath.sqrt(self._Ok0)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1710,7 +1710,7 @@ class LambdaCDM(FLRW):
         else:
             return np.ones(np.asanyarray(z).shape)
 
-    def _elliptic_comoving_transverse_distance_z1z2(self, z1, z2):
+    def _elliptic_comoving_distance_z1z2(self, z1, z2):
         """ Comoving transverse distance in Mpc between two redshifts.
 
         This value is the transverse comoving distance at redshift ``z``
@@ -1749,7 +1749,6 @@ class LambdaCDM(FLRW):
         if self._Om0 == 0 or self._Ode0 == 0 or self._Ok0 == 0:
             return self._integral_comoving_distance_z1z2(z1, z2)
 
-        prefactor = self._hubble_distance / np.lib.scimath.sqrt(self._Ok0)
         b = -(27./2) * self._Om0**2 * self._Ode0 / self._Ok0**3
         kappa = b / abs(b)
         if (b < 0) or (2 < b):
@@ -1784,8 +1783,8 @@ class LambdaCDM(FLRW):
         else:
             return self._integral_comoving_distance_z1z2(z1, z2)
 
-        return prefactor * \
-            np.sinh(-g * (ellipkinc(phi_z2, k2) - ellipkinc(phi_z1, k2)))
+        prefactor = self._hubble_distance / sqrt(abs(self._Ok0))
+        return prefactor * g * (ellipkinc(phi_z1, k2) - ellipkinc(phi_z2, k2))
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1707,6 +1707,43 @@ class LambdaCDM(FLRW):
         else:
             return np.ones(np.asanyarray(z).shape)
 
+    def _elliptic_comoving_distance_z1z2(self, z):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        For Omega_radiation = 0 the comoving distance can be directly calculated
+        as a hypergeometric function.
+        Equation here taken from
+            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+
+        Parameters
+        ----------
+        z1, z2 : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        prefactor = self._hubble_distance / np.sqrt(self._Ok0)
+        g = 1
+        delta_phi_z = 1
+        k = 1
+        return prefactor * np.sinh(-g * F(delta_phi_z, k))
+
+        
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -2,7 +2,7 @@
 
 
 import sys
-from math import acos, cos, sqrt, pi, exp, log, floor
+from math import acos, sin, cos, sqrt, pi, exp, log, floor
 from abc import ABCMeta, abstractmethod
 from inspect import signature
 
@@ -1775,8 +1775,8 @@ class LambdaCDM(FLRW):
             yb = cos(acos(1-b)/3)
             yc = sqrt(3) * sin(acos(1-b)/3)
             y1 = (1./3) * (-1 + yb + yc)
-            y1 = (1./3) * (-1 - 2 * ya)
-            y3 = (1./3) * (-1 + ya - yc)
+            y2 = (1./3) * (-1 - 2 * yb)
+            y3 = (1./3) * (-1 + yb - yc)
             g = 2/sqrt(y1-y2)
             k2 = (y1-y3)/(y1-y2)
             phi_z1 = phi_z(self._Om0, self._Ok0, y1, y2, z1)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1646,25 +1646,7 @@ class LambdaCDM(FLRW):
             self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
             if self._Ok0 == 0:
-                # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
-                # The dS case is required because the hypergeometric case
-                #    for Omega_M=0 would lead to an infinity in its argument.
-                # The EdS case is three times faster than the hypergeometric.
-                if self._Om0 == 0:
-                    self._comoving_distance_z1z2 = \
-                        self._dS_comoving_distance_z1z2
-                    self._age = self._dS_age
-                    self._lookback_time = self._dS_lookback_time
-                elif self._Om0 == 1:
-                    self._comoving_distance_z1z2 = \
-                        self._EdS_comoving_distance_z1z2
-                    self._age = self._EdS_age
-                    self._lookback_time = self._EdS_lookback_time
-                else:
-                    self._comoving_distance_z1z2 = \
-                        self._hypergeometric_comoving_distance_z1z2
-                    self._age = self._flat_age
-                    self._lookback_time = self._flat_lookback_time
+                self._optimize_flat_norad()
             else:
                 self._comoving_distance_z1z2 = \
                     self._elliptic_comoving_distance_z1z2
@@ -1678,6 +1660,29 @@ class LambdaCDM(FLRW):
                                            self._Ogamma0, self._neff_per_nu,
                                            self._nmasslessnu,
                                            self._nu_y_list)
+
+    def _optimize_flat_norad(self):
+        """Set optimizations for flat LCDM cosmologies with no radiation.
+        """
+        # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
+        # The dS case is required because the hypergeometric case
+        #    for Omega_M=0 would lead to an infinity in its argument.
+        # The EdS case is three times faster than the hypergeometric.
+        if self._Om0 == 0:
+            self._comoving_distance_z1z2 = \
+                self._dS_comoving_distance_z1z2
+            self._age = self._dS_age
+            self._lookback_time = self._dS_lookback_time
+        elif self._Om0 == 1:
+            self._comoving_distance_z1z2 = \
+                self._EdS_comoving_distance_z1z2
+            self._age = self._EdS_age
+            self._lookback_time = self._EdS_lookback_time
+        else:
+            self._comoving_distance_z1z2 = \
+                self._hypergeometric_comoving_distance_z1z2
+            self._age = self._flat_age
+            self._lookback_time = self._flat_lookback_time
 
     def w(self, z):
         """Returns dark energy equation of state at redshift ``z``.
@@ -2184,26 +2189,7 @@ class FlatLambdaCDM(LambdaCDM):
             # Repeat the optimization reassignments here because the init
             # of the LambaCDM above didn't actually create a flat cosmology.
             # That was done through the explicit tweak setting self._Ok0.
-            #
-            # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
-            # The dS case is required because the hypergeometric case
-            #    for Omega_M=0 would lead to an infinity in its argument.
-            # The EdS case is three times faster than the hypergeometric.
-            if self._Om0 == 0:
-                self._comoving_distance_z1z2 = \
-                    self._dS_comoving_distance_z1z2
-                self._age = self._dS_age
-                self._lookback_time = self._dS_lookback_time
-            elif self._Om0 == 1:
-                self._comoving_distance_z1z2 = \
-                    self._EdS_comoving_distance_z1z2
-                self._age = self._EdS_age
-                self._lookback_time = self._EdS_lookback_time
-            else:
-                self._comoving_distance_z1z2 = \
-                    self._hypergeometric_comoving_distance_z1z2
-                self._age = self._flat_age
-                self._lookback_time = self._flat_lookback_time
+            self._optimize_flat_norad()
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1645,7 +1645,7 @@ class LambdaCDM(FLRW):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
-            if self.Ok0 == 0:
+            if self._Ok0 == 0:
                 # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
                 # The dS case is required because the hypergeometric case
                 #    for Omega_M=0 would lead to an infinity in its argument.
@@ -1653,12 +1653,18 @@ class LambdaCDM(FLRW):
                 if self._Om0 == 0:
                     self._comoving_distance_z1z2 = \
                         self._dS_comoving_distance_z1z2
+                    self._age = self._dS_age
+                    self._lookback_time = self._dS_lookback_time
                 elif self._Om0 == 1:
                     self._comoving_distance_z1z2 = \
                         self._EdS_comoving_distance_z1z2
+                    self._age = self._EdS_age
+                    self._lookback_time = self._EdS_lookback_time
                 else:
                     self._comoving_distance_z1z2 = \
                         self._hypergeometric_comoving_distance_z1z2
+                    self._age = self._flat_age
+                    self._lookback_time = self._flat_lookback_time
             else:
                 self._comoving_distance_z1z2 = \
                     self._elliptic_comoving_distance_z1z2
@@ -1910,6 +1916,145 @@ class LambdaCDM(FLRW):
         from scipy.special import hyp2f1
         return 2 * np.sqrt(x) * hyp2f1(1./6, 1./2, 7./6, -x**3)
 
+    def _dS_age(self, z):
+        """ Age of the universe in Gyr at redshift ``z``.
+
+        The age of a de Sitter Universe is infinite.
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          The age of the universe in Gyr at each input redshift.
+        """
+        return self._hubble_time * inf_like(z)
+
+    def _EdS_age(self, z):
+        """ Age of the universe in Gyr at redshift ``z``.
+
+        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
+        the age can be directly calculated as an elliptic integral.
+        See, e.g.,
+            Thomas and Kantowski, arXiv:0003463
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          The age of the universe in Gyr at each input redshift.
+        """
+        if isiterable(z):
+            z = np.asarray(z)
+
+        return (2./3) * self._hubble_time * (1+z)**(-3./2)
+
+    def _flat_age(self, z):
+        """ Age of the universe in Gyr at redshift ``z``.
+
+        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
+        the age can be directly calculated as an elliptic integral.
+        See, e.g.,
+            Thomas and Kantowski, arXiv:0003463
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          The age of the universe in Gyr at each input redshift.
+        """
+        if isiterable(z):
+            z = np.asarray(z)
+
+        # Use np.sqrt, np.arcsinh instead of math.sqrt, math.asinh
+        # to handle properly the complex numbers for 1 - Om0 < 0
+        prefactor = (2./3) * self._hubble_time / \
+            np.lib.scimath.sqrt(1 - self._Om0)
+        arg = np.arcsinh(np.lib.scimath.sqrt((1 / self._Om0 - 1 + 0j) /
+                                             (1 + z)**3))
+        return (prefactor * arg).real
+
+    def _EdS_lookback_time(self, z):
+        """ Lookback time in Gyr to redshift ``z``.
+
+        The lookback time is the difference between the age of the
+        Universe now and the age at redshift ``z``.
+
+        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
+        the age can be directly calculated as an elliptic integral.
+        The lookback time is here calculated based on the age(0) - age(z)
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          Lookback time in Gyr to each input redshift.
+        """
+        return self._EdS_age(0) - self._EdS_age(z)
+
+    def _dS_lookback_time(self, z):
+        """ Lookback time in Gyr to redshift ``z``.
+
+        The lookback time is the difference between the age of the
+        Universe now and the age at redshift ``z``.
+
+        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
+        the age can be directly calculated.
+        a = exp(H * t)   where t=0 at z=0
+        t = (1/H) (ln 1 - ln a) = (1/H) (0 - ln (1/(1+z))) = (1/H) ln(1+z)
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          Lookback time in Gyr to each input redshift.
+        """
+        if isiterable(z):
+            z = np.asarray(z)
+
+        return self._hubble_time * np.log(1+z)
+
+    def _flat_lookback_time(self, z):
+        """ Lookback time in Gyr to redshift ``z``.
+
+        The lookback time is the difference between the age of the
+        Universe now and the age at redshift ``z``.
+
+        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
+        the age can be directly calculated.
+        The lookback time is here calculated based on the age(0) - age(z)
+
+        Parameters
+        ----------
+        z : array-like
+          Input redshifts.  Must be 1D or scalar
+
+        Returns
+        -------
+        t : `~astropy.units.Quantity`
+          Lookback time in Gyr to each input redshift.
+        """
+        return self._flat_age(0) - self._flat_age(z)
+
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
 
@@ -2036,17 +2181,29 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
-            # Distances for Om0=0, Om1=0 and the general flat case are already
-            # optimized in LambdaCDM.
+            # Repeat the optimization reassignments here because the init
+            # of the LambaCDM above didn't actually create a flat cosmology.
+            # That was done through the explicit tweak setting self._Ok0.
+            #
+            # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
+            # The dS case is required because the hypergeometric case
+            #    for Omega_M=0 would lead to an infinity in its argument.
+            # The EdS case is three times faster than the hypergeometric.
             if self._Om0 == 0:
+                self._comoving_distance_z1z2 = \
+                    self._dS_comoving_distance_z1z2
                 self._age = self._dS_age
                 self._lookback_time = self._dS_lookback_time
             elif self._Om0 == 1:
+                self._comoving_distance_z1z2 = \
+                    self._EdS_comoving_distance_z1z2
                 self._age = self._EdS_age
                 self._lookback_time = self._EdS_lookback_time
             else:
-                self._age = self._analytic_age
-                self._lookback_time = self._analytic_lookback_time
+                self._comoving_distance_z1z2 = \
+                    self._hypergeometric_comoving_distance_z1z2
+                self._age = self._flat_age
+                self._lookback_time = self._flat_lookback_time
         elif not self._massivenu:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_nomnu
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0,
@@ -2057,145 +2214,6 @@ class FlatLambdaCDM(LambdaCDM):
                                            self._Ogamma0, self._neff_per_nu,
                                            self._nmasslessnu,
                                            self._nu_y_list)
-
-    def _dS_age(self, z):
-        """ Age of the universe in Gyr at redshift ``z``.
-
-        The age of a de Sitter Universe is infinite.
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          The age of the universe in Gyr at each input redshift.
-        """
-        return self._hubble_time * inf_like(z)
-
-    def _EdS_age(self, z):
-        """ Age of the universe in Gyr at redshift ``z``.
-
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the age can be directly calculated as an elliptic integral.
-        See, e.g.,
-            Thomas and Kantowski, arXiv:0003463
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          The age of the universe in Gyr at each input redshift.
-        """
-        if isiterable(z):
-            z = np.asarray(z)
-
-        return (2./3) * self._hubble_time * (1+z)**(-3./2)
-
-    def _analytic_age(self, z):
-        """ Age of the universe in Gyr at redshift ``z``.
-
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the age can be directly calculated as an elliptic integral.
-        See, e.g.,
-            Thomas and Kantowski, arXiv:0003463
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          The age of the universe in Gyr at each input redshift.
-        """
-        if isiterable(z):
-            z = np.asarray(z)
-
-        # Use np.sqrt, np.arcsinh instead of math.sqrt, math.asinh
-        # to handle properly the complex numbers for 1 - Om0 < 0
-        prefactor = (2./3) * self._hubble_time / \
-            np.lib.scimath.sqrt(1 - self._Om0)
-        arg = np.arcsinh(np.lib.scimath.sqrt((1 / self._Om0 - 1 + 0j) /
-                                             (1 + z)**3))
-        return (prefactor * arg).real
-
-    def _EdS_lookback_time(self, z):
-        """ Lookback time in Gyr to redshift ``z``.
-
-        The lookback time is the difference between the age of the
-        Universe now and the age at redshift ``z``.
-
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the age can be directly calculated as an elliptic integral.
-        The lookback time is here calculated based on the age(0) - age(z)
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.  Must be 1D or scalar
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          Lookback time in Gyr to each input redshift.
-        """
-        return self._EdS_age(0) - self._EdS_age(z)
-
-    def _dS_lookback_time(self, z):
-        """ Lookback time in Gyr to redshift ``z``.
-
-        The lookback time is the difference between the age of the
-        Universe now and the age at redshift ``z``.
-
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the age can be directly calculated.
-        a = exp(H * t)   where t=0 at z=0
-        t = (1/H) (ln 1 - ln a) = (1/H) (0 - ln (1/(1+z))) = (1/H) ln(1+z)
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          Lookback time in Gyr to each input redshift.
-        """
-        if isiterable(z):
-            z = np.asarray(z)
-
-        return self._hubble_time * np.log(1+z)
-
-    def _analytic_lookback_time(self, z):
-        """ Lookback time in Gyr to redshift ``z``.
-
-        The lookback time is the difference between the age of the
-        Universe now and the age at redshift ``z``.
-
-        For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
-        the age can be directly calculated.
-        The lookback time is here calculated based on the age(0) - age(z)
-
-        Parameters
-        ----------
-        z : array-like
-          Input redshifts.  Must be 1D or scalar
-
-        Returns
-        -------
-        t : `~astropy.units.Quantity`
-          Lookback time in Gyr to each input redshift.
-        """
-        return self._analytic_age(0) - self._analytic_age(z)
 
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1743,6 +1743,9 @@ class LambdaCDM(FLRW):
                 msg = "z1 and z2 have different shapes"
                 raise ValueError(msg)
 
+        if self._Om0 == 0 or self._Ode0 == 0:
+            return self._integral_comoving_distance_z1z2(z1, z2)
+
         prefactor = self._hubble_distance / np.sqrt(self._Ok0)
         b = -(27./2) * self._Om0**2 * self._Ode0 / self._Ok0**3
         kappa = b / abs(b)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1710,18 +1710,17 @@ class LambdaCDM(FLRW):
         else:
             return np.ones(np.asanyarray(z).shape)
 
-    def _elliptic_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at
-        redshifts z1 and z2.
+    def _elliptic_comoving_transverse_distance_z1z2(self, z1, z2):
+        """ Comoving transverse distance in Mpc between two redshifts.
 
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
+        This value is the transverse comoving distance at redshift ``z``
+        corresponding to an angular separation of 1 radian. This is
+        the same as the comoving distance if omega_k is zero.
 
         For Omega_rad = 0 the comoving distance can be directly calculated
-        as a hypergeometric function.
+        as an elliptic integral.
         Equation here taken from
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+            Kantowski, Kao, and Thomas, arXiv:0002334
 
         Not valid or appropriate for flat cosmologies (Ok0=0).
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1645,7 +1645,21 @@ class LambdaCDM(FLRW):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.lcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0, self._Ok0)
-            if self._Ok0 != 0:
+            if self.Ok0 == 0:
+                # Call out the Om0=0 (de Sitter) and Om0=1 (Einstein-de Sitter)
+                # The dS case is required because the hypergeometric case
+                #    for Omega_M=0 would lead to an infinity in its argument.
+                # The EdS case is three times faster than the hypergeometric.
+                if self._Om0 == 0:
+                    self._comoving_distance_z1z2 = \
+                        self._dS_comoving_distance_z1z2
+                elif self._Om0 == 1:
+                    self._comoving_distance_z1z2 = \
+                        self._EdS_comoving_distance_z1z2
+                else:
+                    self._comoving_distance_z1z2 = \
+                        self._hypergeometric_comoving_distance_z1z2
+            else:
                 self._comoving_distance_z1z2 = \
                     self._elliptic_comoving_distance_z1z2
         elif not self._massivenu:
@@ -1786,6 +1800,116 @@ class LambdaCDM(FLRW):
         prefactor = self._hubble_distance / sqrt(abs(self._Ok0))
         return prefactor * g * (ellipkinc(phi_z1, k2) - ellipkinc(phi_z2, k2))
 
+    def _dS_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at redshifts
+        z1 and z2 in a flat, Omega_Lambda=1 cosmology (de Sitter).
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        The de Sitter case has an analytic solution.
+
+        Parameters
+        ----------
+        z1, z2 : array-like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        return self._hubble_distance * (z2 - z1)
+
+    def _EdS_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at redshifts
+        z1 and z2 in a flat, Omega_M=1 cosmology (Einstein - de Sitter).
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        For OM=1, Omega_rad=0 the comoving distance has an analytic solution.
+
+        Parameters
+        ----------
+        z1, z2 : array-like, shape (N,)
+          Input redshifts.  Must be 1D or scalar.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        prefactor = 2 * self._hubble_distance
+        return prefactor * ((1+z1)**(-1./2) - (1+z2)**(-1./2))
+
+    def _hypergeometric_comoving_distance_z1z2(self, z1, z2):
+        """ Comoving line-of-sight distance in Mpc between objects at
+        redshifts z1 and z2.
+
+        The comoving distance along the line-of-sight between two
+        objects remains constant with time for objects in the Hubble
+        flow.
+
+        For Omega_radiation = 0 the comoving distance can be directly calculated
+        as a hypergeometric function.
+        Equation here taken from
+            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+
+        Parameters
+        ----------
+        z1, z2 : array-like
+          Input redshifts.
+
+        Returns
+        -------
+        d : `~astropy.units.Quantity`
+          Comoving distance in Mpc between each input redshift.
+        """
+        if isiterable(z1):
+            z1 = np.asarray(z1)
+            z2 = np.asarray(z2)
+            if z1.shape != z2.shape:
+                msg = "z1 and z2 have different shapes"
+                raise ValueError(msg)
+
+        s = ((1 - self._Om0) / self._Om0) ** (1./3)
+        # Use np.sqrt here to handle negative s (Om0>1).
+        prefactor = self._hubble_distance / np.sqrt(s * self._Om0)
+        return prefactor * (self._T_hypergeometric(s / (1 + z1)) -
+                            self._T_hypergeometric(s / (1 + z2)))
+
+    def _T_hypergeometric(self, x):
+        """ Compute T_hypergeometric(x) using Gauss Hypergeometric function 2F1
+
+        T(x) = 2 \\sqrt(x) _{2}F_{1} \\left(\\frac{1}{6}, \\frac{1}{2}; \\frac{7}{6}; -x^3)
+
+        Note:
+        The scipy.special.hyp2f1 code already implements the hypergeometric
+        transformation suggested by
+            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+        for use in actual numerical evaulations.
+
+        """
+        from scipy.special import hyp2f1
+        return 2 * np.sqrt(x) * hyp2f1(1./6, 1./2, 7./6, -x**3)
+
     def efunc(self, z):
         """ Function used to calculate H(z), the Hubble parameter.
 
@@ -1912,23 +2036,15 @@ class FlatLambdaCDM(LambdaCDM):
         if self._Tcmb0.value == 0:
             self._inv_efunc_scalar = scalar_inv_efuncs.flcdm_inv_efunc_norel
             self._inv_efunc_scalar_args = (self._Om0, self._Ode0)
-            # Call out Om0=1 (Einstein-de Sitter) and Om0=0 (de Sitter) cases.
-            # The dS case is required because the hypergeometric case
-            #    for Omega_M=0 would lead to an infinity in its argument.
-            # The EdS case is three times faster than the hypergeometric.
+            # Distances for Om0=0, Om1=0 and the general flat case are already
+            # optimized in LambdaCDM.
             if self._Om0 == 0:
-                self._comoving_distance_z1z2 = \
-                    self._dS_comoving_distance_z1z2
                 self._age = self._dS_age
                 self._lookback_time = self._dS_lookback_time
             elif self._Om0 == 1:
-                self._comoving_distance_z1z2 = \
-                    self._EdS_comoving_distance_z1z2
                 self._age = self._EdS_age
                 self._lookback_time = self._EdS_lookback_time
             else:
-                self._comoving_distance_z1z2 = \
-                    self._hypergeometric_comoving_distance_z1z2
                 self._age = self._analytic_age
                 self._lookback_time = self._analytic_lookback_time
         elif not self._massivenu:
@@ -1941,116 +2057,6 @@ class FlatLambdaCDM(LambdaCDM):
                                            self._Ogamma0, self._neff_per_nu,
                                            self._nmasslessnu,
                                            self._nu_y_list)
-
-    def _dS_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at redshifts
-        z1 and z2 in a flat, Omega_Lambda=1 cosmology (de Sitter).
-
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
-
-        The de Sitter case has an analytic solution.
-
-        Parameters
-        ----------
-        z1, z2 : array-like, shape (N,)
-          Input redshifts.  Must be 1D or scalar.
-
-        Returns
-        -------
-        d : `~astropy.units.Quantity`
-          Comoving distance in Mpc between each input redshift.
-        """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
-
-        return self._hubble_distance * (z2 - z1)
-
-    def _EdS_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at redshifts
-        z1 and z2 in a flat, Omega_M=1 cosmology (Einstein - de Sitter).
-
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
-
-        For OM=1, Omega_rad=0 the comoving distance has an analytic solution.
-
-        Parameters
-        ----------
-        z1, z2 : array-like, shape (N,)
-          Input redshifts.  Must be 1D or scalar.
-
-        Returns
-        -------
-        d : `~astropy.units.Quantity`
-          Comoving distance in Mpc between each input redshift.
-        """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
-
-        prefactor = 2 * self._hubble_distance
-        return prefactor * ((1+z1)**(-1./2) - (1+z2)**(-1./2))
-
-    def _hypergeometric_comoving_distance_z1z2(self, z1, z2):
-        """ Comoving line-of-sight distance in Mpc between objects at
-        redshifts z1 and z2.
-
-        The comoving distance along the line-of-sight between two
-        objects remains constant with time for objects in the Hubble
-        flow.
-
-        For Omega_radiation = 0 the comoving distance can be directly calculated
-        as a hypergeometric function.
-        Equation here taken from
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
-
-        Parameters
-        ----------
-        z1, z2 : array-like
-          Input redshifts.
-
-        Returns
-        -------
-        d : `~astropy.units.Quantity`
-          Comoving distance in Mpc between each input redshift.
-        """
-        if isiterable(z1):
-            z1 = np.asarray(z1)
-            z2 = np.asarray(z2)
-            if z1.shape != z2.shape:
-                msg = "z1 and z2 have different shapes"
-                raise ValueError(msg)
-
-        s = ((1 - self._Om0) / self._Om0) ** (1./3)
-        # Use np.sqrt here to handle negative s (Om0>1).
-        prefactor = self._hubble_distance / np.sqrt(s * self._Om0)
-        return prefactor * (self._T_hypergeometric(s / (1 + z1)) -
-                            self._T_hypergeometric(s / (1 + z2)))
-
-    def _T_hypergeometric(self, x):
-        """ Compute T_hypergeometric(x) using Gauss Hypergeometric function 2F1
-
-        T(x) = 2 \\sqrt(x) _{2}F_{1} \\left(\\frac{1}{6}, \\frac{1}{2}; \\frac{7}{6}; -x^3)
-
-        Note:
-        The scipy.special.hyp2f1 code already implements the hypergeometric
-        transformation suggested by
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
-        for use in actual numerical evaulations.
-
-        """
-        from scipy.special import hyp2f1
-        return 2 * np.sqrt(x) * hyp2f1(1./6, 1./2, 7./6, -x**3)
 
     def _dS_age(self, z):
         """ Age of the universe in Gyr at redshift ``z``.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1746,7 +1746,7 @@ class LambdaCDM(FLRW):
         if self._Om0 == 0 or self._Ode0 == 0:
             return self._integral_comoving_distance_z1z2(z1, z2)
 
-        prefactor = self._hubble_distance / np.sqrt(self._Ok0)
+        prefactor = self._hubble_distance / np.lib.scimath.sqrt(self._Ok0)
         b = -(27./2) * self._Om0**2 * self._Ode0 / self._Ok0**3
         kappa = b / abs(b)
         if (b < 0) or (2 < b):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1770,7 +1770,7 @@ class LambdaCDM(FLRW):
                 raise ValueError(msg)
 
         # The analytic solution is not valid for any of Om0, Ode0, Ok0 == 0.
-        # Use the explicit inmtegral solution for these cases.
+        # Use the explicit integral solution for these cases.
         if self._Om0 == 0 or self._Ode0 == 0 or self._Ok0 == 0:
             return self._integral_comoving_distance_z1z2(z1, z2)
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1149,6 +1149,14 @@ def test_distance_in_special_cosmologies():
     assert allclose(c_EdS.comoving_distance(z=0), 0 * u.Mpc)
     assert allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
 
+    c_dS = core.LambdaCDM(100, 0, 1, Tcmb0=0)
+    assert allclose(c_dS.comoving_distance(z=0), 0 * u.Mpc)
+    assert allclose(c_dS.comoving_distance(z=1), 2997.92458 * u.Mpc)
+
+    c_EdS = core.LambdaCDM(100, 1, 0, Tcmb0=0)
+    assert allclose(c_EdS.comoving_distance(z=0), 0 * u.Mpc)
+    assert allclose(c_EdS.comoving_distance(z=1), 1756.1435599923348 * u.Mpc)
+
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_comoving_transverse_distance_z1z2():
     tcos = core.FlatLambdaCDM(100, 0.3, Tcmb0=0.0)


### PR DESCRIPTION
Speed up LambdaCDM distance calculations by a factor of 20 using elliptic integrals from Kantowski, Kao, and Thomas, arXiv:0002334.

Together with previous improvements, distance in both flat and non-flat cosmologies for `LambdaCDM` and `FlatLambdaCDM` are now 20x faster over explicit integration.

Lift the `FlatLambdaCDM` analytic distance and age functions into `LambdaCDM` so that they can be used for special flat cases in `LambdaCDM`.
