### PR TITLE
Add alternate unit path in frame initializer 

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1285,8 +1285,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             return ''
 
         if self.representation:
-            if (issubclass(self.representation, r.SphericalRepresentation) and
-                    isinstance(self.data, r.UnitSphericalRepresentation)):
+            if (hasattr(self.representation, '_unit_representation') and
+                    isinstance(self.data, self.representation._unit_representation)):
                 rep_cls = self.data.__class__
             else:
                 rep_cls = self.representation

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -15,6 +15,8 @@ from ...utils.exceptions import AstropyWarning
 from .. import representation as r
 from ..representation import REPRESENTATION_CLASSES
 
+from .test_representation import unitphysics  # this fixture is used below
+
 
 def setup_function(func):
     func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
@@ -1011,3 +1013,16 @@ def test_missing_component_error_names():
         ICRS(ra=150*u.deg, dec=-11*u.deg,
              pm_ra=100*u.mas/u.yr, pm_dec=10*u.mas/u.yr)
     assert "pm_ra_cosdec" in str(e)
+
+
+def test_non_spherical_representation_unit_creation(unitphysics):
+    from ..builtin_frames import ICRS
+
+    class PhysicsICRS(ICRS):
+        default_representation = r.PhysicsSphericalRepresentation
+
+    pic = PhysicsICRS(phi=1*u.deg, theta=25*u.deg, r=1*u.kpc)
+    assert isinstance(pic.data, r.PhysicsSphericalRepresentation)
+
+    picu = PhysicsICRS(phi=1*u.deg, theta=25*u.deg)
+    assert isinstance(picu.data, unitphysics)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1474,7 +1474,7 @@ def test_unitphysics(unitphysics):
     asphys = obj.represent_as(PhysicsSphericalRepresentation)
     assert asphys.phi == obj.phi
     assert asphys.theta == obj.theta
-    assert asphys.r == 1*u.dimensionless_unscaled
+    assert_quantity_allclose(asphys.r, 1*u.dimensionless_unscaled)
 
     assph = obj.represent_as(SphericalRepresentation)
     assert assph.lon == obj.phi

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1474,9 +1474,9 @@ def test_unitphysics(unitphysics):
     asphys = obj.represent_as(PhysicsSphericalRepresentation)
     assert asphys.phi == obj.phi
     assert asphys.theta == obj.theta
-    assert_quantity_allclose(asphys.r, 1*u.dimensionless_unscaled)
+    assert_allclose_quantity(asphys.r, 1*u.dimensionless_unscaled)
 
     assph = obj.represent_as(SphericalRepresentation)
     assert assph.lon == obj.phi
     assert assph.lat == 80*u.deg
-    assert assph.distance == 1*u.dimensionless_unscaled
+    assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1374,3 +1374,109 @@ def test_recommended_units_deprecation():
             attr_classes = SphericalRepresentation.attr_classes
             recommended_units = {}
     assert 'recommended_units' in str(w[0].message)
+
+
+@pytest.fixture
+def unitphysics():
+    """
+    This fixture is used
+    """
+    had_unit = False
+    if hasattr(PhysicsSphericalRepresentation, '_unit_representation'):
+        orig = PhysicsSphericalRepresentation._unit_representation
+        had_unit = True
+
+
+    class UnitPhysicsSphericalRepresentation(BaseRepresentation):
+        attr_classes = OrderedDict([('phi', Angle),
+                                    ('theta', Angle)])
+
+        def __init__(self, phi, theta, differentials=None, copy=True):
+            super().__init__(phi, theta, copy=copy, differentials=differentials)
+
+            # Wrap/validate phi/theta
+            if copy:
+                self._phi = self._phi.wrap_at(360 * u.deg)
+            else:
+                # necessary because the above version of `wrap_at` has to be a copy
+                self._phi.wrap_at(360 * u.deg, inplace=True)
+
+            if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
+                raise ValueError('Inclination angle(s) must be within '
+                                 '0 deg <= angle <= 180 deg, '
+                                 'got {0}'.format(theta.to(u.degree)))
+
+        @property
+        def phi(self):
+            return self._phi
+
+        @property
+        def theta(self):
+            return self._theta
+
+        def unit_vectors(self):
+            sinphi, cosphi = np.sin(self.phi), np.cos(self.phi)
+            sintheta, costheta = np.sin(self.theta), np.cos(self.theta)
+            return OrderedDict(
+                (('phi', CartesianRepresentation(-sinphi, cosphi, 0., copy=False)),
+                 ('theta', CartesianRepresentation(costheta*cosphi,
+                                                   costheta*sinphi,
+                                                   -sintheta, copy=False))))
+
+        def scale_factors(self):
+            sintheta = np.sin(self.theta)
+            l = np.broadcast_to(1.*u.one, self.shape, subok=True)
+            return OrderedDict((('phi', sintheta),
+                                ('theta', l)))
+
+        def to_cartesian(self):
+            x = np.sin(self.theta) * np.cos(self.phi)
+            y = np.sin(self.theta) * np.sin(self.phi)
+            z = np.cos(self.theta)
+
+            return CartesianRepresentation(x=x, y=y, z=z, copy=False)
+
+        @classmethod
+        def from_cartesian(cls, cart):
+            """
+            Converts 3D rectangular cartesian coordinates to spherical polar
+            coordinates.
+            """
+            s = np.hypot(cart.x, cart.y)
+
+            phi = np.arctan2(cart.y, cart.x)
+            theta = np.arctan2(s, cart.z)
+
+            return cls(phi=phi, theta=theta, copy=False)
+
+        def norm(self):
+            return u.Quantity(np.ones(self.shape), u.dimensionless_unscaled,
+                              copy=False)
+
+    PhysicsSphericalRepresentation._unit_representation = UnitPhysicsSphericalRepresentation
+    yield UnitPhysicsSphericalRepresentation
+
+    if had_unit:
+        PhysicsSphericalRepresentation._unit_representation = orig
+    else:
+        del PhysicsSphericalRepresentation._unit_representation
+
+    # remove from the module-level representations, if present
+    REPRESENTATION_CLASSES.pop(UnitPhysicsSphericalRepresentation.get_name(), None)
+
+
+def test_unitphysics(unitphysics):
+    obj = unitphysics(phi=0*u.deg, theta=10*u.deg)
+    objkw = unitphysics(phi=0*u.deg, theta=10*u.deg)
+    assert objkw.phi == obj.phi
+    assert objkw.theta == obj.theta
+
+    asphys = obj.represent_as(PhysicsSphericalRepresentation)
+    assert asphys.phi == obj.phi
+    assert asphys.theta == obj.theta
+    assert asphys.r == 1*u.dimensionless_unscaled
+
+    assph = obj.represent_as(SphericalRepresentation)
+    assert assph.lon == obj.phi
+    assert assph.lat == 80*u.deg
+    assert assph.distance == 1*u.dimensionless_unscaled

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -250,9 +250,10 @@ class CoordinateTransform(CurvedTransform):
         if self.same_frames:
             return input_coords
 
+        input_coords = input_coords*u.deg
         x_in, y_in = input_coords[:, 0], input_coords[:, 1]
 
-        c_in = SkyCoord(x_in, y_in, unit=(u.deg, u.deg),
+        c_in = SkyCoord(UnitSphericalRepresentation(x_in, y_in),
                         frame=self.input_system)
 
         # We often need to transform arrays that contain NaN values, and filtering


### PR DESCRIPTION
This PR is a tweak to the machinery for initializing frame objects based on a discussion with @Cadair  about a rather obscure SunPy use case.  There's a coordinate system that uses a different lat/lon convention, and he has a custom representation (and unit representation) for this.  This PR makes it so that custom unit representations actually get called even if it isn't a `SphericalRepresentation`.

This *shouldn't* actually change anything in the public API (hence the no-changelog-entry-needed). The idea is that we can test this in 3.0 via SunPy (which is using the `_unit_representation` trick anyway) and perhaps move towards it being a more public feature in the future.  So I've slated it for v3.0 as it then gets the "testing" in SunPy now.