### PR TITLE
Make unit related attributes on model read-only

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -310,6 +310,12 @@ astropy.modeling
 - Fix the shape of the outputs when a model set is evaluated with
   ``model_set_axis=False`` . [#7317]
 
+- Fix behaviour of certain models with units, by making certain unit-related
+  attributes readonly. [#7210]
+
+- Add a ``Multiply`` model which preseves unit through evaluate, unlike
+  ``Scale`` which is dimensionless. [#7210]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -72,6 +72,31 @@ class ScaleType(TransformType):
         assert_array_equal(a.factor, b.factor)
 
 
+class MultiplyType(TransformType):
+    name = "transform/multiplyscale"
+    version = '1.0.0'
+    types = ['astropy.modeling.models.Multiply']
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        factor = node['factor']
+        return modeling.models.Multiply(factor)
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        factor = model.factor
+        node = {'factor': _parameter_to_value(factor)}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+    @classmethod
+    def assert_equal(cls, a, b):
+        # TODO: If models become comparable themselves, remove this.
+        TransformType.assert_equal(a, b)
+        assert (isinstance(a, modeling.models.Multiply) and
+                isinstance(b, modeling.models.Multiply))
+        assert_array_equal(a.factor, b.factor)
+
+
 class PolynomialType(TransformType):
     name = "transform/polynomial"
     types = ['astropy.modeling.models.Polynomial1D',

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -11,7 +11,7 @@ from astropy import modeling
 from .basic import TransformType
 from . import _parameter_to_value
 
-__all__ = ['ShiftType', 'ScaleType', 'PolynomialType']
+__all__ = ['ShiftType', 'ScaleType', 'PolynomialType', 'Linear1DType']
 
 
 class ShiftType(TransformType):

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -11,7 +11,7 @@ from astropy import modeling
 from .basic import TransformType
 from . import _parameter_to_value
 
-__all__ = ['ShiftType', 'ScaleType', 'PolynomialType', 'Linear1DType']
+__all__ = ['ShiftType', 'ScaleType', 'PolynomialType']
 
 
 class ShiftType(TransformType):

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -15,6 +15,7 @@ test_models = [
     astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
     astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
     astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
+    astmodels.Multiply(3), astmodels.Multiply(10*u.m),
     astmodels.RotateCelestial2Native(5.63, -72.5, 180),
     astmodels.EulerAngleRotation(23, 14, 2.3, axes_order='xzx'),
     astmodels.Mapping((0, 1), n_inputs=3),

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -709,13 +709,6 @@ class Model(metaclass=_ModelMeta):
         """
         return self._input_units_strict
 
-    @input_units_strict.setter
-    def input_units_strict(self, val):
-        if isinstance(val, bool):
-            self._input_units_strict = {key: val for key in self.__class__.inputs}
-        else:
-            self._input_units_strict = val
-
     @property
     def input_units_allow_dimensionless(self):
         """
@@ -726,13 +719,6 @@ class Model(metaclass=_ModelMeta):
         Only has an effect if input_units is defined.
         """
         return self._input_units_allow_dimensionless
-
-    @input_units_allow_dimensionless.setter
-    def input_units_allow_dimensionless(self, val):
-        if isinstance(val, bool):
-            self._input_units_allow_dimensionless = {key: val for key in self.__class__.inputs}
-        else:
-            self._input_units_allow_dimensionless = val
 
     def __repr__(self):
         return self._format_repr()
@@ -1424,10 +1410,6 @@ class Model(metaclass=_ModelMeta):
             # None means any unit is accepted
             return None
 
-    @input_units.setter
-    def input_units(self, input_units):
-        self._input_units = input_units
-
     @property
     def return_units(self):
         """
@@ -1447,10 +1429,6 @@ class Model(metaclass=_ModelMeta):
         else:
             # None means any unit is accepted
             return None
-
-    @return_units.setter
-    def return_units(self, return_units):
-        self._return_units = return_units
 
     def prepare_inputs(self, *inputs, model_set_axis=None, equivalencies=None,
                        **kwargs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -707,7 +707,11 @@ class Model(metaclass=_ModelMeta):
         they are converted. If this is a dictionary then it should map input
         name to a bool to set strict input units for that parameter.
         """
-        return self._input_units_strict
+        val = self._input_units_strict
+        if isinstance(val, bool):
+            return {key: val for key in self.__class__.inputs}
+        else:
+            return val
 
     @property
     def input_units_allow_dimensionless(self):
@@ -718,7 +722,11 @@ class Model(metaclass=_ModelMeta):
         dimensionless numbers for that input.
         Only has an effect if input_units is defined.
         """
-        return self._input_units_allow_dimensionless
+        val = self._input_units_allow_dimensionless
+        if isinstance(val, bool):
+            return {key: val for key in self.__class__.inputs}
+        else:
+            return val
 
     def __repr__(self):
         return self._format_repr()
@@ -735,9 +743,6 @@ class Model(metaclass=_ModelMeta):
         that were specified when the model was instantiated.
         """
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
-
-        # Check whether any of the inputs are quantities
-        inputs_are_quantity = any([isinstance(i, Quantity) for i in inputs])
 
         parameters = self._param_sets(raw=True, units=True)
         with_bbox = kwargs.pop('with_bounding_box', False)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1562,7 +1562,7 @@ class Model(metaclass=_ModelMeta):
             else:
                 return_units = self.return_units
 
-            outputs = tuple([Quantity(out, return_units[out_name], subok=True)
+            outputs = tuple([Quantity(out, return_units.get(out_name, None), subok=True)
                             for out, out_name in zip(outputs, self.outputs)])
 
         return outputs

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -461,10 +461,6 @@ class Shift(Fittable1DModel):
     offset = Parameter(default=0)
     linear = True
 
-    _input_units_strict = True
-
-    _input_units_allow_dimensionless = True
-
     @property
     def input_units(self):
         if self.offset.unit is None:
@@ -513,17 +509,6 @@ class Scale(Fittable1DModel):
     factor = Parameter(default=1)
     linear = True
     fittable = True
-
-    _input_units_strict = True
-
-    _input_units_allow_dimensionless = True
-
-    @property
-    def input_units(self):
-        if self.factor.unit is None:
-            return None
-        else:
-            return {'x': self.factor.unit}
 
     @property
     def inverse(self):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -19,7 +19,7 @@ __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
            'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D',
            'Gaussian2D', 'Linear1D', 'Lorentz1D',
            'MexicanHat1D', 'MexicanHat2D', 'RedshiftScaleFactor',
-           'Scale', 'Sersic1D', 'Sersic2D', 'Shift', 'Sine1D', 'Trapezoid1D',
+           'Scale', 'Multiply', 'Sersic1D', 'Sersic2D', 'Shift', 'Sine1D', 'Trapezoid1D',
            'TrapezoidDisk2D', 'Ring2D', 'Voigt1D']
 
 TWOPI = 2 * np.pi

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -55,8 +55,8 @@ class Mapping(FittableModel):
                                  for idx in range(n_inputs))
         self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
-        self.input_units_strict = {key: False for key in self._inputs}
-        self.input_units_allow_dimensionless = {key: False for key in self._inputs}
+        self._input_units_strict = {key: False for key in self._inputs}
+        self._input_units_allow_dimensionless = {key: False for key in self._inputs}
         super().__init__(name=name, meta=meta)
 
 

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -386,7 +386,7 @@ class Rotation2D(Model):
         orig_shape = x.shape or (1,)
         inarr = np.array([x.flatten(), y.flatten()])
         if isinstance(angle, u.Quantity):
-            angle = angle.value
+            angle = angle.to_value(u.rad)
         result = np.dot(cls._compute_matrix(angle), inarr)
         x, y = result[0], result[1]
         x.shape = y.shape = orig_shape

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -171,6 +171,11 @@ def test_Scale_inverse():
     assert_allclose(m.inverse(m(6.789)), 6.789)
 
 
+def test_Multiply_inverse():
+    m = models.Multiply(1.2345)
+    assert_allclose(m.inverse(m(6.789)), 6.789)
+
+
 def test_Shift_inverse():
     m = models.Shift(1.2345)
     assert_allclose(m.inverse(m(6.789)), 6.789)
@@ -205,10 +210,11 @@ def test_Shift_model_set_linear_fit():
     assert_allclose(fitted_model.parameters, [0.1, -0.2], atol=1e-15)
 
 
-def test_Scale_model_set_linear_fit():
+@pytest.mark.parametrize('Model', (models.Scale, models.Multiply))
+def test_Scale_model_set_linear_fit(Model):
     """Test linear fitting of Scale model (#6103)."""
 
-    init_model = models.Scale(factor=[0, 0], n_models=2)
+    init_model = Model(factor=[0, 0], n_models=2)
 
     x = np.arange(-3, 7)
     yy = np.array([1.15*x, 0.96*x])

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -107,7 +107,7 @@ class TestInputUnits():
 
     def test_input_units(self):
 
-        self.model.input_units = {'a': u.deg}
+        self.model._input_units = {'a': u.deg}
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
         assert_quantity_allclose(self.model(4 * u.rad, 2), 8 * u.rad)
@@ -125,8 +125,8 @@ class TestInputUnits():
 
     def test_input_units_allow_dimensionless(self):
 
-        self.model.input_units = {'a': u.deg}
-        self.model.input_units_allow_dimensionless = True
+        self.model._input_units = {'a': u.deg}
+        self.model._input_units_allow_dimensionless = True
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
         assert_quantity_allclose(self.model(4 * u.rad, 2), 8 * u.rad)
@@ -140,8 +140,8 @@ class TestInputUnits():
 
     def test_input_units_strict(self):
 
-        self.model.input_units = {'a': u.deg}
-        self.model.input_units_strict = True
+        self.model._input_units = {'a': u.deg}
+        self.model._input_units_strict = True
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
 
@@ -151,7 +151,7 @@ class TestInputUnits():
 
     def test_input_units_equivalencies(self):
 
-        self.model.input_units = {'a': u.micron}
+        self.model._input_units = {'a': u.micron}
 
         with pytest.raises(UnitsError) as exc:
             self.model(3 * u.PHz, 3)
@@ -166,8 +166,8 @@ class TestInputUnits():
 
     def test_return_units(self):
 
-        self.model.input_units = {'a': u.deg}
-        self.model.return_units = {'f': u.rad}
+        self.model._input_units = {'a': u.deg}
+        self.model._return_units = {'f': u.rad}
 
         result = self.model(3 * u.deg, 4)
 
@@ -179,8 +179,8 @@ class TestInputUnits():
         # Check that return_units also works when giving a single unit since
         # there is only one output, so is unambiguous.
 
-        self.model.input_units = {'a': u.deg}
-        self.model.return_units = u.rad
+        self.model._input_units = {'a': u.deg}
+        self.model._return_units = u.rad
 
         result = self.model(3 * u.deg, 4)
 

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -357,7 +357,7 @@ def test_compound_input_units_allow_dimensionless():
         input_units = {'x': u.deg}
 
     s1 = ScaleDegrees(2)
-    s1.input_units_allow_dimensionless = True
+    s1._input_units_allow_dimensionless = True
     s2 = Scale(2)
 
     cs = s1 | s2
@@ -372,7 +372,7 @@ def test_compound_input_units_allow_dimensionless():
         out = cs(10 * u.m)
     assert exc.value.args[0] == "TestModel: Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
 
-    s1.input_units_allow_dimensionless = False
+    s1._input_units_allow_dimensionless = False
 
     cs = s1 | s2
     cs = cs.rename('TestModel')
@@ -381,7 +381,7 @@ def test_compound_input_units_allow_dimensionless():
         out = cs(10)
     assert exc.value.args[0] == "TestModel: Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
 
-    s1.input_units_allow_dimensionless = True
+    s1._input_units_allow_dimensionless = True
 
     cs = s2 | s1
     cs = cs.rename('TestModel')
@@ -396,7 +396,7 @@ def test_compound_input_units_allow_dimensionless():
         out = cs(10 * u.m)
     assert exc.value.args[0] == "ScaleDegrees: Units of input 'x', m (length), could not be converted to required input units of deg (angle)"
 
-    s1.input_units_allow_dimensionless = False
+    s1._input_units_allow_dimensionless = False
 
     cs = s2 | s1
 
@@ -404,12 +404,12 @@ def test_compound_input_units_allow_dimensionless():
         out = cs(10)
     assert exc.value.args[0] == "ScaleDegrees: Units of input 'x', (dimensionless), could not be converted to required input units of deg (angle)"
 
-    s1.input_units_allow_dimensionless = True
+    s1._input_units_allow_dimensionless = True
 
     s1 = ScaleDegrees(2)
-    s1.input_units_allow_dimensionless = True
+    s1._input_units_allow_dimensionless = True
     s2 = ScaleDegrees(2)
-    s2.input_units_allow_dimensionless = False
+    s2._input_units_allow_dimensionless = False
 
     cs = s1 & s2
     cs = cs.rename('TestModel')

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,8 +1,12 @@
 # Various tests of models not related to evaluation, fitting, or parameters
+import pytest
 
 from ...tests.helper import assert_quantity_allclose
 from ... import units as u
 from ..functional_models import Gaussian1D
+
+from astropy.modeling import models
+from astropy.modeling.core import Model, _ModelMeta
 
 
 def test_gaussian1d_bounding_box():
@@ -13,13 +17,78 @@ def test_gaussian1d_bounding_box():
 
 
 def test_gaussian1d_n_models():
-    g = Gaussian1D(amplitude=[1 * u.J, 2. * u.J],
-                   mean=[1 * u.m, 5000 * u.AA],
-                   stddev=[0.1 * u.m, 100 * u.AA],
-                   n_models=2)
+    g = Gaussian1D(
+        amplitude=[1 * u.J, 2. * u.J],
+        mean=[1 * u.m, 5000 * u.AA],
+        stddev=[0.1 * u.m, 100 * u.AA],
+        n_models=2)
     assert_quantity_allclose(g(1.01 * u.m), [0.99501248, 0.] * u.J)
-    assert_quantity_allclose(g(u.Quantity([1.01 * u.m, 5010 * u.AA])), [0.99501248, 1.990025] * u.J)
+    assert_quantity_allclose(
+        g(u.Quantity([1.01 * u.m, 5010 * u.AA])), [0.99501248, 1.990025] * u.J)
     # FIXME: The following doesn't work as np.asanyarray doesn't work with a
     # list of quantity objects.
     # assert_quantity_allclose(g([1.01 * u.m, 5010 * u.AA]),
     #                            [ 0.99501248, 1.990025] * u.J)
+
+
+"""
+Test the "rules" of model units.
+"""
+
+
+def test_quantity_call():
+    """
+    Test that if constructed with Quanties models must be called with quantities.
+    """
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.Jy)
+
+    g(10 * u.m)
+
+    with pytest.raises(u.UnitsError):
+        g(10)
+
+
+def test_no_quantity_call():
+    """
+    Test that if not constructed with Quantites they can be called without quantities.
+    """
+    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
+    assert isinstance(g, Gaussian1D)
+    g(10)
+
+
+def test_default_parameters():
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm)
+    assert isinstance(g, Gaussian1D)
+    g(10*u.m)
+
+
+def _allmodels():
+    allmodels = []
+    for name in dir(models):
+        model = getattr(models, name)
+        if type(model) is _ModelMeta:
+            try:
+                m = model()
+            except Exception:
+                pass
+            allmodels.append(m)
+    return allmodels
+
+
+@pytest.mark.parametrize("m", _allmodels())
+def test_read_only(m):
+    """
+    input_units
+    return_units
+    input_units_allow_dimensionless
+    input_units_strict
+    """
+    with pytest.raises(AttributeError):
+        m.input_units = {}
+    with pytest.raises(AttributeError):
+        m.return_units = {}
+    with pytest.raises(AttributeError):
+        m.input_units_allow_dimensionless = {}
+    with pytest.raises(AttributeError):
+        m.input_units_strict = {}

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -58,6 +58,8 @@ def test_no_quantity_call():
 
 
 def test_default_parameters():
+    # Test that calling with a quantity works when one of the parameters
+    # defaults to dimensionless
     g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm)
     assert isinstance(g, Gaussian1D)
     g(10*u.m)

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -7,6 +7,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
+import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
+
 from .. import models
 from ...wcs import wcs
 
@@ -53,6 +56,12 @@ def test_Rotation2D():
     model = models.Rotation2D(angle=90)
     x, y = model(1, 0)
     assert_allclose([x, y], [0, 1], atol=1e-10)
+
+
+def test_Rotation2D_quantity():
+    model = models.Rotation2D(angle=90*u.deg)
+    x, y = model(1*u.deg, 0*u.arcsec)
+    assert_quantity_allclose([x, y], [0, 1]*u.deg, atol=1e-10*u.deg)
 
 
 def test_Rotation2D_inverse():


### PR DESCRIPTION
The motivation for this is that these parameters describe how the model is implemented, so should not be user settable.

This also does a little refactoring of how some of the models use these attributes currently.

This is a much less tricky and less controversial subset of #7204.