### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/astropy/io/votable/tests/data/names.xml
+++ b/astropy/io/votable/tests/data/names.xml
@@ -12,7 +12,7 @@
    Intrinsically Red Sources observed by Spitzer in the Galactic Mid-
    Plane  (Robitaille T.P. et al.)
   </DESCRIPTION>
-  <LINK href="http://dx.doi.org/10.1088/0004-6256/136/6/2413"/>
+  <LINK href="https://doi.org/10.1088/0004-6256/136/6/2413"/>
   <TABLE nrows="18949">
    <DESCRIPTION>
     Final red source catalog

--- a/cextern/wcslib/C/fitshdr.h
+++ b/cextern/wcslib/C/fitshdr.h
@@ -37,7 +37,7 @@
 *
 =   "Definition of the Flexible Image Transport System (FITS), version 3.0",
 =   Pence, W.D., Chiappetti, L., Page, C.G., Shaw, R.A., & Stobie, E. 2010,
-=   A&A, 524, A42 - http://dx.doi.org/10.1051/0004-6361/201015362
+=   A&A, 524, A42 - https://doi.org/10.1051/0004-6361/201015362
 *
 * See also http://fits.gsfc.nasa.gov
 *

--- a/cextern/wcslib/C/wcsunits.h
+++ b/cextern/wcslib/C/wcsunits.h
@@ -43,7 +43,7 @@
 *
 =   "Definition of the Flexible Image Transport System (FITS), version 3.0",
 =   Pence, W.D., Chiappetti, L., Page, C.G., Shaw, R.A., & Stobie, E. 2010,
-=   A&A, 524, A42 - http://dx.doi.org/10.1051/0004-6361/201015362
+=   A&A, 524, A42 - https://doi.org/10.1051/0004-6361/201015362
 *
 * See also http://fits.gsfc.nasa.gov
 *


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links. _PS: And nothing but those, so `no-changelog-entry-needed`_ ;-)

Cheers!