### PR TITLE
Fix convolve_models example in docs

### DIFF
--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -342,7 +342,7 @@ function in which the resulting mean (variance) is the sum of the means
     g2 = models.Gaussian1D(1, 1, 1)
     g3 = convolve_models(g1, g2)
 
-    x = np.linspace(-3, -3, 50)
+    x = np.linspace(-3, 3, 50)
     plt.plot(x, g1(x), 'k-')
     plt.plot(x, g2(x), 'k-')
     plt.plot(x, g3(x), 'k-')


### PR DESCRIPTION
The example plot for `convolve_models` at the end of [this section](http://docs.astropy.org/en/latest/modeling/index.html#compound-models) is broken. I think it is just a matter of setting the correct upper limit. It was introduced in https://github.com/astropy/astropy/commit/e091cebf72fa79c17d9ebb831cd34ced250104b6 for v3.0, cc @mirca 
Does this needs a changelog for v3.0.1 ?

Here is the result with my change:
![tmp](https://user-images.githubusercontent.com/311639/35944426-a312d554-0c5c-11e8-8b50-dd94d4a0f273.png)

Btw, I would suggest to use another color for the convolved model.