### PR TITLE
Add Python 3.7 testing to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,9 @@ matrix:
         - stage: Initial tests
           env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
+        - stage: Initial tests
+          env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
+
         # Try MacOS X.
         - os: osx
           stage: Cron tests
@@ -116,8 +119,7 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          env: CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PYTEST_VERSION='>3.2'
+          env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
 


### PR DESCRIPTION
~~DO NOT MERGE~~

Slightly different approach from #7416 . Here, I am running it as "initial test", so if it fails, CI won't waste time on the rest.

When it works, we'll have to think about rearranging the actual CI matrix for `master`. Do we need to support Python 3.7 for 2.x series? Do we still need to test Python 3.5, and so forth?