### PR TITLE
Use np.nan[func] in visualization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -357,6 +357,9 @@ astropy.visualization
 - In ``ImageNormalize``, the default for ``clip`` is set to ``True``.
   [#7800]
 
+- Changed ``AsymmetricPercentileInterval`` and ``MinMaxInterval`` to
+  ignore NaN values in arrays. [#7360]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -112,7 +112,7 @@ class MinMaxInterval(BaseInterval):
     """
 
     def get_limits(self, values):
-        return np.min(values), np.max(values)
+        return np.nanmin(values), np.nanmax(values)
 
 
 class AsymmetricPercentileInterval(BaseInterval):
@@ -150,8 +150,9 @@ class AsymmetricPercentileInterval(BaseInterval):
         values = values[np.isfinite(values)]
 
         # Determine values at percentiles
-        vmin, vmax = np.percentile(values, (self.lower_percentile,
-                                            self.upper_percentile))
+        vmin, vmax = np.nanpercentile(values,
+                                      (self.lower_percentile,
+                                       self.upper_percentile))
 
         return vmin, vmax
 


### PR DESCRIPTION
Change np.min, np.max, np.percentile to the nan-ignoring versions.
There are probably no use cases in which the expected return from
MinMaxInterval is `[nan, nan]`.