### PR TITLE
evaluate model sets with model_set_axis=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,6 +299,8 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Fix model set evaluation over common input when model_set_axis > 0. [#7222]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -505,8 +505,16 @@ class Parameter(OrderedDescriptor):
 
             if model_axis < 0:
                 model_axis = len(shape) + model_axis
+                shape = shape[:model_axis] + shape[model_axis + 1:]
+            else:
+                # When a model set is initialized, the dimension of the parameters
+                # is increased by model_set_axis+1. To find the shape of a parameter
+                # within a single model the extra dimensions need to be removed first.
+                # The following dimension shows the number of models.
+                # The rest of the shape tuple represents the shape of the parameter
+                # in a single model.
 
-            shape = shape[:model_axis] + shape[model_axis + 1:]
+                shape = shape[model_axis + 1:]
 
         return shape
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -258,7 +258,7 @@ class TestEvaluation:
 
         p1 = models.Polynomial1D(4, n_models=2)
         y1 = p1(np.array([self.x1, self.x1]).T, model_set_axis=-1)
-        assert y1.shape == (2, 20)
+        assert y1.shape == (20, 2)
         assert_allclose(y1[0, :], y1[1, :], atol=10 ** (-12))
 
     def test_p2_1set_1pset(self):
@@ -279,21 +279,26 @@ class TestEvaluation:
 
     def test_nset_domain(self):
         """
-        Polynomial evaluation of multiple data sets with different domain
+        Test model set with negative model_set_axis.
+
+        In this case model_set_axis=-1 is identical to model_set_axis=1.
         """
 
         xx = np.array([self.x1, self.x1]).T
         xx[0, 0] = 100
         xx[1, 0] = 100
         xx[2, 0] = 99
-        p1 = models.Polynomial1D(5, n_models=2)
+        p1 = models.Polynomial1D(5, c0=[1, 2], c1=[3, 4], n_models=2)
         yy = p1(xx, model_set_axis=-1)
-        x1 = xx[:, 0]
-        x2 = xx[:, 1]
-        p1 = models.Polynomial1D(5)
-        assert_allclose(p1(x1), yy[0, :], atol=10 ** (-12))
-        p1 = models.Polynomial1D(5)
-        assert_allclose(p1(x2), yy[1, :], atol=10 ** (-12))
+        assert_allclose(xx.shape, yy.shape)
+        yy1 = p1(xx, model_set_axis=1)
+        assert_allclose(yy, yy1)
+        #x1 = xx[:, 0]
+        #x2 = xx[:, 1]
+        #p1 = models.Polynomial1D(5)
+        #assert_allclose(p1(x1), yy[0, :], atol=10 ** (-12))
+        #p1 = models.Polynomial1D(5)
+        #assert_allclose(p1(x2), yy[1, :], atol=10 ** (-12))
 
     def test_evaluate_gauss2d(self):
         cov = np.array([[1., 0.8], [0.8, 3]])

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -1,0 +1,224 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This module tests model set evaluation for some common use cases.
+"""
+import pytest
+import numpy as np
+from numpy.testing.utils import assert_allclose
+
+from ..models import Polynomial1D, Polynomial2D
+from ..fitting import LinearLSQFitter
+from ..core import Model
+from ..parameters import Parameter
+
+
+x = np.arange(4)
+xx = np.array([x, x + 10])
+xxx = np.arange(24).reshape((3, 4, 2))
+
+
+class TParModel(Model):
+    """
+    A toy model to test parameters machinery
+    """
+    #standard_broadasting = False
+    inputs = ('x',)
+    outputs = ('x',)
+    coeff = Parameter()
+    e = Parameter()
+
+    def __init__(self, coeff, e, **kwargs):
+        super().__init__(coeff=coeff, e=e, **kwargs)
+
+    @staticmethod
+    def evaluate(x, coeff, e):
+        return x*coeff + e
+
+
+def test_model_axis_1():
+    """
+    Test that a model initialized with model_set_axis=1
+    can be evaluated with model_set_axis=False.
+    """
+
+    p1 = Polynomial1D(1, n_models=2, model_set_axis=1)
+    p1.c0 = [2, 3]
+    p1.c1 = [1, 2]
+    t1 = Polynomial1D(1, c0=2, c1=1)
+    t2 = Polynomial1D(1, c0=3, c1=2)
+
+    with pytest.raises(ValueError):
+        p1(x)
+
+    with pytest.raises(ValueError):
+        p1(xx)
+
+    y = p1(x, model_set_axis=False)
+    assert len(y) == 2
+    assert_allclose(y[0], t1(x))
+    assert_allclose(y[1], t2(x))
+
+    y = p1(xx, model_set_axis=False)
+    assert len(y) == 2
+    assert_allclose(y[0], t1(xx))
+    assert_allclose(y[1], t2(xx))
+
+    y = p1(xxx, model_set_axis=False)
+    assert_allclose(y[0], t1(xxx))
+    assert_allclose(y[1], t2(xxx))
+    assert len(y) == 2
+
+
+def test_model_axis_2():
+    """
+    Test that a model initialized with model_set_axis=2
+    can be evaluated with model_set_axis=False.
+    """
+    p1 = Polynomial1D(1, c0=[[[1, 2,3 ]]], c1=[[[10, 20, 30]]],
+                      n_models=3, model_set_axis=2)
+    t1 = Polynomial1D(1, c0=1, c1=10)
+    t2 = Polynomial1D(1, c0=2, c1=20)
+    t3 = Polynomial1D(1, c0=3, c1=30)
+
+    with pytest.raises(ValueError):
+        p1(x)
+
+    with pytest.raises(ValueError):
+        p1(xx)
+
+    y = p1(x, model_set_axis=False)
+    assert y.shape == (4, 1, 3)
+    assert_allclose(y[:, :, 0].flatten(), t1(x))
+    assert_allclose(y[:, :, 1].flatten(), t2(x))
+    assert_allclose(y[:, :, 2].flatten(), t3(x))
+
+    p2 = Polynomial2D(1, c0_0=[[[0,1,2]]], c0_1=[[[3,4,5]]],
+                      c1_0=[[[5,6,7]]], n_models=3, model_set_axis=2)
+    t1 = Polynomial2D(1, c0_0=0, c0_1=3, c1_0=5)
+    t2 = Polynomial2D(1, c0_0=1, c0_1=4, c1_0=6)
+    t3 = Polynomial2D(1, c0_0=2, c0_1=5, c1_0=7)
+
+    assert p2.c0_0.shape == ()
+    y = p2(x, x, model_set_axis=False)
+    assert y.shape == (4, 1, 3)
+    # These are columns along the 2nd axis.
+    assert_allclose(y[:, :, 0].flatten(), t1(x, x))
+    assert_allclose(y[:, :, 1].flatten(), t2(x, x))
+    assert_allclose(y[:, :, 2].flatten(), t3(x, x))
+
+
+def test_axis_0():
+    """
+    Test that a model initialized with model_set_axis=0
+    can be evaluated with model_set_axis=False.
+    """
+    x = np.arange(4)
+    xx = np.array([x, x + 10])
+    xxx = np.arange(24).reshape((3, 4, 2))
+
+    p1 = Polynomial1D(1, n_models=2, model_set_axis=0)
+    p1.c0 = [2, 3]
+    p1.c1 = [1, 2]
+    t1 = Polynomial1D(1, c0=2, c1=1)
+    t2 = Polynomial1D(1, c0=3, c1=2)
+
+    with pytest.raises(ValueError):
+        p1(x)
+
+    y = p1(xx)
+    assert len(y) == 2
+    assert_allclose(y[0], t1(xx[0]))
+    assert_allclose(y[1], t2(xx[1]))
+
+    y = p1(x, model_set_axis=False)
+    assert len(y) == 2
+    assert_allclose(y[0], t1(x))
+    assert_allclose(y[1], t2(x))
+
+    y = p1(xx, model_set_axis=False)
+    assert len(y) == 2
+    assert_allclose(y[0], t1(xx))
+    assert_allclose(y[1], t2(xx))
+    y = p1(xxx, model_set_axis=False)
+    assert_allclose(y[0], t1(xxx))
+    assert_allclose(y[1], t2(xxx))
+    assert len(y) == 2
+
+
+def test_negative_axis():
+    p1 = Polynomial1D(1, c0=[1, 2], c1=[3, 4], n_models=2, model_set_axis=-1)
+    x = np.arange(4)
+    xx = np.array([x, x + 10])
+    t1 = Polynomial1D(1, c0=1,c1=3)
+    t2 = Polynomial1D(1, c0=2,c1=4)
+
+    with pytest.raises(ValueError):
+        p1(x)
+
+    with pytest.raises(ValueError):
+        p1(xx)
+
+    xxt = xx.T
+    y = p1(xxt)
+    assert_allclose(y[: ,0], t1(xxt[: ,0]))
+    assert_allclose(y[: ,1], t2(xxt[: ,1]))
+
+
+def test_shapes():
+    p2 = Polynomial1D(1, n_models=3, model_set_axis=2)
+    assert p2.c0.shape == ()
+    assert p2.c1.shape == ()
+
+    p1 = Polynomial1D(1, n_models=2, model_set_axis=1)
+    assert p1.c0.shape == ()
+    assert p1.c1.shape == ()
+
+    p1 = Polynomial1D(1, c0=[1, 2], c1=[3, 4], n_models=2, model_set_axis=-1)
+    assert p1.c0.shape == ()
+    assert p1.c1.shape == ()
+
+    e1 = [1, 2]
+    e2 = [3, 4]
+
+    a1 = np.array([[10, 20], [30, 40]])
+    a2 = np.array([[50, 60], [70, 80]])
+
+    t = TParModel([a1, a2], [e1, e2], n_models=2, model_set_axis=-1)
+    assert t.coeff.shape == (2, 2)
+    assert t.e.shape == (2,)
+
+
+
+    t = TParModel([[a1, a2]], [[e1, e2]], n_models=2, model_set_axis=1)
+    assert t.coeff.shape == (2, 2)
+    assert t.e.shape == (2,)
+
+    t = TParModel([a1, a2], [e1, e2], n_models=2, model_set_axis=0)
+    assert t.coeff.shape == (2, 2)
+    assert t.e.shape == (2,)
+
+    t = TParModel([a1, a2], e=[1, 2], n_models=2, model_set_axis=0)
+    assert t.coeff.shape == (2, 2)
+    assert t.e.shape == ()
+
+
+def test_linearlsqfitter():
+    """
+    Issue #7159
+    """
+    x = np.arange(0,4)
+    p = Polynomial1D(1, n_models=2, model_set_axis=1)
+
+    # Generate data for fitting 2 models and re-stack them along the last axis:
+    y = np.array([2*x+1, x+4])
+    y = np.moveaxis(y, 0, -1)
+
+    f = LinearLSQFitter()
+    # This seems to fit the model_set correctly:
+    fit = f(p, x, y)
+    model_y = fit(x, model_set_axis=False)
+
+    m1 = Polynomial1D(1, c0=fit.c0[0][0], c1=fit.c1[0][0])
+    m2 = Polynomial1D(1, c0=fit.c0[0][1], c1=fit.c1[0][1])
+    assert_allclose(model_y[0], m1(x))
+    assert_allclose(model_y[1], m2(x))

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -211,7 +211,7 @@ def test_linearlsqfitter():
 
     # Generate data for fitting 2 models and re-stack them along the last axis:
     y = np.array([2*x+1, x+4])
-    y = np.moveaxis(y, 0, -1)
+    y = np.rollaxis(y, 0, -1).T
 
     f = LinearLSQFitter()
     # This seems to fit the model_set correctly:

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -534,22 +534,22 @@ class TestParameterInitialization:
     def test_two_model_nonzero_model_set_axis(self):
         # An example where the model set axis is the *last* axis of the
         # parameter arrays
-        coeff = np.array([[[10, 20], [30, 40]], [[50, 60], [70, 80]]])
+        coeff = np.array([[[10, 20, 30], [30, 40, 50]], [[50, 60, 70], [70, 80, 90]]])
         coeff = np.rollaxis(coeff, 0, 3)
-        e = np.array([[1, 2], [3, 4]])
+        e = np.array([[1, 2, 3], [3, 4, 5]])
         e = np.rollaxis(e, 0, 2)
-        t = TParModel(coeff, e, model_set_axis=-1)
+        t = TParModel(coeff, e, n_models=2, model_set_axis=-1)
         assert len(t) == 2
         assert t.model_set_axis == -1
         assert len(t.param_sets) == 2
         assert np.issubdtype(t.param_sets.dtype, np.object_)
-        assert np.all(t.param_sets[0] == [[[10, 50], [20, 60]],
-                                          [[30, 70], [40, 80]]])
-        assert np.all(t.param_sets[1] == [[[1, 3], [2, 4]]])
-        assert np.all(t.parameters == [10, 50, 20, 60, 30, 70, 40, 80,
-                                       1, 3, 2, 4])
-        assert t.coeff.shape == (2, 2)
-        assert t.e.shape == (2,)
+        assert np.all(t.param_sets[0] == [[[10, 50], [20, 60], [30, 70]],
+                                          [[30, 70], [40, 80], [50, 90]]])
+        assert np.all(t.param_sets[1] == [[[1, 3], [2, 4], [3, 5]]])
+        assert np.all(t.parameters == [10, 50, 20, 60, 30, 70, 30, 70, 40, 80,
+                                       50, 90, 1, 3, 2, 4, 3, 5])
+        assert t.coeff.shape == (2, 3)
+        assert t.e.shape == (3,)
 
     def test_wrong_number_of_params(self):
         with pytest.raises(InputParameterError):


### PR DESCRIPTION
Fixes #7159 - a model initialized with `model_set_axis > 0` can't be evaluated with `model_set_axis=False`.

My interpretation of the bug is that in this case what is reported by `Model.parameter.shape` for any parameter used in the initialization is not correct. There's some inconsistency between docstrings and [code](https://github.com/astropy/astropy/blob/master/astropy/modeling/parameters.py#L492) in this case, as the doc states that in this case the shape of the parameter is the shape it would have in a single model, however it returns something different (depending on the shape of the parameter value).

In addition `model_set_axis` was not passed to `prepare_outputs_model_set` which caused incorrect shape of the output.

@jehturner @perrygreenfield 

Does this seem like a reasonable solution? Do you see a better one?
There are other issues with model sets which I will address in a separate issue.
