### PR TITLE
Add TimeDeltaDatetime format class for datetime.timedelta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ htmlcov
 
 # Pytest
 v
+
+# VSCode
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "yapf"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "yapf"
+}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ astropy.time
 - Added supper for a 'local' time scale (for free-running clocks, etc.),
   and round-tripping to the corresponding FITS time scale. [#7122]
 
+- Added `datetime.timedelta` format class for ``TimeDelta``. [#7441]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1773,6 +1773,9 @@ class TimeDelta(Time):
         return out
 
     def to_datetime(self):
+        """
+        Convert to ``datetime.timedelta`` object.
+        """
         tm = self.replicate(format='datetime')
         return tm._shaped_like_input(tm._time.value)
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -10,7 +10,7 @@ astronomy.
 
 import copy
 import operator
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import numpy as np
 
@@ -1603,7 +1603,7 @@ class Time(ShapedLikeNDArray):
                 other = getattr(other, out.scale)
         else:
             if other.scale is None:
-                    out._set_scale('tai')
+                out._set_scale('tai')
             else:
                 if self.scale not in TIME_TYPES[other.scale]:
                     raise TypeError("Cannot add Time and TimeDelta instances "
@@ -1708,7 +1708,7 @@ class TimeDelta(Time):
     The allowed values for ``format`` can be listed with::
 
       >>> list(TimeDelta.FORMATS)
-      ['sec', 'jd']
+      ['sec', 'jd', 'datetime']
 
     Note that for time differences, the scale can be among three groups:
     geocentric ('tai', 'tt', 'tcg'), barycentric ('tcb', 'tdb'), and rotational
@@ -1744,6 +1744,9 @@ class TimeDelta(Time):
     info = TimeDeltaInfo()
 
     def __init__(self, val, val2=None, format=None, scale=None, copy=False):
+        if isinstance(val, timedelta) and not format:
+            format = 'datetime'
+
         if isinstance(val, TimeDelta):
             if scale is not None:
                 self._set_scale(scale)
@@ -1771,7 +1774,7 @@ class TimeDelta(Time):
 
     def to_datetime(self):
         tm = self.replicate(format='datetime')
-        return tm
+        return tm._shaped_like_input(tm._time.value)
 
     def _set_scale(self, scale):
         """

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1769,6 +1769,10 @@ class TimeDelta(Time):
         out.SCALES = self.SCALES
         return out
 
+    def to_datetime(self):
+        tm = self.replicate(format='datetime')
+        return tm
+
     def _set_scale(self, scale):
         """
         This is the key routine that actually does time scale conversions.

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -952,6 +952,7 @@ Format            Class
 =========  ===================================================
 sec        :class:`~astropy.time.TimeDeltaSec`
 jd         :class:`~astropy.time.TimeDeltaJD`
+datetime   :class:`~astropy.time.TimeDeltaDatetime`
 =========  ===================================================
 
 Examples


### PR DESCRIPTION
`TimeDelta` now can be initialized and can be converted to `datetime.timedelta`. Overridden `to_datetime` in `TimeDelta` to return `timedelta` and ignore `timezone`.

Closes #4982.