### PR TITLE
Simple refactoring to reduce astropy import time.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,8 @@ astropy.wcs
 Performance Improvements
 ------------------------
 
+- Reduced import time by more cautious use of the standard library. [#7647]
+
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -4,9 +4,10 @@
 
 
 import inspect
-import re
 import types
 import importlib
+from distutils.version import LooseVersion
+
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',
            'isinstancemethod']
@@ -120,7 +121,6 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     >>> minversion(astropy, '0.4.4')
     True
     """
-
     if isinstance(module, types.ModuleType):
         module_name = module.__name__
     elif isinstance(module, str):
@@ -138,15 +138,6 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
         have_version = getattr(module, version_path)
     else:
         have_version = resolve_name(module.__name__, version_path)
-
-    from distutils.version import LooseVersion
-    # LooseVersion raises a TypeError when strings like dev, rc1 are part
-    # of the version number. Match the dotted numbers only. Regex taken
-    # from PEP440, https://www.python.org/dev/peps/pep-0440/, Appendix B
-    expr = '^([1-9]\\d*!)?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*'
-    m = re.match(expr, version)
-    if m:
-        version = m.group(0)
 
     if inclusive:
         return LooseVersion(have_version) >= LooseVersion(version)

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -92,10 +92,6 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     Returns `True` if the specified Python module satisfies a minimum version
     requirement, and `False` if not.
 
-    By default this uses `pkg_resources.parse_version` to do the version
-    comparison if available.  Otherwise it falls back on
-    `distutils.version.LooseVersion`.
-
     Parameters
     ----------
 
@@ -143,22 +139,19 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     else:
         have_version = resolve_name(module.__name__, version_path)
 
-    try:
-        from pkg_resources import parse_version
-    except ImportError:
-        from distutils.version import LooseVersion as parse_version
-        # LooseVersion raises a TypeError when strings like dev, rc1 are part
-        # of the version number. Match the dotted numbers only. Regex taken
-        # from PEP440, https://www.python.org/dev/peps/pep-0440/, Appendix B
-        expr = '^([1-9]\\d*!)?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*'
-        m = re.match(expr, version)
-        if m:
-            version = m.group(0)
+    from distutils.version import LooseVersion
+    # LooseVersion raises a TypeError when strings like dev, rc1 are part
+    # of the version number. Match the dotted numbers only. Regex taken
+    # from PEP440, https://www.python.org/dev/peps/pep-0440/, Appendix B
+    expr = '^([1-9]\\d*!)?(0|[1-9]\\d*)(\\.(0|[1-9]\\d*))*'
+    m = re.match(expr, version)
+    if m:
+        version = m.group(0)
 
     if inclusive:
-        return parse_version(have_version) >= parse_version(version)
+        return LooseVersion(have_version) >= LooseVersion(version)
     else:
-        return parse_version(have_version) > parse_version(version)
+        return LooseVersion(have_version) > LooseVersion(version)
 
 
 def find_current_module(depth=1, finddiff=False):

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -17,7 +17,6 @@ import unicodedata
 import locale
 import threading
 import re
-import urllib.request
 
 from itertools import zip_longest
 from contextlib import contextmanager
@@ -195,7 +194,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
 
     """
     import webbrowser
-
+    import urllib.request
     from zlib import decompress
 
     if (not isinstance(obj, str) and

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -63,7 +63,7 @@ def test_find_mod_objs():
     assert namedtuple not in objs
 
 
-def _minversion_test():
+def test_minversion():
     from types import ModuleType
     test_module = ModuleType(str("test_module"))
     test_module.__version__ = '0.12.2'

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -73,14 +73,3 @@ def _minversion_test():
         assert minversion(test_module, version)
     for version in bad_versions:
         assert not minversion(test_module, version)
-
-
-def test_minversion():
-    import sys
-    if 'pkg_resources' in sys.modules:
-        pkg_resources_saved = sys.modules['pkg_resources']
-        # Force ImportError for pkg_resources in minversion()
-        sys.modules['pkg_resource'] = None
-        _minversion_test()
-        sys.modules['pkg_resource'] = pkg_resources_saved
-    _minversion_test()


### PR DESCRIPTION
This does two things: remove the use of `pkg_resources` in `utils.misc.minversion` in favour of its backup (`distutils.version.LooseVersion`), which is much more light-weight; ensure `urllib` gets imported only when actually needed, at least at import time.

Especially the removal of `pkg_resources` has a large effect; with this PR:
```
python -X importtime -c "import astropy"
# 0.28 s -> 0.16 s
```