### PR TITLE
Add back mirror URL for image tests

### DIFF
--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -7,7 +7,8 @@ MPL_VERSION = matplotlib.__version__
 
 ROOT = "http://{server}/testing/astropy/2018-02-01T23:31:45.013149/{mpl_version}/"
 
-IMAGE_REFERENCE_DIR = ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x')
+IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x') + ',' +
+                       ROOT.format(server='www.astropy.org/astropy-data', mpl_version=MPL_VERSION[:3] + '.x'))
 
 
 def ignore_matplotlibrc(func):


### PR DESCRIPTION
This was removed accidentally in https://github.com/astropy/astropy/pull/7150