### PR TITLE
Raise error when opening gzipped FITS file in append mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -360,6 +360,9 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Raise error when attempting to open gzipped FITS file in 'append' mode.
+  [#7473]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -416,6 +416,9 @@ class _File:
     def _try_read_compressed(self, obj_or_name, magic, mode, ext=''):
         """Attempt to determine if the given file is compressed"""
         if ext == '.gz' or magic.startswith(GZIP_MAGIC):
+            if mode == 'append':
+                raise OSError("'append' mode is not supported with gzip files."
+                              "Use 'update' mode instead")
             # Handle gzip files
             kwargs = dict(mode=IO_FITS_MODES[mode])
             if isinstance(obj_or_name, str):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -724,6 +724,25 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.temp('test.fits.gz')) as hdul:
             assert hdul[0].header == h.header
 
+    def test_fits_update_mode_gzip(self):
+        """Test updating a GZipped FITS file"""
+
+        with fits.open(self._make_gzip_file('update.gz'), mode='update') as fits_handle:
+            hdu = fits.ImageHDU(data=[x for x in range(100)])
+            fits_handle.append(hdu)
+
+        with fits.open(self.temp('update.gz')) as new_handle:
+            assert len(new_handle) == 6
+            assert (new_handle[-1].data == [x for x in range(100)]).all()
+
+    def test_fits_append_mode_gzip(self):
+        """Make sure that attempting to open an existing GZipped FITS file in
+        'append' mode raises an error"""
+
+        with pytest.raises(OSError):
+            with fits.open(self._make_gzip_file('append.gz'), mode='append') as fits_handle:
+                pass
+
     def test_open_bzipped(self):
         bzip_file = self._make_bzip2_file()
         with ignore_warnings():


### PR DESCRIPTION
This resolves #7457. It also adds tests for opening gzipped FITS files in both `append` and `update` mode.