### PR TITLE
Make convolve accept more general set of array-like things

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
-- ``convolve`` now accepts any array-like input, not just ```numpy.ndarray``s or
+- ``convolve`` now accepts any array-like input, not just ``numpy.ndarray``s or
   lists. [#7303]
 
 astropy.coordinates

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
-- `convolve` now accepts any array-like input, not just ``numpy.ndarray``s or
+- ``convolve`` now accepts any array-like input, not just ```numpy.ndarray``s or
   lists. [#7303]
 
 astropy.coordinates

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
-- ``convolve`` now accepts any array-like input, not just ``numpy.ndarray``s or
+- ``convolve`` now accepts any array-like input, not just ``numpy.ndarray`` or
   lists. [#7303]
 
 astropy.coordinates

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
+- `convolve` now accepts any array-like input, not just ``numpy.ndarray``s or
+  lists. [#7303]
+
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -40,7 +40,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
     Parameters
     ----------
-    array : `numpy.ndarray` or `~astropy.nddata.NDData`
+    array : `~astropy.nddata.NDData` or `numpy.ndarray` or array-like
         The array to convolve. This should be a 1, 2, or 3-dimensional array
         or a list or a set of nested lists representing a 1, 2, or
         3-dimensional array.  If an `~astropy.nddata.NDData`, the ``mask`` of
@@ -159,16 +159,19 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
     # Check that the arguments are lists or Numpy arrays
 
-    if isinstance(array, list):
-        array_internal = np.array(array, dtype=float)
-        array_dtype = array_internal.dtype
-    elif isinstance(array, np.ndarray):
+    if isinstance(array, np.ndarray):
         # Note this won't copy if it doesn't have to -- which is okay
         # because none of what follows modifies array_internal.
         array_dtype = array.dtype
         array_internal = array.astype(float, copy=False)
     else:
-        raise TypeError("array should be a list or a Numpy array")
+        try:
+            array_internal = np.array(array, dtype=float)
+        except Exception as e:
+            raise TypeError("array should be a Numpy array or something "
+                            "convertable into a float array", e)
+        array_dtype = array_internal.dtype
+
 
     if isinstance(kernel, list):
         kernel_internal = np.array(kernel, dtype=float)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -158,19 +158,14 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         kernel = kernel.array
 
     # Check that the arguments are lists or Numpy arrays
-
-    if isinstance(array, np.ndarray):
+    try:
         # Note this won't copy if it doesn't have to -- which is okay
         # because none of what follows modifies array_internal.
-        array_dtype = array.dtype
-        array_internal = array.astype(float, copy=False)
-    else:
-        try:
-            array_internal = np.array(array, dtype=float)
-        except (TypeError, ValueError) as e:
-            raise TypeError("array should be a Numpy array or something "
-                            "convertable into a float array", e)
-        array_dtype = array_internal.dtype
+        array_internal = np.asanyarray(array, dtype=float)
+    except (TypeError, ValueError) as e:
+        raise TypeError('array should be a Numpy array or something '
+                        'convertable into a float array', e)
+    array_dtype = getattr(array, 'dtype', array_internal.dtype)
 
 
     if isinstance(kernel, list):

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -167,7 +167,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     else:
         try:
             array_internal = np.array(array, dtype=float)
-        except Exception as e:
+        except (TypeError, ValueError) as e:
             raise TypeError("array should be a Numpy array or something "
                             "convertable into a float array", e)
         array_dtype = array_internal.dtype

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -768,3 +768,9 @@ def test_regression_6099():
     series_result  = convolve(wave_series, np.ones((boxcar,))/boxcar)
 
     assert_array_almost_equal(nonseries_result, series_result)
+
+def test_invalid_array_convolve():
+    kernel = np.ones(3)/3.
+
+    with pytest.raises(TypeError):
+        convolve('glork', kernel)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -30,6 +30,12 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+HAS_PANDAS = True
+try:
+    import pandas
+except ImportError:
+    HAS_PANDAS = False
+
 
 class TestConvolve1D:
     def test_list(self):
@@ -751,3 +757,14 @@ def test_astropy_convolution_against_scipy():
                               convolve(y, x, normalize_kernel=False))
     assert_array_almost_equal(fftconvolve(y, x, 'same'),
                               convolve_fft(y, x, normalize_kernel=False))
+
+@pytest.mark.skipif('not HAS_PANDAS')
+def test_regression_6099():
+    wave = np.array((np.linspace(5000, 5100, 10)))
+    boxcar = 3
+    nonseries_result = convolve(wave, np.ones((boxcar,))/boxcar)
+
+    wave_series = pandas.Series(wave)
+    series_result  = convolve(wave_series, np.ones((boxcar,))/boxcar)
+
+    assert_array_almost_equal(nonseries_result, series_result)


### PR DESCRIPTION
This is proximately a fix that closes #6099 - that is, it allows `pandas` series to be convolved (and indeed it adds a test based exactly on @janerigby's test case from #6099).  More generally, though, it uses duck-typing to allow anything "array-like" to be a valid argument to `convolve`.  I think this is better because previous lots of things would fail somewhat counter-intuitively (e.g., tuples that could be happily converted to arrays, array-like objects that aren't `ndarray` subclasses, etc).

I *think* this also makes `convolve` and `convolve_fft` *more* consistent rather than less, because it looks to me like `convolve_fft` is also fairly duck-typed due to needing to copy the array.  But Maybe @keflavich can correct me if I missed something?