### PR TITLE
Remove side-effects from convolution.convolve()

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -162,7 +162,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
             if np.ma.is_masked(array):
                 # np.ma.maskedarray.filled() returns a copy.
                 array_internal = array_internal.filled(np.nan)
-                # MaskedArray.astype() has niether copy nor order params like ndarray.astype has.
+                # MaskedArray.astype() has neither copy nor order params like ndarray.astype has.
                 # np.ma.maskedarray.filled() returns an ndarray not a maksedarray (implicit default subok=False).
                 # astype must be called after filling the masked data to avoid possible additional copying.
                 array_internal = array_internal.astype(float, copy=False, order='C', subok=True) # subok=True is redundant but leave for future.
@@ -197,7 +197,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         # *kernel* doesn't support NaN interpolation, so instead we just fill it.
         # np.ma.maskedarray.filled() returns a copy.
         kernel_internal = kernel_internal.filled(fill_value)
-        # MaskedArray.astype() has niether copy nor order params like ndarray.astype has.
+        # MaskedArray.astype() has neither copy nor order params like ndarray.astype has.
         # np.ma.maskedarray.filled() returns an ndarray not a maksedarray (implicit default subok=False).
         # astype must be called after filling the masked data to avoid possible additional copying.
         kernel_internal = kernel_internal.astype(float, copy=False, order='C', subok=True) # subok=True is redundant here but leave for future.

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -137,65 +137,82 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     # but, if we just so happen to be lucky enough to have the input array
     # have exactly the desired type, we just alias to array_internal
 
-    # Check if kernel is kernel instance
-    if isinstance(kernel, Kernel):
-        # Check if array is also kernel instance, if so convolve and
-        # return new kernel instance
-        if isinstance(array, Kernel):
-            if isinstance(array, Kernel1D) and isinstance(kernel, Kernel1D):
-                new_array = convolve1d_boundary_fill(array.array, kernel.array,
-                                                     0, True)
-                new_kernel = Kernel1D(array=new_array)
-            elif isinstance(array, Kernel2D) and isinstance(kernel, Kernel2D):
-                new_array = convolve2d_boundary_fill(array.array, kernel.array,
-                                                     0, True)
-                new_kernel = Kernel2D(array=new_array)
-            else:
-                raise Exception("Can't convolve 1D and 2D kernel.")
-            new_kernel._separable = kernel._separable and array._separable
-            new_kernel._is_bool = False
-            return new_kernel
-        kernel = kernel.array
+    # If array and kernel are both Kernal instances, convolve here and return.
+    if isinstance(kernel, Kernel) and isinstance(array, Kernel):
+        if isinstance(array, Kernel1D) and isinstance(kernel, Kernel1D):
+            new_array = convolve1d_boundary_fill(array.array, kernel.array,
+                                                 0, True)
+            new_kernel = Kernel1D(array=new_array)
+        elif isinstance(array, Kernel2D) and isinstance(kernel, Kernel2D):
+            new_array = convolve2d_boundary_fill(array.array, kernel.array,
+                                                 0, True)
+            new_kernel = Kernel2D(array=new_array)
+        else:
+            raise Exception("Can't convolve 1D and 2D kernel.")
+        new_kernel._separable = kernel._separable and array._separable
+        new_kernel._is_bool = False
+        return new_kernel
 
-    # Check that the arguments are lists or Numpy arrays
+    # Copy or alias array to array_internal
     try:
-        # Note this won't copy if it doesn't have to -- which is okay
-        # because none of what follows modifies array_internal.
-        array_internal = np.asanyarray(array, dtype=float)
+        # Anything that's masked must be turned into NaNs for the interpolation.
+        # This requires copying. A copy is also needed for nan_treatment == 'fill'
+        # A copy prevents possible function side-effects of the input array.
+        if nan_treatment == 'fill' or np.ma.is_masked(array) or mask is not None:
+            if np.ma.is_masked(array):
+                # np.ma.maskedarray.filled() returns a copy.
+                array_internal = array_internal.filled(np.nan)
+                # MaskedArray.astype() has niether copy nor order params like ndarray.astype has.
+                # np.ma.maskedarray.filled() returns an ndarray not a maksedarray (implicit default subok=False).
+                # astype must be called after filling the masked data to avoid possible additional copying.
+                array_internal = array_internal.astype(float, copy=False, order='C', subok=True) # subok=True is redundant but leave for future.
+            else:
+                # Since we're making a copy, we might as well use `subok=False` to save,
+                # what is probably, a negligible amount of memory.
+                array_internal = np.array(array, dtype=float, copy=True, order='C', subok=False)
+
+            if mask is not None:
+                # mask != 0 yields a bool mask for all ints/floats/bool
+                array_internal[mask != 0] = np.nan
+        else:
+            # The call below is synonymous with np.asanyarray(array, ftype=float, order='C')
+            # The advantage of `subok=True` is that it won't copy when array is an ndarray subclass. If it
+            # is and `subok=False` (default), then it will copy even if `copy=False`. This uses less memory
+            # when ndarray subclasses are passed in.
+            array_internal = np.array(array, dtype=float, copy=False, order='C', subok=True)
     except (TypeError, ValueError) as e:
         raise TypeError('array should be a Numpy array or something '
                         'convertable into a float array', e)
     array_dtype = getattr(array, 'dtype', array_internal.dtype)
 
 
-    if isinstance(kernel, (list, tuple)):
-        kernel_internal = np.array(kernel, dtype=float)
-    elif isinstance(kernel, np.ndarray):
-        # Note this always makes a copy, since we will be modifying it
-        kernel_internal = kernel.astype(float)
+    # Copy or alias kernel to kernel_internal
+    # Due to NaN interpolation and kernel normalization, a copy must always be made.
+    # 1st alias and then copy after depending on whether kernel is masked (so as not to copy twice).
+    if isinstance(kernel, Kernel):
+        kernel_internal = kernel.array
     else:
-        raise TypeError("kernel should be a list or a Numpy array")
+        kernel_internal = kernel
+    if np.ma.is_masked(kernel_internal):
+        # *kernel* doesn't support NaN interpolation, so instead we just fill it.
+        # np.ma.maskedarray.filled() returns a copy.
+        kernel_internal = kernel_internal.filled(fill_value)
+        # MaskedArray.astype() has niether copy nor order params like ndarray.astype has.
+        # np.ma.maskedarray.filled() returns an ndarray not a maksedarray (implicit default subok=False).
+        # astype must be called after filling the masked data to avoid possible additional copying.
+        kernel_internal = kernel_internal.astype(float, copy=False, order='C', subok=True) # subok=True is redundant here but leave for future.
+    else:
+        try:
+            kernel_internal = np.array(kernel_internal, dtype=float, copy=True, order='C', subok=False)
+        except (TypeError, ValueError) as e:
+            raise TypeError('kernel should be a Numpy array or something '
+                            'convertable into a float array', e)
+
 
     # Check that the number of dimensions is compatible
     if array_internal.ndim != kernel_internal.ndim:
         raise Exception('array and kernel have differing number of '
                         'dimensions.')
-
-    # anything that's masked must be turned into NaNs for the interpolation.
-    # This requires copying the array_internal
-    array_internal_copied = False
-    if np.ma.is_masked(array):
-        array_internal = array_internal.filled(np.nan)
-        array_internal_copied = True
-    if mask is not None:
-        if not array_internal_copied:
-            array_internal = array_internal.copy()
-            array_internal_copied = True
-        # mask != 0 yields a bool mask for all ints/floats/bool
-        array_internal[mask != 0] = np.nan
-    if np.ma.is_masked(kernel):
-        # *kernel* doesn't support NaN interpolation, so instead we just fill it
-        kernel_internal = kernel_internal.filled(fill_value)
 
     # Mark the NaN values so we can replace them later if interpolate_nan is
     # not set

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -11,10 +11,7 @@ from numpy.testing import assert_array_almost_equal_nulp, assert_array_almost_eq
 import itertools
 
 VALID_DTYPES = ('>f4', '<f4', '>f8', '<f8')
-VALID_DTYPE_MATRIX = []
-for dtype_array in VALID_DTYPES:
-    for dtype_kernel in VALID_DTYPES:
-        VALID_DTYPE_MATRIX.append((dtype_array, dtype_kernel))
+VALID_DTYPE_MATRIX = list(itertools.product(VALID_DTYPES, VALID_DTYPES))
 
 BOUNDARY_OPTIONS = [None, 'fill', 'wrap', 'extend']
 NANHANDLING_OPTIONS = ['interpolate', 'fill']
@@ -61,7 +58,7 @@ class TestConvolve1D:
         z = convolve(x, y, boundary=None)
         assert_array_almost_equal_nulp(z,
             np.array([0., 3.6, 5., 5.6, 5.6, 6.8, 0.]), 10)
-        
+
     @pytest.mark.parametrize(('boundary', 'nan_treatment',
                               'normalize_kernel', 'preserve_nan', 'dtype'),
                              itertools.product(BOUNDARY_OPTIONS,


### PR DESCRIPTION
This extends #7303.
See [this comment](https://github.com/astropy/astropy/pull/7293#issuecomment-391184153) in #7293

Principle directive - if the input arrays are altered during the lifetime of ``convolve()``, but returned to their original state before returning, side-effects are still possible if the call lifetime is cut short, e.g. an exception is raised.

This currently happens when ``nan_treatment='fill'`` with the input array as a ``float`` ``np.ndarray`` containing at least one ``NaN``, such that it gets aliased and not copied. Technically, the array is attempted to be assigned to even without the presence of a ``NaN`` [here](https://github.com/astropy/astropy/blob/master/astropy/convolution/convolve.py#L297-L298):
```python
...
if nan_treatment == 'fill':
        array_internal[initially_nan] = np.nan
...
```
which can trivially be replaced with the following, at the conditional expense of an extra pass of the array. May not be worth it, such worth may depend on what happens under the hood for null vector ops.
```python
...
if nan_treatment == 'fill' and initially_nan.any():
        array_internal[initially_nan] = np.nan
...
```

There is only a [single test](https://github.com/astropy/astropy/blob/master/astropy/convolution/tests/test_convolve.py#L53-L61) semantically designed to cover this, though it, unfortunately, does not.
```python
def test_input_unmodified(self):
        """
        Test that convolve works correctly when inputs are lists
        """

        inlist = [1, 4, 5, 6, 5, 7, 8]
        x = np.array(inlist)
        y = [0.2, 0.6, 0.2]
        z = convolve(x, y, boundary=None)

        assert np.all(np.array(inlist) == x)
```
For actual coverage the test should be the following (i.e. contain a ``NaN``,  ``nan_treatment='fill'``, ``dtype=float``).
```python
def test_input_unmodified(self):
        """
        Test that convolve works correctly when inputs are lists
        """

        inlist = [np.nan, 4., 5., 6., 5., 7., 8.]
        x = np.array(inlist)
        y = [0.2, 0.6, 0.2]
        z = convolve(x, y, boundary=None, nan_treatment='fill')

        assert np.all(np.array(inlist) == x)
```
Note that this test only checks the data and not the flags so isn't a complete test against side-effects.

Signed-off-by: James Noss <jnoss@stsci.edu>