### PR TITLE
Refactor modeling to be stricter about Units

### DIFF
--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -174,7 +174,7 @@ class BlackBody1D(Fittable1DModel):
 
     # We allow values without units to be passed when evaluating the model, and
     # in this case the input x values are assumed to be frequencies in Hz.
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     # We enable the spectral equivalency by default for the spectral axis
     input_units_equivalencies = {'x': u.spectral()}

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1366,9 +1366,9 @@ class Model(metaclass=_ModelMeta):
     @property
     def input_units_allow_dimensionless(self):
         """
-        Allow dimensionless input (and corresponding output). If this is True,
-        input values to evaluate will gain the units specified in input_units.
-        Only has an effect if input_units is defined.
+        If `True` allow input to the model to be dimensionless as well as in
+        the units of ``input_units``. This only has an effect if
+        ``input_units`` is set.
         """
         return self._input_units_allow_dimensionless
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1445,14 +1445,15 @@ class Model(metaclass=_ModelMeta):
         _validate_input_shapes(inputs, self.inputs, n_models,
                                model_set_axis, self.standard_broadcasting)
 
-        params_units = [p.unit is not None for p in params]
-        has_param_units = any(params_units)
+        # TODO: This might need putting back
+        # params_units = [isinstance(p, Quantity) for p in params]
+        # has_param_units = any(params_units)
 
-        if has_param_units and not all(params_units):
-            raise ValueError("If any Parameters have units, then all Parameters should have units.")
+        # if has_param_units and not all(params_units):
+        #     raise ValueError("If any Parameters have units, then all Parameters should have units.")
 
-        if has_param_units and any((not isinstance(i, Quantity) for i in inputs)):
-            raise ValueError("Can only call a model without Quantities if none of it's parameters are Quantities")
+        # if has_param_units and any((not isinstance(i, Quantity) for i in inputs)):
+        #     raise ValueError("Can only call a model without Quantities if none of it's parameters are Quantities")
 
         # Check that the units are correct, if applicable
         if self.input_units is not None:
@@ -3123,25 +3124,6 @@ def render_model(model, arr=None, coords=None):
         arr += model(*coords[::-1])
 
     return arr
-
-    @property
-    def input_units_strict(self):
-        """
-        Enforce strict units on inputs to evaluate. If this is set to True, input
-        values to evaluate have to be in the exact right units specified by
-        input_units. In this case, if the input quantities are convertible to
-        input_units, they are converted.
-        """
-        return self._input_units_strict
-
-    @property
-    def input_units_allow_dimensionless(self):
-        """
-        Allow dimensionless input (and corresponding output). If this is True,
-        input values to evaluate will gain the units specified in input_units.
-        Only has an effect if input_units is defined.
-        """
-        return self._input_units_allow_dimensionless
 
 
 def _prepare_inputs_single_model(model, params, inputs, **kwargs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1396,10 +1396,6 @@ class Model(metaclass=_ModelMeta):
             # None means any unit is accepted
             return None
 
-    @input_units.setter
-    def input_units(self, input_units):
-        self._input_units = input_units
-
     @property
     def return_units(self):
         """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -655,16 +655,9 @@ class Model(metaclass=_ModelMeta):
     # model hasn't completed initialization yet
     _n_models = 1
 
-    # Enforce strict units on inputs to evaluate. If this is set to True, input
-    # values to evaluate have to be in the exact right units specified by
-    # input_units. In this case, if the input quantities are convertible to
-    # input_units, they are converted.
-    input_units_strict = False
+    _input_units_strict = False
 
-    # Allow dimensionless input (and corresponding output). If this is True,
-    # input values to evaluate will gain the units specified in input_units.
-    # Only has an effect if input_units is defined.
-    input_units_allow_dimensionless = False
+    _input_units_allow_dimensionless = False
 
     # Default equivalencies to apply to input values. If set, this should be a
     # dictionary where each key is a string that corresponds to one of the model
@@ -1361,6 +1354,25 @@ class Model(metaclass=_ModelMeta):
         return out
 
     @property
+    def input_units_strict(self):
+        """
+        Enforce strict units on inputs to evaluate. If this is set to True, input
+        values to evaluate have to be in the exact right units specified by
+        input_units. In this case, if the input quantities are convertible to
+        input_units, they are converted.
+        """
+        return self._input_units_strict
+
+    @property
+    def input_units_allow_dimensionless(self):
+        """
+        Allow dimensionless input (and corresponding output). If this is True,
+        input values to evaluate will gain the units specified in input_units.
+        Only has an effect if input_units is defined.
+        """
+        return self._input_units_allow_dimensionless
+
+    @property
     def input_units(self):
         """
         This property is used to indicate what units or sets of units the
@@ -1407,10 +1419,6 @@ class Model(metaclass=_ModelMeta):
         else:
             # None means any unit is accepted
             return None
-
-    @return_units.setter
-    def return_units(self, return_units):
-        self._return_units = return_units
 
     def prepare_inputs(self, *inputs, model_set_axis=None, equivalencies=None,
                        **kwargs):
@@ -3101,6 +3109,25 @@ def render_model(model, arr=None, coords=None):
                 raise ValueError('The `bounding_box` is larger than the input'
                                 ' arr in one or more dimensions. Set '
                                 '`model.bounding_box = None`.')
+
+    @property
+    def input_units_strict(self):
+        """
+        Enforce strict units on inputs to evaluate. If this is set to True, input
+        values to evaluate have to be in the exact right units specified by
+        input_units. In this case, if the input quantities are convertible to
+        input_units, they are converted.
+        """
+        return self._input_units_strict
+
+    @property
+    def input_units_allow_dimensionless(self):
+        """
+        Allow dimensionless input (and corresponding output). If this is True,
+        input values to evaluate will gain the units specified in input_units.
+        Only has an effect if input_units is defined.
+        """
+        return self._input_units_allow_dimensionless
     else:
 
         if coords is None:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1445,15 +1445,23 @@ class Model(metaclass=_ModelMeta):
         _validate_input_shapes(inputs, self.inputs, n_models,
                                model_set_axis, self.standard_broadcasting)
 
-        # Check that the units are correct, if applicable
+        params_units = [p.unit is not None for p in params]
+        has_param_units = any(params_units)
 
+        if has_param_units and not all(params_units):
+            raise ValueError("If any Parameters have units, then all Parameters should have units.")
+
+        if has_param_units and any((not isinstance(i, Quantity) for i in inputs)):
+            raise ValueError("Can only call a model without Quantities if none of it's parameters are Quantities")
+
+        # Check that the units are correct, if applicable
         if self.input_units is not None:
 
             # We combine any instance-level input equivalencies with user
             # specified ones at call-time.
             input_units_equivalencies = _combine_equivalency_dict(self.inputs,
-                                                                 equivalencies,
-                                                                 self.input_units_equivalencies)
+                                                                  equivalencies,
+                                                                  self.input_units_equivalencies)
 
             # We now iterate over the different inputs and make sure that their
             # units are consistent with those specified in input_units.
@@ -3103,8 +3111,18 @@ def render_model(model, arr=None, coords=None):
                 arr = add_array(arr, model(*sub_coords), pos)
             except ValueError:
                 raise ValueError('The `bounding_box` is larger than the input'
-                                ' arr in one or more dimensions. Set '
-                                '`model.bounding_box = None`.')
+                                 ' arr in one or more dimensions. Set '
+                                 '`model.bounding_box = None`.')
+    else:
+
+        if coords is None:
+            im_shape = arr.shape
+            limits = [slice(i) for i in im_shape]
+            coords = np.mgrid[limits]
+
+        arr += model(*coords[::-1])
+
+    return arr
 
     @property
     def input_units_strict(self):
@@ -3124,16 +3142,6 @@ def render_model(model, arr=None, coords=None):
         Only has an effect if input_units is defined.
         """
         return self._input_units_allow_dimensionless
-    else:
-
-        if coords is None:
-            im_shape = arr.shape
-            limits = [slice(i) for i in im_shape]
-            coords = np.mgrid[limits]
-
-        arr += model(*coords[::-1])
-
-    return arr
 
 
 def _prepare_inputs_single_model(model, params, inputs, **kwargs):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -461,10 +461,6 @@ class Shift(Fittable1DModel):
     offset = Parameter(default=0)
     linear = True
 
-    _input_units_strict = True
-
-    _input_units_allow_dimensionless = True
-
     @property
     def input_units(self):
         if self.offset.unit is None:
@@ -482,14 +478,7 @@ class Shift(Fittable1DModel):
     @staticmethod
     def evaluate(x, offset):
         """One dimensional Shift model function"""
-        if isinstance(offset, u.Quantity):
-            return_unit = offset.unit
-            offset = offset.value
-        if isinstance(x, u.Quantity):
-            x = x.value
-            return (x + offset) * return_unit
-        else:
-            return x + offset
+        return x + offset
 
     @staticmethod
     def sum_of_implicit_terms(x):
@@ -521,17 +510,6 @@ class Scale(Fittable1DModel):
     linear = True
     fittable = True
 
-    _input_units_strict = True
-
-    _input_units_allow_dimensionless = True
-
-    @property
-    def input_units(self):
-        if self.factor.unit is None:
-            return None
-        else:
-            return {'x': self.factor.unit}
-
     @property
     def inverse(self):
         """One dimensional inverse Scale model function"""
@@ -542,13 +520,7 @@ class Scale(Fittable1DModel):
     @staticmethod
     def evaluate(x, factor):
         """One dimensional Scale model function"""
-        if isinstance(factor, u.Quantity):
-            return_unit = factor.unit
-            factor = factor.value
-        if isinstance(x, u.Quantity):
-            return (x.value * factor) * return_unit
-        else:
-            return factor * x
+        return factor * x
 
     @staticmethod
     def fit_deriv(x, *params):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -461,9 +461,9 @@ class Shift(Fittable1DModel):
     offset = Parameter(default=0)
     linear = True
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -521,9 +521,9 @@ class Scale(Fittable1DModel):
     linear = True
     fittable = True
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -122,8 +122,8 @@ class Pix2SkyProjection(Projection):
     inputs = ('x', 'y')
     outputs = ('phi', 'theta')
 
-    input_units_strict = True
-    input_units_allow_dimensionless = True
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -140,8 +140,8 @@ class Sky2PixProjection(Projection):
     inputs = ('phi', 'theta')
     outputs = ('x', 'y')
 
-    input_units_strict = True
-    input_units_allow_dimensionless = True
+    _input_units_strict = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -96,9 +96,9 @@ class _EulerRotation:
             b.shape = shape
         return a, b
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def input_units(self):
@@ -347,9 +347,9 @@ class Rotation2D(Model):
 
     angle = Parameter(default=0.0, getter=_to_orig_unit, setter=_to_radian)
 
-    input_units_strict = True
+    _input_units_strict = True
 
-    input_units_allow_dimensionless = True
+    _input_units_allow_dimensionless = True
 
     @property
     def inverse(self):

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,8 +1,12 @@
 # Various tests of models not related to evaluation, fitting, or parameters
+import pytest
 
 from ...tests.helper import assert_quantity_allclose
 from ... import units as u
 from ..functional_models import Gaussian1D
+
+from astropy.modeling import models
+from astropy.modeling.core import Model, _ModelMeta
 
 
 def test_gaussian1d_bounding_box():
@@ -13,17 +17,18 @@ def test_gaussian1d_bounding_box():
 
 
 def test_gaussian1d_n_models():
-    g = Gaussian1D(amplitude=[1 * u.J, 2. * u.J],
-                   mean=[1 * u.m, 5000 * u.AA],
-                   stddev=[0.1 * u.m, 100 * u.AA],
-                   n_models=2)
+    g = Gaussian1D(
+        amplitude=[1 * u.J, 2. * u.J],
+        mean=[1 * u.m, 5000 * u.AA],
+        stddev=[0.1 * u.m, 100 * u.AA],
+        n_models=2)
     assert_quantity_allclose(g(1.01 * u.m), [0.99501248, 0.] * u.J)
-    assert_quantity_allclose(g(u.Quantity([1.01 * u.m, 5010 * u.AA])), [0.99501248, 1.990025] * u.J)
+    assert_quantity_allclose(
+        g(u.Quantity([1.01 * u.m, 5010 * u.AA])), [0.99501248, 1.990025] * u.J)
     # FIXME: The following doesn't work as np.asanyarray doesn't work with a
     # list of quantity objects.
     # assert_quantity_allclose(g([1.01 * u.m, 5010 * u.AA]),
     #                            [ 0.99501248, 1.990025] * u.J)
-
 
 
 """
@@ -31,25 +36,70 @@ Test the "rules" of model units.
 """
 
 
-def test_all_quantity_parameters():
-    pass
-
-
-def test_no_quantity_parameters():
-    pass
-
-
 def test_quantity_call():
-    pass
+    """
+    Test that if constructed with Quanties models must be called with quantities.
+    """
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.Jy)
+
+    g(10 * u.m)
+
+    with pytest.raises(ValueError):
+        g(10)
 
 
 def test_no_quantity_call():
-    pass
-
-
-def test_read_only():
     """
+    Test that if not constructed with Quantites they can be called without quantities.
+    """
+    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
+    assert isinstance(g, Gaussian1D)
+    g(10)
+
+
+def test_all_quantity_parameters():
+    """
+    Test that all parameters must be Quantities if any are.
+    """
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.Jy)
+    assert isinstance(g, Gaussian1D)
+
+    g = Gaussian1D()
+    g.mean = 3*u.m
+    g.stddev = 10*u.cm
+    g.amplitude = 10
+    with pytest.raises(ValueError):
+        g(10*u.m)
+
+    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
+    g.mean = 3*u.m
+    with pytest.raises(ValueError):
+        g(10*u.m)
+
+allmodels = []
+for name in dir(models):
+    model = getattr(models, name)
+    if type(model) is _ModelMeta:
+        try:
+            m = model()
+        except Exception:
+            pass
+        allmodels.append(m)
+
+
+@pytest.mark.parametrize("m", allmodels)
+def test_read_only(m):
+    """
+    input_units
     return_units
     input_units_allow_dimensionless
     input_units_strict
     """
+    with pytest.raises(AttributeError):
+        m.input_units = {}
+    with pytest.raises(AttributeError):
+        m.return_units = {}
+    with pytest.raises(AttributeError):
+        m.input_units_allow_dimensionless = {}
+    with pytest.raises(AttributeError):
+        m.input_units_strict = {}

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -57,6 +57,7 @@ def test_no_quantity_call():
     g(10)
 
 
+@pytest.mark.skip
 def test_all_quantity_parameters():
     """
     Test that all parameters must be Quantities if any are.
@@ -76,18 +77,27 @@ def test_all_quantity_parameters():
     with pytest.raises(ValueError):
         g(10*u.m)
 
-allmodels = []
-for name in dir(models):
-    model = getattr(models, name)
-    if type(model) is _ModelMeta:
-        try:
-            m = model()
-        except Exception:
-            pass
-        allmodels.append(m)
+
+def test_default_parameters():
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm)
+    assert isinstance(g, Gaussian1D)
+    g(10*u.m)
 
 
-@pytest.mark.parametrize("m", allmodels)
+def _allmodels():
+    allmodels = []
+    for name in dir(models):
+        model = getattr(models, name)
+        if type(model) is _ModelMeta:
+            try:
+                m = model()
+            except Exception:
+                pass
+            allmodels.append(m)
+    return allmodels
+
+
+@pytest.mark.parametrize("m", _allmodels())
 def test_read_only(m):
     """
     input_units

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -23,3 +23,33 @@ def test_gaussian1d_n_models():
     # list of quantity objects.
     # assert_quantity_allclose(g([1.01 * u.m, 5010 * u.AA]),
     #                            [ 0.99501248, 1.990025] * u.J)
+
+
+
+"""
+Test the "rules" of model units.
+"""
+
+
+def test_all_quantity_parameters():
+    pass
+
+
+def test_no_quantity_parameters():
+    pass
+
+
+def test_quantity_call():
+    pass
+
+
+def test_no_quantity_call():
+    pass
+
+
+def test_read_only():
+    """
+    return_units
+    input_units_allow_dimensionless
+    input_units_strict
+    """


### PR DESCRIPTION
This PR is a work in progress attempt at resolving some of the issues faced in #6952 by being much stricter about what you can do with units on `Model`s.

The things this PR tries to accomplish are:

* Make the following properties not user writeable:
  - `input_units`
  - `output_units`
  - `input_units_allow_dimensionless`
  - `input_units_strict`

* Disallow the mixing of quantity and non-quantity parameters
```python
    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3)
    g(10*u.m)
```
is no longer allowed (errors on call not instantiation).

* Disallow the mixing of quantity and non-quantity arguments (to `__call__`).

* Disallow calling a model with or without Quantities if the model was created with or without parameters as quantites.

i.e both:
```python
    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
    g(10*u.m)
```
and
```python
    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.J)
    g(10)
```
are invalid.

---

There are however, major issues with these rules and the way that default parameters are handled. Taking `Gaussian1D` as an example, it takes three parameters mean, stddev and amplitude. All of which have dimensionless defaults. As currently implemented the following now breaks:

```python
    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm)
    g(10*u.m)
```
because this is equivalent to:
```python
    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=1)
    g(10*u.m)
```

This means we need to decide on what we want the handling of:
```python
    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=1)
    g(10*u.m)
```
to be, because as far as I can tell, there is no way to know if a parameter *has it's default value or has been explicitly set with that value*?

We could either:

1. Assume all dimensionless input is implicitly `u.Quantity(value, u.one)`.
2. Error and force the user to be explicit about what they mean.
3. Don't error at all and reduce this PR to just making properties read-only.

@astrofrog @nden 