### PR TITLE
Speed up creation of simple composite units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -561,7 +561,7 @@ astropy.units
 ^^^^^^^^^^^^^
 
 - Sped up creating new composite units, and raising units to some power
-  [#7549]
+  [#7549, #7649]
 
 - Sped up Unit.to when target unit is the same as the original unit.
   [#7643]

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -12,7 +12,6 @@ code under a BSD license.
 
 from .core import *
 from .quantity import *
-from .decorators import *
 
 from . import si
 from . import cgs
@@ -32,6 +31,8 @@ from .equivalencies import *
 from .function.core import *
 from .function.logarithmic import *
 from .function import magnitude_zero_points
+
+from .decorators import *
 
 del bases
 

--- a/astropy/units/__init__.py
+++ b/astropy/units/__init__.py
@@ -9,7 +9,10 @@ This code is adapted from the `pynbody
 Pontzen, who has granted the Astropy project permission to use the
 code under a BSD license.
 """
-
+# Lots of things to import - go from more basic to advanced, so that
+# whatever advanced ones need generally has been imported already;
+# this helps prevent circular imports and makes it easier to understand
+# where most time is spent (e.g., using python -X importtime).
 from .core import *
 from .quantity import *
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1772,11 +1772,11 @@ class _UnitMetaClass(InheritDocstrings):
             if is_effectively_unity(represents.value):
                 represents = represents.unit
             else:
-                # cannot use _error_check=False: scale may be effectively unity
                 represents = CompositeUnit(represents.value *
                                            represents.unit.scale,
                                            bases=represents.unit.bases,
-                                           powers=represents.unit.powers)
+                                           powers=represents.unit.powers,
+                                           _error_check=False)
 
         if isinstance(s, Quantity):
             if is_effectively_unity(s.value):
@@ -1784,7 +1784,8 @@ class _UnitMetaClass(InheritDocstrings):
             else:
                 s = CompositeUnit(s.value * s.unit.scale,
                                   bases=s.unit.bases,
-                                  powers=s.unit.powers)
+                                  powers=s.unit.powers,
+                                  _error_check=False)
 
         # now decide what we really need to do; define derived Unit?
         if isinstance(represents, UnitBase):
@@ -1833,7 +1834,7 @@ class _UnitMetaClass(InheritDocstrings):
                 return UnrecognizedUnit(s)
 
         elif isinstance(s, (int, float, np.floating, np.integer)):
-            return CompositeUnit(s, [], [])
+            return CompositeUnit(s, [], [], _error_check=False)
 
         elif s is None:
             raise TypeError("None is not a valid Unit")
@@ -1958,7 +1959,8 @@ class Unit(NamedUnit, metaclass=_UnitMetaClass):
         if len(physical_type_id) == 1 and powers[0] == 1:
             unit = bases[0]
         else:
-            unit = CompositeUnit(1, bases, powers)
+            unit = CompositeUnit(1, bases, powers,
+                                 _error_check=False)
 
         return unit
 
@@ -2006,7 +2008,6 @@ class CompositeUnit(UnitBase):
         # kwarg `_error_check` is False, the error checking is turned
         # off.
         if _error_check:
-            scale = sanitize_scale(scale)
             for base in bases:
                 if not isinstance(base, UnitBase):
                     raise TypeError(

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1994,6 +1994,8 @@ class CompositeUnit(UnitBase):
         A sequence of powers (in parallel with ``bases``) for each
         of the base units.
     """
+    _decomposed_cache = None
+    _hash = None
 
     def __init__(self, scale, bases, powers, decompose=False,
                  decompose_bases=set(), _error_check=True):
@@ -2011,12 +2013,18 @@ class CompositeUnit(UnitBase):
                         "bases must be sequence of UnitBase instances")
             powers = [validate_power(p) for p in powers]
 
-        self._scale = scale
-        self._bases = bases
-        self._powers = powers
-        self._decomposed_cache = None
-        self._expand_and_gather(decompose=decompose, bases=decompose_bases)
-        self._hash = None
+        if not decompose and len(bases) == 1 and powers == [1]:
+            # Short-cut
+            unit = bases[0]
+            self._scale = sanitize_scale(scale * unit.scale)
+            self._bases = unit.bases
+            self._powers = unit.powers
+        else:
+            self._scale = scale
+            self._bases = bases
+            self._powers = powers
+            self._expand_and_gather(decompose=decompose,
+                                    bases=decompose_bases)
 
     def __repr__(self):
         if len(self._bases):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2021,7 +2021,7 @@ class CompositeUnit(UnitBase):
             powers = [validate_power(p) for p in powers]
 
         if not decompose and len(bases) == 1:
-            # Short-cut; with one unit there's no expand and gather.
+            # Short-cut; with one unit there's nothing to expand and gather.
             unit = bases[0]
             power = powers[0]
             if power == 1:
@@ -2038,6 +2038,8 @@ class CompositeUnit(UnitBase):
                                 for p in unit.powers]
             self._scale = sanitize_scale(scale)
         else:
+            # Regular case: use inputs as preliminary scale, bases, and powers,
+            # then "expand and gather" identical bases, sanitize the scale, &c.
             self._scale = scale
             self._bases = bases
             self._powers = powers

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2014,12 +2014,23 @@ class CompositeUnit(UnitBase):
                         "bases must be sequence of UnitBase instances")
             powers = [validate_power(p) for p in powers]
 
-        if not decompose and len(bases) == 1 and powers == [1]:
-            # Short-cut
+        if not decompose and len(bases) == 1:
+            # Short-cut; with one unit there's no expand and gather.
             unit = bases[0]
-            self._scale = sanitize_scale(scale * unit.scale)
-            self._bases = unit.bases
-            self._powers = unit.powers
+            power = powers[0]
+            if power == 1:
+                scale *= unit.scale
+                self._bases = unit.bases
+                self._powers = unit.powers
+            elif power == 0:
+                self._bases = []
+                self._powers = []
+            else:
+                scale *= unit.scale ** power
+                self._bases = unit.bases
+                self._powers = [operator.mul(*resolve_fractions(p, power))
+                                for p in unit.powers]
+            self._scale = sanitize_scale(scale)
         else:
             self._scale = scale
             self._bases = bases

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -252,8 +252,10 @@ def resolve_fractions(a, b):
     This ensures that any operation involving a Fraction will use
     rational arithmetic and preserve precision.
     """
-    a_is_fraction = isinstance(a, Fraction)
-    b_is_fraction = isinstance(b, Fraction)
+    a_is_fraction = (a.__class__ is not int and a.__class__ is not float and
+                     isinstance(a, Fraction))
+    b_is_fraction = (b.__class__ is not int and b.__class__ is not float and
+                     isinstance(b, Fraction))
     if a_is_fraction and not b_is_fraction:
         b = Fraction(b)
     elif not a_is_fraction and b_is_fraction:

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -178,6 +178,8 @@ def sanitize_scale(scale):
     if scale.__class__ is float:
         return scale
 
+    # All classes that scale can be (int, float, complex, Fraction)
+    # have an "imag" attribute.
     if scale.imag:
         if abs(scale.real) > abs(scale.imag):
             if is_effectively_unity(scale.imag/scale.real + 1):
@@ -252,6 +254,8 @@ def resolve_fractions(a, b):
     This ensures that any operation involving a Fraction will use
     rational arithmetic and preserve precision.
     """
+    # We short-circuit on the most common cases of int and float, since
+    # isinstance(a, Fraction) is very slow for any non-Fraction instances.
     a_is_fraction = (a.__class__ is not int and a.__class__ is not float and
                      isinstance(a, Fraction))
     b_is_fraction = (b.__class__ is not int and b.__class__ is not float and

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -174,18 +174,22 @@ def sanitize_scale(scale):
     if is_effectively_unity(scale):
         return 1.0
 
-    if np.iscomplex(scale):  # scale is complex
-        if scale == 0.0:
-            return 0.0
+    # Maximum speed for regular case where scale is a float.
+    if scale.__class__ is float:
+        return scale
 
+    if scale.imag:
         if abs(scale.real) > abs(scale.imag):
             if is_effectively_unity(scale.imag/scale.real + 1):
-                scale = scale.real
-        else:
-            if is_effectively_unity(scale.real/scale.imag + 1):
-                scale = complex(0., scale.imag)
+                return scale.real
 
-    return scale
+        elif is_effectively_unity(scale.real/scale.imag + 1):
+            return complex(0., scale.imag)
+
+        return scale
+
+    else:
+        return scale.real
 
 
 def validate_power(p, support_tuples=False):


### PR DESCRIPTION
With this PR, the call that gets done in creating prefix units:
```
import astropy.units as u
%timeit u.CompositeUnit(1.e-9, [u.m], [1], _error_check=False)
# 100000 loops, best of 3: 6.77 -> 1.05 µs per loop
```
As this is done a lot during import, it reduces the `import astropy.units` time by 20% (only the units part, not including the `astropy` part).

EDIT: I carried on a bit with this. Now:
```
%timeit u.m / u.s**2
10000 loops, best of 3: 17.3 -> 8.3 µs per loop
```
Import time reduced from 0.118 to 0.088 s
(Measured by `python -X importtime -c "import astropy; import astropy.units"` and looking at just the `astropy.units` part).