### PR TITLE
Temporarily disable sphinx-gallery due to an incompatibility with Sphinx 1.7

### DIFF
--- a/.rtd-environment.yml
+++ b/.rtd-environment.yml
@@ -8,7 +8,7 @@ name: astropy
 
 dependencies:
   - python>=3
-  - sphinx<1.7
+  - sphinx
   - numpy
   - cython
   - matplotlib
@@ -25,5 +25,7 @@ dependencies:
   - mpmath
   - pytest
   - pip:
-    - sphinx-gallery>=0.1.12
+    # Temporarily disable sphinx-gallery as it is incompatible
+    # with Sphinx 1.7 and we can't pin Sphinx to <1.7 on RTD.
+    # - sphinx-gallery>=0.1.12
     - jplephem


### PR DESCRIPTION
There is a bug in sphinx-gallery which is causing issues with our RTD build:

https://github.com/sphinx-gallery/sphinx-gallery/issues/351

Basically sphinx-gallery is incompatible with Sphinx 1.7. There are several options:

* Wait until there is a new version of sphinx-gallery, which could take a while

* Fix the bug in sphinx-gallery ourselves and point the environment file to our sphinx-gallery fork if we manage to fix it

* Disable the gallery temporarily

* Pin Sphinx to <1.7 on RTD - but can't figure out how

This PR does the latter - let's not merge yet but we can merge if we decide this is the only sane way to go. I think this could be then cherry-picked to the stable branch for the docs there to compile.