### PR TITLE
Correct documented default boundary case for convolution.convolve

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -53,9 +53,9 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         A flag indicating how to handle boundaries:
             * `None`
                 Set the ``result`` values to zero where the kernel
-                extends beyond the edge of the array (default).
+                extends beyond the edge of the array.
             * 'fill'
-                Set values outside the array boundary to ``fill_value``.
+                Set values outside the array boundary to ``fill_value`` (default).
             * 'wrap'
                 Periodic boundary that wrap to the other side of ``array``.
             * 'extend'


### PR DESCRIPTION
Signed-off-by: James Noss <jnoss@stsci.edu>