### PR TITLE
Tabular outputs shape

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -955,6 +955,8 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Fixed ``Tabular`` models to not change the shape of data. [#7411]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -215,7 +215,7 @@ class _Tabular(Model):
         """
         if isinstance(inputs, u.Quantity):
             inputs = inputs.value
-
+        shape = inputs[0].shape
         inputs = [inp.flatten() for inp in inputs[: self.n_inputs]]
         inputs = np.array(inputs).T
         if not has_scipy:  # pragma: no cover
@@ -229,6 +229,10 @@ class _Tabular(Model):
                 not isinstance(self.points[0], u.Quantity)):
             result = result * self.lookup_table.unit
 
+        if self.n_outputs == 1:
+            result = result.reshape(shape)
+        else:
+            result = [r.reshape(shape) for r in result]
         return result
 
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -20,6 +20,16 @@ from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
                       Tabular1D)
 
 
+try:
+    import scipy
+    from scipy import optimize  # pylint: disable=W0611
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+HAS_SCIPY_14 = HAS_SCIPY and minversion(scipy, "0.14")
+
+
 @pytest.mark.parametrize(('expr', 'result'),
                          [(lambda x, y: x + y, 5.0),
                           (lambda x, y: x - y, -1.0),
@@ -901,7 +911,7 @@ def test_name():
     assert m.name == "M"
     assert m1.name == "M1"
 
-
+@pytest.mark.skipif("not HAS_SCIPY_14")
 def test_tabular_in_compound():
     """
     Issue #7411 - evaluate should not change the shape of the output.

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -16,7 +16,8 @@ from ..parameters import Parameter
 from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
                       Gaussian2D, Polynomial1D, Polynomial2D,
                       Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D,
-                      AffineTransformation2D, Identity, Mapping)
+                      AffineTransformation2D, Identity, Mapping,
+                      Tabular1D)
 
 
 @pytest.mark.parametrize(('expr', 'result'),
@@ -899,3 +900,21 @@ def test_name():
     m1 = m.rename("M1")
     assert m.name == "M"
     assert m1.name == "M1"
+
+
+def test_tabular_in_compound():
+    """
+    Issue #7411 - evaluate should not change the shape of the output.
+    """
+    t = Tabular1D(points=([1, 5, 7],), lookup_table=[12, 15, 19],
+                  bounds_error=False)
+    rot = Rotation2D(2)
+    p = Polynomial1D(1)
+    x = np.arange(12).reshape((3,4))
+    # Create a compound model which does ot execute Tabular.__call__,
+    # but model.evaluate and is followed by a Rotation2D which
+    # checks the exact shapes.
+    model = p & t | rot
+    x1, y1 = model(x, x)
+    assert x1.ndim == 2
+    assert y1.ndim == 2

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from numpy.testing import assert_allclose, assert_array_equal
 
-
+from ...utils import minversion
 from ..core import Model, ModelDefinitionError
 from ..parameters import Parameter
 from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,


### PR DESCRIPTION
The original shape of the inputs was not preserved in Tabular models.
This leads to problems when Tabular is combined with other models checking for shape of inputs like rotations.