### PR TITLE
Doctests to be picked up from narrative documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -539,6 +539,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Fixing bug that doctests were not picked up from the narrative
+  documentation when tests were run for all modules. [#7767]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -564,6 +564,9 @@ class TestRunner(TestRunnerBase):
                                    "docs path ({path}) does not exist.")
                 paths = self.packages_path(kwargs['package'], docs_path,
                                            warning=warning_message)
+            else:
+                paths = [docs_path, ]
+
             if len(paths) and not kwargs['test_path']:
                 paths.append('--doctest-rst')
 


### PR DESCRIPTION
this fixes #7762, the case when no modules were selected was not handled correctly. 

Passing CI means nothing here, it need to be confirmed that the rst files from `docs/` is indeed being picked up. But if that's done, no need to wait for the full CI to finish, this can be then merged.