### PR TITLE
DOC: Description and workaround of Spyder UMR conflict in known_issues

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -357,3 +357,22 @@ and search for the line that adds the option ``-Wl,--no-undefined`` to the
 .. [#] Continuum `says
        <https://groups.google.com/a/continuum.io/forum/#!topic/anaconda/mCQL6fVx55A>`_
        this will be fixed in their next Python build.
+
+Conflicts with the Spyder User Module Reloader under Python 2.7
+---------------------------------------------------------------
+
+When running Astropy in the Python 2 version of the
+`Spyder IDE <https://pythonhosted.org/spyder/>`_, failures to reload
+``astropy`` modules by Spyder's User Module Reloader (UMR) have been
+observed on repeatedly running a script through the builtin
+``runfile()``, raising an Exception in `astropy.logger`. In such a
+case it is recommended to disable the reloading in
+
+``Preferences > Console > Advanced settings > Set UMR excluded``
+(for Spyder < 3)
+
+``Preferences > Python Interpreter > Set UMR excluded`` (in Spyder 3)
+
+by adding ``astropy`` to the list of modules not to be reloaded.
+
+See: https://github.com/astropy/astropy/issues/7363


### PR DESCRIPTION
Fix #7363

Close #7374 

This is basically the same as #7374 but it is opened against `v2.0.x` branch instead of `master`. I tried cherry-picking but that didn't work. I also didn't want to clobber @dhomeier 's branch although theoretically I could.