### PR TITLE
Opening FITS files stored in HDFS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ astropy.io.fits
 - ``HDUList.pop()`` now accepts string and tuple extension name
   specifications. [#7236]
 
+- ``.open()`` is now able to read FITS files stored in HDFS.
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
@@ -207,8 +209,6 @@ astropy.io.fits
 - Added support for ``copy.copy`` and ``copy.deepcopy`` for ``HDUList``. [#7218]
 
 - Override ``HDUList.copy()`` to return a shallow HDUList instance. [#7218]
-
-- ``.open()`` is now able to read FITS files stored in HDFS.
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,6 +208,8 @@ astropy.io.fits
 
 - Override ``HDUList.copy()`` to return a shallow HDUList instance. [#7218]
 
+- ``.open()`` is now able to read FITS files stored in HDFS.
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -25,6 +25,7 @@ from ....utils.exceptions import AstropyUserWarning
 from ....utils.decorators import deprecated_renamed_argument
 
 connectedToHDFS = False
+hdfs = None
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
@@ -168,6 +169,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     # If hadoop is True, then the code connects to the specified host and port
     if 'hadoop' in kwargs and kwargs['hadoop']:
+        global hdfs
         if not connectedToHDFS:
             hdfs = connectToHDFS()
         if hdfs is None:
@@ -198,6 +200,7 @@ def connectToHDFS():
     hosty = input("Type the HDFS host: ")
     porty = int(input("Type the NameNode port: "))
     hdfs = HDFileSystem(host=hosty, port=porty)
+    global connectedToHDFS
     connectedToHDFS = True
     return hdfs
 


### PR DESCRIPTION
With these changes, it is now possible to use the .open() function to open FITS files stored in HDFS (Hadoop Distributed File System). 
When opening files in HDFS, it is necessary to specify the 'hadoop' kwarg as True. Also, the file path needs to be the path in HDFS. (Example of use: .open('HDFS_file_path', hadoop=True)).
The purpose of this change is to facilitate the use of files stored in HDFS through the functions of Astropy, even if, for the time being, it is only possible to open them.