### PR TITLE
Introduce | as the operator to get Quantity views of arrays.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -138,6 +138,12 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- To simplify fast creation of ``Quantity`` instances from arrays, one can now
+  write ``array | unit`` (equivalent to ``Quantity(array, unit, copy=False)``).
+  If ``array`` is already a ``Quantity``, this will convert the quantity to the
+  requested units; in-place conversion can be done with ``quantity |= unit``.
+  [#7652]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -716,6 +716,13 @@ class UnitBase(metaclass=InheritDocstrings):
         except TypeError:
             return NotImplemented
 
+    def __ror__(self, m):
+        try:
+            from .quantity import Quantity
+            return Quantity(m, self, copy=False, subok=True)
+        except Exception:
+            return NotImplemented
+
     def __hash__(self):
         # This must match the hash used in CompositeUnit for a unit
         # with only one base and no scale or power.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -890,6 +890,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         else:
             self.view(np.ndarray)[...] *= factor
 
+        self._set_unit(other)
         return self
 
     def __ror__(self, other):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -17,7 +17,7 @@ import numpy as np
 
 # AstroPy
 from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
-                   UnitBase, UnitsError, UnitTypeError)
+                   UnitBase, UnitsError, UnitConversionError, UnitTypeError)
 from .utils import is_effectively_unity
 from .format.latex import Latex
 from ..utils.compat import NUMPY_LT_1_14
@@ -860,6 +860,42 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return True
         except TypeError:
             return NotImplemented
+
+    # Unit conversion operator (|).
+    def __or__(self, other):
+        try:
+            other = Unit(other, parse_strict='silent')
+        except UnitTypeError:
+            return NotImplemented
+
+        return self.__class__(self, other, copy=False, subok=True)
+
+    def __ior__(self, other):
+        try:
+            other = Unit(other, parse_strict='silent')
+        except UnitTypeError:
+            return NotImplemented
+
+        try:
+            factor = self.unit._to(other)
+        except UnitConversionError:
+            # Maybe via equivalencies?  Now we do make a temporary copy.
+            try:
+                value = self._to_value(other)
+            except UnitConversionError:
+                return NotImplemented
+
+            self.view(np.ndarray)[...] = value
+
+        else:
+            self.view(np.ndarray)[...] *= factor
+
+        return self
+
+    def __ror__(self, other):
+        if not self.isscalar:
+            return NotImplemented
+        return Unit(self).__ror__(other)
 
     # Arithmetic operations
     def __mul__(self, other):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -260,6 +260,52 @@ class TestQuantityCreation:
         with pytest.raises(TypeError):
             u.Quantity(mylookalike)
 
+    def test_creation_via_view(self):
+        # This works but is no better than 1. * u.m
+        q1 = 1. | u.m
+        assert isinstance(q1, u.Quantity)
+        assert q1.unit == u.m
+        assert q1.value == 1.
+        # With an array, we get an acual view.
+        a2 = np.arange(10.)
+        q2 = a2 | u.m / u.s
+        assert isinstance(q2, u.Quantity)
+        assert q2.unit == u.m / u.s
+        assert np.all(q2.value == a2)
+        a2[9] = 0.
+        assert np.all(q2.value == a2)
+        # But with a unit change we get a copy.
+        q3 = q2 | u.mm / u.s
+        assert isinstance(q3, u.Quantity)
+        assert q3.unit == u.mm / u.s
+        assert np.all(q3.value == a2 * 1000.)
+        a2[8] = 0.
+        assert q3[8].value == 8000.
+        # Without a unit change, we do get a view.
+        q4 = q2 | q2.unit
+        a2[7] = 0.
+        assert np.all(q4.value == a2)
+        with pytest.raises(u.UnitsError):
+            q2 | u.s
+        # But one can do an in-place unit change.
+        a2_copy = a2.copy()
+        q2 |= u.mm / u.s
+        # Of course, this changes a2 as well.
+        assert np.all(q2.value == a2)
+        # Sanity check on the values.
+        assert np.all(q2.value == a2_copy * 1000.)
+        a2[8] = -1.
+        # Using quantities, one can also work with strings.
+        q5 = q2 | 'km/hr'
+        assert q5.unit == u.km / u.hr
+        assert np.all(q5 == q2)
+        # Finally, we can use scalar quantities as units.
+        not_quite_a_foot = 30. * u.cm
+        a6 = np.arange(5.)
+        q6 = a6 | not_quite_a_foot
+        assert q6.unit == u.Unit(not_quite_a_foot)
+        assert np.all(q6.to_value(u.cm) == 30. * a6)
+
 
 class TestQuantityOperations:
     q1 = u.Quantity(11.42, u.meter)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -290,6 +290,7 @@ class TestQuantityCreation:
         # But one can do an in-place unit change.
         a2_copy = a2.copy()
         q2 |= u.mm / u.s
+        assert q2.unit == u.mm / u.s
         # Of course, this changes a2 as well.
         assert np.all(q2.value == a2)
         # Sanity check on the values.


### PR DESCRIPTION
As well as possibly in-place unit conversion of Quantities. Following https://github.com/astropy/astropy/issues/3174#issuecomment-404802610 and https://github.com/astropy/astropy/issues/3174#issuecomment-404875614.

Timings:
```
a = np.arange(100000.)
%timeit a * u.m
# 10000 loops, best of 5: 36.8 µs per loop
%timeit a | u.m
# 100000 loops, best of 5: 4.73 µs per loop
```
To get a sense of how it should behave otherwise, here are the relevant tests.
```
    def test_creation_via_view(self):
        # This works but is no better than 1. * u.m
        q1 = 1. | u.m
        assert isinstance(q1, u.Quantity)
        assert q1.unit == u.m
        assert q1.value == 1.
        # With an array, we get an acual view.
        a2 = np.arange(10.)
        q2 = a2 | u.m / u.s
        assert isinstance(q2, u.Quantity)
        assert q2.unit == u.m / u.s
        assert np.all(q2.value == a2)
        a2[9] = 0.
        assert np.all(q2.value == a2)
        # But with a unit change we get a copy.
        q3 = q2 | u.mm / u.s
        assert isinstance(q3, u.Quantity)
        assert q3.unit == u.mm / u.s
        assert np.all(q3.value == a2 * 1000.)
        a2[8] = 0.
        assert q3[8].value == 8000.
        # Without a unit change, we do get a view.
        q4 = q2 | q2.unit
        a2[7] = 0.
        assert np.all(q4.value == a2)
        with pytest.raises(u.UnitsError):
            q2 | u.s
        # But one can do an in-place unit change.
        a2_copy = a2.copy()
        q2 |= u.mm / u.s
        # Of course, this change a2 as well.
        assert np.all(q2.value == a2)
        # Sanity check on the values.
        assert np.all(q2.value == a2_copy * 1000.)
        a2[8] = -1.
        # Using quantities, one can also work with strings.
        q5 = q2 | 'km/hr'
        assert q5.unit == u.km / u.hr
        assert np.all(q5 == q2)
        # Finally, we can use scalar quantities as units.
        not_quite_a_foot = 30. * u.cm
        a6 = np.arange(5.)
        q6 = a6 | not_quite_a_foot
        assert q6.unit == u.Unit(not_quite_a_foot)
        assert np.all(q6.to_value(u.cm) == 30. * a6)
```