### PR TITLE
Make sure HDUs are loaded before hdulist.pop is called

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,6 +267,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Make sure that lazily-loaded ``HDUList`` is automatically loaded when calling
+  ``hdulist.pop``. [#7186]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,9 +267,6 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- Make sure that lazily-loaded ``HDUList`` is automatically loaded when calling
-  ``hdulist.pop``. [#7186]
-
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -800,6 +797,9 @@ astropy.io.fits
 ^^^^^^^^^^^^^^^
 
 - Fixed the ``fitsdiff`` script for matching fits file with one in a directory path. [#7085]
+
+- Make sure that lazily-loaded ``HDUList`` is automatically loaded when calling
+  ``hdulist.pop``. [#7186]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -238,16 +238,14 @@ class HDUList(list, _Verify):
 
     def __len__(self):
         if not self._in_read_next_hdu:
-            while self._read_next_hdu():
-                pass
+            self._read_all_hdus()
 
         return super().__len__()
 
     def __repr__(self):
         # In order to correctly repr an HDUList we need to load all the
         # HDUs as well
-        while self._read_next_hdu():
-            pass
+        self._read_all_hdus()
 
         return super().__repr__()
 
@@ -511,6 +509,15 @@ class HDUList(list, _Verify):
             output = None
 
         return output
+
+    def _read_all_hdus(self):
+        while self._read_next_hdu():
+            pass
+
+    def pop(self, index=-1):
+        # Make sure that HDUs are loaded before attempting to pop
+        self._read_all_hdus()
+        return super(HDUList, self).pop(index)
 
     def insert(self, index, hdu):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -238,14 +238,14 @@ class HDUList(list, _Verify):
 
     def __len__(self):
         if not self._in_read_next_hdu:
-            self._read_all_hdus()
+            self.readall()
 
         return super().__len__()
 
     def __repr__(self):
         # In order to correctly repr an HDUList we need to load all the
         # HDUs as well
-        self._read_all_hdus()
+        self.readall()
 
         return super().__repr__()
 
@@ -510,13 +510,9 @@ class HDUList(list, _Verify):
 
         return output
 
-    def _read_all_hdus(self):
-        while self._read_next_hdu():
-            pass
-
     def pop(self, index=-1):
         # Make sure that HDUs are loaded before attempting to pop
-        self._read_all_hdus()
+        self.readall()
         return super(HDUList, self).pop(index)
 
     def insert(self, index, hdu):
@@ -718,10 +714,8 @@ class HDUList(list, _Verify):
         """
         Read data of all HDUs into memory.
         """
-
-        for hdu in self:
-            if hdu.data is not None:
-                continue
+        while self._read_next_hdu():
+            pass
 
     @ignore_sigint
     def flush(self, output_verify='fix', verbose=False):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -963,3 +963,22 @@ class TestHDUListFunctions(FitsTestCase):
                 fits.open(filename, ignore_missing_end=True)
 
         assert len(ws) == 0
+
+    def test_pop_with_lazy_load(self):
+        filename = self.data('checksum.fits')
+        hdul = fits.open(filename)
+        # Try popping the hdulist before doing anything else. This makes sure
+        # that https://github.com/astropy/astropy/issues/7185 is fixed.
+        hdu = hdul.pop()
+        assert len(hdul) == 1
+
+        # Read the file again and try popping from the beginning
+        hdul2 = fits.open(filename)
+        hdu2 = hdul2.pop(0)
+        assert len(hdul2) == 1
+
+        # Just a sanity check
+        hdul3 = fits.open(filename)
+        assert len(hdul3) == 2
+        assert hdul3[0].header == hdu2.header
+        assert hdul3[1].header == hdu.header


### PR DESCRIPTION
This change seems pretty straightforward. I'm not sure whether it needs a change log entry. I also refactored all of the force-lazy-loading functionality into a single method.

Fixes #7185.