### PR TITLE
Improve performance of converting CartesianRepresentation to xyz

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -333,6 +333,9 @@ astropy.coordinates
 
 - Sped up creating SkyCoord objects by a factor of ~2 in some cases. [#7615]
 
+- Sped up getting xyz vectors from ``CartesianRepresentation`` (which
+  is used a lot internally). [#7638]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -550,6 +550,23 @@ class TestCartesianRepresentation:
         assert_allclose_quantity(y, s1.y)
         assert_allclose_quantity(z, s1.z)
 
+    def test_xyz_is_view_if_possible(self):
+        xyz = np.arange(1., 10.).reshape(3, 3)
+        s1 = CartesianRepresentation(xyz, unit=u.kpc, copy=False)
+        s1_xyz = s1.xyz
+        assert s1_xyz.value[0, 0] == 1.
+        xyz[0, 0] = 0.
+        assert s1.x[0] == 0.
+        assert s1_xyz.value[0, 0] == 0.
+        # Not possible: we don't check that tuples are from the same array
+        xyz = np.arange(1., 10.).reshape(3, 3)
+        s2 = CartesianRepresentation(*xyz, unit=u.kpc, copy=False)
+        s2_xyz = s2.xyz
+        assert s2_xyz.value[0, 0] == 1.
+        xyz[0, 0] = 0.
+        assert s2.x[0] == 0.
+        assert s2_xyz.value[0, 0] == 1.
+
     def test_reprobj(self):
 
         s1 = CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc)


### PR DESCRIPTION
Partially by keeping a link to an original xyz array passed in.  EDIT: ~partially by caching the result of a get_xyz call.~ On second thought, am not caching `xyz`, since it seems risky with in-place changes. Can revisit it later.

For many transformations, this doesn't matter all that much, but one can find ones where it does:
```
import numpy as np
from astropy.coordinates import SkyCoord
from astropy.time import Time
sc = SkyCoord(10., 0., unit='deg,deg', obstime=Time(np.arange(50000., 51000.), format='mjd'))
%timeit sc.transform_to('cirs')
# 1 loop, best of 3: 331 -> 257 ms per loop
```

It will help especially when we start using `erfa` to transform to and from Cartesian, since the `erfa` routines want xyz as a single array.