### PR TITLE
Add support for popping items from HDULists using strings or tuples

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,8 +40,8 @@ Added support for saving all representation classes and many coordinate frames t
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-``HDUList.pop()`` now accepts string and tuple extension name
- specifications. [#7236]
+- ``HDUList.pop()`` now accepts string and tuple extension name
+  specifications. [#7236]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Added support for saving all representation classes and many coordinate frames t
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+``HDUList.pop()`` now accepts string and tuple extension name
+ specifications. [#7236]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -511,9 +511,36 @@ class HDUList(list, _Verify):
         return output
 
     def pop(self, index=-1):
+        """ Remove an item from the list and return it.
+
+        Parameters
+        ----------
+        index : int, str, tuple of (string, int), optional
+            An integer value of ``index`` indicates the position from which 
+            ``pop()`` removes and returns an HDU. A string value or a tuple
+            of ``(string, int)`` functions as a key for identifying the
+            HDU to be removed and returned. If ``key`` is a tuple, it is
+            of the form ``(key, ver)`` where ``ver`` is an ``EXTVER``
+            value that must match the HDU being searched for.
+
+            If the key is ambiguous (e.g. there are multiple 'SCI' extensions)
+            the first match is returned.  For a more precise match use the
+            ``(name, ver)`` pair.
+
+            If even the ``(name, ver)`` pair is ambiguous the numeric index
+            must be used to index the duplicate HDU.
+
+        Returns
+        -------
+        hdu : HDU object
+            The HDU object at position indicated by ``index`` or having name
+            and version specified by ``index``.
+        """
+
         # Make sure that HDUs are loaded before attempting to pop
         self.readall()
-        return super(HDUList, self).pop(index)
+        list_index = self.index_of(index)
+        return super(HDUList, self).pop(list_index)
 
     def insert(self, index, hdu):
         """

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -516,7 +516,7 @@ class HDUList(list, _Verify):
         Parameters
         ----------
         index : int, str, tuple of (string, int), optional
-            An integer value of ``index`` indicates the position from which 
+            An integer value of ``index`` indicates the position from which
             ``pop()`` removes and returns an HDU. A string value or a tuple
             of ``(string, int)`` functions as a key for identifying the
             HDU to be removed and returned. If ``key`` is a tuple, it is

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -990,7 +990,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu4 = hdul[4]
         hdu_popped = hdul.pop(('SCI', 2))
         assert len(hdul) == 6
-        assert hdu_popped == hdu4
+        assert hdu_popped is hdu4
         hdu_popped = hdul.pop('SCI')
         assert len(hdul) == 5
-        assert hdu_popped == hdu1
+        assert hdu_popped is hdu1

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -982,3 +982,15 @@ class TestHDUListFunctions(FitsTestCase):
         assert len(hdul3) == 2
         assert hdul3[0].header == hdu2.header
         assert hdul3[1].header == hdu.header
+
+    def test_pop_extname(self):
+        hdul = fits.open(self.data('o4sp040b0_raw.fits'))
+        assert len(hdul) == 7
+        hdu1 = hdul[1]
+        hdu4 = hdul[4]
+        hdu_popped = hdul.pop(('SCI', 2))
+        assert len(hdul) == 6
+        assert hdu_popped == hdu4
+        hdu_popped = hdul.pop('SCI')
+        assert len(hdul) == 5
+        assert hdu_popped == hdu1


### PR DESCRIPTION
This Pull Request adds support for popping items from ``HDUList`` using string extension names or tuples of extension ``(name, ver)`` in addition to the integer indices, as proposed in https://github.com/astropy/astropy/issues/7229