### PR TITLE
Don't break on not getting "Downloading" message in doctest.

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -418,7 +418,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
 
         >>> from astropy.utils.data import get_pkg_data_fileobj
         >>> with get_pkg_data_fileobj('allsky/allsky_rosat.fits',
-        ...                           encoding='binary') as fobj:  # doctest: +REMOTE_DATA
+        ...                           encoding='binary') as fobj:  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
         ...     fcontents = fobj.read()
         ...
         Downloading http://data.astropy.org/allsky/allsky_rosat.fits [Done]
@@ -426,7 +426,7 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
     This does the same thing but does *not* cache it locally::
 
         >>> with get_pkg_data_fileobj('allsky/allsky_rosat.fits',
-        ...                           encoding='binary', cache=False) as fobj:  # doctest: +REMOTE_DATA
+        ...                           encoding='binary', cache=False) as fobj:  # doctest: +REMOTE_DATA +IGNORE_OUTPUT
         ...     fcontents = fobj.read()
         ...
         Downloading http://data.astropy.org/allsky/allsky_rosat.fits [Done]


### PR DESCRIPTION
Currently, our allowed failure test which includes remotes is failing because a `Downloading...` message is not seen. This is because our tests are not run in a terminal, and in #7577 we ensured that in that case none of those messages are shown. However, since users copy & pasting the test on a terminal would see the message, it is best to keep it in the text, but just ignore the output (which hopefully will work).

Milestone is the same as for #7577; should only be merged if the allowed-failure test passes!