### PR TITLE
Makes Latex reader ignore table rules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+Latex reader now ignores ``\toprule``, ``\midrule``, and ``\bottomrule`` commands [#7349]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -310,7 +310,7 @@ class Latex(core.BaseReader):
     data_class = LatexData
     inputter_class = LatexInputter
 
-    def __init__(self, ignore_latex_commands=['hline', 'vspace', 'tableline'],
+    def __init__(self, ignore_latex_commands=['hline', 'vspace', 'tableline', 'toprule', 'midrule', 'bottomrule'],
                  latexdict={}, caption='', col_align=None):
 
         super().__init__()

--- a/astropy/io/ascii/tests/t/latex2.tex
+++ b/astropy/io/ascii/tests/t/latex2.tex
@@ -6,9 +6,13 @@
 \tablehead{\colhead{Facility} & \colhead{Id} & \colhead{exposure} & \colhead{date}}
 
 \startdata
+\toprule
 Chandra & \dataset[ADS/Sa.CXO#obs/06438]{ObsId 6438} & 23 ks & 2006-12-10\\
+\midrule
 Spitzer & AOR 3656448  & 41.6 s & 2004-06-09\\
+\midrule
 FLWO    & filter: $B$ & 600 s & 2009-11-18\\
+\bottomrule
 \enddata
 
 \end{deluxetable}

--- a/astropy/io/ascii/tests/t/latex3.tex
+++ b/astropy/io/ascii/tests/t/latex3.tex
@@ -2,6 +2,7 @@
 cola & colb & colc\\
 \hline
 a & 1 & 2\\
+\midrule
 b & 3 & 4\\
 \hline
 \end{tabular}


### PR DESCRIPTION
There is a problem when reading LaTex tables that include table-rules instead of hlines.
This PR adds `\toprule`, `\midrule` and `\bottomrule` to the default ignore list of commands in the Latex reader. 
Closes issue #7260.