### PR TITLE
Adding python 3.7-dev to the travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ matrix:
 
         - language: python
           python: "3.7-dev"
-          install: pip install -r pip-requirements matplotlib jplephem Cython>=0.21 jinja2>=2.7 beautifulsoup4 bleach pytest-astropy skyfield mpmath pytest-mpl
+          install: pip install -r pip-requirements matplotlib jplephem Cython>=0.28 jinja2>=2.7 beautifulsoup4 bleach pytest-astropy skyfield mpmath pytest-mpl
 
     allow_failures:
       - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -172,7 +172,7 @@ matrix:
 
         - language: python
           python: "3.7-dev"
-          install: pip install -r pip-requirements-dev
+          install: pip install -r pip-requirements matplotlib jplephem Cython>=0.21 jinja2>=2.7 beautifulsoup4 bleach pytest-astropy skyfield mpmath pytest-mpl
 
     allow_failures:
       - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,9 @@ matrix:
         - stage: Initial tests
           env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+
         # Try MacOS X. Use a slightly old numpy version to help test against
         # all supported numpy versions.
         - os: osx
@@ -119,7 +122,8 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+          env: PYTHON_VERSION=3.7
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PYTEST_VERSION='>3.2'
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
@@ -171,7 +175,7 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
         - language: python
-          python: "3.7-dev"
+          python: "3.7"
           install: pip install -r pip-requirements matplotlib jplephem Cython>=0.28 jinja2>=2.7 beautifulsoup4 bleach pytest-astropy skyfield mpmath pytest-mpl
 
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -170,6 +170,10 @@ matrix:
           env: NUMPY_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
 
+        - language: python
+          python: "3.7-dev"
+          install: pip install -r pip-requirements-dev
+
     allow_failures:
       - os: linux
         env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'


### PR DESCRIPTION
The release is almost out, so adding this now won't hurt. If it fails I'll move it to the allowed to fail section