### PR TITLE
Fix bug writing FITS table with column description with newlines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -365,6 +365,9 @@ astropy.io.fits
 - Raise error when attempting to open gzipped FITS file in 'append' mode.
   [#7473]
 
+- Fix a bug when writing to FITS a table that has a column description
+  with embedded blank lines. [#7482]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -354,10 +354,13 @@ def _encode_mixins(tbl):
     encode_tbl.meta['comments'].append('--BEGIN-ASTROPY-SERIALIZED-COLUMNS--')
 
     for line in meta_yaml_lines:
-        # Split line into 70 character chunks for COMMENT cards
-        idxs = list(range(0, len(line) + 70, 70))
-        lines = [line[i0:i1] + '\\' for i0, i1 in zip(idxs[:-1], idxs[1:])]
-        lines[-1] = lines[-1][:-1]
+        if len(line) == 0:
+            lines = ['']
+        else:
+            # Split line into 70 character chunks for COMMENT cards
+            idxs = list(range(0, len(line) + 70, 70))
+            lines = [line[i0:i1] + '\\' for i0, i1 in zip(idxs[:-1], idxs[1:])]
+            lines[-1] = lines[-1][:-1]
         encode_tbl.meta['comments'].extend(lines)
 
     encode_tbl.meta['comments'].append('--END-ASTROPY-SERIALIZED-COLUMNS--')

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -593,7 +593,7 @@ def test_fits_mixins_per_column(table_cls, name_col, tmpdir):
 
     c = [1.0, 2.0]
     t = table_cls([c, col, c], names=['c1', name, 'c2'])
-    t[name].info.description = 'my description'
+    t[name].info.description = 'my \n\n\n description'
     t[name].info.meta = {'list': list(range(50)), 'dict': {'a': 'b' * 200}}
 
     if not t.has_mixin_columns:


### PR DESCRIPTION
This fixes (partially) #7480.