### PR TITLE
Implement datetime64 support for Time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,7 @@ astropy.time
   These methods are similar to those in the Python standard library
   `time` package and provide flexible input and output formatting. [#7323]
 
+- Added `numpy.datetime64` format class for ``Time`` class. [#7361]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,7 +171,7 @@ astropy.time
   `time` package and provide flexible input and output formatting. [#7323]
 
 - Added ``datetime64`` format to the ``Time`` class to support working with
-  `numpy.datetime64` dtype arrays. [#7361]
+  ``numpy.datetime64`` dtype arrays. [#7361]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,7 +170,8 @@ astropy.time
   These methods are similar to those in the Python standard library
   `time` package and provide flexible input and output formatting. [#7323]
 
-- Added `numpy.datetime64` format class for ``Time`` class. [#7361]
+- Added ``datetime64`` format to the ``Time`` class to support working with
+  `numpy.datetime64` dtype arrays. [#7361]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2045,7 +2045,7 @@ def _make_array(val, copy=False):
     # Allow only float64, string or object arrays as input
     # (object is for datetime, maybe add more specific test later?)
     # This also ensures the right byteorder for float64 (closes #2942).
-    if not (val.dtype == np.float64 or val.dtype.kind in 'OSUa'):
+    if not (val.dtype == np.float64 or val.dtype.kind in 'OSUMa'):
         val = np.asanyarray(val, dtype=np.float64)
 
     return val

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -260,7 +260,7 @@ class Time(ShapedLikeNDArray):
 
       >>> list(Time.FORMATS)
       ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
-       'datetime', 'iso', 'isot', 'yday', 'datetime64' 'fits', 'byear',
+       'datetime', 'iso', 'isot', 'yday', 'datetime64', 'fits', 'byear',
        'jyear', 'byear_str', 'jyear_str']
 
     Parameters

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -260,8 +260,8 @@ class Time(ShapedLikeNDArray):
 
       >>> list(Time.FORMATS)
       ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
-       'datetime', 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str',
-       'jyear_str']
+       'datetime', 'iso', 'isot', 'yday', 'datetime64' 'fits', 'byear',
+       'jyear', 'byear_str', 'jyear_str']
 
     Parameters
     ----------
@@ -549,8 +549,8 @@ class Time(ShapedLikeNDArray):
 
           >>> list(Time.FORMATS)
           ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
-           'datetime', 'iso', 'isot', 'yday', 'fits', 'byear', 'jyear', 'byear_str',
-           'jyear_str']
+           'datetime', 'iso', 'isot', 'yday', 'datetime64', 'fits', 'byear',
+           'jyear', 'byear_str', 'jyear_str']
         """
         return self._format
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -771,6 +771,8 @@ class Time(ShapedLikeNDArray):
 
     def _shaped_like_input(self, value):
         out = value
+        if value.dtype.kind == 'M':
+            return value[()]
         if not self._time.jd1.shape and not np.ma.is_masked(value):
             out = value.item()
         return out

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -971,6 +971,7 @@ class TimeYearDayTime(TimeISO):
 
 class TimeDatetime64(TimeISOT):
     name = 'datetime64'
+
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class`
         if not val1.dtype.kind == 'M':
@@ -990,7 +991,7 @@ class TimeDatetime64(TimeISOT):
     def value(self):
         precision = self.precision
         self.precision = 9
-        ret = super(TimeDatetime64, self).value
+        ret = super().value
         self.precision = precision
         return ret.astype('datetime64')
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -23,7 +23,7 @@ __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
            'TimeDeltaFormat', 'TimeDeltaSec', 'TimeDeltaJD',
            'TimeEpochDateString', 'TimeBesselianEpochString',
            'TimeJulianEpochString', 'TIME_FORMATS', 'TIME_DELTA_FORMATS',
-           'TimezoneInfo', 'TimeDeltaDatetime']
+           'TimezoneInfo', 'TimeDeltaDatetime', 'TimeDatetime64']
 
 __doctest_skip__ = ['TimePlotDate']
 
@@ -973,25 +973,26 @@ class TimeDatetime64(TimeISOT):
     name = 'datetime64'
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class`
-        if not all(isinstance(val, np.datetime64) for val in val1.flat):
+        if not val1.dtype.kind == 'M':
             raise TypeError('Input values for {0} class must be '
                             'datetime64 objects'.format(self.name))
         return val1, None
 
     def set_jds(self, val1, val2):
         if val1.dtype.name in ['datetime64[M]', 'datetime64[Y]']:
-            val1 = val1.astype('M8[D]')
+            val1 = val1.astype('datetime64[D]')
 
-        val1 = val1.astype('<U30')
+        val1 = val1.astype('S')
 
-        if '.' in val1.item(0):
-            self.precision = len(val1.item(0).split('.')[-1])
-
-        super(TimeDatetime64, self).set_jds(val1, val2)
+        super().set_jds(val1, val2)
 
     @property
     def value(self):
-        return super(TimeDatetime64, self).value.astype('<M8')
+        precision = self.precision
+        self.precision = 9
+        ret = super(TimeDatetime64, self).value
+        self.precision = precision
+        return ret.astype('datetime64')
 
 
 class TimeFITS(TimeString):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -969,6 +969,31 @@ class TimeYearDayTime(TimeISO):
                 '{year:d}:{yday:03d}'))
 
 
+class TimeDatetime64(TimeISOT):
+    name = 'datetime64'
+    def _check_val_type(self, val1, val2):
+        # Note: don't care about val2 for this class`
+        if not all(isinstance(val, np.datetime64) for val in val1.flat):
+            raise TypeError('Input values for {0} class must be '
+                            'datetime64 objects'.format(self.name))
+        return val1, None
+
+    def set_jds(self, val1, val2):
+        if val1.dtype.name in ['datetime64[M]', 'datetime64[Y]']:
+            val1 = val1.astype('M8[D]')
+
+        val1 = val1.astype('<U30')
+
+        if '.' in val1.item(0):
+            self.precision = len(val1.item(0).split('.')[-1])
+
+        super(TimeDatetime64, self).set_jds(val1, val2)
+
+    @property
+    def value(self):
+        return super(TimeDatetime64, self).value.astype('<M8')
+
+
 class TimeFITS(TimeString):
     """
     FITS format: "[±Y]YYYY-MM-DD[THH:MM:SS[.sss]][(SCALE[(REALIZATION)])]".

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -355,6 +355,9 @@ class TestBasic():
         dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
         Time(dt, format='datetime', scale='tai')
         Time([dt, dt], format='datetime', scale='tai')
+        dt64 = np.datetime64('2012-06-18T02:00:05.453000000', format='datetime64')
+        Time(dt64, format='datetime64', scale='tai')
+        Time([dt64, dt64], format='datetime64', scale='tai')
 
     def test_local_format_transforms(self):
         """
@@ -415,6 +418,40 @@ class TestBasic():
         assert np.all(t3[1].value == dt3[1])
         assert np.all(t3[:, 2] == Time(dt3[:, 2]))
         assert Time(t3[2, 0]) == t3[2, 0]
+
+    def test_datetime64(self):
+        dt64 = np.datetime64('2000-01-02T03:04:05.123456789')
+        dt64_2 = np.datetime64('2000-01-02')
+        t = Time(dt64, scale='utc', precision=9, format='datetime64')
+        assert t.iso == '2000-01-02 03:04:05.123456789'
+        assert t.datetime64 == dt64
+        assert t.value == dt64
+        t2 = Time(t.iso, scale='utc')
+        assert t2.datetime64 == dt64
+
+        t = Time(dt64_2, scale='utc', precision=3, format='datetime64')
+        assert t.iso == '2000-01-02 00:00:00.000'
+        assert t.datetime64 == dt64_2
+        assert t.value == dt64_2
+        t2 = Time(t.iso, scale='utc')
+        assert t2.datetime64 == dt64_2
+
+        t = Time([dt64, dt64_2], scale='utc', format='datetime64')
+        assert np.all(t.value == [dt64, dt64_2])
+
+        t = Time('2000-01-01 01:01:01.123456789', scale='tai')
+        assert t.datetime64 == np.datetime64('2000-01-01T01:01:01.123456789')
+
+        # broadcasting
+        dt3 = (dt64 + (dt64_2-dt64)*np.arange(12)).reshape(4, 3)
+        t3 = Time(dt3, scale='utc', format='datetime64')
+        assert t3.shape == (4, 3)
+        assert t3[2, 1].value == dt3[2, 1]
+        assert t3[2, 1] == Time(dt3[2, 1], format='datetime64')
+        assert np.all(t3.value == dt3)
+        assert np.all(t3[1].value == dt3[1])
+        assert np.all(t3[:, 2] == Time(dt3[:, 2], format='datetime64'))
+        assert Time(t3[2, 0], format='datetime64') == t3[2, 0]
 
     def test_epoch_transform(self):
         """Besselian and julian epoch transforms"""

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -157,9 +157,9 @@ that derives from the base :class:`~astropy.time.TimeFormat` class.
 This class structure can be easily adapted and extended by users for
 specialized time formats not supplied in `astropy.time`.
 
-===========  =================================================  ==============================
+===========  =================================================  =====================================
 Format            Class                                         Example argument
-===========  =================================================  ==============================
+===========  =================================================  =====================================
 byear        :class:`~astropy.time.TimeBesselianEpoch`          1950.0
 byear_str    :class:`~astropy.time.TimeBesselianEpochString`    'B1950.0'
 cxcsec       :class:`~astropy.time.TimeCxcSec`                  63072064.184
@@ -176,7 +176,8 @@ mjd          :class:`~astropy.time.TimeMJD`                     51544.0
 plot_date    :class:`~astropy.time.TimePlotDate`                730120.0003703703
 unix         :class:`~astropy.time.TimeUnix`                    946684800.0
 yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:00.000
-===========  =================================================  ==============================
+datetime64   :class:`~astropy.time.TimeDatetime64`              np.datetime64('2000-01-01T01:01:01')
+===========  =================================================  =====================================
 
 .. note:: The :class:`~astropy.time.TimeFITS` format implements most
    of the FITS standard [#]_, including support for the ``LOCAL`` timescale.
@@ -1302,8 +1303,8 @@ that can be parsed with Python standard library `time.strptime`
   >>> t
   <Time object: scale='utc' format='isot' value=2015-06-30T23:59:60.000>
 
-.. note that if this section gets too long, it should be moved to a separate 
-   doc page - see the top of performance.inc.rst for the instructions on how to do 
+.. note that if this section gets too long, it should be moved to a separate
+   doc page - see the top of performance.inc.rst for the instructions on how to do
    that
 .. include:: performance.inc.rst
 


### PR DESCRIPTION
I just wanted to know if this is the right way to go.

This PR implements `numpy.datetime64` support for `Time`. This method first converts `datetime64` to string and then convert to `Time`.

The other methods (using unix time) gave errors at nanosecond precision.

Closes #6428.