### PR TITLE
DOC: Fix change log typo 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,7 +89,7 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
-- Add a ``Multiply`` model which preseves unit through evaluate, unlike
+- Add a ``Multiply`` model which preserves unit through evaluate, unlike
   ``Scale`` which is dimensionless. [#7210]
 
 - Add a ``uses_quantity`` property to ``Model`` which allows introspection of if


### PR DESCRIPTION
Just a tiny typo. Would have pushed directly to master if someone didn't protect it. :wink: 

xref #7210 