### PR TITLE
Improve error message when ascii guessing fails [skip ci]

### DIFF
--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -566,8 +566,9 @@ def _guess(table, read_kwargs, format, fast_reader):
                    '** ERROR: Unable to guess table format with the guesses listed above. **',
                    '**                                                                    **',
                    '** To figure out why the table did not read, use guess=False and      **',
-                   '** appropriate arguments to read().  In particular specify the format **',
-                   '** and any known attributes like the delimiter.                       **',
+                   '** fast_reader=False, along with any appropriate arguments to read(). **',
+                   '** In particular specify the format and any known attributes like the **',
+                   '** delimiter.                                                         **',
                    '************************************************************************']
             lines.extend(msg)
             raise core.InconsistentTableError('\n'.join(lines))


### PR DESCRIPTION
This is a tiny little improvement to partially address #7624.  It just adds that one should also disable the fast C reader since the Python reader tends to have more to the point exception messages (because of the way it is structured).

This passes local `io.ascii` tests, and have skipped tests here because the change is so minor.  But if desired I can run this through CI.