### PR TITLE
Fix and test for correct stripping of header line in CommentedHeader.read() with header_start!=0

### DIFF
--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -154,10 +154,13 @@ class CommentedHeader(Basic):
         """
         out = super().read(table)
 
-        # Strip off first comment since this is the header line for
-        # commented_header format.
+        # Strip off the comment line set as the header line for
+        # commented_header format (first by default).
         if 'comments' in out.meta:
-            out.meta['comments'] = out.meta['comments'][1:]
+            idx = self.header.start_line
+            if idx < 0:
+                idx = len(out.meta['comments']) + idx
+            out.meta['comments'] = out.meta['comments'][:idx] + out.meta['comments'][idx+1:]
             if not out.meta['comments']:
                 del out.meta['comments']
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -263,7 +263,10 @@ class FastCommentedHeader(FastBasic):
         """
         meta = OrderedDict()
         if comments:
-            meta['comments'] = comments[1:]
+            idx = self.header_start
+            if idx < 0:
+                idx = len(comments) + idx
+            meta['comments'] = comments[:idx] + comments[idx+1:]
             if not meta['comments']:
                 del meta['comments']
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1034,23 +1034,39 @@ def test_almost_but_not_quite_daophot():
     assert len(dat) == 3
 
 
-@pytest.mark.parametrize('fast', [True, False])
+@pytest.mark.parametrize('fast', [True, False, 'force'])
 def test_commented_header_comments(fast):
     """
     Test that comments in commented_header are as expected and that the
     table round-trips.
     """
+    comments = ['comment 1', 'comment 2', 'comment 3']
     lines = ['# a b',
              '# comment 1',
              '# comment 2',
+             '# comment 3',
              '1 2',
              '3 4']
     dat = ascii.read(lines, format='commented_header', fast_reader=fast)
-    assert dat.meta['comments'] == ['comment 1', 'comment 2']
+    assert dat.meta['comments'] == comments
 
     out = StringIO()
     ascii.write(dat, out, format='commented_header', fast_writer=fast)
     assert out.getvalue().splitlines() == lines
+
+    lines.insert(1, lines.pop(0))
+    dat = ascii.read(lines, format='commented_header', header_start=1, fast_reader=fast)
+
+    lines.insert(2, lines.pop(1))
+    dat = ascii.read(lines, format='commented_header', header_start=2, fast_reader=fast)
+    assert dat.meta['comments'] == comments
+    dat = ascii.read(lines, format='commented_header', header_start=-2, fast_reader=fast)
+    assert dat.meta['comments'] == comments
+
+    lines.insert(3, lines.pop(2))
+    dat = ascii.read(lines, format='commented_header', header_start=-1, fast_reader=fast)
+    assert dat.meta['comments'] == comments
+    assert dat.colnames == ['a', 'b']
 
     lines = ['# a b',
              '1 2',


### PR DESCRIPTION
Fixes #7507 - `CommentedHeader.read()` was always stripping the first item from `table.meta['comments']`, even when `header_start` was given with nonzero argument; thus not removing the line with the header specification as intended.
Extended test_commented_header_comments() to different header_start positions.