### PR TITLE
A few fixes for Pypy

### DIFF
--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -14,7 +14,6 @@ deviations from the original APE5 plan.
 
 import pytest
 import numpy as np
-from numpy.random import randn
 from numpy import testing as npt
 
 from ...tests.helper import raises, assert_quantity_allclose as assert_allclose
@@ -115,17 +114,19 @@ def test_representations_api():
     c3 = PhysicsSphericalRepresentation(phi=120*u.deg, theta=85*u.deg, r=3*u.kpc)
 
     # first dimension must be length-3 if a lone `Quantity` is passed in.
-    c1 = CartesianRepresentation(randn(3, 100) * u.kpc)
+    c1 = CartesianRepresentation(np.random.randn(3, 100) * u.kpc)
     assert c1.xyz.shape[0] == 3
     assert c1.xyz.unit == u.kpc
     assert c1.x.shape[0] == 100
     assert c1.y.shape[0] == 100
     assert c1.z.shape[0] == 100
     # can also give each as separate keywords
-    CartesianRepresentation(x=randn(100)*u.kpc, y=randn(100)*u.kpc, z=randn(100)*u.kpc)
+    CartesianRepresentation(x=np.random.randn(100)*u.kpc,
+                            y=np.random.randn(100)*u.kpc,
+                            z=np.random.randn(100)*u.kpc)
     # if the units don't match but are all distances, they will automatically be
     # converted to match `x`
-    xarr, yarr, zarr = randn(3, 100)
+    xarr, yarr, zarr = np.random.randn(3, 100)
     c1 = CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.kpc)
     c2 = CartesianRepresentation(x=xarr*u.kpc, y=yarr*u.kpc, z=zarr*u.pc)
     assert c1.xyz.unit == c2.xyz.unit == u.kpc

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -673,7 +673,9 @@ def test_write_quoted_empty_field(fast_writer):
 def test_write_overwrite_ascii(format, fast_writer, tmpdir):
     """Test overwrite argument for various ASCII writers"""
     filename = tmpdir.join("table-tmp.dat").strpath
-    open(filename, 'w').close()
+    with open(filename, 'w'):
+        # create empty file
+        pass
     t = table.Table([['Hello', ''], ['', '']], dtype=['S10', 'S10'])
 
     with pytest.raises(OSError) as err:

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -2,7 +2,6 @@
 
 import pytest
 import numpy as np
-from numpy.random import randn, normal
 from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
 
 from ..biweight import (biweight_location, biweight_scale,
@@ -15,7 +14,7 @@ from ...utils.misc import NumpyRNGContext
 def test_biweight_location():
     with NumpyRNGContext(12345):
         # test that it runs
-        randvar = randn(10000)
+        randvar = np.random.randn(10000)
         cbl = biweight_location(randvar)
         assert abs(cbl - 0) < 1e-2
 
@@ -30,7 +29,7 @@ def test_biweight_location_axis():
     with NumpyRNGContext(12345):
         ny = 100
         nx = 200
-        data = normal(5, 2, (ny, nx))
+        data = np.random.normal(5, 2, (ny, nx))
 
         bw = biweight_location(data, axis=0)
         bwi = []
@@ -53,7 +52,7 @@ def test_biweight_location_axis_3d():
         nz = 3
         ny = 4
         nx = 5
-        data = normal(5, 2, (nz, ny, nx))
+        data = np.random.normal(5, 2, (nz, ny, nx))
         bw = biweight_location(data, axis=0)
         assert bw.shape == (ny, nx)
 
@@ -76,7 +75,7 @@ def test_biweight_scale():
 def test_biweight_midvariance():
     with NumpyRNGContext(12345):
         # test that it runs
-        randvar = randn(10000)
+        randvar = np.random.randn(10000)
         var = biweight_midvariance(randvar)
         assert_allclose(var, 1.0, rtol=0.02)
 
@@ -103,7 +102,7 @@ def test_biweight_midvariance_axis():
     with NumpyRNGContext(12345):
         ny = 100
         nx = 200
-        data = normal(5, 2, (ny, nx))
+        data = np.random.normal(5, 2, (ny, nx))
 
         bw = biweight_midvariance(data, axis=0)
         bwi = []
@@ -126,7 +125,7 @@ def test_biweight_midvariance_axis_3d():
         nz = 3
         ny = 4
         nx = 5
-        data = normal(5, 2, (nz, ny, nx))
+        data = np.random.normal(5, 2, (nz, ny, nx))
         bw = biweight_midvariance(data, axis=0)
         assert bw.shape == (ny, nx)
 

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -3,7 +3,6 @@
 import pytest
 
 import numpy as np
-from numpy.random import randn, normal
 from numpy.testing import assert_equal, assert_allclose
 
 try:
@@ -29,7 +28,7 @@ from ...utils.misc import NumpyRNGContext
 def test_median_absolute_deviation():
     with NumpyRNGContext(12345):
         # test that it runs
-        randvar = randn(10000)
+        randvar = np.random.randn(10000)
         mad = funcs.median_absolute_deviation(randvar)
 
         # test whether an array is returned if an axis is used
@@ -316,13 +315,13 @@ def test_bootstrap_multiple_outputs():
 
 def test_mad_std():
     with NumpyRNGContext(12345):
-        data = normal(5, 2, size=(100, 100))
+        data = np.random.normal(5, 2, size=(100, 100))
         assert_allclose(funcs.mad_std(data), 2.0, rtol=0.05)
 
 
 def test_mad_std_scalar_return():
     with NumpyRNGContext(12345):
-        data = normal(5, 2, size=(10, 10))
+        data = np.random.normal(5, 2, size=(10, 10))
         # make a masked array with no masked points
         data = np.ma.masked_where(np.isnan(data), data)
         rslt = funcs.mad_std(data)
@@ -345,7 +344,7 @@ def test_mad_std_scalar_return():
 
 def test_mad_std_warns():
     with NumpyRNGContext(12345):
-        data = normal(5, 2, size=(10, 10))
+        data = np.random.normal(5, 2, size=(10, 10))
         data[5, 5] = np.nan
 
         with catch_warnings() as warns:
@@ -357,7 +356,7 @@ def test_mad_std_withnan():
     with NumpyRNGContext(12345):
         data = np.empty([102, 102])
         data[:] = np.nan
-        data[1:-1, 1:-1] = normal(5, 2, size=(100, 100))
+        data[1:-1, 1:-1] = np.random.normal(5, 2, size=(100, 100))
         assert_allclose(funcs.mad_std(data, ignore_nan=True), 2.0, rtol=0.05)
 
     assert np.isnan(funcs.mad_std([1, 2, 3, 4, 5, np.nan]))

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -4,7 +4,6 @@
 import pytest
 import numpy as np
 
-from numpy.random import randn
 from numpy.testing import assert_equal, assert_allclose
 
 try:
@@ -24,7 +23,7 @@ def test_sigma_clip():
 
     with NumpyRNGContext(12345):
         # Amazing, I've got the same combination on my luggage!
-        randvar = randn(10000)
+        randvar = np.random.randn(10000)
 
         filtered_data = sigma_clip(randvar, sigma=1, maxiters=2)
 
@@ -72,7 +71,7 @@ def test_compare_to_scipy_sigmaclip():
 
     with NumpyRNGContext(12345):
 
-        randvar = randn(10000)
+        randvar = np.random.randn(10000)
 
         astropyres = sigma_clip(randvar, sigma=3, maxiters=None,
                                 cenfunc=np.mean)
@@ -91,7 +90,7 @@ def test_sigma_clip_scalar_mask():
 
 def test_sigma_clip_class():
     with NumpyRNGContext(12345):
-        data = randn(100)
+        data = np.random.randn(100)
         data[10] = 1.e5
         sobj = SigmaClip(sigma=1, maxiters=2)
         sfunc = sigma_clip(data, sigma=1, maxiters=2)
@@ -152,7 +151,7 @@ def test_sigma_clipped_stats():
 
 def test_sigma_clipped_stats_ddof():
     with NumpyRNGContext(12345):
-        data = randn(10000)
+        data = np.random.randn(10000)
         data[10] = 1.e5
         mean1, median1, stddev1 = sigma_clipped_stats(data)
         mean2, median2, stddev2 = sigma_clipped_stats(data, std_ddof=1)


### PR DESCRIPTION
Fix test collection (for some reason doctest fails with functions imported from `np.random`], and one fix for a `open` use. But a lot remains, especially with refcounting on which `io.fits` (to know if mmap can be closed) or `Table` relies on.

Ref #7768