### PR TITLE
For convolve(boundary=None) raise exception if kernel larger than array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -845,6 +845,10 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
+- convolve(boundary=None) requires the kernel to be smaller than the image.
+  This was never actually checked, it now is and an exception is raised.
+  [#7313]
+
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Resolves #7310

Signed-off-by: James Noss <jnoss@stsci.edu>