### PR TITLE
Implementation of Table Index Engine using sortedcontainers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem bintrees"
+               PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem bintrees sortedcontainers"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,9 @@ astropy.table
 - Added support for full use of ``Time`` mixin column for join, hstack, and
   vstack table operations. [#6888]
 
+- Added a new table index engine, ``SCEngine``, based on the Sorted Containers
+  package. [#7574]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -45,6 +45,7 @@ from .table import (Table, QTable, TableColumns, Row, TableFormatter,
 from .operations import join, setdiff, hstack, vstack, unique, TableMergeError
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray
+from .soco import SCEngine
 from .serialize import SerializedColumn
 
 # Finally import the formats for the read and write method but delay building

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -59,7 +59,7 @@ class Index:
         create an empty index for purposes of deep copying.
     engine : type, instance, or None
         Indexing engine class to use (from among SortedArray, BST,
-        FastBST, and FastRBT) or actual engine instance.
+        FastBST, FastRBT, and SCEngine) or actual engine instance.
         If the supplied argument is None (by default), use SortedArray.
     unique : bool (defaults to False)
         Whether the values of the index must be unique

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -1,0 +1,170 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+The SCEngine class uses the `sortedcontainers` package to implement an
+Index engine for Tables.
+"""
+
+from collections import OrderedDict
+from itertools import starmap
+
+try:
+    from sortedcontainers import SortedList
+    HAS_SOCO = True
+except ImportError:
+    HAS_SOCO = False
+
+
+class Node(object):
+    __slots__ = ('key', 'value')
+
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+
+    def __lt__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) < (other.key, other.value)
+        return self.key < other
+
+    def __le__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) <= (other.key, other.value)
+        return self.key <= other
+
+    def __eq__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) == (other.key, other.value)
+        return self.key == other
+
+    def __ne__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) != (other.key, other.value)
+        return self.key != other
+
+    def __gt__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) > (other.key, other.value)
+        return self.key > other
+
+    def __ge__(self, other):
+        if other.__class__ is Node:
+            return (self.key, self.value) >= (other.key, other.value)
+        return self.key >= other
+
+    __hash__ = None
+
+    def __repr__(self):
+        return 'Node({0!r}, {1!r})'.format(self.key, self.value)
+
+
+class SCEngine:
+    '''
+    Fast tree-based implementation for indexing, using the
+    `sortedcontainers` package.
+
+    Parameters
+    ----------
+    data : Table
+        Sorted columns of the original table
+    row_index : Column object
+        Row numbers corresponding to data columns
+    unique : bool (defaults to False)
+        Whether the values of the index must be unique
+    '''
+    def __init__(self, data, row_index, unique=False):
+        node_keys = map(tuple, data)
+        self._nodes = SortedList(starmap(Node, zip(node_keys, row_index)))
+        self._unique = unique
+
+    def add(self, key, value):
+        '''
+        Add a key, value pair.
+        '''
+        if self._unique and (key in self._nodes):
+            message = 'duplicate {0:!r} in unique index'.format(key)
+            raise ValueError(message)
+        self._nodes.add(Node(key, value))
+
+    def find(self, key):
+        '''
+        Find rows corresponding to the given key.
+        '''
+        return [node.value for node in self._nodes.irange(key, key)]
+
+    def remove(self, key, data=None):
+        '''
+        Remove data from the given key.
+        '''
+        if data is not None:
+            item = Node(key, data)
+            try:
+                self._nodes.remove(item)
+            except ValueError:
+                return False
+            return True
+        items = list(self._nodes.irange(key, key))
+        for item in items:
+            self._nodes.remove(item)
+        return bool(items)
+
+    def shift_left(self, row):
+        '''
+        Decrement rows larger than the given row.
+        '''
+        for node in self._nodes:
+            if node.value > row:
+                node.value -= 1
+
+    def shift_right(self, row):
+        '''
+        Increment rows greater than or equal to the given row.
+        '''
+        for node in self._nodes:
+            if node.value >= row:
+                node.value += 1
+
+    def items(self):
+        '''
+        Return a list of key, data tuples.
+        '''
+        result = OrderedDict()
+        for node in self._nodes:
+            if node.key in result:
+                result[node.key].append(node.value)
+            else:
+                result[node.key] = [node.value]
+        return result.items()
+
+    def sort(self):
+        '''
+        Make row order align with key order.
+        '''
+        for index, node in enumerate(self._nodes):
+            node.value = index
+
+    def sorted_data(self):
+        '''
+        Return a list of rows in order sorted by key.
+        '''
+        return [node.value for node in self._nodes]
+
+    def range(self, lower, upper, bounds=(True, True)):
+        '''
+        Return row values in the given range.
+        '''
+        iterator = self._nodes.irange(lower, upper, bounds)
+        return [node.value for node in iterator]
+
+    def replace_rows(self, row_map):
+        '''
+        Replace rows with the values in row_map.
+        '''
+        nodes = [node for node in self._nodes if node.value in row_map]
+        for node in nodes:
+            node.value = row_map[node.value]
+        self._nodes.clear()
+        self._nodes.update(nodes)
+
+    def __repr__(self):
+        return '{0!r}'.format(list(self._nodes))

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 """
-The SCEngine class uses the `sortedcontainers` package to implement an
+The SCEngine class uses the ``sortedcontainers`` package to implement an
 Index engine for Tables.
 """
 
@@ -61,7 +61,7 @@ class Node(object):
 class SCEngine:
     '''
     Fast tree-based implementation for indexing, using the
-    `sortedcontainers` package.
+    ``sortedcontainers`` package.
 
     Parameters
     ----------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -521,8 +521,8 @@ class Table:
             List of column names (or a single column name) to index
         engine : type or None
             Indexing engine class to use, from among SortedArray, BST,
-            FastBST, and FastRBT. If the supplied argument is None (by
-            default), use SortedArray.
+            FastBST, FastRBT, and SCEngine. If the supplied argument is None
+            (by default), use SortedArray.
         unique : bool
             Whether the values of the index must be unique. Default is False.
         '''

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -6,6 +6,7 @@ import numpy as np
 from .test_table import SetupData
 from ..bst import BST, FastRBT, FastBST
 from ..sorted_array import SortedArray
+from ..soco import SCEngine, HAS_SOCO
 from ..table import QTable, Row, Table
 from ... import units as u
 from ...time import Time
@@ -23,6 +24,9 @@ if HAS_BINTREES:
     available_engines = [BST, FastBST, FastRBT, SortedArray]
 else:
     available_engines = [BST, SortedArray]
+
+if HAS_SOCO:
+    available_engines.append(SCEngine)
 
 
 @pytest.fixture(params=available_engines)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,6 +38,10 @@ Astropy also depends on other packages for optional features:
   ``FastBST`` indexing engines with ``Table``, although these will still be
   slower in most cases than the default indexing engine.
 
+- `sortedcontainers <https://pypi.org/project/sortedcontainers/>`_ for faster
+  ``SCEngine`` indexing engine with ``Table``, although this may still be
+  slower in some cases than the default indexing engine.
+
 - `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between timezones.
 
 - `jplephem <https://pypi.org/project/jplephem/>`_: To retrieve JPL

--- a/docs/table/indexing.rst
+++ b/docs/table/indexing.rst
@@ -270,14 +270,17 @@ specified to use a particular indexing engine. The available engines are
 
 * `~astropy.table.SortedArray`, a sorted array engine using an underlying
   sorted Table
+* `~astropy.table.SCEngine`, a sorted list engine using the `Sorted Containers
+  <https://pypi.org/project/sortedcontainers/>`_ package
 * `~astropy.table.FastRBT`, a C-based red-black tree engine
 * `~astropy.table.FastBST`, a C-based binary search tree engine
 * `~astropy.table.BST`, a Python-based binary search tree engine
 
 Note that FastRBT and FastBST depend on the bintrees dependency; without this
-dependency, both classes default to `~astropy.table.BST`. For a comparison of
+dependency, both classes default to `~astropy.table.BST`. The SCEngine depends
+on the sortedcontainers dependency. For a comparison of
 engine performance, see `this IPython notebook
-<http://nbviewer.jupyter.org/github/mdmueller/astropy-notebooks/blob/master/table/indexing-profiling.ipynb>`_. Probably
+<http://nbviewer.jupyter.org/github/grantjenks/astropy-notebooks/blob/master/table/indexing-profiling.ipynb>`_. Probably
 the most important takeaway is that `~astropy.table.SortedArray` (the default
-engine) is usually best, although `~astropy.table.FastRBT` may be more
+engine) is usually best, although `~astropy.table.SCEngine` may be more
 appropriate for an index created on an empty column since adding new values is quicker.


### PR DESCRIPTION
This is an implementation of a table index engine using sortedcontainers. It does not yet pass all tests. It's based on the FastRBT engine in bst.py. My thought for moving forward would be to introduce a new engine like SortedArray and then deprecate the old engines based on bintrees.

Using the bintrees design, I replaced bintrees.FastRBTree with sortedcontainers.SortedDict. The flaw here is that SortedDict requires that keys be hashable and the Time object doesn't support hashing though it supports comparisons. These changes add support for hashing based on #7532

There's also a fix for the hash function in astropy.units.Quantity. Previously it xor'd the units but that requirement is not checked in equality. Example with old changes:

```
In [6]: from astropy.units import *

In [8]: Quantity(1.0) == 1.0
Out[8]: True

In [9]: hash(Quantity(1.0)) == hash(1.0)
Out[9]: False
```

Reference: Issue #6539. Previous pull request #7531. Time hash function modified from #7532.