### PR TITLE
WCSaxes fail when projection two PV WCSes onto each other

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -474,8 +474,12 @@ class WCSAxes(Axes):
 
         if isinstance(frame, WCS):
 
-            coord_in = wcs_to_celestial_frame(self.wcs)
-            coord_out = wcs_to_celestial_frame(frame)
+            try:
+                coord_in = wcs_to_celestial_frame(self.wcs)
+                coord_out = wcs_to_celestial_frame(frame)
+            except:
+                coord_in = self.wcs
+                coord_out = frame
 
             if coord_in == coord_out:
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -477,7 +477,7 @@ class WCSAxes(Axes):
             try:
                 coord_in = wcs_to_celestial_frame(self.wcs)
                 coord_out = wcs_to_celestial_frame(frame)
-            except:
+            except ValueError:
                 coord_in = self.wcs
                 coord_out = frame
 


### PR DESCRIPTION
@astrofrog

PV WCSes, i.e., those with a single spatial/celestial dimension and a spectral
dimension, are a bit of a hack, but we want to support them.

If you try to use wcsaxes with these and give another wcs as the frame to transform to (e.g., for overlaying two projections), it fails:

```
from astropy.io import fits
from astropy import wcs
import pylab as pl

fh = fits.open('sourceI_Unknown_8_B6_robust0.5_diskpv_0.1.fits')
ww = wcs.WCS(fh[0].header)

fig = pl.figure(1)
ax = fig.add_axes([0.15, 0.1, 0.8, 0.8],projection=ww)
ax.get_transform(ww)
```
results in
```
Traceback (most recent call last):
  File "<ipython-input-9-fa8f33f06421>", line 1, in <module>
    ax.get_transform(ww)
  File "/Users/adam/repos/astropy/astropy/visualization/wcsaxes/core.py", line 465, in get_transform
    return self._get_transform_no_transdata(frame).inverted() + self.transData
  File "/Users/adam/repos/astropy/astropy/visualization/wcsaxes/core.py", line 477, in _get_transform_no_transdata
    coord_in = wcs_to_celestial_frame(self.wcs)
  File "/Users/adam/repos/astropy/astropy/wcs/utils.py", line 205, in wcs_to_celestial_frame
    raise ValueError("Could not determine celestial frame corresponding to "
ValueError: Could not determine celestial frame corresponding to the specified WCS object
```

This PR hacks around that by letting the frame transformation fail.  However, I
don't think this is the right thing to do, it's just a step in the ~~right~~
usable direction.