### PR TITLE
Fix incorrect WCS after slicing or making image cutouts when WCS has SIP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1076,6 +1076,14 @@ astropy.nddata
 - Fixed ``Cutout2D`` output WCS NAXIS values to reflect the cutout
   image size. [#7552]
 
+- Fixed an bug when creating the ``WCS`` of a cutout (see ``nddata.Cutout2D``)
+  when input image's ``WCS`` contains ``SIP`` distortion corrections by
+  adjusting the ``crpix`` of the ``astropy.wcs.Sip`` (in addition to
+  adjusting the ``crpix`` of the ``astropy.wcs.WCS`` object). This bug
+  had the potential to produce large errors in ``WCS`` coordinate
+  transformations depending on the position of the cutout relative
+  to the input image's ``crpix``. [#7553, #7550]
+
 astropy.samp
 ^^^^^^^^^^^^
 
@@ -1108,6 +1116,13 @@ astropy.vo
 
 astropy.wcs
 ^^^^^^^^^^^
+
+- Fixed an bug when creating the ``WCS`` slice (see ``WCS.slice()``)
+  when ``WCS`` contains ``SIP`` distortion corrections by
+  adjusting the ``WCS.sip.crpix`` in addition to adjusting
+  ``WCS.wcs.crpix``. This bug had the potential to produce large errors in
+  ``WCS`` coordinate transformations depending on the position of the slice
+  relative to ``WCS.wcs.crpix``. [#7553, #7550]
 
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1082,7 +1082,7 @@ astropy.nddata
   adjusting the ``crpix`` of the ``astropy.wcs.WCS`` object). This bug
   had the potential to produce large errors in ``WCS`` coordinate
   transformations depending on the position of the cutout relative
-  to the input image's ``crpix``. [#7553, #7550]
+  to the input image's ``crpix``. [#7556, #7550]
 
 astropy.samp
 ^^^^^^^^^^^^
@@ -1122,7 +1122,7 @@ astropy.wcs
   adjusting the ``WCS.sip.crpix`` in addition to adjusting
   ``WCS.wcs.crpix``. This bug had the potential to produce large errors in
   ``WCS`` coordinate transformations depending on the position of the slice
-  relative to ``WCS.wcs.crpix``. [#7553, #7550]
+  relative to ``WCS.wcs.crpix``. [#7556, #7550]
 
 
 Other Changes and Additions

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -11,6 +11,7 @@ from .. import units as u
 from ..coordinates import SkyCoord
 from ..utils import lazyproperty
 from ..wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
+from ..wcs import Sip
 
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',
@@ -733,6 +734,10 @@ class Cutout2D:
             self.wcs = deepcopy(wcs)
             self.wcs.wcs.crpix -= self._origin_original_true
             self.wcs._naxis = [self.data.shape[1], self.data.shape[0]]
+            if wcs.sip is not None:
+                self.wcs.sip = Sip(wcs.sip.a, wcs.sip.b,
+                                   wcs.sip.ap, wcs.sip.bp,
+                                   wcs.sip.crpix - self._origin_original_true)
         else:
             self.wcs = None
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -410,6 +410,45 @@ def test_validate_with_2_wcses():
     assert "WCS key 'A':" in str(results)
 
 
+def test_crpix_maps_to_crval():
+    twcs = wcs.WCS(naxis=2)
+    twcs.wcs.crval = [251.29, 57.58]
+    twcs.wcs.cdelt = [1, 1]
+    twcs.wcs.crpix = [507, 507]
+    twcs.wcs.pc = np.array([[7.7e-6, 3.3e-5], [3.7e-5, -6.8e-6]])
+    twcs._naxis = [1014, 1014]
+    twcs.wcs.ctype = ['RA---TAN-SIP', 'DEC--TAN-SIP']
+    a = np.array(
+        [[0, 0, 5.33092692e-08, 3.73753773e-11, -2.02111473e-13],
+         [0, 2.44084308e-05, 2.81394789e-11, 5.17856895e-13, 0.0],
+         [-2.41334657e-07, 1.29289255e-10, 2.35753629e-14, 0.0, 0.0],
+         [-2.37162007e-10, 5.43714947e-13, 0.0, 0.0, 0.0],
+         [ -2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    b = np.array(
+        [[0, 0, 2.99270374e-05, -2.38136074e-10, 7.23205168e-13],
+         [0, -1.71073858e-07, 6.31243431e-11, -5.16744347e-14, 0.0],
+         [6.95458963e-06, -3.08278961e-10, -1.75800917e-13, 0.0, 0.0],
+         [3.51974159e-11, 5.60993016e-14, 0.0, 0.0, 0.0],
+         [-5.92438525e-13, 0.0, 0.0, 0.0, 0.0]]
+    )
+    twcs.sip = wcs.Sip(a, b, None, None, twcs.wcs.crpix)
+    twcs.wcs.set()
+    pscale = np.sqrt(wcs.utils.proj_plane_pixel_area(twcs))
+
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        twcs.wcs_pix2world(*twcs.wcs.crpix, 1), twcs.wcs.crval,
+        rtol=0.0, atol=1e-6 * pscale
+    )
+
+    # test that CRPIX maps to CRVAL:
+    assert_allclose(
+        twcs.all_pix2world(*twcs.wcs.crpix, 1), twcs.wcs.crval,
+        rtol=0.0, atol=1e-6 * pscale
+    )
+
+
 def test_all_world2pix(fname=None, ext=0,
                        tolerance=1.0e-4, origin=0,
                        random_npts=25000,

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -2932,6 +2932,9 @@ reduce these to 2 dimensions using the naxis kwarg.
                              "axes.")
 
         wcs_new = self.deepcopy()
+        if wcs_new.sip is not None:
+            sip_crpix = wcs_new.sip.crpix.tolist()
+
         for i, iview in enumerate(view):
             if iview.step is not None and iview.step < 0:
                 raise NotImplementedError("Reversing an axis is not "
@@ -2958,9 +2961,13 @@ reduce these to 2 dimensions using the naxis kwarg.
                     crp = ((crpix - iview.start - 1.)/iview.step
                            + 0.5 + 1./iview.step/2.)
                     wcs_new.wcs.crpix[wcs_index] = crp
+                    if wcs_new.sip is not None:
+                        sip_crpix[wcs_index] = crp
                     wcs_new.wcs.cdelt[wcs_index] = cdelt * iview.step
                 else:
                     wcs_new.wcs.crpix[wcs_index] -= iview.start
+                    if wcs_new.sip is not None:
+                        sip_crpix[wcs_index] -= iview.start
 
             try:
                 # range requires integers but the other attributes can also
@@ -2974,6 +2981,10 @@ reduce these to 2 dimensions using the naxis kwarg.
                               "".format(wcs_index, iview), AstropyUserWarning)
             else:
                 wcs_new._naxis[wcs_index] = nitems
+
+        if wcs_new.sip is not None:
+            wcs_new.sip = Sip(self.sip.a, self.sip.b, self.sip.ap, self.sip.bp,
+                              sip_crpix)
 
         return wcs_new
 


### PR DESCRIPTION
This PR addresses the issue of large errors produced by either sliced `WCS` objects or image cutouts (see `nddata.Cutout2D`) when original `WCS` contains `SIP` distortion corrections. This issue was described in detail in https://github.com/astropy/astropy/issues/7550.

Fundamentally, if you look at the last parameter in the [`Sip` class](http://docs.astropy.org/en/stable/api/astropy.wcs.Sip.html), you will notice that`Sip` class has its own `crpix` parameter. `Sip.crpix` in a `astropy.wcs.WCS` object is independent from `WCS.wcs.crpix`. This has nothing to do with either `FITS WCS` standard or `SIP` convention (or, required by the standard/convention) and so `Sip.crpix` is never written to the header. Instead this is a feature of how `astropy.wcs` implements `SIP` corrections. So, when `WCS.wcs.crpix` is modified (as it is when slicing or making cutouts) the two `crpix`es get out of sync.

In this PR I add code to adjust `Sip.crpix` in addition to adjustment of `WCS.wcs.crpix` so that both values are in sync.

Without this synchronization, SIP corrections are computed relative to the old `CRPIX` and depending on the position of the cutout/slice relative to original `CRPIX`, this can lead to very large errors: tens of pixels for HST ACS/HRC image and probably larger for ACS/WFC images.

CC: @larrybradley @keflavich @pllim 