### PR TITLE
Fixed WCS utilities when axes are swapped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1238,6 +1238,9 @@ astropy.wcs
   ``WCS`` coordinate transformations depending on the position of the slice
   relative to ``WCS.wcs.crpix``. [#7556, #7550]
 
+- Fixed a bug that caused ``wcs_to_celestial_frame``, ``skycoord_to_pixel``, and
+  ``pixel_to_skycoord`` to raise an error if the axes of the celestial WCS were
+  swapped. [#7691]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .. import units as u
 
-from .wcs import WCS, WCSSUB_CELESTIAL
+from .wcs import WCS, WCSSUB_LONGITUDE, WCSSUB_LATITUDE
 
 __doctest_skip__ = ['wcs_to_celestial_frame', 'celestial_frame_to_wcs']
 
@@ -51,7 +51,7 @@ def _wcs_to_celestial_frame_builtin(wcs):
     from ..time import Time
 
     # Keep only the celestial part of the axes
-    wcs = wcs.sub([WCSSUB_CELESTIAL])
+    wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE])
 
     if wcs.wcs.lng == -1 or wcs.wcs.lat == -1:
         return None
@@ -524,7 +524,7 @@ def skycoord_to_pixel(coords, wcs, origin=0, mode='all'):
         raise ValueError("Can only handle WCS with distortions for 2-dimensional WCS")
 
     # Keep only the celestial part of the axes, also re-orders lon/lat
-    wcs = wcs.sub([WCSSUB_CELESTIAL])
+    wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE])
 
     if wcs.naxis != 2:
         raise ValueError("WCS should contain celestial component")
@@ -606,7 +606,7 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
         raise ValueError("Can only handle WCS with distortions for 2-dimensional WCS")
 
     # Keep only the celestial part of the axes, also re-orders lon/lat
-    wcs = wcs.sub([WCSSUB_CELESTIAL])
+    wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE])
 
     if wcs.naxis != 2:
         raise ValueError("WCS should contain celestial component")


### PR DESCRIPTION
It turns out ``WCSSUB_CELESTIAL`` does not always re-order axes so we need to do the re-ordering explicitly using ``WCSSUB_LONGITUDE`` and ``WCSSUB_LATITUDE``

<s>Not sure if this should be 3.0.4 or 3.0.5?</s>I'm silly, it should be 2.0.8