### PR TITLE
Improved inherited registration handling in astropy.io

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -982,6 +982,8 @@ astropy.io.misc
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed bug in identifying inherited registrations from multiple ancestors [#7156]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -569,9 +569,10 @@ def _is_best_match(class1, class2, format_classes):
     Determine if class2 is the "best" match for class1 in the list
     of classes.  It is assumed that (class2 in classes) is True.
     class2 is the the best match if:
-      - class1 is class2 => class1 was directly registered.
-      - OR class1 is a subclass of class2 and class1 is not in classes
-        and class2 is the nearest ancestor of class2 that is in classes.
+
+    - ``class1`` is a subclass of ``class2`` AND
+    - ``class2`` is the nearest ancestor of ``class1`` that is in classes
+      (which includes the case that ``class1 is class2``)
     """
     if issubclass(class1, class2):
         classes = {cls for fmt, cls in format_classes}

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -573,20 +573,14 @@ def _is_best_match(class1, class2, format_classes):
       - OR class1 is a subclass of class2 and class1 is not in classes
         and class2 is the nearest ancestor of class2 that is in classes.
     """
-    if class1 is class2:
-        return True
-
-    classes = {cls for fmt, cls in format_classes}
-
-    if class1 in classes:  # superceded by class1
-        return False
-
     if issubclass(class1, class2):
+        classes = {cls for fmt, cls in format_classes}
         for parent in class1.__mro__:
             if parent is class2:  # class2 is closest registered ancestor
                 return True
             if parent in classes:  # class2 was superceded
                 return False
+    return False
 
 
 def _get_valid_format(mode, cls, path, fileobj, args, kwargs):

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -570,14 +570,23 @@ def _is_best_match(class1, class2, format_classes):
     of classes.  It is assumed that (class2 in classes) is True.
     class2 is the the best match if:
       - class1 is class2 => class1 was directly registered.
-      - OR class1 is a subclass of class2 and class1 is not in classes.
-        In this case the subclass will use the parent reader/writer.
+      - OR class1 is a subclass of class2 and class1 is not in classes
+        and class2 is the nearest ancestor of class2 that is in classes.
     """
-    # The set with the classes is only created if class1 is not class2 and
-    # class1 is a subclass of class2.
-    return (class1 is class2 or
-            (issubclass(class1, class2) and
-             class1 not in {cls for fmt, cls in format_classes}))
+    if class1 is class2:
+        return True
+
+    classes = {cls for fmt, cls in format_classes}
+
+    if class1 in classes:  # superceded by class1
+        return False
+
+    if issubclass(class1, class2):
+        for parent in class1.__mro__:
+            if parent is class2:  # class2 is closest registered ancestor
+                return True
+            if parent in classes:  # class2 was superceded
+                return False
 
 
 def _get_valid_format(mode, cls, path, fileobj, args, kwargs):


### PR DESCRIPTION
This PR patches the internal `_is_best_match` method to handle the case where multiple ancestors of a class are registered for a given format.

The modified logic nows returns `True` (best match) if

1. the target class and registered class are the same
1. the target class is not registered, and the registered class is the nearest registered ancestor of the target class

This means that if `Child` is not registered, but both `Parent` and `Grandparent` are, only `Parent` will be identified as the 'best match'. Without this patch, both `Parent` and `Grandparent` would be 'best match' resulting in a 'Format is ambiguous' `IORegistryError`.