### PR TITLE
Speed up Unit.to when target unit is the same as original unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -318,6 +318,9 @@ astropy.units
 - Sped up creating new composite units, and raising units to some power
   [#7549]
 
+- Sped up Unit.to when target unit is the same as the original unit.
+  [#7643]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -932,7 +932,7 @@ class UnitBase(metaclass=InheritDocstrings):
         raise UnitConversionError(
             "'{0!r}' is not a scaled version of '{1!r}'".format(self, other))
 
-    def to(self, other, value=1.0, equivalencies=[]):
+    def to(self, other, value=None, equivalencies=[]):
         """
         Return the converted values in the specified unit.
 
@@ -963,7 +963,11 @@ class UnitBase(metaclass=InheritDocstrings):
         UnitsError
             If units are inconsistent
         """
-        return self._get_converter(other, equivalencies=equivalencies)(value)
+        if other is self and value is None:
+            return 1.0
+        else:
+            converter = self._get_converter(other, equivalencies=equivalencies)
+            return converter(1.0 if value is None else value)
 
     def in_units(self, other, value=1.0, equivalencies=[]):
         """

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -29,6 +29,8 @@ __all__ = [
     'set_enabled_equivalencies', 'add_enabled_equivalencies',
     'dimensionless_unscaled', 'one']
 
+UNITY = 1.0
+
 
 def _flatten_units_collection(items):
     """
@@ -932,7 +934,7 @@ class UnitBase(metaclass=InheritDocstrings):
         raise UnitConversionError(
             "'{0!r}' is not a scaled version of '{1!r}'".format(self, other))
 
-    def to(self, other, value=None, equivalencies=[]):
+    def to(self, other, value=UNITY, equivalencies=[]):
         """
         Return the converted values in the specified unit.
 
@@ -963,11 +965,10 @@ class UnitBase(metaclass=InheritDocstrings):
         UnitsError
             If units are inconsistent
         """
-        if other is self and value is None:
-            return 1.0
+        if other is self and value is UNITY:
+            return UNITY
         else:
-            converter = self._get_converter(other, equivalencies=equivalencies)
-            return converter(1.0 if value is None else value)
+            return self._get_converter(other, equivalencies=equivalencies)(value)
 
     def in_units(self, other, value=1.0, equivalencies=[]):
         """


### PR DESCRIPTION
This was split out from https://github.com/astropy/astropy/pull/7616

### Before

```python
In [1]: from astropy.units import deg

In [3]: %timeit deg.to(deg)
3.69 µs ± 149 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

### After

```python
In [3]: from astropy.units import deg

In [4]: %timeit deg.to(deg)
542 ns ± 28.4 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

cc @mhvk