### PR TITLE
Make relative humidity a QuantityAttribute.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1142,12 +1142,16 @@ astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
 - Correct data type conversion for non-float masked kernels. [#7542]
+
 - Fix non-float or masked, zero sum kernels when ``normalize_kernel=False``.
   Non-floats would yeild a type error and masked kernels were not being filled.
   [#7541]
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- Ensure that relative humidities can be given as Quantities, rather than take
+  any quantity and just strip its unit. [#7668]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -306,7 +306,7 @@ class QuantityAttribute(Attribute):
         if np.all(value == 0) and self.unit is not None:
             return u.Quantity(np.zeros(self.shape), self.unit), True
         else:
-            if not hasattr(value, 'unit'):
+            if not hasattr(value, 'unit') and self.unit != u.dimensionless_unscaled:
                 raise TypeError('Tried to set a QuantityAttribute with '
                                 'something that does not have a unit.')
             oldvalue = value

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -52,9 +52,9 @@ doc_footer = """
     temperature : `~astropy.units.Quantity`
         The ground-level temperature as an `~astropy.units.Quantity` in
         deg C.  This is necessary for performing refraction corrections.
-    relative_humidity`` : numeric
-        The relative humidity as a number from 0 to 1.  This is necessary for
-        performing refraction corrections.
+    relative_humidity`` : `~astropy.units.Quantity` or number.
+        The relative humidity as a dimensionless quantity between 0 to 1.
+        This is necessary for performing refraction corrections.
     obswl : `~astropy.units.Quantity`
         The average wavelength of observations as an `~astropy.units.Quantity`
          with length units.  This is necessary for performing refraction
@@ -98,7 +98,7 @@ class AltAz(BaseCoordinateFrame):
     location = EarthLocationAttribute(default=None)
     pressure = QuantityAttribute(default=0, unit=u.hPa)
     temperature = QuantityAttribute(default=0, unit=u.deg_C)
-    relative_humidity = Attribute(default=0)
+    relative_humidity = QuantityAttribute(default=0, unit=u.dimensionless_unscaled)
     obswl = QuantityAttribute(default=1*u.micron, unit=u.micron)
 
     def __init__(self, *args, **kwargs):

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -60,7 +60,7 @@ def cirs_to_altaz(cirs_coo, altaz_frame):
                          # all below are already in correct units because they are QuantityFrameAttribues
                          altaz_frame.pressure.value,
                          altaz_frame.temperature.value,
-                         altaz_frame.relative_humidity,
+                         altaz_frame.relative_humidity.value,
                          altaz_frame.obswl.value)
 
     az, zen, _, _, _ = erfa.atioq(cirs_ra, cirs_dec, astrom)
@@ -100,7 +100,7 @@ def altaz_to_cirs(altaz_coo, cirs_frame):
                          # all below are already in correct units because they are QuantityFrameAttribues
                          altaz_coo.pressure.value,
                          altaz_coo.temperature.value,
-                         altaz_coo.relative_humidity,
+                         altaz_coo.relative_humidity.value,
                          altaz_coo.obswl.value)
 
     # the 'A' indicates zen/az inputs

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -512,7 +512,7 @@ def test_repr_altaz():
     assert repr(sc4).startswith("<SkyCoord (AltAz: obstime=2005-03-21 00:00:00.000, "
                          "location=(-2309223.0, -3695529.0, "
                                 "-4641767.0) m, pressure=0.0 hPa, "
-                         "temperature=0.0 deg_C, relative_humidity=0, "
+                         "temperature=0.0 deg_C, relative_humidity=0.0, "
                          "obswl=1.0 micron): (az, alt, distance) in "
                          "(deg, deg, m)\n")
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -219,7 +219,7 @@ Similar broadcasting happens if you transform to another frame.  E.g.::
     ...            obstime=['2012-03-21T00:00:00', '2012-06-21T00:00:00'])
     >>> lcoo = coo.transform_to(lf)  # this can load finals2000A.all # doctest: +IGNORE_OUTPUT
     >>> lcoo  # doctest: +FLOAT_CMP
-    <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
+    <AltAz Coordinate (obstime=['2012-03-21T00:00:00.000' '2012-06-21T00:00:00.000'], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
         [( 94.71264944, 89.21424252), (307.69488825, 37.98077771)]>
 
 Above, the shapes -- ``()`` for ``coo`` and ``(2,)`` for ``lf`` -- were
@@ -242,7 +242,7 @@ set of coordinates, you'd need to make sure that the shapes allowed this::
     <AltAz Coordinate (obstime=[['2012-03-21T00:00:00.000' '2012-03-21T00:00:00.000'
       '2012-03-21T00:00:00.000']
      ['2012-06-21T00:00:00.000' '2012-06-21T00:00:00.000'
-      '2012-06-21T00:00:00.000']], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0, obswl=1.0 micron): (az, alt) in deg
+      '2012-06-21T00:00:00.000']], location=(3980608.9024681724, -102.47522910648239, 4966861.273100675) m, pressure=0.0 hPa, temperature=0.0 deg_C, relative_humidity=0.0, obswl=1.0 micron): (az, alt) in deg
         [[( 93.09845202, 89.21613119), (126.85789652, 25.46600543),
           ( 51.37993229, 37.18532521)],
          [(307.71713699, 37.99437658), (231.37407871, 26.36768329),


### PR DESCRIPTION
This ensures that one can pass in a dimensionless quantity without getting problems with the erfa ufuncs, and also stops being passed in a quantity with a wrong unit (which is why I labeled this as a bug that should be backported). For backwards compatibility, passing in regular numbers remains possible; they are just converted to dimensionless.

fixes #7665