### PR TITLE
Fits documentation enhancements

### DIFF
--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -75,70 +75,57 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
         .. versionadded:: 1.3
 
-    kwargs : dict, optional
-        additional optional keyword arguments, possible values are:
+    uint : bool
+        Interpret signed integer data where ``BZERO`` is the central value and
+        ``BSCALE == 1`` as unsigned integer data.  For example, ``int16`` data
+        with ``BZERO = 32768`` and ``BSCALE = 1`` would be treated as
+        ``uint16`` data.  This is enabled by default so that the
+        pseudo-unsigned integer convention is assumed.
 
-        - **uint** : bool
+        Note, for backward compatibility, the kwarg **uint16** may be used
+        instead.  The kwarg was renamed when support was added for integers of
+        any size.
 
-            Interpret signed integer data where ``BZERO`` is the
-            central value and ``BSCALE == 1`` as unsigned integer
-            data.  For example, ``int16`` data with ``BZERO = 32768``
-            and ``BSCALE = 1`` would be treated as ``uint16`` data.
-            This is enabled by default so that the pseudo-unsigned
-            integer convention is assumed.
+    ignore_missing_end : bool
+        Do not issue an exception when opening a file that is missing an
+        ``END`` card in the last header.
 
-            Note, for backward compatibility, the kwarg **uint16** may
-            be used instead.  The kwarg was renamed when support was
-            added for integers of any size.
+    checksum : bool, str
+        If `True`, verifies that both ``DATASUM`` and ``CHECKSUM`` card values
+        (when present in the HDU header) match the header and data of all HDU's
+        in the file.  Updates to a file that already has a checksum will
+        preserve and update the existing checksums unless this argument is
+        given a value of 'remove', in which case the CHECKSUM and DATASUM
+        values are not checked, and are removed when saving changes to the
+        file.
 
-        - **ignore_missing_end** : bool
+    disable_image_compression : bool
+        If `True`, treats compressed image HDU's like normal binary table
+        HDU's.
 
-            Do not issue an exception when opening a file that is
-            missing an ``END`` card in the last header.
+    do_not_scale_image_data : bool
+        If `True`, image data is not scaled using BSCALE/BZERO values
+        when read.
 
-        - **checksum** : bool, str
+    character_as_bytes : bool
+        Whether to return bytes for string columns. By default this is `False`
+        and (unicode) strings are returned, but this does not respect memory
+        mapping and loads the whole column in memory when accessed.
 
-            If `True`, verifies that both ``DATASUM`` and
-            ``CHECKSUM`` card values (when present in the HDU header)
-            match the header and data of all HDU's in the file.  Updates to a
-            file that already has a checksum will preserve and update the
-            existing checksums unless this argument is given a value of
-            'remove', in which case the CHECKSUM and DATASUM values are not
-            checked, and are removed when saving changes to the file.
+    ignore_blank : bool
+        If `True`, the BLANK keyword is ignored if present.
 
-        - **disable_image_compression** : bool
-
-            If `True`, treats compressed image HDU's like normal
-            binary table HDU's.
-
-        - **do_not_scale_image_data** : bool
-
-            If `True`, image data is not scaled using BSCALE/BZERO values
-            when read.
-
-        - **character_as_bytes** : bool
-
-            Whether to return bytes for string columns. By default this is `False`
-            and (unicode) strings are returned, but this does not respect memory
-            mapping and loads the whole column in memory when accessed.
-
-        - **ignore_blank** : bool
-
-            If `True`, the BLANK keyword is ignored if present.
-
-        - **scale_back** : bool
-
-            If `True`, when saving changes to a file that contained scaled
-            image data, restore the data to the original type and reapply the
-            original BSCALE/BZERO values.  This could lead to loss of accuracy
-            if scaling back to integer values after performing floating point
-            operations on the data.
+    scale_back : bool
+        If `True`, when saving changes to a file that contained scaled
+        image data, restore the data to the original type and reapply the
+        original BSCALE/BZERO values.  This could lead to loss of accuracy
+        if scaling back to integer values after performing floating point
+        operations on the data.
 
     Returns
     -------
         hdulist : an `HDUList` object
-            `HDUList` containing all of the header data units in the
-            file.
+            `HDUList` containing all of the header data units in the file.
 
     """
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -48,17 +48,18 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         ``astropy.io.fits.Conf.use_memmap``.
 
     save_backup : bool, optional
-        If the file was opened in update or append mode, this ensures that a
-        backup of the original file is saved before any changes are flushed.
-        The backup has the same name as the original file with ".bak" appended.
-        If "file.bak" already exists then "file.bak.1" is used, and so on.
+        If the file was opened in update or append mode, this ensures that
+        a backup of the original file is saved before any changes are flushed
+        (default: False).  The backup has the same name as the original file
+        with ".bak" appended.  If "file.bak" already exists then "file.bak.1"
+        is used, and so on.
 
     cache : bool, optional
         If the file name is a URL, `~astropy.utils.data.download_file` is used
         to open the file.  This specifies whether or not to save the file
         locally in Astropy's download cache (default: `True`).
 
-    lazy_load_hdus : bool, option
+    lazy_load_hdus : bool, optional
         By default `~astropy.io.fits.open` will not read all the HDUs and
         headers in a FITS file immediately upon opening.  This is an
         optimization especially useful for large files, as FITS has no way
@@ -75,48 +76,48 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
         .. versionadded:: 1.3
 
-    uint : bool
+    uint : bool, optional
         Interpret signed integer data where ``BZERO`` is the central value and
         ``BSCALE == 1`` as unsigned integer data.  For example, ``int16`` data
         with ``BZERO = 32768`` and ``BSCALE = 1`` would be treated as
         ``uint16`` data.  This is enabled by default so that the
         pseudo-unsigned integer convention is assumed.
 
-    ignore_missing_end : bool
+    ignore_missing_end : bool, optional
         Do not issue an exception when opening a file that is missing an
-        ``END`` card in the last header.
+        ``END`` card in the last header (default: False).
 
-    checksum : bool, str
+    checksum : bool, str, optional
         If `True`, verifies that both ``DATASUM`` and ``CHECKSUM`` card values
         (when present in the HDU header) match the header and data of all HDU's
-        in the file.  Updates to a file that already has a checksum will
-        preserve and update the existing checksums unless this argument is
-        given a value of 'remove', in which case the CHECKSUM and DATASUM
-        values are not checked, and are removed when saving changes to the
-        file.
+        in the file (default: False).  Updates to a file that already has
+        a checksum will preserve and update the existing checksums unless this
+        argument is given a value of 'remove', in which case the CHECKSUM and
+        DATASUM values are not checked, and are removed when saving changes to
+        the file.
 
-    disable_image_compression : bool
+    disable_image_compression : bool, optional
         If `True`, treats compressed image HDU's like normal binary table
-        HDU's.
+        HDU's (default: False).
 
-    do_not_scale_image_data : bool
+    do_not_scale_image_data : bool, optional
         If `True`, image data is not scaled using BSCALE/BZERO values
-        when read.
+        when read (default: False).
 
-    character_as_bytes : bool
+    character_as_bytes : bool, optional
         Whether to return bytes for string columns. By default this is `False`
         and (unicode) strings are returned, but this does not respect memory
         mapping and loads the whole column in memory when accessed.
 
-    ignore_blank : bool
-        If `True`, the BLANK keyword is ignored if present.
+    ignore_blank : bool, optional
+        If `True`, the BLANK keyword is ignored if present (default: False).
 
-    scale_back : bool
-        If `True`, when saving changes to a file that contained scaled
-        image data, restore the data to the original type and reapply the
-        original BSCALE/BZERO values.  This could lead to loss of accuracy
-        if scaling back to integer values after performing floating point
-        operations on the data.
+    scale_back : bool, optional
+        If `True`, when saving changes to a file that contained scaled image
+        data, restore the data to the original type and reapply the original
+        BSCALE/BZERO values (default: False).  This could lead to loss of
+        accuracy if scaling back to integer values after performing floating
+        point operations on the data.
 
     Returns
     -------

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -35,36 +35,36 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         File to be opened.
 
     mode : str, optional
-        Open mode, 'readonly' (default), 'update', 'append', 'denywrite', or
-        'ostream'.
+        Open mode, 'readonly', 'update', 'append', 'denywrite', or
+        'ostream'. Default is 'readonly'.
 
         If ``name`` is a file object that is already opened, ``mode`` must
         match the mode the file was opened with, readonly (rb), update (rb+),
         append (ab+), ostream (w), denywrite (rb)).
 
     memmap : bool, optional
-        Is memory mapping to be used? ``memmap=True`` by default. This value
-        is obtained from the configuration item
-        ``astropy.io.fits.Conf.use_memmap``.
+        Is memory mapping to be used? This value is obtained from the
+        configuration item ``astropy.io.fits.Conf.use_memmap``.
+        Default is `True`.
 
     save_backup : bool, optional
         If the file was opened in update or append mode, this ensures that
-        a backup of the original file is saved before any changes are flushed
-        (default: False).  The backup has the same name as the original file
-        with ".bak" appended.  If "file.bak" already exists then "file.bak.1"
-        is used, and so on.
+        a backup of the original file is saved before any changes are flushed.
+        The backup has the same name as the original file with ".bak" appended.
+        If "file.bak" already exists then "file.bak.1" is used, and so on.
+        Default is `False`.
 
     cache : bool, optional
         If the file name is a URL, `~astropy.utils.data.download_file` is used
         to open the file.  This specifies whether or not to save the file
-        locally in Astropy's download cache (default: `True`).
+        locally in Astropy's download cache. Default is `True`.
 
     lazy_load_hdus : bool, optional
-        By default `~astropy.io.fits.open` will not read all the HDUs and
-        headers in a FITS file immediately upon opening.  This is an
-        optimization especially useful for large files, as FITS has no way
-        of determining the number and offsets of all the HDUs in a file
-        without scanning through the file and reading all the headers.
+        To avoid reading all the HDUs and headers in a FITS file immediately
+        upon opening.  This is an optimization especially useful for large
+        files, as FITS has no way of determining the number and offsets of all
+        the HDUs in a file without scanning through the file and reading all
+        the headers. Default is `True`.
 
         To disable lazy loading and read all HDUs immediately (the old
         behavior) use ``lazy_load_hdus=False``.  This can lead to fewer
@@ -80,44 +80,45 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         Interpret signed integer data where ``BZERO`` is the central value and
         ``BSCALE == 1`` as unsigned integer data.  For example, ``int16`` data
         with ``BZERO = 32768`` and ``BSCALE = 1`` would be treated as
-        ``uint16`` data.  This is enabled by default so that the
-        pseudo-unsigned integer convention is assumed.
+        ``uint16`` data. Default is `True` so that the pseudo-unsigned
+        integer convention is assumed.
 
     ignore_missing_end : bool, optional
         Do not issue an exception when opening a file that is missing an
-        ``END`` card in the last header (default: False).
+        ``END`` card in the last header. Default is `False`.
 
     checksum : bool, str, optional
         If `True`, verifies that both ``DATASUM`` and ``CHECKSUM`` card values
         (when present in the HDU header) match the header and data of all HDU's
-        in the file (default: False).  Updates to a file that already has
-        a checksum will preserve and update the existing checksums unless this
-        argument is given a value of 'remove', in which case the CHECKSUM and
-        DATASUM values are not checked, and are removed when saving changes to
-        the file.
+        in the file.  Updates to a file that already has a checksum will
+        preserve and update the existing checksums unless this argument is
+        given a value of 'remove', in which case the CHECKSUM and DATASUM
+        values are not checked, and are removed when saving changes to the
+        file. Default is `False`.
 
     disable_image_compression : bool, optional
         If `True`, treats compressed image HDU's like normal binary table
-        HDU's (default: False).
+        HDU's.  Default is `False`.
 
     do_not_scale_image_data : bool, optional
         If `True`, image data is not scaled using BSCALE/BZERO values
-        when read (default: False).
+        when read.  Default is `False`.
 
     character_as_bytes : bool, optional
-        Whether to return bytes for string columns. By default this is `False`
-        and (unicode) strings are returned, but this does not respect memory
-        mapping and loads the whole column in memory when accessed.
+        Whether to return bytes for string columns, otherwise unicode strings
+        are returned, but this does not respect memory mapping and loads the
+        whole column in memory when accessed. Default is `False`.
 
     ignore_blank : bool, optional
-        If `True`, the BLANK keyword is ignored if present (default: False).
+        If `True`, the BLANK keyword is ignored if present.
+        Default is `False`.
 
     scale_back : bool, optional
         If `True`, when saving changes to a file that contained scaled image
         data, restore the data to the original type and reapply the original
-        BSCALE/BZERO values (default: False).  This could lead to loss of
-        accuracy if scaling back to integer values after performing floating
-        point operations on the data.
+        BSCALE/BZERO values. This could lead to loss of accuracy if scaling
+        back to integer values after performing floating point operations on
+        the data. Default is `False`.
 
     Returns
     -------

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -82,10 +82,6 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         ``uint16`` data.  This is enabled by default so that the
         pseudo-unsigned integer convention is assumed.
 
-        Note, for backward compatibility, the kwarg **uint16** may be used
-        instead.  The kwarg was renamed when support was added for integers of
-        any size.
-
     ignore_missing_end : bool
         Do not issue an exception when opening a file that is missing an
         ``END`` card in the last header.

--- a/docs/io/fits/api/verification.rst
+++ b/docs/io/fits/api/verification.rst
@@ -39,7 +39,7 @@ No warning message will be printed out. This is like a silent warn (see below)
 option.
 
 fix
-^^^
+===
 
 This option will try to fix any FITS standard violations. It is not always
 possible to fix such violations. In general, there are two kinds of FITS

--- a/docs/io/fits/usage/scripts.rst
+++ b/docs/io/fits/usage/scripts.rst
@@ -31,5 +31,5 @@ interface--it outputs the report from a :class:`FITSDiff` of two FITS files,
 and like common diff-like commands returns a 0 status code if no differences
 were found, and 1 if differences were found:
 
-With Astropy installed, please run ``fitscheck --help`` to see the full program
+With Astropy installed, please run ``fitsdiff --help`` to see the full program
 usage documentation.

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -130,6 +130,14 @@ the input table is generated::
     ...     hdu = fits.BinTableHDU(data=newdata)
     ...     hdu.writeto('newtable.fits')
 
+It is also possible to update in-place the data from the HDU object::
+
+    >>> with fits.open(fits_table_filename) as hdul:
+    ...     hdu = hdul[1]
+    ...     mask = hdu.data['mag'] > -0.5
+    ...     hdu.data = hdu.data[mask]
+    ...     hdu.writeto('newtable2.fits')
+
 
 Merging Tables
 --------------

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -284,35 +284,52 @@ Here are a few Columns using various combination of these arguments::
 
     >>> counts = np.array([312, 334, 308, 317])
     >>> names = np.array(['NGC1', 'NGC2', 'NGC3', 'NGC4'])
+    >>> values = np.arange(2*2*4).reshape(4, 2, 2)
     >>> col1 = fits.Column(name='target', format='10A', array=names)
     >>> col2 = fits.Column(name='counts', format='J', unit='DN', array=counts)
     >>> col3 = fits.Column(name='notes', format='A10')
-    >>> col4 = fits.Column(name='spectrum', format='1000E')
+    >>> col4 = fits.Column(name='spectrum', format='10E')
     >>> col5 = fits.Column(name='flag', format='L', array=[True, False, True, True])
+    >>> col6 = fits.Column(name='intarray', format='4I', dim='(2, 2)', array=values)
 
 In this example, formats are specified with the FITS letter codes. When there
 is a number (>1) preceding a (numeric type) letter code, it means each cell in
-that field is a one-dimensional array. In the case of column c4, each cell is
-an array (a numpy array) of 1000 elements.
+that field is a one-dimensional array. In the case of column "col4", each cell
+is an array (a Numpy array) of 10 elements. And in the case of column "col6",
+with the use of the "dim" argument, each cell is a multi-dimensional array of
+2x2 elements.
 
 For character string fields, the number be to the *left* of the letter 'A' when
 creating binary tables, and should be to the *right* when creating ASCII
 tables.  However, as this is a common confusion both formats are understood
 when creating binary tables (note, however, that upon writing to a file the
-correct format will be written in the header).  So, for columns c1 and c3, they
-both have 10 characters in each of their cells. For numeric data type, the
-dimension number must be before the letter code, not after.
+correct format will be written in the header).  So, for columns "col1" and
+"col3", they both have 10 characters in each of their cells. For numeric data
+type, the dimension number must be before the letter code, not after.
 
 After the columns are constructed, the :meth:`BinTableHDU.from_columns` class
 method can be used to construct a table HDU. We can either go through the
 column definition object::
 
-    >>> coldefs = fits.ColDefs([col1, col2, col3, col4, col5])
+    >>> coldefs = fits.ColDefs([col1, col2, col3, col4, col5, col6])
     >>> hdu = fits.BinTableHDU.from_columns(coldefs)
+    >>> coldefs
+    ColDefs(
+        name = 'target'; format = '10A'
+        name = 'counts'; format = 'J'; unit = 'DN'
+        name = 'notes'; format = '10A'
+        name = 'spectrum'; format = '10E'
+        name = 'flag'; format = 'L'
+        name = 'intarray'; format = '4I'; dim = '(2, 2)'
+    )
 
 or directly use the :meth:`BinTableHDU.from_columns` method::
 
-    >>> hdu = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5])
+    >>> hdu = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5, col6])
+    >>> hdu.data[:2]
+    FITS_rec([('NGC1', 312, '', [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],  1, [[0, 1], [2, 3]]),
+            ('NGC2', 334, '', [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],  0, [[4, 5], [6, 7]])],
+            dtype=(numpy.record, [('target', 'S10'), ('counts', '<i4'), ('notes', 'S10'), ('spectrum', '<f4', (10,)), ('flag', 'i1'), ('intarray', '<i2', (2, 2))]))
 
 .. note::
 
@@ -329,11 +346,11 @@ properly populated::
     XTENSION= 'BINTABLE'           / binary table extension
     BITPIX  =                    8 / array data type
     NAXIS   =                    2 / number of array dimensions
-    NAXIS1  =                 4025 / length of dimension 1
+    NAXIS1  =                   73 / length of dimension 1
     NAXIS2  =                    4 / length of dimension 2
     PCOUNT  =                    0 / number of group parameters
     GCOUNT  =                    1 / number of groups
-    TFIELDS =                    5 / number of table fields
+    TFIELDS =                    6 / number of table fields
     TTYPE1  = 'target  '
     TFORM1  = '10A     '
     TTYPE2  = 'counts  '
@@ -342,9 +359,12 @@ properly populated::
     TTYPE3  = 'notes   '
     TFORM3  = '10A     '
     TTYPE4  = 'spectrum'
-    TFORM4  = '1000E   '
+    TFORM4  = '10E     '
     TTYPE5  = 'flag    '
     TFORM5  = 'L       '
+    TTYPE6  = 'intarray'
+    TFORM6  = '4I      '
+    TDIM6   = '(2, 2)  '
 
 .. warning::
 

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -334,10 +334,15 @@ column definition object::
 or directly use the :meth:`BinTableHDU.from_columns` method::
 
     >>> hdu = fits.BinTableHDU.from_columns([col1, col2, col3, col4, col5, col6])
-    >>> hdu.data[:2]
-    FITS_rec([('NGC1', 312, '', [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],  1, [[0, 1], [2, 3]]),
-            ('NGC2', 334, '', [0., 0., 0., 0., 0., 0., 0., 0., 0., 0.],  0, [[4, 5], [6, 7]])],
-            dtype=(numpy.record, [('target', 'S10'), ('counts', '<i4'), ('notes', 'S10'), ('spectrum', '<f4', (10,)), ('flag', 'i1'), ('intarray', '<i2', (2, 2))]))
+    >>> hdu.columns
+    ColDefs(
+        name = 'target'; format = '10A'
+        name = 'counts'; format = 'J'; unit = 'DN'
+        name = 'notes'; format = '10A'
+        name = 'spectrum'; format = '10E'
+        name = 'flag'; format = 'L'
+        name = 'intarray'; format = '4I'; dim = '(2, 2)'
+    )
 
 .. note::
 

--- a/docs/io/fits/usage/table.rst
+++ b/docs/io/fits/usage/table.rst
@@ -130,7 +130,7 @@ the input table is generated::
     ...     hdu = fits.BinTableHDU(data=newdata)
     ...     hdu.writeto('newtable.fits')
 
-It is also possible to update in-place the data from the HDU object::
+It is also possible to update the data from the HDU object in-place::
 
     >>> with fits.open(fits_table_filename) as hdul:
     ...     hdu = hdul[1]


### PR DESCRIPTION
- Add example use of TDIM for fits table (closes #6900) 
- Use standard numpydoc format for fits.open's docstring (closes #7566) 
- Add example about in-place modification of HDU's data (closes #2325) 
- And a couple of minor fixes.