### PR TITLE
Add quantity attribute to uncertainty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- ``NDUncertainty`` objects now have a ``quantity`` attribute for simple
+  conversion to quantities. [#7704]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -145,6 +145,13 @@ class NDUncertainty(metaclass=ABCMeta):
         return self._unit
 
     @property
+    def quantity(self):
+        """
+        This uncertainty as an `~astropy.units.Quantity` object.
+        """
+        return u.Quantity(self.array, self.unit, copy=False)
+
+    @property
     def parent_nddata(self):
         """`NDData` : reference to `NDData` instance with this uncertainty.
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -149,7 +149,7 @@ class NDUncertainty(metaclass=ABCMeta):
         """
         This uncertainty as an `~astropy.units.Quantity` object.
         """
-        return u.Quantity(self.array, self.unit, copy=False)
+        return Quantity(self.array, self.unit, copy=False)
 
     @property
     def parent_nddata(self):

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -149,7 +149,7 @@ class NDUncertainty(metaclass=ABCMeta):
         """
         This uncertainty as an `~astropy.units.Quantity` object.
         """
-        return Quantity(self.array, self.unit, copy=False)
+        return Quantity(self.array, self.unit, copy=False, dtype=self.array.dtype)
 
     @property
     def parent_nddata(self):

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -55,9 +55,9 @@ class FakeUncertainty(NDUncertainty):
 # Test the fake (added also StdDevUncertainty which should behave identical)
 
 # the list of classes used for parametrization in tests below
-paramet_uncert_classes = [FakeUncertainty, StdDevUncertainty, UnknownUncertainty]
+uncertainty_types_to_be_tested = [FakeUncertainty, StdDevUncertainty, UnknownUncertainty]
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_list(UncertClass):
     fake_uncert = UncertClass([1, 2, 3])
     assert_array_equal(fake_uncert.array, np.array([1, 2, 3]))
@@ -69,7 +69,7 @@ def test_init_fake_with_list(UncertClass):
     assert fake_uncert.unit is u.adu
 
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_ndarray(UncertClass):
     uncert = np.arange(100).reshape(10, 10)
     fake_uncert = UncertClass(uncert)
@@ -86,7 +86,7 @@ def test_init_fake_with_ndarray(UncertClass):
     assert fake_uncert.unit is u.adu
 
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_quantity(UncertClass):
     uncert = np.arange(10).reshape(2, 5) * u.adu
     fake_uncert = UncertClass(uncert)
@@ -105,7 +105,7 @@ def test_init_fake_with_quantity(UncertClass):
     assert fake_uncert.unit is u.m  # It took the explicit one
 
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_fake(UncertClass):
     uncert = np.arange(5).reshape(5, 1)
     fake_uncert1 = UncertClass(uncert)
@@ -131,7 +131,7 @@ def test_init_fake_with_fake(UncertClass):
     assert fake_uncert2.unit is u.cm
 
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_init_fake_with_somethingElse(UncertClass):
     # What about a dict?
     uncert = {'rdnoise': 2.9, 'gain': 0.6}
@@ -239,7 +239,7 @@ def test_for_stolen_uncertainty():
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data
 
 
-@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
+@pytest.mark.parametrize(('UncertClass'), uncertainty_types_to_be_tested)
 def test_quantity(UncertClass):
     fake_uncert = UncertClass([1, 2, 3], unit=u.adu)
     assert isinstance(fake_uncert.quantity, u.Quantity)

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -240,3 +240,15 @@ def test_for_stolen_uncertainty():
     ndd2 = NDData(2, uncertainty=ndd1.uncertainty)
     # uncertainty.parent_nddata.data should be the original data!
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data
+
+
+@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
+                                           UnknownUncertainty])
+def test_quantity(UncertClass):
+    fake_uncert = UncertClass([1, 2, 3], unit=u.adu)
+    assert isinstance(fake_uncert.quantity, u.Quantity)
+    assert fake_uncert.quantity.unit.is_equivalent(u.adu)
+
+    fake_uncert_nounit = UncertClass([1, 2, 3])
+    assert isinstance(fake_uncert_nounit.quantity, u.Quantity)
+    assert fake_uncert_nounit.quantity.unit.is_equivalent(u.dimensionless_unscaled)

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -54,9 +54,10 @@ class FakeUncertainty(NDUncertainty):
 
 # Test the fake (added also StdDevUncertainty which should behave identical)
 
+# the list of classes used for parametrization in tests below
+paramet_uncert_classes = [FakeUncertainty, StdDevUncertainty, UnknownUncertainty]
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_init_fake_with_list(UncertClass):
     fake_uncert = UncertClass([1, 2, 3])
     assert_array_equal(fake_uncert.array, np.array([1, 2, 3]))
@@ -68,8 +69,7 @@ def test_init_fake_with_list(UncertClass):
     assert fake_uncert.unit is u.adu
 
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_init_fake_with_ndarray(UncertClass):
     uncert = np.arange(100).reshape(10, 10)
     fake_uncert = UncertClass(uncert)
@@ -86,8 +86,7 @@ def test_init_fake_with_ndarray(UncertClass):
     assert fake_uncert.unit is u.adu
 
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_init_fake_with_quantity(UncertClass):
     uncert = np.arange(10).reshape(2, 5) * u.adu
     fake_uncert = UncertClass(uncert)
@@ -106,8 +105,7 @@ def test_init_fake_with_quantity(UncertClass):
     assert fake_uncert.unit is u.m  # It took the explicit one
 
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_init_fake_with_fake(UncertClass):
     uncert = np.arange(5).reshape(5, 1)
     fake_uncert1 = UncertClass(uncert)
@@ -133,8 +131,7 @@ def test_init_fake_with_fake(UncertClass):
     assert fake_uncert2.unit is u.cm
 
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_init_fake_with_somethingElse(UncertClass):
     # What about a dict?
     uncert = {'rdnoise': 2.9, 'gain': 0.6}
@@ -242,8 +239,7 @@ def test_for_stolen_uncertainty():
     assert ndd1.uncertainty.parent_nddata.data == ndd1.data
 
 
-@pytest.mark.parametrize(('UncertClass'), [FakeUncertainty, StdDevUncertainty,
-                                           UnknownUncertainty])
+@pytest.mark.parametrize(('UncertClass'), paramet_uncert_classes)
 def test_quantity(UncertClass):
     fake_uncert = UncertClass([1, 2, 3], unit=u.adu)
     assert isinstance(fake_uncert.quantity, u.Quantity)


### PR DESCRIPTION
This is a pretty straightforward thing - it just adds a `quantity` property to ``NDUncertainty`` so that any uncertainty can be easily converted to a quantity object (without unnecessary copying).