### PR TITLE
Add `show_progress` option to `IERS.open`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -259,9 +259,6 @@ astropy.utils
 - ``diff_values()``, ``report_diff_values()``, and ``where_not_allclose()``
   utility functions are moved from ``astropy.io.fits.diff``. [#7444]
 
-- Added a ``show_progress`` option to ``IERS.open``, which allows the download
-  progress bar to be hidden. [#7577]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -357,6 +354,9 @@ astropy.utils
 
 - Fixed a bug due to which ``report_diff_values()`` was reporting incorrect
   number of differences when comparing two ``numpy.ndarray``. [#7470]
+
+- The download progress bar is now only displayed in terminals, to avoid
+  polluting piped output. [#7577]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -259,6 +259,9 @@ astropy.utils
 - ``diff_values()``, ``report_diff_values()``, and ``where_not_allclose()``
   utility functions are moved from ``astropy.io.fits.diff``. [#7444]
 
+- Added a ``show_progress`` option to ``IERS.open``, which allows the download
+  progress bar to be hidden. [#7577]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -961,7 +961,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
     show_progress : bool, optional
         Whether to display a progress bar during the download (default
-        is `True`)
+        is `True`). Regardless of this setting, the progress bar is only
+        displayed when outputting to a terminal.
 
     timeout : float, optional
         The timeout, in seconds.  Otherwise, use
@@ -1036,7 +1037,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                 if cache:
                     check_free_space_in_dir(dldir, size)
 
-            if show_progress:
+            if show_progress and sys.stdout.isatty():
                 progress_stream = sys.stdout
             else:
                 progress_stream = io.StringIO()

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -120,7 +120,7 @@ class IERS(QTable):
     iers_table = None
 
     @classmethod
-    def open(cls, file=None, cache=False, **kwargs):
+    def open(cls, file=None, cache=False, show_progress=True, **kwargs):
         """Open an IERS table, reading it from a file if not loaded before.
 
         Parameters
@@ -156,7 +156,8 @@ class IERS(QTable):
         if file is not None or cls.iers_table is None:
             if file is not None:
                 if urlparse(file).netloc:
-                    kwargs.update(file=download_file(file, cache=cache))
+                    kwargs.update(file=download_file(file, cache=cache,
+                                                     show_progress=show_progress))
                 else:
                     kwargs.update(file=file)
             cls.iers_table = cls.read(**kwargs)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -133,6 +133,8 @@ class IERS(QTable):
         cache : bool
             Whether to use cache. Defaults to False, since IERS files
             are regularly updated.
+        show_progress : bool
+            Whether to show download progress bar. Defaults to True.
 
         Returns
         -------

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -120,7 +120,7 @@ class IERS(QTable):
     iers_table = None
 
     @classmethod
-    def open(cls, file=None, cache=False, show_progress=True, **kwargs):
+    def open(cls, file=None, cache=False, **kwargs):
         """Open an IERS table, reading it from a file if not loaded before.
 
         Parameters
@@ -133,8 +133,6 @@ class IERS(QTable):
         cache : bool
             Whether to use cache. Defaults to False, since IERS files
             are regularly updated.
-        show_progress : bool
-            Whether to show download progress bar. Defaults to True.
 
         Returns
         -------
@@ -158,8 +156,7 @@ class IERS(QTable):
         if file is not None or cls.iers_table is None:
             if file is not None:
                 if urlparse(file).netloc:
-                    kwargs.update(file=download_file(file, cache=cache,
-                                                     show_progress=show_progress))
+                    kwargs.update(file=download_file(file, cache=cache))
                 else:
                     kwargs.update(file=file)
             cls.iers_table = cls.read(**kwargs)


### PR DESCRIPTION
Currently, the progress bar shown for file downloads, e.g. IERS tables, is printed to stdout, which is problematic when piping data between scripts, since the progress bar ends up in the output. This pull request exposes in `IERS.open` the `show_progress` option of the `download_file` method, which allows one to hide the download progress bar. See discussion in #7576.