### PR TITLE
Alternate fix for FITS regression with table keywords

### DIFF
--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -332,13 +332,14 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                             continue                # skip if there is no match
                         if base_keyword in {'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT', 'TRPOS'}:
                             future_ignore.add(base_keyword)
-                    keys = ', '.join(x + 'n' for x in sorted(future_ignore))
-                    warnings.warn("The following keywords are now recognized as special "
-                                  "column-related attributes and should be set via the "
-                                  "Column objects: {0}. In future, these values will be "
-                                  "dropped from manually specified headers automatically "
-                                  "and replaced with values generated based on the "
-                                  "Column objects.".format(keys), AstropyDeprecationWarning)
+                    if future_ignore:
+                        keys = ', '.join(x + 'n' for x in sorted(future_ignore))
+                        warnings.warn("The following keywords are now recognized as special "
+                                      "column-related attributes and should be set via the "
+                                      "Column objects: {0}. In future, these values will be "
+                                      "dropped from manually specified headers automatically "
+                                      "and replaced with values generated based on the "
+                                      "Column objects.".format(keys), AstropyDeprecationWarning)
 
                 # TODO: Too much of the code in this class uses header keywords
                 # in making calculations related to the data size.  This is

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -243,7 +243,11 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
     data : array
         Data to be used.
     header : `Header` instance
-        Header to be used.
+        Header to be used. If the ``data`` is also specified, header keywords
+        specifically related to defining the table structure (such as the
+        "TXXXn" keywords like TTYPEn) will be overridden by the supplied column
+        definitions, but all other informational and data model-specific
+        keywords are kept.
     name : str
         Name to be populated in ``EXTNAME`` keyword.
     uint : bool, optional


### PR DESCRIPTION
This is an alternative to https://github.com/astropy/astropy/pull/7153 to fix #7145 - basically it just prevents time-related keywords from being automatically removed from the Header. Time-related keywords can still be overwritten if the corresponding attributes are set on Column objects, but this doesn't affect backward-compatibility since those Column attributes didn't exist before. This approach thus guarantees full backward-compatibility (unless I've overlooked something), and emits a deprecation warning to mention that these keywords will be dropped in future. Example usage:

```python
In [1]: import astropy
   ...: from astropy.io import fits
   ...: import numpy as np
   ...: 
   ...: def create_column_descriptions():
   ...:     col = []
   ...:     col.append(fits.Column(name="TIME", format="1E", unit="s"))
   ...:     col.append(fits.Column(name="RAWX", format="1I", unit="pixel"))
   ...:     cd = fits.ColDefs(col)
   ...: 
   ...:     return cd
   ...: 
   ...: def create_header():
   ...:     hdr = fits.Header()
   ...:     hdr['RA'] = (1.581250000000E+00, 'RA of reference aperture center ')
   ...:     hdr['DEC'] = (2.020277777778E+01, 'Declination of reference aperture center')
   ...:     hdr['TCTYP2'] = ('RA---TAN', 'axis type for dimension 1')
   ...:     hdr['TCRVL2'] = (-999.0, 'sky coordinates of 1st axis')
   ...: 
   ...:     return hdr
   ...: 
   ...: columns = create_column_descriptions()
   ...: header = create_header()
   ...: 

In [2]: print(header.tostring(sep='\n'))
   ...: print(columns)
   ...: 
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TCTYP2  = 'RA---TAN'           / axis type for dimension 1                      
TCRVL2  =               -999.0 / sky coordinates of 1st axis                    
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'
)
```

So far so good. Let's make a new HDU from the columns and header:

```python
In [3]: hdu = fits.BinTableHDU.from_columns(columns, header)
   ...: 
/Users/tom/Dropbox/Code/Astropy/astropy/astropy/io/fits/hdu/table.py:341: UserWarning: The following keywords are now recognized as special column-related attributes and should be set via the Column objects: TCRVLn, TCTYPn. In future, these values will be dropped from manually specified headers automatically and replaced with values generated based on the Column objects.
  "Column objects.".format(keys))
```

We see that this causes the above warning. The header still contains those keywords, and the columns don't (consistent with previous behavior):

```
In [4]: print(hdu.header.tostring(sep='\n'))
   ...: print(hdu.columns)
   ...: 
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                    6 / length of dimension 1                          
NAXIS2  =                    0 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                         
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TCTYP2  = 'RA---TAN'           / axis type for dimension 1                      
TCRVL2  =               -999.0 / sky coordinates of 1st axis                    
TTYPE1  = 'TIME    '                                                            
TFORM1  = '1E      '                                                            
TUNIT1  = 's       '                                                            
TTYPE2  = 'RAWX    '                                                            
TFORM2  = '1I      '                                                            
TUNIT2  = 'pixel   '                                                            
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'
)
```

Now let's write out the file and read in back in:

```python
In [5]: hdu.writeto('time.fits', overwrite=True)
   ...: 
   ...: hdu2 = fits.open('time.fits')[1]
   ...: 

In [6]: print(hdu2.header.tostring(sep='\n'))
   ...: print(hdu2.columns)
   ...: 
XTENSION= 'BINTABLE'           / binary table extension                         
BITPIX  =                    8 / array data type                                
NAXIS   =                    2 / number of array dimensions                     
NAXIS1  =                    6 / length of dimension 1                          
NAXIS2  =                    0 / length of dimension 2                          
PCOUNT  =                    0 / number of group parameters                     
GCOUNT  =                    1 / number of groups                               
TFIELDS =                    2 / number of table fields                         
RA      =              1.58125 / RA of reference aperture center                
DEC     =       20.20277777778 / Declination of reference aperture center       
TCTYP2  = 'RA---TAN'           / axis type for dimension 1                      
TCRVL2  =               -999.0 / sky coordinates of 1st axis                    
TTYPE1  = 'TIME    '                                                            
TFORM1  = '1E      '                                                            
TUNIT1  = 's       '                                                            
TTYPE2  = 'RAWX    '                                                            
TFORM2  = '1I      '                                                            
TUNIT2  = 'pixel   '                                                            
END                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
ColDefs(
    name = 'TIME'; format = '1E'; unit = 's'
    name = 'RAWX'; format = '1I'; unit = 'pixel'; coord_type = 'RA---TAN'; coord_ref_value = -999.0
)
```

At this point, the new column attributes are picked up (as expected) and they are still in the header as everything is now in sync. No warning was emitted when reading a file.

Let's just set a column attribute:

```python
In [9]: hdu2.columns[1].coord_type = 'DEC--TAN'

In [10]: hdu2.header['TCTYP2']
Out[10]: 'DEC--TAN'
```

The attributes in the header are now kept in sync and are not cleared by default when initializing from a header.