### PR TITLE
Throw a more helpful error message in CCDData.read with invalid BUNIT.

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -534,7 +534,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         'argument explicitly or change the header of the FITS '
                         'file before reading it.'
                         .format(fits_unit_string))
-            if unit is not None and fits_unit_string:
+            else:
                 log.info("using the unit {0} passed to the FITS reader instead "
                          "of the unit {1} in the FITS file."
                          .format(unit, fits_unit_string))

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -520,10 +520,24 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         else:
             fits_unit_string = None
 
-        if unit is not None and fits_unit_string:
-            log.info("using the unit {0} passed to the FITS reader instead of "
-                     "the unit {1} in the FITS file.".format(unit,
-                                                             fits_unit_string))
+        if fits_unit_string:
+            if unit is None:
+                # Convert the BUNIT header keyword to a unit and if that's not
+                # possible raise a meaningful error message.
+                try:
+                    fits_unit_string = u.Unit(fits_unit_string)
+                except ValueError:
+                    raise ValueError(
+                        'The Header value for the key BUNIT ({}) cannot be '
+                        'interpreted as valid unit. To successfully read the '
+                        'file as CCDData you can pass in a valid `unit` '
+                        'argument explicitly or change the header of the FITS '
+                        'file before reading it.'
+                        .format(fits_unit_string))
+            if unit is not None and fits_unit_string:
+                log.info("using the unit {0} passed to the FITS reader instead "
+                         "of the unit {1} in the FITS file."
+                         .format(unit, fits_unit_string))
 
         use_unit = unit or fits_unit_string
         hdr, wcs = _generate_wcs_and_update_header(hdr)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -144,6 +144,15 @@ def test_initialize_from_fits_with_ADU_in_header(tmpdir):
     assert ccd.unit is u.adu
 
 
+def test_initialize_from_fits_with_invalid_unit_in_header(tmpdir):
+    hdu = fits.PrimaryHDU(np.ones((2, 2)))
+    hdu.header['bunit'] = 'definetely-not-a-unit'
+    filename = tmpdir.join('afile.fits').strpath
+    hdu.writeto(filename)
+    with pytest.raises(ValueError):
+        CCDData.read(filename)
+
+
 def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     fake_img = np.random.random(size=(100, 100))
     hdu1 = fits.PrimaryHDU()


### PR DESCRIPTION
In case the BUNIT header keyword is not a valid unit the exception message should actually contain a helpful message how this can be fixed.

Related #7608 

No idea which milestone. 🤷‍♂️ 