### PR TITLE
Python 2 compatibility for utils data download and caching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fixed a bug that improperly handled unicode case of URL mirror in Python 2.
+  [#7493]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -97,6 +97,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Bundled ``pytest-remotedata`` plugin is upgraded to 0.3. [#7493]
 
 
 2.0.6 (2018-04-23)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1071,6 +1071,9 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                         if url_key.startswith(cur_url):
                             url_mirror = url_key.replace(cur_url,
                                                          conf.dataurl_mirror)
+                            if six.PY2 and isinstance(url_mirror,
+                                                      six.text_type):
+                                url_mirror = url_mirror.encode('utf-8')
                             if url_mirror in url2hash:
                                 return url2hash[url_mirror]
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -50,7 +50,7 @@ else:
     HAS_PATHLIB = True
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_nocache():
     from ..data import download_file
 
@@ -58,7 +58,7 @@ def test_download_nocache():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_parallel():
     from ..data import (download_file, download_files_in_parallel,
                         _get_download_cache_locs, get_cached_urls,
@@ -84,7 +84,7 @@ def test_download_parallel():
             (mirror_url in c_urls) and (main_url not in c_urls))
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_noprogress():
     from ..data import download_file
 
@@ -92,7 +92,7 @@ def test_download_noprogress():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_cache():
 
     from ..data import download_file, clear_download_cache
@@ -125,7 +125,7 @@ def test_download_cache():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_url_nocache():
 
     from ..data import get_readable_fileobj
@@ -134,7 +134,7 @@ def test_url_nocache():
         assert page.read().find('Astropy') > -1
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_find_by_hash():
 
     from ..data import get_readable_fileobj, get_pkg_data_filename, clear_download_cache
@@ -153,7 +153,7 @@ def test_find_by_hash():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_find_invalid():
     from ..data import get_pkg_data_filename
 
@@ -299,7 +299,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
@@ -436,7 +436,7 @@ def test_compressed_stream():
         assert f.read().rstrip() == b'CONTENT'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_invalid_location_download():
     """
     checks that download_file gives a URLError and not an AttributeError,
@@ -459,7 +459,7 @@ def test_invalid_location_download_noconnect():
         download_file('http://astropy.org/nonexistentfile')
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_is_url_in_cache():
     from ..data import download_file, is_url_in_cache
 


### PR DESCRIPTION
Fix #7488 

This is also a backport of #7494

First commit is to see where things are failing because I think some things slipped through perhaps due to astropy/pytest-remotedata#26

This is only for v2.0.x as it only concerns Python 2 compatibility.

TODO:
- [x] ~~Modify the test to reproduce error reporting in #7488~~ Nope, can't reproduce it. I give up. I'll just open a test PR over at `healpy` when this is ready.
- [x] Apply bug fix patch -- I think `url_mirror` needs the same treatment as `url_key` at L1049.
- [x] See if things are peachy over at healpy/healpy#444 -- https://travis-ci.org/healpy/healpy/builds/383840075
- [x] Wait for `pytest-remotedata` release and see if tests pass here then.
- [x] Add change log