### PR TITLE
Add LaTeX complex numbers representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,8 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- Add complex numbers support for ``Quantity._repr_latex_``. [#7676]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1088,8 +1088,16 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return Latex.format_exponential_notation(value,
                                                      format_spec=format_spec)
 
+        def complex_formatter(value):
+            return '({0}{1}i)'.format(
+                Latex.format_exponential_notation(value.real,
+                                                  format_spec=format_spec),
+                Latex.format_exponential_notation(value.imag,
+                                                  format_spec='+' + format_spec))
+
         try:
-            formatter = {'float_kind': float_formatter}
+            formatter = {'float_kind': float_formatter,
+                         'complex_kind': complex_formatter}
             if conf.latex_array_threshold > -1:
                 np.set_printoptions(threshold=conf.latex_array_threshold,
                                     formatter=formatter)
@@ -1099,6 +1107,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                 latex_value = np.array2string(
                     self.view(np.ndarray),
                     style=(float_formatter if self.dtype.kind == 'f'
+                           else complex_formatter if self.dtype.kind == 'c'
                            else repr),
                     max_line_width=np.inf, separator=',~')
             else:

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -760,6 +760,12 @@ class TestQuantityDisplay:
     scalarfloatq = u.Quantity(1.3, unit='m')
     arrq = u.Quantity([1, 2.3, 8.9], unit='m')
 
+    scalar_complex_q = u.Quantity(complex(1.0, 2.0))
+    scalar_big_complex_q = u.Quantity(complex(1.0, 2.0e27) * 1e25)
+    scalar_big_neg_complex_q = u.Quantity(complex(-1.0, -2.0e27) * 1e36)
+    arr_complex_q = u.Quantity(np.arange(3) * (complex(-1.0, -2.0e27) * 1e36))
+    big_arr_complex_q = u.Quantity(np.arange(125) * (complex(-1.0, -2.0e27) * 1e36))
+
     def test_dimensionless_quantity_repr(self):
         q2 = u.Quantity(1., unit='m-1')
         q3 = u.Quantity(1, unit='m-1', dtype=int)
@@ -824,6 +830,17 @@ class TestQuantityDisplay:
         assert (q2scalar._repr_latex_() ==
                 r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$')
         assert self.arrq._repr_latex_() == r'$[1,~2.3,~8.9] \; \mathrm{m}$'
+
+        # Complex quantities
+        assert self.scalar_complex_q._repr_latex_() == r'$(1+2i) \; \mathrm{}$'
+        assert (self.scalar_big_complex_q._repr_latex_() ==
+                r'$(1 \times 10^{25}+2 \times 10^{52}i) \; \mathrm{}$')
+        assert (self.scalar_big_neg_complex_q._repr_latex_() ==
+                r'$(-1 \times 10^{36}-2 \times 10^{63}i) \; \mathrm{}$')
+        assert (self.arr_complex_q._repr_latex_() ==
+                (r'$[(0-0i),~(-1 \times 10^{36}-2 \times 10^{63}i),'
+                 r'~(-2 \times 10^{36}-4 \times 10^{63}i)] \; \mathrm{}$'))
+        assert r'\dots' in self.big_arr_complex_q._repr_latex_()
 
         qmed = np.arange(100)*u.m
         qbig = np.arange(1000)*u.m


### PR DESCRIPTION
Complex numbers are presented by Quantity::_repr_latex_() as (real +- imag i), where real and imag parts are represented by Latex.format_exponential_notation.