### PR TITLE
add prior/posterior constraints to modeling parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -734,6 +734,8 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Added ``prior`` and ``posterior`` constraints to modeling parameters. [#7558]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,7 +140,10 @@ astropy.modeling
   of inputs and outputs. [#7803]
 
 - Fixed compatibility of ``JointFitter`` with the latest version of Numpy. [#7984]
-- Add ``prior`` and ``posterior`` constraints to modeling parameters. [#7558]
+
+- Add ``prior`` and ``posterior`` constraints to modeling parameters. These are
+  not used by any current fitters, but are provided to allow user code to
+  experiment with Bayesian fitters.  [#7558]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -734,8 +734,6 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
-- Added ``prior`` and ``posterior`` constraints to modeling parameters. [#7558]
-
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,7 @@ astropy.modeling
   of inputs and outputs. [#7803]
 
 - Fixed compatibility of ``JointFitter`` with the latest version of Numpy. [#7984]
+- Add ``prior`` and ``posterior`` constraints to modeling parameters. [#7558]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -198,7 +198,7 @@ class Parameter(OrderedDescriptor):
         as class attributes
     """
 
-    constraints = ('fixed', 'tied', 'bounds')
+    constraints = ('fixed', 'tied', 'bounds', 'prior', 'posterior')
     """
     Types of constraints a parameter can have.  Excludes 'min' and 'max'
     which are just aliases for the first and second elements of the 'bounds'
@@ -530,19 +530,41 @@ class Parameter(OrderedDescriptor):
 
     @property
     def prior(self):
-        return self._prior
+        if self._model is not None:
+            prior = self._model._constraints['prior']
+            return prior.get(self._name, self._prior)
+        else:
+            return self._prior
 
     @prior.setter
     def prior(self, val):
-        self._prior = val
+        if self._model is not None:
+            #if not isinstance(value, bool):
+            #    raise TypeError("check for type")
+            self._model._constraints['prior'][self._name] = val
+        else:
+            raise AttributeError("can't set attribute 'prior' on Parameter "
+                                 "definition")
+        
 
     @property
     def posterior(self):
-        return self._posterior
+        if self._model is not None:
+            posterior = self._model._constraints['posterior']
+            return posterior.get(self._name, self._posterior)
+        else:
+            return self._posterior
+      
 
     @posterior.setter
     def posterior(self, val):
-        self._posterior = val
+        if self._model is not None:
+            #if not isinstance(value, bool):
+            #    raise TypeError("check for type")
+            self._model._constraints['posterior'][self._name] = val
+        else:
+            raise AttributeError("can't set attribute 'posterior' on Parameter "
+                                 "definition")
         
     @property
     def fixed(self):

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -211,7 +211,7 @@ class Parameter(OrderedDescriptor):
 
     def __init__(self, name='', description='', default=None, unit=None,
                  getter=None, setter=None, fixed=False, tied=False, min=None,
-                 max=None, bounds=None, model=None):
+                 max=None, bounds=None, prior = None, posterior=None, model=None):
         super().__init__()
 
         self._name = name
@@ -244,7 +244,8 @@ class Parameter(OrderedDescriptor):
         self._fixed = fixed
         self._tied = tied
         self._bounds = bounds
-
+        self._posterior = posterior
+        self._prior = prior
         self._order = None
         self._model = None
 
@@ -527,6 +528,22 @@ class Parameter(OrderedDescriptor):
 
         return np.size(self.value)
 
+    @property
+    def prior(self):
+        return self._prior
+
+    @property.setter
+    def prior(self, val):
+        self._prior = val
+
+    @property
+    def posterior(self):
+        return self._posterior
+
+    @property.setter
+    def posterior(self, val):
+        self._posterior = val
+        
     @property
     def fixed(self):
         """

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -755,7 +755,7 @@ class Parameter(OrderedDescriptor):
 
     def copy(self, name=None, description=None, default=None, unit=None,
              getter=None, setter=None, fixed=False, tied=False, min=None,
-             max=None, bounds=None):
+             max=None, bounds=None, prior=None, posterior=None):
         """
         Make a copy of this `Parameter`, overriding any of its core attributes
         in the process (or an exact copy).

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -539,13 +539,10 @@ class Parameter(OrderedDescriptor):
     @prior.setter
     def prior(self, val):
         if self._model is not None:
-            #if not isinstance(value, bool):
-            #    raise TypeError("check for type")
             self._model._constraints['prior'][self._name] = val
         else:
             raise AttributeError("can't set attribute 'prior' on Parameter "
                                  "definition")
-        
 
     @property
     def posterior(self):
@@ -554,18 +551,15 @@ class Parameter(OrderedDescriptor):
             return posterior.get(self._name, self._posterior)
         else:
             return self._posterior
-      
 
     @posterior.setter
     def posterior(self, val):
         if self._model is not None:
-            #if not isinstance(value, bool):
-            #    raise TypeError("check for type")
             self._model._constraints['posterior'][self._name] = val
         else:
             raise AttributeError("can't set attribute 'posterior' on Parameter "
                                  "definition")
-        
+
     @property
     def fixed(self):
         """

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -532,7 +532,7 @@ class Parameter(OrderedDescriptor):
     def prior(self):
         return self._prior
 
-    @property.setter
+    @prior.setter
     def prior(self, val):
         self._prior = val
 
@@ -540,7 +540,7 @@ class Parameter(OrderedDescriptor):
     def posterior(self):
         return self._posterior
 
-    @property.setter
+    @posterior.setter
     def posterior(self, val):
         self._posterior = val
         

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -202,7 +202,9 @@ class Parameter(OrderedDescriptor):
     """
     Types of constraints a parameter can have.  Excludes 'min' and 'max'
     which are just aliases for the first and second elements of the 'bounds'
-    constraint (which is represented as a 2-tuple).
+    constraint (which is represented as a 2-tuple). 'prior' and 'posterior'
+    are available for use by user fitters but are not used by any built-in
+    fitters as of this writing.
     """
 
     # Settings for OrderedDescriptor
@@ -211,7 +213,7 @@ class Parameter(OrderedDescriptor):
 
     def __init__(self, name='', description='', default=None, unit=None,
                  getter=None, setter=None, fixed=False, tied=False, min=None,
-                 max=None, bounds=None, prior = None, posterior=None, model=None):
+                 max=None, bounds=None, prior=None, posterior=None, model=None):
         super().__init__()
 
         self._name = name

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -523,12 +523,12 @@ def test_2d_model():
         assert_allclose(m.parameters, p2.parameters, rtol=0.05)
 
 
-def prior_posterior():
+def test_prior_posterior():
     model = models.Gaussian1D()
     model.amplitude.prior = models.Polynomial1D(1, c0=1, c1=2)
     assert isinstance(model.amplitude.prior, models.Polynomial1D)
     assert model.amplitude.prior.c0 == 1
-    assert model.amplitude.prior.c0 == 2
+    assert model.amplitude.prior.c1 == 2
     assert isinstance(model._constraints['prior']['amplitude'], models.Polynomial1D)
 
     model.amplitude.prior = None

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -521,3 +521,16 @@ def test_2d_model():
         assert_allclose(m.parameters, p2.parameters, rtol=0.05)
         m = fitter(p2, x, y, z + 2 * n, weights=None)
         assert_allclose(m.parameters, p2.parameters, rtol=0.05)
+
+
+def prior_posterior():
+    model = models.Gaussian1D()
+    model.amplitude.prior = models.Polynomial1D(1, c0=1, c1=2)
+    assert isinstance(model.amplitude.prior, models.Polynomial1D)
+    assert model.amplitude.prior.c0 == 1
+    assert model.amplitude.prior.c0 == 2
+    assert isinstance(model._constraints['prior']['amplitude'], models.Polynomial1D)
+
+    model.amplitude.prior = None
+    assert model.amplitude.prior is None
+    assert model._constraints['prior']['amplitude'] is None

--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -112,7 +112,7 @@ Fitting examples
 
 .. plot::
     :include-source:
-  
+
     import numpy as np
     from astropy.stats import sigma_clip
     from astropy.modeling import models, fitting
@@ -212,6 +212,11 @@ bounds internally.
     ['fixed', 'tied', 'bounds']
     >>> fitting.SLSQPLSQFitter.supported_constraints
     ['bounds', 'eqcons', 'ineqcons', 'fixed', 'tied']
+
+Note that there are two "constraints" (``prior`` and ``posterior``) that are
+not currently used by any of the built-in fitters.  They are provided to allow
+possible user code that might implement Bayesian fitters (e.g.,
+https://gist.github.com/rkiman/5c5e6f80b455851084d112af2f8ed04f).
 
 Plugin Fitters
 ==============


### PR DESCRIPTION
At PyAstro2018 a team worked on using emcee with modeling. For that to work `Parameter.prior` and `Parameter.posterior` need to be defined in modeling. This PR adds them. I'd like to ask experts in the field if this is correct and whether we should go with these to modeling.
@rkiman has ideas about how to use these - feel free to link here any examples you have.
Any opinions? 
@eteq @astrofrog @perrygreenfield @karllark 