### PR TITLE
Speed up SkyCoord initialization by a factor of ~2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -306,6 +306,11 @@ astropy.wcs
 Performance Improvements
 ------------------------
 
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Sped up creating SkyCoord objects by a factor of ~2 in some cases. [#7615]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -808,7 +808,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         return repr_attrs
 
-    @property
+    @lazyproperty
     def representation_info(self):
         """
         A dictionary with the information of what attribute names for this frame


### PR DESCRIPTION
This implements the caching of ``representation_info`` on frames on an instance level to speed up initialization of SkyCoords (as described in https://github.com/astropy/astropy/issues/2989)

See https://github.com/astropy/astropy/pull/7614 for trying to cache on a class level (which doesn't work but would be ideal)

### Before

```python
In [2]: %timeit SkyCoord(1, 2, unit='deg', frame='icrs')
1.15 ms ± 54.3 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [5]: ra = np.random.random(1000) * u.deg

In [6]: dec = np.random.random(1000) * u.deg

In [7]: %timeit SkyCoord(ra, dec)
1.17 ms ± 51.5 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

### After

```python
In [3]: %timeit SkyCoord(1, 2, unit='deg', frame='icrs')
623 µs ± 26 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

In [6]: ra = np.random.random(1000) * u.deg

In [7]: dec = np.random.random(1000) * u.deg

In [9]: %timeit SkyCoord(ra, dec)
695 µs ± 56.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

Also, do I win some kind of prize for being lazy and doing a pull request where all I do is write 'lazy'? ;)