### PR TITLE
Small speed-ups of sqrt and composite unit creation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -260,6 +260,16 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+Performance Improvements
+------------------------
+
+astropy.units
+^^^^^^^^^^^^^
+
+- Sped up creating new composite units, and raising units to some power
+  [#7549]
+
+
 Bug Fixes
 ---------
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -637,7 +637,8 @@ class UnitBase(metaclass=InheritDocstrings):
         return normalized
 
     def __pow__(self, p):
-        return CompositeUnit(1, [self], [p])
+        p = validate_power(p)
+        return CompositeUnit(1, [self], [p], _error_check=False)
 
     def __div__(self, m):
         if isinstance(m, (bytes, str)):
@@ -2036,7 +2037,7 @@ class CompositeUnit(UnitBase):
 
     def _expand_and_gather(self, decompose=False, bases=set()):
         def add_unit(unit, power, scale):
-            if unit not in bases:
+            if bases and unit not in bases:
                 for base in bases:
                     try:
                         scale *= unit._to(base) ** power
@@ -2054,9 +2055,9 @@ class CompositeUnit(UnitBase):
             return scale
 
         new_parts = {}
-        scale = self.scale
+        scale = self._scale
 
-        for b, p in zip(self.bases, self.powers):
+        for b, p in zip(self._bases, self._powers):
             if decompose and b not in bases:
                 b = b.decompose(bases=bases)
 
@@ -2072,7 +2073,7 @@ class CompositeUnit(UnitBase):
         new_parts.sort(key=lambda x: (-x[1], getattr(x[0], 'name', '')))
 
         self._bases = [x[0] for x in new_parts]
-        self._powers = [validate_power(x[1]) for x in new_parts]
+        self._powers = [x[1] for x in new_parts]
         self._scale = sanitize_scale(scale)
 
     def __copy__(self):

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -114,11 +114,6 @@ def helper_invariant(f, unit):
     return ([None], _d(unit))
 
 
-def helper_sqrt(f, unit):
-    return ([None], unit ** Fraction(1, 2) if unit is not None
-            else dimensionless_unscaled)
-
-
 def helper_square(f, unit):
     return ([None], unit ** 2 if unit is not None else dimensionless_unscaled)
 
@@ -127,8 +122,17 @@ def helper_reciprocal(f, unit):
     return ([None], unit ** -1 if unit is not None else dimensionless_unscaled)
 
 
+one_half = 0.5  # faster than Fraction(1, 2)
+one_third = Fraction(1, 3)
+
+
+def helper_sqrt(f, unit):
+    return ([None], unit ** one_half if unit is not None
+            else dimensionless_unscaled)
+
+
 def helper_cbrt(f, unit):
-    return ([None], (unit ** Fraction(1, 3) if unit is not None
+    return ([None], (unit ** one_third if unit is not None
                      else dimensionless_unscaled))
 
 

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -202,7 +202,7 @@ def validate_power(p, support_tuples=False):
     p : float, int, Rational, Fraction
         Power to be converted
     """
-    if isinstance(p, (numbers.Rational, Fraction)):
+    if isinstance(p, (Fraction, numbers.Rational)):
         denom = p.denominator
         if denom == 1:
             p = int(p.numerator)

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -202,15 +202,8 @@ def validate_power(p, support_tuples=False):
     p : float, int, Rational, Fraction
         Power to be converted
     """
-    if isinstance(p, (Fraction, numbers.Rational)):
-        denom = p.denominator
-        if denom == 1:
-            p = int(p.numerator)
-        # This is bit-twiddling hack to see if the integer is a
-        # power of two
-        elif (denom & (denom - 1)) == 0:
-            p = float(p)
-    else:
+    denom = getattr(p, 'denominator', None)
+    if denom is None:
         try:
             p = float(p)
         except Exception:
@@ -238,6 +231,13 @@ def validate_power(p, support_tuples=False):
                    8. * _float_finfo.eps):
                     p = Fraction(int(round(scaled)), i)
                     break
+
+    elif denom == 1:
+        p = int(p.numerator)
+
+    elif (denom & (denom - 1)) == 0:
+        # Above is a bit-twiddling hack to see if denom is a power of two.
+        p = float(p)
 
     return p
 


### PR DESCRIPTION
Inspired by #7546, some small speed-ups for units. Some avoiding initialization, some avoiding unnecessary checks, but with some effect:
```
a = np.arange(10.) * u.m
%timeit np.sqrt(a)
# 26.2 -> 18.4 us
```
EDIT: with the second commit, 14.8 us.
