### PR TITLE
Fix IP lookup error for astropy remote data option

### DIFF
--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -23,6 +23,20 @@ INTERNET_OFF = False
 _orig_opener = None
 
 
+def _resolve_host_ips(hostname, port=80):
+    """
+    Obtain all the IPs, including aliases, in a way that supports
+    IPv4/v6 dual stack.
+    """
+    try:
+        ips = set([s[-1][0] for s in socket.getaddrinfo(hostname, port)])
+    except socket.gaierror:
+        ips = set([])
+
+    ips.add(hostname)
+    return ips
+
+
 # ::1 is apparently another valid name for localhost?
 # it is returned by getaddrinfo when that function is given localhost
 
@@ -31,6 +45,8 @@ def check_internet_off(original_function, allow_astropy_data=False):
     Wraps ``original_function``, which in most cases is assumed
     to be a `socket.socket` method, to raise an `IOError` for any operations
     on non-local AF_INET sockets.
+
+    Allowing Astropy data also automatically allow GitHub data.
     """
 
     def new_function(*args, **kwargs):
@@ -42,7 +58,7 @@ def check_internet_off(original_function, allow_astropy_data=False):
                 return original_function(*args, **kwargs)
             host = args[1][0]
             addr_arg = 1
-            valid_hosts = ('localhost', '127.0.0.1', '::1')
+            valid_hosts = set(['localhost', '127.0.0.1', '::1'])
         else:
             # The only other function this is used to wrap currently is
             # socket.create_connection, which should be passed a 2-tuple, but
@@ -52,22 +68,26 @@ def check_internet_off(original_function, allow_astropy_data=False):
 
             host = args[0][0]
             addr_arg = 0
-            valid_hosts = ('localhost', '127.0.0.1')
+            valid_hosts = set(['localhost', '127.0.0.1'])
 
+        # Astropy + GitHub data
         if allow_astropy_data:
-            for valid_host in ('data.astropy.org', 'astropy.stsci.edu', 'www.astropy.org'):
-                valid_host_ip = socket.gethostbyname(valid_host)
-                valid_hosts += (valid_host, valid_host_ip)
+            for valid_host in ('data.astropy.org', 'astropy.stsci.edu',
+                               'www.astropy.org'):
+                valid_hosts = valid_hosts.union(_resolve_host_ips(valid_host))
 
         hostname = socket.gethostname()
         fqdn = socket.getfqdn()
 
         if host in (hostname, fqdn):
             host = 'localhost'
+            host_ips = set([host])
             new_addr = (host, args[addr_arg][1])
             args = args[:addr_arg] + (new_addr,) + args[addr_arg + 1:]
+        else:
+            host_ips = _resolve_host_ips(host)
 
-        if any(h in host for h in valid_hosts):
+        if len(host_ips & valid_hosts) > 0:  # Any overlap is acceptable
             return original_function(*args, **kwargs)
         else:
             raise IOError("An attempt was made to connect to the internet "
@@ -104,9 +124,12 @@ def turn_off_internet(verbose=False, allow_astropy_data=False):
     opener = urllib.request.build_opener(no_proxy_handler)
     urllib.request.install_opener(opener)
 
-    socket.create_connection = check_internet_off(socket_create_connection, allow_astropy_data=allow_astropy_data)
-    socket.socket.bind = check_internet_off(socket_bind, allow_astropy_data=allow_astropy_data)
-    socket.socket.connect = check_internet_off(socket_connect, allow_astropy_data=allow_astropy_data)
+    socket.create_connection = check_internet_off(
+        socket_create_connection, allow_astropy_data=allow_astropy_data)
+    socket.socket.bind = check_internet_off(
+        socket_bind, allow_astropy_data=allow_astropy_data)
+    socket.socket.connect = check_internet_off(
+        socket_connect, allow_astropy_data=allow_astropy_data)
 
     return socket
 

--- a/astropy/tests/tests/test_skip_remote_data.py
+++ b/astropy/tests/tests/test_skip_remote_data.py
@@ -40,10 +40,13 @@ def test_skip_remote_data_astropy(pytestconfig):
     # Test Astropy URL
     get_pkg_data_filename('galactic_center/gc_2mass_k.fits')
 
+    # Test GitHub URL
+    download_file('http://astropy.github.io')
+
     # Test non-Astropy URL
     if pytestconfig.getoption('remote_data') == 'astropy':
         with pytest.raises(Exception) as exc:
             download_file('http://www.google.com')
         assert "An attempt was made to connect to the internet" in str(exc.value)
-    else:
+    else:  # remote_data=any
         download_file('http://www.google.com')

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -50,7 +50,7 @@ else:
     HAS_PATHLIB = True
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_nocache():
     from ..data import download_file
 
@@ -58,7 +58,7 @@ def test_download_nocache():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_parallel():
     from ..data import (download_file, download_files_in_parallel,
                         _get_download_cache_locs, get_cached_urls,
@@ -84,7 +84,7 @@ def test_download_parallel():
             (mirror_url in c_urls) and (main_url not in c_urls))
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_noprogress():
     from ..data import download_file
 
@@ -92,7 +92,7 @@ def test_download_noprogress():
     assert os.path.isfile(fnout)
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_download_cache():
 
     from ..data import download_file, clear_download_cache
@@ -125,7 +125,7 @@ def test_download_cache():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_url_nocache():
 
     from ..data import get_readable_fileobj
@@ -134,7 +134,7 @@ def test_url_nocache():
         assert page.read().find('Astropy') > -1
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_find_by_hash():
 
     from ..data import get_readable_fileobj, get_pkg_data_filename, clear_download_cache
@@ -153,7 +153,7 @@ def test_find_by_hash():
     assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_find_invalid():
     from ..data import get_pkg_data_filename
 
@@ -299,7 +299,7 @@ def test_get_pkg_data_contents():
     assert contents1 == contents2
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
@@ -436,7 +436,7 @@ def test_compressed_stream():
         assert f.read().rstrip() == b'CONTENT'
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_invalid_location_download():
     """
     checks that download_file gives a URLError and not an AttributeError,
@@ -459,7 +459,7 @@ def test_invalid_location_download_noconnect():
         download_file('http://astropy.org/nonexistentfile')
 
 
-@remote_data('astropy')
+@remote_data(source='astropy')
 def test_is_url_in_cache():
     from ..data import download_file, is_url_in_cache
 


### PR DESCRIPTION
1. Direct backport of #7494 (needed for testing and might save some work for @bsipocz )
2. Partial backport of astropy/pytest-remotedata#28 (without new `'github'` option)