### PR TITLE
Use unique configuration variable for astropy cache in pytest plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1243,6 +1243,12 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Change the name of the configuration variable controlling the location of the
+  Astropy cache in the Pytest plugin from ``cache_dir`` to
+  ``astropy_cache_dir``. The command line flag also changed to
+  ``--astropy-cache-dir``.  This prevents a conflict with the ``cache_dir``
+  variable provided by pytest itself. [#7721]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1247,7 +1247,8 @@ astropy.tests
   Astropy cache in the Pytest plugin from ``cache_dir`` to
   ``astropy_cache_dir``. The command line flag also changed to
   ``--astropy-cache-dir``.  This prevents a conflict with the ``cache_dir``
-  variable provided by pytest itself. [#7721]
+  variable provided by pytest itself. Also made similar change to
+  ``config_dir`` option as a precaution. [#7721]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/plugins/config.py
+++ b/astropy/tests/plugins/config.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
                           "file other than the default can cause some tests "
                           "to fail unexpectedly")
 
-    parser.addoption("--cache-dir", nargs='?', type=writeable_directory,
+    parser.addoption("--astropy-cache-dir", nargs='?', type=writeable_directory,
                      help="specify directory for storing and retrieving the "
                           "Astropy cache during tests (default is "
                           "to use a temporary directory created by the test "
@@ -44,7 +44,7 @@ def pytest_addoption(parser):
                   "file other than the default can cause some tests "
                   "to fail unexpectedly", default=None)
 
-    parser.addini("cache_dir",
+    parser.addini("astropy_cache_dir",
                   "specify directory for storing and retrieving the "
                   "Astropy cache during tests (default is "
                   "to use a temporary directory created by the test "
@@ -55,11 +55,11 @@ def pytest_configure(config):
 
 def pytest_runtest_setup(item):
     config_dir = item.config.getini('config_dir')
-    cache_dir = item.config.getini('cache_dir')
+    cache_dir = item.config.getini('astropy_cache_dir')
 
     # Command-line options can override, however
     config_dir = item.config.getoption('config_dir') or config_dir
-    cache_dir = item.config.getoption('cache_dir') or cache_dir
+    cache_dir = item.config.getoption('astropy_cache_dir') or cache_dir
 
     # We can't really use context managers directly in py.test (although
     # py.test 2.7 adds the capability), so this may look a bit hacky

--- a/astropy/tests/plugins/config.py
+++ b/astropy/tests/plugins/config.py
@@ -23,7 +23,7 @@ import importlib.machinery as importlib_machinery
 
 def pytest_addoption(parser):
 
-    parser.addoption("--config-dir", nargs='?', type=writeable_directory,
+    parser.addoption("--astropy-config-dir", nargs='?', type=writeable_directory,
                      help="specify directory for storing and retrieving the "
                           "Astropy configuration during tests (default is "
                           "to use a temporary directory created by the test "
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
                           "Astropy cache during tests (default is "
                           "to use a temporary directory created by the test "
                           "runner)")
-    parser.addini("config_dir",
+    parser.addini("astropy_config_dir",
                   "specify directory for storing and retrieving the "
                   "Astropy configuration during tests (default is "
                   "to use a temporary directory created by the test "
@@ -54,11 +54,11 @@ def pytest_configure(config):
     treat_deprecations_as_exceptions()
 
 def pytest_runtest_setup(item):
-    config_dir = item.config.getini('config_dir')
+    config_dir = item.config.getini('astropy_config_dir')
     cache_dir = item.config.getini('astropy_cache_dir')
 
     # Command-line options can override, however
-    config_dir = item.config.getoption('config_dir') or config_dir
+    config_dir = item.config.getoption('astropy_config_dir') or config_dir
     cache_dir = item.config.getoption('astropy_cache_dir') or cache_dir
 
     # We can't really use context managers directly in py.test (although

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -423,14 +423,14 @@ a context manager within a test to temporarily set the cache to a custom
 location, or as a *decorator* that takes effect for an entire test function
 (not including setup or teardown, which would have to be decorated separately).
 
-Furthermore, it is possible to set an option ``cache_dir`` in the pytest
-config file which sets the cache location for the entire test run.  A
-``--cache-dir`` command-line option is also supported (which overrides all
-other settings).  Currently it is not directly supported by the
+Furthermore, it is possible to set an option ``astropy_cache_dir`` in the
+pytest config file which sets the cache location for the entire test run.  A
+``--astropy-cache-dir`` command-line option is also supported (which overrides
+all other settings).  Currently it is not directly supported by the
 ``./setup.py test`` command, so it is necessary to use it with the ``-a``
 argument like::
 
-    $ ./setup.py test -a "--cache-dir=/path/to/custom/cache/dir"
+    $ ./setup.py test -a "--astropy-cache-dir=/path/to/custom/cache/dir"
 
 
 Tests that create files


### PR DESCRIPTION
This fixes #7720.