### PR TITLE
Travis: Remove some egg_info builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,12 +70,6 @@ matrix:
     include:
 
         - stage: Initial tests
-          env: PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
-          env: PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
-
-        - stage: Initial tests
           env: PYTHON_VERSION=3.7 SETUP_CMD='egg_info'
 
         # Try MacOS X.


### PR DESCRIPTION
We don't really need three egg_info builds - the main reason we had two originally was to have Python 2 and 3, but I doubt that there would be much difference between the different Python 3 versions for this command.