### PR TITLE
Implement a Flag on Model for if the model should be called with units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,9 @@ astropy.modeling
 - Add a ``Multiply`` model which preseves unit through evaluate, unlike
   ``Scale`` which is dimensionless. [#7210]
 
+- Add a ``uses_quantity`` property to ``Model`` which allows introspection of if
+  the ``Model`` can accept ``Quantity`` objects. [#7417]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 
@@ -320,9 +323,6 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
-
-- Add a ``uses_quantity`` property to ``Model`` which allows introspection of if
-  the ``Model`` can accept ``Quantity`` objects. [#7417]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,6 +321,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Add a ``uses_quantity`` property to ``Model`` which allows introspection of if
+  the ``Model`` can accept ``Quantity`` objects. [#7417]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -728,6 +728,21 @@ class Model(metaclass=_ModelMeta):
         else:
             return val
 
+    @property
+    def uses_quantity(self):
+        """
+        True if this model has been created with `~astropy.units.Quantity`
+        objects or if there are no parameters.
+
+        This can be used to determine if this model should be evaluated with
+        `~astropy.units.Quantity` or regular floats.
+        """
+        pisq = [isinstance(p, Quantity) for p in self._param_sets(units=True)]
+        if not len(pisq) or any(pisq):
+            return True
+        else:
+            return False
+
     def __repr__(self):
         return self._format_repr()
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -738,10 +738,7 @@ class Model(metaclass=_ModelMeta):
         `~astropy.units.Quantity` or regular floats.
         """
         pisq = [isinstance(p, Quantity) for p in self._param_sets(units=True)]
-        if not len(pisq) or any(pisq):
-            return True
-        else:
-            return False
+        return (len(pisq) == 0) or any(pisq)
 
     def __repr__(self):
         return self._format_repr()

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -3,10 +3,10 @@ import pytest
 
 from ...tests.helper import assert_quantity_allclose
 from ... import units as u
-from ..functional_models import Gaussian1D
 
+from astropy.modeling.models import Mapping, Pix2Sky_TAN, Gaussian1D
 from astropy.modeling import models
-from astropy.modeling.core import Model, _ModelMeta
+from astropy.modeling.core import _ModelMeta
 
 
 def test_gaussian1d_bounding_box():
@@ -63,6 +63,46 @@ def test_default_parameters():
     g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm)
     assert isinstance(g, Gaussian1D)
     g(10*u.m)
+
+
+def test_uses_quantity():
+    """
+    Test Quantity
+    """
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.Jy)
+
+    assert g.uses_quantity
+
+    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
+
+    assert not g.uses_quantity
+
+    g.mean = 3 * u.m
+
+    assert g.uses_quantity
+
+
+def test_uses_quantity_compound():
+    """
+    Test Quantity
+    """
+    g = Gaussian1D(mean=3 * u.m, stddev=3 * u.cm, amplitude=3 * u.Jy)
+    g2 = Gaussian1D(mean=5 * u.m, stddev=5 * u.cm, amplitude=5 * u.Jy)
+
+    assert (g | g2).uses_quantity
+
+    g = Gaussian1D(mean=3, stddev=3, amplitude=3)
+    g2 = Gaussian1D(mean=5, stddev=5, amplitude=5)
+
+    comp = g | g2
+
+    assert not (comp).uses_quantity
+
+
+def test_uses_quantity_no_param():
+    comp = Mapping((0, 1)) | Pix2Sky_TAN()
+
+    assert comp.uses_quantity
 
 
 def _allmodels():


### PR DESCRIPTION
This adds a property to Model that allows introspection of if the Model allows Quantity objects to it's `__call__`.