### PR TITLE
Enable `xfail_strict` pytest config by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true
 addopts = -p no:warnings
 asdf_schema_root = astropy/io/misc/asdf/schemas
+xfail_strict = true
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
Fixes #7065 