### PR TITLE
TST: Fix parallel download caching in test

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -67,7 +67,7 @@ def test_download_parallel():
     main_url = 'http://data.astropy.org/intersphinx/README'
     mirror_url = 'http://www.astropy.org/astropy-data/intersphinx/README'
     fnout = download_files_in_parallel([
-        'http://data.astropy.org', main_url, mirror_url])
+        'http://data.astropy.org', main_url, mirror_url], cache=True)
     assert all([os.path.isfile(f) for f in fnout]), fnout
 
     # Now test that download_file looks in mirror's cache before download.


### PR DESCRIPTION
Backport of #6987 did not take account of #6671 , which did not make it back to v2.0.x. I'll take responsibility of letting this slip through. I apologize.