### PR TITLE
Fix copy of mask when copying a Table

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy "pytest<3.6" pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1039,6 +1039,9 @@ astropy.table
 
 - Fix printing table row indexed with unsigned integer. [#7469]
 
+- Fix copy of mask when copying a Table, as this is no more done systematically
+  by Numpy since version 1.14. [#7486]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1040,7 +1040,8 @@ astropy.table
 - Fix printing table row indexed with unsigned integer. [#7469]
 
 - Fix copy of mask when copying a Table, as this is no more done systematically
-  by Numpy since version 1.14. [#7486]
+  by Numpy since version 1.14. Also fixed a problem when MaskedColumn was
+  initialized with ``mask=np.ma.nomask``. [#7486]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1120,7 +1120,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             # gets quickly broadcast to the expected bool array of False.
             mask = getattr(data, 'mask', False)
             if mask is not False:
-                mask = np.array(data.mask, copy=copy)
+                mask = np.array(mask, copy=copy)
         elif mask is np.ma.nomask:
             # Force the creation of a full mask array as nomask is tricky to
             # use and will fail in an unexpected manner when setting a value

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1116,7 +1116,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
         if mask is None:
             if hasattr(data, 'mask'):
-                mask = data.mask
+                mask = np.array(data.mask, copy=copy)
             else:
                 # Issue #7399 with fix #7422.  Passing mask=None to ma.MaskedArray
                 # is extremely slow (~3 seconds for 1e7 elements), while mask=False

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1115,13 +1115,17 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
                 copy=False, copy_indices=True):
 
         if mask is None:
-            if hasattr(data, 'mask'):
+            # Issue #7399 with fix #7422.  Passing mask=None to ma.MaskedArray
+            # is extremely slow (~3 seconds for 1e7 elements), while mask=False
+            # gets quickly broadcast to the expected bool array of False.
+            mask = getattr(data, 'mask', False)
+            if mask is not False:
                 mask = np.array(data.mask, copy=copy)
-            else:
-                # Issue #7399 with fix #7422.  Passing mask=None to ma.MaskedArray
-                # is extremely slow (~3 seconds for 1e7 elements), while mask=False
-                # gets quickly broadcast to the expected bool array of False.
-                mask = False
+        elif mask is np.ma.nomask:
+            # Force the creation of a full mask array as nomask is tricky to
+            # use and will fail in an unexpected manner when setting a value
+            # to the mask.
+            mask = False
         else:
             mask = deepcopy(mask)
 

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -419,14 +419,8 @@ def test_coercing_fill_value_type():
 def test_mask_copy():
     """Test that the mask is copied when copying a table (issue #7362)."""
 
-    t = Table([[2, 4, 1, 3], [3., 2., np.nan, 4]],
-              names=('a', 'b'), masked=True)
-    t['b'] = np.ma.masked_invalid(t['b'])
-    orig_mask = t['b'].mask.copy()
-
-    t2 = t.copy()
-    t2.sort('a')
-
-    # Check that the mask from the initial table was not modified
-    np.testing.assert_array_equal(t['b'].mask, orig_mask)
-    np.testing.assert_array_equal(t2['b'].mask, [True, False, False, False])
+    c = MaskedColumn([1, 2], mask=[False, True])
+    c2 = MaskedColumn(c, copy=True)
+    c2.mask[0] = True
+    assert np.all(c.mask == [False, True])
+    assert np.all(c2.mask == [True, True])

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -414,3 +414,19 @@ def test_coercing_fill_value_type():
     c.set_fill_value('0')
     c2 = MaskedColumn(c, dtype=np.int32)
     assert isinstance(c2.fill_value, np.int32)
+
+
+def test_mask_copy():
+    """Test that the mask is copied when copying a table (issue #7362)."""
+
+    t = Table([[2, 4, 1, 3], [3., 2., np.nan, 4]],
+              names=('a', 'b'), masked=True)
+    t['b'] = np.ma.masked_invalid(t['b'])
+    orig_mask = t['b'].mask.copy()
+
+    t2 = t.copy()
+    t2.sort('a')
+
+    # Check that the mask from the initial table was not modified
+    np.testing.assert_array_equal(t['b'].mask, orig_mask)
+    np.testing.assert_array_equal(t2['b'].mask, [True, False, False, False])


### PR DESCRIPTION
Fix #7362.

Since Numpy 1.14 the mask is no more copied systematically (see  #5060), so it needs to be copied when a copy of a Table is done.

Milestone set to 2.0.7 as I think it needs to be backported.