### PR TITLE
TWO_OR_THREE_ARGS --> TWO_OR_MORE_ARGS in __all__ of wcs/_docutil.py

### DIFF
--- a/astropy/wcs/_docutil.py
+++ b/astropy/wcs/_docutil.py
@@ -5,7 +5,7 @@ astropy.wcs-specific utilities for generating boilerplate in docstrings.
 
 
 
-__all__ = ['TWO_OR_THREE_ARGS', 'RETURNS', 'ORIGIN', 'RA_DEC_ORDER']
+__all__ = ['RETURNS', 'ORIGIN', 'RA_DEC_ORDER']
 
 
 def _fix(content, indent=0):

--- a/astropy/wcs/_docutil.py
+++ b/astropy/wcs/_docutil.py
@@ -5,7 +5,7 @@ astropy.wcs-specific utilities for generating boilerplate in docstrings.
 
 
 
-__all__ = ['RETURNS', 'ORIGIN', 'RA_DEC_ORDER']
+__all__ = ['TWO_OR_MORE_ARGS', 'RETURNS', 'ORIGIN', 'RA_DEC_ORDER']
 
 
 def _fix(content, indent=0):


### PR DESCRIPTION
Discovered via #7727 
* https://travis-ci.org/astropy/astropy/jobs/415130021#L763

__TWO_OR_THREE_ARGS__ is not defined or imported in this file so it should not be exported via `__all__`.  This is the only occurrence of the literal __TWO_OR_THREE_ARGS__ in this repo.  https://github.com/astropy/astropy/search?q=TWO_OR_THREE_ARGS