### PR TITLE
Remove a few setup warnings for missing files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ include pip-requirements*
 include CITATION
 include astropy/CITATION
 
-include ez_setup.py
 include ah_bootstrap.py
 include setup.cfg
 include astropy/tests/coveragerc
@@ -43,7 +42,6 @@ include astropy_helpers/CHANGES.rst
 include astropy_helpers/LICENSE.rst
 recursive-include astropy_helpers/licenses *
 
-include astropy_helpers/ez_setup.py
 include astropy_helpers/ah_bootstrap.py
 
 recursive-include astropy_helpers/astropy_helpers *.py *.pyx *.c *.h *.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,15 +19,12 @@ include astropy/astropy.cfg
 include astropy/extern/configobj/*.py
 recursive-include astropy/utils/compat *.py
 
-include astropy/utils/misc/data/.hidden_file.txt
-
 recursive-include docs *
 recursive-include examples *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
 recursive-include static *
-recursive-include astropy/sphinx/themes *
 
 prune docs/_build
 prune build

--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -116,7 +116,6 @@ except:
 # End compatibility imports...
 
 
-# In case it didn't successfully import before the ez_setup checks
 import pkg_resources
 
 from setuptools import Distribution

--- a/docs/development/building.rst
+++ b/docs/development/building.rst
@@ -4,10 +4,7 @@ Building Astropy and its Subpackages
 
 The build process currently uses the `setuptools
 <https://setuptools.readthedocs.io>`_ package to build and install the
-astropy core (and any affiliated packages that use the template).  The user
-doesn't necessarily need to have `setuptools`_ installed, as it will
-automatically bootstrap itself using the ``ez_setup.py`` file in the source
-distribution if it isn't installed for the user.
+astropy core (and any affiliated packages that use the template).
 
 
 Astropy-helpers


### PR DESCRIPTION
`ez_setup` and Sphinx theme were removed. The `.hidden_file.txt` path here is not the good one, and the file (in `utils/tests/data`) is included with the `setup_package.py`.
Not sure which label to use for packaging stuff ?