### PR TITLE
Use representation_type in narrative docs

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -165,7 +165,7 @@ So far we have been using a spherical coordinate representation in the all the
 examples, and this is the default for the built-in frames.  Frequently it is
 convenient to initialize or work with a coordinate using a different
 representation such as cartesian or cylindrical.  This can be done by setting
-the ``representation`` for either |skycoord| objects or low-level frame
+the ``representation_type`` for either |skycoord| objects or low-level frame
 coordinate objects::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -530,7 +530,7 @@ Initialization
 
 Most of what you need to know can be inferred from the examples below and
 by extrapolating the previous documentation for spherical representations.
-Initialization just requires setting the ``representation`` keyword and
+Initialization just requires setting the ``representation_type`` keyword and
 supplying the corresponding components for that representation::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')
@@ -609,9 +609,9 @@ can specify one or more coordinate positions as follows:
 
 The representation can be supplied either as a
 `~astropy.coordinates.representation.BaseRepresentation` class (e.g.
-`~astropy.coordinates.CartesianRepresentation` or as a string name which is
-simply the class name in lower case and without the final ``representation``
-(e.g. ``'cartesian'``).
+`~astropy.coordinates.CartesianRepresentation` or as a string name
+that is simply the class name in lower case without the
+``'representation'`` suffix (e.g. ``'cartesian'``).
 
 The rest of the inputs for creating a |SkyCoord| object in the general case are
 the same as for spherical.
@@ -667,7 +667,7 @@ This is a bit messy but it shows that for each representation there is a
 - ``units``: defines the units of each component when output, where ``None``
   means to not force a particular unit.
 
-For a particular coordinate instance you can use the ``representation``
+For a particular coordinate instance you can use the ``representation_type``
 attribute in conjunction with the ``representation_component_names`` attribute
 to figure out what keywords are accepted by a particular class object.  The
 former will be the representation class the system is expressed in (e.g.,
@@ -693,10 +693,9 @@ data in two ways:
 - The available attributes change to match those of the new representation
   (e.g. from ``ra, dec, distance`` to ``x, y, z``).
 
-Setting the ``representation`` thus changes a *property* of the object (how it
-appears) without changing the intrinsic object itself which represents a point
-in 3d space.
-::
+Setting the ``representation_type`` thus changes a *property* of the
+object (how it appears) without changing the intrinsic object itself
+which represents a point in 3d space::
 
     >>> c = SkyCoord(x=1, y=2, z=3, unit='kpc', representation_type='cartesian')
     >>> c  # doctest: +FLOAT_CMP

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -309,8 +309,8 @@ the mixin column with column(s) representing the underlying data component(s)
 and then inserting meta data which informs the reader how to reconstruct the
 original column.  For example a `~astropy.coordinates.SkyCoord` mixin column in
 ``'spherical'`` representation would have data attributes ``ra``, ``dec``,
-``distance``, along with object attributes like ``representation`` or ``frame``.
-For example::
+``distance``, along with object attributes like ``representation_type`` or
+``frame``.  For example::
 
   >>> from astropy.io import ascii
   >>> from astropy.coordinates import SkyCoord


### PR DESCRIPTION
In some places the `representation` keyword/attribute was still used instead of `representation_type`.

I've put the milestone at `v3.0.3`, but feel free to move to `v3.1`.