### PR TITLE
Allow attributes to specify how to be represented in the frame repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ astropy.coordinates
 
 - Added a ``concatenate_representations`` function to combine coordinate
   representation data and any associated differentials. [#7922]
+
 - ``BaseCoordinateFrame`` will now check for a method named
   ``_astropy_repr_in_frame`` when constructing the string forms of attributes.
   Allowing any class to control how ``BaseCoordinateFrame`` represents it when

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ astropy.coordinates
 
 - Added a ``concatenate_representations`` function to combine coordinate
   representation data and any associated differentials. [#7922]
+- ``BaseCoordinateFrame`` will now check for a method named
+  ``_astropy_repr_in_frame`` when constructing the string forms of attributes.
+  Allowing any class to control how ``BaseCoordinateFrame`` represents it when
+  it is an attribute of a frame. [#7745]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1342,12 +1342,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         attr_strs = []
         for attribute_name in self.get_frame_attr_names():
             attr = getattr(self, attribute_name)
-            if hasattr(attr, "_repr_attribute"):
-                attrstr = attr._repr_attribute()
+            # Check to see if this object has a way of representing itself
+            # specific to being an attribute of a frame. (Note, this is not the
+            # Attribute class, it's the actual object).
+            if hasattr(attr, "_astropy_repr_in_frame"):
+                attrstr = attr._astropy_repr_in_frame()
             else:
                 attrstr = str(attr)
-            attr_strs.append("{attribute_name}={attrstr}".format(attribute_name=attribute_name,
-                                                                 attrstr=attrstr))
+            attr_strs.append("{attribute_name}={attrstr}".format(
+                attribute_name=attribute_name,
+                attrstr=attrstr))
+
         return ', '.join(attr_strs)
 
     def _apply(self, method, *args, **kwargs):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1339,8 +1339,16 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         Returns a string representation of the frame's attributes, if any.
         """
-        return ', '.join([attrnm + '=' + str(getattr(self, attrnm))
-                          for attrnm in self.get_frame_attr_names()])
+        attr_strs = []
+        for attribute_name in self.get_frame_attr_names():
+            attr = getattr(self, attribute_name)
+            if hasattr(attr, "_repr_attribute"):
+                attrstr = attr._repr_attribute()
+            else:
+                attrstr = str(attr)
+            attr_strs.append("{attribute_name}={attrstr}".format(attribute_name=attribute_name,
+                                                                 attrstr=attrstr))
+        return ', '.join(attr_strs)
 
     def _apply(self, method, *args, **kwargs):
         """Create a new instance, applying a method to the underlying data.

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1027,3 +1027,17 @@ def test_non_spherical_representation_unit_creation(unitphysics):
 
     picu = PhysicsICRS(phi=1*u.deg, theta=25*u.deg)
     assert isinstance(picu.data, unitphysics)
+
+
+def test_attribute_repr():
+    from ..attributes import Attribute
+    from ..baseframe import BaseCoordinateFrame
+
+    class Spam:
+        def _repr_in_frame_repr(self):
+            return "TEST REPR"
+
+    class TestFrame(BaseCoordinateFrame):
+        attrtest = Attribute(default=Spam())
+
+    assert "TEST REPR" in repr(TestFrame())

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1034,7 +1034,7 @@ def test_attribute_repr():
     from ..baseframe import BaseCoordinateFrame
 
     class Spam:
-        def _repr_in_frame_repr(self):
+        def _astropy_repr_in_frame(self):
             return "TEST REPR"
 
     class TestFrame(BaseCoordinateFrame):

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -348,7 +348,7 @@ user-created frames.
 
 
 Customising Display of Attributes
-#################################
+---------------------------------
 
 If you want objects displayed as attributes of the frame to customise their
 display you can define a method named ``_astropy_repr_in_frame``. This method

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -347,6 +347,31 @@ user-created frames.
     for a more annotated example of defining a new coordinate frame.
 
 
+Customising Display of Attributes
+#################################
+
+If you want objects displayed as attributes of the frame to customise their
+display you can define a method named ``_astropy_repr_in_frame``. This method
+should be defined on the actual object that is the attribute **not** the
+`~astropy.coordinates.Attribute` descriptor itself.
+
+For example, you could have an object ``Spam`` which you have as an attribute of your frame::
+
+  >>> class Spam:
+  ...     def _astropy_repr_in_frame(self):
+  ...         return "<A can of Spam>"
+
+If your frame has this class as an attribute::
+
+  >>> class Egg(BaseCoordinateFrame):
+  ...     can = Attribute(default=Spam())
+
+When it is displayed by the frame it will use the result of ``_astropy_repr_in_frame``::
+
+  >>> Egg()
+  <Egg Frame (can=<A can of Spam>)>
+
+
 Defining Transformations
 ========================
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -347,13 +347,14 @@ user-created frames.
     for a more annotated example of defining a new coordinate frame.
 
 
-Customising Display of Attributes
+Customizing Display of Attributes
 ---------------------------------
 
-If you want objects displayed as attributes of the frame to customise their
-display you can define a method named ``_astropy_repr_in_frame``. This method
-should be defined on the actual object that is the attribute **not** the
-`~astropy.coordinates.Attribute` descriptor itself.
+While the default `repr` for coordinate frames is suitable for most cases, you may want
+to customize how frame attributes are displayed in certain cases.  To do this you can
+define a method named ``_astropy_repr_in_frame``. This method should be defined on the
+the object that's set to the frame attribute itself, **not** the 
+`~astropy.coordinates.Attribute` descriptor.
 
 For example, you could have an object ``Spam`` which you have as an attribute of your frame::
 


### PR DESCRIPTION
This implements a hook to customise the way an attribute is represented in the frame repr. The motivation for this is in https://github.com/sunpy/sunpy/pull/2723. 

Which to summarise is basically we want to be able to represent a coordinate frame as the celestial body it was generated from rather than the full coordinate frame that it is, but only really in the SkyCoord / Frame repr, the rest of the time we would quite like it to be a normal frame.

Basically that

```
'earth'
```

is much more meaningful to most humans than:

```
<SkyCoord (HeliographicStonyhurst: obstime=2018-08-17 17:13:20.523028): (lon, lat, radius) in (deg, deg, AU)
    (0., 6.75658585, 1.01238948)>
```

This is just to test the water, I am happy to actually finish this PR if there are no major objections!