### PR TITLE
Fix build_docs warnings

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -6,8 +6,6 @@ Methods for selecting the bin width of histograms
 Ported from the astroML project: http://astroML.org/
 """
 
-
-
 import numpy as np
 from . import bayesian_blocks
 
@@ -51,7 +49,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     Returns
     -------
     hist : array
-        The values of the histogram. See ``normed`` and ``weights`` for a
+        The values of the histogram. See ``density`` and ``weights`` for a
         description of the possible semantics.
     bin_edges : array of dtype float
         Return the bin edges ``(length(hist)+1)``.

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -173,12 +173,12 @@ class TestRunnerBase:
         """
         Run the tests for the package.
 
+        This method builds arguments for and then calls ``pytest.main``.
+
         Parameters
         ----------
         {keywords}
-        See Also
-        --------
-        pytest.main : This method builds arguments for and then calls this function.
+
         """
 
     def run_tests(self, **kwargs):

--- a/docs/visualization/histogram.rst
+++ b/docs/visualization/histogram.rst
@@ -37,7 +37,7 @@ matplotlib's default of 10 bins, the second with an arbitrarily chosen
 
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate([10, 200]):
-        ax[i].hist(t, bins=bins, histtype='stepfilled', alpha=0.2, normed=True)
+        ax[i].hist(t, bins=bins, histtype='stepfilled', alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
         ax[i].set_title('plt.hist(t, bins={0})'.format(bins),
@@ -88,12 +88,11 @@ The following figure shows the results of these two rules on the above dataset:
 
     # draw histograms with two different bin widths
     fig, ax = plt.subplots(1, 2, figsize=(10, 4))
-    hist_kwds1 = dict(histtype='stepfilled', alpha=0.2, normed=True)
 
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate(['scott', 'freedman']):
         hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
-             alpha=0.2, normed=True)
+             alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
         ax[i].set_title('hist(t, bins="{0}")'.format(bins),
@@ -143,14 +142,13 @@ the results of these procedures for the above dataset:
 
     # draw histograms with two different bin widths
     fig, ax = plt.subplots(1, 2, figsize=(10, 4))
-    hist_kwds1 = dict(histtype='stepfilled', alpha=0.2, normed=True)
 
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate(['knuth', 'blocks']):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')  # Ignore bayesian block p0 warning
             hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
-                 alpha=0.2, normed=True)
+                 alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
         ax[i].set_title('hist(t, bins="{0}")'.format(bins),


### PR DESCRIPTION
Fix #7298 . Local build gave me 3 warnings but I think those are localized (e.g., errors from running Blackbody1D, Powerlaw1D, and coordinates examples).

Note to self: Check RTD log after merge.