### PR TITLE
Ensure Angle.__str__ does not assume array2print passes subclasses.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -786,6 +786,8 @@ astropy.coordinates
 
 - Add a workaround for a bug in the einsum function in Numpy 1.14.0. [#7187]
 
+- Fix problems with printing ``Angle`` instances under numpy 1.14.1. [#7234]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -18,6 +18,7 @@ except ImportError:
 
 from ....io import fits
 from ....tests.helper import catch_warnings, ignore_warnings
+from ....utils.compat import NUMPY_LT_1_14_1
 from ....utils.exceptions import AstropyDeprecationWarning
 
 from ..column import Delayed, NUMPY2FITS
@@ -844,6 +845,8 @@ class TestTableFunctions(FitsTestCase):
             assert header['TNULL2'] == 'b'
             assert header['TNULL3'] == 2.3
 
+    @pytest.mark.xfail(not NUMPY_LT_1_14_1,
+        reason="See https://github.com/astropy/astropy/issues/7214")
     def test_mask_array(self):
         t = fits.open(self.data('table.fits'))
         tbdata = t[1].data

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,7 +7,8 @@ from ...utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_10_4', 'NUMPY_LT_1_11', 'NUMPY_LT_1_11_2',
-           'NUMPY_LT_1_12', 'NUMPY_LT_1_13', 'NUMPY_LT_1_14']
+           'NUMPY_LT_1_12', 'NUMPY_LT_1_13', 'NUMPY_LT_1_14',
+           'NUMPY_LT_1_14_1']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -17,4 +18,5 @@ NUMPY_LT_1_11 = not minversion('numpy', '1.11.0')
 NUMPY_LT_1_11_2 = not minversion('numpy', '1.11.2')
 NUMPY_LT_1_12 = not minversion('numpy', '1.12')
 NUMPY_LT_1_13 = not minversion('numpy', '1.13')
-NUMPY_LT_1_14 = not minversion('numpy', '1.14dev')
+NUMPY_LT_1_14 = not minversion('numpy', '1.14')
+NUMPY_LT_1_14_1 = not minversion('numpy', '1.14.1')

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -27,7 +27,12 @@ table, Astropy will automatically detect what kind of table it is.
     >>> filename = fits.util.get_testdata_filepath('ascii.fits')
     >>> hdul = fits.open(filename)
 
-.. doctest-requires:: numpy<=1.14.1
+..
+    This needs to be skipped for numpy-1.14.1. It should be removed when 1.14.2
+    is available. See https://github.com/astropy/astropy/issues/7214.
+
+.. doctest-skip::
+
     >>> hdul[1].data[:1]  # doctest: +FLOAT_CMP
     FITS_rec([(10.123, 37)],
              dtype=(numpy.record, {'names':['a','b'], 'formats':['S10','S5'], 'offsets':[0,11], 'itemsize':16}))
@@ -95,7 +100,12 @@ The other difference is the need to specify the table type when using the
     >>> col3 = fits.Column(name='t1', format='I', array=[91, 92, 93], ascii=True)
     >>> hdu = fits.TableHDU.from_columns([col1, col2, col3])
 
-.. doctest-requires:: numpy<=1.14.1
+..
+    This needs to be skipped for numpy-1.14.1. It should be removed when 1.14.2
+    is available. See https://github.com/astropy/astropy/issues/7214.
+
+.. doctest-skip::
+
     >>> hdu.data
     FITS_rec([('abc', 11.0, 91), ('def', 12.0, 92), ('', 0.0, 93)],
              dtype=(numpy.record, [('abc', 'S3'), ('def', 'S15'), ('t1', 'S10')]))

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -26,6 +26,8 @@ table, Astropy will automatically detect what kind of table it is.
     >>> from astropy.io import fits
     >>> filename = fits.util.get_testdata_filepath('ascii.fits')
     >>> hdul = fits.open(filename)
+
+.. doctest-requires:: numpy<=1.14.1
     >>> hdul[1].data[:1]  # doctest: +FLOAT_CMP
     FITS_rec([(10.123, 37)],
              dtype=(numpy.record, {'names':['a','b'], 'formats':['S10','S5'], 'offsets':[0,11], 'itemsize':16}))
@@ -92,6 +94,8 @@ The other difference is the need to specify the table type when using the
     ...                    bzero=0.6, ascii=True)
     >>> col3 = fits.Column(name='t1', format='I', array=[91, 92, 93], ascii=True)
     >>> hdu = fits.TableHDU.from_columns([col1, col2, col3])
+
+.. doctest-requires:: numpy<=1.14.1
     >>> hdu.data
     FITS_rec([('abc', 11.0, 91), ('def', 12.0, 92), ('', 0.0, 93)],
              dtype=(numpy.record, [('abc', 'S3'), ('def', 'S15'), ('t1', 'S10')]))


### PR DESCRIPTION
In numpy 1.14.1, fixes to array2print include a cast of all input to a regular ndarray. Hence, in formatters one can no longer assume that what is passed on is a subclass. To counteract this, we now explicitly cast back to Angle in __str__ and _repr_latex.

fixes #7214 

(Note: the bug affects 2.0 too, hence the 2.0.5 milestone)