### PR TITLE
Fix Cutout2D NAXIS in cutout WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1073,6 +1073,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Fixed ``Cutout2D`` output WCS NAXIS values to reflect the cutout
+  image size. [#7552]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -331,7 +331,7 @@ class TestCutout2D:
         rho = np.pi / 3.
         scale = 0.05 / 3600.
         wcs.wcs.cd = [[scale*np.cos(rho), -scale*np.sin(rho)],
-                        [scale*np.sin(rho), scale*np.cos(rho)]]
+                      [scale*np.sin(rho), scale*np.cos(rho)]]
         wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
         wcs.wcs.crval = [self.position.ra.to_value(u.deg),
                          self.position.dec.to_value(u.deg)]
@@ -407,7 +407,7 @@ class TestCutout2D:
     def test_cutout_partial_overlap_fill_value(self):
         fill_value = -99
         c = Cutout2D(self.data, (0, 0), (3, 3), mode='partial',
-                   fill_value=fill_value)
+                     fill_value=fill_value)
         assert c.data.shape == (3, 3)
         assert c.data[1, 1] == 0
         assert c.data[0, 0] == fill_value
@@ -450,7 +450,7 @@ class TestCutout2D:
 
     def test_skycoord_partial(self):
         c = Cutout2D(self.data, self.position, (3, 3), wcs=self.wcs,
-                   mode='partial')
+                     mode='partial')
         skycoord_original = self.position.from_pixel(c.center_original[1],
                                                      c.center_original[0],
                                                      self.wcs)

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -458,3 +458,10 @@ class TestCutout2D:
                                                    c.center_cutout[0], c.wcs)
         assert_quantity_allclose(skycoord_original.ra, skycoord_cutout.ra)
         assert_quantity_allclose(skycoord_original.dec, skycoord_cutout.dec)
+
+    def test_naxis_update(self):
+        xsize = 2
+        ysize = 3
+        c = Cutout2D(self.data, self.position, (ysize, xsize), wcs=self.wcs)
+        assert c.wcs._naxis[0] == xsize
+        assert c.wcs._naxis[1] == ysize

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -732,6 +732,7 @@ class Cutout2D:
         if wcs is not None:
             self.wcs = deepcopy(wcs)
             self.wcs.wcs.crpix -= self._origin_original_true
+            self.wcs._naxis = [self.data.shape[1], self.data.shape[0]]
         else:
             self.wcs = None
 


### PR DESCRIPTION
This PR fixes the `Cutout2D` output WCS NAXIS values to reflect the cutout image size.  This was reported in #7550.