### PR TITLE
WIP: Adding TDISPn translation to Python format strings

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -114,9 +114,10 @@ TFORMAT_ASCII_RE = re.compile(r'(?:(?P<format>[AIJ])(?P<width>[0-9]+)?)|'
 
 # TDISPn for both ASCII and Binary tables
 TDISP_RE_DICT = {}
-TDISP_RE_DICT['A'] = re.compile(r'(?:(?P<formatc>[AL])(?P<width>[0-9]+)+)|')
 TDISP_RE_DICT['F'] = re.compile(r'(?:(?P<formatc>[F])(?:(?P<width>[0-9]+)\.{1}'
                                 r'(?P<precision>[0-9])+)+)|')
+TDISP_RE_DICT['A'] = TDISP_RE_DICT['L'] = \
+    re.compile(r'(?:(?P<formatc>[AL])(?P<width>[0-9]+)+)|')
 TDISP_RE_DICT['I'] = TDISP_RE_DICT['B'] = \
     TDISP_RE_DICT['O'] = TDISP_RE_DICT['Z'] =  \
     re.compile(r'(?:(?P<formatc>[IBOZ])(?:(?P<width>[0-9]+)'
@@ -142,11 +143,11 @@ TDISP_RE_DICT['EN'] = TDISP_RE_DICT['ES'] = \
 # Z: Hexadecimal Integer
 # F: Float (64-bit; fixed decimal notation)
 # EN: Float (engineering fortran format, exponential multiple of thee
-#     Not supported in Python format types, moving to default exponential
 # ES: Float (scientific, same as EN but non-zero leading digit
 # E: Float, exponential notation
 #    Can't get exponential restriction to work without knowing value
-#    before hand, so just using width and precision, same with D and G format
+#    before hand, so just using width and precision, same with D, G, EN, and
+#    ES formats
 # D: Double-precision Floating Point
 # G: Double-precision Floating Point
 TDISP_FMT_DICT = {'I' : '{{:0{precision}d}}',
@@ -157,8 +158,8 @@ TDISP_FMT_DICT = {'I' : '{{:0{precision}d}}',
                   'G' : '{{:>{width}.{precision}g}}'}
 TDISP_FMT_DICT['A'] = TDISP_FMT_DICT['L'] = '{{:>{width}}}'
 TDISP_FMT_DICT['EN'] = TDISP_FMT_DICT['ES'] = '{:e}'
-TDISP_FMT_DICT['E'] = TDISP_FMT_DICT['D'] = '{{:>{width}.{precision}e}}'
-
+TDISP_FMT_DICT['E'] = TDISP_FMT_DICT['D'] =  \
+    TDISP_FMT_DICT['EN'] = TDISP_FMT_DICT['ES'] ='{{:>{width}.{precision}e}}'
 
 TTYPE_RE = re.compile(r'[0-9a-zA-Z_]+')
 """
@@ -2507,9 +2508,7 @@ def _fortran_to_python_format(tdisp):
 
     try:
         fmt = TDISP_FMT_DICT[format_type]
-        if format_type not in ['EN', 'ES']:
-            return fmt.format(width=width, precision=precision)
-        else:
-            return fmt
+        return fmt.format(width=width, precision=precision)
+
     except KeyError:
         raise VerifyError('Format {!r} is not recognized.'.format(format_type))

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -112,6 +112,18 @@ TFORMAT_ASCII_RE = re.compile(r'(?:(?P<format>[AIJ])(?P<width>[0-9]+)?)|'
                               r'(?:(?P<widthf>[0-9]+)\.'
                               r'(?P<precision>[0-9]+))?)')
 
+# TDISPn for both ASCII and Binary tables
+TDISP_RE_DICT = {'A':re.compile(r'(?:(?P<formatc>[AL])(?P<width>[0-9]+)+)|'),
+            'IBOZ':re.compile(r'(?:(?P<formatc>[IBOZ])(?:(?P<width>[0-9]+)'
+                      r'(?:\.{0,1}(?P<precision>[0-9]+))?))|'),
+            'F':re.compile(r'(?:(?P<formatc>[F])(?:(?P<width>[0-9]+)\.{1}'
+                      r'(?P<precision>[0-9])+)+)|'),
+            'EGD':re.compile(r'(?:(?P<formatc>[EGD])(?:(?P<width>[0-9]+)\.'
+                      r'(?P<precision>[0-9]+))+)'
+                      r'(?:E{0,1}(?P<exponential>[0-9]+)?)|'),
+            'ENES':re.compile(r'(?:(?P<formatc>E[NS])(?:(?P<width>[0-9]+)\.{1}'
+                      r'(?P<precision>[0-9])+)+)')}
+
 TTYPE_RE = re.compile(r'[0-9a-zA-Z_]+')
 """
 Regular expression for valid table column names.  See FITS Standard v3.0 section
@@ -2402,3 +2414,105 @@ def _convert_ascii_format(format, reverse=False):
             recformat += str(width)
 
         return recformat
+
+
+def _parse_tdisp_format(tdisp):
+    """
+    Parse the ``TDISPn`` keywords for ASCII and binary tables into a
+    ``(format, width, precision, exponential)`` tuple (the TDISP values
+    for ASCII and binary are identical except for 'Lw', which is only present in BINTABLE
+    extensions
+    """
+
+    # Use appropriate regex for format type
+    tdisp = tdisp.strip()
+    if tdisp[0] == 'E':
+        if tdisp[1] in ('N', 'S'):
+            tdisp_re = TDISP_RE_DICT['ENES']
+        else:
+            tdisp_re = TDISP_RE_DICT['EGD']
+    elif tdisp[0] in ('A', 'L'):
+        tdisp_re = TDISP_RE_DICT['A']
+    elif tdisp[0] in ('I', 'B', 'O', 'Z'):
+        tdisp_re = TDISP_RE_DICT['IBOZ']
+    elif tdisp[0] == 'F':
+        tdisp_re = TDISP_RE_DICT['F']
+    elif tdisp[0] in ('G', 'D'):
+        tdisp_re = TDISP_RE_DICT['EGD']
+    else:
+        raise VerifyError('Format {!r} is not recognized.'.format(tdisp))
+
+    match = tdisp_re.match(tdisp.strip())
+    if not match or match.group('formatc') is None:
+        raise VerifyError('Format {!r} is not recognized.'.format(tdisp))
+
+    formatc = match.group('formatc')
+    width = match.group('width')
+    precision = None
+    exponential = None
+
+    # Some formats have
+    if tdisp[0] in ('I', 'B', 'O', 'Z', 'F', 'E', 'G', 'D'):
+        precision = match.group('precision')
+        if precision is None:
+            precision = 1
+    if tdisp[0] in ('E', 'D', 'G') and tdisp[1] not in ('N', 'S'):
+        exponential = match.group('exponential')
+        if exponential is None:
+            exponential = 1
+
+    return formatc, width, precision, exponential
+
+
+def _fortran_to_python_format(format_type, width, precision):
+    """
+    Turn the TDISPn fortran format pieces into a final Python format string.
+    See the format_type definitions below. If codes is changed to take
+    advantage of the exponential specification, will need to add it as another
+    input parameter.
+
+    # mapping from TDISP format to python format (code)
+    # A: Character
+    # L: Logical (Boolean)
+    # I: 16-bit Integer
+    # B: Binary Integer
+    # O: Octal Integer
+    # Z: Hexadecimal Integer
+    # F: Float (64-bit; fixed decimal notation)
+    # EN: Float (engineering fortran format, exponential multiple of thee
+    # ES: Float (scientific, same as EN but non-zero leading digit
+    # E: Float, exponential notation
+    # D: Double-precision Floating Point
+    # G: Double-precision Floating Point
+    """
+
+    if format_type in ('A','L'):
+        return '{{:>{}}}'.format(width)
+    elif format_type == 'I':
+        # Can't predefine zero padding and space padding before hand without
+        # knowing the value being formatted, so grabbing precision and using
+        # that to zero pad, ignoring width
+        return '{{:0{}d}}'.format(precision)
+    elif format_type == 'B':
+        # Same as I format above
+        return '{{:0{}b}}'.format(precision)
+    elif format_type == 'O':
+        # Same as I format above
+        return '{{:0{}o}}'.format(precision)
+    elif format_type == 'Z':
+        # Same as I format above
+        return '{{:0{}x}}'.format(precision)
+    elif format_type == 'F':
+        return '{{:{}.{}f}}'.format(width, precision)
+    elif format_type in ('EN', 'ES'):
+        # Not supported in Python format types, moving to default exponential
+        return '{:e}'
+    elif format_type in ('E', 'D'):
+        # Can't get exponential restriction to work without knowing value
+        # before hand, so just using width and precision
+        return '{{:>{}.{}e}}'.format(width, precision)
+    elif format_type == 'G':
+        # Same as above for E format, can't get explicit exponential to work
+        return '{{:>{}.{}g}}'.format(width, precision)
+    else:
+        raise VerifyError('Format {!r} is not recognized.'.format(format_type))


### PR DESCRIPTION
see history in #7230
So, here's the first two functions that will be needed for this.  "This" being parsing the TDSIPn keywords.  But I'm not totally sure how to preceed from here.

The background for those not familiar is.... I need the TDISPn keywords to roundtrip from FITS binary table to Astropy Table.  Right now, they don't get included in the Astropy Table at all.  The hope was to move the tdisp value to the `format` attribute of the Astropy Table.  When searching for any other code that already did this translation I landed on the code in column.py for `fits.io`, which did something sort of similar for TFORM (but with data types).  So it was suggested that I add this functionality into the column.py file, since it was on the to-do list anyway to parse the tdisp keyword.

Now for the complication part....
There are several formats in the FORTRAN format standard that will not (as far as I can tell) round trip to a pre-set Python format string without losing some information.  For example, in the FORTRAN format there is a way to define an exponential format where you specify the exponent value explicitely, along with the zero padding AND space padding. 

So, if I just over-write the `tdsip` attribute currently in the FITS IO `Column` class with the Pythonized format string, we can't get  back the original string without storing some extra information. I had a long conversation about this with @eteq, and he suggested we could write a view function that would edit the display format only if the user requested it.  And we could leave the `tdisp` attribute completely un-touched so that the roundtripping of the keyword in the header proceeds as normal. I'm not totally sure how to implement this since it seems like it would require a conditional call to overwrite `__repr__` (is that even possible?), but maybe I"m mixing up some of the things @eteq and I talked about (this is probably what's happening).

I don't need this functionality to solve my original problem for Astropy `Table`s, (#6806, #7226) and could definitely just use these functions inside the `Table` class to do what I need to do.  But if someone has a path foward for putting it here, and it won't take any major refactoring of the classes in this file, I'm up for working on it more.

(FYI, I know I still need to add more comments and doc strings to these functions, as well as write some tests, was holding off on that until I knew what was going to happen to them).

cc @saimn, @mhvk 