### PR TITLE
Improve contour performance in WCSAxes by 10-1000x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,10 @@ astropy.units
 - Sped up creating new composite units, and raising units to some power
   [#7549]
 
+astropy.visualization
+^^^^^^^^^^^^^^^^^^^^^
+
+- Significantly sped up drawing of contours in WCSAxes.
 
 Bug Fixes
 ---------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -277,7 +277,7 @@ astropy.units
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Significantly sped up drawing of contours in WCSAxes.
+- Significantly sped up drawing of contours in WCSAxes. [#7568]
 
 Bug Fixes
 ---------

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -197,11 +197,20 @@ class WCSAxes(Axes):
         return super().imshow(X, *args, **kwargs)
 
     def contour(self, *args, **kwargs):
+        """
+        Plot contours.
+
+        This is a custom implementation of :meth:`~matplotlib.axes.Axes.contour`
+        which applies the transform (if specified) to all contours in one go for
+        performance rather than to each contour line individually. All
+        positional and keyword arguments are the same as for
+        :meth:`~matplotlib.axes.Axes.contour`.
+        """
 
         # In Matplotlib, when calling contour() with a transform, each
         # individual path in the contour map is transformed separately. However,
         # this is much too slow for us since each call to the transforms results
-        # in an Astropy coordinate transformation, which has a non-negligeable
+        # in an Astropy coordinate transformation, which has a non-negligible
         # overhead - therefore a better approach is to override contour(), call
         # the Matplotlib one with no transform, then apply the transform in one
         # go to all the segments that make up the contour map.
@@ -220,6 +229,15 @@ class WCSAxes(Axes):
         return cset
 
     def contourf(self, *args, **kwargs):
+        """
+        Plot filled contours.
+
+        This is a custom implementation of :meth:`~matplotlib.axes.Axes.contourf`
+        which applies the transform (if specified) to all contours in one go for
+        performance rather than to each contour line individually. All
+        positional and keyword arguments are the same as for
+        :meth:`~matplotlib.axes.Axes.contourf`.
+        """
 
         # See notes for contour above.
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -119,6 +119,38 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   filename='contourf_overlay.png',
+                                   tolerance=0, style={})
+    def test_contourf_overlay(self):
+        # Test for overlaying contours on images
+        hdu_msx = datasets.fetch_msx_hdu()
+        wcs_msx = WCS(self.msx_header)
+
+        fig = plt.figure(figsize=(6, 6))
+        ax = fig.add_axes([0.15, 0.15, 0.8, 0.8],
+                          projection=WCS(self.twoMASS_k_header),
+                          aspect='equal')
+        ax.set_xlim(-0.5, 720.5)
+        ax.set_ylim(-0.5, 720.5)
+
+        # Overplot contour
+        ax.contourf(hdu_msx.data, transform=ax.get_transform(wcs_msx),
+                    levels=[2.5e-5, 5e-5, 1.e-4])
+        ax.coords[0].set_ticks(size=5, width=1)
+        ax.coords[1].set_ticks(size=5, width=1)
+        ax.set_xlim(0., 720.)
+        ax.set_ylim(0., 720.)
+
+        # In previous versions, all angle axes defaulted to being displayed in
+        # degrees. We now automatically show RA axes in hour angle units, but
+        # for backward-compatibility with previous reference images we
+        # explicitly use degrees here.
+        ax.coords[0].set_format_unit(u.degree)
+
+        return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    filename='overlay_features_image.png',
                                    tolerance=0, style={})
     def test_overlay_features_image(self):

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -143,7 +143,7 @@ def transform_contour_set_inplace(cset, transform):
 
     Using transforms with the native Matplotlib contour/contourf can be slow if
     the transforms have a non-negligible overhead (which is the case for
-    WCS/Skycoord transforms) since the transform is called for each individual
+    WCS/SkyCoord transforms) since the transform is called for each individual
     contour line. It is more efficient to stack all the contour lines together
     temporarily and transform them in one go.
     """
@@ -159,10 +159,8 @@ def transform_contour_set_inplace(cset, transform):
     pos_segments = []
 
     for collection in cset.collections:
-
         paths = collection.get_paths()
         all_paths.append(paths)
-
         # The last item in pos isn't needed for np.split and in fact causes
         # issues if we keep it because it will cause an extra empty array to be
         # returned.
@@ -185,5 +183,5 @@ def transform_contour_set_inplace(cset, transform):
     # Now re-populate the segments in the line collections
     for ilevel, vert in enumerate(vertices):
         vert = np.split(vert, pos_segments[ilevel])
-        for iseg in range(len(vert)):
-            all_paths[ilevel][iseg].vertices = vert[iseg]
+        for iseg, ivert in enumerate(vert):
+            all_paths[ilevel][iseg].vertices = ivert


### PR DESCRIPTION
### Background

WCSAxes has a [mechanism](http://docs.astropy.org/en/stable/visualization/wcsaxes/overlays.html#contours) for overplotting contours from an image in a different coordinate system from the original image. This essentially boils down to:

```python
ax.contour(contour_data, transform=ax.get_transform(contour_wcs))
```

However, the way Matplotlib deals with this internally is to compute the contours on ``contour_data``, then to represent each line in the contour map as a Matplotlib ``Path`` (note - each line, not each level - there might be multiple lines per level), then to transform each path individually using the specified transform. In the case where coordinate conversions are needed, the transform includes calls to ``SkyCoord``, which we know is a little slow, especially if called once for each line in the contour map. For some contour maps I've made, there are sometimes thousands of individual lines.

### New approach

The approach implemented here is to overload ``contour`` and ``contourf``, and internally call them without transform, but to then modify the resulting ContourSet manually. We do this by extracting all the vertices of the lines, stacking them into a single array, transforming them, and splitting them again. This is far more efficient because we then only effectively call ``SkyCoord`` once.

### Performance

The following functions test the new approach, the old approach, and also test the performance without contours:

```python
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.axes import Axes

from astropy.io import fits
from astropy.wcs import WCS
from astropy.utils.data import get_pkg_data_filename

hdu_2mass = fits.open(get_pkg_data_filename('galactic_center/gc_2mass_h.fits'))[0]
hdu_msx = fits.open(get_pkg_data_filename('galactic_center/gc_msx_e.fits'))[0]


def new():
    ax = plt.subplot(1, 1, 1, projection=WCS(hdu_2mass.header))
    ax.imshow(hdu_2mass.data)
    ax.contour(hdu_msx.data, levels=np.logspace(-6, -3, 10),
               transform=ax.get_transform(WCS(hdu_msx.header)), colors='white')
    plt.savefig('new.png')


def old():
    ax = plt.subplot(1, 1, 1, projection=WCS(hdu_2mass.header))
    ax.imshow(hdu_2mass.data)
    Axes.contour(ax, hdu_msx.data, levels=np.logspace(-6, -3, 10),
                 transform=ax.get_transform(WCS(hdu_msx.header)), colors='white')
    plt.savefig('old.png')


def nocontour():
    ax = plt.subplot(1, 1, 1, projection=WCS(hdu_2mass.header))
    ax.imshow(hdu_2mass.data)
    plt.savefig('nocontour.png')
```

The results are as follows:

```python
In [10]: %timeit old()
14.5 s ± 710 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [11]: %timeit new()
198 ms ± 8.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [13]: %timeit nocontour()
125 ms ± 1.39 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

If we subtract the base time for the plot excluding the contour, the old approach took 14+ seconds, whereas now it takes ~70ms, a speedup of around 200x.

The exact speedup will depend a lot on the number of lines in the contour map. The worst case scenario (for the new implementation) would be if there was just a single contour line. If I take the example above and set ``levels=[5.8e-4]``, I get a single contour line. In that case, the timings look like:

```python
In [5]: %timeit old()
156 ms ± 3.65 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [4]: %timeit new()
145 ms ± 1.85 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [6]: %timeit nocontour()
153 ms ± 7.71 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Basically the differences are in the noise. So there should not really be any cases where this results in worse performance.

I've added a couple of benchmark to astropy-benchmarks: https://github.com/astropy/astropy-benchmarks/pull/58