### PR TITLE
Make python setup.py less verbose

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -347,6 +347,10 @@ Other Changes and Additions
 - The documentation build now uses the Sphinx configuration from sphinx-astropy
   rather than from astropy-helpers. [#7139]
 
+- Running tests now suppresses the output of the installation stage by default,
+  to allow easier viewing of the test results. To re-enable the output as
+  before, use ``python setup.py test --verbose-install``. [#7512]
+
 
 3.0.3 (unreleased)
 ==================

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -20,7 +20,7 @@ def _suppress_stdout():
     '''
     A context manager to temporarily disable stdout.
 
-    Used later when installing a temperory copy of astropy to avoid a
+    Used later when installing a temporary copy of astropy to avoid a
     very verbose output.
     '''
     with open(os.devnull, "w") as devnull:
@@ -111,7 +111,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
          'in the documentation for tempfile.mkstemp.'),
         ('verbose-install', None,
          'Turn on terminal output from the installation of astropy in a '
-         'temperory folder.')
+         'temporary folder.')
     ]
 
     package_name = ''

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -108,7 +108,10 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         ('temp-root=', None,
          'The root directory in which to create the temporary testing files. '
          'If unspecified the system default is used (e.g. /tmp) as explained '
-         'in the documentation for tempfile.mkstemp.')
+         'in the documentation for tempfile.mkstemp.'),
+        ('verbose-install', None,
+         'Turn on terminal output from the installation of astropy in a '
+         'temperory folder.')
     ]
 
     package_name = ''
@@ -130,6 +133,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.skip_docs = False
         self.repeat = None
         self.temp_root = None
+        self.verbose_install = False
 
     def finalize_options(self):
         # Normally we would validate the options here, but that's handled in
@@ -259,8 +263,11 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.reinitialize_command('install')
         install_cmd = self.distribution.get_command_obj('install')
         install_cmd.prefix = self.tmp_dir
-        with _suppress_stdout():
+        if self.verbose_install:
             self.run_command('install')
+        else:
+            with _suppress_stdout():
+                self.run_command('install')
 
         # We now get the path to the site-packages directory that was created
         # inside self.tmp_dir


### PR DESCRIPTION
Should fix #7511. This disables `stdout` when the temporary copy of astropy is compiled and installed, which saves a lot of useless lines from the test output. This leaves `stderr` alone, so compiler warnings etc. still show up during the installation.