### PR TITLE
Remove the ask for issue numbers for changelog entries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,18 +45,18 @@ include the following:
   detailed [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html)
   to help you out.
 
-  **Performance improvements**: if you are making changes that impact Astropy
+- **Performance improvements**: if you are making changes that impact Astropy
   performance, consider adding a performance benchmark in the
   [astropy-benchmarks](https://github.com/astropy/astropy-benchmarks)
   repository. You can find out more about how to do this
   [in the README for that repository](https://github.com/astropy/astropy-benchmarks#contributing-a-benchmark).
 
-- **Changelog entry**: whether you are fixing a bug or adding new functionality,
-  you should add an entry to the ``CHANGES.rst`` file that includes the PR
-  number and if possible the issue number (if you are opening a pull request you
-  may not know this yet, but you can add it once the pull request is open). If
-  you're not sure where to put the changelog entry, wait at least until a
-  maintainer has reviewed your PR and assigned it to a milestone.
+- **Changelog entry**: whether you are fixing a bug or adding new
+  functionality, you should add an entry to the ``CHANGES.rst`` file that
+  includes the PR number (if you are opening a pull request you may not know
+  this yet, but you can add it once the pull request is open). If you're not
+  sure where to put the changelog entry, wait at least until a maintainer
+  has reviewed your PR and assigned it to a milestone.
 
   You do not need to include a changelog entry for fixes to bugs introduced in
   the developer version and therefore are not present in the stable releases. In

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -370,15 +370,17 @@ Add a changelog entry
 *********************
 
 Add an entry to the file ``CHANGES.rst`` briefly describing the change you
-made. Include the pull request number if the change fixes an issue. An
+made. Include the pull request number, too at the end of the entry. An
 example entry, for the changes which fixed
 `issue 1845 <https://github.com/astropy/astropy/pull/1845>`_, is::
 
   - ``astropy.wcs.Wcs.printwcs`` will no longer warn that ``cdelt`` is
     being ignored when none was present in the FITS file. [#1845]
 
-If the change is a new feature, rather than an existing issue, you will not be
-able to put in the issue number until *after* you make the pull request.
+If you are opening a new pull request, you may not know its number yet, but you
+can add it *after* you make the pull request. If you're not sure where to
+put the changelog entry, wait at least until a maintainer has reviewed your
+PR and assigned it to a milestone.
 
 When writing changelog entries, do not attempt to make API reference links
 by using single-backticks.  This is because the changelog (in its current

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -495,19 +495,21 @@ entry went there.
     .. image:: milestone.png
 
 The entry in ``CHANGES.rst`` should summarize was you did and include the
-issue number. For writing changelog entries you don't need to know much about
-the markup language being used (though you can read as much as you want about
-it at the `Sphinx primer`_); look at other entries and imitate.
+pull request number. For writing changelog entries you don't need to know
+much about the markup language being used (though you can read as much as
+you want about it at the `Sphinx primer`_); look at other entries and
+imitate.
 
 For this issue the entry was the line that starts ``- Implemented``::
 
-    - ``astropy.coordinates``
+    astropy.coordinates
+    ^^^^^^^^^^^^^^^^^^^
 
-      - Implemented `len()` for coordinate objects. [#1761]
+    - Implemented ``len()`` for coordinate objects. [#1761]
 
 Starting the line with a ``-`` makes a bulleted list item, indenting it makes
-it a sublist of ``astropy.coordinates`` and putting ``len()`` in single
-backticks makes that text render in a typewriter font.
+it a sublist of ``astropy.coordinates`` and putting ``len()`` in double
+backticks makes that text render in a monospace font.
 
 Commit your changes to the CHANGES.rst
 --------------------------------------


### PR DESCRIPTION
We only need the PR number in the changelog not the issue numbers. However as it was mentioned (https://github.com/astropy/astropy/pull/7556#discussion_r194794933) the docs doesn't reflect this.