### PR TITLE
Disable coverage checking on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pip3 install coveralls
             python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
-            coveralls || true
   image-tests-mpl202:
     docker:
       - image: astropy/image-tests-py35-mpl202:1.2
@@ -31,9 +29,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pip3 install coveralls
             python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
-            coveralls || true
   image-tests-mpl212:
     docker:
       - image: astropy/image-tests-py35-mpl212:1.2
@@ -42,9 +38,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            pip3 install coveralls
             python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
-            coveralls || true
 
 
 workflows:


### PR DESCRIPTION
This doesn't actually work and causes weird issues in the coverage graph: https://coveralls.io/github/astropy/astropy

(Coveralls doesn't merge coverage reports from different CI: https://github.com/lemurheavy/coveralls-public/issues/1073)