### PR TITLE
parser for objects with J coordinates embedded in their name

### DIFF
--- a/astropy/coordinates/jparser.py
+++ b/astropy/coordinates/jparser.py
@@ -1,3 +1,8 @@
+"""
+Module for parsing astronomical object names to extract embedded coordinates
+eg: '2MASS J06495091-0737408'
+"""
+
 import re
 
 import numpy as np
@@ -5,68 +10,59 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
+RA_REGEX = '()([0-2]\d)([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+DEC_REGEX = '([+-])(\d{1,2})([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+JCOORD_REGEX = '(.*?J)' + RA_REGEX + DEC_REGEX
+JPARSER = re.compile(JCOORD_REGEX)
+
 
 def _sexagesimal(g):
     # convert matched regex groups to sexigesimal array
     sign, h, m, s, frac = g
-    sign = [1, -1][sign == '-']
+    sign = -1 if (sign == '-') else 1
     s = '.'.join((s, frac))
     return sign * np.array([h, m, s], float)
 
 
-class Jparser(object):
+def search(name, raise_=False):
+    """Regex match for coordinates in name"""
+    # extract the coordinate data from name
+    match = JPARSER.search(name)
+    if match is None and raise_:
+        raise ValueError('No coordinate match found!')
+    return match
+
+
+def to_ra_dec_angles(name):
+    """get RA in hourangle and DEC in degrees by parsing name """
+    groups = search(name, True).groups()
+    prefix, hms, dms = np.split(groups, [1, 6])
+    ra = (_sexagesimal(hms) / (1, 60, 60 * 60) * u.hourangle).sum()
+    dec = (_sexagesimal(dms) * (u.deg, u.arcmin, u.arcsec)).sum()
+    return ra, dec
+
+
+def to_skycoord(name, frame='icrs'):
+    """Convert to `name` to `SkyCoords` object"""
+    return SkyCoord(*to_ra_dec_angles(name), frame=frame)
+
+
+def shorten(name):
     """
-    Class that extracts coordinates from object names containing coordinated
-    eg: '2MASS J06495091-0737408'
+    Produce a shortened version of the full object name using: the prefix
+    (usually the survey name) and RA (hour, minute), DEC (deg, arcmin) parts.
+        e.g.: '2MASS J06495091-0737408' --> '2MASS J0649-0737'
+    Parameters
+    ----------
+    name : str
+        Full object name with J-coords embedded.
+    Returns
+    -------
+    shortName: str
     """
-    basePattern = '([+-]?)(\d{1,2})(\d{2})(\d{2})\.?(\d{0,3})'
-    single_parser = re.compile(basePattern)
-    fullPattern = '(.*?J)' + basePattern * 2
-    parser = re.compile(fullPattern)
+    match = search(name)
+    return ''.join(match.group(1, 3, 4, 7, 8, 9))
 
-    def __call__(self, name):
-        """Convert to `name` to `SkyCoords` object"""
-        return self.to_skycoord(name)
-
-    def match(self, name, raise_=False):
-        """Regex match for coordinates in name"""
-        # extract the coordinate data from name
-        match = self.parser.search(name)
-        if match is None and raise_:
-            raise ValueError('No coordinate match found!')
-        return match
-
-    def ra_dec(self, name):
-        """get RA in hourangle and DEC in degrees by parsing name """
-        groups = self.match(name, True).groups()
-        prefix, hms, dms = np.split(groups, [1, 6])
-        ra = (_sexagesimal(hms) / (1, 60, 60 * 60) * u.hourangle).sum()
-        dec = (_sexagesimal(dms) * (u.deg, u.arcmin, u.arcsec)).sum()
-        return ra, dec
-
-    def to_skycoord(self, name, frame='icrs'):
-        return SkyCoord(*self.ra_dec(name), frame=frame)
-
-    def shorten(self, name):
-        """
-        Produce a shortened version of the full object name using: the prefix
-        (usually the survey name) and RA (hour, minute), DEC (deg, arcmin) parts.
-            e.g.: '2MASS J06495091-0737408' --> '2MASS J0649-0737'
-
-        Parameters
-        ----------
-        name : str
-            Full object name with J-coords embedded.
-
-        Returns
-        -------
-        shortName: str
-        """
-        match = self.match(name)
-        return ''.join(match.group(1, 3, 4, 7, 8, 9))
-
-
-jparser = Jparser()
 
 if __name__ == '__main__':
     # a few test cases:
@@ -78,4 +74,4 @@ if __name__ == '__main__':
                  'DENIS-P J203137.5-000511',
                  '2QZ J142438.9-022739',
                  'CXOU J141312.3-652013']:
-        print(name, jparser(name))
+        print(name, to_skycoord(name))

--- a/astropy/coordinates/jparser.py
+++ b/astropy/coordinates/jparser.py
@@ -1,0 +1,81 @@
+import re
+
+import numpy as np
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+
+def _sexagesimal(g):
+    # convert matched regex groups to sexigesimal array
+    sign, h, m, s, frac = g
+    sign = [1, -1][sign == '-']
+    s = '.'.join((s, frac))
+    return sign * np.array([h, m, s], float)
+
+
+class Jparser(object):
+    """
+    Class that extracts coordinates from object names containing coordinated
+    eg: '2MASS J06495091-0737408'
+    """
+    basePattern = '([+-]?)(\d{1,2})(\d{2})(\d{2})\.?(\d{0,3})'
+    single_parser = re.compile(basePattern)
+    fullPattern = '(.*?J)' + basePattern * 2
+    parser = re.compile(fullPattern)
+
+    def __call__(self, name):
+        """Convert to `name` to `SkyCoords` object"""
+        return self.to_skycoord(name)
+
+    def match(self, name, raise_=False):
+        """Regex match for coordinates in name"""
+        # extract the coordinate data from name
+        match = self.parser.search(name)
+        if match is None and raise_:
+            raise ValueError('No coordinate match found!')
+        return match
+
+    def ra_dec(self, name):
+        """get RA in hourangle and DEC in degrees by parsing name """
+        groups = self.match(name, True).groups()
+        prefix, hms, dms = np.split(groups, [1, 6])
+        ra = (_sexagesimal(hms) / (1, 60, 60 * 60) * u.hourangle).sum()
+        dec = (_sexagesimal(dms) * (u.deg, u.arcmin, u.arcsec)).sum()
+        return ra, dec
+
+    def to_skycoord(self, name, frame='icrs'):
+        return SkyCoord(*self.ra_dec(name), frame)
+
+    def shorten(self, name):
+        """
+        Produce a shortened version of the full object name using: the prefix
+        (usually the survey name) and RA (hour, minute), DEC (deg, arcmin) parts.
+            e.g.: '2MASS J06495091-0737408' --> '2MASS J0649-0737'
+
+        Parameters
+        ----------
+        name : str
+            Full object name with J-coords embedded.
+
+        Returns
+        -------
+        shortName: str
+        """
+        match = self.match(name)
+        return ''.join(match.group(1, 3, 4, 7, 8, 9))
+
+
+jparser = Jparser()
+
+if __name__ == '__main__':
+    # a few test cases:
+    for name in ['CRTS SSS100805 J194428-420209',
+                 'MASTER OT J061451.7-272535.5',
+                 '2MASS J06495091-0737408',
+                 '1RXS J042555.8-194534',
+                 'SDSS J132411.57+032050.5',
+                 'DENIS-P J203137.5-000511',
+                 '2QZ J142438.9-022739',
+                 'CXOU J141312.3-652013']:
+        print(name, jparser(name))

--- a/astropy/coordinates/jparser.py
+++ b/astropy/coordinates/jparser.py
@@ -45,7 +45,7 @@ class Jparser(object):
         return ra, dec
 
     def to_skycoord(self, name, frame='icrs'):
-        return SkyCoord(*self.ra_dec(name), frame)
+        return SkyCoord(*self.ra_dec(name), frame=frame)
 
     def shorten(self, name):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1702,6 +1702,9 @@ class SkyCoord(ShapedLikeNDArray):
             from . import jparser
             if jparser.search(name):
                 icrs_coord = jparser.to_skycoord(name, frame)
+            else:
+                # if the parser failed, do sesame query
+                icrs_coord = get_icrs_coordinates(name)
         else:
             icrs_coord = get_icrs_coordinates(name)
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1685,9 +1685,16 @@ class SkyCoord(ShapedLikeNDArray):
             Instance of the SkyCoord class.
         """
 
+        from .jparser import jparser
         from .name_resolve import get_icrs_coordinates
 
-        icrs_coord = get_icrs_coordinates(name)
+        # first try extract coordinates from name. do this first since it
+        # may be much faster than sesame query
+        if jparser.match(name):
+            icrs_coord = jparser.to_skycoord(name, frame)
+        else:
+            icrs_coord = get_icrs_coordinates(name)
+
         icrs_sky_coord = cls(icrs_coord)
         if frame in ('icrs', icrs_coord.__class__):
             return icrs_sky_coord


### PR DESCRIPTION
This PR adds functionality to `SkyCoord.from_name` by enabling parsing of object names with embedded coordinates.

```
from astropy.coordinates import SkyCoord

coords = SkyCoord.from_name('2MASS J06495091-0737408')
print(coords)
```
which prints
```
<SkyCoord (ICRS): (ra, dec) in deg
    (102.462125, -7.628)>
```