### PR TITLE
InheritDocstrings to work on class property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,8 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- ``InheritDocstrings`` now also works on class properties. [#7166]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -4,9 +4,6 @@
 A "grab bag" of relatively small general-purpose utilities that don't have
 a clear module/package to live in.
 """
-
-
-
 import abc
 import contextlib
 import difflib
@@ -25,7 +22,6 @@ import urllib.request
 from itertools import zip_longest
 from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
-
 
 
 __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
@@ -528,9 +524,9 @@ class InheritDocstrings(type):
                 not key.startswith('_'))
 
         for key, val in dct.items():
-            if (inspect.isfunction(val) and
-                is_public_member(key) and
-                val.__doc__ is None):
+            if ((inspect.isfunction(val) or inspect.isdatadescriptor(val)) and
+                    is_public_member(key) and
+                    val.__doc__ is None):
                 for base in cls.__mro__[1:]:
                     super_method = getattr(base, key, None)
                     if super_method is not None:

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -80,13 +80,25 @@ def test_inherit_docstrings():
             "FOO"
             pass
 
+        @property
+        def bar(self):
+            "BAR"
+            pass
+
     class Subclass(Base):
         def __call__(self, *args):
             pass
 
+        @property
+        def bar(self):
+            return 42
+
     if Base.__call__.__doc__ is not None:
         # TODO: Maybe if __doc__ is None this test should be skipped instead?
         assert Subclass.__call__.__doc__ == "FOO"
+
+    if Base.bar.__doc__ is not None:
+        assert Subclass.bar.__doc__ == "BAR"
 
 
 def test_set_locale():


### PR DESCRIPTION
Fix #7162 

Was not really a bug, so milestoned this for 3.1.