### PR TITLE
Let transform_to() take strings as arguments

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1119,7 +1119,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         Parameters
         ----------
-        new_frame : class or frame object or SkyCoord object
+        new_frame : class or frame object or SkyCoord object or string
             The frame to transform this coordinate frame into.
 
         Returns
@@ -1156,8 +1156,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             # likely a SkyCoord object.
             new_frame = new_frame._sky_coord_frame
 
+        if isinstance(new_frame, str):
+            new_frame_cls = frame_transform_graph.lookup_name(new_frame)
+            if new_frame_cls is None:
+                raise ConvertError("Could not find frame with name " +
+                                   "'{}' ".format(new_frame) +
+                                   "in the frame transformation graph.")
+        else:
+            new_frame_cls = new_frame.__class__
+
         trans = frame_transform_graph.get_transform(self.__class__,
-                                                    new_frame.__class__)
+                                                    new_frame_cls)
         if trans is None:
             if new_frame is self.__class__:
                 # no special transform needed, but should update frame info

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -424,6 +424,7 @@ def test_transform():
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
     f = i.transform_to(FK5)
     i2 = f.transform_to(ICRS)
+    i3 = f.transform_to('icrs')
 
     assert i2.data.__class__ == r.UnitSphericalRepresentation
 

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -395,6 +395,10 @@ class TransformGraph:
         1-hop transformations.
 
         """
+        if isinstance(fromsys, str):
+            fromsys = self.lookup_name(fromsys)
+        if isinstance(tosys, str):
+            tosys = self.lookup_name(tosys)
         if not inspect.isclass(fromsys):
             raise TypeError('fromsys is not a class')
         if not inspect.isclass(tosys):


### PR DESCRIPTION
e.g. can now do something like `.transform_to('icrs')` instead of having to pass the `ICRS` class.