### PR TITLE
Preventing CCData object from finding non-image extension data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1268,6 +1268,8 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Fixed the bug in CCData.read when the HDU is not specified and the first one is empty so the function searches for the first HDU with data which may not have an image extension. [#7739]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -500,7 +500,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         # the primary header is empty.
         if hdu == 0 and hdus[hdu].data is None:
             for i in range(len(hdus)):
-                if hdus.fileinfo(i)['datSpan'] > 0:
+                if hdus.info(hdu)[i][3] == 'ImageHDU' and hdus.fileinfo(i)['datSpan'] > 0:
                     hdu = i
                     comb_hdr = hdus[hdu].header.copy()
                     # Add header values from the primary header that aren't


### PR DESCRIPTION
_**I closed and reopen the pull request due to conflicts in several files. It turned easier just refresh the PL**_

As pointed in #7595, is the HDU is not specified, an interaction is performed on each HDU until one is found with data. However, it is not taken into account if the HDU has image extension.

Therefore, I added in the interaction this condition. Since hdus.fileinfo() does not have any parameters that indicate the HDU extension, I looked for this information in hdus.info()

Besides, I was supposed to provide a test for this change. It is located in test_ccddata.py, and I follow the example given in #7595. 

The milestone chosen was v2.0.9, but I could change to another one if necessary :) 

EDIT: Superseded #7613 and #7738