### PR TITLE
Move link to additional developers tools.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,10 +123,6 @@ Astropy or affiliated packages, as well as coding, documentation, and
 testing guidelines. For the guiding vision of this process and the project
 as a whole, see :doc:`development/vision`.
 
-There are additional tools of use for developers in the
-`astropy/astropy-tools repository
-<https://github.com/astropy/astropy-tools>`__.
-
 .. toctree::
    :maxdepth: 1
 
@@ -141,6 +137,10 @@ There are additional tools of use for developers in the
    development/workflow/maintainer_workflow
    development/astropy-package-template
    changelog
+
+There are some additional tools, mostly of use for maintainers, in the
+`astropy/astropy-procedures repository
+<https://github.com/astropy/astropy-procedures>`__.
 
 .. _project-details:
 


### PR DESCRIPTION
Currently, it comes before actual content, which suggests it is important, when really it points to a collection of tools that are useful only to very advanced developers.  Hence, moved it after the list of contents.

Note: I found this while setting up for a mini-course on code development, where I'm using astropy as a the prime example to follow; it seems logical for the first link that people see to be "How to make a code contribution".
