### PR TITLE
Remove the word 'obvious' from documentation pages

### DIFF
--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -366,9 +366,9 @@ documentation::
   sc.itrs                                sc.z_sun
   sc.location
 
-Here we see a bunch of stuff there but much of it should be recognizable or
-easily guessed.  The most obvious may be the longitude and latitude attributes
-which are named ``ra`` and ``dec`` for the ``ICRS`` frame::
+Here we see many attributes and methods, the most recognizable may be the
+longitude and latitude attributes which are named ``ra`` and ``dec`` for the
+``ICRS`` frame::
 
   >>> sc.ra  # doctest: +FLOAT_CMP
   <Longitude 1. deg>

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -176,7 +176,7 @@ resulting mask will be. There are several options.
       ...     result[start+1::2] = mask2[start+1::2]
       ...     return result
 
-  This function is obviously non-sense but let's see how it performs::
+  This function is non-sense but let's see how it performs::
 
       >>> ndd1 = NDDataRef(1, mask=np.array([True, False, True, False]))
       >>> ndd2 = NDDataRef(1, mask=np.array([True, False, False, True]))

--- a/docs/stats/lombscargle.rst
+++ b/docs/stats/lombscargle.rst
@@ -297,7 +297,7 @@ arguments which control the model for the data:
   and likely other names as well.
 - ``nterms`` (``1`` by default) controls how many Fourier terms are used in the
   model. As seen above, the standard Lomb-Scargle periodogram is equivalent to
-  a single-term sinusoidal fit to the data at each frequency; the obvious
+  a single-term sinusoidal fit to the data at each frequency; the
   generalization is to expand this to a truncated Fourier series with multiple
   frequencies. While this can be very useful in some cases, in others the
   additional model complexity can lead to spurious periodogram peaks that

--- a/docs/table/mixin_columns.rst
+++ b/docs/table/mixin_columns.rst
@@ -199,7 +199,7 @@ the following will fail::
 
 The problem lies in knowing if and how to assemble the individual elements
 for each column into an appropriate mixin column.  The current code uses
-numpy to perform this function on numerical or string types, but it obviously
+numpy to perform this function on numerical or string types, but it
 does not handle mixin column types like |Quantity| or |SkyCoord|.
 
 **Masking**
@@ -210,7 +210,7 @@ mixins within a masked table.  In this case a ``mask`` attribute is assigned to
 the mixin column object.  This ``mask`` is a special object that is a boolean
 array of ``False`` corresponding to the mixin data shape.  The ``mask`` looks
 like a normal numpy array but an exception will be raised if ``True`` is assigned
-to any element.  The consequences of the limitation are most obvious in the
+to any element.  The consequences of the limitation are most apparent in the
 high-level table operations.
 
 **High-level table operations**

--- a/docs/units/decomposing_and_composing.rst
+++ b/docs/units/decomposing_and_composing.rst
@@ -73,7 +73,7 @@ Composition can be combined with :ref:`unit_equivalencies`::
     Unit("4.58743e+17 Ry"),
     Unit("6.24151e+18 eV")]
 
-Obviously a name doesn't exist for every arbitrary derived unit
+A name doesn't exist for every arbitrary derived unit
 imaginable.  In that case, the system will do its best to reduce the
 unit to the fewest possible symbols::
 

--- a/docs/wcs/relax.rst
+++ b/docs/wcs/relax.rst
@@ -176,7 +176,7 @@ The flag bits are:
 
 - ``WCSHDR_CNAMn``: Accept ``iCNAMn``, ``iCRDEn``, ``iCSYEn``,
   ``TCNAMn``, ``TCRDEn``, and ``TCSYEn``, i.e. with ``a`` blank.
-  While non-standard, these are the obvious analogues of ``iCTYPn``,
+  While non-standard, these are the analogues of ``iCTYPn``,
   ``TCTYPn``, etc.
 
 - ``WCSHDR_AUXIMG``: Allow the image-header form of an auxiliary WCS
@@ -339,7 +339,7 @@ The flag bits are:
 - ``WCSHDO_DOBSn``: Write ``DOBSn``, the column-specific analogue of
   ``DATE-OBS`` for use in binary tables and pixel lists.  WCS Paper
   III introduced ``DATE-AVG`` and ``DAVGn`` but by an oversight
-  ``DOBSn`` (the obvious analogy) was never formally defined by the
+  ``DOBSn`` was never formally defined by the
   standard.  The alternative to using ``DOBSn`` is to write
   ``DATE-OBS`` which applies to the whole table.  This usage is
   considered to be safe and is recommended.
@@ -390,7 +390,7 @@ The flag bits are:
     pixel lists
 
     for use with an alternate version specifier (the ``a``).  Like the
-    ``PC``, ``CD``, ``PV``, and ``PS`` keywords there is an obvious
+    ``PC``, ``CD``, ``PV``, and ``PS`` keywords there is a
     tendency to confuse these two forms for column numbers up to 99.
     It is very unlikely that any parser would reject keywords in the
     first set with a non-blank alternate version specifier so this


### PR DESCRIPTION
This was done as an example of a contribution to Astropy with @elliesch @jpventura135 @mlarichardson

The motivation is to remove the assumption that the user find a given statement "obvious."