### PR TITLE
Bugfix: Make pytest optional for tests.helper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -319,6 +319,8 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Make pytest dependency optional for ``astropy.tests.helper``. [#7366]
+
 astropy.time
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
This is an alternative to #7252 to fix #7235 for the 3.0.x bugfix series. It makes the minimal changes needed so that SunPy can continue to use `quantity_allclose` without needing pytest.