### PR TITLE
[BUG]: Remove fit_deriv in Box1D model

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1607,15 +1607,6 @@ class Box1D(Fittable1DModel):
         else:
             return result
 
-    @classmethod
-    def fit_deriv(cls, x, amplitude, x_0, width):
-        """One dimensional Box model derivative with respect to parameters"""
-
-        d_amplitude = cls.evaluate(x, 1, x_0, width)
-        d_x_0 = np.zeros_like(x)
-        d_width = np.zeros_like(x)
-        return [d_amplitude, d_x_0, d_width]
-
     @property
     def bounding_box(self):
         """


### PR DESCRIPTION
The derivatives of the Box1D (with respect to `x_0` and `width`) model are wrong.
That makes fitting routines fail without an apparent reason (see https://github.com/astropy/astropy/issues/1728).

Additionally, fitting `x_0` and `width` in a Box model seems to be a highly nonlinear problem. Others have been using a grid search approach in order to to circumvent that (see http://adsabs.harvard.edu/abs/2002A%26A...391..369K).

Nonetheless, using a bigger step size to estimate the Jacobian (``epsilon=.1``) seems to give better results (however, not very robust ones with respect to changes in ``epsilon``), see:

```
import numpy as np
import matplotlib.pyplot as plt
from astropy.modeling import models, fitting
import astropy
print(astropy.__path__)

# Generate fake data
np.random.seed(0)
x = np.linspace(-5., 5., 200)
y = 3 * np.exp(-0.5 * (x - 1.3)**2 / 0.8**2)
y += np.random.normal(0., 0.2, x.shape)

# Fit the data using a box model
b = models.Box1D()
fitter = fitting.LevMarLSQFitter()
b_fit = fitter(b, x, y, epsilon=.1)

# Plot the data with the best-fit model
plt.figure()
plt.plot(x, y, 'ko')
plt.plot(x, b(x), 'b-', lw=2, label='Initial model')
plt.plot(x, b_fit(x), 'r-', lw=2, label='Fitted model')
plt.legend()
```


![screen shot 2018-03-12 at 4 10 50 pm](https://user-images.githubusercontent.com/13077051/37271956-0738e34e-2610-11e8-87be-30d4e7ee4fe7.png)
