### PR TITLE
Fix ID lookup error in to_table()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -276,6 +276,8 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Fix lookup fields by ID. [#7208]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -107,6 +107,17 @@ def test_names_over_ids():
         'Emag', '24mag', 'f_Name']
 
 
+def test_explicit_ids():
+    with get_pkg_data_fileobj('data/names.xml', encoding='binary') as fd:
+        votable = parse(fd)
+
+    table = votable.get_first_table().to_table(use_names_over_ids=False)
+
+    assert table.colnames == [
+        'col1', 'col2', 'col3', 'col4', 'col5', 'col6', 'col7', 'col8', 'col9',
+        'col10', 'col11', 'col12', 'col13', 'col14', 'col15', 'col16', 'col17']
+
+
 def test_table_read_with_unnamed_tables():
     """
     Issue #927

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2860,14 +2860,11 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     new_name = '{0}{1}'.format(name, i)
                     i += 1
                 unique_names.append(new_name)
-            array = self.array.copy()
-            array.dtype.names = unique_names
             names = unique_names
         else:
-            array = self.array
             names = [field.ID for field in self.fields]
 
-        table = Table(self.array, meta=meta)
+        table = Table(self.array, names=names, meta=meta)
 
         for name, field in zip(names, self.fields):
             column = table[name]


### PR DESCRIPTION
PR for https://github.com/astropy/astropy/issues/7203 for discussion

This change allows to actually lookup fields by ID.

names is now explicitly passed to the Table constructor,
and the array.copy() call is removed because this is already done in the
constructor