### PR TITLE
model sets: fix output shape when model_set_axis=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,7 +302,7 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
 
 - Fix the shape of the outputs when a model set is evaluated with
-  ``model_set_axis`` different from the one it was initialized with. [#7317]
+  ``model_set_axis=False`` . [#7317]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,6 +301,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Fix the shape of the outputs when a model set is evaluated with
+  ``model_set_axis`` different from the one it was initialized with. [#7317]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3369,7 +3369,7 @@ def _prepare_outputs_model_set(model, outputs, format_info, model_set_axis):
 
     # If model_set_axis = False was passed then use
     # model._model_set_axis to format the output.
-    if model_set_axis is None or not model_set_axis:
+    if model_set_axis is None or model_set_axis is False:
         model_set_axis = model.model_set_axis
     outputs = list(outputs)
     for idx, output in enumerate(outputs):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -748,7 +748,6 @@ class Model(metaclass=_ModelMeta):
         Evaluate this model using the given input(s) and the parameter values
         that were specified when the model was instantiated.
         """
-
         inputs, format_info = self.prepare_inputs(*inputs, **kwargs)
 
         # Check whether any of the inputs are quantities
@@ -1585,12 +1584,8 @@ class Model(metaclass=_ModelMeta):
 
         return outputs
 
-    def prepare_outputs(self, format_info, *outputs, model_set_axis=None, **kwargs):
-        if model_set_axis is None:
-            # By default the model_set_axis for the input is assumed to be the
-            # same as that for the parameters the model was defined with
-            # TODO: Ensure that negative model_set_axis arguments are respected
-            model_set_axis = self.model_set_axis
+    def prepare_outputs(self, format_info, *outputs, **kwargs):
+        model_set_axis = kwargs.get('model_set_axis', None)
 
         if len(self) == 1:
             return _prepare_outputs_single_model(self, outputs, format_info)
@@ -3372,6 +3367,10 @@ def _prepare_inputs_model_set(model, params, inputs, n_models, model_set_axis,
 def _prepare_outputs_model_set(model, outputs, format_info, model_set_axis):
     pivots = format_info[0]
 
+    # If model_set_axis = False was passed then use
+    # model._model_set_axis to format the output.
+    if model_set_axis is None or not model_set_axis:
+        model_set_axis = model.model_set_axis
     outputs = list(outputs)
     for idx, output in enumerate(outputs):
         pivot = pivots[idx]

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -426,10 +426,9 @@ class LinearLSQFitter(metaclass=_FitterMeta):
                     # z has 3 dimensions it represents multiple models where
                     # the value of z is one plane per model.  It's then
                     # flattening each plane and transposing so that the model
-                    # axis is *last*.  That's fine, but this could be
-                    # generalized for other dimensionalities of z.
-                    # TODO: See above comment
-                    rhs = z.reshape((z.shape[0], -1)).T
+                    # axis is *last*.
+                    model_axis = model_copy.model_set_axis or 0
+                    rhs = z.reshape((z.shape[model_axis], -1)).T
                 else:
                     rhs = z.T
             else:


### PR DESCRIPTION
This PR addresses the issue in [this comment](https://github.com/astropy/astropy/pull/7199#issuecomment-371680814).

When a model set is initialized with `model_set_axis` set to an integer, this axis is used in fitting and the result of a fitting operation is a model with the same `model_set_axis`.  The fitted model can be evaluated with `model_set_axis=False`. Previously the output would be formatted in such a way that the outputs for different models are stacked along the 0-axis. With this change the outputs are stacked along `model.model_set_axis`. If an integer `model_set_axis` is passed it is used to format the output.

This also fixed a small bug in fitting where the reshaping of the inputs before passing them to `np.linalg.leastsq` now uses `model_set_axis`.