### PR TITLE
Default to origin='lower' for WCSAxes since 'upper' isn't supported

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -909,6 +909,8 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Explicilty default to origin='lower' in WCSAxes. [#7331]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -175,7 +175,7 @@ class WCSAxes(Axes):
         All arguments are passed to :meth:`~matplotlib.axes.Axes.imshow`.
         """
 
-        origin = kwargs.get('origin', None)
+        origin = kwargs.get('origin', 'lower')
 
         if origin == 'upper':
             raise ValueError("Cannot use images with origin='upper' in WCSAxes.")


### PR DESCRIPTION
The current logic didn't make sense because ``origin=None`` means ``origin='upper'`` but the error message related to ``upper`` was only shown when explicitly using ``upper`` even though not specifying ``origin`` was equivalent.

cc @Cadair