### PR TITLE
Add backticks around format type in FITS error

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -2266,7 +2266,7 @@ def _convert_fits2record(format):
     elif dtype == 'F':
         output_format = 'f8'
     else:
-        raise ValueError('Illegal format {}.'.format(format))
+        raise ValueError('Illegal format `{}`.'.format(format))
 
     return output_format
 
@@ -2310,7 +2310,7 @@ def _convert_record2fits(format):
             repeat = ''
         output_format = repeat + NUMPY2FITS[recformat]
     else:
-        raise ValueError('Illegal format {}.'.format(format))
+        raise ValueError('Illegal format `{}`.'.format(format))
 
     return output_format
 


### PR DESCRIPTION
I downloaded a table with pyvo and tried to save to FITS (using `table_obj.write('whatever.fits')`) and got this error: `ValueError: Illegal format object.`

Ideally, the error message would be improved with some more information about what column(s) are failing, but in the mean time this PR just addresses some ambiguity in the error message. It's not that the format object is illegal, it's that somehow it's trying to get the FITS format for type `object`. So this just adds backticks around the format type, as is done currently in one other version of the same error message (e.g., on L893).