### PR TITLE
fix histogram bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -940,6 +940,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- In ``freedman_bin_width``, if the data has too small IQR, use median
+  absolute deviation instead. If both IQR and median absolute deviation
+  values are too small, give an value error. [#7248]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -8,6 +8,7 @@ Ported from the astroML project: http://astroML.org/
 
 import numpy as np
 from . import bayesian_blocks
+from . import median_absolute_deviation
 
 __all__ = ['histogram', 'scott_bin_width', 'freedman_bin_width',
            'knuth_bin_width']
@@ -203,14 +204,13 @@ def freedman_bin_width(data, return_bins=False):
 
     v25, v75 = np.percentile(data, [25, 75])
     dx = 2 * (v75 - v25) / (n ** (1 / 3))
-    
-    def mad(array):
-        return np.mean(np.absolute(array-np.mean(array)))    
 
     if return_bins:
         dmin, dmax = data.min(), data.max()
         if dx < 1e-6:
-            dx=mad(data)
+            dx = median_absolute_deviation(data)
+        if dx < 1e-6:
+            raise ValueError("data has too small IQR and median_absolute_deviation values")
         Nbins = max(1, np.ceil((dmax - dmin) / dx))
         bins = dmin + dx * np.arange(Nbins + 1)
         return dx, bins

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -203,9 +203,14 @@ def freedman_bin_width(data, return_bins=False):
 
     v25, v75 = np.percentile(data, [25, 75])
     dx = 2 * (v75 - v25) / (n ** (1 / 3))
+    
+    def mad(array):
+        return np.mean(np.absolute(array-np.mean(array)))    
 
     if return_bins:
         dmin, dmax = data.min(), data.max()
+        if dx < 1e-6:
+            dx=mad(data)
         Nbins = max(1, np.ceil((dmax - dmin) / dx))
         bins = dmin + dx * np.arange(Nbins + 1)
         return dx, bins

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
+from .. import median_absolute_deviation
 from .. import histogram, scott_bin_width, freedman_bin_width, knuth_bin_width
 
 try:
@@ -44,6 +45,16 @@ def test_freedman_bin_width(N=10000, rseed=0):
     with pytest.raises(ValueError):
         freedman_bin_width(rng.rand(2, 10))
 
+    # data with too small IQR and median absolute deviation value
+    test_x = [1,2,3] + [4] * 100 + [5, 6, 7]
+    with pytest.raises(ValueError):
+        freedman_bin_width(test_x, return_bins=True)
+
+    # data with too samll IQR, use median absolute deviation value instead
+    test_x = np.asarray([1,2,3]*100+ [4] + [5, 6, 7],dtype=np.float32)
+    test_x = test_x * 1.5e-6
+    delta, bins = freedman_bin_width(test_x, return_bins=True)
+    assert_allclose(delta, median_absolute_deviation(test_x))
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_knuth_bin_width(N=10000, rseed=0):


### PR DESCRIPTION
Bug in Freedman histogram method #7125
The bug arises from the case that IQR is zero. That's why Nbins blows up to infinity.
In the case when IQR is zero, Median Absolute Deviation (MAD) should be used instead.