### PR TITLE
Fix incorrect WCS after slicing or making image cutouts when WCS has SIP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -273,6 +273,14 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Fixed an bug when creating the ``WCS`` of a cutout (see ``nddata.Cutout2D``)
+  when input image's ``WCS`` contains ``SIP`` distortion corrections by
+  adjusting the ``crpix`` of the ``astropy.wcs.Sip`` (in addition to
+  adjusting the ``crpix`` of the ``astropy.wcs.WCS`` object). This bug
+  had the potential to produce large errors in ``WCS`` coordinate
+  transformations depending on the position of the cutout relative
+  to the input image's ``crpix``. [#7553, #7550]
+
 astropy.samp
 ^^^^^^^^^^^^
 
@@ -303,6 +311,13 @@ astropy.visualization
 
 astropy.wcs
 ^^^^^^^^^^^
+
+- Fixed an bug when creating the ``WCS`` slice (see ``WCS.slice()``)
+  when ``WCS`` contains ``SIP`` distortion corrections by
+  adjusting the ``WCS.sip.crpix`` in addition to adjusting
+  ``WCS.wcs.crpix``. This bug had the potential to produce large errors in
+  ``WCS`` coordinate transformations depending on the position of the slice
+  relative to ``WCS.wcs.crpix``. [#7553, #7550]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -9,7 +9,8 @@ from ..utils import (extract_array, add_array, subpixel_indices,
                      block_reduce, block_replicate,
                      overlap_slices, NoOverlapError, PartialOverlapError,
                      Cutout2D)
-from ...wcs import WCS
+from ...wcs import WCS, Sip
+from ...wcs.utils import proj_plane_pixel_area
 from ...coordinates import SkyCoord
 from ... import units as u
 
@@ -338,6 +339,29 @@ class TestCutout2D:
         wcs.wcs.crpix = [3, 3]
         self.wcs = wcs
 
+        # add SIP
+        sipwcs = wcs.deepcopy()
+        sipwcs.wcs.ctype = ['RA---TAN-SIP', 'DEC--TAN-SIP']
+        a = np.array(
+            [[0, 0, 5.33092692e-08, 3.73753773e-11, -2.02111473e-13],
+             [0, 2.44084308e-05, 2.81394789e-11, 5.17856895e-13, 0.0],
+             [-2.41334657e-07, 1.29289255e-10, 2.35753629e-14, 0.0, 0.0],
+             [-2.37162007e-10, 5.43714947e-13, 0.0, 0.0, 0.0],
+             [ -2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
+        )
+
+        b = np.array(
+            [[0, 0, 2.99270374e-05, -2.38136074e-10, 7.23205168e-13],
+             [0, -1.71073858e-07, 6.31243431e-11, -5.16744347e-14, 0.0],
+             [6.95458963e-06, -3.08278961e-10, -1.75800917e-13, 0.0, 0.0],
+             [3.51974159e-11, 5.60993016e-14, 0.0, 0.0, 0.0],
+             [-5.92438525e-13, 0.0, 0.0, 0.0, 0.0]]
+        )
+
+        sipwcs.sip = Sip(a, b, None, None, wcs.wcs.crpix)
+        sipwcs.wcs.set()
+        self.sipwcs = sipwcs
+
     def test_cutout(self):
         sizes = [3, 3*u.pixel, (3, 3), (3*u.pixel, 3*u.pix), (3., 3*u.pixel),
                  (2.9, 3.3)]
@@ -458,3 +482,16 @@ class TestCutout2D:
                                                    c.center_cutout[0], c.wcs)
         assert_quantity_allclose(skycoord_original.ra, skycoord_cutout.ra)
         assert_quantity_allclose(skycoord_original.dec, skycoord_cutout.dec)
+
+    def test_crpix_maps_to_crval(self):
+        w = Cutout2D(self.data, (0, 0), (3, 3), wcs=self.sipwcs,
+                     mode='partial').wcs
+        pscale = np.sqrt(proj_plane_pixel_area(w))
+        assert_allclose(
+            w.wcs_pix2world(*w.wcs.crpix, 1), w.wcs.crval,
+            rtol=0.0, atol=1e-6 * pscale
+        )
+        assert_allclose(
+            w.all_pix2world(*w.wcs.crpix, 1), w.wcs.crval,
+            rtol=0.0, atol=1e-6 * pscale
+        )

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -11,6 +11,7 @@ from .. import units as u
 from ..coordinates import SkyCoord
 from ..utils import lazyproperty
 from ..wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
+from ..wcs import Sip
 
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
@@ -732,6 +733,10 @@ class Cutout2D:
         if wcs is not None:
             self.wcs = deepcopy(wcs)
             self.wcs.wcs.crpix -= self._origin_original_true
+            if wcs.sip is not None:
+                self.wcs.sip = Sip(wcs.sip.a, wcs.sip.b,
+                                   wcs.sip.ap, wcs.sip.bp,
+                                   wcs.sip.crpix - self._origin_original_true)
         else:
             self.wcs = None
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -10,8 +10,9 @@ from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
 from ...time import Time
 from ... import units as u
 
-from ..wcs import WCS
-from ..utils import (proj_plane_pixel_scales, is_proj_plane_distorted,
+from ..wcs import WCS, Sip
+from ..utils import (proj_plane_pixel_scales, proj_plane_pixel_area,
+                     is_proj_plane_distorted,
                      non_celestial_pixel_scales, wcs_to_celestial_frame,
                      celestial_frame_to_wcs, skycoord_to_pixel,
                      pixel_to_skycoord, custom_wcs_to_frame_mappings,
@@ -87,15 +88,26 @@ def test_slice():
     mywcs.wcs.cdelt = [0.1, 0.1]
     mywcs.wcs.crpix = [1, 1]
     mywcs._naxis = [1000, 500]
+    pscale = 0.1 # from cdelt
 
     slice_wcs = mywcs.slice([slice(1, None), slice(0, None)])
     assert np.all(slice_wcs.wcs.crpix == np.array([1, 0]))
     assert slice_wcs._naxis == [1000, 499]
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        slice_wcs.wcs_pix2world(*slice_wcs.wcs.crpix, 1),
+        slice_wcs.wcs.crval, rtol=0.0, atol=1e-6 * pscale
+    )
 
     slice_wcs = mywcs.slice([slice(1, None, 2), slice(0, None, 4)])
     assert np.all(slice_wcs.wcs.crpix == np.array([0.625, 0.25]))
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.4, 0.2]))
     assert slice_wcs._naxis == [250, 250]
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        slice_wcs.wcs_pix2world(*slice_wcs.wcs.crpix, 1),
+        slice_wcs.wcs.crval, rtol=0.0, atol=1e-6 * pscale
+    )
 
     slice_wcs = mywcs.slice([slice(None, None, 2), slice(0, None, 2)])
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2, 0.2]))
@@ -108,6 +120,46 @@ def test_slice():
     assert slice_wcs._naxis == [20, 500]
     slice_wcs = mywcs.slice([slice(50), slice(20.5)])
     assert slice_wcs._naxis == [1000, 50]
+
+
+def test_slice_with_sip():
+    mywcs = WCS(naxis=2)
+    mywcs.wcs.crval = [1, 1]
+    mywcs.wcs.cdelt = [0.1, 0.1]
+    mywcs.wcs.crpix = [1, 1]
+    mywcs._naxis = [1000, 500]
+    mywcs.wcs.ctype = ['RA---TAN-SIP', 'DEC--TAN-SIP']
+    a = np.array(
+        [[0, 0, 5.33092692e-08, 3.73753773e-11, -2.02111473e-13],
+         [0, 2.44084308e-05, 2.81394789e-11, 5.17856895e-13, 0.0],
+         [-2.41334657e-07, 1.29289255e-10, 2.35753629e-14, 0.0, 0.0],
+         [-2.37162007e-10, 5.43714947e-13, 0.0, 0.0, 0.0],
+         [ -2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    b = np.array(
+        [[0, 0, 2.99270374e-05, -2.38136074e-10, 7.23205168e-13],
+         [0, -1.71073858e-07, 6.31243431e-11, -5.16744347e-14, 0.0],
+         [6.95458963e-06, -3.08278961e-10, -1.75800917e-13, 0.0, 0.0],
+         [3.51974159e-11, 5.60993016e-14, 0.0, 0.0, 0.0],
+         [-5.92438525e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    mywcs.sip = Sip(a, b, None, None, mywcs.wcs.crpix)
+    mywcs.wcs.set()
+    pscale = 0.1 # from cdelt
+
+    slice_wcs = mywcs.slice([slice(1, None), slice(0, None)])
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        slice_wcs.all_pix2world(*slice_wcs.wcs.crpix, 1),
+        slice_wcs.wcs.crval, rtol=0.0, atol=1e-6 * pscale
+    )
+
+    slice_wcs = mywcs.slice([slice(1, None, 2), slice(0, None, 4)])
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        slice_wcs.all_pix2world(*slice_wcs.wcs.crpix, 1),
+        slice_wcs.wcs.crval, rtol=0.0, atol=1e-6 * pscale
+    )
 
 
 def test_slice_getitem():

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -410,6 +410,45 @@ def test_validate_with_2_wcses():
     assert "WCS key 'A':" in str(results)
 
 
+def test_crpix_maps_to_crval():
+    twcs = wcs.WCS(naxis=2)
+    twcs.wcs.crval = [251.29, 57.58]
+    twcs.wcs.cdelt = [1, 1]
+    twcs.wcs.crpix = [507, 507]
+    twcs.wcs.pc = np.array([[7.7e-6, 3.3e-5], [3.7e-5, -6.8e-6]])
+    twcs._naxis = [1014, 1014]
+    twcs.wcs.ctype = ['RA---TAN-SIP', 'DEC--TAN-SIP']
+    a = np.array(
+        [[0, 0, 5.33092692e-08, 3.73753773e-11, -2.02111473e-13],
+         [0, 2.44084308e-05, 2.81394789e-11, 5.17856895e-13, 0.0],
+         [-2.41334657e-07, 1.29289255e-10, 2.35753629e-14, 0.0, 0.0],
+         [-2.37162007e-10, 5.43714947e-13, 0.0, 0.0, 0.0],
+         [ -2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    b = np.array(
+        [[0, 0, 2.99270374e-05, -2.38136074e-10, 7.23205168e-13],
+         [0, -1.71073858e-07, 6.31243431e-11, -5.16744347e-14, 0.0],
+         [6.95458963e-06, -3.08278961e-10, -1.75800917e-13, 0.0, 0.0],
+         [3.51974159e-11, 5.60993016e-14, 0.0, 0.0, 0.0],
+         [-5.92438525e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    twcs.sip = wcs.Sip(a, b, None, None, twcs.wcs.crpix)
+    twcs.wcs.set()
+    pscale = np.sqrt(wcs.utils.proj_plane_pixel_area(twcs))
+
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        twcs.wcs_pix2world(*twcs.wcs.crpix, 1), twcs.wcs.crval,
+        rtol=0.0, atol=1e-6 * pscale
+    )
+
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        twcs.all_pix2world(*twcs.wcs.crpix, 1), twcs.wcs.crval,
+        rtol=0.0, atol=1e-6 * pscale
+    )
+
+
 def test_all_world2pix(fname=None, ext=0,
                        tolerance=1.0e-4, origin=0,
                        random_npts=25000,

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2932,6 +2932,10 @@ reduce these to 2 dimensions using the naxis kwarg.
                              "axes.")
 
         wcs_new = self.deepcopy()
+
+        if wcs_new.sip is not None:
+            sip_crpix = wcs_new.sip.crpix.tolist()
+
         for i, iview in enumerate(view):
             if iview.step is not None and iview.step < 0:
                 raise NotImplementedError("Reversing an axis is not "
@@ -2958,9 +2962,13 @@ reduce these to 2 dimensions using the naxis kwarg.
                     crp = ((crpix - iview.start - 1.)/iview.step
                            + 0.5 + 1./iview.step/2.)
                     wcs_new.wcs.crpix[wcs_index] = crp
+                    if wcs_new.sip is not None:
+                        sip_crpix[wcs_index] = crp
                     wcs_new.wcs.cdelt[wcs_index] = cdelt * iview.step
                 else:
                     wcs_new.wcs.crpix[wcs_index] -= iview.start
+                    if wcs_new.sip is not None:
+                        sip_crpix[wcs_index] -= iview.start
 
             try:
                 # range requires integers but the other attributes can also
@@ -2974,6 +2982,10 @@ reduce these to 2 dimensions using the naxis kwarg.
                               "".format(wcs_index, iview), AstropyUserWarning)
             else:
                 wcs_new._naxis[wcs_index] = nitems
+
+        if wcs_new.sip is not None:
+            wcs_new.sip = Sip(self.sip.a, self.sip.b, self.sip.ap, self.sip.bp,
+                              sip_crpix)
 
         return wcs_new
 


### PR DESCRIPTION
This PR addresses the issue of large errors produced by either sliced `WCS` objects or image cutouts (see `nddata.Cutout2D`) when original `WCS` contains `SIP` distortion corrections. This issue was described in detail in https://github.com/astropy/astropy/issues/7550.

Fundamentally, if you look at the last parameter in the [`Sip` class](http://docs.astropy.org/en/stable/api/astropy.wcs.Sip.html), you will notice that`Sip` class has its own `crpix` parameter. `Sip.crpix` is independent from `WCS.wcs.crpix`. This is not in the `FITS WCS` standard (or, required by the standard): `Sip.crpix` is never written to the header. Instead this is a feature of how `astropy.wcs` implements `SIP` corrections. So, when `WCS.wcs.crpix` is modified (as it is when slicing or making cutouts) the two `crpix`es get out of sync.

In this PR I add code to adjust `Sip.crpix` in addition to adjustment of `WCS.wcs.crpix` so that both values are in sync.

Without this synchronization, SIP corrections are computed relative to the old `CRPIX` and depending on the position of the cutout/slice relative to original `CRPIX`, this can lead to very large errors: tens of pixels for HST ACS/HRC image and probably larger for ACS/WFC images.

CC: @larrybradley @keflavich @pllim 