### PR TITLE
Undefined name: lsr_frame --> icrs_frame

### DIFF
--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -41,8 +41,8 @@ def test_faux_lsr(dt, symmetric):
                                      LSR2, ICRS, finite_difference_dt=dt,
                                      symmetric_finite_difference=symmetric)
     def lsr_to_icrs(lsr_coo, icrs_frame):
-        dt = lsr_frame.obstime - J2000
-        offset = lsr_frame.v_bary * dt.to(u.second)
+        dt = icrs_frame.obstime - J2000
+        offset = icrs_frame.v_bary * dt.to(u.second)
         return icrs_frame.realize_frame(lsr_coo.data - offset)
 
     ic = ICRS(ra=12.3*u.deg, dec=45.6*u.deg, distance=7.8*u.au,

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -41,8 +41,8 @@ def test_faux_lsr(dt, symmetric):
                                      LSR2, ICRS, finite_difference_dt=dt,
                                      symmetric_finite_difference=symmetric)
     def lsr_to_icrs(lsr_coo, icrs_frame):
-        dt = icrs_frame.obstime - J2000
-        offset = icrs_frame.v_bary * dt.to(u.second)
+        dt = lsr_coo.obstime - J2000
+        offset = lsr_coo.v_bary * dt.to(u.second)
         return icrs_frame.realize_frame(lsr_coo.data - offset)
 
     ic = ICRS(ra=12.3*u.deg, dec=45.6*u.deg, distance=7.8*u.au,


### PR DESCRIPTION
__lsr_frame__ is an _undefined name_ in this context so this PR recommends using the function parameter __icrs_frame__ in its place.  This fix was first suggested at https://github.com/astropy/astropy/pull/7727/commits/95fd0a5b403f961ca4cca68ea6d835ab7d817e81 but it is being moved into a separate PR because it is no longer related to #7727 

The initial assumption was that this was a copy and paste error in copying from the function just above however @mhvk thought that might not be correct and requested that @eteq have a look...