### PR TITLE
Smart formatting of tick labels in WCSAxes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4
   image-tests-mpl153:
     docker:
-      - image: astropy/image-tests-py35-mpl153:1.0
+      - image: astropy/image-tests-py35-mpl153:1.2
     steps:
       - checkout
       - run:
@@ -25,7 +25,7 @@ jobs:
             coveralls || true
   image-tests-mpl202:
     docker:
-      - image: astropy/image-tests-py35-mpl202:1.0
+      - image: astropy/image-tests-py35-mpl202:1.2
     steps:
       - checkout
       - run:
@@ -36,7 +36,7 @@ jobs:
             coveralls || true
   image-tests-mpl212:
     docker:
-      - image: astropy/image-tests-py35-mpl212:1.0
+      - image: astropy/image-tests-py35-mpl212:1.2
     steps:
       - checkout
       - run:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,6 +340,10 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Right ascension coordinates are now shown in hours by default, and the
+  ``set_format_unit`` method on ``CoordinateHelper`` now works correctly
+  with angle coordinates. [#7215]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -242,6 +242,10 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Right ascension coordinates are now shown in hours by default, and the
+  ``set_format_unit`` method on ``CoordinateHelper`` now works correctly
+  with angle coordinates. [#7215]
+
 astropy.wcs
 ^^^^^^^^^^^
 
@@ -339,10 +343,6 @@ astropy.utils
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
-
-- Right ascension coordinates are now shown in hours by default, and the
-  ``set_format_unit`` method on ``CoordinateHelper`` now works correctly
-  with angle coordinates. [#7215]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -61,8 +61,9 @@ class CoordinateHelper:
         The frame of the :class:`~astropy.visualization.wcsaxes.WCSAxes`.
     """
 
-    def __init__(self, parent_axes=None, parent_map=None, transform=None, coord_index=None,
-                 coord_type='scalar', coord_unit=None, coord_wrap=None, frame=None, coord_display_unit=None):
+    def __init__(self, parent_axes=None, parent_map=None, transform=None,
+                 coord_index=None, coord_type='scalar', coord_unit=None,
+                 coord_wrap=None, frame=None, display_unit=None):
 
         # Keep a reference to the parent axes and the transform
         self.parent_axes = parent_axes
@@ -70,7 +71,7 @@ class CoordinateHelper:
         self.transform = transform
         self.coord_index = coord_index
         self.coord_unit = coord_unit
-        self.coord_display_unit = coord_display_unit
+        self.display_unit = display_unit
         self.frame = frame
 
         self.set_coord_type(coord_type, coord_wrap)
@@ -188,7 +189,7 @@ class CoordinateHelper:
             else:
                 self._coord_unit_scale = self.coord_unit.to(u.deg)
             self._formatter_locator = AngleFormatterLocator(unit=self.coord_unit,
-                                                            format_unit=self.coord_display_unit)
+                                                            format_unit=self.display_unit)
         else:
             raise ValueError("coord_type should be one of 'scalar', 'longitude', or 'latitude'")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -69,10 +69,9 @@ class CoordinateHelper:
         self.parent_map = parent_map
         self.transform = transform
         self.coord_index = coord_index
-        self.coord_unit = coord_unit
         self.frame = frame
 
-        self.set_coord_type(coord_type, coord_wrap)
+        self.set_coord_type(coord_type, coord_unit, coord_wrap)
 
         # Initialize ticks
         self.dpi_transform = Affine2D()
@@ -152,7 +151,7 @@ class CoordinateHelper:
         else:
             self.grid_lines_kwargs['visible'] = True
 
-    def set_coord_type(self, coord_type, coord_wrap=None):
+    def set_coord_type(self, coord_type, coord_unit=None, coord_wrap=None):
         """
         Set the coordinate type for the axis.
 
@@ -160,10 +159,14 @@ class CoordinateHelper:
         ----------
         coord_type : str
             One of 'longitude', 'latitude' or 'scalar'
+        coord_unit : `~astropy.units.Unit`
+            The default unit to use for formatting if an explicit format is
+            not given.
         coord_wrap : float, optional
             The value to wrap at for angular coordinates
         """
 
+        self.coord_unit = coord_unit
         self.coord_type = coord_type
 
         if coord_type == 'longitude' and coord_wrap is None:
@@ -183,7 +186,7 @@ class CoordinateHelper:
                 self._coord_unit_scale = None
             else:
                 self._coord_unit_scale = self.coord_unit.to(u.deg)
-            self._formatter_locator = AngleFormatterLocator()
+            self._formatter_locator = AngleFormatterLocator(unit=self.coord_unit)
         else:
             raise ValueError("coord_type should be one of 'scalar', 'longitude', or 'latitude'")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -269,9 +269,7 @@ class CoordinateHelper:
         unit : class:`~astropy.units.Unit`
             The unit to which the tick labels should be converted to.
         """
-        if not issubclass(unit.__class__, u.UnitBase):
-            raise TypeError("unit should be an astropy UnitBase subclass")
-        self._formatter_locator.format_unit = unit
+        self._formatter_locator.format_unit = u.Unit(unit)
 
     def set_ticks(self, values=None, spacing=None, number=None, size=None,
                   width=None, color=None, alpha=None, exclude_overlapping=False):

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -55,6 +55,8 @@ class CoordinateHelper:
         and do not wrap.
     coord_unit : `~astropy.units.Unit`
         The unit that this coordinate is in given the output of transform.
+    format_unit : `~astropy.units.Unit`, optional
+        The unit to use to display the coordinates.
     coord_wrap : float
         The angle at which the longitude wraps (defaults to 360)
     frame : `~astropy.visualization.wcsaxes.frame.BaseFrame`
@@ -63,7 +65,7 @@ class CoordinateHelper:
 
     def __init__(self, parent_axes=None, parent_map=None, transform=None,
                  coord_index=None, coord_type='scalar', coord_unit=None,
-                 coord_wrap=None, frame=None, display_unit=None):
+                 coord_wrap=None, frame=None, format_unit=None):
 
         # Keep a reference to the parent axes and the transform
         self.parent_axes = parent_axes
@@ -71,7 +73,7 @@ class CoordinateHelper:
         self.transform = transform
         self.coord_index = coord_index
         self.coord_unit = coord_unit
-        self.display_unit = display_unit
+        self.format_unit = format_unit
         self.frame = frame
 
         self.set_coord_type(coord_type, coord_wrap)
@@ -162,9 +164,6 @@ class CoordinateHelper:
         ----------
         coord_type : str
             One of 'longitude', 'latitude' or 'scalar'
-        coord_unit : `~astropy.units.Unit`
-            The default unit to use for formatting if an explicit format is
-            not given.
         coord_wrap : float, optional
             The value to wrap at for angular coordinates
         """
@@ -189,7 +188,7 @@ class CoordinateHelper:
             else:
                 self._coord_unit_scale = self.coord_unit.to(u.deg)
             self._formatter_locator = AngleFormatterLocator(unit=self.coord_unit,
-                                                            format_unit=self.display_unit)
+                                                            format_unit=self.format_unit)
         else:
             raise ValueError("coord_type should be one of 'scalar', 'longitude', or 'latitude'")
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -62,16 +62,18 @@ class CoordinateHelper:
     """
 
     def __init__(self, parent_axes=None, parent_map=None, transform=None, coord_index=None,
-                 coord_type='scalar', coord_unit=None, coord_wrap=None, frame=None):
+                 coord_type='scalar', coord_unit=None, coord_wrap=None, frame=None, coord_display_unit=None):
 
         # Keep a reference to the parent axes and the transform
         self.parent_axes = parent_axes
         self.parent_map = parent_map
         self.transform = transform
         self.coord_index = coord_index
+        self.coord_unit = coord_unit
+        self.coord_display_unit = coord_display_unit
         self.frame = frame
 
-        self.set_coord_type(coord_type, coord_unit, coord_wrap)
+        self.set_coord_type(coord_type, coord_wrap)
 
         # Initialize ticks
         self.dpi_transform = Affine2D()
@@ -151,7 +153,7 @@ class CoordinateHelper:
         else:
             self.grid_lines_kwargs['visible'] = True
 
-    def set_coord_type(self, coord_type, coord_unit=None, coord_wrap=None):
+    def set_coord_type(self, coord_type, coord_wrap=None):
         """
         Set the coordinate type for the axis.
 
@@ -166,7 +168,6 @@ class CoordinateHelper:
             The value to wrap at for angular coordinates
         """
 
-        self.coord_unit = coord_unit
         self.coord_type = coord_type
 
         if coord_type == 'longitude' and coord_wrap is None:
@@ -186,7 +187,8 @@ class CoordinateHelper:
                 self._coord_unit_scale = None
             else:
                 self._coord_unit_scale = self.coord_unit.to(u.deg)
-            self._formatter_locator = AngleFormatterLocator(unit=self.coord_unit)
+            self._formatter_locator = AngleFormatterLocator(unit=self.coord_unit,
+                                                            format_unit=self.coord_display_unit)
         else:
             raise ValueError("coord_type should be one of 'scalar', 'longitude', or 'latitude'")
 
@@ -207,7 +209,7 @@ class CoordinateHelper:
             raise TypeError("formatter should be a string or a Formatter "
                             "instance")
 
-    def format_coord(self, value):
+    def format_coord(self, value, plain=False):
         """
         Given the value of a coordinate, will format it according to the
         format of the formatter_locator.
@@ -229,7 +231,7 @@ class CoordinateHelper:
             value = value.to_value(fl._unit)
 
         spacing = self._fl_spacing
-        string = fl.formatter(values=[value] * fl._unit, spacing=spacing)
+        string = fl.formatter(values=[value] * fl._unit, spacing=spacing, plain=plain)
 
         return string[0]
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -130,7 +130,7 @@ class CoordinateHelper:
         ----------
         draw_grid : bool
             Whether to show the gridlines
-        grid_type : { 'lines' | 'contours' }
+        grid_type : {'lines', 'contours'}
             Whether to plot the contours by determining the grid lines in
             world coordinates and then plotting them in world coordinates
             (``'lines'``) or by determining the world coordinates at many
@@ -218,7 +218,7 @@ class CoordinateHelper:
         ----------
         value : float
             The value to format
-        format : { 'auto' | 'ascii' | 'latex' }, optional
+        format : {'auto', 'ascii', 'latex'}, optional
             The format to use - by default the formatting will be adjusted
             depending on whether Matplotlib is using LaTeX or MathTex. To
             get plain ASCII strings, use format='ascii'.

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -209,10 +209,19 @@ class CoordinateHelper:
             raise TypeError("formatter should be a string or a Formatter "
                             "instance")
 
-    def format_coord(self, value, plain=False):
+    def format_coord(self, value, format='auto'):
         """
         Given the value of a coordinate, will format it according to the
         format of the formatter_locator.
+
+        Parameters
+        ----------
+        value : float
+            The value to format
+        format : { 'auto' | 'ascii' | 'latex' }, optional
+            The format to use - by default the formatting will be adjusted
+            depending on whether Matplotlib is using LaTeX or MathTex. To
+            get plain ASCII strings, use format='ascii'.
         """
 
         if not hasattr(self, "_fl_spacing"):
@@ -231,7 +240,7 @@ class CoordinateHelper:
             value = value.to_value(fl._unit)
 
         spacing = self._fl_spacing
-        string = fl.formatter(values=[value] * fl._unit, spacing=spacing, plain=plain)
+        string = fl.formatter(values=[value] * fl._unit, spacing=spacing, format=format)
 
         return string[0]
 

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -101,6 +101,7 @@ class CoordinatesMap:
                     coord_wrap = coord_meta['wrap'][coord_index]
                     coord_unit = coord_meta['unit'][coord_index]
                     name = coord_meta['name'][coord_index]
+                    format_unit = None
                 except IndexError:
                     raise ValueError("coord_meta items should have a length of {0}".format(len(wcs.wcs.naxis)))
 

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -92,15 +92,17 @@ class CoordinatesMap:
 
             # Extract coordinate metadata from WCS object or transform
             if wcs is not None:
-                coord_type, coord_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
-                if coord_unit is None:
-                    coord_unit = wcs.wcs.cunit[coord_index]
+                coord_unit = wcs.wcs.cunit[coord_index]
+                coord_type, coord_display_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
+                if coord_display_unit is None:
+                    coord_display_unit = coord_unit
                 name = wcs.wcs.ctype[coord_index][:4].replace('-', '')
             else:
                 try:
                     coord_type = coord_meta['type'][coord_index]
                     coord_wrap = coord_meta['wrap'][coord_index]
                     coord_unit = coord_meta['unit'][coord_index]
+                    coord_display_unit = coord_unit
                     name = coord_meta['name'][coord_index]
                 except IndexError:
                     raise ValueError("coord_meta items should have a length of {0}".format(len(wcs.wcs.naxis)))
@@ -112,6 +114,7 @@ class CoordinatesMap:
                                                  coord_type=coord_type,
                                                  coord_wrap=coord_wrap,
                                                  coord_unit=coord_unit,
+                                                 coord_display_unit=coord_display_unit,
                                                  frame=self.frame))
 
             # Set up aliases for coordinates

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -93,7 +93,7 @@ class CoordinatesMap:
             # Extract coordinate metadata from WCS object or transform
             if wcs is not None:
                 coord_unit = wcs.wcs.cunit[coord_index]
-                coord_type, display_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
+                coord_type, format_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
                 name = wcs.wcs.ctype[coord_index][:4].replace('-', '')
             else:
                 try:
@@ -111,7 +111,7 @@ class CoordinatesMap:
                                                  coord_type=coord_type,
                                                  coord_wrap=coord_wrap,
                                                  coord_unit=coord_unit,
-                                                 display_unit=display_unit,
+                                                 format_unit=format_unit,
                                                  frame=self.frame))
 
             # Set up aliases for coordinates

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -93,16 +93,13 @@ class CoordinatesMap:
             # Extract coordinate metadata from WCS object or transform
             if wcs is not None:
                 coord_unit = wcs.wcs.cunit[coord_index]
-                coord_type, coord_display_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
-                if coord_display_unit is None:
-                    coord_display_unit = coord_unit
+                coord_type, display_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
                 name = wcs.wcs.ctype[coord_index][:4].replace('-', '')
             else:
                 try:
                     coord_type = coord_meta['type'][coord_index]
                     coord_wrap = coord_meta['wrap'][coord_index]
                     coord_unit = coord_meta['unit'][coord_index]
-                    coord_display_unit = coord_unit
                     name = coord_meta['name'][coord_index]
                 except IndexError:
                     raise ValueError("coord_meta items should have a length of {0}".format(len(wcs.wcs.naxis)))
@@ -114,7 +111,7 @@ class CoordinatesMap:
                                                  coord_type=coord_type,
                                                  coord_wrap=coord_wrap,
                                                  coord_unit=coord_unit,
-                                                 coord_display_unit=coord_display_unit,
+                                                 display_unit=display_unit,
                                                  frame=self.frame))
 
             # Set up aliases for coordinates

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -92,8 +92,9 @@ class CoordinatesMap:
 
             # Extract coordinate metadata from WCS object or transform
             if wcs is not None:
-                coord_type, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
-                coord_unit = wcs.wcs.cunit[coord_index]
+                coord_type, coord_unit, coord_wrap = coord_type_from_ctype(wcs.wcs.ctype[coord_index])
+                if coord_unit is None:
+                    coord_unit = wcs.wcs.cunit[coord_index]
                 name = wcs.wcs.ctype[coord_index][:4].replace('-', '')
             else:
                 try:

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -133,7 +133,7 @@ class WCSAxes(Axes):
 
         world = coords._transform.transform(np.array([pixel]))[0]
 
-        xw = coords[self._x_index].format_coord(world[self._x_index])
+        xw = coords[self._x_index].format_coord(world[self._x_index], plain=True)
         yw = coords[self._y_index].format_coord(world[self._y_index])
 
         if self._display_coords_index == 0:

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -134,7 +134,7 @@ class WCSAxes(Axes):
         world = coords._transform.transform(np.array([pixel]))[0]
 
         xw = coords[self._x_index].format_coord(world[self._x_index], plain=True)
-        yw = coords[self._y_index].format_coord(world[self._y_index])
+        yw = coords[self._y_index].format_coord(world[self._y_index], plain=True)
 
         if self._display_coords_index == 0:
             system = "world"

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -133,8 +133,8 @@ class WCSAxes(Axes):
 
         world = coords._transform.transform(np.array([pixel]))[0]
 
-        xw = coords[self._x_index].format_coord(world[self._x_index], plain=True)
-        yw = coords[self._y_index].format_coord(world[self._y_index], plain=True)
+        xw = coords[self._x_index].format_coord(world[self._x_index], format='ascii')
+        yw = coords[self._y_index].format_coord(world[self._y_index], format='ascii')
 
         if self._display_coords_index == 0:
             system = "world"

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -97,9 +97,7 @@ class BaseFormatterLocator:
 
     @format_unit.setter
     def format_unit(self, unit):
-        if not issubclass(unit.__class__, u.UnitBase):
-            raise TypeError("unit should be an astropy UnitBase subclass")
-        self._format_unit = unit
+        self._format_unit = u.Unit(unit)
 
     @staticmethod
     def _locate_values(value_min, value_max, spacing):

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -303,7 +303,6 @@ class AngleFormatterLocator(BaseFormatterLocator):
             raise TypeError("values should be a Quantities array")
 
         if len(values) > 0:
-
             decimal = self._decimal
             unit = self._format_unit
 

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -299,7 +299,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
             values = self._locate_values(value_min, value_max, spacing_deg)
             return values * spacing_deg * u.degree, spacing_deg * u.degree
 
-    def formatter(self, values, spacing, plain=False):
+    def formatter(self, values, spacing, format='auto'):
 
         if not isinstance(values, u.Quantity) and values is not None:
             raise TypeError("values should be a Quantities array")
@@ -353,17 +353,20 @@ class AngleFormatterLocator(BaseFormatterLocator):
             else:
                 sep = 'fromunit'
                 if unit == u.degree:
-                    if rcParams['text.usetex']:
+                    if format == 'latex' or (format == 'auto' and rcParams['text.usetex']):
                         fmt = 'latex'
                     else:
                         sep = ('\xb0', "'", '"')
                         fmt = None
                 else:
-                    if plain:
+                    if format == 'ascii':
                         fmt = None
-                    elif rcParams['text.usetex']:
+                    elif format == 'latex' or (format == 'auto' and rcParams['text.usetex']):
                         fmt = 'latex'
                     else:
+                        # Here we still use LaTeX but this is for Matplotlib's
+                        # LaTeX engine - we can't use fmt='latex' as this
+                        # doesn't produce LaTeX output that respects the fonts.
                         sep = (r'$\mathregular{^h}$', r'$\mathregular{^m}$', r'$\mathregular{^s}$')
                         fmt = None
 
@@ -488,7 +491,7 @@ class ScalarFormatterLocator(BaseFormatterLocator):
             values = self._locate_values(value_min, value_max, spacing)
             return values * spacing * self._unit, spacing * self._unit
 
-    def formatter(self, values, spacing, plain=False):
+    def formatter(self, values, spacing, format='auto'):
 
         if len(values) > 0:
             if self.format is None:

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -108,12 +108,14 @@ class AngleFormatterLocator(BaseFormatterLocator):
                  unit=None, decimal=None, format_unit=None):
 
         if unit is None:
-            unit = u.degree
-        elif unit not in (u.degree, u.hourangle, u.hour):
-            if decimal is None:
+            raise UnitsError("Coordinate units should be given")
+
+        if format_unit not in (u.degree, u.hourangle, u.hour):
+            if decimal is not None:
                 decimal = True
             elif decimal is False:
                 raise UnitsError("Units should be degrees or hours when using non-decimal (sexagesimal) mode")
+
         self._unit = unit
         self._format_unit = format_unit or unit
         self._decimal = decimal
@@ -270,7 +272,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
                     spacing_deg = self.base_spacing.to_value(u.degree)
                 else:
                     # otherwise we clip to the nearest 'sensible' spacing
-                    if self._unit is u.degree:
+                    if self._format_unit is u.degree:
                         from .utils import select_step_degree
                         spacing_deg = select_step_degree(dv).to_value(u.degree)
                     else:

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -110,7 +110,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
-        assert string_world == '2563 3h43m01s (world)'
+        assert string_world == '2563 3h26m52.0s (world)'
 
         # Test pixel coordinates
         event1 = KeyEvent('test_pixel_coords', canvas, 'w')

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -110,7 +110,7 @@ class TestDisplayWorldCoordinate(BaseImageTests):
 
         # Testing default displayed world coordinates
         string_world = ax._display_world_coords(0.523412, 0.518311)
-        assert string_world == '2563 51\xb043\'01" (world)'
+        assert string_world == '2563 3h43m01s (world)'
 
         # Test pixel coordinates
         event1 = KeyEvent('test_pixel_coords', canvas, 'w')

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -134,7 +134,7 @@ class TestAngleFormatterLocator:
                                                     ])
     def test_format(self, format, string):
         fl = AngleFormatterLocator(number=5, format=format)
-        assert fl.formatter([15.392231] * u.degree, None, plain=True)[0] == string
+        assert fl.formatter([15.392231] * u.degree, None, format='ascii')[0] == string
 
     @pytest.mark.parametrize(('separator', 'format', 'string'), [(('deg', "'", '"'), 'dd', '15deg'),
                                                                  (('deg', "'", '"'), 'dd:mm', '15deg24\''),
@@ -224,7 +224,7 @@ class TestAngleFormatterLocator:
         # Check the formatter works when specifying the default units and
         # decimal behavior to use.
         fl = AngleFormatterLocator(unit=u.degree, format_unit=format_unit, decimal=decimal)
-        assert fl.formatter([15.392231] * u.degree, spacing, plain=True)[0] == string
+        assert fl.formatter([15.392231] * u.degree, spacing, format='ascii')[0] == string
 
     def test_incompatible_unit_decimal(self):
         with pytest.raises(UnitsError) as exc:

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -134,7 +134,7 @@ class TestAngleFormatterLocator:
                                                     ])
     def test_format(self, format, string):
         fl = AngleFormatterLocator(number=5, format=format)
-        assert fl.formatter([15.392231] * u.degree, None)[0] == string
+        assert fl.formatter([15.392231] * u.degree, None, plain=True)[0] == string
 
     @pytest.mark.parametrize(('separator', 'format', 'string'), [(('deg', "'", '"'), 'dd', '15deg'),
                                                                  (('deg', "'", '"'), 'dd:mm', '15deg24\''),
@@ -201,7 +201,7 @@ class TestAngleFormatterLocator:
         fl = AngleFormatterLocator()
         assert fl.formatter([15.392231] * u.degree, spacing)[0] == string
 
-    @pytest.mark.parametrize(('unit', 'decimal', 'spacing', 'string'),
+    @pytest.mark.parametrize(('format_unit', 'decimal', 'spacing', 'string'),
                              [(u.degree, False, 2 * u.degree, '15\xb0'),
                               (u.degree, False, 2 * u.arcmin, '15\xb024\''),
                               (u.degree, False, 2 * u.arcsec, '15\xb023\'32"'),
@@ -220,10 +220,10 @@ class TestAngleFormatterLocator:
                               # Make sure that specifying None defaults to
                               # decimal for non-degree or non-hour angles
                               (u.arcsec, None, 0.01 * u.arcsec, '55412.03')])
-    def test_formatter_no_format_with_units(self, unit, decimal, spacing, string):
+    def test_formatter_no_format_with_units(self, format_unit, decimal, spacing, string):
         # Check the formatter works when specifying the default units and
         # decimal behavior to use.
-        fl = AngleFormatterLocator(unit=unit, decimal=decimal)
+        fl = AngleFormatterLocator(unit=u.degree, format_unit=format_unit, decimal=decimal)
         assert fl.formatter([15.392231] * u.degree, spacing, plain=True)[0] == string
 
     def test_incompatible_unit_decimal(self):

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -155,7 +155,7 @@ class TestAngleFormatterLocator:
         fl = AngleFormatterLocator(number=5, format="dd:mm:ss")
         assert fl.formatter([15.392231] * u.degree, None)[0] == '15\xb023\'32"'
         with rc_context(rc={'text.usetex': True}):
-            assert fl.formatter([15.392231] * u.degree, None)[0] == "15$^\\circ$23'32\""
+            assert fl.formatter([15.392231] * u.degree, None)[0] == "$15^\\circ23{}^\\prime32{}^{\\prime\\prime}$"
 
     @pytest.mark.parametrize(('format'), ['x.xxx', 'dd.ss', 'dd:ss', 'mdd:mm:ss'])
     def test_invalid_formats(self, format):
@@ -224,7 +224,7 @@ class TestAngleFormatterLocator:
         # Check the formatter works when specifying the default units and
         # decimal behavior to use.
         fl = AngleFormatterLocator(unit=unit, decimal=decimal)
-        assert fl.formatter([15.392231] * u.degree, spacing)[0] == string
+        assert fl.formatter([15.392231] * u.degree, spacing, plain=True)[0] == string
 
     def test_incompatible_unit_decimal(self):
         with pytest.raises(UnitsError) as exc:

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -582,3 +582,30 @@ class TestBasic(BaseImageTests):
         fig = plt.figure(figsize=(5, 3))
         ax = fig.add_axes([0.2, 0.2, 0.6, 0.6], projection=wcs, frame_class=EllipticalFrame)
         return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
+    def test_hms_labels(self):
+        # This tests the apparance of the hms superscripts in tick labels
+        fig = plt.figure(figsize=(3, 3))
+        ax = fig.add_axes([0.3, 0.2, 0.65, 0.6],
+                          projection=WCS(self.twoMASS_k_header),
+                          aspect='equal')
+        ax.set_xlim(-0.5, 0.5)
+        ax.set_ylim(-0.5, 0.5)
+        ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
+        return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={'text.usetex': True})
+    def test_latex_labels(self):
+        fig = plt.figure(figsize=(3, 3))
+        ax = fig.add_axes([0.3, 0.2, 0.65, 0.6],
+                          projection=WCS(self.twoMASS_k_header),
+                          aspect='equal')
+        ax.set_xlim(-0.5, 0.5)
+        ax.set_ylim(-0.5, 0.5)
+        ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
+        return fig

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -109,7 +109,10 @@ class TestBasic(BaseImageTests):
         ax.set_xlim(0., 720.)
         ax.set_ylim(0., 720.)
 
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
         return fig
@@ -235,7 +238,10 @@ class TestBasic(BaseImageTests):
         ax.coords[0].grid(grid_type='contours', color='blue', linestyle='solid')
         ax.coords[1].grid(grid_type='contours', color='red', linestyle='solid')
 
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
         return fig
@@ -254,7 +260,10 @@ class TestBasic(BaseImageTests):
         c = SkyCoord(266 * u.deg, -29 * u.deg)
         ax.plot_coord(c, 'o')
 
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
         return fig
@@ -273,7 +282,10 @@ class TestBasic(BaseImageTests):
         c = SkyCoord([266, 266.8] * u.deg, [-29, -28.9] * u.deg)
         ax.plot_coord(c)
 
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
 
         return fig
@@ -394,7 +406,10 @@ class TestBasic(BaseImageTests):
         ax.grid(color='gray', alpha=0.5, linestyle='solid')
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
         return fig
 
@@ -420,7 +435,10 @@ class TestBasic(BaseImageTests):
         ax.grid(color='gray', alpha=0.5, linestyle='solid')
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
-        # For backward-compatibility with previous reference images
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
         ax.coords[0].set_format_unit(u.degree)
         return fig
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -110,7 +110,7 @@ class TestBasic(BaseImageTests):
         ax.set_ylim(0., 720.)
 
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
 
         return fig
 
@@ -236,7 +236,7 @@ class TestBasic(BaseImageTests):
         ax.coords[1].grid(grid_type='contours', color='red', linestyle='solid')
 
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
 
         return fig
 
@@ -255,7 +255,7 @@ class TestBasic(BaseImageTests):
         ax.plot_coord(c, 'o')
 
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
 
         return fig
 
@@ -274,7 +274,7 @@ class TestBasic(BaseImageTests):
         ax.plot_coord(c)
 
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
 
         return fig
 
@@ -395,7 +395,7 @@ class TestBasic(BaseImageTests):
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
         return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -421,7 +421,7 @@ class TestBasic(BaseImageTests):
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
         # For backward-compatibility with previous reference images
-        ax.coords[0].set_major_formatter('dd:mm:ss')
+        ax.coords[0].set_format_unit(u.degree)
         return fig
 
     @pytest.mark.remote_data(source='astropy')

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -109,6 +109,9 @@ class TestBasic(BaseImageTests):
         ax.set_xlim(0., 720.)
         ax.set_ylim(0., 720.)
 
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
+
         return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -232,6 +235,9 @@ class TestBasic(BaseImageTests):
         ax.coords[0].grid(grid_type='contours', color='blue', linestyle='solid')
         ax.coords[1].grid(grid_type='contours', color='red', linestyle='solid')
 
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
+
         return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -248,6 +254,9 @@ class TestBasic(BaseImageTests):
         c = SkyCoord(266 * u.deg, -29 * u.deg)
         ax.plot_coord(c, 'o')
 
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
+
         return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -263,6 +272,9 @@ class TestBasic(BaseImageTests):
 
         c = SkyCoord([266, 266.8] * u.deg, [-29, -28.9] * u.deg)
         ax.plot_coord(c)
+
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
 
         return fig
 
@@ -382,6 +394,8 @@ class TestBasic(BaseImageTests):
         ax.grid(color='gray', alpha=0.5, linestyle='solid')
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
         return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -406,6 +420,8 @@ class TestBasic(BaseImageTests):
         ax.grid(color='gray', alpha=0.5, linestyle='solid')
         ax.coords['ra'].set_ticks(color='red', size=20)
         ax.coords['dec'].set_ticks(color='red', size=20)
+        # For backward-compatibility with previous reference images
+        ax.coords[0].set_major_formatter('dd:mm:ss')
         return fig
 
     @pytest.mark.remote_data(source='astropy')

--- a/astropy/visualization/wcsaxes/tests/test_utils.py
+++ b/astropy/visualization/wcsaxes/tests/test_utils.py
@@ -61,10 +61,10 @@ def test_select_step_scalar():
 
 
 def test_coord_type_from_ctype():
-    assert coord_type_from_ctype(' LON') == ('longitude', None)
-    assert coord_type_from_ctype(' LAT') == ('latitude', None)
-    assert coord_type_from_ctype('HPLN') == ('longitude', 180.)
-    assert coord_type_from_ctype('HPLT') == ('latitude', None)
-    assert coord_type_from_ctype('RA--') == ('longitude', None)
-    assert coord_type_from_ctype('DEC-') == ('latitude', None)
-    assert coord_type_from_ctype('spam') == ('scalar', None)
+    assert coord_type_from_ctype(' LON') == ('longitude', None, None)
+    assert coord_type_from_ctype(' LAT') == ('latitude', None, None)
+    assert coord_type_from_ctype('HPLN') == ('longitude', None, 180.)
+    assert coord_type_from_ctype('HPLT') == ('latitude', None, None)
+    assert coord_type_from_ctype('RA--') == ('longitude', u.hourangle, None)
+    assert coord_type_from_ctype('DEC-') == ('latitude', None, None)
+    assert coord_type_from_ctype('spam') == ('scalar', None, None)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -80,7 +80,10 @@ class TickLabels(Text):
                         start = j + 1
                 t1 = self.text[axis][i]
                 if start != 0:
+                    starts_dollar = self.text[axis][i].startswith('$')
                     self.text[axis][i] = self.text[axis][i][start:]
+                    if starts_dollar:
+                        self.text[axis][i] = '$' + self.text[axis][i]
 
     def set_visible_axes(self, visible_axes):
         self._visible_axes = visible_axes

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -124,11 +124,13 @@ def coord_type_from_ctype(ctype):
     Determine whether a particular WCS ctype corresponds to an angle or scalar
     coordinate.
     """
-    if ctype[:4] in ['RA--'] or ctype[1:4] == 'LON':
-        return 'longitude', None
+    if ctype[:4] in ['RA--']:
+        return 'longitude', u.hourangle, None
+    if ctype[1:4] == 'LON':
+        return 'longitude', None, None
     elif ctype[:4] in ['HPLN']:
-        return 'longitude', 180.
+        return 'longitude', None, 180.
     elif ctype[:4] in ['DEC-', 'HPLT'] or ctype[1:4] == 'LAT':
-        return 'latitude', None
+        return 'latitude', None, None
     else:
-        return 'scalar', None
+        return 'scalar', None, None

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -126,7 +126,7 @@ def coord_type_from_ctype(ctype):
     """
     if ctype[:4] in ['RA--']:
         return 'longitude', u.hourangle, None
-    if ctype[1:4] == 'LON':
+    elif ctype[1:4] == 'LON':
         return 'longitude', None, None
     elif ctype[:4] in ['HPLN']:
         return 'longitude', None, 180.


### PR DESCRIPTION
This fixes the formatting of tick labels when used with a right ascension axis, in which case the hh:mm:ss format should be used (not dd:mm:ss). This is done by making it so that ``AngleFormatterLocator`` takes a ``format_unit`` (like ``ScalarFormatterLocator``). This also fixes the use of ``set_format_unit`` with angle coordinates.

This is a bordeline bug/enhancement case, but I'd argue that the fact that ``set_format_unit`` didn't work correctly for angle coordinates previously was a bug.

Here's what an RA/Dec plot now looks like by default:

![wcsaxes](https://user-images.githubusercontent.com/314716/36400536-600f37ae-15c9-11e8-8b24-af75271790b4.png)

Remaining to-dos:

* [x] Improve auto-determination of ticks when using hh:mm:ss as above (which shows the default spacing is not ideal)
* [x] Update existing image tests
* [x] Add new image tests, including with LaTeX tick labels

Fixes https://github.com/astropy/astropy/issues/7209