### PR TITLE
TST: Add astropy_helpers version info to test header

### DIFF
--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -94,6 +94,14 @@ def pytest_report_header(config):
                 version = 'unknown (no __version__ attribute)'
             s += "{0}: {1}\n".format(module_display, version)
 
+    # Helpers version
+    try:
+        from ...version import astropy_helpers_version
+    except ImportError:
+        pass
+    else:
+        s += "astropy_helpers: {0}\n".format(astropy_helpers_version)
+
     special_opts = ["remote_data", "pep8"]
     opts = []
     for op in special_opts:


### PR DESCRIPTION
Fix #7385 

Depends on astropy/astropy-helpers#387

Before this patch:
```
Numpy: 1.14.1
Scipy: 1.0.0
Matplotlib: 2.1.1
h5py: 2.7.0
Pandas: 0.20.3
Asdf: 2.0.0.dev1248
Cython: 0.26.1
Using Astropy options: remote_data: none.
```

After this patch:
```
Numpy: 1.14.1
Scipy: 1.0.0
Matplotlib: 2.1.1
h5py: 2.7.0
Pandas: 0.20.3
Asdf: 2.0.0.dev1248
Cython: 0.26.1
astropy_helpers: 3.0.1
Using Astropy options: remote_data: none.
```

Note: Check CI logs carefully to make sure this is applied across the board before merging.