### PR TITLE
Add a more helpful warning if frame not found in transformation graph

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1162,6 +1162,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             if new_frame is self.__class__:
                 # no special transform needed, but should update frame info
                 return new_frame.realize_frame(self.data)
+            elif isinstance(new_frame, str):
+                raise ConvertError("Could not find frame with name " +
+                                   "'{}' ".format(new_frame) +
+                                   "in the frame transformation graph")
             msg = 'Cannot transform from {0} to {1}'
             raise ConvertError(msg.format(self.__class__, new_frame.__class__))
         return trans(self, new_frame)


### PR DESCRIPTION
Currently if you try and do `.transform_to('random string')`, and `'random string'` isn't registered as a frame in the transformation graph, the following error is raised:

```
    astropy.coordinates.errors.ConvertError: Cannot transform from <class 'heliopy.coordinates.frames.HeliocentricEarthEcliptic'> to <class 'str'>
```

This PR changes the error to make it clear that the reason the transformation failed is that the requested frame couldn't be found in the transformation graph:

```
astropy.coordinates.errors.ConvertError: Could not find frame with name 'random string' in the frame transformation graph
```