### PR TITLE
Add vmeasured option for radial velocity correction

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1480,7 +1480,8 @@ class SkyCoord(ShapedLikeNDArray):
             to an observed radial velocity to get the barycentric (or
             heliocentric) velocity. If m/s precision or better is needed,
             use the ``vmeasured`` keyword, in which case the returned correction
-            will be :math:`v_b + \frac{v_b v_m}{c}`.
+            will be :math:`v_b + \frac{v_b v_m}{c}`, the correction that should
+            be added to ``vmeasured`` to get the true velocity.
 
         Notes
         -----
@@ -1585,12 +1586,18 @@ class SkyCoord(ShapedLikeNDArray):
             # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
             # neglecting Shapiro delay and effects of the star's own motion
             zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light) - 1
-            return zb * speed_of_light
+            vcorr = zb * speed_of_light
         else:
             # do a simpler correction ignoring time dilation and gravitational redshift
             # this is adequate since Heliocentric corrections shouldn't be used if
             # cm/s precision is required.
-            return targcart.dot(v_origin_to_earth + gcrs_v)
+            vcorr = targcart.dot(v_origin_to_earth + gcrs_v)
+
+        if vmeasured is not None:
+            mult_term = vcorr * vmeasured / cnst.c
+            vcorr += mult_term
+
+        return vcorr
 
     # Table interactions
     @classmethod


### PR DESCRIPTION
This PR builds on @StuartLittlefair's work making the radial velocity correction reach mm/s in #6861 . It basically adds a way to use the function to do the "multiplicative" version of the correction that Wright & Eastmann 2014 (correctly) espouse.

The awkwardness (and reason why this is a WIP) is that the way I've implemented this you use it by doing:
```
vtrue = vobs + target.radial_velocity_correction(vmeasured=vobs)
```
which feels a bit odd to me because you have to give `vobs` twice.  But the alternative of having the return value already add in the `vobs` (i.e., be `vtrue` in my above snipper) seems even worse, because then depending on whether `vmeasured` is None or something else, the return value has a very different meaning (either the "correction" or the "result of the correction").

So before I proceed with adding tests, I'm curious what others opinion's are on the best API direction: is this good as implemented, or should we do something else to enable this functionality (i.e., either my "alternative" in the above paragraph or something else I haven't thought of)?

cc @mhvk @adrn @StuartLittlefair 