### PR TITLE
Speed up initialization of Longitude

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -505,10 +505,8 @@ astropy.coordinates
 
 - Refactored ``SkyCoord`` initializer to improve performance and code clarity.
   [#7958]
-astropy.coordinates
-^^^^^^^^^^^^^^^^^^^
 
-- Sped up initialization of Longitude by ~40%. [#7616]
+- Sped up initialization of ``Longitude`` by ~40%. [#7616]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -505,6 +505,10 @@ astropy.coordinates
 
 - Refactored ``SkyCoord`` initializer to improve performance and code clarity.
   [#7958]
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+- Sped up initialization of Longitude by ~40%. [#7616]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -650,7 +650,7 @@ class Longitude(Angle):
 
     @wrap_angle.setter
     def wrap_angle(self, value):
-        self._wrap_angle = Angle(value)
+        self._wrap_angle = Angle(value, copy=False)
         self._wrap_internal()
 
     def __array_finalize__(self, obj):


### PR DESCRIPTION
This just avoids an extra ``Angle`` initialization if ``wrap_angle`` is already an ``Angle`` object.

### Before

```python
In [4]: ra = 3 * u.deg

In [5]: %timeit Longitude(ra)
71.3 µs ± 4.75 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

### After

```python
In [6]: ra = 3 * u.deg

In [7]: %timeit Longitude(ra)
51.2 µs ± 2.8 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

This also includes a speed up of ``Unit.to`` when the unit passed is the same as the original unit. This can actually happen quite commonly in code where in most cases the default will be for the unit to be the same (such as in Longitude):

### Before

```python
In [6]: %timeit u.deg.to(u.deg)
1.68 µs ± 38.5 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

### After

```python
In [10]: %timeit u.deg.to(u.deg)
279 ns ± 23.8 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```
