### PR TITLE
fix bug during error handeling for timeouts in name_resolve

### DIFF
--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -146,6 +146,8 @@ def get_icrs_coordinates(name):
             # There are some cases where urllib2 does not catch socket.timeout
             # especially while receiving response data on an already previously
             # working request
+            e.reason = 'Request took longer than the allowed %.1f seconds' % \
+                       data.conf.remote_timeout
             exceptions.append(e)
             continue
 

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -146,8 +146,8 @@ def get_icrs_coordinates(name):
             # There are some cases where urllib2 does not catch socket.timeout
             # especially while receiving response data on an already previously
             # working request
-            e.reason = 'Request took longer than the allowed %.1f seconds' % \
-                       data.conf.remote_timeout
+            e.reason = "Request took longer than the allowed {:.1f} " \
+                       "seconds".format(data.conf.remote_timeout)
             exceptions.append(e)
             continue
 


### PR DESCRIPTION
Addresses #7261 

```
from astropy.coordinates import SkyCoord
from astropy.utils import data

data.conf.remote_timeout = 0.1
coords = SkyCoord.from_name('m42')
```

Traceback:
```
---------------------------------------------------------------------------
NameResolveError                          Traceback (most recent call last)
<ipython-input-9-14ab69307ccc> in <module>()
      3 
      4 data.conf.remote_timeout = 0.1
----> 5 coords = SkyCoord.from_name('m42')

/usr/local/lib/python3.6/dist-packages/astropy/coordinates/sky_coordinate.py in from_name(cls, name, frame)
   1688         from .name_resolve import get_icrs_coordinates
   1689 
-> 1690         icrs_coord = get_icrs_coordinates(name)
   1691         icrs_sky_coord = cls(icrs_coord)
   1692         if frame in ('icrs', icrs_coord.__class__):

/usr/local/lib/python3.6/dist-packages/astropy/coordinates/name_resolve.py in get_icrs_coordinates(name)
    158         raise NameResolveError("All Sesame queries failed. Unable to "
    159                                "retrieve coordinates. See errors per URL "
--> 160                                "below: \n {}".format("\n".join(messages)))
    161 
    162     ra, dec = _parse_response(resp_data)

NameResolveError: All Sesame queries failed. Unable to retrieve coordinates. See errors per URL below: 
 http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/A?m42: Request took longer than the allowed 0.1 seconds
http://vizier.cfa.harvard.edu/viz-bin/nph-sesame/A?m42: Request took longer than the allowed 0.1 seconds
```