### PR TITLE
MNT: Remove quantity_allclose wrapper in test helper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -155,6 +155,11 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- ``from astropy.tests.helper import *`` no longer includes
+  ``quantity_allclose``. However,
+  ``from astropy.tests.helper import quantity_allclose`` would still work.
+  [#7381]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     pass
 
-from ..units import allclose as _quantity_allclose
+from ..units import allclose as quantity_allclose  # noqa
 from ..utils.exceptions import (AstropyDeprecationWarning,
                                 AstropyPendingDeprecationWarning)
 
@@ -29,7 +29,7 @@ from .runner import TestRunner  # pylint: disable=W0611
 
 __all__ = ['raises', 'enable_deprecations_as_exceptions', 'remote_data',
            'treat_deprecations_as_exceptions', 'catch_warnings',
-           'assert_follows_unicode_guidelines', 'quantity_allclose',
+           'assert_follows_unicode_guidelines',
            'assert_quantity_allclose', 'check_pickling_recovery',
            'pickle_protocol', 'generic_recursive_equality_test']
 
@@ -467,11 +467,3 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
     from ..units.quantity import _unquantify_allclose_arguments
     np.testing.assert_allclose(*_unquantify_allclose_arguments(
         actual, desired, rtol, atol), **kwargs)
-
-
-# TODO: This is a workaround to preserve API compatibility for the bugfix
-def quantity_allclose(*args, **kwargs):
-    return _quantity_allclose(*args, **kwargs)
-
-
-quantity_allclose.__doc__ = _quantity_allclose.__doc__


### PR DESCRIPTION
Remove `quantity_allclose` wrapper in test helper. This is a follow-up of #7252. The wrapper was needed so Sphinx documentation would build correctly in a backward compatible way for bugfix release. This removes it from helper doc.