### PR TITLE
 Allow round-trip of MaskedColumn in ECSV, FITS, HDF5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,7 @@ astropy.io.fits
 
 - Add an ``ignore_hdus`` keyword to ``FITSDiff`` to allow ignoring HDUs by
   NAME when diffing two FITS files [#7538]
+
 - Optionally allow writing masked columns to FITS with the mask explicitly
   specified as a separate column instead of using the FITS standard of
   certain embedded null values (``NaN`` for float, ``TNULL`` for integers).

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,10 @@ astropy.io.ascii
 - Emit a warning when reading an ECSV file without specifying the ``format``
   and without PyYAML installed.  Previously this silently fell through to
   parsing as a basic format file and the file metadata was lost. [#7580]
+- Optionally allow writing masked columns to ECSV with the mask explicitly
+  specified as a separate column instead of marking masked elements with ""
+  (empty string).  This allows handling the case of a masked string column
+  with "" data rows.  [#7481]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
@@ -76,6 +80,10 @@ astropy.io.fits
 
 - Add an ``ignore_hdus`` keyword to ``FITSDiff`` to allow ignoring HDUs by
   NAME when diffing two FITS files [#7538]
+- Optionally allow writing masked columns to FITS with the mask explicitly
+  specified as a separate column instead of using the FITS standard of
+  certain embedded null values (``NaN`` for float, ``TNULL`` for integers).
+  This can be used to work around limitations in the FITS standard. [#7481]
 
 - All time coordinates can now be written to and read from FITS binary tables,
   including those with vectorized locations. [#7430]
@@ -116,6 +124,8 @@ astropy.table
 
 - Added a new table index engine, ``SCEngine``, based on the Sorted Containers
   package. [#7574]
+- Add a new keyword argument ``serialize_method`` to ``Table.write`` to
+  control how ``Time`` and ``MaskedColumn`` columns are written. [#7481]
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -362,6 +372,11 @@ astropy.io.ascii
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
+
+- Fixed bug when writing a table with masked columns to HDF5. Previously
+  the mask was being silently dropped.  If the ``serialize_meta`` option is
+  enabled the data mask will now be written as an additional column and the
+  masked columns will round-trip correctly. [#7481]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,7 @@ astropy.io.ascii
 - Emit a warning when reading an ECSV file without specifying the ``format``
   and without PyYAML installed.  Previously this silently fell through to
   parsing as a basic format file and the file metadata was lost. [#7580]
+
 - Optionally allow writing masked columns to ECSV with the mask explicitly
   specified as a separate column instead of marking masked elements with ""
   (empty string).  This allows handling the case of a masked string column
@@ -157,6 +158,7 @@ astropy.visualization
 
 - Add support for setting ``set_separator(None)`` in WCSAxes to use default
   separators. [#7570]
+
 - Added two keyword argument options to ``CoordinateHelper.set_format_unit``: ``decimal`` can
   be used to specify whether to use decimal formatting for the labels (by default this is
   False for degrees and hours and True otherwise), and ``show_decimal_unit`` can be used to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,7 @@ astropy.table
 
 - Added a new table index engine, ``SCEngine``, based on the Sorted Containers
   package. [#7574]
+
 - Add a new keyword argument ``serialize_method`` to ``Table.write`` to
   control how ``Time`` and ``MaskedColumn`` columns are written. [#7481]
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -201,6 +201,37 @@ class EcsvOutputter(core.TableOutputter):
         return out
 
 
+class EcsvData(basic.BasicData):
+    def _set_fill_values(self, cols):
+        """Set the fill values of the individual cols based on fill_values of BaseData
+
+        For ECSV handle the corner case of data that has been serialized using
+        the serialize_method='data_mask' option, which writes the full data and
+        mask directly, AND where that table includes a string column with zero-length
+        string entries ("") which are valid data.
+
+        Normally the super() method will set col.fill_value=('', '0') to replace
+        blanks with a '0'.  But for that corner case subset, instead do not do
+        any filling.
+        """
+        super()._set_fill_values(cols)
+
+        # Get the serialized columns spec.  It might not exist and there might
+        # not even be any table meta, so punt in those cases.
+        try:
+            scs = self.header.table_meta['__serialized_columns__']
+        except (AttributeError, KeyError):
+            return
+
+        # Got some serialized columns, so check for string type and serialized
+        # as a MaskedColumn.  Without 'data_mask', MaskedColumn objects are
+        # stored to ECSV as normal columns.
+        for col in cols:
+            if (col.dtype == 'str' and col.name in scs and
+                    scs[col.name]['__class__'] == 'astropy.table.column.MaskedColumn'):
+                col.fill_values = {}  # No data value replacement
+
+
 class Ecsv(basic.Basic):
     """
     Read a file which conforms to the ECSV (Enhanced Character Separated
@@ -235,6 +266,7 @@ class Ecsv(basic.Basic):
     _io_registry_suffix = '.ecsv'
 
     header_class = EcsvHeader
+    data_class = EcsvData
     outputter_class = EcsvOutputter
 
     def update_table_data(self, table):

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -436,3 +436,60 @@ def test_ecsv_but_no_yaml_warning():
     with pytest.raises(ascii.InconsistentTableError) as exc:
         ascii.read(SIMPLE_LINES, format='ecsv')
     assert "PyYAML package is required" in str(exc)
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_round_trip_masked_table_default(tmpdir):
+    """Test (mostly) round-trip of MaskedColumn through ECSV using default serialization
+    that uses an empty string "" to mark NULL values.  Note:
+
+    >>> simple_table(masked=True)
+    <Table masked=True length=3>
+      a      b     c
+    int64 float64 str1
+    ----- ------- ----
+       --     1.0    c
+        2     2.0   --
+        3      --    e
+    """
+    filename = str(tmpdir.join('test.ecsv'))
+
+    t = simple_table(masked=True)  # int, float, and str cols with one masked element
+    t.write(filename)
+
+    t2 = Table.read(filename)
+    assert t2.masked is True
+    assert t2.colnames == t.colnames
+    for name in t2.colnames:
+        # From formal perspective the round-trip columns are the "same"
+        assert np.all(t2[name].mask == t[name].mask)
+        assert np.all(t2[name] == t[name])
+
+        # But peeking under the mask shows that the underlying data are changed
+        # because by default ECSV uses "" to represent masked elements.
+        t[name].mask = False
+        t2[name].mask = False
+        assert not np.all(t2[name] == t[name])  # Expected diff
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_round_trip_masked_table_serialize_mask(tmpdir):
+    """Same as prev but set the serialize_method to 'data_mask' so mask is written out"""
+    filename = str(tmpdir.join('test.ecsv'))
+
+    t = simple_table(masked=True)  # int, float, and str cols with one masked element
+    t['c'][0] = ''  # This would come back as masked for default "" NULL marker
+
+    t.write(filename, serialize_method='data_mask')
+
+    t2 = Table.read(filename)
+    assert t2.masked is True
+    assert t2.colnames == t.colnames
+    for name in t2.colnames:
+        assert np.all(t2[name].mask == t[name].mask)
+        assert np.all(t2[name] == t[name])
+
+        # Data under the mask round-trips also (unmask data to show this).
+        t[name].mask = False
+        t2[name].mask = False
+        assert np.all(t2[name] == t[name])

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -877,7 +877,7 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     if isinstance(table, Table):
         # Note that making a copy of the table here is inefficient but
         # without this copy a number of tests break (e.g. in test_fixedwidth).
-        # TODO: investigate.
+        # See #7605.
         new_tbl = table.__class__(table, names=names)
 
         # This makes a copy of the table columns.  This is subject to a

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -34,7 +34,7 @@ from . import fastbasic
 from . import cparser
 from . import fixedwidth
 
-from ...table import Table, vstack
+from ...table import Table, vstack, MaskedColumn
 from ...utils.data import get_readable_fileobj
 from ...utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
@@ -872,8 +872,26 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     if output is None:
         output = sys.stdout
 
-    table_cls = table.__class__ if isinstance(table, Table) else Table
-    table = table_cls(table, names=kwargs.get('names'))
+    # Ensure that `table` is a Table subclass.
+    names = kwargs.get('names')
+    if isinstance(table, Table):
+        # Note that making a copy of the table here is inefficient but
+        # without this copy a number of tests break (e.g. in test_fixedwidth).
+        # TODO: investigate.
+        new_tbl = table.__class__(table, names=names)
+
+        # This makes a copy of the table columns.  This is subject to a
+        # corner-case problem if writing a table with masked columns to ECSV
+        # where serialize_method is set to 'data_mask'.  In this case that
+        # attribute gets dropped in the copy, so do the copy here.  This
+        # should be removed when `info` really contains all the attributes
+        # (#6720).
+        for new_col, col in zip(new_tbl.itercols(), table.itercols()):
+            if isinstance(col, MaskedColumn):
+                new_col.info.serialize_method = col.info.serialize_method
+        table = new_tbl
+    else:
+        table = Table(table, names=names)
 
     table0 = table[:0].copy()
     core._apply_include_exclude_names(table0, kwargs.get('names'),

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -657,38 +657,6 @@ def test_info_attributes_with_no_mixins(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_YAML')
-def test_round_trip_masked_table_default(tmpdir):
-    """This is a regression test showing the currently BROKEN default
-    behavior of Table.write() to a FITS bintable.  Note:
-
-    >>> simple_table(masked=True)
-    <Table masked=True length=3>
-      a      b     c
-    int64 float64 str1
-    ----- ------- ----
-       --     1.0    c
-        2     2.0   --
-        3      --    e
-    """
-    filename = str(tmpdir.join('test.fits'))
-
-    t = simple_table(masked=True)
-    t['a'].fill_value = 2
-    t.write(filename)
-    t2 = Table.read(filename)
-
-    assert t2.masked is True
-    assert np.all(t2['a'].mask == [True, True, False])  # This is WRONG
-    assert np.all(t2['b'].mask == [False, False, False])  # This is WRONG
-    assert np.all(t2['c'].mask == [False, False, False])  # This is WRONG
-
-    assert np.all(t2['a'] == [1, 2, 3])
-    assert np.all(t2['b'][:2] == [1.0, 2.0])  # OK
-    assert np.isnan(t2['b'][2])  # WRONG
-    assert np.all(t2['c'] == ['c', 'N', 'e'])  # WRONG ('N' is first char of 'N/A')
-
-
-@pytest.mark.skipif('not HAS_YAML')
 @pytest.mark.parametrize('method', ['set_cols', 'names', 'class'])
 def test_round_trip_masked_table_serialize_mask(tmpdir, method):
     """

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -211,8 +211,5 @@ def serialize_method_as(tbl, serialize_method):
         # Teardown (restore) for the context block.  Be sure to do this even
         # if an exception occurred.
         if serialize_method:
-            for col in tbl.itercols():
-                # Go through every column and if it has a serialize_method info
-                # attribute then potentially update it for the duration of the write.
-                if col.info.name in original_sms:
-                    col.info.serialize_method = original_sms[col.info.name]
+            for name, original_sm in original_sms.items():
+                tbl[name].info.serialize_method = original_sm

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -4,11 +4,13 @@ Table property for providing information about table.
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import sys
 import os
+from contextlib import contextmanager
+from inspect import isclass
 
 import numpy as np
 from ..utils.data_info import DataInfo
 
-__all__ = ['table_info', 'TableInfo']
+__all__ = ['table_info', 'TableInfo', 'serialize_method_as']
 
 
 def table_info(tbl, option='attributes', out=''):
@@ -121,3 +123,96 @@ class TableInfo(DataInfo):
         return table_info(self._parent, option, out)
 
     __call__.__doc__ = table_info.__doc__
+
+
+@contextmanager
+def serialize_method_as(tbl, serialize_method):
+    """Context manager to temporarily override individual
+    column info.serialize_method dict values.  The serialize_method
+    attribute is an optional dict which might look like ``{'fits':
+    'jd1_jd2', 'ecsv': 'formatted_value', ..}``.
+
+    ``serialize_method`` is a str or dict.  If str then it the the value
+    is the ``serialize_method`` that will be used for all formats.
+    If dict then the key values can be either:
+
+    - Column name.  This has higher precedence than the second option of
+      matching class.
+    - Class (matches any column which is an instance of the class)
+
+    This context manager is expected to be used only within ``Table.write``.
+    It could have been a private method on Table but prefer not to add
+    clutter to that class.
+
+    Parameters
+    ----------
+    tbl : Table object
+        Input table
+    serialize_method : dict, str
+        Dict with key values of column names or types, or str
+
+    Returns
+    -------
+    None (context manager)
+    """
+    def get_override_sm(col):
+        """
+        Determine if the ``serialize_method`` str or dict specifies an
+        override of column presets for ``col``.  Returns the matching
+        serialize_method value or ``None``.
+        """
+        # If a string then all columns match
+        if isinstance(serialize_method, str):
+            return serialize_method
+
+        # If column name then return that serialize_method
+        if col.info.name in serialize_method:
+            return serialize_method[col.info.name]
+
+        # Otherwise look for subclass matches
+        for key in serialize_method:
+            if isclass(key) and isinstance(col, key):
+                return serialize_method[key]
+
+        return None
+
+    # Setup for the context block.  Set individual column.info.serialize_method
+    # values as appropriate and keep a backup copy.  If ``serialize_method``
+    # is None or empty then don't do anything.
+
+    if serialize_method:
+        # Original serialize_method dict, keyed by column name.  This only
+        # gets set if there is an override.
+        original_sms = {}
+
+        # Go through every column and if it has a serialize_method info
+        # attribute then potentially update it for the duration of the write.
+        for col in tbl.itercols():
+            if hasattr(col.info, 'serialize_method'):
+                override_sm = get_override_sm(col)
+                if override_sm:
+                    # Make a reference copy of the column serialize_method
+                    # dict which maps format (e.g. 'fits') to the
+                    # appropriate method (e.g. 'data_mask').
+                    original_sms[col.info.name] = col.info.serialize_method
+
+                    # Set serialize method for *every* available format.  This is
+                    # brute force, but at this point the format ('fits', 'ecsv', etc)
+                    # is not actually known (this gets determined by the write function
+                    # in registry.py).  Note this creates a new temporary dict object
+                    # so that the restored version is the same original object.
+                    col.info.serialize_method = {fmt: override_sm
+                                                 for fmt in col.info.serialize_method}
+
+    # Finally yield for the context block
+    try:
+        yield
+    finally:
+        # Teardown (restore) for the context block.  Be sure to do this even
+        # if an exception occurred.
+        if serialize_method:
+            for col in tbl.itercols():
+                # Go through every column and if it has a serialize_method info
+                # attribute then potentially update it for the duration of the write.
+                if col.info.name in original_sms:
+                    col.info.serialize_method = original_sms[col.info.name]

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -60,9 +60,8 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
     obj_attrs = col.info._represent_as_dict()
     ordered_keys = col.info._represent_as_dict_attrs
 
-    # If not a mixin, or if class in ``exclude_classes`` tuple then
-    # treat as a normal column.  Excluded sub-classes must be explicitly
-    # specified.
+    # If serialization is not required (see function docstring above)
+    # or explicitly specified as excluded, then treat as a normal column.
     if not obj_attrs or col.__class__ in exclude_classes:
         new_cols.append(col)
         return

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -36,7 +36,27 @@ class SerializedColumn(dict):
 
 def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
                                exclude_classes=()):
-    """Convert a mixin column to a plain columns or a set of mixin columns."""
+    """Carry out processing needed to serialize ``col`` in an output table
+    consisting purely of plain ``Column`` or ``MaskedColumn`` columns.  This
+    relies on the object determine if any transformation is required and may
+    depend on the ``serialize_method`` and ``serialize_context`` context
+    variables.  For instance a ``MaskedColumn`` may be stored directly to
+    FITS, but can also be serialized as separate data and mask columns.
+
+    This function builds up a list of plain columns in the ``new_cols`` arg (which
+    is passed as a persistent list).  This includes both plain columns from the
+    original table and plain columns that represent data from serialized columns
+    (e.g. ``jd1`` and ``jd2`` arrays from a ``Time`` column).
+
+    For serialized columns the ``mixin_cols`` dict is updated with required
+    attributes and information to subsequently reconstruct the table.
+
+    Table mixin columns are always serialized and get represented by one
+    or more data columns.  In earlier versions of the code *only* mixin
+    columns were serialized, hence the use within this code of "mixin"
+    to imply serialization.  Starting with version 3.1, the non-mixin
+    ``MaskedColumn`` can also be serialized.
+    """
     obj_attrs = col.info._represent_as_dict()
     ordered_keys = col.info._represent_as_dict_attrs
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -25,7 +25,7 @@ from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_copy)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
-from .info import TableInfo
+from .info import TableInfo, serialize_method_as
 from .index import Index, _IndexModeContext, get_index
 from . import conf
 
@@ -2545,8 +2545,7 @@ class Table:
         return out
 
     def write(self, *args, **kwargs):
-        """
-        Write this Table object out in the specified format.
+        """Write this Table object out in the specified format.
 
         This function provides the Table interface to the astropy unified I/O
         layer.  This allows easily writing a file in many supported data formats
@@ -2556,10 +2555,13 @@ class Table:
           >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
           >>> dat.write('table.dat', format='ascii')
 
-        The arguments and keywords (other than ``format``) provided to this function are
-        passed through to the underlying data reader (e.g. `~astropy.io.ascii.write`).
+        The arguments and keywords (other than ``format`` and
+        ``serialize_methods``) provided to this function are passed through to
+        the underlying data reader (e.g. `~astropy.io.ascii.write`).
         """
-        io_registry.write(self, *args, **kwargs)
+        serialize_method = kwargs.pop('serialize_method', None)
+        with serialize_method_as(self, serialize_method):
+            io_registry.write(self, *args, **kwargs)
 
     def copy(self, copy_data=True):
         '''

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2533,16 +2533,19 @@ class Table:
         ----------
         format : str
             File format specifier.
-        *args
+        *args : tuple, optional
             Positional arguments passed through to data reader. If supplied the
             first argument is the input filename.
-        **kwargs
+        **kwargs : dict, optional
             Keyword arguments passed through to data reader.
 
+        Returns
         -------
         out : `Table`
             Table corresponding to file contents
 
+        Notes
+        -----
         """
         out = io_registry.read(cls, *args, **kwargs)
         # For some readers (e.g., ascii.ecsv), the returned `out` class is not
@@ -2577,11 +2580,14 @@ class Table:
             File format specifier.
         serialize_method : str, dict, optional
             Serialization method specifier for columns.
-        *args
+        *args : tuple, optional
             Positional arguments passed through to data writer. If supplied the
             first argument is the output filename.
-        **kwargs
+        **kwargs : dict, optional
             Keyword arguments passed through to data writer.
+
+        Notes
+        -----
         """
         serialize_method = kwargs.pop('serialize_method', None)
         with serialize_method_as(self, serialize_method):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2547,6 +2547,10 @@ class Table:
         Notes
         -----
         """
+        # The hanging Notes section just above is a section placeholder for
+        # import-time processing that collects available formats into an
+        # RST table and inserts at the end of the docstring.  DO NOT REMOVE.
+
         out = io_registry.read(cls, *args, **kwargs)
         # For some readers (e.g., ascii.ecsv), the returned `out` class is not
         # guaranteed to be the same as the desired output `cls`.  If so,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2527,8 +2527,22 @@ class Table:
           >>> dat = Table.read('table.dat', format='ascii')
           >>> events = Table.read('events.fits', format='fits')
 
-        The arguments and keywords (other than ``format``) provided to this function are
-        passed through to the underlying data reader (e.g. `~astropy.io.ascii.read`).
+        See http://docs.astropy.org/en/stable/io/unified.html for details.
+
+        Parameters
+        ----------
+        format : str
+            File format specifier.
+        *args
+            Positional arguments passed through to data reader. If supplied the
+            first argument is the input filename.
+        **kwargs
+            Keyword arguments passed through to data reader.
+
+        -------
+        out : `Table`
+            Table corresponding to file contents
+
         """
         out = io_registry.read(cls, *args, **kwargs)
         # For some readers (e.g., ascii.ecsv), the returned `out` class is not
@@ -2555,9 +2569,19 @@ class Table:
           >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
           >>> dat.write('table.dat', format='ascii')
 
-        The arguments and keywords (other than ``format`` and
-        ``serialize_methods``) provided to this function are passed through to
-        the underlying data reader (e.g. `~astropy.io.ascii.write`).
+        See http://docs.astropy.org/en/stable/io/unified.html for details.
+
+        Parameters
+        ----------
+        format : str
+            File format specifier.
+        serialize_method : str, dict, optional
+            Serialization method specifier for columns.
+        *args
+            Positional arguments passed through to data writer. If supplied the
+            first argument is the output filename.
+        **kwargs
+            Keyword arguments passed through to data writer.
         """
         serialize_method = kwargs.pop('serialize_method', None)
         with serialize_method_as(self, serialize_method):

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -23,6 +23,7 @@ import numpy as np
 
 from ...coordinates import EarthLocation
 from ...table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
+from ...table import serialize
 from ... import time
 from ... import coordinates
 from ... import units as u
@@ -738,3 +739,14 @@ def test_rename_mixin_columns(mixin_cols):
         assert np.all(t['mm'].dec == tc['m'].dec)
     else:
         assert np.all(t['mm'] == tc['m'])
+
+
+def test_represent_mixins_as_columns_unit_fix():
+    """
+    If the unit is invalid for a column that gets serialized this would
+    cause an exception.  Fixed in #7481.
+    """
+    t = Table({'a': [1, 2]}, masked=True)
+    t['a'].unit = 'not a valid unit'
+    t['a'].mask[1] = True
+    serialize._represent_mixins_as_columns(t)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -105,6 +105,10 @@ class TimeInfo(MixinInfo):
     _represent_as_dict_extra_attrs = ('format', 'scale', 'precision',
                                       'in_subfmt', 'out_subfmt', 'location',
                                       '_delta_ut1_utc', '_delta_tdb_tt')
+
+    # When serializing, write out the `value` attribute using the column name.
+    _represent_as_dict_primary_data = 'value'
+
     mask_val = np.ma.masked
 
     @property

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -141,12 +141,8 @@ class QuantityInfo(QuantityInfoBase):
     be used as a general way to store meta information.
     """
     _represent_as_dict_attrs = ('value', 'unit')
-
-    def _construct_from_dict(self, map):
-        # Need to pop value because different Quantity subclasses use
-        # different first arg name for the value.  :-(
-        value = map.pop('value')
-        return self._parent_cls(value, **map)
+    _construct_from_dict_args = ['value']
+    _represent_as_dict_primary_data = 'value'
 
     def new_like(self, cols, length, metadata_conflicts='warn', name=None):
         """

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -222,6 +222,19 @@ the fast Cython/C engine for reading and writing.
 ========================= ===== ==== ============================================================================================
 
 
+.. attention:: **ECSV is recommended**
+
+   For writing and reading tables to ASCII in a way that fully reproduces the
+   table data, types and metadata (i.e. the table will "round-trip"), we highly
+   recommend using the :ref:`ecsv_format`.  This writes the actual data in a
+   simple space-delimited format (the ``basic`` format) that any ASCII table
+   reader can parse, but also includes metadata encoded in a comment block that
+   allows full reconstruction of the original columns.  This includes support
+   for :ref:`ecsv_format_mixin_columns` (such as
+   `~astropy.coordinates.SkyCoord` or `~astropy.time.Time`) and
+   :ref:`ecsv_format_masked_columns`.
+
+
 Using `astropy.io.ascii`
 ========================
 

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -381,7 +381,7 @@ The FITS standard has a few limitations:
   of later unmasking the values.
 
 Astropy provides a work-around for this limitation that users can choose to
-use.  The key part using the ``serialize_method='data_mask'`` keyword argument
+use.  The key part is to use the ``serialize_method='data_mask'`` keyword argument
 when writing the table.  This tells the FITS writer to split each masked
 column into two separate columns, one for the data and one for the mask.
 When it gets read back that process is reversed and the two columns are

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -362,11 +362,13 @@ FITS.  By default this will replace the masked data elements with certain
 sentinel values according to the FITS standard:
 
 - ``NaN`` for float columns
-- Value of ``TNULLn`` for integer columns
+- Value of ``TNULLn`` for integer columns, as defined by the column
+  ``fill_value`` attribute
 - Null string for string columns (not currently implemented)
 
-When the file is read back those elements are marked as masked in the
-returned table.
+When the file is read back those elements are marked as masked in the returned
+table, but see `issue #4708 <https://github.com/astropy/astropy/issues/4708>`_
+for problems in all three cases.
 
 The FITS standard has a few limitations:
 


### PR DESCRIPTION
This provides a workaround for #4708.  It *allows* fully robust round-trip of `MaskedColumn` in ECSV, FITS, and HDF5 by explicitly writing the mask as a separate column (if there are any masked elements).  However, the new machinery is only enabled by default for HDF5, where writing a masked column is currently entirely unsupported.

For FITS the standard is mostly adequate, with the exception that it may not always be possible to choose a TNULL value that is not represented within the data.  In this case it would be useful to issue a warning when writing, and point to a new opt-in feature to use this MaskedColumn serialization and store the data and mask separately.

For ECSV the current standard of using `""` is robust for all cases except storing a blank entry in a string column.  Like FITS, this situation could generate a warning on write and allow for explicitly choosing to separate the data and mask.

To get MaskedColumn to work I had to introduce some generalizations in the table serialization machinery.  I added some more inline docs, though this really would deserve a longer treatment in some design docs somewhere (in a perfect world).