### PR TITLE
Update h5py imports for deprecated h5py.highlevel

### DIFF
--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -55,7 +55,7 @@ def is_hdf5(origin, filepath, fileobj, *args, **kwargs):
     except ImportError:
         return False
     else:
-        return isinstance(args[0], (h5py.highlevel.File, h5py.highlevel.Group, h5py.highlevel.Dataset))
+        return isinstance(args[0], (h5py.File, h5py.Group, h5py.Dataset))
 
 
 def read_table_hdf5(input, path=None):
@@ -88,7 +88,7 @@ def read_table_hdf5(input, path=None):
     # Here, we save its value to be used at the end when the conditions are
     # right.
     input_save = input
-    if isinstance(input, (h5py.highlevel.File, h5py.highlevel.Group)):
+    if isinstance(input, (h5py.File, h5py.Group)):
 
         # If a path was specified, follow the path
 
@@ -103,7 +103,7 @@ def read_table_hdf5(input, path=None):
         # is one we can proceed otherwise an error is raised. If it is a
         # dataset, we just proceed with the reading.
 
-        if isinstance(input, h5py.highlevel.Group):
+        if isinstance(input, h5py.Group):
 
             # Find all structured arrays in group
             arrays = _find_all_structured_arrays(input)
@@ -119,7 +119,7 @@ def read_table_hdf5(input, path=None):
                               AstropyUserWarning)
                 return read_table_hdf5(input, path=path)
 
-    elif not isinstance(input, h5py.highlevel.Dataset):
+    elif not isinstance(input, h5py.Dataset):
 
         # If a file object was passed, then we need to extract the filename
         # because h5py cannot properly read in file objects.
@@ -262,7 +262,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
     else:
         group, name = None, path
 
-    if isinstance(output, (h5py.highlevel.File, h5py.highlevel.Group)):
+    if isinstance(output, (h5py.File, h5py.Group)):
 
         if group:
             try:


### PR DESCRIPTION
There is an issue with the recent h5py 2.8 release:
https://github.com/h5py/h5py/issues/1046
that caused AttributeErrors for `h5py.highlevel` accesses in `astropy/io/misc/hdf5py`:
https://travis-ci.org/gammapy/gammapy/jobs/382758346#L3846

It looks like `h5py.highlevel` was deprecated in 2015:
https://github.com/h5py/h5py/commit/cac43fd03bdf45bbe8cd8e7836368868d2f439f7
I could not find a mention in the changelog:
http://docs.h5py.org/en/latest/whatsnew/2.6.html

So I think the change here should be relatively safe, i.e. work for the last few `h5py` releases at least ~ 3 years back.

I'm also not sure why from Gammapy an import of `hdf5` is triggered at all. We don't read any HDF5 file, only FITS. The error you see here happens because we try to convert a BinTableHDU to a Table:
https://travis-ci.org/gammapy/gammapy/jobs/382758346#L3846
Since FITS is natively supported in Astropy, in the IO registry FITS should be tried first and the `import hdf5` should never be triggered, no?
(this is inefficient, but also error prone to `h5py` installation issues as we see here)

@astrofrog @taldcroft or anyone knowlegeable about the HDF5 Table I/O - thoughts?