### PR TITLE
Enforce ASDF version compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -272,6 +272,9 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Make sure that a sufficiently recent version of ASDF is installed when
+  running test suite against ASDF tags and schemas. [#7205]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -9,9 +9,12 @@ from importlib.util import find_spec
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
-if find_spec('asdf') is not None:
-    pytest_plugins = ['asdf.tests.schema_tester']
 
+if find_spec('asdf') is not None:
+    from asdf import __version__ as asdf_version
+    if asdf_version >= '2.0.0':
+        pytest_plugins = ['asdf.tests.schema_tester']
+        PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
 
 enable_deprecations_as_exceptions(
     include_astropy_deprecations=False,

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf.tests.helpers import assert_roundtrip_tree
 
 from astropy import units

--- a/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from astropy.io import fits
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf.tests import helpers
 
 

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from astropy import table
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf.tests import helpers
 
 

--- a/astropy/io/misc/asdf/tags/time/tests/test_time.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_time.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from astropy import time
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf import AsdfFile, yamlutil, tagged
 from asdf.tests import helpers
 import asdf.schema as asdf_schema

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -4,7 +4,7 @@
 import pytest
 import numpy as np
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf import util
 from asdf.tests import helpers
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
@@ -6,7 +6,7 @@ import pytest
 
 from astropy import units
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf.tests import helpers
 
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
@@ -6,7 +6,7 @@ import pytest
 
 from astropy import units as u
 
-asdf = pytest.importorskip('asdf')
+asdf = pytest.importorskip('asdf', minversion='2.0.0')
 from asdf.tests import helpers
 
 


### PR DESCRIPTION
As of v3.0, Astropy provides some tags and schemas for ASDF. ASDF is already an optional dependency. However, we also need to check that a sufficiently recent version of ASDF is available in order to make these features available. Without this check, if an older version of ASDF is installed, errors will occur when running the test suite. 

This PR introduces minimum version checks for ASDF.

This addresses an issue that @jehturner mentioned in slack.