### PR TITLE
TST: Fix failing remote tests

### DIFF
--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -4,7 +4,6 @@
 """Test initialization of angles not already covered by the API tests"""
 
 import pickle
-import time as _time
 
 import pytest
 import numpy as np
@@ -299,10 +298,17 @@ def test_of_address():
         EarthLocation.of_address("lkjasdflkja")
 
     # a location and height
-    loc = EarthLocation.of_address("New York, NY", get_height=True)
-    assert quantity_allclose(loc.lat, 40.7128*u.degree)
-    assert quantity_allclose(loc.lon, -74.0059*u.degree)
-    assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)
+    try:
+        loc = EarthLocation.of_address("New York, NY", get_height=True)
+    except NameResolveError as e:
+        # Buffer above insufficient to get around API limit but
+        # we also do not want to drag things out with time.sleep(0.195),
+        # where 0.195 was empirically determined on some physical machine.
+        pytest.xfail(str(e))
+    else:
+        assert quantity_allclose(loc.lat, 40.7128*u.degree)
+        assert quantity_allclose(loc.lon, -74.0059*u.degree)
+        assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)
 
 
 def test_geodetic_tuple():

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-
 """Test initialization of angles not already covered by the API tests"""
 
 import pickle
+import time as _time
 
 import pytest
 import numpy as np
@@ -288,15 +287,16 @@ def test_repr_latex():
 
 @pytest.mark.remote_data
 def test_of_address():
-    # no match
-    with pytest.raises(NameResolveError):
-        EarthLocation.of_address("lkjasdflkja")
-
     # just a location
     loc = EarthLocation.of_address("New York, NY")
     assert quantity_allclose(loc.lat, 40.7128*u.degree)
     assert quantity_allclose(loc.lon, -74.0059*u.degree)
     assert np.allclose(loc.height.value, 0.)
+
+    # Put this one here as buffer to get around Google map API limit per sec.
+    # no match
+    with pytest.raises(NameResolveError):
+        EarthLocation.of_address("lkjasdflkja")
 
     # a location and height
     loc = EarthLocation.of_address("New York, NY", get_height=True)

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -298,7 +298,7 @@ def test_of_address():
         assert np.allclose(loc.height.value, 0.)
 
     # Put this one here as buffer to get around Google map API limit per sec.
-    # no match
+    # no match: This always raises NameResolveError
     with pytest.raises(NameResolveError):
         EarthLocation.of_address("lkjasdflkja")
 

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -287,10 +287,15 @@ def test_repr_latex():
 @pytest.mark.remote_data
 def test_of_address():
     # just a location
-    loc = EarthLocation.of_address("New York, NY")
-    assert quantity_allclose(loc.lat, 40.7128*u.degree)
-    assert quantity_allclose(loc.lon, -74.0059*u.degree)
-    assert np.allclose(loc.height.value, 0.)
+    try:
+        loc = EarthLocation.of_address("New York, NY")
+    except NameResolveError as e:
+        # Google map API limit might surface even here in Travis CI.
+        pytest.xfail(str(e))
+    else:
+        assert quantity_allclose(loc.lat, 40.7128*u.degree)
+        assert quantity_allclose(loc.lon, -74.0059*u.degree)
+        assert np.allclose(loc.height.value, 0.)
 
     # Put this one here as buffer to get around Google map API limit per sec.
     # no match
@@ -301,7 +306,7 @@ def test_of_address():
     try:
         loc = EarthLocation.of_address("New York, NY", get_height=True)
     except NameResolveError as e:
-        # Buffer above insufficient to get around API limit but
+        # Buffer above sometimes insufficient to get around API limit but
         # we also do not want to drag things out with time.sleep(0.195),
         # where 0.195 was empirically determined on some physical machine.
         pytest.xfail(str(e))

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -254,12 +254,14 @@ also (optionally) query Google maps to get the height of the location. As with
 Google maps, this works with fully specified addresses, location names, city
 names, and etc.::
 
-    >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')  # doctest: +REMOTE_DATA +FLOAT_CMP
+.. doctest-skip::
+
+    >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO')
     <EarthLocation (-26726.98216371, -4997009.8604809, 3950271.16507911) m>
     >>> EarthLocation.of_address('1002 Holy Grail Court, St. Louis, MO',
-    ...                          get_height=True)  # doctest: +REMOTE_DATA +FLOAT_CMP
+    ...                          get_height=True)
     <EarthLocation (-26727.6272786, -4997130.47437768, 3950367.15622108) m>
-    >>> EarthLocation.of_address('Danbury, CT')  # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> EarthLocation.of_address('Danbury, CT')
     <EarthLocation ( 1364606.64511651, -4593292.9428273,  4195415.93695139) m>
 
 .. note::


### PR DESCRIPTION
Fix #7264 

If this works (i.e., make the remote data job green), I think we should merge this sooner than later. When it fails chronically, we tend to ignore it and then get caught by surprise by Numpy dev stuff (since that job runs remote data tests with Numpy dev).