### PR TITLE
Make NDUncertainty picklable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1009,6 +1009,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Added support for pickling ``NDData`` instances that have an uncertainty.
+  [#7383]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -891,6 +891,9 @@ astropy.nddata
 - Fixed rounding behavior in ``overlap_slices`` for even-sized small
   arrays. [#7859]
 
+- Added support for pickling ``NDData`` instances that have an uncertainty.
+  [#7383]
+
 astropy.samp
 ^^^^^^^^^^^^
 
@@ -1008,9 +1011,6 @@ astropy.modeling
 
 astropy.nddata
 ^^^^^^^^^^^^^^
-
-- Added support for pickling ``NDData`` instances that have an uncertainty.
-  [#7383]
 
 astropy.samp
 ^^^^^^^^^^^^

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -271,9 +271,13 @@ class NDUncertainty(metaclass=ABCMeta):
     def __setstate__(self, state):
         if len(state) != 3:
             raise TypeError('The state should contain 3 items.')
-        self.array = state[0]
+        self._array = state[0]
         self._unit = state[1]
-        self.parent_nddata = state[2]
+
+        parent = state[2]
+        if parent is not None:
+            parent = weakref.ref(parent)
+        self._parent_nddata = parent
 
     def __getitem__(self, item):
         """Normal slicing on the array, keep the unit and return a reference.

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -247,6 +247,18 @@ class NDUncertainty(metaclass=ABCMeta):
             body = str(self.array)
         return ''.join([prefix, body, ')'])
 
+    def __reduce__(self):
+        """Because of the weak reference the class wouldn't be picklable."""
+        try:
+            return (type(self),
+                    (self._array, False, self._unit),
+                    (self.parent_nddata, ))
+        except MissingDataAssociationException:
+            return type(self), (self._array, False, self._unit)
+
+    def __setstate__(self, state):
+        self.parent_nddata = state[0]
+
     def __getitem__(self, item):
         """Normal slicing on the array, keep the unit and return a reference.
         """

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-
+import pickle
 import textwrap
 from collections import OrderedDict
 
@@ -353,6 +353,15 @@ def test_param_unit():
     # (another NDData as data)
     nd3 = NDData(nd, unit='km')
     assert nd3.unit == u.km
+
+
+def test_pickle_nddata_with_uncertainty():
+    ndd = NDData(np.ones(3), uncertainty=StdDevUncertainty(np.ones(5), unit=u.m))
+    dumped = pickle.dumps(ndd)
+    ndd_restored = pickle.loads(dumped)
+    assert type(ndd_restored.uncertainty) is StdDevUncertainty
+    assert ndd_restored.uncertainty.parent_nddata is ndd_restored
+    assert ndd_restored.uncertainty.unit == u.m
 
 
 # Check that the meta descriptor is working as expected. The MetaBaseTest class

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -356,7 +356,9 @@ def test_param_unit():
 
 
 def test_pickle_nddata_with_uncertainty():
-    ndd = NDData(np.ones(3), uncertainty=StdDevUncertainty(np.ones(5), unit=u.m))
+    ndd = NDData(np.ones(3),
+                 uncertainty=StdDevUncertainty(np.ones(5), unit=u.m),
+                 unit=u.m)
     ndd_dumped = pickle.dumps(ndd)
     ndd_restored = pickle.loads(ndd_dumped)
     assert type(ndd_restored.uncertainty) is StdDevUncertainty
@@ -365,7 +367,9 @@ def test_pickle_nddata_with_uncertainty():
 
 
 def test_pickle_uncertainty_only():
-    ndd = NDData(np.ones(3), uncertainty=StdDevUncertainty(np.ones(5), unit=u.m))
+    ndd = NDData(np.ones(3),
+                 uncertainty=StdDevUncertainty(np.ones(5), unit=u.m),
+                 unit=u.m)
     uncertainty_dumped = pickle.dumps(ndd.uncertainty)
     uncertainty_restored = pickle.loads(uncertainty_dumped)
     np.testing.assert_array_equal(ndd.uncertainty.array,
@@ -378,7 +382,7 @@ def test_pickle_uncertainty_only():
 
 
 def test_pickle_nddata_without_uncertainty():
-    ndd = NDData(np.ones(3))
+    ndd = NDData(np.ones(3), unit=u.m)
     dumped = pickle.dumps(ndd)
     ndd_restored = pickle.loads(dumped)
     np.testing.assert_array_equal(ndd.data, ndd_restored.data)

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -357,11 +357,31 @@ def test_param_unit():
 
 def test_pickle_nddata_with_uncertainty():
     ndd = NDData(np.ones(3), uncertainty=StdDevUncertainty(np.ones(5), unit=u.m))
-    dumped = pickle.dumps(ndd)
-    ndd_restored = pickle.loads(dumped)
+    ndd_dumped = pickle.dumps(ndd)
+    ndd_restored = pickle.loads(ndd_dumped)
     assert type(ndd_restored.uncertainty) is StdDevUncertainty
     assert ndd_restored.uncertainty.parent_nddata is ndd_restored
     assert ndd_restored.uncertainty.unit == u.m
+
+
+def test_pickle_uncertainty_only():
+    ndd = NDData(np.ones(3), uncertainty=StdDevUncertainty(np.ones(5), unit=u.m))
+    uncertainty_dumped = pickle.dumps(ndd.uncertainty)
+    uncertainty_restored = pickle.loads(uncertainty_dumped)
+    np.testing.assert_array_equal(ndd.uncertainty.array,
+                                  uncertainty_restored.array)
+    assert ndd.uncertainty.unit == uncertainty_restored.unit
+    # Even though it has a parent there is no one that references the parent
+    # after unpickling so the weakref "dies" immediately after unpickling
+    # finishes.
+    assert uncertainty_restored.parent_nddata is None
+
+
+def test_pickle_nddata_without_uncertainty():
+    ndd = NDData(np.ones(3))
+    dumped = pickle.dumps(ndd)
+    ndd_restored = pickle.loads(dumped)
+    np.testing.assert_array_equal(ndd.data, ndd_restored.data)
 
 
 # Check that the meta descriptor is working as expected. The MetaBaseTest class

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import pickle
+
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
@@ -9,6 +11,7 @@ from ..nduncertainty import (StdDevUncertainty,
                              InverseVariance,
                              NDUncertainty,
                              IncompatibleUncertaintiesException,
+                             MissingDataAssociationException)
                              UnknownUncertainty)
 from ..nddata import NDData
 from ..compat import NDDataArray
@@ -257,6 +260,13 @@ def test_for_stolen_uncertainty():
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data
     assert ndd2.uncertainty.parent_nddata.data == ndd2.data
 
+def test_stddevuncertainty_pickle():
+    uncertainty = StdDevUncertainty(np.ones(3), unit=u.m)
+    uncertainty_restored = pickle.loads(pickle.dumps(uncertainty))
+    np.testing.assert_array_equal(uncertainty.array, uncertainty_restored.array)
+    assert uncertainty.unit == uncertainty_restored.unit
+    with pytest.raises(MissingDataAssociationException):
+        uncertainty_restored.parent_nddata
 
 @pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_quantity(UncertClass):

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -11,7 +11,7 @@ from ..nduncertainty import (StdDevUncertainty,
                              InverseVariance,
                              NDUncertainty,
                              IncompatibleUncertaintiesException,
-                             MissingDataAssociationException)
+                             MissingDataAssociationException,
                              UnknownUncertainty)
 from ..nddata import NDData
 from ..compat import NDDataArray


### PR DESCRIPTION
Fixes #7315 

I'm not sure if that's the best approach though.

Given that it might break backwards-compatibility I'm adding it to the 3.1 milestone.