### PR TITLE
Let time operations return NotImplemented

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -247,6 +247,13 @@ astropy.time
 - Added the ability to use ``local`` as time scale in ``Time`` and
   ``TimeDelta``. [#6487]
 
+- Comparisons, addition, and subtraction of ``Time`` instances with non-time
+  instances will now return `NotImplemented` rather than raise the
+  ``Time``-specific ``OperandTypeError``.  This will generally lead to a
+  regular `TypeError`.  As a result, ``OperandTypeError`` now only occurs if
+  the operation is between ``Time`` instances of incompatible type or scale.
+  [#7584]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -777,7 +777,8 @@ class Time(ShapedLikeNDArray):
             if hasattr(self, attr):
                 delattr(self, attr)
 
-        if value in (np.ma.masked, np.nan):
+        if (value is np.ma.masked or value is np.nan or
+                (getattr(value, 'ndim', 0) == 0 and value == np.nan)):
             self._time.jd2[item] = np.nan
             return
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -777,8 +777,7 @@ class Time(ShapedLikeNDArray):
             if hasattr(self, attr):
                 delattr(self, attr)
 
-        if (value is np.ma.masked or value is np.nan or
-                (getattr(value, 'ndim', 0) == 0 and value == np.nan)):
+        if value is np.ma.masked or value is np.nan:
             self._time.jd2[item] = np.nan
             return
 

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -28,9 +28,6 @@ class TestTimeComparisons():
                            (operator.lt, '<')):
             with pytest.raises(TypeError) as err:
                 op(t1, None)
-            assert str(err).endswith(
-                "'{0}' not supported between instances of 'Time' and 'NoneType'"
-                .format(op_str))
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__
         assert (t1 == None) is False  # nopep8

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -5,7 +5,7 @@ import operator
 import pytest
 import numpy as np
 
-from .. import Time, TimeDelta, OperandTypeError
+from .. import Time, TimeDelta
 
 
 class TestTimeComparisons():
@@ -19,17 +19,18 @@ class TestTimeComparisons():
         """
         If an incompatible object is compared to a Time object, == should
         return False and != should return True. All other comparison
-        operators should raise an OperandTypeError.
+        operators should raise a TypeError.
         """
         t1 = Time('J2000', scale='utc')
         for op, op_str in ((operator.ge, '>='),
                            (operator.gt, '>'),
                            (operator.le, '<='),
                            (operator.lt, '<')):
-            with pytest.raises(OperandTypeError) as err:
+            with pytest.raises(TypeError) as err:
                 op(t1, None)
-            assert str(err).endswith("Unsupported operand type(s) for {0}: 'Time' and 'NoneType'"
-                                     .format(op_str))
+            assert str(err).endswith(
+                "'{0}' not supported between instances of 'Time' and 'NoneType'"
+                .format(op_str))
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__
         assert (t1 == None) is False  # nopep8
@@ -66,7 +67,7 @@ class TestTimeComparisons():
 
     def test_timedelta(self):
         dt = self.t2 - self.t1
-        with pytest.raises(OperandTypeError):
+        with pytest.raises(TypeError):
             self.t1 > dt
         dt_gt_td0 = dt > TimeDelta(0., format='sec')
         assert np.all(dt_gt_td0 == np.array([False, False, False, False, False,

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -4,7 +4,7 @@ import functools
 import pytest
 import numpy as np
 
-from .. import Time, TimeDelta, OperandTypeError
+from .. import Time, TimeDelta
 from ... import units as u
 from ...table import Column
 
@@ -95,9 +95,9 @@ class TestTimeQuantity():
     def test_invalid_quantity_operations(self):
         """Check that comparisons of Time with quantities does not work
         (even for time-like, since we cannot compare Time to TimeDelta)"""
-        with pytest.raises(OperandTypeError):
+        with pytest.raises(TypeError):
             Time(100000., format='cxcsec') > 10.*u.m
-        with pytest.raises(OperandTypeError):
+        with pytest.raises(TypeError):
             Time(100000., format='cxcsec') > 10.*u.second
 
 
@@ -120,7 +120,7 @@ class TestTimeDeltaQuantity():
         with pytest.raises(u.UnitsError):
             Time(2450000.*u.dimensionless_unscaled, format='jd', scale='utc')
 
-        with pytest.raises(OperandTypeError):
+        with pytest.raises(TypeError):
             TimeDelta(100, format='sec') > 10.*u.m
 
     def test_quantity_output(self):
@@ -178,7 +178,7 @@ class TestTimeDeltaQuantity():
 
     def test_invalid_quantity_operations(self):
         """Check comparisons of TimeDelta with non-time quantities fails."""
-        with pytest.raises(OperandTypeError):
+        with pytest.raises(TypeError):
             TimeDelta(100000., format='sec') > 10.*u.m
 
     def test_invalid_quantity_broadcast(self):


### PR DESCRIPTION
Following https://github.com/astropy/astropy/pull/7574#issuecomment-398733035

Not just for comparisons, but also for `__add__` and `__sub__`.