### PR TITLE
Repeating omit section for the reporting of coverage

### DIFF
--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -11,6 +11,7 @@ omit =
    astropy/version*
    astropy/wcs/docstrings*
    astropy/_erfa/*
+   astropy/_compiler.c
 
 [report]
 exclude_lines =
@@ -44,3 +45,4 @@ omit =
    astropy/version*
    astropy/wcs/docstrings*
    astropy/_erfa/*
+   astropy/_compiler.c

--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -12,6 +12,8 @@ omit =
    astropy/wcs/docstrings*
    astropy/_erfa/*
    astropy/_compiler.c
+   cextern/*
+   cextern/*/*
 
 [report]
 exclude_lines =
@@ -46,3 +48,5 @@ omit =
    astropy/wcs/docstrings*
    astropy/_erfa/*
    astropy/_compiler.c
+   cextern/*
+   cextern/*/*

--- a/astropy/tests/coveragerc
+++ b/astropy/tests/coveragerc
@@ -7,7 +7,6 @@ omit =
    astropy/*/tests/*
    astropy/tests/test_*
    astropy/extern/*
-   astropy/sphinx/*
    astropy/utils/compat/*
    astropy/version*
    astropy/wcs/docstrings*
@@ -33,3 +32,15 @@ exclude_lines =
 
    # Don't complain about IPython completion helper
    def _ipython_key_completions_
+
+omit =
+   astropy/__init__*
+   astropy/conftest.py
+   astropy/*setup*
+   astropy/*/tests/*
+   astropy/tests/test_*
+   astropy/extern/*
+   astropy/utils/compat/*
+   astropy/version*
+   astropy/wcs/docstrings*
+   astropy/_erfa/*


### PR DESCRIPTION
There was some changes in how coverage.py handles omissions, and anyway the config file needed some cleanup as directories got removed in the meantime. 

https://github.com/astropy/astropy-helpers/pull/396

There are still tons of warnings left about missing c files at the end of the coverage travis job that shouldn't even considered for coverage (e.g. https://travis-ci.org/astropy/astropy/jobs/394470019#L1734), I not yet see what's the right approach to deal with them.