### PR TITLE
Correct documentation for parallel= option to astropy.test()

### DIFF
--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -94,7 +94,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
          'psutil package.'),
         ('parallel=', 'j',
          'Run the tests in parallel on the specified number of '
-         'CPUs.  If negative, all the cores on the machine will be '
+         'CPUs.  If "auto", all the cores on the machine will be '
          'used.  Requires the pytest-xdist plugin.'),
         ('docs-path=', None,
          'The path to the documentation .rst files.  If not provided, and '

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -534,9 +534,9 @@ class TestRunner(TestRunnerBase):
     @keyword(0)
     def parallel(self, parallel, kwargs):
         """
-        parallel : int, optional
+        parallel : int or 'auto', optional
             When provided, run the tests in parallel on the specified
-            number of CPUs.  If parallel is negative, it will use the all
+            number of CPUs.  If parallel is ``'auto'``, it will use the all
             the cores on the machine.  Requires the ``pytest-xdist`` plugin.
         """
         if parallel != 0:

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -237,8 +237,8 @@ commandline option.  For example, to use 4 processes::
 
     python setup.py test --parallel=4
 
-Pass a negative number to ``'--parallel'`` to create the same number of
-processes as cores on your machine.
+Pass ``--parallel=auto`` to create the same number of processes as cores
+on your machine.
 
 Similarly, this feature can be invoked from Python::
 


### PR DESCRIPTION
Fixes #7547.