### PR TITLE
Add Quantity.to_string method with arbitrary delimiter

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1257,9 +1257,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                                  prefix=prefixstr)
         return '{0}{1}{2:s}>'.format(prefixstr, arrstr, self._unitstr)
 
-    def _repr_latex_(self):
+    def to_string(self, delimiter="$"):
         """
-        Generate a latex representation of the quantity and its unit.
+        Generate a string representation of the quantity and its unit.
 
         The behavior of this function can be altered via the
         `numpy.set_printoptions` function and its various keywords.  The
@@ -1268,10 +1268,15 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         This is treated separately because the numpy default of 1000 is too big
         for most browsers to handle.
 
+        Parameters
+        ----------
+        delimiter : str, optional
+            Character that opens and closes the string (by default '$').
+
         Returns
         -------
         lstr
-            A LaTeX string with the contents of this Quantity
+            A string with the contents of this Quantity
         """
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
@@ -1311,7 +1316,16 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                       if self.unit is not None
                       else _UNIT_NOT_INITIALISED)
 
-        return r'${0} \; {1}$'.format(latex_value, latex_unit)
+        return r'{2}{0} \; {1}{2}'.format(latex_value, latex_unit, delimiter)
+
+    def _repr_latex_(self):
+        """
+        Generate a latex representation of the quantity and its unit.
+
+        For more documentation, read the Quantity.to_string() method.
+
+        """
+        return self.to_string(delimiter="$")
 
     def __format__(self, format_spec):
         """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -875,6 +875,12 @@ class TestQuantityDisplay:
         qinfnan = [np.inf, -np.inf, np.nan] * u.m
         assert qinfnan._repr_latex_() == r'$[\infty,~-\infty,~{\rm NaN}] \; \mathrm{m}$'
 
+    def test_to_string(self):
+        q2scalar = u.Quantity(1.5e14, 'm/s')
+        delimiter = "_"
+
+        assert q2scalar.to_string(delimiter=delimiter) == "{1}{0}{1}".format(q2scalar._repr_latex_()[1:-1], delimiter)
+
 
 def test_decompose():
     q1 = 5 * u.N


### PR DESCRIPTION
This is an attempt to prepare the ground for using double dollar signs in notebook output without breaking everyone else's code, essentially doing what @hamogu suggested in https://github.com/astropy/astropy/pull/6502#issuecomment-338419383.

I was not sure if it's worth it to test every simple case in `test_to_string` (basically duplicating test_repr_latex) and also am not sure how to do this part:

> We encourage everybody to use the "to_string" method in their code instead of _repr_latex which is intended only to enable the automatic rendering of notebooks..

Should I put some sort of future warning?