### PR TITLE
TST: Disable exception capture for pytest-qt

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ remote_data_strict = true
 addopts = -p no:warnings
 asdf_schema_root = astropy/io/misc/asdf/schemas
 xfail_strict = true
+qt_no_exception_capture = 1
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
Fix #7572

This solution works for me with and without `pytest-qt` (2.4.1) installed.
ref: http://pytest-qt.readthedocs.io/en/1.4.0/virtual_methods.html (at the bottom)

p.s. Please remilestone if you don't need to backport this one.