### PR TITLE
Fix biweight stats functions for constant arrays

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1245,6 +1245,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed bugs in biweight statistics functions where a constant data
+  array (or if using the axis keyword, constant along an axis) would
+  return NaN. [#7737]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -102,8 +102,15 @@ def biweight_location(data, c=6.0, M=None, axis=None):
 
     # set up the weighting
     mad = median_absolute_deviation(data, axis=axis)
+
+    if axis is None and mad == 0.:
+        return M  # return median if data is a constant array
+
     if axis is not None:
         mad = np.expand_dims(mad, axis=axis)
+        const_mask = (mad == 0.)
+        mad[const_mask] = 1.  # prevent divide by zero
+
     u = d / (c * mad)
 
     # now remove the outlier points
@@ -111,6 +118,8 @@ def biweight_location(data, c=6.0, M=None, axis=None):
     u = (1 - u ** 2) ** 2
     u[mask] = 0
 
+    # along the input axis if data is constant, d will be zero, thus
+    # the median value will be returned along that axis
     return M.squeeze() + (d * u).sum(axis=axis) / u.sum(axis=axis)
 
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -546,6 +546,10 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
 
     # set up the weighting
     mad = median_absolute_deviation(data, axis=1)
+
+    const_mask = (mad == 0.)
+    mad[const_mask] = 1.  # prevent divide by zero
+
     u = (d.T / (c * mad)).T
 
     # now remove the outlier points

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -345,8 +345,15 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
 
     # set up the weighting
     mad = median_absolute_deviation(data, axis=axis)
+
+    if axis is None and mad == 0.:
+        return 0.  # return zero if data is a constant array
+
     if axis is not None:
         mad = np.expand_dims(mad, axis=axis)
+        const_mask = (mad == 0.)
+        mad[const_mask] = 1.  # prevent divide by zero
+
     u = d / (c * mad)
 
     # now remove the outlier points

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -172,6 +172,38 @@ def test_biweight_midvariance_axis_3d():
         assert_allclose(bw[y], bwi)
 
 
+def test_biweight_midvariance_constant_axis():
+    bw = biweight_midvariance(np.ones((10, 5)))
+    assert bw == 0.0
+
+
+def test_biweight_midvariance_constant_axis_2d():
+    shape = (10, 5)
+    data = np.ones(shape)
+    cbl = biweight_midvariance(data, axis=0)
+    assert_allclose(cbl, np.zeros(shape[1]))
+    cbl = biweight_midvariance(data, axis=1)
+    assert_allclose(cbl, np.zeros(shape[0]))
+
+    data = np.arange(50).reshape(10, 5)
+    data[2] = 100.
+    data[7] = 2.
+    bw = biweight_midvariance(data, axis=1)
+    assert_allclose(bw[2], 0.)
+    assert_allclose(bw[7], 0.)
+
+
+def test_biweight_midvariance_constant_axis_3d():
+    shape = (10, 5, 2)
+    data = np.ones(shape)
+    cbl = biweight_midvariance(data, axis=0)
+    assert_allclose(cbl, np.zeros((shape[1], shape[2])))
+    cbl = biweight_midvariance(data, axis=1)
+    assert_allclose(cbl, np.zeros((shape[0], shape[2])))
+    cbl = biweight_midvariance(data, axis=2)
+    assert_allclose(cbl, np.zeros((shape[0], shape[1])))
+
+
 def test_biweight_midcovariance_1d():
     d = [0, 1, 2]
     cov = biweight_midcovariance(d)
@@ -193,6 +225,12 @@ def test_biweight_midcovariance_2d():
     cov = biweight_midcovariance(d, modify_sample_size=True)
     assert_allclose(cov, [[14.54159077, -5.19350838],
                           [-5.19350838, 4.61391501]])
+
+
+def test_biweight_midcovariance_constant():
+    data = np.ones((3, 10))
+    cov = biweight_midcovariance(data)
+    assert_allclose(cov, np.zeros((3, 3)))
 
 
 def test_biweight_midcovariance_midvariance():

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -20,6 +20,40 @@ def test_biweight_location():
         assert abs(cbl - 0) < 1e-2
 
 
+def test_biweight_location_constant():
+    cbl = biweight_location(np.ones((10, 5)))
+    assert cbl == 1.
+
+
+def test_biweight_location_constant_axis_2d():
+    shape = (10, 5)
+    data = np.ones(shape)
+    cbl = biweight_location(data, axis=0)
+    assert_allclose(cbl, np.ones(shape[1]))
+    cbl = biweight_location(data, axis=1)
+    assert_allclose(cbl, np.ones(shape[0]))
+
+    val1 = 100.
+    val2 = 2.
+    data = np.arange(50).reshape(10, 5)
+    data[2] = val1
+    data[7] = val2
+    cbl = biweight_location(data, axis=1)
+    assert_allclose(cbl[2], val1)
+    assert_allclose(cbl[7], val2)
+
+
+def test_biweight_location_constant_axis_3d():
+    shape = (10, 5, 2)
+    data = np.ones(shape)
+    cbl = biweight_location(data, axis=0)
+    assert_allclose(cbl, np.ones((shape[1], shape[2])))
+    cbl = biweight_location(data, axis=1)
+    assert_allclose(cbl, np.ones((shape[0], shape[2])))
+    cbl = biweight_location(data, axis=2)
+    assert_allclose(cbl, np.ones((shape[0], shape[1])))
+
+
 def test_biweight_location_small():
     cbl = biweight_location([1, 3, 5, 500, 2])
     assert abs(cbl - 2.745) < 1e-3


### PR DESCRIPTION
This PR fixes an issue in `biweight_location`, `biweight_midvariance`, and `biweight_midcovariance` where they would return NaN due to a divide-by-zero (`mad=0.`) for a constant array or a constant array along the input `axis`.

Closes #7657.