### PR TITLE
Updating CITATION to include published 2018 paper

### DIFF
--- a/astropy/CITATION
+++ b/astropy/CITATION
@@ -5,11 +5,9 @@ the following acknowledgment:
   This research made use of Astropy, a community-developed core Python package
   for Astronomy (Astropy Collaboration, 2018).
 
-where (Astropy Collaboration, 2018) is a citation to this paper (currently
-under review):
+where (Astropy Collaboration, 2018) is a citation to this paper:
 
-  http://adsabs.harvard.edu/abs/2018arXiv180102634T
-
+  http://adsabs.harvard.edu/abs/2018AJ....156..123T
 
 An earlier paper is also available describing the status of the package at
 the time of v0.2. If you have used Astropy for a long time, you are
@@ -28,55 +26,61 @@ wherever appropriate.
 
 Recommended BibTeX entries for the above citations are:
 
-@ARTICLE{2018arXiv180102634T,
-   author = {{The Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H o}cz}, B.~M. and
-   {G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and
-   {Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and
-   {Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and
-   {P{\'e}rez-Su{\'a}rez}, D. and {de Val-Borro}, M. and {Aldcroft}, T.~L. and
-   {Cruz}, K.~L. and {Robitaille}, T.~P. and {Tollerud}, E.~J. and
-   {Ardelean}, C. and {Babej}, T. and {Bachetti}, M. and {Bakanov}, A.~V. and
-   {Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and
-   {Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and
-   {Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and
-   {Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and
-   {Cano Rodr{\'{\i}}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and
-   {Cheedella}, S. and {Copin}, Y. and {Crichton}, D. and {D{\'A}vella}, D. and
-   {Deil}, C. and {Depagne}, {\'E}. and {Dietrich}, J.~P. and {Donath}, A. and
-   {Droettboom}, M. and {Earl}, N. and {Erben}, T. and {Fabbro}, S. and
-   {Ferreira}, L.~A. and {Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and
-   {Gibbons}, S.~L.~J. and {Goldstein}, D.~A. and {Gommers}, R. and
-   {Greco}, J.~P. and {Greenfield}, P. and {Groener}, A.~M. and
-   {Grollier}, F. and {Hagen}, A. and {Hirst}, P. and {Homeier}, D. and
-   {Horton}, A.~J. and {Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and
-   {Ivezi{\'c}}, {\v Z}. and {Jain}, A. and {Jenness}, T. and {Kanarek}, G. and
-   {Kendrew}, S. and {Kern}, N.~S. and {Kerzendorf}, W.~E. and
-   {Khvalko}, A. and {King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and
-   {Kumar}, A. and {Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and
-   {Ma}, Z. and {Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and
-   {Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and
-   {Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and
-   {Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and
-   {Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and
-   {Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and
-   {Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and
-   {Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and
-   {Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and
-   {Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and
-   {Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and
-   {Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and
-   {van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and
-   {Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and
-   {Zabalza}, V.},
-    title = "{The Astropy Project: Building an inclusive, open-science project and status of the v2.0 core package}",
-  journal = {ArXiv e-prints},
+@ARTICLE{2018AJ....156..123T,
+   author = {{The Astropy Collaboration} and {Price-Whelan}, A.~M. and {Sip{\H o}cz}, B.~M. and 
+	{G{\"u}nther}, H.~M. and {Lim}, P.~L. and {Crawford}, S.~M. and 
+	{Conseil}, S. and {Shupe}, D.~L. and {Craig}, M.~W. and {Dencheva}, N. and 
+	{Ginsburg}, A. and {VanderPlas}, J.~T. and {Bradley}, L.~D. and 
+	{P{\'e}rez-Su{\'a}rez}, D. and {de Val-Borro}, M. and {Paper Contributors}, (. and 
+	{Aldcroft}, T.~L. and {Cruz}, K.~L. and {Robitaille}, T.~P. and 
+	{Tollerud}, E.~J. and {Coordination Committee}, (. and {Ardelean}, C. and 
+	{Babej}, T. and {Bach}, Y.~P. and {Bachetti}, M. and {Bakanov}, A.~V. and 
+	{Bamford}, S.~P. and {Barentsen}, G. and {Barmby}, P. and {Baumbach}, A. and 
+	{Berry}, K.~L. and {Biscani}, F. and {Boquien}, M. and {Bostroem}, K.~A. and 
+	{Bouma}, L.~G. and {Brammer}, G.~B. and {Bray}, E.~M. and {Breytenbach}, H. and 
+	{Buddelmeijer}, H. and {Burke}, D.~J. and {Calderone}, G. and 
+	{Cano Rodr{\'{\i}}guez}, J.~L. and {Cara}, M. and {Cardoso}, J.~V.~M. and 
+	{Cheedella}, S. and {Copin}, Y. and {Corrales}, L. and {Crichton}, D. and 
+	{D{\rsquo}Avella}, D. and {Deil}, C. and {Depagne}, {\'E}. and 
+	{Dietrich}, J.~P. and {Donath}, A. and {Droettboom}, M. and 
+	{Earl}, N. and {Erben}, T. and {Fabbro}, S. and {Ferreira}, L.~A. and 
+	{Finethy}, T. and {Fox}, R.~T. and {Garrison}, L.~H. and {Gibbons}, S.~L.~J. and 
+	{Goldstein}, D.~A. and {Gommers}, R. and {Greco}, J.~P. and 
+	{Greenfield}, P. and {Groener}, A.~M. and {Grollier}, F. and 
+	{Hagen}, A. and {Hirst}, P. and {Homeier}, D. and {Horton}, A.~J. and 
+	{Hosseinzadeh}, G. and {Hu}, L. and {Hunkeler}, J.~S. and {Ivezi{\'c}}, {\v Z}. and 
+	{Jain}, A. and {Jenness}, T. and {Kanarek}, G. and {Kendrew}, S. and 
+	{Kern}, N.~S. and {Kerzendorf}, W.~E. and {Khvalko}, A. and 
+	{King}, J. and {Kirkby}, D. and {Kulkarni}, A.~M. and {Kumar}, A. and 
+	{Lee}, A. and {Lenz}, D. and {Littlefair}, S.~P. and {Ma}, Z. and 
+	{Macleod}, D.~M. and {Mastropietro}, M. and {McCully}, C. and 
+	{Montagnac}, S. and {Morris}, B.~M. and {Mueller}, M. and {Mumford}, S.~J. and 
+	{Muna}, D. and {Murphy}, N.~A. and {Nelson}, S. and {Nguyen}, G.~H. and 
+	{Ninan}, J.~P. and {N{\"o}the}, M. and {Ogaz}, S. and {Oh}, S. and 
+	{Parejko}, J.~K. and {Parley}, N. and {Pascual}, S. and {Patil}, R. and 
+	{Patil}, A.~A. and {Plunkett}, A.~L. and {Prochaska}, J.~X. and 
+	{Rastogi}, T. and {Reddy Janga}, V. and {Sabater}, J. and {Sakurikar}, P. and 
+	{Seifert}, M. and {Sherbert}, L.~E. and {Sherwood-Taylor}, H. and 
+	{Shih}, A.~Y. and {Sick}, J. and {Silbiger}, M.~T. and {Singanamalla}, S. and 
+	{Singer}, L.~P. and {Sladen}, P.~H. and {Sooley}, K.~A. and 
+	{Sornarajah}, S. and {Streicher}, O. and {Teuben}, P. and {Thomas}, S.~W. and 
+	{Tremblay}, G.~R. and {Turner}, J.~E.~H. and {Terr{\'o}n}, V. and 
+	{van Kerkwijk}, M.~H. and {de la Vega}, A. and {Watkins}, L.~L. and 
+	{Weaver}, B.~A. and {Whitmore}, J.~B. and {Woillez}, J. and 
+	{Zabalza}, V. and {Contributors}, (.},
+    title = "{The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package}",
+  journal = {\aj},
 archivePrefix = "arXiv",
    eprint = {1801.02634},
  primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics},
+ keywords = {methods: data analysis, methods: miscellaneous, methods: statistical, reference systems },
      year = 2018,
-    month = jan,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180102634T},
+    month = sep,
+   volume = 156,
+      eid = {123},
+    pages = {123},
+      doi = {10.3847/1538-3881/aabc4f},
+   adsurl = {http://adsabs.harvard.edu/abs/2018AJ....156..123T},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 


### PR DESCRIPTION
This PR updates the citation information (in `CITATION`) with the ADS urls and BibTeX entry for the peer reviewed publication: http://adsabs.harvard.edu/abs/2018AJ....156..123T