### PR TITLE
Make plugins and dependency checking overrideable in the test runner

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -168,17 +168,18 @@ class TestRunnerBase:
 
         """
 
-    @staticmethod
-    def _has_test_dependencies():  # pragma: no cover
+    _required_dependancies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus']
+    _missing_dependancy_error = "Test dependencies are missing. You should install the 'pytest-astropy' package."
+
+    @classmethod
+    def _has_test_dependencies(cls):  # pragma: no cover
         # Using the test runner will not work without these dependencies, but
         # pytest-openfiles is optional, so it's not listed here.
-        required = ['pytest', 'pytest_remotedata', 'pytest_doctestplus']
-        for module in required:
+        for module in cls._required_dependancies:
             spec = find_spec(module)
             # Checking loader accounts for packages that were uninstalled
             if spec is None or spec.loader is None:
-                msg = "Test dependencies are missing. You should install the 'pytest-astropy' package."
-                raise RuntimeError(msg)
+                raise RuntimeError(cls._missing_dependancy_error)
 
     def run_tests(self, **kwargs):
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -347,7 +347,10 @@ class TestRunner(TestRunnerBase):
                     all_args.append('--doctest-rst')
                     test_path = abs_test_path
 
-            if not (os.path.isdir(test_path) or ext in ('.py', '.rst')):
+            # Check that the extensions are in the path and not at the end to
+            # support specifying the name of the test, i.e.
+            # test_quantity.py::test_unit
+            if not (os.path.isdir(test_path) or ('.py' in test_path or '.rst' in test_path)):
                 raise ValueError("Test path must be a directory or a path to "
                                  "a .py or .rst file")
 


### PR DESCRIPTION
The idea of the very OTT test runner is there is nothing in there which is astropy specific that can't easily be turned off in a subclass ;)

@drdavella git suggests this code was once yours?