### PR TITLE
Fix pytest warning about tree fixture being called directly

### DIFF
--- a/astropy/table/tests/test_bst.py
+++ b/astropy/table/tests/test_bst.py
@@ -29,8 +29,8 @@ def tree():
 
 
 @pytest.fixture
-def bst():
-    return tree()
+def bst(tree):
+    return tree
 
 
 def test_bst_add(bst):


### PR DESCRIPTION
This fixes the following warning raised by pytest:

```
_pytest.deprecated.RemovedInPytest4Warning: Fixture tree called directly. Fixtures are not meant to be called directly, are created automatically when test functions request them as parameters.
```