### PR TITLE
Improve HDUList.__contains__ to work with HDU objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1262,6 +1262,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- ``HDUList.__contains__()`` now works with ``HDU`` arguments. That is,
+  ``hdulist[0] in hdulist`` now works as expected. [#7282]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -2346,9 +2349,6 @@ astropy.io.ascii
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
-
-- ``HDUList.__contains__()`` now works with ``HDU`` arguments. That is,
-  ``hdulist[0] in hdulist`` now works as expected. [#7282]
 
 - ``comments`` meta key (which is ``io.ascii``'s table convention) is output
   to ``COMMENT`` instead of ``COMMENTS`` header. Similarly, ``COMMENT``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,7 +97,7 @@ astropy.io.fits
 - The ``fitsheader`` command line tool now supports a ``dfits+fitsort`` mode,
   and the dotted notation for keywords (e.g. ``ESO.INS.ID``). [#7240]
 - ``HDUList.__contains__()`` now works with HDU arguments. That is,
-  ``hdulist[0] in hdulist`` now works as expected. [#7269]
+  ``hdulist[0] in hdulist`` now works as expected. [#7282]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- ``HDUList.__contains__()`` now works with HDU arguments. That is,
+  ``hdulist[0] in hdulist`` now works as expected. [#7282]
+
 - ``HDUList.pop()`` now accepts string and tuple extension name
   specifications. [#7236]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,9 +80,6 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- ``HDUList.__contains__()`` now works with HDU arguments. That is,
-  ``hdulist[0] in hdulist`` now works as expected. [#7282]
-
 - ``HDUList.pop()`` now accepts string and tuple extension name
   specifications. [#7236]
 
@@ -99,8 +96,6 @@ astropy.io.fits
 
 - The ``fitsheader`` command line tool now supports a ``dfits+fitsort`` mode,
   and the dotted notation for keywords (e.g. ``ESO.INS.ID``). [#7240]
-- ``HDUList.__contains__()`` now works with HDU arguments. That is,
-  ``hdulist[0] in hdulist`` now works as expected. [#7282]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -2351,6 +2346,9 @@ astropy.io.ascii
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+
+- ``HDUList.__contains__()`` now works with ``HDU`` arguments. That is,
+  ``hdulist[0] in hdulist`` now works as expected. [#7282]
 
 - ``comments`` meta key (which is ``io.ascii``'s table convention) is output
   to ``COMMENT`` instead of ``COMMENTS`` header. Similarly, ``COMMENT``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,8 @@ astropy.io.fits
 
 - The ``fitsheader`` command line tool now supports a ``dfits+fitsort`` mode,
   and the dotted notation for keywords (e.g. ``ESO.INS.ID``). [#7240]
+- ``HDUList.__contains__()`` now works with HDU arguments. That is,
+  ``hdulist[0] in hdulist`` now works as expected. [#7269]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -316,7 +316,7 @@ class HDUList(list, _Verify):
         try:
             self._try_while_unread_hdus(self.index_of, item)
         except KeyError:
-            return self.index(item)
+            return super().__contains__(item)
 
         return True
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -309,13 +309,14 @@ class HDUList(list, _Verify):
 
     def __contains__(self, item):
         """
-        Returns `True` if ``HDUList.index_of(item)`` succeeds.
+        Returns `True` if ``HDUList.index_of(item)`` or
+        ``HDUList.index(item)`` succeeds.
         """
 
         try:
             self._try_while_unread_hdus(self.index_of, item)
         except KeyError:
-            return False
+            return self.index(item)
 
         return True
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -315,8 +315,8 @@ class HDUList(list, _Verify):
 
         try:
             self._try_while_unread_hdus(self.index_of, item)
-        except KeyError:
-            return super().__contains__(item)
+        except (KeyError, ValueError):
+            return False
 
         return True
 
@@ -667,7 +667,7 @@ class HDUList(list, _Verify):
 
         Parameters
         ----------
-        key : int, str or tuple of (string, int)
+        key : int, str, tuple of (string, int) or an HDU object
            The key identifying the HDU.  If ``key`` is a tuple, it is of the
            form ``(key, ver)`` where ``ver`` is an ``EXTVER`` value that must
            match the HDU being searched for.
@@ -680,16 +680,32 @@ class HDUList(list, _Verify):
            but it's not impossible) the numeric index must be used to index
            the duplicate HDU.
 
+           When ``key`` is an HDU object, this function returns the
+           index of that HDU object in the ``HDUList``.
+
         Returns
         -------
         index : int
            The index of the HDU in the `HDUList`.
+
+        Raises
+        ------
+        ValueError
+           If ``key`` is an HDU object and it is not found in the ``HDUList``.
+
+        KeyError
+           If an HDU specified by the ``key`` that is an extension number,
+           extension name, or a tuple of extension name and version is not
+           found in the ``HDUList``.
+
         """
 
         if _is_int(key):
             return key
         elif isinstance(key, tuple):
             _key, _ver = key
+        elif isinstance(key, _BaseHDU):
+            return self.index(key)
         else:
             _key = key
             _ver = None

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -309,10 +309,12 @@ class HDUList(list, _Verify):
 
     def __contains__(self, item):
         """
-        Returns `True` if ``HDUList.index_of(item)`` or
-        ``HDUList.index(item)`` succeeds.
-        """
+        Returns `True` if ``item`` is an ``HDU`` _in_ ``self`` or a valid
+        extension specification (e.g., integer extension number, extension
+        name, or a tuple of extension name and an extension version)
+        of a ``HDU`` in ``self``.
 
+        """
         try:
             self._try_while_unread_hdus(self.index_of, item)
         except (KeyError, ValueError):
@@ -669,7 +671,7 @@ class HDUList(list, _Verify):
         ----------
         key : int, str, tuple of (string, int) or an HDU object
            The key identifying the HDU.  If ``key`` is a tuple, it is of the
-           form ``(key, ver)`` where ``ver`` is an ``EXTVER`` value that must
+           form ``(name, ver)`` where ``ver`` is an ``EXTVER`` value that must
            match the HDU being searched for.
 
            If the key is ambiguous (e.g. there are multiple 'SCI' extensions)

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -874,6 +874,7 @@ class TestHDUListFunctions(FitsTestCase):
         assert ('b', 1) not in hdulist
         assert ('b', 2) not in hdulist
         assert hdulist[0] in hdulist
+        assert fits.ImageHDU() not in hdulist
 
     def test_overwrite_vs_clobber(self):
         hdulist = fits.HDUList([fits.PrimaryHDU()])

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -873,6 +873,7 @@ class TestHDUListFunctions(FitsTestCase):
         assert ('a', 2) not in hdulist
         assert ('b', 1) not in hdulist
         assert ('b', 2) not in hdulist
+        assert hdulist[0] in hdulist
 
     def test_overwrite_vs_clobber(self):
         hdulist = fits.HDUList([fits.PrimaryHDU()])

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -423,11 +423,13 @@ class TestHDUListFunctions(FitsTestCase):
         f = fits.open(self.data('test0.fits'))
         hdul = fits.HDUList()
         hdul.append(f[0].copy())
-        hdul.append(fits.ImageHDU(header=f[1].header))
+        hdu = fits.ImageHDU(header=f[1].header)
+        hdul.append(hdu)
 
         assert hdul[1].header['EXTNAME'] == 'SCI'
         assert hdul[1].header['EXTVER'] == 1
         assert hdul.index_of(('SCI', 1)) == 1
+        assert hdul.index_of(hdu) == len(hdul) - 1
 
     def test_update_filelike(self):
         """Test opening a file-like object in update mode and resizing the

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -861,8 +861,7 @@ class TestHDUListFunctions(FitsTestCase):
 
         Regression test for https://github.com/astropy/astropy/issues/3060
         """
-
-        hdulist = fits.HDUList()
+        hdulist = fits.open(self.data('o4sp040b0_raw.fits'))
         hdulist.append(fits.ImageHDU(name='a'))
 
         assert 'a' in hdulist


### PR DESCRIPTION
Currently, as mentioned in https://github.com/astropy/astropy/issues/7269, `HDUList.__contains__()` works in unexpected ways. This PR addresses the issue that `in` can't check if an HDU is part of an `HDUList`:

```python
hdulist = fits.HDUList([hdu1, hdu2])
hdu1 in hdulist # ALWAYS FAILS
```