### PR TITLE
Use released intersphinxs rather than development version.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,11 +66,12 @@ check_sphinx_version("1.2.1")
 del intersphinx_mapping['astropy']
 
 # add any custom intersphinx for astropy
-intersphinx_mapping['pytest'] = ('https://docs.pytest.org/en/latest/', None)
+intersphinx_mapping['pytest'] = ('https://docs.pytest.org/en/stable/', None)
 intersphinx_mapping['ipython'] = ('http://ipython.readthedocs.io/en/stable/', None)
 intersphinx_mapping['pandas'] = ('http://pandas.pydata.org/pandas-docs/stable/', None)
 intersphinx_mapping['sphinx_automodapi'] = ('https://sphinx-automodapi.readthedocs.io/en/stable/', None)
 intersphinx_mapping['packagetemplate'] = ('http://docs.astropy.org/projects/package-template/en/latest/', None)
+intersphinx_mapping['h5py'] = ('http://docs.h5py.org/en/stable/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
We should use the intersphinx mapping for the released version we install rather than the development version. This should fix the recent docs builds and we'll see whether they fix it the issue upstream at h5py.

The link for h5py was provided by astropy_helpers, so now we're overriding it locally.
