### PR TITLE
Fixes for Python 3.7

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -318,17 +318,17 @@ def online_help(query):
     webbrowser.open(url)
 
 
-__dir__ = ['__version__', '__githash__', '__minimum_numpy_version__',
-           '__bibtex__', 'test', 'log', 'find_api_page', 'online_help',
-           'online_docs_root', 'conf']
+__dir_inc__ = ['__version__', '__githash__', '__minimum_numpy_version__',
+               '__bibtex__', 'test', 'log', 'find_api_page', 'online_help',
+               'online_docs_root', 'conf']
 
 
 from types import ModuleType as __module_type__
-# Clean up top-level namespace--delete everything that isn't in __dir__
+# Clean up top-level namespace--delete everything that isn't in __dir_inc__
 # or is a magic attribute, and that isn't a submodule of this package
 for varname in dir():
     if not ((varname.startswith('__') and varname.endswith('__')) or
-            varname in __dir__ or
+            varname in __dir_inc__ or
             (varname[0] != '_' and
                 isinstance(locals()[varname], __module_type__) and
                 locals()[varname].__name__.startswith(__name__ + '.'))):

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -7,7 +7,7 @@ misc.py:
 """
 
 
-import collections
+import collections.abc
 import itertools
 import operator
 
@@ -95,10 +95,10 @@ def sortmore(*args, **kw):
     if globalkey is None:
         globalkey = lambda *x: 0
 
-    if not isinstance(globalkey, collections.Callable):
+    if not isinstance(globalkey, collections.abc.Callable):
         raise ValueError('globalkey needs to be callable')
 
-    if isinstance(key, collections.Callable):
+    if isinstance(key, collections.abc.Callable):
         k = lambda x: (globalkey(*x), key(x[0]))
     elif isinstance(key, tuple):
         key = (k if k else lambda x: 0 for k in key)

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -301,7 +301,8 @@ class TestFitsTime(FitsTestCase):
         assert isinstance(tm['datetime'], Time)
         assert tm['datetime'].location.lon.value == 0
         assert tm['datetime'].location.lat.value == 0
-        assert tm['datetime'].location.height.value == 0
+        assert np.isclose(tm['datetime'].location.height.value, 0,
+                          rtol=0, atol=1e-9)
 
     @pytest.mark.parametrize('table_types', (Table, QTable))
     def test_io_time_read_fits_scale(self, table_types):

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -181,10 +181,9 @@ def test_wrap_preserve_signature_docstring():
     if wrapped_function_6.__doc__ is not None:
         assert wrapped_function_6.__doc__.strip() == "An awesome function"
 
-    signature = inspect.formatargspec(
-        *inspect.getfullargspec(wrapped_function_6))
+    signature = inspect.signature(wrapped_function_6)
 
-    assert signature == "(data, wcs=None, unit=None)"
+    assert str(signature) == "(data, wcs=None, unit=None)"
 
 
 def test_setup_failures1():

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -157,7 +157,20 @@ _warnings_to_ignore_by_pyver = {
         # https://github.com/astropy/astropy/pull/7372
         r"Importing from numpy\.testing\.decorators is deprecated, import from numpy\.testing instead\.",
         # Deprecation warnings ahead of pytest 4.x
-        r"MarkInfo objects are deprecated"])}
+        r"MarkInfo objects are deprecated"]),
+    (3, 7): set([
+        # py.test reads files with the 'U' flag, which is
+        # deprecated.
+        r"'U' mode is deprecated",
+        # inspect raises this slightly different warning on Python 3.6.
+        # Keeping it since e.g. lxml as of 3.8.0 is still calling getargspec()
+        r"inspect\.getargspec\(\) is deprecated, use "
+        r"inspect\.signature\(\) or inspect\.getfullargspec\(\)",
+        # https://github.com/astropy/astropy/pull/7372
+        r"Importing from numpy\.testing\.decorators is deprecated, import from numpy\.testing instead\.",
+        # Deprecation warnings ahead of pytest 4.x
+        r"MarkInfo objects are deprecated"]),
+}
 
 
 def enable_deprecations_as_exceptions(include_astropy_deprecations=True,

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -169,7 +169,11 @@ _warnings_to_ignore_by_pyver = {
         # https://github.com/astropy/astropy/pull/7372
         r"Importing from numpy\.testing\.decorators is deprecated, import from numpy\.testing instead\.",
         # Deprecation warnings ahead of pytest 4.x
-        r"MarkInfo objects are deprecated"]),
+        r"MarkInfo objects are deprecated",
+        # Deprecation warning for collections.abc, fixed in Astropy but still
+        # used in lxml, and maybe others
+        r"Using or importing the ABCs from 'collections'",
+    ]),
 }
 
 

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -150,7 +150,7 @@ _warnings_to_ignore_by_pyver = {
         # py.test reads files with the 'U' flag, which is
         # deprecated.
         r"'U' mode is deprecated",
-        # inspect raises this slightly different warning on Python 3.6.
+        # inspect raises this slightly different warning on Python 3.6-3.7.
         # Keeping it since e.g. lxml as of 3.8.0 is still calling getargspec()
         r"inspect\.getargspec\(\) is deprecated, use "
         r"inspect\.signature\(\) or inspect\.getfullargspec\(\)",
@@ -162,7 +162,7 @@ _warnings_to_ignore_by_pyver = {
         # py.test reads files with the 'U' flag, which is
         # deprecated.
         r"'U' mode is deprecated",
-        # inspect raises this slightly different warning on Python 3.6.
+        # inspect raises this slightly different warning on Python 3.6-3.7.
         # Keeping it since e.g. lxml as of 3.8.0 is still calling getargspec()
         r"inspect\.getargspec\(\) is deprecated, use "
         r"inspect\.signature\(\) or inspect\.getfullargspec\(\)",


### PR DESCRIPTION
Running the test suite on Python 3.7 with a few optional dependencies (the ones easily installable, but not scipy or matplotlib).
With these fixes:
```
============== 2 failed, 9905 passed, 787 skipped, 70 xfailed in 351.16 seconds ===============
```
The annoying one is that overriding `astropy`'s `__dir__` attribute with a list no more works, not sure if it was really supported before ...

One remaining failure with FitsTime, a rounding error, but I don't know if using `isclose` would be adequate here (@mhvk, @taldcroft ?):
```
astropy/io/fits/tests/test_fitstime.py .............F
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

self = <astropy.io.fits.tests.test_fitstime.TestFitsTime object at 0x7fef164aaa20>
table_types = <class 'astropy.table.table.Table'>

    @pytest.mark.parametrize('table_types', (Table, QTable))
    def test_io_time_read_fits_location(self, table_types):
        """
            Test that geocentric/geodetic observatory position is read
            properly, as and when it is specified.
            """
        # Datetime column
        c = fits.Column(name='datetime', format='A29', coord_type='TT',
                        time_ref_pos='TOPOCENTER', array=self.time)
    
        # Observatory position in ITRS Cartesian coordinates (geocentric)
        cards = [('OBSGEO-X', -2446354), ('OBSGEO-Y', 4237210),
                 ('OBSGEO-Z', 4077985)]
    
        # Explicitly create a FITS Binary Table
        bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
        bhdu.writeto(self.temp('time.fits'), overwrite=True)
    
        tm = table_types.read(self.temp('time.fits'), astropy_native=True)
    
        assert isinstance(tm['datetime'], Time)
        assert tm['datetime'].location.x.value == -2446354
        assert tm['datetime'].location.y.value == 4237210
        assert tm['datetime'].location.z.value == 4077985
    
        # Observatory position in geodetic coordinates
        cards = [('OBSGEO-L', 0), ('OBSGEO-B', 0), ('OBSGEO-H', 0)]
    
        # Explicitly create a FITS Binary Table
        bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
        bhdu.writeto(self.temp('time.fits'), overwrite=True)
    
        tm = table_types.read(self.temp('time.fits'), astropy_native=True)
    
        assert isinstance(tm['datetime'], Time)
        assert tm['datetime'].location.lon.value == 0
        assert tm['datetime'].location.lat.value == 0
>       assert tm['datetime'].location.height.value == 0
E       AssertionError: assert -2.1723632570150343e-10 == 0
E        +  where -2.1723632570150343e-10 = <Quantity -2.17236326e-10 m>.value
E        +    where <Quantity -2.17236326e-10 m> = <EarthLocation (6378137., 0., 0.) m>.height
E        +      where <EarthLocation (6378137., 0., 0.) m> = <Time object: scale='tt' format='fits' value=['1999-01-01T00:00:00.123456789(TT)' '2010-01-01T00:00:00.000000000(TT)']>.location

astropy/io/fits/tests/test_fitstime.py:304: AssertionError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
[11] > /home/simon/dev/astropy/astropy/io/fits/tests/test_fitstime.py(304)test_io_time_read_fits_location()
-> assert tm['datetime'].location.height.value == 0
   6 frames hidden (try 'help hidden_frames')
(Pdb++) tm['datetime'].location
<EarthLocation (6378137., 0., 0.) m>
(Pdb++) tm['datetime'].location.lon
<Longitude 0. deg>
(Pdb++) tm['datetime'].location.lat
<Latitude 0. deg>
(Pdb++) tm['datetime'].location.height
<Quantity -2.17236326e-10 m>
```

Full log here: https://gist.github.com/saimn/88e5120119363ff53590e900ea76142a