### PR TITLE
Fix bug with separation_3d failing when velocity data present

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,7 +279,7 @@ astropy.coordinates
 
 - Computing a 3D separation between two ``SkyCoord`` objects (with the
   ``separation_3d`` method) now works with or without velocity data attached to
-  the objects. [#9999]
+  the objects. [#7387]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -277,6 +277,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Computing a 3D separation between two ``SkyCoord`` objects (with the
+  ``separation_3d`` method) now works with or without velocity data attached to
+  the objects. [#9999]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -978,7 +978,9 @@ class SkyCoord(ShapedLikeNDArray):
             raise ValueError('The other object does not have a distance; '
                              'cannot compute 3d separation.')
 
-        return Distance((self.cartesian - other.cartesian).norm())
+        c1 = self.cartesian.without_differentials()
+        c2 = other.cartesian.without_differentials()
+        return Distance((c1 - c2).norm())
 
     def spherical_offsets_to(self, tocoord):
         r"""

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -200,3 +200,16 @@ def test_position_angle(sc, sc_for_sep):
 def test_constellations(sc):
     const = sc.get_constellation()
     assert const == 'Pisces'
+
+def test_separation_3d_with_differentials():
+    c1 = SkyCoord(ra=138*u.deg, dec=-17*u.deg, distance=100*u.pc,
+                  pm_ra_cosdec=5*u.mas/u.yr,
+                  pm_dec=-7*u.mas/u.yr,
+                  radial_velocity=160*u.km/u.s)
+    c2 = SkyCoord(ra=138*u.deg, dec=-17*u.deg, distance=105*u.pc,
+                  pm_ra_cosdec=15*u.mas/u.yr,
+                  pm_dec=-74*u.mas/u.yr,
+                  radial_velocity=-60*u.km/u.s)
+
+    sep = c1.separation_3d(c2)
+    assert_quantity_allclose(sep, 5*u.pc)

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -201,6 +201,7 @@ def test_constellations(sc):
     const = sc.get_constellation()
     assert const == 'Pisces'
 
+
 def test_separation_3d_with_differentials():
     c1 = SkyCoord(ra=138*u.deg, dec=-17*u.deg, distance=100*u.pc,
                   pm_ra_cosdec=5*u.mas/u.yr,


### PR DESCRIPTION
In master:
```python
c1 = SkyCoord(ra=138*u.deg, dec=-17*u.deg, distance=100*u.pc,
             pm_ra_cosdec=5*u.mas/u.yr,
             pm_dec=-7*u.mas/u.yr,
             radial_velocity=160*u.km/u.s)
c2 = SkyCoord(ra=138*u.deg, dec=-17*u.deg, distance=105*u.pc,
             pm_ra_cosdec=15*u.mas/u.yr,
             pm_dec=-74*u.mas/u.yr,
             radial_velocity=-60*u.km/u.s)

sep = c1.separation_3d(c2)
```
results in
```
ERROR: TypeError: Operation 'sub' is not supported when differentials are attached to a CartesianRepresentation.
```

But computing the positional separation between two coordinates shouldn't care about velocities! 

Note @bsipocz - it would be good to have this in 3.0.2, and out ASAP because I suspect this will be an issue for Gaia data users (I found the bug when playing with some mock DR2 data 😄)