### PR TITLE
Use `stderr` instead of `stdout` for download progress bar

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1037,7 +1037,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                     check_free_space_in_dir(dldir, size)
 
             if show_progress:
-                progress_stream = sys.stdout
+                progress_stream = sys.stderr
             else:
                 progress_stream = io.StringIO()
 
@@ -1178,7 +1178,7 @@ def download_files_in_parallel(urls, cache=True, show_progress=True,
         cache = True
 
     if show_progress:
-        progress = sys.stdout
+        progress = sys.stderr
     else:
         progress = io.BytesIO()
 


### PR DESCRIPTION
Currently, the progress bar shown for file downloads, e.g. IERS tables, is printed to `stdout`, which is problematic when piping data between scripts, since the progress bar ends up in the output. This pull request changes the progress bar to use `stderr`, which I think makes more sense and fixes the aforementioned problem.