### PR TITLE
Add workaround for einsum issues in norm()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -889,6 +889,8 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Add a workaround for a bug in the einsum function in Numpy 1.14.0. [#7187]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -119,7 +119,13 @@ def norm(p):
     """
     Normalise a p-vector.
     """
-    return p/np.sqrt(np.einsum('...i,...i', p, p))[..., np.newaxis]
+    if np.__version__ == '1.14.0':
+        # there is a bug in numpy v1.14.0 (fixed in 1.14.1) that causes
+        # this einsum call to break with the default of optimize=True
+        # see https://github.com/astropy/astropy/issues/7051
+        return p / np.sqrt(np.einsum('...i,...i', p, p, optimize=False))[..., np.newaxis]
+    else:
+        return p / np.sqrt(np.einsum('...i,...i', p, p))[..., np.newaxis]
 
 
 def get_cip(jd1, jd2):


### PR DESCRIPTION
This doesn't actually cause issues in master at the moment but does cause issues in v2.0.x. @mhvk suggested including the fix in master anyway just to be safe, and we can backport this to v2.0.x.