### PR TITLE
Introduce the << operator to get Quantity views of arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -436,6 +436,12 @@ astropy.time
 astropy.units
 ^^^^^^^^^^^^^
 
+- To simplify fast creation of ``Quantity`` instances from arrays, one can now
+  write ``array << unit`` (equivalent to ``Quantity(array, unit, copy=False)``).
+  If ``array`` is already a ``Quantity``, this will convert the quantity to the
+  requested units; in-place conversion can be done with ``quantity <<= unit``.
+  [#7734]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -716,6 +716,13 @@ class UnitBase(metaclass=InheritDocstrings):
         except TypeError:
             return NotImplemented
 
+    def __rlshift__(self, m):
+        try:
+            from .quantity import Quantity
+            return Quantity(m, self, copy=False, subok=True)
+        except Exception:
+            return NotImplemented
+
     def __hash__(self):
         # This must match the hash used in CompositeUnit for a unit
         # with only one base and no scale or power.

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -723,6 +723,12 @@ class UnitBase(metaclass=InheritDocstrings):
         except Exception:
             return NotImplemented
 
+    def __rrshift__(self, m):
+        warnings.warn(">> is not implemented. Did you mean to convert "
+                      "to a Quantity with unit {} using '<<'?".format(self),
+                      AstropyWarning)
+        return NotImplemented
+
     def __hash__(self):
         # This must match the hash used in CompositeUnit for a unit
         # with only one base and no scale or power.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -22,7 +22,7 @@ from .utils import is_effectively_unity
 from .format.latex import Latex
 from ..utils.compat import NUMPY_LT_1_14
 from ..utils.compat.misc import override__dir__
-from ..utils.exceptions import AstropyDeprecationWarning
+from ..utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from ..utils.misc import isiterable, InheritDocstrings
 from ..utils.data_info import ParentDtypeInfo
 from .. import config as _config
@@ -858,8 +858,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         except TypeError:
             return NotImplemented
 
-    # Unit conversion operator (|).
-    def __or__(self, other):
+    # Unit conversion operator (<<).
+    def __lshift__(self, other):
         try:
             other = Unit(other, parse_strict='silent')
         except UnitTypeError:
@@ -867,7 +867,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
         return self.__class__(self, other, copy=False, subok=True)
 
-    def __ior__(self, other):
+    def __ilshift__(self, other):
         try:
             other = Unit(other, parse_strict='silent')
         except UnitTypeError:
@@ -890,10 +890,26 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         self._set_unit(other)
         return self
 
-    def __ror__(self, other):
+    def __rlshift__(self, other):
         if not self.isscalar:
             return NotImplemented
-        return Unit(self).__ror__(other)
+        return Unit(self).__rlshift__(other)
+
+    # Give warning for other >> self, since probably other << self was meant.
+    def __rrshift__(self, other):
+        warnings.warn(">> is not implemented. Did you mean to convert "
+                      "something to this quantity as a unit using '<<'?",
+                      AstropyWarning)
+        return NotImplemented
+
+    # Also define __rshift__ and __irshift__ so we override default ndarray
+    # behaviour, but instead of emitting a warning here, let it be done by
+    # other (which likely is a unit if this was a mistake).
+    def __rshift__(self, other):
+        return NotImplemented
+
+    def __irshift__(self, other):
+        return NotImplemented
 
     # Arithmetic operations
     def __mul__(self, other):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -17,7 +17,7 @@ from numpy.testing import (assert_allclose, assert_array_equal,
 from ...tests.helper import catch_warnings, raises
 from ...utils import isiterable, minversion
 from ...utils.compat import NUMPY_LT_1_14
-from ...utils.exceptions import AstropyDeprecationWarning
+from ...utils.exceptions import AstropyDeprecationWarning, AstropyWarning
 from ... import units as u
 from ...units.quantity import _UNIT_NOT_INITIALISED
 
@@ -306,6 +306,33 @@ class TestQuantityCreation:
         q6 = a6 << not_quite_a_foot
         assert q6.unit == u.Unit(not_quite_a_foot)
         assert np.all(q6.to_value(u.cm) == 30. * a6)
+
+    def test_rshift_warns(self):
+        with pytest.raises(TypeError), \
+                catch_warnings() as warning_lines:
+            1 >> u.m
+        assert len(warning_lines) == 1
+        assert warning_lines[0].category == AstropyWarning
+        assert 'is not implemented' in str(warning_lines[0].message)
+        q = 1. * u.km
+        with pytest.raises(TypeError), \
+                catch_warnings() as warning_lines:
+            q >> u.m
+        assert len(warning_lines) == 1
+        assert warning_lines[0].category == AstropyWarning
+        assert 'is not implemented' in str(warning_lines[0].message)
+        with pytest.raises(TypeError), \
+                catch_warnings() as warning_lines:
+            q >>= u.m
+        assert len(warning_lines) == 1
+        assert warning_lines[0].category == AstropyWarning
+        assert 'is not implemented' in str(warning_lines[0].message)
+        with pytest.raises(TypeError), \
+                catch_warnings() as warning_lines:
+            1. >> q
+        assert len(warning_lines) == 1
+        assert warning_lines[0].category == AstropyWarning
+        assert 'is not implemented' in str(warning_lines[0].message)
 
 
 class TestQuantityOperations:

--- a/docs/units/performance.inc.rst
+++ b/docs/units/performance.inc.rst
@@ -35,5 +35,5 @@ Conversion that copies only when necessary::
 In-place conversion to a different unit::
 
   >>> q2 <<= u.cm
-  >>> q2
+  >>> q2  # doctest: +FLOAT_CMP
   <Quantity [  0., 100., 200., 300., 400.] cm>

--- a/docs/units/performance.inc.rst
+++ b/docs/units/performance.inc.rst
@@ -1,6 +1,6 @@
-.. note that if this is changed from the default approach of using an *include* 
+.. note that if this is changed from the default approach of using an *include*
    (in index.rst) to a separate performance page, the header needs to be changed
-   from === to ***, the filename extension needs to be changed from .inc.rst to 
+   from === to ***, the filename extension needs to be changed from .inc.rst to
    .rst, and a link needs to be added in the subpackage toctree
 
 .. _astropy-units-performance:
@@ -10,3 +10,30 @@ Performance Tips
 
 Here we provide some tips and tricks for how to optimize performance of code
 using `astropy.units`.
+
+Initialization without a copy::
+
+  >>> import numpy as np
+  >>> import astropy.units as u
+  >>> a = np.arange(5.)
+  >>> q1 = u.Quantity(a, u.m, copy=False)
+  >>> np.may_share_memory(a, q1)
+  True
+  >>> q2 = a << u.m
+  >>> np.may_share_memory(a, q2)
+  True
+
+Conversion that copies only when necessary::
+
+  >>> q3 = q2 << u.m
+  >>> np.may_share_memory(q2, q3)
+  True
+  >>> q3 = q2 << u.cm
+  >>> np.may_share_memory(q2, q3)
+  False
+
+In-place conversion to a different unit::
+
+  >>> q2 <<= u.cm
+  >>> q2
+  <Quantity [  0., 100., 200., 300., 400.] cm>

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -473,12 +473,12 @@ the initializer::
 
     >>> a = np.arange(5.)
     >>> q = u.Quantity(a, u.m, copy=False)
-    >>> q
+    >>> q  # doctest: +FLOAT_CMP
     <Quantity [0., 1., 2., 3., 4.] m>
     >>> np.may_share_memory(a, q)
     True
     >>> a[0] = -1.
-    >>> q
+    >>> q  # doctest: +FLOAT_CMP
     <Quantity [-1.,  1.,  2.,  3.,  4.] m>
 
 This may be particularly useful in functions which do not change their input;
@@ -491,21 +491,21 @@ operator::
     >>> q = a << u.m
     >>> np.may_share_memory(a, q)
     True
-    >>> q
+    >>> q  # doctest: +FLOAT_CMP
     <Quantity [-1.,  1.,  2.,  3.,  4.] m>
 
 The operator works identically to the initialization with ``copy=False``
 mentioned above::
 
-    >>> q << u.cm
+    >>> q << u.cm  # doctest: +FLOAT_CMP
     <Quantity [-100.,  100.,  200.,  300.,  400.] cm>
 
 It can also be used for in-place conversion::
 
     >>> q <<= u.cm
-    >>> q
+    >>> q  # doctest: +FLOAT_CMP
     <Quantity [-100.,  100.,  200.,  300.,  400.] cm>
-    >>> a
+    >>> a  # doctest: +FLOAT_CMP
     array([-100.,  100.,  200.,  300.,  400.])
 
 Known issues with conversion to numpy arrays


### PR DESCRIPTION
This is a replacement of #7652, using `array << unit` instead of `array | unit` to get `Quantity` views of arrays, and to change units of quantities. It includes updates to the documentation (also the performance section). For discussion, see #7652.