### PR TITLE
Add an imshow_norm function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -220,6 +220,11 @@ astropy.visualization.wcsaxes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add support for setting ``set_separator(None)`` to use default
+
+- Added ``imshow_norm`` function, which combines imshow and creation of a
+  ``ImageNormalize`` object. [#7785]
+
+- Add support for setting ``set_separator(None)`` in WCSAxes to use default
   separators. [#7570]
 
 - Added two keyword argument options to ``CoordinateHelper.set_format_unit``:

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -240,9 +240,9 @@ def imshow_norm(data, ax=None, **kwargs):
 
     Parameters
     ----------
-    data
-        The data to show. Can be whatever type `matplotlib.pyplot.imshow` and
-        `ImageNormalize` accept.
+    data : 2D or 3D array-like - see `~matplotlib.pyplot.imshow`
+        The data to show. Can be whatever `~matplotlib.pyplot.imshow` and
+        `ImageNormalize` both accept.
     ax : None or `~matplotlib.axes.Axes`
         If None, use pyplot's imshow.  Otherwise, calls ``imshow`` method of the
         supplied axes.
@@ -252,15 +252,15 @@ def imshow_norm(data, ax=None, **kwargs):
 
     Notes
     -----
-    The ``data`` matplotlib keyword is not supported.
+    The ``norm`` matplotlib keyword is not supported.
     """
     if 'X' in kwargs:
         raise ValueError('Cannot give both ``X`` and ``data``')
 
     if 'norm' in kwargs:
-        raise ValueError('There is not point in using imshow_norm if you give '
-                         's ``norm`` keyword - use imshow directly if you want '
-                         'that.')
+        raise ValueError('There is no point in using imshow_norm if you give '
+                         'the ``norm`` keyword - use imshow directly if you '
+                         'want that.')
 
     imshow_kwargs = dict(kwargs)
 
@@ -269,11 +269,11 @@ def imshow_norm(data, ax=None, **kwargs):
         if pname in kwargs:
             norm_kwargs[pname] = imshow_kwargs.pop(pname)
 
-    # now re-assign any "_mpl" kweywords to their equivalents
+    # now re-assign any "_mpl" keywords to their equivalents
     for pname in tuple(imshow_kwargs):
         if pname.endswith('_mpl'):
             if pname[:-4] in imshow_kwargs:
-                raise ValueError('Give both {} and {}, but the latter is not an'
+                raise ValueError('Gave both {} and {}, but the latter is not an'
                                  ' ImageNormalize keyword.'.format(pname[:-4],
                                                                    pname))
             imshow_kwargs[pname[:-4]] = imshow_kwargs.pop(pname)

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -277,6 +277,10 @@ def imshow_norm(data, ax=None, imshow_only_kwargs={}, **kwargs):
 
     for k, v in imshow_only_kwargs.items():
         if k not in _norm_sig.parameters:
+            # the below is not strictly "has to be true", but is here so that
+            # users don't start using both imshow_only_kwargs *and* keyword
+            # arguments to this function, as that makes for more confusing
+            # user code
             raise ValueError('Provided a keyword to imshow_only_kwargs ({}) '
                              'that is not a keyword for ImageNormalize. This is'
                              ' not supported, you should pass the keyword'

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -257,10 +257,15 @@ def imshow_norm(data, ax=None, **kwargs):
     if 'X' in kwargs:
         raise ValueError('Cannot give both ``X`` and ``data``')
 
+    if 'norm' in kwargs:
+        raise ValueError('There is not point in using imshow_norm if you give '
+                         's ``norm`` keyword - use imshow directly if you want '
+                         'that.')
+
     imshow_kwargs = dict(kwargs)
 
     norm_kwargs = {'data': data}
-    for pname in _norm_sig:
+    for pname in _norm_sig.parameters:
         if pname in kwargs:
             norm_kwargs[pname] = imshow_kwargs.pop(pname)
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -243,7 +243,7 @@ def imshow_norm(data, ax=None, **kwargs):
     data
         The data to show. Can be whatever type `matplotlib.pyplot.imshow` and
         `ImageNormalize` accept.
-    ax : None or `~matplotlib.axes._axes.Axes`
+    ax : None or `~matplotlib.axes.Axes`
         If None, use pyplot's imshow.  Otherwise, calls ``imshow`` method of the
         supplied axes.
 

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -188,9 +188,12 @@ def test_imshow_norm():
         # illegal to manually pass in normalization since that defeats the point
         imshow_norm(image, ax=ax, norm=ImageNormalize())
 
-    # vmin/vmax "shadow" the MPL versions, so we allow direct-setting
     imshow_norm(image, ax=ax, vmin=0, vmax=1)
-    imshow_norm(image, ax=ax, vmin_mpl=0, vmax_mpl=1)
+    # vmin/vmax "shadow" the MPL versions, so imshow_only_kwargs allows direct-setting
+    imshow_norm(image, ax=ax, imshow_only_kwargs=dict(vmin=0, vmax=1))
+    # but it should fail for an argument that is not in ImageNormalize
+    with pytest.raises(ValueError):
+        imshow_norm(image, ax=ax, imshow_only_kwargs=dict(cmap='jet'))
 
     # make sure the pyplot version works
     imres, norm = imshow_norm(image, ax=None)

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -172,8 +172,9 @@ class TestImageScaling:
         with pytest.raises(ValueError):
             simple_norm(DATA2, stretch='invalid')
 
+
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
-def testy_imshow_norm():
+def test_imshow_norm():
     image = np.random.randn(10, 10)
 
     ax = plt.subplot()

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -173,10 +173,32 @@ the data and the interval and stretch objects:
 
 As shown above, the colorbar ticks are automatically adjusted.
 
-Also note that while the input image to
-:class:`~astropy.visualization.mpl_normalize.ImageNormalize` is
-typically the one to be displayed, a completely different image can be
-used to establish the normalization (e.g. if one wants to display
+The input image to :class:`~astropy.visualization.mpl_normalize.ImageNormalize`
+is typically the one to be displayed, so there is a convenience function
+:func:`~astropy.visualization.mpl_normalize.imshow_norm` to ease this use case:
+
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.visualization import imshow_norm, MinMaxInterval, SqrtStretch
+
+    # Generate a test image
+    image = np.arange(65536).reshape((256, 256))
+
+    # Display the exact same thing as the above plot
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    im, norm = imshow_norm(image, ax, origin='lower',
+                           interval=MinMaxInterval(), stretch=SqrtStretch())
+    fig.colorbar(im)
+
+While this is the simplest case, it is also possible for a completely different
+image to be used to establish the normalization (e.g. if one wants to display
 several images with exactly the same normalization and stretch).
 
 The inputs to the


### PR DESCRIPTION
First the problem this is solving: I really like the `ImageNormalize` object as a way to use imshow to inspect an image.  But I find it really irritating that it means I have to provide the same data *twice* (once to the normalize object, then to imshow).  I realize that's a feature not a bug, but for *most* cases, it's extra effort.

So this PR adds an `imshow_norm` that deals with that: it combines `ImageNormalize` and `imshow` into a single function.  It also updates the narrative docs for `visualization` to point this out, but still keeps the example that shows why you might not want to do this.