### PR TITLE
Running tests for multiple modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -359,6 +359,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Enabling running tests for multiple packages when specified comma
+  separated. [#7463]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -46,7 +46,8 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
     user_options = [
         ('package=', 'P',
-         "The name of a specific package to test, e.g. 'io.fits' or 'utils'.  "
+         "The name of a specific package to test, e.g. 'io.fits' or 'utils'. "
+         "Accepts comma separated string to specify multiple packages. "
          "If nothing is specified, all default tests are run."),
         ('test-path=', 't',
          'Specify a test location by path.  If a relative path to a  .py file, '

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -280,8 +280,29 @@ class TestRunner(TestRunnerBase):
     A test runner for astropy tests
     """
 
-    def packages_path(self, packages, base_path, warning=None, error=None):
+    def packages_path(self, packages, base_path, error=None, warning=None):
         """
+        Generates the path for multiple packages.
+
+        Parameters
+        ----------
+        packages : str
+            Comma separated string of packages.
+        base_path : str
+            Base path to the source code or documentation.
+        error : str
+            Error message to be raised as ``ValueError``. Individual package
+            name and path can be accessed by ``{0}`` or ``{1}``
+            respectively. No error is raised if `None`. (Default: `None`)
+        warning : str
+            Warning message to be issued. Individual package
+            name and path can be accessed by ``{0}`` or ``{1}``
+            respectively. No warning is issues if `None`. (Default: `None`)
+
+        Returns
+        -------
+        paths : list of str
+            List of stings of existing package paths.
         """
         packages = packages.split(",")
 
@@ -323,7 +344,7 @@ class TestRunner(TestRunnerBase):
         if package is None:
             self.package_path = [self.base_path]
         else:
-            error_message = 'package not found: {0}.'
+            error_message = 'package to test is not found: {0} (at path {1}).'
             self.package_path = self.packages_path(package, self.base_path,
                                                    error=error_message)
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -339,8 +339,9 @@ class TestRunner(TestRunnerBase):
     def package(self, package, kwargs):
         """
         package : str, optional
-            The name of a specific package to test, e.g. 'io.fits' or 'utils'.
-            If nothing is specified all default Astropy tests are run.
+            The name of a specific package to test, e.g. 'io.fits' or
+            'utils'. Accepts comma separated string to specify multiple
+            packages. If nothing is specified all default tests are run.
         """
         if package is None:
             self.package_path = [self.base_path]

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -522,19 +522,28 @@ class TestRunner(TestRunnerBase):
         docs_path : str, optional
             The path to the documentation .rst files.
         """
+
+        paths = []
+
         if docs_path is not None and not kwargs['skip_docs']:
             if kwargs['package'] is not None:
-                docs_path = os.path.join(
-                    docs_path, kwargs['package'].replace('.', os.path.sep))
-            if not os.path.exists(docs_path):
-                warnings.warn(
-                    "Can not test .rst docs, since docs path "
-                    "({0}) does not exist.".format(docs_path))
-                docs_path = None
-        if docs_path and not kwargs['skip_docs'] and not kwargs['test_path']:
-            return [docs_path, '--doctest-rst']
+                packages = kwargs['package'].split(',')
 
-        return []
+                for package in packages:
+                    path = os.path.join(docs_path,
+                                        package.replace('.', os.path.sep))
+
+                    if not os.path.exists(path):
+                        warnings.warn(
+                            "Can not test .rst docs for {0}, since docs path "
+                            "({1}) does not exist.".format(package, path))
+                    else:
+                        paths.append(path)
+
+        if len(paths) and not kwargs['test_path']:
+            paths.append('--doctest-rst')
+
+        return paths
 
     @keyword()
     def skip_docs(self, skip_docs, kwargs):

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -292,11 +292,11 @@ class TestRunner(TestRunnerBase):
             Base path to the source code or documentation.
         error : str
             Error message to be raised as ``ValueError``. Individual package
-            name and path can be accessed by ``{0}`` or ``{1}``
+            name and path can be accessed by ``{name}`` and ``{path}``
             respectively. No error is raised if `None`. (Default: `None`)
         warning : str
             Warning message to be issued. Individual package
-            name and path can be accessed by ``{0}`` or ``{1}``
+            name and path can be accessed by ``{name}`` and ``{path}``
             respectively. No warning is issues if `None`. (Default: `None`)
 
         Returns
@@ -311,10 +311,11 @@ class TestRunner(TestRunnerBase):
             path = os.path.join(
                 base_path, package.replace('.', os.path.sep))
             if not os.path.isdir(path):
+                info = {'name': package, 'path': path}
                 if error is not None:
-                    raise ValueError(error.format(package, path))
+                    raise ValueError(error.format(**info))
                 if warning is not None:
-                    warnings.warn(warning.format(package, path))
+                    warnings.warn(warning.format(**info))
             else:
                 paths.append(path)
 
@@ -344,7 +345,8 @@ class TestRunner(TestRunnerBase):
         if package is None:
             self.package_path = [self.base_path]
         else:
-            error_message = 'package to test is not found: {0} (at path {1}).'
+            error_message = ('package to test is not found: {name} '
+                             '(at path {path}).')
             self.package_path = self.packages_path(package, self.base_path,
                                                    error=error_message)
 
@@ -554,19 +556,17 @@ class TestRunner(TestRunnerBase):
             The path to the documentation .rst files.
         """
 
+        paths = []
         if docs_path is not None and not kwargs['skip_docs']:
             if kwargs['package'] is not None:
-                warning_message = ("Can not test .rst docs for {0}, since "
-                                   "docs path ({1}) does not exist.")
+                warning_message = ("Can not test .rst docs for {name}, since "
+                                   "docs path ({path}) does not exist.")
                 paths = self.packages_path(kwargs['package'], docs_path,
                                            warning=warning_message)
             if len(paths) and not kwargs['test_path']:
                 paths.append('--doctest-rst')
 
-            return paths
-
-        else:
-            return []
+        return paths
 
     @keyword()
     def skip_docs(self, skip_docs, kwargs):

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -302,16 +302,23 @@ class TestRunner(TestRunnerBase):
             If nothing is specified all default Astropy tests are run.
         """
         if package is None:
-            self.package_path = self.base_path
+            self.package_path = [self.base_path]
         else:
-            self.package_path = os.path.join(self.base_path,
-                                        package.replace('.', os.path.sep))
+            packages = package.split(',')
 
-            if not os.path.isdir(self.package_path):
-                raise ValueError('Package not found: {0}'.format(package))
+            self.package_path = []
+            for package in packages:
+                package_path = os.path.join(self.base_path,
+                                            package.replace('.', os.path.sep))
+                if not os.path.isdir(package_path):
+                    warnings.warn('Package not found: {0}'.format(package))
+                else:
+                    self.package_path.append(package_path)
+            if len(self.package_path) == 0:
+                raise ValueError('No packages found: {0}'.format(packages))
 
         if not kwargs['test_path']:
-            return [self.package_path]
+            return self.package_path
 
         return []
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -161,15 +161,20 @@ Test-running options
 Running parts of the test suite
 -------------------------------
 
-It is possible to run only the tests for a particular subpackage.  For
-example, to run only the ``wcs`` tests from the commandline::
+It is possible to run only the tests for a particular subpackage or set of
+subpackages.  For example, to run only the ``wcs`` tests from the
+commandline::
 
     python setup.py test -P wcs
+
+Or, to run only the ``wcs`` and ``utils`` tests::
+
+    python setup.py test -P wcs,utils
 
 Or from Python::
 
     >>> import astropy
-    >>> astropy.test(package="wcs")
+    >>> astropy.test(package="wcs,utils")
 
 You can also specify a single file to test from the commandline::
 


### PR DESCRIPTION
As discussed in #7459 it's favourable to have a way to run tests in multiple, but not all modules. @drdavella suggested that it can be 🐰 🕳 to dive into the distutils command line arguments handler, so I stick with the simplest approach in this PR. Further feature suggestions from the issue can be implemented in follow-up PRs.

I'm milestoning to 3.0.3 as it's infrastructure, and we can use similar arguments as in #7461... 

closes #7459 