### PR TITLE
Rename vo.client.async to vo.client.vo_async

### DIFF
--- a/astropy/vo/client/conesearch.py
+++ b/astropy/vo/client/conesearch.py
@@ -11,7 +11,7 @@ import numpy as np
 
 # LOCAL
 from . import vos_catalog
-from .async import AsyncBase
+from .vo_async import AsyncBase
 from .exceptions import ConeSearchError, VOSError
 from ... import units as u
 from ...coordinates import (ICRS, BaseCoordinateFrame, Longitude, Latitude,
@@ -39,7 +39,7 @@ class AsyncConeSearch(AsyncBase):
 
     .. note::
 
-        See `~astropy.vo.client.async.AsyncBase` for more details.
+        See `~astropy.vo.client.vo_async.AsyncBase` for more details.
 
     Parameters
     ----------
@@ -201,7 +201,7 @@ class AsyncSearchAll(AsyncBase):
 
     .. note::
 
-        See `~astropy.vo.client.async.AsyncBase` for more details.
+        See `~astropy.vo.client.vo_async.AsyncBase` for more details.
 
     Parameters
     ----------

--- a/astropy/vo/client/tests/test_conesearch.py
+++ b/astropy/vo/client/tests/test_conesearch.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""Tests for `astropy.vo.client.conesearch` and `astropy.vo.client.async`."""
+"""Tests for `astropy.vo.client.conesearch` and `astropy.vo.client.vo_async`."""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 

--- a/astropy/vo/client/vo_async.py
+++ b/astropy/vo/client/vo_async.py
@@ -11,7 +11,7 @@ __all__ = ['AsyncBase']
 
 
 @deprecated(
-    '2.0', alternative='astroquery.vo_conesearch.async.AsyncBase')
+    '2.0', alternative='astroquery.vo_conesearch.vo_async.AsyncBase')
 class AsyncBase(object):
     """Base class for asynchronous VO service requests
     using :py:class:`concurrent.futures.ThreadPoolExecutor`.

--- a/docs/vo/conesearch/index.rst
+++ b/docs/vo/conesearch/index.rst
@@ -190,7 +190,7 @@ Reference/API
 .. automodapi:: astropy.vo.client.conesearch
    :no-inheritance-diagram:
 
-.. automodapi:: astropy.vo.client.async
+.. automodapi:: astropy.vo.client.vo_async
    :no-inheritance-diagram:
 
 .. automodapi:: astropy.vo.client.exceptions


### PR DESCRIPTION
This change has already been done in astroquery (https://github.com/astropy/astroquery/pull/1185/), copying over it to the deprecated core module to be python 3.7 compatible.