### PR TITLE
Make astropy.utils.decorators.wraps much more like functools.wraps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,6 +148,10 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Deprecate ``make_function_with_signature`` in anticipation of removing it
+  in a future release and use ``functools.wraps`` instead of providing a
+  custom implementation. [#7554]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -3,7 +3,7 @@
 data/cache files used by Astropy should be placed.
 """
 
-from astropy.utils.decorators import wraps
+from functools import wraps
 
 import os
 import shutil

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -16,13 +16,14 @@ import threading
 import warnings
 import weakref
 from contextlib import contextmanager, suppress
+from functools import wraps
+
 from astropy.utils import data
 
 from distutils.version import LooseVersion
 
 import numpy as np
 
-from astropy.utils import wraps
 from astropy.utils.exceptions import AstropyUserWarning
 
 cmp = lambda a, b: (a > b) - (a < b)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -332,7 +332,6 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
             kwargs.append((param.name, param.default))
 
-        # __call__ = make_function_with_signature(__call__, ('self',), kwargs)
         __call__.__signature__ = sig
 
         return type(str('_{0}BoundingBox'.format(cls.name)), (_BoundingBox,),

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -332,7 +332,8 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
             kwargs.append((param.name, param.default))
 
-        __call__ = make_function_with_signature(__call__, ('self',), kwargs)
+        # __call__ = make_function_with_signature(__call__, ('self',), kwargs)
+        __call__.__signature__ = sig
 
         return type(str('_{0}BoundingBox'.format(cls.name)), (_BoundingBox,),
                     {'__call__': __call__})

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -173,6 +173,7 @@ def support_nddata(_func=None, accepts=NDData,
 
         @wraps(func)
         def wrapper(data, *args, **kwargs):
+            bound_args = signature(func).bind(data, *args, **kwargs)
             unpack = isinstance(data, accepts)
             input_data = data
             ignored = []
@@ -205,7 +206,7 @@ def support_nddata(_func=None, accepts=NDData,
 
                     # Check if the property was explicitly given and issue a
                     # Warning if it is.
-                    if propmatch in kwargs:
+                    if propmatch in bound_args.arguments:
                         # If it's in the func_args it's trivial but if it was
                         # in the func_kwargs we need to compare it to the
                         # default.
@@ -221,7 +222,7 @@ def support_nddata(_func=None, accepts=NDData,
                         # NDData.
                         if (propmatch in func_args or
                                 (propmatch in func_kwargs and
-                                 (kwargs[propmatch] is not
+                                 (bound_args.arguments[propmatch] is not
                                   sig[propmatch].default))):
                             warnings.warn(
                                 "Property {0} has been passed explicitly and "

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -5,8 +5,8 @@ from copy import deepcopy
 from inspect import signature
 from itertools import islice
 import warnings
+from functools import wraps
 
-from astropy.utils import wraps
 from astropy.utils.exceptions import AstropyUserWarning
 
 from .nddata import NDData

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -250,7 +250,7 @@ class TestRunnerBase:
 
         runner = cls(path)
 
-        @wraps(runner.run_tests, ('__doc__',), exclude_args=('self',))
+        @wraps(runner.run_tests, ('__doc__',))
         def test(**kwargs):
             return runner.run_tests(**kwargs)
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -11,9 +11,10 @@ import warnings
 import importlib
 from collections import OrderedDict
 from importlib.util import find_spec
+from functools import wraps
 
 from astropy.config.paths import set_temp_config, set_temp_cache
-from astropy.utils import wraps, find_current_module
+from astropy.utils import find_current_module
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 __all__ = ['TestRunner', 'TestRunnerBase', 'keyword']

--- a/astropy/timeseries/core.py
+++ b/astropy/timeseries/core.py
@@ -2,9 +2,9 @@
 
 from types import FunctionType
 from contextlib import contextmanager
+from functools import wraps
 
 from astropy.table import QTable
-from astropy.utils import wraps
 
 __all__ = ['BaseTimeSeries', 'autocheck_required_columns']
 

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -11,6 +11,7 @@ import re
 import textwrap
 
 from .introspection import find_current_module
+from .decorators import deprecated
 
 
 __all__ = ['make_function_with_signature']
@@ -24,6 +25,7 @@ the ASCII range and not beginning with '_' are allowed, currently.
 """
 
 
+@deprecated("3.1", "This function is no longer needed, directly use `inspect.Signature`.")
 def make_function_with_signature(func, args=(), kwargs={}, varargs=None,
                                  varkwargs=None, name=None):
     """

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -9,8 +9,8 @@ import textwrap
 import types
 import warnings
 from inspect import signature
+from functools import wraps
 
-from .codegen import make_function_with_signature
 from .exceptions import (AstropyDeprecationWarning, AstropyUserWarning,
                          AstropyPendingDeprecationWarning)
 
@@ -84,7 +84,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         old_doc = textwrap.dedent(old_doc).strip('\n')
         new_doc = (('\n.. deprecated:: {since}'
                     '\n    {message}\n\n'.format(
-                    **{'since': since, 'message': message.strip()})) + old_doc)
+                     **{'since': since, 'message': message.strip()})) + old_doc)
         if not old_doc:
             # This is to prevent a spurious 'unexpected unindent' warning from
             # docutils when the original docstring was blank.
@@ -832,72 +832,6 @@ class sharedmethod(classmethod):
     @staticmethod
     def _make_method(func, instance):
         return types.MethodType(func, instance)
-
-
-def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
-          updated=functools.WRAPPER_UPDATES):
-    """
-    An alternative to `functools.wraps` which also preserves the original
-    function's call signature by way of assigning the ``__signature__``
-    attribute with the signature of the wrapped function.
-
-    The documentation for the original `functools.wraps` follows:
-    """
-
-    def wrapper(func):
-        func = functools.update_wrapper(func, wrapped, assigned=assigned,
-                                        updated=updated)
-        func.__signature__ = inspect.signature(wrapped)
-        return func
-
-    return wrapper
-
-
-if (isinstance(wraps.__doc__, str) and
-        wraps.__doc__ is not None and functools.wraps.__doc__ is not None):
-    wraps.__doc__ += functools.wraps.__doc__
-
-
-def _get_function_args_internal(func):
-    """
-    Utility function for `wraps`.
-
-    Reads the argspec for the given function and converts it to arguments
-    for `make_function_with_signature`.
-    """
-
-    argspec = inspect.getfullargspec(func)
-
-    if argspec.defaults:
-        args = argspec.args[:-len(argspec.defaults)]
-        kwargs = zip(argspec.args[len(args):], argspec.defaults)
-    else:
-        args = argspec.args
-        kwargs = []
-
-    if argspec.kwonlyargs:
-        kwargs.extend((argname, argspec.kwonlydefaults[argname])
-                      for argname in argspec.kwonlyargs)
-
-    return {'args': args, 'kwargs': kwargs, 'varargs': argspec.varargs,
-            'varkwargs': argspec.varkw}
-
-
-def _get_function_args(func, exclude_args=()):
-    all_args = _get_function_args_internal(func)
-
-    if exclude_args:
-        exclude_args = set(exclude_args)
-
-        for arg_type in ('args', 'kwargs'):
-            all_args[arg_type] = [arg for arg in all_args[arg_type]
-                                  if arg not in exclude_args]
-
-        for arg_type in ('varargs', 'varkwargs'):
-            if all_args[arg_type] in exclude_args:
-                all_args[arg_type] = None
-
-    return all_args
 
 
 def format_doc(docstring, *args, **kwargs):

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -835,31 +835,19 @@ class sharedmethod(classmethod):
 
 
 def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
-          updated=functools.WRAPPER_UPDATES, exclude_args=()):
+          updated=functools.WRAPPER_UPDATES):
     """
     An alternative to `functools.wraps` which also preserves the original
-    function's call signature by way of
-    `~astropy.utils.codegen.make_function_with_signature`.
-
-    This also adds an optional ``exclude_args`` argument.  If given it should
-    be a sequence of argument names that should not be copied from the wrapped
-    function (either positional or keyword arguments).
+    function's call signature by way of assigning the ``__signature__``
+    attribute with the signature of the wrapped function.
 
     The documentation for the original `functools.wraps` follows:
-
     """
 
-    wrapped_args = _get_function_args(wrapped, exclude_args=exclude_args)
-
     def wrapper(func):
-        if '__name__' in assigned:
-            name = wrapped.__name__
-        else:
-            name = func.__name__
-
-        func = make_function_with_signature(func, name=name, **wrapped_args)
         func = functools.update_wrapper(func, wrapped, assigned=assigned,
                                         updated=updated)
+        func.__signature__ = inspect.signature(wrapped)
         return func
 
     return wrapper

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -3,7 +3,7 @@
 This module contains helper functions and classes for handling metadata.
 """
 
-from astropy.utils import wraps
+from functools import wraps
 
 import warnings
 

--- a/astropy/utils/tests/test_codegen.py
+++ b/astropy/utils/tests/test_codegen.py
@@ -36,7 +36,5 @@ def test_make_function_with_signature_lineno():
         # make_function_with_signature call was one
         tb_lines = traceback.format_tb(tb)
         assert '1 / 0' in tb_lines[-1]
-        # The deprecated decorator breaks this check
-        # assert line in tb_lines[-2] and 'line =' not in tb_lines[-2]
     else:
         pytest.fail('This should have caused an exception')

--- a/astropy/utils/tests/test_codegen.py
+++ b/astropy/utils/tests/test_codegen.py
@@ -36,6 +36,7 @@ def test_make_function_with_signature_lineno():
         # make_function_with_signature call was one
         tb_lines = traceback.format_tb(tb)
         assert '1 / 0' in tb_lines[-1]
-        assert line in tb_lines[-2] and 'line =' not in tb_lines[-2]
+        # The deprecated decorator breaks this check
+        # assert line in tb_lines[-2] and 'line =' not in tb_lines[-2]
     else:
         pytest.fail('This should have caused an exception')

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -53,55 +53,6 @@ def test_wraps():
     assert argspec.defaults == (1, 2, 3)
 
 
-def test_wraps_exclude_names():
-    """
-    Test the optional ``exclude_names`` argument to the wraps decorator.
-    """
-
-    # This particular test demonstrates wrapping an instance method
-    # as a function and excluding the "self" argument:
-
-    class TestClass:
-        def method(self, a, b, c=1, d=2, **kwargs):
-            return (a, b, c, d, kwargs)
-
-    test = TestClass()
-
-    @wraps(test.method, exclude_args=('self',))
-    def func(*args, **kwargs):
-        return test.method(*args, **kwargs)
-
-    argspec = inspect.getfullargspec(func)
-    assert argspec.args == ['a', 'b', 'c', 'd']
-
-    assert func('a', 'b', e=3) == ('a', 'b', 1, 2, {'e': 3})
-
-
-def test_wraps_keep_orig_name():
-    """
-    Test that when __name__ is excluded from the ``assigned`` argument
-    to ``wrap`` that the function being wrapped keeps its original name.
-
-    Regression test for https://github.com/astropy/astropy/pull/4016
-    """
-
-    def foo():
-        pass
-
-    assigned = list(functools.WRAPPER_ASSIGNMENTS)
-    assigned.remove('__name__')
-
-    def bar():
-        pass
-
-    orig_bar = bar
-
-    bar = wraps(foo, assigned=assigned)(bar)
-
-    assert bar is not orig_bar
-    assert bar.__name__ == 'bar'
-
-
 def test_deprecated_attribute():
     class DummyClass:
         def __init__(self):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -46,11 +46,11 @@ def test_wraps():
     if hasattr(foo, '__qualname__'):
         assert bar.__qualname__ == foo.__qualname__
 
-    argspec = inspect.getfullargspec(bar)
-    assert argspec.varkw == 'kwargs'
+    sig = inspect.signature(bar)
+    assert list(sig.parameters) == ['a', 'b', 'c', 'd', 'e', 'kwargs']
 
-    assert argspec.args == ['a', 'b', 'c', 'd', 'e']
-    assert argspec.defaults == (1, 2, 3)
+    defaults = [inspect._empty, inspect._empty, 1, 2, 3, inspect._empty]
+    assert [p.default for p in sig.parameters.values()] == defaults
 
 
 def test_deprecated_attribute():

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -54,6 +54,7 @@ Reference/API
 
 .. automodapi:: astropy.utils.decorators
     :no-inheritance-diagram:
+    :skip: wraps
 
 .. automodapi:: astropy.utils.diff
     :no-inheritance-diagram:


### PR DESCRIPTION
Here is a controversial fix to #7551. This removes two features of `astropy.utils.decorators.wraps` the `exclude_args` method and the way it overwrote the functions name.

In return for this, we make use of the new `__signature__` attribute in Python 3 and we probably don't need a lot more code that I have currently deleted in here.

It seems that the only place astropy was using `exclude_args` was in the test runner, which is now irrelevant as my changes to that mean it generates the documentation automatically anyway. And my opinion on the name thing is that it's deeply horrific and probably never should have been done in the first place :wink: 