### PR TITLE
'main' —> ‘hub_script’ in __all__ of samp/hub_script.py

### DIFF
--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -10,8 +10,6 @@ from .. import log, __version__
 
 from .hub import SAMPHubServer
 
-__all__ = ['main']
-
 
 def hub_script(timeout=0):
     """

--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -10,6 +10,8 @@ from .. import log, __version__
 
 from .hub import SAMPHubServer
 
+__all__ = ['hub_script']
+
 
 def hub_script(timeout=0):
     """


### PR DESCRIPTION
Discovered via #7727
* https://travis-ci.org/astropy/astropy/jobs/415130021#L660

__main__ is not defined or imported in this file so it should not be exported via __all__. Looking through _history_, there was never a __main__ defined in this file.  Looking through the uses of __hub_script__ in this repo, this change looks benign. https://github.com/astropy/astropy/search?q=hub_script