### PR TITLE
Removing doctest-skip workaround for np 1.14.1

### DIFF
--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -26,13 +26,6 @@ table, Astropy will automatically detect what kind of table it is.
     >>> from astropy.io import fits
     >>> filename = fits.util.get_testdata_filepath('ascii.fits')
     >>> hdul = fits.open(filename)
-
-..
-    This needs to be skipped for numpy-1.14.1. It should be removed when 1.14.2
-    is available. See https://github.com/astropy/astropy/issues/7214.
-
-.. doctest-skip::
-
     >>> hdul[1].data[:1]  # doctest: +FLOAT_CMP
     FITS_rec([(10.123, 37)],
              dtype=(numpy.record, {'names':['a','b'], 'formats':['S10','S5'], 'offsets':[0,11], 'itemsize':16}))
@@ -99,13 +92,6 @@ The other difference is the need to specify the table type when using the
     ...                    bzero=0.6, ascii=True)
     >>> col3 = fits.Column(name='t1', format='I', array=[91, 92, 93], ascii=True)
     >>> hdu = fits.TableHDU.from_columns([col1, col2, col3])
-
-..
-    This needs to be skipped for numpy-1.14.1. It should be removed when 1.14.2
-    is available. See https://github.com/astropy/astropy/issues/7214.
-
-.. doctest-skip::
-
     >>> hdu.data
     FITS_rec([('abc', 11.0, 91), ('def', 12.0, 92), ('', 0.0, 93)],
              dtype=(numpy.record, [('abc', 'S3'), ('def', 'S15'), ('t1', 'S10')]))


### PR DESCRIPTION
Numpy 1.14.2 is out for a while, so the last remaining bit for #7258 can be removed.

closes #7258