### PR TITLE
Speed up SkyCoord initialization by a factor of 2-3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -306,6 +306,11 @@ astropy.wcs
 Performance Improvements
 ------------------------
 
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Sped up creating SkyCoord objects by a factor of ~2-3 in some cases. [#7614]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -764,6 +764,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def representation(self, value):
         self.representation_type = value
 
+    _representation_info_cache = None
+
     @classmethod
     def _get_representation_info(cls):
 
@@ -771,7 +773,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
 
-        if hasattr(cls, '_representation_info_cache'):
+        if cls._representation_info_cache is not None:
             return cls._representation_info_cache
 
         repr_attrs = {}

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -766,9 +766,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     @classmethod
     def _get_representation_info(cls):
+
         # This exists as a class method only to support handling frame inputs
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
+
+        if hasattr(cls, '_representation_info_cache'):
+            return cls._representation_info_cache
 
         repr_attrs = {}
         for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
@@ -805,6 +809,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             # Convert to tuples so that this can't mess with frame internals
             repr_attrs[repr_diff_cls]['names'] = tuple(nms)
             repr_attrs[repr_diff_cls]['units'] = tuple(uns)
+
+        cls._representation_info_cache = repr_attrs
 
         return repr_attrs
 

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -67,7 +67,13 @@ def make_skyoffset_cls(framecls):
             newname = name[:-5] if name.endswith('Frame') else name
             newname += framecls.__name__
 
-            return super().__new__(cls, newname, bases, members)
+            newcls = super().__new__(cls, newname, bases, members)
+
+            # Reset representation info cache to make sure that this is not
+            # inherited from a base class
+            newcls._representation_info_cache = None
+
+            return newcls
 
     # We need this to handle the intermediate metaclass correctly, otherwise we could
     # just subclass SkyOffsetFrame.


### PR DESCRIPTION
This implements the caching of ``representation_info`` on frames on a class level to speed up initialization of SkyCoords (as described in https://github.com/astropy/astropy/issues/2989)

### Before

```python
In [2]: %timeit SkyCoord(1, 2, unit='deg', frame='icrs')
1.15 ms ± 54.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [5]: ra = np.random.random(1000) * u.deg

In [6]: dec = np.random.random(1000) * u.deg

In [7]: %timeit SkyCoord(ra, dec)
1.17 ms ± 51.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

### After

```python
In [2]: %timeit SkyCoord(1, 2, unit='deg', frame='icrs')
494 µs ± 63.7 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [6]: ra = np.random.random(1000) * u.deg

In [7]: dec = np.random.random(1000) * u.deg

In [8]: %timeit SkyCoord(ra, dec)
456 µs ± 24.6 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

There is a speedup even when initializing a single ``SkyCoord`` because ``_get_representation_info`` gets called 10 times for each ``SkyCoord`` initialization, so the caching helps even for a single initialization.

I think in general there are other things in frames that could be classed at a class level, for example ``representation_component_names`` and ``representation_component_units``. I don't have time to look into other optimizations, but this one was bugging me since it's such a simple fix.