### PR TITLE
Remove markup from user documentation

### DIFF
--- a/docs/io/fits/api/verification.rst
+++ b/docs/io/fits/api/verification.rst
@@ -7,8 +7,8 @@ Verification options
 
 There are 5 options for the ``output_verify`` argument of the following methods
 of :class:`HDUList`: :meth:`~HDUList.close`, :meth:`~HDUList.writeto`, and
-:meth:`~HDUList.flush`, or the :meth:``~_BaseHDU.writeto`` method on any HDU
-object.  In these cases, the verification option is passed to a :meth:``verify``
+:meth:`~HDUList.flush`, or the ``_BaseHDU.writeto`` method on any HDU
+object.  In these cases, the verification option is passed to a ``verify``
 call within these methods.
 
 exception


### PR DESCRIPTION
I noticed two cases of markup making it through to the user at http://docs.astropy.org/en/stable/io/fits/api/verification.html - I am not sure what the best or suggested approach here is, and haven't run this through Sphinx on my own machine to check if it makes sense (for the `_BaseHDU` case).