### PR TITLE
deprecated_renamed_argument to emit AstropyPendingDeprecationWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -333,6 +333,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``InheritDocstrings`` now also works on class properties. [#7166]
+- ``deprecated_renamed_argument`` now shows
+  ``AstropyPendingDeprecationWarning`` when ``pending=True``. [#7311]
 
 - ``diff_values()``, ``report_diff_values()``, and ``where_not_allclose()``
   utility functions are moved from ``astropy.io.fits.diff``. [#7444]

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -2,7 +2,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """Sundry function and class decorators."""
 
-
 import functools
 import inspect
 import textwrap
@@ -299,8 +298,10 @@ def deprecated_renamed_argument(old_name, new_name, since,
         Default is ``False``.
 
     pending : bool or list/tuple thereof, optional
-        If ``True`` this will hide the deprecation warning and ignore the
-        corresponding ``relax`` parameter value.
+        If ``True``, this will show ``AstropyPendingDeprecationWarning``,
+        not ``AstropyDeprecationWarning``. In addition, it also
+        ignores the corresponding ``relax`` parameter value (no extra
+        warning or error).
         Default is ``False``.
 
     Raises
@@ -453,14 +454,18 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 if old_name[i] in kwargs:
                     value = kwargs.pop(old_name[i])
                     # Display the deprecation warning only when it's only
-                    # pending.
-                    if not pending[i]:
-                        warnings.warn(
-                            '"{0}" was deprecated in version {1} '
-                            'and will be removed in a future version. '
-                            'Use argument "{2}" instead.'
-                            ''.format(old_name[i], since[i], new_name[i]),
-                            AstropyDeprecationWarning, stacklevel=2)
+                    # not pending.
+                    if pending[i]:
+                        category = AstropyPendingDeprecationWarning
+                    else:
+                        category = AstropyDeprecationWarning
+
+                    warnings.warn(
+                        '"{0}" was deprecated in version {1} '
+                        'and will be removed in a future version. '
+                        'Use argument "{2}" instead.'
+                        ''.format(old_name[i], since[i], new_name[i]),
+                        category, stacklevel=2)
 
                     # Check if the newkeyword was given as well.
                     newarg_in_args = (position[i] is not None and


### PR DESCRIPTION
`deprecated_renamed_argument` now emits `AstropyPendingDeprecationWarning` when `pending=True` is given. It is previously a no-op. Follow-up of #5761. Fixes #6313.

I didn't add new tests because there are no existing tests for `AstropyPendingDeprecationWarning` in `astropy/utils/tests/test_decorators.py`. Perhaps it is overkill to test for a *pending* deprecation warning? Unless you explicitly catch it with `warnings.catch_warnings()` and filter it to make it into an exception, it is silent.