### PR TITLE
Added same note about memmap default to the fits.open docstring.

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -43,7 +43,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         append (ab+), ostream (w), denywrite (rb)).
 
     memmap : bool, optional
-        Is memory mapping to be used?
+        Is memory mapping to be used? ``memmap=True`` by default. This value is obtained from the configuration item ``astropy.io.fits.Conf.use_memmap``.
 
     save_backup : bool, optional
         If the file was opened in update or append mode, this ensures that a

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -43,7 +43,9 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         append (ab+), ostream (w), denywrite (rb)).
 
     memmap : bool, optional
-        Is memory mapping to be used? ``memmap=True`` by default. This value is obtained from the configuration item ``astropy.io.fits.Conf.use_memmap``.
+        Is memory mapping to be used? ``memmap=True`` by default. This value 
+        is obtained from the configuration item 
+        ``astropy.io.fits.Conf.use_memmap``.
 
     save_backup : bool, optional
         If the file was opened in update or append mode, this ensures that a

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -106,7 +106,9 @@ Working with large files
 The :func:`open` function supports a ``memmap=True`` argument that allows the
 array data of each HDU to be accessed with mmap, rather than being read into
 memory all at once.  This is particularly useful for working with very large
-arrays that cannot fit entirely into physical memory.
+arrays that cannot fit entirely into physical memory. Here ``memmap=True`` by
+default. This value is obtained from the configuration item
+``astropy.io.fits.Conf.use_memmap``.
 
 This has minimal impact on smaller files as well, though some operations, such
 as reading the array data sequentially, may incur some additional overhead.  On

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -106,9 +106,7 @@ Working with large files
 The :func:`open` function supports a ``memmap=True`` argument that allows the
 array data of each HDU to be accessed with mmap, rather than being read into
 memory all at once.  This is particularly useful for working with very large
-arrays that cannot fit entirely into physical memory. Here ``memmap=True`` by
-default. This value is obtained from the configuration item
-``astropy.io.fits.Conf.use_memmap``.
+arrays that cannot fit entirely into physical memory. Here ``memmap=True`` by default, and this value is obtained from the configuration item ``astropy.io.fits.Conf.use_memmap``.
 
 This has minimal impact on smaller files as well, though some operations, such
 as reading the array data sequentially, may incur some additional overhead.  On


### PR DESCRIPTION
Responding to @saimn regarding adding the default information (memmap=True) to fits.open docstring.