### PR TITLE
Fix running test suite with coverage enabled on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,8 +136,6 @@ astropy.tests
 - Added an option ``--readonly`` to the test command to change the
   permissions on the temporary installation location to read-only. [#7598]
 
-- Fix running ``./setup.py test --coverage`` on Windows machines. [#7673]
-
 astropy.time
 ^^^^^^^^^^^^
 
@@ -1203,6 +1201,8 @@ astropy.table
 
 astropy.tests
 ^^^^^^^^^^^^^
+
+- Fixed bug in ``python setup.py test --coverage`` on Windows machines. [#7673]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,8 @@ astropy.tests
 - Added an option ``--readonly`` to the test command to change the
   permissions on the temporary installation location to read-only. [#7598]
 
+- Fix running ``./setup.py test --coverage`` on Windows machines. [#7673]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -344,13 +344,13 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
         cmd_pre = (
             'import coverage; '
-            'cov = coverage.coverage(data_file="{0}", config_file="{1}"); '
+            'cov = coverage.coverage(data_file=r"{0}", config_file=r"{1}"); '
             'cov.start();'.format(
-                os.path.abspath(".coverage"), tmp_coveragerc))
+                os.path.abspath(".coverage"), os.path.abspath(tmp_coveragerc)))
         cmd_post = (
             'cov.stop(); '
             'from astropy.tests.helper import _save_coverage; '
-            '_save_coverage(cov, result, "{0}", "{1}");'.format(
-                os.path.abspath('.'), self.testing_path))
+            '_save_coverage(cov, result, r"{0}", r"{1}");'.format(
+                os.path.abspath('.'), os.path.abspath(self.testing_path)))
 
         return cmd_pre, cmd_post


### PR DESCRIPTION
There is a bug where running `./setup.py test` with `--coverage` causes a `SyntaxError` on Windows. Check out PlasmaPy/PlasmaPy#516 for more info.

This PR fixes it by passing the path as raw strings.