### PR TITLE
Use Green Bank Convention to write and read vectorized location for time coordinates to/from FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,7 @@ astropy.io.fits
 
 - Add an ``ignore_hdus`` keyword to ``FITSDiff`` to allow ignoring HDUs by
   NAME when diffing two FITS files [#7538]
+
 - All time coordinates can now be written to and read from FITS binary tables,
   including those with vectorized locations. [#7430]
 
@@ -481,9 +482,6 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
-
-- Added a feature to write and read vectorized location for time coordinates 
-  to/from FITS Binary Table. [#7430]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ astropy.io.fits
 
 - Add an ``ignore_hdus`` keyword to ``FITSDiff`` to allow ignoring HDUs by
   NAME when diffing two FITS files [#7538]
+- All time coordinates can now be written to and read from FITS binary tables,
+  including those with vectorized locations. [#7430]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -479,6 +481,9 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Added a feature to write and read vectorized location for time coordinates 
+  to/from FITS Binary Table. [#7430]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -451,7 +451,7 @@ def fits_to_time(hdr, table):
             hcopy.remove(key)
 
         elif (value in ('OBSGEO-X', 'OBSGEO-Y', 'OBSGEO-Z') and
-                re.match('TTYPE[0-9]+', key) is not None):
+              re.match('TTYPE[0-9]+', key)):
 
             global_info[value] = table[value]
 
@@ -559,7 +559,7 @@ def time_to_fits(table):
             if location is None:
                 # Set global geocentric location
                 location = col.location
-                if col.location.size > 1:
+                if location.size > 1:
                     for dim in ('x', 'y', 'z'):
                         newtable.add_column(Column(getattr(location, dim).to_value(u.m)),
                                             name='OBSGEO-{}'.format(dim.upper()))

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -450,6 +450,11 @@ def fits_to_time(hdr, table):
             time_columns[int(idx)][base] = value
             hcopy.remove(key)
 
+        elif (value in ('OBSGEO-X', 'OBSGEO-Y', 'OBSGEO-Z') and
+                re.match('TTYPE[0-9]+', key) is not None):
+
+            global_info[value] = table[value]
+
     # Verify and get the global time reference frame information
     _verify_global_info(global_info)
     _convert_global_time(table, global_info)
@@ -550,14 +555,17 @@ def time_to_fits(table):
                     'Earth Location "TOPOCENTER" for Time Column "{}" is incompatabile '
                     'with scale "{}".'.format(col.info.name, col.scale.upper()),
                     AstropyUserWarning)
-            if col.location.size > 1:
-                raise ValueError('Vectorized Location of Time Column "{}" cannot be '
-                                 'written, as it is not supported.'.format(col.info.name))
+
             if location is None:
                 # Set global geocentric location
                 location = col.location
-                hdr.extend([Card(keyword='OBSGEO-{}'.format(dim.upper()),
-                                 value=getattr(location, dim).to_value(u.m))
+                if col.location.size > 1:
+                    for dim in ('x', 'y', 'z'):
+                        newtable.add_column(Column(getattr(location, dim).to_value(u.m)),
+                                            name='OBSGEO-{}'.format(dim.upper()))
+                else:
+                    hdr.extend([Card(keyword='OBSGEO-{}'.format(dim.upper()),
+                                     value=getattr(location, dim).to_value(u.m))
                             for dim in ('x', 'y', 'z')])
             elif location != col.location:
                 raise ValueError('Multiple Time Columns with different geocentric '

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -324,6 +324,8 @@ class Time(ShapedLikeNDArray):
                 self.location = location
             else:
                 self.location = EarthLocation(*location)
+            if self.location.size == 1:
+                self.location = self.location.squeeze()
         else:
             self.location = None
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -653,14 +653,20 @@ By default, ``serialize_method['fits']`` in a Time column ``info`` is equal to
      Astropy Time allows for many other formats like ``unix`` or ``cxcsec``
      for representing the values.
 
+     Hence, the ``format`` attribute of Time is not stored.  After reading from FITS
+     the user must set the ``format`` as desired.
+
    * LOCATION
 
-     In Astropy Time, location can be an array which is broadcastable to the
-     Time values. In the FITS standard, location is a scalar expressed via
-     keywords.
+     In the FITS standard, the reference position for a time coordinate is a scalar
+     expressed via keywords. However, vectorized reference position or location can
+     be supported by the `Green Bank Keyword Convention
+     <https://fits.gsfc.nasa.gov/registry/greenbank.html/>`_ which is a Registered FITS
+     Convention. In Astropy Time, location can be an array which is broadcastable to the
+     Time values.
 
-   Hence the ``format`` attribute and a vector ``location`` attribute are not
-   stored.  After reading from FITS the user must set the ``format`` as desired.
+     Hence, vectorized ``location`` attribute of Time is stored and read following this
+     convention.
 
 .. doctest-skip-all
 


### PR DESCRIPTION
This PR allows the user to write and read vectorized location for time coordinates following the ``astropy.time.Time`` machinery. Refer to the [FITS Green Bank](https://fits.gsfc.nasa.gov/registry/greenbank.html) convention for details.

@mhvk @taldcroft We had decided to do this as it is fairly simple. I have added some basic tests.