### PR TITLE
Add support for calling CoordinateHelper.set_separator(None)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -127,6 +127,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Add support for setting ``set_separator(None)`` in WCSAxes to use default
+  separators. [#7570]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -250,15 +250,16 @@ class CoordinateHelper:
 
         Parameters
         ----------
-        separator : The separator between numbers in sexagesimal
-        representation. Can be either a string or a tuple.
+        separator : str or tuple or None
+            The separator between numbers in sexagesimal representation. Can be
+            either a string or a tuple (or `None` for default).
         """
         if not (self._formatter_locator.__class__ == AngleFormatterLocator):
             raise TypeError("Separator can only be specified for angle coordinates")
-        if isinstance(separator, str) or isinstance(separator, tuple):
+        if isinstance(separator, (str, tuple)) or separator is None:
             self._formatter_locator.sep = separator
         else:
-            raise TypeError("separator should be a string or a tuple")
+            raise TypeError("separator should be a string, a tuple, or None")
 
     def set_format_unit(self, unit):
         """

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -351,8 +351,8 @@ class AngleFormatterLocator(BaseFormatterLocator):
             if decimal:
                 sep = None
                 fmt = None
-            elif self._sep is not None:
-                sep = self._sep
+            elif self.sep is not None:
+                sep = self.sep
                 fmt = None
             else:
                 sep = 'fromunit'


### PR DESCRIPTION
This allows the separators to be set back to the default values (whatever those are).