### PR TITLE
Put the frame transform graph in a div with a class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,6 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-Added the container directive in order to wrap all graphs in a div, done deliberatley so that the sunpy sphinx theme can write css for the container to style it differently. [#7121]
 
 - The new function ``make_transform_graph_docs`` can be used to create a
   docstring graph from a custom ``TransformGraph`` object. [#7135]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+Added the container directive in order to wrap all graphs in a div, done deliberatley so that the sunpy sphinx theme can write css for the container to style it differently. [#7121]
 
 - The new function ``make_transform_graph_docs`` can be used to create a
   docstring graph from a custom ``TransformGraph`` object. [#7135]

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -100,12 +100,13 @@ def make_transform_graph_docs(transform_graph):
     frames) is set by the type of transformation; the legend box defines the
     mapping from transform class name to color.
 
+    .. container:: gvcustom
 
-    .. graphviz::
+        .. graphviz::
 
     """
 
-    docstr = dedent(docstr) + '    ' + graphstr.replace('\n', '\n    ')
+    docstr = dedent(docstr) + '        ' + graphstr.replace('\n', '\n        ')
 
     # colors are in dictionary at the bottom of transformations.py
     from ..transformations import trans_to_color

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -100,7 +100,8 @@ def make_transform_graph_docs(transform_graph):
     frames) is set by the type of transformation; the legend box defines the
     mapping from transform class name to color.
 
-    .. container:: gvcustom
+    .. Wrap the graph in a div with a custom class to allow themeing.
+    .. container:: frametransformgraph
 
         .. graphviz::
 


### PR DESCRIPTION
This is an update to #7121 

The idea of this is to allow sphinx themes to provide custom css for the frame transform graph by putting it in a div with a class that can be themed. We would like this for SunPy.

ping @adrn 