### PR TITLE
Reset matplotlib rcParams to defaults before tests.

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -45,8 +45,7 @@ def pytest_configure(config):
 def pytest_unconfigure(config):
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:
-        for k, v in matplotlibrc_cache.items():
-            matplotlib.rcParams[k] = v
+        matplotlib.rcParams.update(matplotlibrc_cache)
         matplotlibrc_cache.clear()
 
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -9,6 +9,12 @@ from importlib.util import find_spec
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
+try:
+    import matplotlib
+except ImportError:
+    HAS_MATPLOTLIB = False
+else:
+    HAS_MATPLOTLIB = True
 
 if find_spec('asdf') is not None:
     from asdf import __version__ as asdf_version
@@ -23,34 +29,25 @@ enable_deprecations_as_exceptions(
     # installed. This can be removed once pyopenssl 1.7.20+ is released.
     modules_to_ignore_on_import=['requests'])
 
-try:
-    import matplotlib
-except ImportError:
-    pass
-else:
+if HAS_MATPLOTLIB:
     matplotlib.use('Agg')
-
 
 matplotlibrc_cache = {}
 
+
 def pytest_configure(config):
-    try:
-        import matplotlib
-    except ImportError:
-        pass
-    else:
+    # do not assign to matplotlibrc_cache in function scope
+    if HAS_MATPLOTLIB:
         matplotlibrc_cache.update(matplotlib.rcParams)
         matplotlib.rcdefaults()
 
+
 def pytest_unconfigure(config):
-    try:
-        import matplotlib
-    except ImportError:
-        pass
-    else:
+    # do not assign to matplotlibrc_cache in function scope
+    if HAS_MATPLOTLIB:
         for k, v in matplotlibrc_cache.items():
             matplotlib.rcParams[k] = v
         matplotlibrc_cache.clear()
 
-    
+
 PYTEST_HEADER_MODULES['Cython'] = 'cython'

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -30,4 +30,27 @@ except ImportError:
 else:
     matplotlib.use('Agg')
 
+
+matplotlibrc_cache = {}
+
+def pytest_configure(config):
+    try:
+        import matplotlib
+    except ImportError:
+        pass
+    else:
+        matplotlibrc_cache.update(matplotlib.rcParams)
+        matplotlib.rcdefaults()
+
+def pytest_unconfigure(config):
+    try:
+        import matplotlib
+    except ImportError:
+        pass
+    else:
+        for k, v in matplotlibrc_cache.items():
+            matplotlib.rcParams[k] = v
+        matplotlibrc_cache.clear()
+
+    
 PYTEST_HEADER_MODULES['Cython'] = 'cython'


### PR DESCRIPTION
Resolves #7715.