### PR TITLE
Fix decimal spacing in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -913,6 +913,7 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Explicilty default to origin='lower' in WCSAxes. [#7331]
+
 - Fixed a bug that caused the position of the tick values in decimal mode
   to be incorrectly determined. [#7332]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -913,6 +913,8 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Explicilty default to origin='lower' in WCSAxes. [#7331]
+- Fixed a bug that caused the position of the tick values in decimal mode
+  to be incorrectly determined. [#7332]
 
 astropy.vo
 ^^^^^^^^^^

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -5,8 +5,7 @@ from ..utils.decorators import wraps
 
 MPL_VERSION = matplotlib.__version__
 
-ROOT = "http://{server}/testing/astropy/2018-02-01T23:31:45.013149/{mpl_version}/"
-
+ROOT = "http://{server}/testing/astropy/2018-03-27T18:38:34.793133/{mpl_version}/"
 IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x') + ',' +
                        ROOT.format(server='www.astropy.org/astropy-data', mpl_version=MPL_VERSION[:3] + '.x'))
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -748,7 +748,7 @@ class CoordinateHelper:
         coord_range = self.parent_map.get_coord_range()
 
         tick_world_coordinates, spacing = self.locator(*coord_range[self.coord_index])
-        tick_world_coordinates_values = tick_world_coordinates.value
+        tick_world_coordinates_values = tick_world_coordinates.to_value(self.coord_unit)
 
         n_coord = len(tick_world_coordinates_values)
 
@@ -770,11 +770,6 @@ class CoordinateHelper:
         # We now convert all the world coordinates to pixel coordinates in a
         # single go rather than doing this in the gridline to path conversion
         # to fully benefit from vectorized coordinate transformations.
-
-        # Currently xy_world is in deg, but transform function needs it in
-        # native units
-        if self._coord_scale_to_deg is not None:
-            xy_world /= self._coord_scale_to_deg
 
         # Transform line to pixel coordinates
         pixel = self.transform.inverted().transform(xy_world)

--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -9,6 +9,8 @@ from ... import units as u
 
 # Algorithm inspired by PGSBOX from WCSLIB by M. Calabretta
 
+LONLAT = {'longitude', 'latitude'}
+
 
 def wrap_180(values):
     values_new = values % 360.
@@ -51,7 +53,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
 
         xw = world[:, coord_index].reshape(xp.shape)
 
-        if coord_type in ['longitude', 'latitude']:
+        if coord_type in LONLAT:
 
             unit = coord_units[coord_index]
             xw = xw * unit.to(u.deg)
@@ -81,7 +83,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
 
         # Check if range is smaller when normalizing to the range 0 to 360
 
-        if coord_type in ['longitude', 'latitude']:
+        if coord_type in LONLAT:
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
@@ -94,7 +96,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
 
         # Check if range is smaller when normalizing to the range -180 to 180
 
-        if coord_type in ['longitude', 'latitude']:
+        if coord_type in LONLAT:
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", RuntimeWarning)
@@ -120,7 +122,7 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
             xw_min = max(-90., xw_min - 0.1 * x_range)
             xw_max = min(+90., xw_max + 0.1 * x_range)
 
-        if coord_type in ['longitude', 'latitude']:
+        if coord_type in LONLAT:
             xw_min *= u.deg.to(unit)
             xw_max *= u.deg.to(unit)
 

--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -120,6 +120,10 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
             xw_min = max(-90., xw_min - 0.1 * x_range)
             xw_max = min(+90., xw_max + 0.1 * x_range)
 
+        if coord_type in ['longitude', 'latitude']:
+            xw_min *= u.deg.to(unit)
+            xw_max *= u.deg.to(unit)
+
         ranges.append((xw_min, xw_max))
 
     return ranges

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -285,12 +285,19 @@ class AngleFormatterLocator(BaseFormatterLocator):
                     spacing_deg = self.base_spacing.to_value(u.degree)
                 else:
                     # otherwise we clip to the nearest 'sensible' spacing
-                    if self._format_unit is u.degree:
-                        from .utils import select_step_degree
-                        spacing_deg = select_step_degree(dv).to_value(u.degree)
+                    if self._decimal:
+                        from .utils import select_step_scalar
+                        if self._format_unit in (u.hour, u.hourangle):
+                            spacing_deg = select_step_scalar(dv.to_value(u.hourangle)) * 15
+                        else:
+                            spacing_deg = select_step_scalar(dv.to_value(u.degree))
                     else:
-                        from .utils import select_step_hour
-                        spacing_deg = select_step_hour(dv).to_value(u.degree)
+                        if self._format_unit is u.degree:
+                            from .utils import select_step_degree
+                            spacing_deg = select_step_degree(dv).to_value(u.degree)
+                        else:
+                            from .utils import select_step_hour
+                            spacing_deg = select_step_hour(dv).to_value(u.degree)
 
             # We now find the interval values as multiples of the spacing and
             # generate the tick positions from this.

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -56,6 +56,9 @@ class BaseFormatterLocator:
     def values(self, values):
         if not isinstance(values, u.Quantity) or (not values.ndim == 1):
             raise TypeError("values should be an astropy.units.Quantity array")
+        if not values.unit.is_equivalent(self._unit):
+            raise UnitsError("value should be in units compatible with "
+                             "coordinate units ({0}) but found {1}".format(self._unit, values.unit))
         self._number = None
         self._spacing = None
         self._values = values

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -52,7 +52,7 @@ def test_label_visibility_rules_default(ax):
 def test_label_visibility_rules_label(ax):
 
     ax.coords[0].set_ticklabel_visible(False)
-    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+    ax.coords[1].set_ticks(values=[-9999]*u.one)
 
     assert_label_draw(ax, False, False)
 
@@ -64,7 +64,7 @@ def test_label_visibility_rules_ticks(ax):
     ax.coords[1].set_axislabel_visibility_rule('ticks')
 
     ax.coords[0].set_ticklabel_visible(False)
-    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+    ax.coords[1].set_ticks(values=[-9999]*u.one)
 
     assert_label_draw(ax, True, False)
 
@@ -76,6 +76,6 @@ def test_label_visibility_rules_always(ax):
     ax.coords[1].set_axislabel_visibility_rule('always')
 
     ax.coords[0].set_ticklabel_visible(False)
-    ax.coords[1].set_ticks(values=[-9999]*u.deg)
+    ax.coords[1].set_ticks(values=[-9999]*u.one)
 
     assert_label_draw(ax, True, True)

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -208,6 +208,30 @@ class TestAngleFormatterLocator:
         assert_quantity_allclose(fl.locator(266.9730, 266.9750)[0],
                                  [17.79825, 17.79830] * u.hourangle)
 
+    def test_values_unit(self):
+
+        # Make sure that the intrinsic unit and format unit are correctly
+        # taken into account when using the locator
+
+        fl = AngleFormatterLocator(unit=u.arcsec, format_unit=u.arcsec, decimal=True)
+        assert_quantity_allclose(fl.locator(850, 2150)[0],
+                                 [1000., 1200., 1400., 1600., 1800., 2000.] * u.arcsec)
+
+        fl = AngleFormatterLocator(unit=u.arcsec, format_unit=u.degree, decimal=False)
+        assert_quantity_allclose(fl.locator(850, 2150)[0],
+                                 [15., 20., 25., 30., 35.] * u.arcmin)
+
+        fl = AngleFormatterLocator(unit=u.arcsec, format_unit=u.hourangle, decimal=False)
+        assert_quantity_allclose(fl.locator(850, 2150)[0],
+                                 [60., 75., 90., 105., 120., 135.] * (15 * u.arcsec))
+
+        fl = AngleFormatterLocator(unit=u.arcsec)
+        fl.format = 'dd:mm:ss'
+        assert_quantity_allclose(fl.locator(0.9, 1.1)[0], [1] * u.arcsec)
+
+        fl = AngleFormatterLocator(unit=u.arcsec, spacing=0.2 * u.arcsec)
+        assert_quantity_allclose(fl.locator(0.3, 0.9)[0], [0.4, 0.6, 0.8] * u.arcsec)
+
     @pytest.mark.parametrize(('spacing', 'string'), [(2 * u.deg, '15\xb0'),
                                                      (2 * u.arcmin, '15\xb024\''),
                                                      (2 * u.arcsec, '15\xb023\'32"'),
@@ -383,3 +407,16 @@ class TestScalarFormatterLocator:
         fl.spacing = 0.032 * u.m
         fl.format = 'x.xx'
         assert_almost_equal(fl.spacing.to_value(u.m), 0.03)
+
+    def test_values_unit(self):
+
+        # Make sure that the intrinsic unit and format unit are correctly
+        # taken into account when using the locator
+
+        fl = ScalarFormatterLocator(unit=u.cm, format_unit=u.m)
+        assert_quantity_allclose(fl.locator(850, 2150)[0],
+                                 [1000., 1200., 1400., 1600., 1800., 2000.] * u.cm)
+
+        fl = ScalarFormatterLocator(unit=u.cm, format_unit=u.m)
+        fl.format = 'x.x'
+        assert_quantity_allclose(fl.locator(1, 19)[0], [10] * u.cm)

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_almost_equal
 from matplotlib import rc_context
 
 from .... import units as u
+from ....tests.helper import assert_quantity_allclose
 from ....units import UnitsError
 from ..formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 
@@ -192,6 +193,20 @@ class TestAngleFormatterLocator:
         fl.spacing = 0.032 * u.deg
         fl.format = 'dd:mm:ss'
         assert_almost_equal(fl.spacing.to_value(u.arcsec), 115.)
+
+    def test_decimal_values(self):
+
+        # Regression test for a bug that meant that the spacing was not
+        # determined correctly for decimal coordinates
+
+        fl = AngleFormatterLocator()
+        fl.format = 'd.dddd'
+        assert_quantity_allclose(fl.locator(266.9730, 266.9750)[0],
+                                 [266.9735, 266.9740, 266.9745, 266.9750] * u.deg)
+
+        fl = AngleFormatterLocator(decimal=True, format_unit=u.hourangle, number=4)
+        assert_quantity_allclose(fl.locator(266.9730, 266.9750)[0],
+                                 [17.79825, 17.79830] * u.hourangle)
 
     @pytest.mark.parametrize(('spacing', 'string'), [(2 * u.deg, '15\xb0'),
                                                      (2 * u.arcmin, '15\xb024\''),


### PR DESCRIPTION
This fixes a bug in the determination of the step between ticks in decimal mode.

This should be backported, but the backporting will need some manual work for tests to pass, so I will do this straight after this is merged.