### PR TITLE
Fix MPL quantity converter for lists of non-quantities

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1080,6 +1080,9 @@ astropy.visualization
 - Fixed a bug that caused the position of the tick values in decimal mode
   to be incorrectly determined. [#7332]
 
+- Fixed a bug that prevented legends from being added to plots done with
+  units. [#7510]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -24,8 +24,9 @@ def test_units():
     with quantity_support():
         buff = io.BytesIO()
 
-        plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg)
+        plt.plot([1, 2, 3] * u.m, [3, 4, 5] * u.kg, label='label')
         plt.plot([105, 210, 315] * u.cm, [3050, 3025, 3010] * u.g)
+        plt.legend()
         # Also test fill_between, which requires actual conversion to ndarray
         # with numpy >=1.10 (#4654).
         plt.fill_between([1, 3] * u.m, [3, 5] * u.kg, [3050, 3010] * u.g)

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -80,7 +80,7 @@ def quantity_support(format='latex_inline'):
         def convert(val, unit, axis):
             if isinstance(val, u.Quantity):
                 return val.to_value(unit)
-            elif isinstance(val, list):
+            elif isinstance(val, list) and isinstance(val[0], u.Quantity):
                 return [v.to_value(unit) for v in val]
             else:
                 return val


### PR DESCRIPTION
Fixes #7504. The code now checks that if converting a list, the first time is a quantity. If not, just pass through the list as before.

Also added a legend to the simple visualization test.