### PR TITLE
Move generic diff functions to utils

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -188,6 +188,7 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``InheritDocstrings`` now also works on class properties. [#7166]
+
 - ``diff_values()`, ``report_diff_values()``, and ``where_not_allclose()``
   utility functions are moved from ``astropy.io.fits.diff``. [#7444]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,8 +143,8 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- ``report_diff_values()`` utility function is moved to ``astropy.utils.diff``.
-  [#7444]
+- ``diff_values()`, ``report_diff_values()``, and ``where_not_allclose()``
+  utility functions are moved to ``astropy.utils.diff``. [#7444]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -191,8 +191,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``InheritDocstrings`` now also works on class properties. [#7166]
-- ``report_diff_values()`` utility function is moved from
-  ``astropy.io.fits.diff``. [#7444]
+- ``diff_values()`, ``report_diff_values()``, and ``where_not_allclose()``
+  utility functions are moved from ``astropy.io.fits.diff``. [#7444]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- ``report_diff_values()`` utility function is moved to ``astropy.utils.diff``.
+  [#7444]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
@@ -188,6 +191,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``InheritDocstrings`` now also works on class properties. [#7166]
+- ``report_diff_values()`` utility function is moved from
+  ``astropy.io.fits.diff``. [#7444]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,9 +143,6 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- ``diff_values()`, ``report_diff_values()``, and ``where_not_allclose()``
-  utility functions are moved to ``astropy.utils.diff``. [#7444]
-
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -1040,8 +1040,8 @@ class ImageDataDiff(_BaseDiff):
         for index, values in self.diff_pixels:
             index = [x + 1 for x in reversed(index)]
             self._writeln(' Data differs at {}:'.format(index))
-            report_diff_values(self._fileobj, values[0], values[1],
-                               ind=self._indent + 1)
+            report_diff_values(values[0], values[1], fileobj=self._fileobj,
+                               indent_width=self._indent + 1)
 
         if self.diff_total > self.numdiffs:
             self._writeln(' ...')
@@ -1119,8 +1119,8 @@ class RawDataDiff(ImageDataDiff):
 
         for index, values in self.diff_bytes:
             self._writeln(' Data differs at byte {}:'.format(index))
-            report_diff_values(self._fileobj, values[0], values[1],
-                               ind=self._indent + 1)
+            report_diff_values(values[0], values[1], fileobj=self._fileobj,
+                               indent_width=self._indent + 1)
 
         self._writeln(' ...')
         self._writeln(' {} different bytes found ({:.2%} different).'
@@ -1419,8 +1419,8 @@ class TableDataDiff(_BaseDiff):
             name, attr = col_attr
             self._writeln(' Column {} has different {}:'.format(
                     name, col_attrs[attr]))
-            report_diff_values(self._fileobj, vals[0], vals[1],
-                               ind=self._indent + 1)
+            report_diff_values(vals[0], vals[1], fileobj=self._fileobj,
+                               indent_width=self._indent + 1)
 
         if self.diff_rows:
             self._writeln(' Table rows differ:')
@@ -1435,8 +1435,8 @@ class TableDataDiff(_BaseDiff):
         # Finally, let's go through and report column data differences:
         for indx, values in self.diff_values:
             self._writeln(' Column {} data differs in row {}:'.format(*indx))
-            report_diff_values(self._fileobj, values[0], values[1],
-                               ind=self._indent + 1)
+            report_diff_values(values[0], values[1], fileobj=self._fileobj,
+                               indent_width=self._indent + 1)
 
         if self.diff_values and self.numdiffs < self.diff_total:
             self._writeln(' ...{} additional difference(s) found.'.format(
@@ -1468,4 +1468,5 @@ def report_diff_keyword_attr(fileobj, attr, diffs, keyword, ind=0):
             fileobj.write(
                 fixed_width_indent(' Keyword {:8}{} has different {}:\n'
                                    .format(keyword, dup, attr), ind))
-            report_diff_values(fileobj, val[0], val[1], ind=ind + 1)
+            report_diff_values(val[0], val[1], fileobj=fileobj,
+                               indent_width=ind + 1)

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -5,11 +5,7 @@ FITS files, individual HDUs, FITS headers, or just FITS data.
 
 Used to implement the fitsdiff program.
 """
-
-
-import difflib
 import fnmatch
-import functools
 import glob
 import io
 import operator
@@ -18,7 +14,6 @@ import textwrap
 import warnings
 
 from collections import defaultdict
-from functools import reduce
 from inspect import signature
 from itertools import islice
 
@@ -26,7 +21,6 @@ import numpy as np
 
 from ... import __version__
 
-from ...utils import indent
 from .card import Card, BLANK_CARD
 from .header import Header
 from ...utils.decorators import deprecated_renamed_argument
@@ -34,6 +28,7 @@ from ...utils.decorators import deprecated_renamed_argument
 from .hdu.hdulist import fitsopen  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
 from ...utils.exceptions import AstropyDeprecationWarning
+from ...utils.diff import report_diff_values, fixed_width_indent
 
 __all__ = ['FITSDiff', 'HDUDiff', 'HeaderDiff', 'ImageDataDiff', 'RawDataDiff',
            'TableDataDiff']
@@ -42,10 +37,6 @@ __all__ = ['FITSDiff', 'HDUDiff', 'HeaderDiff', 'ImageDataDiff', 'RawDataDiff',
 _COL_ATTRS = [('unit', 'units'), ('null', 'null values'),
               ('bscale', 'bscales'), ('bzero', 'bzeros'),
               ('disp', 'display formats'), ('dim', 'dimensions')]
-
-
-# Smaller default shift-width for indent:
-indent = functools.partial(indent, width=2)
 
 
 class _BaseDiff:
@@ -187,7 +178,7 @@ class _BaseDiff:
             return fileobj.getvalue()
 
     def _writeln(self, text):
-        self._fileobj.write(indent(text, self._indent) + '\n')
+        self._fileobj.write(fixed_width_indent(text, self._indent) + '\n')
 
     def _diff(self):
         raise NotImplementedError
@@ -1472,56 +1463,6 @@ def diff_values(a, b, rtol=0.0, atol=0.0):
         return a != b
 
 
-def report_diff_values(fileobj, a, b, ind=0):
-    """Write a diff between two values to the specified file-like object."""
-
-    typea = type(a)
-    typeb = type(b)
-
-    if (isinstance(a, str) and not isinstance(b, str)):
-        a = repr(a).lstrip('u')
-    elif (isinstance(b, str) and not isinstance(a, str)):
-        b = repr(b).lstrip('u')
-
-    if isinstance(a, (int, float, complex, np.number)):
-        a = repr(a)
-
-    if isinstance(b, (int, float, complex, np.number)):
-        b = repr(b)
-
-    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
-        diff_indices = np.where(a != b)
-        num_diffs = reduce(operator.mul, map(len, diff_indices), 1)
-        for idx in islice(zip(*diff_indices), 3):
-            fileobj.write(indent('  at {!r}:\n'.format(list(idx)), ind))
-            report_diff_values(fileobj, a[idx], b[idx], ind=ind + 1)
-
-        if num_diffs > 3:
-            fileobj.write(indent('  ...and at {} more indices.\n'
-                                 .format(num_diffs - 3), ind))
-        return
-
-    padding = max(len(typea.__name__), len(typeb.__name__)) + 3
-
-    for line in difflib.ndiff(str(a).splitlines(), str(b).splitlines()):
-        if line[0] == '-':
-            line = 'a>' + line[1:]
-            if typea != typeb:
-                typename = '(' + typea.__name__ + ') '
-                line = typename.rjust(padding) + line
-
-        elif line[0] == '+':
-            line = 'b>' + line[1:]
-            if typea != typeb:
-                typename = '(' + typeb.__name__ + ') '
-                line = typename.rjust(padding) + line
-        else:
-            line = ' ' + line
-            if typea != typeb:
-                line = ' ' * padding + line
-        fileobj.write(indent('  {}\n'.format(line.rstrip('\n')), ind))
-
-
 def report_diff_keyword_attr(fileobj, attr, diffs, keyword, ind=0):
     """
     Write a diff between two header keyword values or comments to the specified
@@ -1537,8 +1478,9 @@ def report_diff_keyword_attr(fileobj, attr, diffs, keyword, ind=0):
                 dup = ''
             else:
                 dup = '[{}]'.format(idx + 1)
-            fileobj.write(indent(' Keyword {:8}{} has different {}:\n'
-                                 .format(keyword, dup, attr), ind))
+            fileobj.write(
+                fixed_width_indent(' Keyword {:8}{} has different {}:\n'
+                                   .format(keyword, dup, attr), ind))
             report_diff_values(fileobj, val[0], val[1], ind=ind + 1)
 
 

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -1,13 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-import io
-
 import pytest
 import numpy as np
 
 from ..column import Column
 from ..diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
-                    HDUDiff, report_diff_values)
+                    HDUDiff)
 from ..hdu import HDUList, PrimaryHDU, ImageHDU
 from ..hdu.table import BinTableHDU
 from ..header import Header
@@ -727,39 +724,6 @@ class TestDiff(FitsTestCase):
         assert diff.diff_values[1][0] == ('colb', 1)
         assert np.isnan(diff.diff_values[1][1][0])
         assert diff.diff_values[1][1][1] == 2.0
-
-    def test_diff_types(self):
-        """
-        Regression test for https://github.com/astropy/astropy/issues/4122
-        """
-
-        f = io.StringIO()
-
-        a = 1.0
-        b = '1.0'
-
-        report_diff_values(f, a, b)
-        out = f.getvalue()
-
-        assert out.lstrip('u') == "  (float) a> 1.0\n    (str) b> '1.0'\n           ? +   +\n"
-
-    def test_float_comparison(self):
-        """
-        Regression test for https://github.com/spacetelescope/PyFITS/issues/21
-        """
-
-        f = io.StringIO()
-
-        a = np.float32(0.029751372)
-        b = np.float32(0.029751368)
-
-        report_diff_values(f, a, b)
-        out = f.getvalue()
-
-        # This test doesn't care about what the exact output is, just that it
-        # did show a difference in their text representations
-        assert 'a>' in out
-        assert 'b>' in out
 
     def test_file_output_from_path_string(self):
         outpath = self.temp('diff_output.txt')

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -1,6 +1,7 @@
 import difflib
 import functools
 import operator
+import sys
 from functools import reduce
 from itertools import islice
 
@@ -43,21 +44,21 @@ def diff_values(a, b, rtol=0.0, atol=0.0):
         return a != b
 
 
-def report_diff_values(fileobj, a, b, ind=0):
+def report_diff_values(a, b, fileobj=sys.stdout, indent_width=0):
     """
     Write a diff report between two values to the specified file-like object.
 
     Parameters
     ----------
-    fileobj : obj
-        File-like object to write to.
-        To write to terminal, use ``sys.stdout``.
-
     a, b
         Values to compare. Anything that can be turned into strings
         and compared using :py:mod:`difflib` should work.
 
-    ind : int
+    fileobj : obj
+        File-like object to write to.
+        The default is ``sys.stdout``, which writes to terminal.
+
+    indent_width : int
         Character column(s) to indent.
 
     Returns
@@ -87,12 +88,15 @@ def report_diff_values(fileobj, a, b, ind=0):
         num_diffs = reduce(operator.mul, map(len, diff_indices), 1)
         for idx in islice(zip(*diff_indices), 3):
             fileobj.write(
-                fixed_width_indent('  at {!r}:\n'.format(list(idx)), ind))
-            report_diff_values(fileobj, a[idx], b[idx], ind=ind + 1)
+                fixed_width_indent('  at {!r}:\n'.format(list(idx)),
+                                   indent_width))
+            report_diff_values(a[idx], b[idx], fileobj=fileobj,
+                               indent_width=indent_width + 1)
 
         if num_diffs > 3:
-            fileobj.write(fixed_width_indent('  ...and at {} more indices.\n'
-                                             .format(num_diffs - 3), ind))
+            fileobj.write(fixed_width_indent(
+                '  ...and at {} more indices.\n'.format(num_diffs - 3),
+                indent_width))
         return num_diffs == 0
 
     padding = max(len(typea.__name__), len(typeb.__name__)) + 3
@@ -116,8 +120,8 @@ def report_diff_values(fileobj, a, b, ind=0):
             line = ' ' + line
             if typea != typeb:
                 line = ' ' * padding + line
-        fileobj.write(
-            fixed_width_indent('  {}\n'.format(line.rstrip('\n')), ind))
+        fileobj.write(fixed_width_indent(
+            '  {}\n'.format(line.rstrip('\n')), indent_width))
 
     return identical
 

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -11,16 +11,30 @@ from .misc import indent
 __all__ = ['fixed_width_indent', 'diff_values', 'report_diff_values',
            'where_not_allclose']
 
-# Smaller default shift-width for indent:
+# Smaller default shift-width for indent
 fixed_width_indent = functools.partial(indent, width=2)
 
 
 def diff_values(a, b, rtol=0.0, atol=0.0):
     """
-    Diff two scalar values.  If both values are floats they are compared to
+    Diff two scalar values. If both values are floats, they are compared to
     within the given absolute and relative tolerance.
-    """
 
+    Parameters
+    ----------
+    a, b : int, float, str
+        Scalar values to compare.
+
+    rtol, atol : float
+        Relative and absolute tolerances as accepted by
+        :func:`numpy.allclose`.
+
+    Returns
+    -------
+    is_different : bool
+        `True` if they are different, else `False`.
+
+    """
     if isinstance(a, float) and isinstance(b, float):
         if np.isnan(a) and np.isnan(b):
             return False
@@ -30,8 +44,23 @@ def diff_values(a, b, rtol=0.0, atol=0.0):
 
 
 def report_diff_values(fileobj, a, b, ind=0):
-    """Write a diff between two values to the specified file-like object."""
+    """
+    Write a diff report between two values to the specified file-like object.
 
+    Parameters
+    ----------
+    fileobj : obj
+        File-like object to write to.
+        To write to terminal, use ``sys.stdout``.
+
+    a, b
+        Values to compare. Anything that can be turned into strings
+        and compared using :py:mod:`difflib` should work.
+
+    ind : int
+        Character column(s) to indent.
+
+    """
     typea = type(a)
     typeb = type(b)
 
@@ -83,10 +112,24 @@ def report_diff_values(fileobj, a, b, ind=0):
 
 def where_not_allclose(a, b, rtol=1e-5, atol=1e-8):
     """
-    A version of numpy.allclose that returns the indices where the two arrays
-    differ, instead of just a boolean value.
-    """
+    A version of :func:`numpy.allclose` that returns the indices
+    where the two arrays differ, instead of just a boolean value.
 
+    Parameters
+    ----------
+    a, b : array_like
+        Input arrays to compare.
+
+    rtol, atol : float
+        Relative and absolute tolerances as accepted by
+        :func:`numpy.allclose`.
+
+    Returns
+    -------
+    idx : tuple of arrays
+        Indices where the two arrays differ.
+
+    """
     # Create fixed mask arrays to handle INF and NaN; currently INF and NaN
     # are handled as equivalent
     if not np.all(np.isfinite(a)):

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -1,0 +1,66 @@
+import difflib
+import functools
+import operator
+from functools import reduce
+from itertools import islice
+
+import numpy as np
+
+from .misc import indent
+
+__all__ = ['fixed_width_indent', 'report_diff_values']
+
+# Smaller default shift-width for indent:
+fixed_width_indent = functools.partial(indent, width=2)
+
+
+def report_diff_values(fileobj, a, b, ind=0):
+    """Write a diff between two values to the specified file-like object."""
+
+    typea = type(a)
+    typeb = type(b)
+
+    if (isinstance(a, str) and not isinstance(b, str)):
+        a = repr(a).lstrip('u')
+    elif (isinstance(b, str) and not isinstance(a, str)):
+        b = repr(b).lstrip('u')
+
+    if isinstance(a, (int, float, complex, np.number)):
+        a = repr(a)
+
+    if isinstance(b, (int, float, complex, np.number)):
+        b = repr(b)
+
+    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+        diff_indices = np.where(a != b)
+        num_diffs = reduce(operator.mul, map(len, diff_indices), 1)
+        for idx in islice(zip(*diff_indices), 3):
+            fileobj.write(
+                fixed_width_indent('  at {!r}:\n'.format(list(idx)), ind))
+            report_diff_values(fileobj, a[idx], b[idx], ind=ind + 1)
+
+        if num_diffs > 3:
+            fileobj.write(fixed_width_indent('  ...and at {} more indices.\n'
+                                             .format(num_diffs - 3), ind))
+        return
+
+    padding = max(len(typea.__name__), len(typeb.__name__)) + 3
+
+    for line in difflib.ndiff(str(a).splitlines(), str(b).splitlines()):
+        if line[0] == '-':
+            line = 'a>' + line[1:]
+            if typea != typeb:
+                typename = '(' + typea.__name__ + ') '
+                line = typename.rjust(padding) + line
+
+        elif line[0] == '+':
+            line = 'b>' + line[1:]
+            if typea != typeb:
+                typename = '(' + typeb.__name__ + ') '
+                line = typename.rjust(padding) + line
+        else:
+            line = ' ' + line
+            if typea != typeb:
+                line = ' ' * padding + line
+        fileobj.write(
+            fixed_width_indent('  {}\n'.format(line.rstrip('\n')), ind))

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -5,9 +5,22 @@ Some might be indirectly tested already in ``astropy.io.fits.tests``.
 import io
 
 import numpy as np
+import pytest
 
-from ..diff import report_diff_values
+from ..diff import diff_values, report_diff_values, where_not_allclose
 from ...table import Table
+
+
+@pytest.mark.parametrize('a', [np.nan, np.inf, 1.11, 1, 'a'])
+def test_diff_values_false(a):
+    assert not diff_values(a, a)
+
+
+@pytest.mark.parametrize(
+    ('a', 'b'),
+    [(np.inf, np.nan), (1.11, 1.1), (1, 2), (1, 'a'), ('a', 'b')])
+def test_diff_values_true(a, b):
+    assert diff_values(a, b)
 
 
 def test_float_comparison():
@@ -72,3 +85,12 @@ NEW     2018-05-08   nan    9.0""", format='ascii')
                    '  b> M101 2012-10-30  15.1  15.5\n'
                    '   ?               ^\n'
                    '  b>  NEW 2018-05-08   nan   9.0\n')
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'atol': 0, 'rtol': 0}])
+def test_where_not_allclose(kwargs):
+    a = np.array([1, np.nan, np.inf, 4.5])
+    b = np.array([1, np.inf, np.nan, 4.6])
+
+    assert where_not_allclose(a, b, **kwargs) == ([3], )
+    assert len(where_not_allclose(a, a, **kwargs)[0]) == 0

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -30,7 +30,7 @@ def test_float_comparison():
     f = io.StringIO()
     a = np.float32(0.029751372)
     b = np.float32(0.029751368)
-    identical = report_diff_values(f, a, b)
+    identical = report_diff_values(a, b, fileobj=f)
     assert not identical
     out = f.getvalue()
 
@@ -47,7 +47,7 @@ def test_diff_types():
     f = io.StringIO()
     a = 1.0
     b = '1.0'
-    identical = report_diff_values(f, a, b)
+    identical = report_diff_values(a, b, fileobj=f)
     assert not identical
     out = f.getvalue()
     assert out.lstrip('u') == ("  (float) a> 1.0\n"
@@ -62,7 +62,7 @@ def test_array_comparison():
     f = io.StringIO()
     a = np.arange(9).reshape(3, 3)
     b = a + 1
-    identical = report_diff_values(f, a, b)
+    identical = report_diff_values(a, b, fileobj=f)
     assert not identical
     out = f.getvalue()
     assert out == ('  at [0, 0]:\n'
@@ -91,7 +91,7 @@ M82     2012-10-29  16.2   15.2
 M101    2012-10-30  15.1   15.5
 NEW     2018-05-08   nan    9.0""", format='ascii')
     f = io.StringIO()
-    identical = report_diff_values(f, a, b)
+    identical = report_diff_values(a, b, fileobj=f)
     assert not identical
     out = f.getvalue()
     assert out == ('     name  obs_date  mag_b mag_v\n'
@@ -108,7 +108,7 @@ NEW     2018-05-08   nan    9.0""", format='ascii')
                    '  b>  NEW 2018-05-08   nan   9.0\n')
 
     # Identical
-    assert report_diff_values(f, a, a)
+    assert report_diff_values(a, a, fileobj=f)
 
 
 @pytest.mark.parametrize('kwargs', [{}, {'atol': 0, 'rtol': 0}])

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -1,0 +1,74 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Some might be indirectly tested already in ``astropy.io.fits.tests``.
+"""
+import io
+
+import numpy as np
+
+from ..diff import report_diff_values
+from ...table import Table
+
+
+def test_float_comparison():
+    """
+    Regression test for https://github.com/spacetelescope/PyFITS/issues/21
+    """
+    f = io.StringIO()
+
+    a = np.float32(0.029751372)
+    b = np.float32(0.029751368)
+
+    report_diff_values(f, a, b)
+    out = f.getvalue()
+
+    # This test doesn't care about what the exact output is, just that it
+    # did show a difference in their text representations
+    assert 'a>' in out
+    assert 'b>' in out
+
+
+def test_diff_types():
+    """
+    Regression test for https://github.com/astropy/astropy/issues/4122
+    """
+    f = io.StringIO()
+
+    a = 1.0
+    b = '1.0'
+
+    report_diff_values(f, a, b)
+    out = f.getvalue()
+
+    assert out.lstrip('u') == ("  (float) a> 1.0\n    (str) b> '1.0'\n"
+                               "           ? +   +\n")
+
+
+def test_tablediff():
+    """
+    Test diff-ing two simple Table objects.
+    """
+    a = Table.read("""name    obs_date    mag_b  mag_v
+M31     2012-01-02  17.0   16.0
+M82     2012-10-29  16.2   15.2
+M101    2012-10-31  15.1   15.5""", format='ascii')
+    b = Table.read("""name    obs_date    mag_b  mag_v
+M31     2012-01-02  17.0   16.5
+M82     2012-10-29  16.2   15.2
+M101    2012-10-30  15.1   15.5
+NEW     2018-05-08   nan    9.0""", format='ascii')
+    f = io.StringIO()
+    report_diff_values(f, a, b)
+    out = f.getvalue()
+    assert out == ('     name  obs_date  mag_b mag_v\n'
+                   '     ---- ---------- ----- -----\n'
+                   '  a>  M31 2012-01-02  17.0  16.0\n'
+                   '   ?                           ^\n'
+                   '  b>  M31 2012-01-02  17.0  16.5\n'
+                   '   ?                           ^\n'
+                   '      M82 2012-10-29  16.2  15.2\n'
+                   '  a> M101 2012-10-31  15.1  15.5\n'
+                   '   ?               ^\n'
+                   '  b> M101 2012-10-30  15.1  15.5\n'
+                   '   ?               ^\n'
+                   '  b>  NEW 2018-05-08   nan   9.0\n')

--- a/docs/io/fits/usage/misc.rst
+++ b/docs/io/fits/usage/misc.rst
@@ -5,6 +5,8 @@ Miscellaneous Features
 
 This section describes some of the miscellaneous features of :mod:`astropy.io.fits`.
 
+.. _io-fits-differs:
+
 Differs
 =======
 

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -1010,7 +1010,7 @@ simple tables::
   ...                       M82     2012-10-29  16.2   15.2
   ...                       M101    2012-10-30  15.1   15.5
   ...                       NEW     2018-05-08   nan    9.0""", format='ascii')
-  >>> identical = report_diff_values(sys.stdout, cat_1, cat_2)
+  >>> identical = report_diff_values(cat_1, cat_2, fileobj=sys.stdout)
        name  obs_date  mag_b mag_v
        ---- ---------- ----- -----
     a>  M31 2012-01-02  17.0  16.0

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -39,6 +39,9 @@ table from one or more input tables.  This includes:
    * - `Set difference`_
      - Set difference of two tables
      - `~astropy.table.setdiff`
+   * - `Table diff`_
+     - Generic difference of two simple tables
+     - `~astropy.utils.diff.report_diff_values`
 
 
 .. _grouped-operations:
@@ -982,3 +985,43 @@ lists using a common subset of the columns in two tables.::
 In this example there is a column in the first table that is not
 present in the second table, so the ``keys`` parameter must be used to specify
 the desired column names.
+
+
+.. _table-diff:
+
+Table diff
+----------
+
+To compare two simple tables, you can use
+:func:`~astropy.utils.diff.report_diff_values`, which would produce a report
+identical to :ref:`FITS diff <io-fits-differs>`.
+The example below illustrates finding the difference between two
+simple tables::
+
+  >>> from astropy.table import Table
+  >>> from astropy.utils.diff import report_diff_values
+  >>> import sys
+  >>> cat_1 = Table.read("""name    obs_date    mag_b  mag_v
+  ...                       M31     2012-01-02  17.0   16.0
+  ...                       M82     2012-10-29  16.2   15.2
+  ...                       M101    2012-10-31  15.1   15.5""", format='ascii')
+  >>> cat_2 = Table.read("""name    obs_date    mag_b  mag_v
+  ...                       M31     2012-01-02  17.0   16.5
+  ...                       M82     2012-10-29  16.2   15.2
+  ...                       M101    2012-10-30  15.1   15.5
+  ...                       NEW     2018-05-08   nan    9.0""", format='ascii')
+  >>> identical = report_diff_values(sys.stdout, cat_1, cat_2)
+       name  obs_date  mag_b mag_v
+       ---- ---------- ----- -----
+    a>  M31 2012-01-02  17.0  16.0
+     ?                           ^
+    b>  M31 2012-01-02  17.0  16.5
+     ?                           ^
+        M82 2012-10-29  16.2  15.2
+    a> M101 2012-10-31  15.1  15.5
+     ?               ^
+    b> M101 2012-10-30  15.1  15.5
+     ?               ^
+    b>  NEW 2018-05-08   nan   9.0
+  >>> identical
+  False

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -55,6 +55,9 @@ Reference/API
 .. automodapi:: astropy.utils.decorators
     :no-inheritance-diagram:
 
+.. automodapi:: astropy.utils.diff
+    :no-inheritance-diagram:
+
 .. automodapi:: astropy.utils.exceptions
     :no-inheritance-diagram:
 


### PR DESCRIPTION
Address part (if not all) of #7442.

c/c @stsci-hack

**Rendered doc screenshots**

This is `astropy.utils.diff` API listing:

![ss_1](https://user-images.githubusercontent.com/2090236/39838863-88835068-53a8-11e8-91d5-5baba1075fc2.png)

This is "Table operations" listing:

![ss_2](https://user-images.githubusercontent.com/2090236/39838869-8c44f620-53a8-11e8-8bd6-289210dce468.png)

This is the new section I added under "Table operations":

![ss_3](https://user-images.githubusercontent.com/2090236/39838878-901b51cc-53a8-11e8-906d-8afe86996038.png)

TODO:
- [x] Move other generic functions out of `astropy.io.fits.diff`?
- [x] Add documentation in `astropy.table` subpackage doc to show example how to use diff function.