### PR TITLE
Fix MaskedColumn performance issue for mask=None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,9 +74,6 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
-- Fix a performance issue in ``MaskedColumn`` where initialization was
-  extremely slow for large arrays with the default ``mask=None``. [#7422]
-
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -974,6 +971,9 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fix a performance issue in ``MaskedColumn`` where initialization was
+  extremely slow for large arrays with the default ``mask=None``. [#7422]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix a performance issue in ``MaskedColumn`` where initialization was
+  extremely slow for large arrays with the default ``mask=None``. [#7422]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1114,8 +1114,14 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
                 description=None, unit=None, format=None, meta=None,
                 copy=False, copy_indices=True):
 
-        if mask is None and hasattr(data, 'mask'):
-            mask = data.mask
+        if mask is None:
+            if hasattr(data, 'mask'):
+                mask = data.mask
+            else:
+                # Issue #7399 with fix #7422.  Passing mask=None to ma.MaskedArray
+                # is extremely slow (~3 seconds for 1e7 elements), while mask=False
+                # gets quickly broadcast to the expected bool array of False.
+                mask = False
         else:
             mask = deepcopy(mask)
 


### PR DESCRIPTION
Fixes #7399 

I think this could be backported to 2.0.x.  As far as I can tell there is no API change, just a performance fix.  It could even be called a bug since it is apparently not expected to use `None` instead of `False` for the `mask` in `MaskedArray` (though it gives the same final result, just very slowly).  

I think we can keep the astropy API for MaskedColumn where `mask=None` is the default and implies `MaskedArray(data, mask=False)`.  One point is we do not use a default of `np.ma.nomask`, which has the effect of giving a scalar `mask`, which generally breaks things later.

@mhvk - this should be an easy review!
cc @adrn