### PR TITLE
Override HDUList.__add__() to return an HDUList instance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -206,6 +206,9 @@ astropy.io.fits
 
 - Override ``HDUList.copy()`` to return a shallow HDUList instance. [#7218]
 
+- Override ``HDUList.__add__()`` to return an HDUList instance instead of
+  list. [#7284]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -510,6 +510,11 @@ class HDUList(list, _Verify):
 
         return output
 
+    def __add__(self, hdulist):
+        new_hdulist = self.copy()
+        new_hdulist.extend(hdulist)
+        return new_hdulist
+
     def __copy__(self):
         """
         Return a shallow copy of an HDUList.

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -414,6 +414,25 @@ class TestHDUListFunctions(FitsTestCase):
             assert hdulcopy[index].header == hdul[index].header
             np.testing.assert_array_equal(hdulcopy[index].data, hdul[index].data)
 
+    def test_concatenate(self):
+        """
+        Tests that addition of two HDULists return an HDUList.
+        """
+
+        n = np.arange(10.0)
+        primary_hdu = fits.PrimaryHDU(n)
+        hdu = fits.ImageHDU(n)
+        primary_hdul = fits.HDUList([primary_hdu, hdu])
+        hdul = fits.HDUList([hdu, hdu])
+
+        primary = len(primary_hdul)
+        result = primary_hdul + hdul
+
+        assert isinstance(result, fits.HDUList)
+        assert len(result) == primary + len(hdul)
+        assert result[:primary] == primary_hdul
+        assert result[primary:] == hdul
+
     def test_new_hdu_extname(self):
         """
         Tests that new extension HDUs that are added to an HDUList can be


### PR DESCRIPTION
As mentioned in https://github.com/astropy/astropy/issues/7185#issuecomment-365112620, adding two slices (or `HDUList` objects) returns a list. We can fix this behavior and return an `HDUList` by overriding `HDUList.__add__()`.