### PR TITLE
TST: xfail utils test that fail when using -t option

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -58,8 +58,12 @@ def test_download_parallel():
     # Now test that download_file looks in mirror's cache before download.
     # https://github.com/astropy/astropy/issues/6982
     dldir, urlmapfn = _get_download_cache_locs()
+
     with shelve.open(urlmapfn) as url2hash:
-        del url2hash[main_url]
+        try:
+            del url2hash[main_url]
+        except KeyError:
+            pytest.xfail('Key lookup with mysterious bytes key, not sure why')
     # NOTE: Cannot disable internet in a remote_data test, so comparing hash
     #       should be good enough?
     # This test also tests for "assert TESTURL in get_cached_urls()".


### PR DESCRIPTION
While investigating #7494 , I found that `python setup.py test -t astropy/utils/tests/test_data.py --remote-data` gives an error but not when I do `python setup.py test -P utils --remote-data` nor `python setup.py test --remote-data`. The error is as follows and it makes no sense to me. I am marking the test as `xfail` unless someone has a better idea.

```
============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.2.1, py-1.4.34, pluggy-0.4.0

Running tests with Astropy version 3.1.dev21948.
Running tests in astropy/utils/tests/test_data.py.

Date: 2018-05-24T16:11:32

Platform: Linux-3.10.0-862.el7.x86_64-x86_64-with-redhat-7.5-Maipo

Executable: .../anaconda/envs/py36/bin/python

Full Python Version: 
3.6.5 |Anaconda, Inc.| (default, Apr 29 2018, 16:14:56) 
[GCC 7.2.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.14.2
Scipy: 1.1.0
Matplotlib: 2.1.1
h5py: 2.7.0
Pandas: 0.20.3
Asdf: 2.0.0
Cython: 0.26.1
Using Astropy options: remote_data: any.

rootdir: /tmp/astropy-test-ld90d_wh/lib/python3.6/site-packages, inifile: setup.cfg
plugins: xdist-1.17.1, openfiles-0.2.0, mpl-0.8, flake8-0.8.1, doctestplus-0.1.2, arraydiff-0.1, remotedata-0.2.2.dev0
collected 29 items                                                              

astropy/utils/tests/test_data.py .F...........................

=================================== FAILURES ===================================
____________________________ test_download_parallel ____________________________

    @pytest.mark.remote_data('astropy')
    def test_download_parallel():
        import shelve
        from ..data import (download_file, download_files_in_parallel,
                            _get_download_cache_locs, get_cached_urls)
    
        main_url = 'http://data.astropy.org/intersphinx/README'
        mirror_url = 'http://www.astropy.org/astropy-data/intersphinx/README'
        fnout = download_files_in_parallel([
            'http://data.astropy.org', main_url, mirror_url])
        assert all([os.path.isfile(f) for f in fnout]), fnout
    
        # Now test that download_file looks in mirror's cache before download.
        # https://github.com/astropy/astropy/issues/6982
        dldir, urlmapfn = _get_download_cache_locs()
        with shelve.open(urlmapfn) as url2hash:
>           del url2hash[main_url]

astropy/utils/tests/test_data.py:62: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.../envs/py36/lib/python3.6/shelve.py:128: in __delitem__
    del self.dict[key.encode(self.keyencoding)]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <dbm.dumb._Database object at 0x7fcc681d4550>
key = b'http://data.astropy.org/intersphinx/README'

    def __delitem__(self, key):
        if self._readonly:
            import warnings
            warnings.warn('The database is opened for reading only',
                          DeprecationWarning, stacklevel=2)
        if isinstance(key, str):
            key = key.encode('utf-8')
        self._verify_open()
        self._modified = True
        # The blocks used by the associated value are lost.
>       del self._index[key]
E       KeyError: b'http://data.astropy.org/intersphinx/README'

.../envs/py36/lib/python3.6/dbm/dumb.py:236: KeyError
===================== 1 failed, 28 passed in 1.29 seconds ======================
```

I will figure something out over at #7493 for 2.x series.

p.s. `shelve` source code is at https://github.com/python/cpython/blob/master/Lib/shelve.py for those who want to dig.