### PR TITLE
Corrected Sersic1D and Sersic2D amplitude definition in docstrings

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -634,7 +634,7 @@ class Sersic1D(Fittable1DModel):
     Parameters
     ----------
     amplitude : float
-        Central surface brightness, within r_eff.
+        Surface brightness at r_eff.
     r_eff : float
         Effective (half-light) radius
     n : float
@@ -2389,7 +2389,7 @@ class Sersic2D(Fittable2DModel):
     Parameters
     ----------
     amplitude : float
-        Central surface brightness, within r_eff.
+        Surface brightness at r_eff.
     r_eff : float
         Effective (half-light) radius
     n : float


### PR DESCRIPTION
As implemented, the `amplitude` parameter for both Sersic1D and Sersic2D is the surface brightness at the effective radius. I updated the docstrings accordingly. 