### PR TITLE
Changed defaults for KDTree to more suitable values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,12 @@ astropy.coordinates
 - The new function ``make_transform_graph_docs`` can be used to create a
   docstring graph from a custom ``TransformGraph`` object. [#7135]
 
+- ``KDTree`` for catalog matching is now built with sliding midpoint rule
+  rather than standard.  In code, this means setting ``compact_nodes=False``
+  and ``balanced_tree=False`` in ``cKDTree``. The sliding midpoint rule is much
+  more suitable for catalog matching, and results in 1000x speedup in some
+  cases. [#7324]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -457,7 +457,15 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt='kdtree', forceunit=None):
         else:
             cartxyz = coord.cartesian.xyz.to(forceunit)
         flatxyz = cartxyz.reshape((3, np.prod(cartxyz.shape) // 3))
-        kdt = KDTree(flatxyz.value.T)
+        try:
+            # Set compact_nodes=False, balanced_tree=False to use
+            # "sliding midpoint" rule, which is much faster than standard for
+            # many common use cases
+            kdt = KDTree(flatxyz.value.T, compact_nodes=False, balanced_tree=False)
+        except TypeError:
+            # Python implementation does not take compact_nodes and balanced_tree
+            # as arguments.  However, it uses sliding midpoint rule by default
+            kdt = KDTree(flatxyz.value.T)
 
     if attrname_or_kdt:
         # cache the kdtree in `coord`

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -124,6 +124,17 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
+def test_python_kdtree(monkeypatch):
+    from .. import ICRS
+
+    cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 2]*u.kpc)
+    ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 2, 3, 4]*u.kpc)
+
+    monkeypatch.delattr("scipy.spatial.cKDTree")
+    matching.match_coordinates_sky(cmatch, ccatalog)
+
+
+@pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_method():
     from .. import ICRS, SkyCoord
     from ...utils import NumpyRNGContext


### PR DESCRIPTION
The defaults for scipy's KDTree are not suitable for catalog matching, so I changed compact_nodes to False and balanced_tree to False.  There are both empirical and theoretical reasons for this.  Empirically, I had one dataset for which match_to_catalog_sky took 2000 seconds with the KDTree defaults and 1 second with compact_nodes=False, balanced_tree=False.  Theoretically, Figure 1 of this paper (https://www.cs.umd.edu/~mount/Papers/cgc99-smpack.pdf) helps explain the issue, which I'll summarize below.

The default settings correspond to the "standard" implementation in Figure 1, while my proposed changes correspond to the "sliding midpoint" implementation.  The standard implementation performs horribly if the points have much larger spread in one dimension than another.  This is because it tends to create lots of skinny hyperrectangles while building the KDtree, dividing the dimension with large spread to the neglect of others.  During query, any hyperball around the query point is bound to intersect lots of these skinny hyperrectangles, making it necessary to visit all the nodes represented by them.

match_to_catalog_sky converts RA/Dec coordinates to 3D Cartesian coordinates by placing them on a unit sphere.  Thus, all points lie along an infinitely thin 2D surface, with zero spread along the third dimension (at least locally)--precisely the worst case scenario for the standard KDtree.  The standard implementation will only ever choose to split along 2 of the 3 dimensions, resulting in partitions that look like a bundle of needles.  

Setting compact_nodes=False, balanced_tree=False is equivalent to using the "sliding midpoint" rule from the paper.  As the paper shows, this gives good performance for a wide range of problems, particularly the poorly scaled problems typical for catalog matching.