### PR TITLE
Added documentation on using transform and coord_meta in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -172,6 +172,8 @@ astropy.visualization
   False for degrees and hours and True otherwise), and ``show_decimal_unit`` can be used to
   determine whether the units should be shown for decimal labels. [#7318]
 
+- Added documentation for ``transform=`` and ``coord_meta=``. [#7698]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/docs/visualization/wcsaxes/generic_transforms.rst
+++ b/docs/visualization/wcsaxes/generic_transforms.rst
@@ -1,0 +1,71 @@
+*******************************************
+Initializing WCSAxes with custom transforms
+*******************************************
+
+In :ref:`initialization`, we saw how to make plots using
+:class:`~astropy.wcs.WCS` objects. However, the
+:class:`~astropy.visualization.wcsaxes.WCSAxes` class can also be initialized
+with more general transformations that don't have to be represented by the
+:class:`~astropy.wcs.WCS` class. Instead, you can initialize
+:class:`~astropy.visualization.wcsaxes.WCSAxes` using a Matplotlib
+:class:`~matplotlib.transforms.Transform` object and a dictionary
+(``coord_meta``) that provides metadata on how to interpret the transformation.
+
+The :class:`~matplotlib.transforms.Transform` should represent the conversion
+from pixel to world coordinates, and should have ``input_dims=2`` and
+``output_dims=2``. In addition, ``has_inverse`` should be set to `True` and
+the ``inverted`` method should be implemented.
+
+The ``coord_meta`` dictionary should include the following keys:
+
+* ``name``: an iterable of two strings giving the names for each dimension
+* ``type``: an iterable of two strings that should be either ``'longitude'``,
+  ``'latitude'``, or ``'scalar'`` (for anything that isn't a longitude or latitude).
+* ``wrap``: an iterable of two values which indicate for longitudes at which
+  angle (in degrees) to wrap the coordinates. This should be `None` unless
+  ``type`` is ``'longitude'``.
+* ``unit``: an iterable of two :class:`~astropy.units.Unit` objects giving the
+  units of the world coordinates returned by the
+  :class:`~matplotlib.transforms.Transform`.
+* ``format_unit``: an iterable of two :class:`~astropy.units.Unit` objects
+  giving the units to use for the formatting of the labels. These can be set to
+  `None` to default to the units given in ``unit``, but can be set for example
+  if the :class:`~matplotlib.transforms.Transform` returns values in degrees
+  and you want the labels should be formatted in hours.
+
+The following example illustrates a custom projection using a transform and
+``coord_meta``:
+
+.. plot::
+   :context: reset
+   :include-source:
+   :align: center
+
+    from astropy import units as u
+    import matplotlib.pyplot as plt
+    from matplotlib.transforms import Affine2D
+    from astropy.visualization.wcsaxes import WCSAxes
+
+    # Set up an affine transformation
+    transform = Affine2D()
+    transform.scale(0.01)
+    transform.translate(40, -30)
+    transform.rotate(0.3)  # radians
+
+    # Set up metadata dictionary
+    coord_meta = {}
+    coord_meta['name'] = 'lon', 'lat'
+    coord_meta['type'] = 'longitude', 'latitude'
+    coord_meta['wrap'] = 180, None
+    coord_meta['unit'] = u.deg, u.deg
+    coord_meta['format_unit'] = None, None
+
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], aspect='equal',
+                 transform=transform, coord_meta=coord_meta)
+    fig.add_axes(ax)
+    ax.set_xlim(-0.5, 499.5)
+    ax.set_ylim(-0.5, 399.5)
+    ax.grid()
+    ax.coords['lon'].set_axislabel('Longitude')
+    ax.coords['lat'].set_axislabel('Latitude')

--- a/docs/visualization/wcsaxes/generic_transforms.rst
+++ b/docs/visualization/wcsaxes/generic_transforms.rst
@@ -31,7 +31,7 @@ The ``coord_meta`` dictionary should include the following keys:
   giving the units to use for the formatting of the labels. These can be set to
   `None` to default to the units given in ``unit``, but can be set for example
   if the :class:`~matplotlib.transforms.Transform` returns values in degrees
-  and you want the labels should be formatted in hours.
+  and you want the labels to be formatted in hours.
 
 The following example illustrates a custom projection using a transform and
 ``coord_meta``:

--- a/docs/visualization/wcsaxes/index.rst
+++ b/docs/visualization/wcsaxes/index.rst
@@ -4,8 +4,8 @@
 Making plots with world coordinates (WCSAxes)
 *********************************************
 
-WCSAxes is a framework for making plots of Astronomical data in 
-`Matplotlib <http://matplotlib.org/>`_. It was previously distributed 
+WCSAxes is a framework for making plots of Astronomical data in
+`Matplotlib <http://matplotlib.org/>`_. It was previously distributed
 as a standalone package, but is now included in
 :ref:`astropy.visualization <astropy-visualization>`.
 
@@ -40,7 +40,7 @@ package:
     plt.ylabel('Galactic Latitude')
 
 This example uses the :mod:`matplotlib.pyplot` interface to Matplotlib, but WCSAxes
-can be used with any of the other ways of using Matplotlib (some examples of which 
+can be used with any of the other ways of using Matplotlib (some examples of which
 are given in :ref:`initialization`). For example, using the partially object-oriented
 interface, you can do::
 
@@ -50,7 +50,7 @@ interface, you can do::
     ax.set_xlabel('Galactic Longitude')
     ax.set_ylabel('Galactic Latitude')
 
-However, the axes object is needed to access some of the more advanced functionality 
+However, the axes object is needed to access some of the more advanced functionality
 of WCSAxes.  An example of this usage is:
 
 .. plot::
@@ -94,6 +94,7 @@ Using WCSAxes
    overlaying_coordinate_systems
    slicing_datacubes
    controlling_axes
+   generic_transforms
    custom_frames
 
 Reference/API


### PR DESCRIPTION
@Cadair - could you review this? This is basically the API that you should use if you want to use e.g. GWCS.

In a separate PR, I will add support for defining the coordinate frame of the transform so that you can then do overlays with different coordinate systems, but for now I just wanted to document what is there currently.

The plot looks like:

![generic_transforms-1](https://user-images.githubusercontent.com/314716/43540386-7f1377ac-95bf-11e8-9989-0182aa16e348.png)
