### PR TITLE
Docstring update: LinearLSQFitter does not handle compound models

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -259,7 +259,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
     model's parameters. Keeps a dictionary of auxiliary fitting information.
     
     Notes
-    ----------
+    -----
     Note that currently LinearLSQFitter does not support compound models.
    
     """

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -257,11 +257,10 @@ class LinearLSQFitter(metaclass=_FitterMeta):
     Uses `numpy.linalg.lstsq` to do the fitting.
     Given a model and data, fits the model to the data and changes the
     model's parameters. Keeps a dictionary of auxiliary fitting information.
-    
+
     Notes
     -----
     Note that currently LinearLSQFitter does not support compound models.
-   
     """
 
     supported_constraints = ['fixed']
@@ -357,6 +356,9 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         if not model.linear:
             raise ModelLinearityError('Model is not linear in parameters, '
                                       'linear fit methods should not be used.')
+
+        if hasattr(model, "sunbmodel_names"):
+            raise ValueError("Model must be simple, not compound")
 
         _validate_constraints(self.supported_constraints, model)
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -257,6 +257,11 @@ class LinearLSQFitter(metaclass=_FitterMeta):
     Uses `numpy.linalg.lstsq` to do the fitting.
     Given a model and data, fits the model to the data and changes the
     model's parameters. Keeps a dictionary of auxiliary fitting information.
+    
+    Notes
+    ----------
+    Note that currently LinearLSQFitter does not support compound models.
+   
     """
 
     supported_constraints = ['fixed']

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -357,7 +357,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             raise ModelLinearityError('Model is not linear in parameters, '
                                       'linear fit methods should not be used.')
 
-        if hasattr(model, "sunbmodel_names"):
+        if hasattr(model, "submodel_names"):
             raise ValueError("Model must be simple, not compound")
 
         _validate_constraints(self.supported_constraints, model)


### PR DESCRIPTION
As mentioned in the issue #6038, the LinearLSQFitter currently does not handle compound models. @jehturner added a note about that in the narrative docs. I'm extending that note to the docstrings in order to make this fact even clearer for users.