### PR TITLE
Speed up coordinate representations using erfa routines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -338,6 +338,9 @@ astropy.coordinates
 - Sped up getting xyz vectors from ``CartesianRepresentation`` (which
   is used a lot internally). [#7638]
 
+- Sped up transformations and some representation methods by replacing
+  python code with (compiled) ``erfa`` ufuncs. [#7639]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1159,6 +1159,23 @@ class CartesianRepresentation(BaseRepresentation):
                                    getattr(second, component))
                                 for component in first.components))
 
+    def norm(self):
+        """Vector norm.
+
+        The norm is the standard Frobenius norm, i.e., the square root of the
+        sum of the squares of all components with non-angular units.
+
+        Note that any associated differentials will be dropped during this
+        operation.
+
+        Returns
+        -------
+        norm : `astropy.units.Quantity`
+            Vector norm, with the same shape as the representation.
+        """
+        # erfa pm: Modulus of p-vector.
+        return erfa_ufunc.pm(self.get_xyz(xyz_axis=-1))
+
     def mean(self, *args, **kwargs):
         """Vector mean.
 
@@ -1208,10 +1225,8 @@ class CartesianRepresentation(BaseRepresentation):
             raise TypeError("cannot only take dot product with another "
                             "representation, not a {0} instance."
                             .format(type(other)))
-        return functools.reduce(operator.add,
-                                (getattr(self, component) *
-                                 getattr(other_c, component)
-                                 for component in self.components))
+        return erfa_ufunc.pdp(self.get_xyz(xyz_axis=-1),
+                              other_c.get_xyz(xyz_axis=-1))
 
     def cross(self, other):
         """Cross product of two representations.
@@ -1233,9 +1248,9 @@ class CartesianRepresentation(BaseRepresentation):
             raise TypeError("cannot only take cross product with another "
                             "representation, not a {0} instance."
                             .format(type(other)))
-        return self.__class__(self.y * other_c.z - self.z * other_c.y,
-                              self.z * other_c.x - self.x * other_c.z,
-                              self.x * other_c.y - self.y * other_c.x)
+        sxo = erfa_ufunc.pxp(self.get_xyz(xyz_axis=-1),
+                             other_c.get_xyz(xyz_axis=-1))
+        return self.__class__(sxo, xyz_axis=-1)
 
 
 class UnitSphericalRepresentation(BaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1099,6 +1099,7 @@ class CartesianRepresentation(BaseRepresentation):
                        [ 1.23205081, 1.59807621],
                        [ 3.        , 4.        ]] pc>
         """
+        # erfa rxp: Multiply a p-vector by an r-matrix.
         p = erfa_ufunc.rxp(matrix, self.get_xyz(xyz_axis=-1))
         # Handle differentials attached to this representation
         if self.differentials:
@@ -1191,6 +1192,7 @@ class CartesianRepresentation(BaseRepresentation):
             raise TypeError("cannot only take dot product with another "
                             "representation, not a {0} instance."
                             .format(type(other)))
+        # erfa pdp: p-vector inner (=scalar=dot) product.
         return erfa_ufunc.pdp(self.get_xyz(xyz_axis=-1),
                               other_c.get_xyz(xyz_axis=-1))
 
@@ -1214,6 +1216,7 @@ class CartesianRepresentation(BaseRepresentation):
             raise TypeError("cannot only take cross product with another "
                             "representation, not a {0} instance."
                             .format(type(other)))
+        # erfa pxp: p-vector outer (=vector=cross) product.
         sxo = erfa_ufunc.pxp(self.get_xyz(xyz_axis=-1),
                              other_c.get_xyz(xyz_axis=-1))
         return self.__class__(sxo, xyz_axis=-1)
@@ -1300,6 +1303,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         # NUMPY_LT_1_16 cannot create a vector automatically
         p = u.Quantity(np.empty(self.shape + (3,)), u.dimensionless_unscaled,
                        copy=False)
+        # erfa s2c: Convert [unit]spherical coordinates to Cartesian.
         p = erfa_ufunc.s2c(self.lon, self.lat, p)
         return CartesianRepresentation(p, xyz_axis=-1, copy=False)
 
@@ -1310,6 +1314,7 @@ class UnitSphericalRepresentation(BaseRepresentation):
         coordinates.
         """
         p = cart.get_xyz(xyz_axis=-1)
+        # erfa c2s: P-vector to [unit]spherical coordinates.
         return cls(*erfa_ufunc.c2s(p), copy=False)
 
     def represent_as(self, other_class, differential_class=None):
@@ -1612,6 +1617,7 @@ class SphericalRepresentation(BaseRepresentation):
 
         # NUMPY_LT_1_16 cannot create a vector automatically
         p = u.Quantity(np.empty(self.shape + (3,)), d.unit, copy=False)
+        # erfa s2p: Convert spherical polar coordinates to p-vector.
         p = erfa_ufunc.s2p(self.lon, self.lat, d, p)
 
         return CartesianRepresentation(p, xyz_axis=-1, copy=False)
@@ -1623,6 +1629,7 @@ class SphericalRepresentation(BaseRepresentation):
         coordinates.
         """
         p = cart.get_xyz(xyz_axis=-1)
+        # erfa p2s: P-vector to spherical polar coordinates.
         return cls(*erfa_ufunc.p2s(p), copy=False)
 
     def norm(self):

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -510,8 +510,8 @@ def test_repr_altaz():
     time = Time('2005-03-21 00:00:00')
     sc4 = sc2.transform_to(AltAz(location=loc, obstime=time))
     assert repr(sc4).startswith("<SkyCoord (AltAz: obstime=2005-03-21 00:00:00.000, "
-                         "location=(-2309223.0, -3695529.0, "
-                                "-4641767.0) m, pressure=0.0 hPa, "
+                         "location=(-2309223., -3695529., "
+                                "-4641767.) m, pressure=0.0 hPa, "
                          "temperature=0.0 deg_C, relative_humidity=0.0, "
                          "obswl=1.0 micron): (az, alt, distance) in "
                          "(deg, deg, m)\n")

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1258,8 +1258,8 @@ def test_setitem_location():
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-1, format='cxcsec')
     assert ('cannot set to Time with different location: '
-            'expected location=(1., 3., 5.) m and '
-            'got location=None') in str(err)
+            'expected location={} and '
+            'got location=None'.format(loc[0])) in str(err)
 
     # Succeeds because the right hand side correctly sets location
     t[0, 0] = Time(-2, format='cxcsec', location=loc[0])
@@ -1269,8 +1269,8 @@ def test_setitem_location():
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
-            'expected location=(1., 3., 5.) m and '
-            'got location=(2., 4., 6.) m') in str(err)
+            'expected location={} and '
+            'got location={}'.format(loc[0], loc[1])) in str(err)
 
     # Fails because the Time has None location and RHS has defined location
     t = Time([[1, 2], [3, 4]], format='cxcsec')
@@ -1278,7 +1278,7 @@ def test_setitem_location():
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
             'expected location=None and '
-            'got location=(2., 4., 6.) m') in str(err)
+            'got location={}'.format(loc[1])) in str(err)
 
     # Broadcasting works
     t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1258,7 +1258,7 @@ def test_setitem_location():
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-1, format='cxcsec')
     assert ('cannot set to Time with different location: '
-            'expected location=(1.0, 3.0, 5.0) m and '
+            'expected location=(1., 3., 5.) m and '
             'got location=None') in str(err)
 
     # Succeeds because the right hand side correctly sets location
@@ -1269,8 +1269,8 @@ def test_setitem_location():
     with pytest.raises(ValueError) as err:
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
-            'expected location=(1.0, 3.0, 5.0) m and '
-            'got location=(2.0, 4.0, 6.0) m') in str(err)
+            'expected location=(1., 3., 5.) m and '
+            'got location=(2., 4., 6.) m') in str(err)
 
     # Fails because the Time has None location and RHS has defined location
     t = Time([[1, 2], [3, 4]], format='cxcsec')
@@ -1278,7 +1278,7 @@ def test_setitem_location():
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
             'expected location=None and '
-            'got location=(2.0, 4.0, 6.0) m') in str(err)
+            'got location=(2., 4., 6.) m') in str(err)
 
     # Broadcasting works
     t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -714,7 +714,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                     # not in-place!
                     value = value * scale
 
-        return value if self.shape else value.item()
+        return value if self.shape else (value[()] if self.dtype.fields
+                                         else value.item())
 
     value = property(to_value,
                      doc="""The numerical value of this instance.

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -482,6 +482,7 @@ UFUNC_HELPERS[erfa_ufunc.s2c] = helper_s2c
 UFUNC_HELPERS[erfa_ufunc.s2p] = helper_s2p
 UFUNC_HELPERS[erfa_ufunc.c2s] = helper_c2s
 UFUNC_HELPERS[erfa_ufunc.p2s] = helper_p2s
+UFUNC_HELPERS[erfa_ufunc.pm] = helper_invariant
 
 
 # UFUNCS FROM SCIPY.SPECIAL

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -13,6 +13,7 @@ from fractions import Fraction
 import numpy as np
 from .core import (UnitsError, UnitConversionError, UnitTypeError,
                    dimensionless_unscaled, get_current_unit_registry)
+from .._erfa import ufunc as erfa_ufunc
 
 
 def _d(unit):
@@ -442,6 +443,45 @@ UFUNC_HELPERS[np.floor_divide] = helper_twoarg_floor_divide
 UFUNC_HELPERS[np.heaviside] = helper_heaviside
 UFUNC_HELPERS[np.float_power] = helper_power
 UFUNC_HELPERS[np.divmod] = helper_divmod
+
+
+# ERFA UFUNCS
+def helper_s2c(f, unit1, unit2):
+    from .si import radian
+    try:
+        return [get_converter(unit1, radian),
+                get_converter(unit2, radian)], dimensionless_unscaled
+    except UnitsError:
+        raise UnitTypeError("Can only apply '{0}' function to "
+                            "quantities with angle units"
+                            .format(f.__name__))
+
+
+def helper_s2p(f, unit1, unit2, unit3):
+    from .si import radian
+    try:
+        return [get_converter(unit1, radian),
+                get_converter(unit2, radian), None], unit3
+    except UnitsError:
+        raise UnitTypeError("Can only apply '{0}' function to "
+                            "quantities with angle units"
+                            .format(f.__name__))
+
+
+def helper_c2s(f, unit1):
+    from .si import radian
+    return [None], (radian, radian)
+
+
+def helper_p2s(f, unit1):
+    from .si import radian
+    return [None], (radian, radian, unit1)
+
+
+UFUNC_HELPERS[erfa_ufunc.s2c] = helper_s2c
+UFUNC_HELPERS[erfa_ufunc.s2p] = helper_s2p
+UFUNC_HELPERS[erfa_ufunc.c2s] = helper_c2s
+UFUNC_HELPERS[erfa_ufunc.p2s] = helper_p2s
 
 
 # UFUNCS FROM SCIPY.SPECIAL

--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -483,6 +483,9 @@ UFUNC_HELPERS[erfa_ufunc.s2p] = helper_s2p
 UFUNC_HELPERS[erfa_ufunc.c2s] = helper_c2s
 UFUNC_HELPERS[erfa_ufunc.p2s] = helper_p2s
 UFUNC_HELPERS[erfa_ufunc.pm] = helper_invariant
+UFUNC_HELPERS[erfa_ufunc.pdp] = helper_multiplication
+UFUNC_HELPERS[erfa_ufunc.pxp] = helper_multiplication
+UFUNC_HELPERS[erfa_ufunc.rxp] = helper_multiplication
 
 
 # UFUNCS FROM SCIPY.SPECIAL

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -953,7 +953,7 @@ def test_arrays():
     qkpc = u.Quantity(a, u.kpc)
     assert not qkpc.isscalar
     qkpc0 = qkpc[0]
-    assert qkpc0.value == a[0].item()
+    assert qkpc0.value == a[0]
     assert qkpc0.unit == qkpc.unit
     assert isinstance(qkpc0, u.Quantity)
     assert qkpc0.isscalar


### PR DESCRIPTION
Follow-up of #7638, using `erfa` ufuncs for conversion of cartesian to (unit)spherical, and some of the cartesian methods.

Sample speed-up:
```
import numpy as np
from astropy.coordinates import CartesianRepresentation, SphericalRepresentation
cr = CartesianRepresentation(np.ones((100, 3)), unit=u.km, xyz_axis=-1)
%timeit cr.represent_as(SphericalRepresentation)
# 1000 loops, best of 3: 200 -> 174 µs
sph = cr.represent_as(SphericalRepresentation)
%timeit sph.represent_as(CartesianRepresentation)
# 1000 loops, best of 3: 233 -> 67 µs
%timeit cr.norm()
# 1000 loops, best of 3: 227 -> 9 µs
%timeit cr.dot(cr)
# 1000 loops, best of 3: 206 -> 28 µs
%timeit cr.cross(cr)
# 1000 loops, best of 3: 447 -> 66 µs
```
