### PR TITLE
Faster sigma clipping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach asdf'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach asdf bottleneck'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- The ``SigmaClip`` class and ``sigma_clip`` and
+  ``sigma_clipped_stats`` functions are now significantly faster.
+  [#7478]
+
 astropy.table
 ^^^^^^^^^^^^^
 
@@ -215,6 +219,19 @@ astropy.samp
 
 astropy.stats
 ^^^^^^^^^^^^^
+
+- String values can now be used for the ``cenfunc`` and ``stdfunc``
+  keywords in the ``SigmaClip`` class and ``sigma_clip`` and
+  ``sigma_clipped_stats`` functions. [#7478]
+
+- The ``SigmaClip`` class and ``sigma_clip`` and
+  ``sigma_clipped_stats`` functions now have a ``masked`` keyword,
+  which can be used to return either a masked array (default) or an
+  ndarray with the min/max values. [#7478]
+
+- The ``iters`` keyword has been renamed (and deprecated) to
+  ``maxiters`` in the ``SigmaClip`` class and ``sigma_clip`` and
+  ``sigma_clipped_stats`` functions. [#7478]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -309,7 +309,7 @@ class SigmaClip:
             output `~numpy.ndarray` will have the same shape as the
             input ``data`` and contain ``np.nan`` where values were
             clipped.  In this case the returned minimum and maximum
-            clipping thresholds will be also be `~numpy.ndarray`\s.
+            clipping thresholds will be also be `~numpy.ndarray`\\s.
         """
 
         data = np.asanyarray(data)
@@ -440,7 +440,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         `~numpy.ndarray` will have the same shape as the input ``data``
         and contain ``np.nan`` where values were clipped.  In this case
         the returned minimum and maximum clipping thresholds will be
-        also be `~numpy.ndarray`\s.
+        also be `~numpy.ndarray`\\s.
 
     See Also
     --------
@@ -564,6 +564,10 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     mean, median, stddev : float
         The mean, median, and standard deviation of the sigma-clipped
         data.
+
+    See Also
+    --------
+    SigmaClip, sigma_clip
     """
 
     if mask is not None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -273,7 +273,7 @@ class SigmaClip:
 
         Parameters
         ----------
-        data : array-like or `~np.ma.MaskedArray`
+        data : array-like or `~numpy.ma.MaskedArray`
             The data to be sigma clipped.
 
         axis : `None` or int or tuple of int, optional
@@ -368,7 +368,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     Parameters
     ----------
-    data : array-like or `~np.ma.MaskedArray`
+    data : array-like or `~numpy.ma.MaskedArray`
         The data to be sigma clipped.
 
     sigma : float, optional
@@ -502,7 +502,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     Parameters
     ----------
-    data : array-like or `~np.ma.MaskedArray`
+    data : array-like or `~numpy.ma.MaskedArray`
         Data array or object that can be converted to an array.
 
     mask : `numpy.ndarray` (bool), optional

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -280,13 +280,9 @@ class SigmaClip:
 
         masked : bool, optional
             If `True`, then a `~numpy.ma.MaskedArray` is returned, where
-            the mask is `True` for clipped values.  If `False`, then
-            a `~numpy.ndarray` and the minimum and maximum clipping
-            thresholds are returned.  If ``axis=None``, then the output
-            `~numpy.ndarray` will not include any clipped values.  If
-            ``axis`` is used, then the output `~numpy.ndarray` will
-            contain ``np.nan`` where values were clipped.  The default
-            is `True`.
+            the mask is `True` for clipped values.  If `False`, then a
+            `~numpy.ndarray` and the minimum and maximum clipping
+            thresholds are returned.  The default is `True`.
 
         copy : bool, optional
             If `True`, then the ``data`` array will be copied.  If
@@ -302,11 +298,18 @@ class SigmaClip:
             returned, where the mask is `True` for clipped values.
 
             If ``masked=False``, then a `~numpy.ndarray` and the minimum
-            and maximum clipping thresholds are returned.  If
-            ``axis=None``, then the output `~numpy.ndarray` will not
-            include any clipped values.  If ``axis`` is used, then the
-            output `~numpy.ndarray` will contain ``np.nan`` where values
-            were clipped.
+            and maximum clipping thresholds are returned.
+
+            If ``masked=False`` and ``axis=None``, then the output array
+            is a flattened 1D `~numpy.ndarray` where the clipped values
+            have been removed and the output minimum and maximum
+            thresholds are scalars.
+
+            If ``masked=False`` and ``axis`` is specified, then the
+            output `~numpy.ndarray` will have the same shape as the
+            input ``data`` and contain ``np.nan`` where values were
+            clipped.  In this case the returned minimum and maximum
+            clipping thresholds will be also be `~numpy.ndarray`\s.
         """
 
         data = np.asanyarray(data)
@@ -326,133 +329,147 @@ class SigmaClip:
 
 @deprecated_renamed_argument('iters', 'maxiters', '3.1')
 def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
-               cenfunc=np.ma.median, stdfunc=np.std, axis=None, copy=True):
+               cenfunc=np.ma.median, stdfunc=np.std, axis=None, masked=True,
+               copy=True):
     """
     Perform sigma-clipping on the provided data.
 
-    The data will be iterated over, each time rejecting points that are
-    discrepant by more than a specified number of standard deviations from a
-    center value. If the data contains invalid values (NaNs or infs),
-    they are automatically masked before performing the sigma clipping.
+    The data will be iterated over, each time rejecting values that are
+    less or more than a specified number of standard deviations from a
+    center value.
+
+    Clipped (rejected) pixels are those where::
+
+        data < cenfunc(data [,axis=int]) - (sigma_lower * stdfunc(data [,axis=int]))
+        data > cenfunc(data [,axis=int]) + (sigma_upper * stdfunc(data [,axis=int]))
+
+    Invalid data values (i.e. NaN or inf) are automatically clipped.
 
     For an object-oriented interface to sigma clipping, see
-    :func:`SigmaClip`.
+    :class:`SigmaClip`.
 
     .. note::
         `scipy.stats.sigmaclip
         <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sigmaclip.html>`_
-        provides a subset of the functionality in this function.
+        provides a subset of the functionality in this class.  Also, its
+        input data cannot be a masked array and it does not handle data
+        that contains invalid values (i.e.  NaN or inf).  Also note that
+        it uses the mean as the centering function.
+
+        If your data is a `~numpy.ndarray` with no invalid values and
+        you want to use the mean as the centering function with
+        ``axis=None``, then `scipy.stats.sigmaclip` is ~25-30% faster
+        than the equivalent settings here (``SigmaClip(cenfunc=np.mean,
+        maxiters=None)``).
 
     Parameters
     ----------
-    data : array-like
+    data : array-like or `~np.ma.MaskedArray`
         The data to be sigma clipped.
+
     sigma : float, optional
         The number of standard deviations to use for both the lower and
-        upper clipping limit. These limits are overridden by
-        ``sigma_lower`` and ``sigma_upper``, if input. Defaults to 3.
+        upper clipping limit.  These limits are overridden by
+        ``sigma_lower`` and ``sigma_upper``, if input.  The default is
+        3.
+
     sigma_lower : float or `None`, optional
         The number of standard deviations to use as the lower bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
+        the clipping limit.  If `None` then the value of ``sigma`` is
+        used.  The default is `None`.
+
     sigma_upper : float or `None`, optional
         The number of standard deviations to use as the upper bound for
-        the clipping limit. If `None` then the value of ``sigma`` is
-        used. Defaults to `None`.
+        the clipping limit.  If `None` then the value of ``sigma`` is
+        used.  The default is `None`.
+
     maxiters : int or `None`, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
         until the last iteration clips nothing).  If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
-        iterations will stop.  Defaults to 5.
+        iterations will stop.  The default is 5.
+
     cenfunc : callable, optional
-        The function used to compute the center for the clipping. Must
-        be a callable that takes in a masked array and outputs the
-        central value. Defaults to the median (`numpy.ma.median`).
+        The function used to compute the center value for the clipping.
+        If the ``axis`` keyword is used, then it must be callable that
+        can ignore NaNs (e.g. `numpy.nanmean`) and has an ``axis``
+        keyword to return an array with axis dimension(s) removed.  The
+        default is `numpy.nanmedian`.
+
     stdfunc : callable, optional
         The function used to compute the standard deviation about the
-        center. Must be a callable that takes in a masked array and
-        outputs a width estimator. Masked (rejected) pixels are those
-        where::
+        center value.  If the ``axis`` keyword is used, then it must be
+        callable that can ignore NaNs (e.g. `numpy.nanstd`) and has an
+        ``axis`` keyword to return an array with axis dimension(s)
+        removed.  The default is `numpy.nanstd`.
 
-             deviation < (-sigma_lower * stdfunc(deviation))
-             deviation > (sigma_upper * stdfunc(deviation))
-
-        where::
-
-            deviation = data - cenfunc(data [,axis=int])
-
-        Defaults to the standard deviation (`numpy.std`).
     axis : `None` or int or tuple of int, optional
-        If not `None`, clip along the given axis or axes.  For this case,
-        ``axis`` will be passed on to ``cenfunc`` and ``stdfunc``, which
-        are expected to return an array with the axis dimension(s) removed
-        (like the numpy functions).  If `None`, clip over all axes.
-        Defaults to `None`.
+        The axis or axes along which to sigma clip the data.  If `None`,
+        then the flattened data will be used.  ``axis`` is passed to the
+        ``cenfunc`` and ``stdfunc``.  The default is `None`.
+
+    masked : bool, optional
+        If `True`, then a `~numpy.ma.MaskedArray` is returned, where the
+        mask is `True` for clipped values.  If `False`, then a
+        `~numpy.ndarray` and the minimum and maximum clipping thresholds
+        are returned.  The default is `True`.
+
     copy : bool, optional
-        If `True`, the ``data`` array will be copied.  If `False`, the
-        returned masked array data will contain the same array as
-        ``data``.  Defaults to `True`.
+        If `True`, then the ``data`` array will be copied.  If `False`
+        and ``masked=True``, then the returned masked array data will
+        contain the same array as the input ``data`` (if ``data`` is a
+        `~numpy.ndarray` or `~numpy.ma.MaskedArray`).  The default is
+        `True`.
 
     Returns
     -------
-    filtered_data : `numpy.ma.MaskedArray`
-        A masked array with the same shape as ``data`` input, where the
-        points rejected by the algorithm have been masked.
+    result : flexible
+        If ``masked=True``, then a `~numpy.ma.MaskedArray` is returned,
+        where the mask is `True` for clipped values.
 
-    Notes
-    -----
-     1. The routine works by calculating::
+        If ``masked=False``, then a `~numpy.ndarray` and the minimum and
+        maximum clipping thresholds are returned.
 
-            deviation = data - cenfunc(data [,axis=int])
+        If ``masked=False`` and ``axis=None``, then the output array is
+        a flattened 1D `~numpy.ndarray` where the clipped values have
+        been removed and the output minimum and maximum thresholds are
+        scalars.
 
-        and then setting a mask for points outside the range::
-
-           deviation < (-sigma_lower * stdfunc(deviation))
-           deviation > (sigma_upper * stdfunc(deviation))
-
-        It will iterate a given number of times, or until no further
-        data are rejected.
-
-     2. Most numpy functions deal well with masked arrays, but if one
-        would like to have an array with just the good (or bad) values, one
-        can use::
-
-            good_only = filtered_data.data[~filtered_data.mask]
-            bad_only = filtered_data.data[filtered_data.mask]
-
-        However, for multidimensional data, this flattens the array,
-        which may not be what one wants (especially if filtering was
-        done along a subset of the axes).
+        If ``masked=False`` and ``axis`` is specified, then the output
+        `~numpy.ndarray` will have the same shape as the input ``data``
+        and contain ``np.nan`` where values were clipped.  In this case
+        the returned minimum and maximum clipping thresholds will be
+        also be `~numpy.ndarray`\s.
 
     See Also
     --------
-    SigmaClip
+    SigmaClip, sigma_clipped_stats
 
     Examples
     --------
-    This example generates random variates from a Gaussian distribution
-    and returns a masked array in which all points that are more than 2
-    sample standard deviations from the median are masked::
+    This example uses a data array of random variates from a Gaussian
+    distribution.  We clip all points that are more than 2 sample
+    standard deviations from the median.  The result is a masked array,
+    where the mask is `True` for clipped data::
 
         >>> from astropy.stats import sigma_clip
         >>> from numpy.random import randn
         >>> randvar = randn(10000)
         >>> filtered_data = sigma_clip(randvar, sigma=2, maxiters=5)
 
-    This example sigma clips on a similar distribution, but uses 3 sigma
-    relative to the sample *mean*, clips until convergence, and does not
-    copy the data::
+    This example clips all points that are more than 3 sigma relative to
+    the sample *mean*, clips until convergence, returns an unmasked
+    `~numpy.ndarray`, and does not copy the data::
 
         >>> from astropy.stats import sigma_clip
         >>> from numpy.random import randn
         >>> from numpy import mean
         >>> randvar = randn(10000)
         >>> filtered_data = sigma_clip(randvar, sigma=3, maxiters=None,
-        ...                            cenfunc=mean, copy=False)
+        ...                            cenfunc=mean, masked=False, copy=False)
 
-    This example sigma clips along one axis on a similar distribution
-    (with bad points inserted)::
+    This example sigma clips along one axis::
 
         >>> from astropy.stats import sigma_clip
         >>> from numpy.random import normal
@@ -460,14 +477,15 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         >>> data = arange(5) + normal(0., 0.05, (5, 5)) + diag(ones(5))
         >>> filtered_data = sigma_clip(data, sigma=2.3, axis=0)
 
-    Note that along the other axis, no points would be masked, as the
-    variance is higher.
+    Note that along the other axis, no points would be clipped, as the
+    standard deviation is higher.
     """
 
     sigclip = SigmaClip(sigma=sigma, sigma_lower=sigma_lower,
                         sigma_upper=sigma_upper, maxiters=maxiters,
                         cenfunc=cenfunc, stdfunc=stdfunc)
-    return sigclip(data, axis=axis, copy=copy)
+
+    return sigclip(data, axis=axis, masked=masked, copy=copy)
 
 
 @deprecated_renamed_argument('iters', 'maxiters', '3.1')

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -40,9 +40,10 @@ class SigmaClip:
 
         If your data is a `~numpy.ndarray` with no invalid values and
         you want to use the mean as the centering function with
-        ``axis=None``, then `scipy.stats.sigmaclip` is ~25-30% faster
-        than the equivalent settings here (``SigmaClip(cenfunc=np.mean,
-        maxiters=None)``).
+        ``axis=None`` and iterate to convergence, then
+        `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
+        settings here (``s = SigmaClip(cenfunc=np.mean, maxiters=None);
+        s(data, axis=None)``).
 
     Parameters
     ----------
@@ -360,9 +361,10 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
         If your data is a `~numpy.ndarray` with no invalid values and
         you want to use the mean as the centering function with
-        ``axis=None``, then `scipy.stats.sigmaclip` is ~25-30% faster
-        than the equivalent settings here (``SigmaClip(cenfunc=np.mean,
-        maxiters=None)``).
+        ``axis=None`` and iterate to convergence, then
+        `scipy.stats.sigmaclip` is ~25-30% faster than the equivalent
+        settings here (``sigma_clip(data, cenfunc=np.mean,
+        maxiters=None, axis=None)``).
 
     Parameters
     ----------

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -257,9 +257,11 @@ class SigmaClip:
             else:
                 # ignore RuntimeWarnings for comparisons with NaN data values
                 with np.errstate(invalid='ignore'):
+                    out = np.ma.masked_invalid(data, copy=False)
+
                     return np.ma.masked_where(np.logical_or(
-                        data < self._min_value, data > self._max_value),
-                        data, copy=False)
+                        out < self._min_value, out > self._max_value),
+                        out, copy=False)
         else:
             # return the truncated array with the mix/max clipping thresholds
             return filtered_data, self._min_value, self._max_value

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -170,10 +170,6 @@ class SigmaClip:
             min_value = min_value.reshape(mshape)
             max_value = max_value.reshape(mshape)
 
-        if max_value is np.ma.masked:
-            max_value = np.ma.MaskedArray(np.nan, mask=True)
-            min_value = np.ma.MaskedArray(np.nan, mask=True)
-
         _filtered_data.mask |= _filtered_data > max_value
         _filtered_data.mask |= _filtered_data < min_value
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -231,6 +231,14 @@ class SigmaClip:
             the points rejected by the algorithm have been masked.
         """
 
+        data = np.asanyarray(data)
+
+        if data.size == 0:
+            return data
+
+        if isinstance(data, np.ma.MaskedArray) and data.mask.all():
+            return data
+
         if axis is None:
             return self._sigmaclip_noaxis(data, copy=copy)
         else:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -343,8 +343,9 @@ class SigmaClip:
             size = filtered_data.size
 
             self._compute_bounds(filtered_data, axis=axis)
-            self._min_value = self._min_value.reshape(mshape)
-            self._max_value = self._max_value.reshape(mshape)
+            if not np.isscalar(self._min_value):
+                self._min_value = self._min_value.reshape(mshape)
+                self._max_value = self._max_value.reshape(mshape)
 
             with np.errstate(invalid='ignore'):
                 filtered_data[(filtered_data < self._min_value) |

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -208,7 +208,7 @@ class SigmaClip:
 
     def _sigmaclip_withaxis(self, data, axis=None, masked=True, copy=True):
         # float array type is needed to insert nans into the array
-        filtered_data = np.copy(data).astype(float)
+        filtered_data = data.astype(float)    # also makes a copy
 
         # remove invalid values
         bad_mask = ~np.isfinite(filtered_data)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -47,7 +47,7 @@ class SigmaClip:
     maxiters : int or `None`, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
-        until the last iteration clips nothing). If convergence is
+        until the last iteration clips nothing).  If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
         iterations will stop.  Defaults to 5.
     cenfunc : callable, optional
@@ -275,7 +275,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     maxiters : int or `None`, optional
         The maximum number of sigma-clipping iterations to perform or
         `None` to clip until convergence is achieved (i.e., iterate
-        until the last iteration clips nothing). If convergence is
+        until the last iteration clips nothing).  If convergence is
         achieved prior to ``maxiters`` iterations, the clipping
         iterations will stop.  Defaults to 5.
     cenfunc : callable, optional
@@ -383,8 +383,9 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     return sigclip(data, axis=axis, copy=copy)
 
 
+@deprecated_renamed_argument('iters', 'maxiters', '3.1')
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
-                        sigma_lower=None, sigma_upper=None, iters=5,
+                        sigma_lower=None, sigma_upper=None, maxiters=5,
                         cenfunc=np.ma.median, stdfunc=np.std, std_ddof=0,
                         axis=None):
     """
@@ -420,11 +421,12 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         the clipping limit.  If `None` then the value of ``sigma`` is used.
         Defaults to `None`.
 
-    iters : int, optional
-        The number of iterations to perform sigma clipping, or `None` to
-        clip until convergence is achieved (i.e., continue until the
-        last iteration clips nothing) when calculating the statistics.
-        Defaults to 5.
+    iters : int or `None`, optional
+        The maximum number of sigma-clipping iterations to perform or
+        `None` to clip until convergence is achieved (i.e., iterate
+        until the last iteration clips nothing).  If convergence is
+        achieved prior to ``maxiters`` iterations, the clipping
+        iterations will stop.  Defaults to 5.
 
     cenfunc : callable, optional
         The function used to compute the center for the clipping. Must
@@ -472,7 +474,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         data = np.ma.masked_values(data, mask_value)
 
     data_clip = sigma_clip(data, sigma=sigma, sigma_lower=sigma_lower,
-                           sigma_upper=sigma_upper, iters=iters,
+                           sigma_upper=sigma_upper, maxiters=maxiters,
                            cenfunc=cenfunc, stdfunc=stdfunc, axis=axis)
 
     mean = np.ma.mean(data_clip, axis=axis)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -112,7 +112,7 @@ class SigmaClip:
 
     @deprecated_renamed_argument('iters', 'maxiters', '3.1')
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None,
-                 maxiters=5, cenfunc=np.ma.median, stdfunc=np.std):
+                 maxiters=5, cenfunc=np.nanmedian, stdfunc=np.nanstd):
 
         self.sigma = sigma
         if sigma_lower is None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -232,13 +232,13 @@ class SigmaClip:
                 if HAS_BOTTLENECK:
                     cenfunc = _nanmedian
                 else:
-                    cenfunc = np.nanmedian
+                    cenfunc = np.nanmedian  # pragma: no cover
 
             elif cenfunc == 'mean':
                 if HAS_BOTTLENECK:
                     cenfunc = _nanmean
                 else:
-                    cenfunc = np.nanmean
+                    cenfunc = np.nanmean  # pragma: no cover
 
             else:
                 raise ValueError('{} is an invalid cenfunc.'.format(cenfunc))
@@ -253,7 +253,7 @@ class SigmaClip:
             if HAS_BOTTLENECK:
                 stdfunc = _nanstd
             else:
-                stdfunc = np.nanstd
+                stdfunc = np.nanstd  # pragma: no cover
 
         return stdfunc
 
@@ -706,7 +706,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         mean = _nanmean(data_clipped, axis=axis)
         median = _nanmedian(data_clipped, axis=axis)
         std = _nanstd(data_clipped, ddof=std_ddof, axis=axis)
-    else:
+    else:  # pragma: no cover
         mean = np.nanmean(data_clipped, axis=axis)
         median = np.nanmedian(data_clipped, axis=axis)
         std = np.nanstd(data_clipped, ddof=std_ddof, axis=axis)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -107,9 +107,15 @@ class SigmaClip:
 
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None, iters=5,
                  cenfunc=np.ma.median, stdfunc=np.std):
+
         self.sigma = sigma
+        if sigma_lower is None:
+            sigma_lower = sigma
+        if sigma_upper is None:
+            sigma_upper = sigma
         self.sigma_lower = sigma_lower
         self.sigma_upper = sigma_upper
+
         self.iters = iters
         self.cenfunc = cenfunc
         self.stdfunc = stdfunc
@@ -192,11 +198,6 @@ class SigmaClip:
             A masked array with the same shape as ``data`` input, where
             the points rejected by the algorithm have been masked.
         """
-
-        if self.sigma_lower is None:
-            self.sigma_lower = self.sigma
-        if self.sigma_upper is None:
-            self.sigma_upper = self.sigma
 
         if np.any(~np.isfinite(data)):
             data = np.ma.masked_invalid(data)

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -116,7 +116,7 @@ class SigmaClip:
         self.sigma_lower = sigma_lower
         self.sigma_upper = sigma_upper
 
-        self.iters = iters
+        self.iters = iters or np.inf
         self.cenfunc = cenfunc
         self.stdfunc = stdfunc
 
@@ -185,14 +185,12 @@ class SigmaClip:
 
         filtered_data = np.ma.array(data, copy=copy)
 
-        if self.iters is None:
-            lastrej = filtered_data.count() + 1
-            while filtered_data.count() != lastrej:
-                lastrej = filtered_data.count()
-                self._perform_clip(filtered_data, axis=axis)
-        else:
-            for i in range(self.iters):
-                self._perform_clip(filtered_data, axis=axis)
+        count = filtered_data.count() + 1
+        iteration = 0
+        while filtered_data.count() != count and (iteration < self.iters):
+            iteration += 1
+            count = filtered_data.count()
+            self._perform_clip(filtered_data, axis=axis)
 
         # prevent filtered_data.mask = False (scalar) if no values are clipped
         if filtered_data.mask.shape == ():

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -98,6 +98,24 @@ def test_sigma_clip_class():
         assert_equal(sobj(data), sfunc)
 
 
+def test_sigma_clip_mean():
+    with NumpyRNGContext(12345):
+        data = np.random.normal(0., 0.05, (10, 10))
+        data[2, 2] = 1.e5
+        sobj1 = SigmaClip(sigma=1, maxiters=2, cenfunc='mean')
+        sobj2 = SigmaClip(sigma=1, maxiters=2, cenfunc=np.nanmean)
+        assert_equal(sobj1(data), sobj2(data))
+        assert_equal(sobj1(data, axis=0), sobj2(data, axis=0))
+
+
+def test_sigma_clip_invalid_cenfunc_stdfunc():
+    with pytest.raises(ValueError):
+        SigmaClip(cenfunc='invalid')
+
+    with pytest.raises(ValueError):
+        SigmaClip(stdfunc='invalid')
+
+
 def test_sigma_clipped_stats():
     """Test list data with input mask or mask_value (#3268)."""
     # test list data with mask

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -108,6 +108,9 @@ def test_sigma_clipped_stats():
     assert isinstance(result[1], float)
     assert result == (1., 1., 0.)
 
+    result2 = sigma_clipped_stats(data, mask=mask, axis=0)
+    assert_equal(result, result2)
+
     # test list data with mask_value
     result = sigma_clipped_stats(data, mask_value=0.)
     assert isinstance(result[1], float)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -26,7 +26,7 @@ def test_sigma_clip():
         # Amazing, I've got the same combination on my luggage!
         randvar = randn(10000)
 
-        filtered_data = sigma_clip(randvar, sigma=1, iters=2)
+        filtered_data = sigma_clip(randvar, sigma=1, maxiters=2)
 
         assert sum(filtered_data.mask) > 0
         assert sum(~filtered_data.mask) < randvar.size
@@ -34,22 +34,24 @@ def test_sigma_clip():
         # this is actually a silly thing to do, because it uses the
         # standard deviation as the variance, but it tests to make sure
         # these arguments are actually doing something
-        filtered_data2 = sigma_clip(randvar, sigma=1, iters=2, stdfunc=np.var)
+        filtered_data2 = sigma_clip(randvar, sigma=1, maxiters=2,
+                                    stdfunc=np.var)
         assert not np.all(filtered_data.mask == filtered_data2.mask)
 
-        filtered_data3 = sigma_clip(randvar, sigma=1, iters=2,
+        filtered_data3 = sigma_clip(randvar, sigma=1, maxiters=2,
                                     cenfunc=np.mean)
         assert not np.all(filtered_data.mask == filtered_data3.mask)
 
-        # make sure the iters=None method works at all.
-        filtered_data = sigma_clip(randvar, sigma=3, iters=None)
+        # make sure the maxiters=None method works at all.
+        filtered_data = sigma_clip(randvar, sigma=3, maxiters=None)
 
         # test copying
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] != randvar[0]
 
-        filtered_data = sigma_clip(randvar, sigma=3, iters=None, copy=False)
+        filtered_data = sigma_clip(randvar, sigma=3, maxiters=None,
+                                   copy=False)
         assert filtered_data.data[0] == randvar[0]
         filtered_data.data[0] += 1.
         assert filtered_data.data[0] == randvar[0]
@@ -72,7 +74,8 @@ def test_compare_to_scipy_sigmaclip():
 
         randvar = randn(10000)
 
-        astropyres = sigma_clip(randvar, sigma=3, iters=None, cenfunc=np.mean)
+        astropyres = sigma_clip(randvar, sigma=3, maxiters=None,
+                                cenfunc=np.mean)
         scipyres = stats.sigmaclip(randvar, 3, 3)[0]
 
         assert astropyres.count() == len(scipyres)
@@ -82,7 +85,7 @@ def test_compare_to_scipy_sigmaclip():
 def test_sigma_clip_scalar_mask():
     """Test that the returned mask is not a scalar."""
     data = np.arange(5)
-    result = sigma_clip(data, sigma=100., iters=1)
+    result = sigma_clip(data, sigma=100., maxiters=1)
     assert result.mask.shape != ()
 
 
@@ -90,8 +93,8 @@ def test_sigma_clip_class():
     with NumpyRNGContext(12345):
         data = randn(100)
         data[10] = 1.e5
-        sobj = SigmaClip(sigma=1, iters=2)
-        sfunc = sigma_clip(data, sigma=1, iters=2)
+        sobj = SigmaClip(sigma=1, maxiters=2)
+        sfunc = sigma_clip(data, sigma=1, maxiters=2)
         assert_equal(sobj(data), sfunc)
 
 
@@ -213,6 +216,7 @@ def test_sigma_clip_axis_tuple_3D():
                                       data_plane > mean + maxdev)
 
     # Do the equivalent thing using sigma_clip:
-    result = sigma_clip(data, sigma=1.5, cenfunc=np.mean, iters=1, axis=(0,-1))
+    result = sigma_clip(data, sigma=1.5, cenfunc=np.mean, maxiters=1,
+                        axis=(0,-1))
 
     assert_equal(result.mask, mask)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -201,7 +201,7 @@ def test_sigma_clip_axis_tuple_3D():
     """Test sigma clipping over a subset of axes (issue #7227).
     """
 
-    data = np.sin(0.78 * np.arange(27)).reshape(3,3,3)
+    data = np.sin(0.78 * np.arange(27)).reshape(3, 3, 3)
     mask = np.zeros_like(data, dtype=np.bool)
 
     data_t = np.rollaxis(data, 1, 0)
@@ -217,6 +217,17 @@ def test_sigma_clip_axis_tuple_3D():
 
     # Do the equivalent thing using sigma_clip:
     result = sigma_clip(data, sigma=1.5, cenfunc=np.mean, maxiters=1,
-                        axis=(0,-1))
+                        axis=(0, -1))
 
     assert_equal(result.mask, mask)
+
+
+def test_sigmaclip_repr():
+    sigclip = SigmaClip()
+    sigclip_repr = ('SigmaClip(sigma=3.0, sigma_lower=3.0, sigma_upper=3.0,'
+                    ' maxiters=5, cenfunc=')
+    sigclip_str = ('<SigmaClip>\n    sigma: 3.0\n    sigma_lower: 3.0\n'
+                   '    sigma_upper: 3.0\n    maxiters: 5\n    cenfunc: ')
+
+    assert repr(sigclip).startswith(sigclip_repr)
+    assert str(sigclip).startswith(sigclip_str)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -189,7 +189,8 @@ def test_invalid_sigma_clip():
 
     # stats along axis with all nans
     data[0, :] = np.nan     # row of all nans
-    result4, minarr, maxarr = sigma_clip(data, axis=1, masked=False)
+    result4, minarr, maxarr = sigma_clip(data, axis=1, masked=False,
+                                         return_bounds=True)
     assert np.isnan(minarr[0])
     assert np.isnan(maxarr[0])
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -157,10 +157,23 @@ def test_invalid_sigma_clip():
     # Pre #4051 if data contains any NaN or infs sigma_clip returns the
     # mask containing `False` only or TypeError if data also contains a
     # masked value.
-
     assert result.mask[2, 2]
     assert result.mask[3, 4]
     assert result.mask[1, 1]
+
+    result2 = sigma_clip(data, axis=0)
+    assert result2.mask[1, 1]
+    assert result2.mask[3, 4]
+
+    result3 = sigma_clip(data, axis=0, copy=False)
+    assert result3.mask[1, 1]
+    assert result3.mask[3, 4]
+
+    # stats along axis with all nans
+    data[0, :] = np.nan     # row of all nans
+    result4, minarr, maxarr = sigma_clip(data, axis=1, masked=False)
+    assert np.isnan(minarr[0])
+    assert np.isnan(maxarr[0])
 
 
 def test_sigmaclip_negative_axis():

--- a/docs/stats/index.rst
+++ b/docs/stats/index.rst
@@ -28,11 +28,12 @@ they can be accessed by importing them::
 A full list of the different tools are provided below.  Please see the
 documentation for their different usage.  For example, sigma clipping,
 which is common way to estimate the background of an image, can be
-performed with the :func:`~astropy.stats.sigma_clip` function.  The
-function returns a masked array where outliers are masked::
+performed with the :func:`~astropy.stats.sigma_clip` function.  By
+default, the function returns a masked array where outliers are
+masked::
 
     >>> data = [1, 5, 6, 8, 100, 5, 3, 2]
-    >>> stats.sigma_clip(data, sigma=2, iters=5)  # doctest: +SKIP
+    >>> stats.sigma_clip(data, sigma=2, maxiters=5)  # doctest: +SKIP
     masked_array(data=[1, 5, 6, 8, --, 5, 3, 2],
                  mask=[False, False, False, False,  True, False, False, False],
            fill_value=999999)
@@ -41,9 +42,10 @@ function returns a masked array where outliers are masked::
    "not NUMPY_LT_1_14"
 
 Alternatively, the :class:`~astropy.stats.SigmaClip` class provides an
-object-oriented interface to sigma clipping::
+object-oriented interface to sigma clipping, which also returns a
+masked array by default::
 
-    >>> sigclip = stats.SigmaClip(sigma=2, iters=5)
+    >>> sigclip = stats.SigmaClip(sigma=2, maxiters=5)
     >>> sigclip(data)  # doctest: +SKIP
     masked_array(data=[1, 5, 6, 8, --, 5, 3, 2],
                  mask=[False, False, False, False,  True, False, False, False],
@@ -54,7 +56,7 @@ the calculation of statistics even easier.  For example,
 :func:`~astropy.stats.sigma_clipped_stats` will return the mean,
 median, and standard deviation of a sigma-clipped array::
 
-     >>> stats.sigma_clipped_stats(data, sigma=2, iters=5)  # doctest: +FLOAT_CMP
+     >>> stats.sigma_clipped_stats(data, sigma=2, maxiters=5)  # doctest: +FLOAT_CMP
      (4.2857142857142856, 5.0, 2.2497165354319457)
 
 There are also tools for calculating :ref:`robust statistics

--- a/docs/stats/robust.rst
+++ b/docs/stats/robust.rst
@@ -18,15 +18,15 @@ Sigma Clipping
 
 Sigma clipping provides a fast method to identify outliers in a
 distribution.  For a distribution of points, a center and a standard
-deviation are calculated.  Values which are a set number of sigma
-times the standard deviation away from the center are rejected.  The
-process can be iterated to further reject outliers.
+deviation are calculated.  Values which are less or more than a
+specified number of standard deviations from a center value are
+rejected.  The process can be iterated to further reject outliers.
 
 The `astropy.stats` package provides both a functional and
 object-oriented interface for sigma clipping.  The function is called
 :func:`~astropy.stats.sigma_clip` and the class is called
-:class:`~astropy.stats.SigmaClip`.  They both return a masked array
-where the rejected points are masked.
+:class:`~astropy.stats.SigmaClip`.  By default, they both return a
+masked array where the rejected points are masked.
 
 First, let's generate some data that has a mean of 0 and standard
 deviation of 0.2, but with outliers:
@@ -48,7 +48,7 @@ clipping on the data:
 .. doctest-requires:: scipy
 
      >>> from astropy.stats import sigma_clip
-     >>> filtered_data = sigma_clip(y, sigma=3, iters=10)
+     >>> filtered_data = sigma_clip(y, sigma=3, maxiters=10)
 
 The output masked array then can be used to calculate statistics on
 the data, fit models to the data, or otherwise explore the data.
@@ -59,13 +59,13 @@ To perform the same sigma clipping with the
 .. doctest-requires:: scipy
 
      >>> from astropy.stats import SigmaClip
-     >>> sigclip = SigmaClip(sigma=3, iters=10)
+     >>> sigclip = SigmaClip(sigma=3, maxiters=10)
      >>> print(sigclip)  # doctest: +SKIP
      <SigmaClip>
         sigma: 3
         sigma_lower: None
         sigma_upper: None
-        iters: 10
+        maxiters: 10
         cenfunc: <function median at 0x108dbde18>
         stdfunc: <function std at 0x103ab52f0>
      >>> filtered_data = sigclip(y)
@@ -84,7 +84,7 @@ outliers returns accurate values for the underlying distribution:
      >>> from astropy.stats import sigma_clipped_stats
      >>> y.mean(), np.median(y), y.std()  # doctest: +FLOAT_CMP
      (0.86586417693378226, 0.03265864495523732, 3.2913811977676444)
-     >>> sigma_clipped_stats(y, sigma=3, iters=10)  # doctest: +FLOAT_CMP
+     >>> sigma_clipped_stats(y, sigma=3, maxiters=10)  # doctest: +FLOAT_CMP
      (-0.0020337793767186197, -0.023632809025713953, 0.19514652532636906)
 
 :func:`~astropy.stats.sigma_clip` and
@@ -107,7 +107,7 @@ statistics to provide improved outlier rejection as well.
     y += (np.random.normal(0., 0.2, x.shape) +
           c*np.random.normal(3.0, 5.0, x.shape))
 
-    filtered_data = sigma_clip(y, sigma=3, iters=1, stdfunc=mad_std)
+    filtered_data = sigma_clip(y, sigma=3, maxiters=1, stdfunc=mad_std)
 
     # plot the original and rejected data
     plt.figure(figsize=(8,5))
@@ -117,6 +117,8 @@ statistics to provide improved outlier rejection as well.
     plt.xlabel('x')
     plt.ylabel('y')
     plt.legend(loc=2, numpoints=1)
+
+.. automodapi:: astropy.stats.sigma_clipping
 
 
 Median Absolute Deviation


### PR DESCRIPTION
This PR is a major refactor of the sigma clipping class/functions (`SigmaClip`, `sigma_clip`, `sigma_clipped_stats`) to significantly improve their performance (see #7086).  For array sizes of 1000x1000 to 5000x5000, these routines are 6.3x - 14x faster.

The new routines do not use masked arrays internally.  If `axis=None`, then the input data is flattened and clipped values are removed from the array during each iteration.  The min/max clipping thresholds are then used to create an output masked array.  Alternatively, a new `masked` keyword can be set to `False` to return the flattened/clipped 1D array and the min/max clipping thresholds.  That can be useful for some applications (it's the same as the output from `scipy.stat.sigmaclip`).

If `axis` is specified then NaN values are used as sentinel values for clipped data.  In this case, the `cenfunc` and `stdfunc` functions must be able to ignore NaNs and accept an `axis` keyword (previously they had to correctly handle masked arrays).  The new defaults for these keywords are `np.nanmedian` and `np.nanstd`, respectively.  By default, a masked array is returned (same as before).  If `masked=False`, an array of the same shape as the input data will be returned and contain NaNs where values were clipped.  In this case the returned minimum and maximum clipping thresholds will be also be arrays.

The `iters` keyword was renamed (and deprecated) to `maxiters`.  Previously `iters` sigma-clipping iterations would be performed even if the clipping had converged before `iters` iterations.  If `iters=10` and the clipping had converged after the second iteration, 8 more iterations would still be performed!  Now `maxiters` represents the *maximum* number of iterations to perform.  If convergence is obtained before `maxiters` iterations, the iterations stop.

This PR also silences the RuntimeWarnings that would occur when the input data contained NaNs.

More information comparing these routines to `scipy.stats.sigmaclip` is also provided in the documentation.  In the limited case where your data is a `ndarray` (not masked) with no invalid values and you want to use the mean as the centering function with `axis=None` and iterate to convergence, then `scipy.stats.sigmaclip` is recommended.  It is ~25-30% faster than the equivalent settings here (``sigma_clip(data, cenfunc=np.mean, maxiters=None, axis=None)``).