### PR TITLE
Added a --readonly option for python setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,9 +108,11 @@ matrix:
             - $INSTALL_CMD
             - $TEST_CMD
 
-        # Now try with all optional dependencies.
+        # Now try with all optional dependencies. We also include the --readonly
+        # flag to make sure no files are being written to the temporary install
+        # location during testing.
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy'
+          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="jplephem"
                LC_CTYPE=C.ascii LC_ALL=C
@@ -130,7 +132,7 @@ matrix:
         # packages are installed from pip.
         # TODO: remove the pinning once the issue is solved upstream.
         - os: linux
-          env: SETUP_CMD='test --coverage --remote-data=astropy'
+          env: SETUP_CMD='test --coverage --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="cpp-coveralls objgraph jplephem bintrees"
                LC_CTYPE=C.ascii LC_ALL=C

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Added an option ``--readonly`` to the test command to change the
+  permissions on the temporary installation location to read-only. [#7598]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,4 +35,4 @@ install:
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test"
+    - "%CMD_IN_ENV% python setup.py test --readonly"

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -11,12 +11,15 @@ import pytest
 def test_wcsapi_extension(tmpdir):
     # Test that we can build a simple C extension with the astropy.wcs C API
 
+    build_dir = tmpdir.mkdir('build').strpath
+    install_dir = tmpdir.mkdir('install').strpath
+
     setup_path = os.path.dirname(__file__)
     astropy_path = os.path.abspath(
         os.path.join(setup_path, '..', '..', '..', '..'))
 
     env = os.environ.copy()
-    paths = [str(tmpdir), astropy_path]
+    paths = [install_dir, astropy_path]
     if env.get('PYTHONPATH'):
         paths.append(env.get('PYTHONPATH'))
     env[str('PYTHONPATH')] = str(os.pathsep.join(paths))
@@ -27,8 +30,9 @@ def test_wcsapi_extension(tmpdir):
     # *unless* the output is redirected.  This bug also did not occur in an
     # interactive session, so it likely had something to do with pytest's
     # output capture
-    p = subprocess.Popen([sys.executable, 'setup.py', 'install',
-                          '--install-lib={0}'.format(tmpdir),
+    p = subprocess.Popen([sys.executable, 'setup.py', 'build',
+                          '--build-base={0}'.format(build_dir), 'install',
+                          '--install-lib={0}'.format(install_dir),
                           astropy_path], cwd=setup_path, env=env,
                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 


### PR DESCRIPTION
This makes the temporary installation directory read-only, which allows us to find issues with tests not using temporary directories for files.

This can help avoid issues like the ones https://github.com/astropy/astropy/pull/7588 is fixing. Example failure currently:

```
___________________________________________________________________________ TestFileFunctions.test_open_file_handle ___________________________________________________________________________

self = <astropy.io.fits.tests.test_core.TestFileFunctions object at 0x81c690160>

    def test_open_file_handle(self):
        # Make sure we can open a FITS file from an open file handle
        with open(self.data('test0.fits'), 'rb') as handle:
            with fits.open(handle) as fitsfile:
                pass
    
        with open(self.temp('temp.fits'), 'wb') as handle:
            with fits.open(handle, mode='ostream') as fitsfile:
                pass
    
        # Opening without explicitly specifying binary mode should fail
        with pytest.raises(ValueError):
            with open(self.data('test0.fits')) as handle:
                with fits.open(handle) as fitsfile:
                    pass
    
        # All of these read modes should fail
        for mode in ['r', 'rt', 'r+', 'rt+', 'a', 'at', 'a+', 'at+']:
            with pytest.raises(ValueError):
>               with open(self.data('test0.fits'), mode=mode) as handle:
E               PermissionError: [Errno 13] Permission denied: '/private/var/folders/zy/t1l3sx310d3d6p0kyxqzlrnr0000gr/T/astropy-test-z929cr5i/lib/python3.6/site-packages/astropy/io/fits/tests/data/test0.fits'

astropy/io/fits/tests/test_core.py:613: PermissionError
```

I don't have time to track down the failures for now so if someone else does then feel free to open pull requests to my branch. I guess maybe we should merge https://github.com/astropy/astropy/pull/7588 first so I can rebase this?

cc @saimn @MSeifert04 @bsipocz @drdavella @eteq 