### PR TITLE
Include license file in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,6 @@ exclude = extern,*parsetab.py,*lextab.py
 
 [pycodestyle]
 exclude = extern,*parsetab.py,*lextab.py
+
+[metadata]
+license_file = LICENSE.rst


### PR DESCRIPTION
Ref #7723

See also https://wheel.readthedocs.io/en/stable/#including-the-license-in-the-generated-wheel-file