### PR TITLE
Support dotted package names as namespace packages for test coverage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -846,6 +846,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Support dotted package names as namespace packages when gathering test
+  coverage. [#7170]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -278,13 +278,14 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         # requires importing astropy.config and thus screwing
         # up coverage results for those packages.
         coveragerc = os.path.join(
-            self.testing_path, self.package_name, 'tests', 'coveragerc')
+            self.testing_path, self.package_name.replace('.', '/'),
+            'tests', 'coveragerc')
 
         with open(coveragerc, 'r') as fd:
             coveragerc_content = fd.read()
 
         coveragerc_content = coveragerc_content.replace(
-            "{packagename}", self.package_name)
+            "{packagename}", self.package_name.replace('.', '/'))
         tmp_coveragerc = os.path.join(self.tmp_dir, 'coveragerc')
         with open(tmp_coveragerc, 'wb') as tmp:
             tmp.write(coveragerc_content.encode('utf-8'))


### PR DESCRIPTION
See also astropy/astropy-helpers#370.