### PR TITLE
Display axes dimensions in summary of NonstandardExtHDU

### DIFF
--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1596,7 +1596,8 @@ class NonstandardExtHDU(ExtensionHDU):
                 xtension not in standard_xtensions)
 
     def _summary(self):
-        return (self.name, self.ver, 'NonstandardExtHDU', len(self._header))
+        axes = tuple(self.data.shape)
+        return (self.name, self.ver, 'NonstandardExtHDU', len(self._header), axes)
 
     @lazyproperty
     def data(self):


### PR DESCRIPTION
It seems like there's no reason not to do this: it just wasn't implemented until now.

@saimn this is a pretty minor and unobtrusive change. However, I think it could be handled in a more general way by defining things like `_summary` and `_axes` higher in the HDU class hierarchy. Let me know whether you think that's worth addressing here, though.

Not sure if something this minor requires a change log or not.