### PR TITLE
Accept non-unit type annotations in @quantity_input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- Accept non-unit type annotations in @quantity_input. [#7672]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -23,8 +23,10 @@ def _get_allowed_units(targets):
         try:  # unit passed in as a string
             target_unit = Unit(target)
 
-        except ValueError:
+        except TypeError:  # unable to convert to target_unit
+            target_unit = target
 
+        except ValueError:
             try:  # See if the function writer specified a physical type
                 physical_type_id = _unit_physical_mapping[target]
 
@@ -50,8 +52,12 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
 
     for allowed_unit in allowed_units:
         try:
-            is_equivalent = arg.unit.is_equivalent(allowed_unit,
-                                                   equivalencies=equivalencies)
+            # any other annotation was provided except for ``astropy.unit``
+            if inspect.isclass(allowed_unit):
+                is_equivalent = True
+            else:
+                is_equivalent = arg.unit.is_equivalent(allowed_unit,
+                                                       equivalencies=equivalencies)
 
             if is_equivalent:
                 break

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -283,6 +283,28 @@ def test_default_value_check():
     assert x.unit == x_unit
 
 
+def test_str_unit_typo():
+    @u.quantity_input
+    def myfunc_args(x: "kilograam"):
+        return x
+
+    with pytest.raises(ValueError):
+        result = myfunc_args(u.kg)
+
+
+def test_type_annotations():
+    @u.quantity_input
+    def myfunc_args(x: u.m, y: str):
+        return x, y
+
+    in_quantity = 2 * u.m
+    in_string = "cool string"
+
+    quantity, string = myfunc_args(in_quantity, in_string)
+    assert quantity == in_quantity
+    assert string == in_string
+
+
 def test_args_None():
     x_target = u.deg
     x_unit = u.arcsec

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -420,6 +420,15 @@ Under Python 3 you can use the annotations syntax to provide the units:
     >>> myfunction(100*u.arcsec)  # doctest: +SKIP
     Unit("arcsec")
 
+You can also annotate for different types in non-unit expecting arguments:
+
+    >>> @u.quantity_input  # doctest: +SKIP
+    ... def myfunction(myarg: u.arcsec, nice_string: str):
+    ...     return myarg.unit, nice_string
+
+    >>> myfunction(100*u.arcsec, "a nice string")  # doctest: +SKIP
+    (Unit("arcsec"), 'a nice string')
+
 Also under Python 3 only you can define a return decoration, to which the return
 value will be converted, i.e.::
 


### PR DESCRIPTION
Closes #7661.

Instead of raising an error, `@quantity_input` will skip any non-unit type annotations in function parameters. So, code such as below won't result in an error:

```python
>>> import astropy.units as u

>>> @u.quantity_input
... def f(x: u.m, y: str) -> u.m:
...    return x

>>> f(1 * u.m, 'x')
<Quantity 1. m>
# this would otherwise give
# TypeError: <class 'str'> can not be converted to a Unit
```

It will however, raise a `ValueError` in cases like these:
```python
>>> import astropy.units as u

>>> @u.quantity_input
... # consider the typo "kilogrammm" instead of "kilogram"
... def f(x: u.m, y: "kilogrammm") -> u.m:
...    return x

>>> f(1 * u.m, 2 * u.kg)
ValueError: Invalid unit or physical type 'kilogrammm'.
```

TLDR; @quantity_input now ignores any parameter in function definition which is non-unit type annotated, but will raise a `ValueError` if a string is passed and `Unit(string)` is unable to parse it (like above example).