### PR TITLE
adding additional example to Tables doc

### DIFF
--- a/docs/table/access_table.rst
+++ b/docs/table/access_table.rst
@@ -288,6 +288,20 @@ selected rows or columns.  ::
        9.000  11
       12.000  14
 
+We can select rows from a table using conditionals to create boolean masks. A
+table indexed with a boolean array will only return rows where the mask array
+element is `True`. Different conditionals can be combined using the bitwise
+operators.  ::
+
+  >>> mask = (t['a'] > 4) & (t['b'] > 8)  # Table rows where column a > 4
+  >>> print(t[mask])                      # and b > 8
+  ...
+       a      b   c
+    m sec^-1
+    -------- --- ---
+       9.000  10  11
+      12.000  13  14
+
 Finally, you can access the underlying table data as a native `numpy`
 structured array by creating a copy or reference with ``np.array``::
 


### PR DESCRIPTION
Hi,

I wanted to add an extra example to the Tables doc that shows how to filter rows on a ``Table`` using a boolean mask (conditionals).  I couldn't find an example of this anywhere else except for one that was actually using the filtering to replace values in the table.  But many beginning users may not see this example if they weren't looking in the "modifying a table" section.