### PR TITLE
Adding workaround for erf ufunc

### DIFF
--- a/astropy/units/quantity_helper.py
+++ b/astropy/units/quantity_helper.py
@@ -124,6 +124,9 @@ UFUNC_HELPERS[np.log10] = helper_dimensionless_to_dimensionless
 UFUNC_HELPERS[np.log2] = helper_dimensionless_to_dimensionless
 UFUNC_HELPERS[np.log1p] = helper_dimensionless_to_dimensionless
 
+if isinstance(getattr(np.core.umath, 'erf', None), np.ufunc):
+    UFUNC_HELPERS[np.core.umath.erf] = helper_dimensionless_to_dimensionless
+
 
 def helper_modf(f, unit):
     if unit is None:


### PR DESCRIPTION
Following the logic of #7058 without relying on the refactoring happened in 3.0

This should fix the travis failure here:
https://travis-ci.org/astropy/astropy/jobs/408122076#L4852


```
self = <astropy.units.tests.test_quantity_ufuncs.TestUfuncCoverage object at 0x7f7e7f23f9b0>
    @pytest.mark.skipif(HAS_SCIPY,
                        reason='scipy.special coverage is incomplete')
    def test_coverage(self):
        all_np_ufuncs = set([ufunc for ufunc in np.core.umath.__dict__.values()
                             if type(ufunc) == np.ufunc])
    
        from .. import quantity_helper as qh
    
        all_q_ufuncs = (qh.UNSUPPORTED_UFUNCS |
                        set(qh.UFUNC_HELPERS.keys()))
    
>       assert all_np_ufuncs - all_q_ufuncs == set([])
E       AssertionError: assert {<ufunc 'erf'>} == set()
E         Extra items in the left set:
E         <ufunc 'erf'>
E         Use -v to get the full diff
```