### PR TITLE
MNT: Remove cache dir config for pytest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,10 +83,6 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
-- Removed ``--astropy-config-dir`` and ``--astropy-cache-dir`` options from
-  testing. Please use caching functionality that is natively in ``pytest``.
-  [#7787]
-
 astropy.time
 ^^^^^^^^^^^^
 
@@ -174,6 +170,10 @@ astropy.tests
 
 - Removed ``pytest_plugins`` as they are completely broken for ``pytest>=4``.
   [#7786]
+
+- Removed ``--astropy-config-dir`` and ``--astropy-cache-dir`` options from
+  testing. Please use caching functionality that is natively in ``pytest``.
+  [#7787]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,10 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Removed ``--astropy-config-dir`` and ``--astropy-cache-dir`` options from
+  testing. Please use caching functionality that is natively in ``pytest``.
+  [#7787]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/plugins/config.py
+++ b/astropy/tests/plugins/config.py
@@ -1,77 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This plugin provides customization of configuration and cache directories used
-by pytest.
+This plugin provides customization of configuration used by pytest.
 """
-import datetime
-import locale
-import os
-import sys
-from collections import OrderedDict
-
-import pytest
-
-from astropy.config.paths import set_temp_config, set_temp_cache
-from astropy.utils.argparse import writeable_directory
 from astropy.tests.helper import treat_deprecations_as_exceptions
 
-import importlib.machinery as importlib_machinery
-
-
-# these pytest hooks allow us to mark tests and run the marked tests with
-# specific command line options.
-
-def pytest_addoption(parser):
-
-    parser.addoption("--astropy-config-dir", nargs='?', type=writeable_directory,
-                     help="specify directory for storing and retrieving the "
-                          "Astropy configuration during tests (default is "
-                          "to use a temporary directory created by the test "
-                          "runner); be aware that using an Astropy config "
-                          "file other than the default can cause some tests "
-                          "to fail unexpectedly")
-
-    parser.addoption("--astropy-cache-dir", nargs='?', type=writeable_directory,
-                     help="specify directory for storing and retrieving the "
-                          "Astropy cache during tests (default is "
-                          "to use a temporary directory created by the test "
-                          "runner)")
-    parser.addini("astropy_config_dir",
-                  "specify directory for storing and retrieving the "
-                  "Astropy configuration during tests (default is "
-                  "to use a temporary directory created by the test "
-                  "runner); be aware that using an Astropy config "
-                  "file other than the default can cause some tests "
-                  "to fail unexpectedly", default=None)
-
-    parser.addini("astropy_cache_dir",
-                  "specify directory for storing and retrieving the "
-                  "Astropy cache during tests (default is "
-                  "to use a temporary directory created by the test "
-                  "runner)", default=None)
 
 def pytest_configure(config):
     treat_deprecations_as_exceptions()
-
-def pytest_runtest_setup(item):
-    config_dir = item.config.getini('astropy_config_dir')
-    cache_dir = item.config.getini('astropy_cache_dir')
-
-    # Command-line options can override, however
-    config_dir = item.config.getoption('astropy_config_dir') or config_dir
-    cache_dir = item.config.getoption('astropy_cache_dir') or cache_dir
-
-    # We can't really use context managers directly in py.test (although
-    # py.test 2.7 adds the capability), so this may look a bit hacky
-    if config_dir:
-        item.set_temp_config = set_temp_config(config_dir)
-        item.set_temp_config.__enter__()
-    if cache_dir:
-        item.set_temp_cache = set_temp_cache(cache_dir)
-        item.set_temp_cache.__enter__()
-
-def pytest_runtest_teardown(item, nextitem):
-    if hasattr(item, 'set_temp_cache'):
-        item.set_temp_cache.__exit__()
-    if hasattr(item, 'set_temp_config'):
-        item.set_temp_config.__exit__()


### PR DESCRIPTION
Follow up of #7721 . xref #7720 

In the long run, it would be better for us to just remove the cache options, as removing them lower maintenance burden going forward and it is unclear whether anyone is even using these options. I'll let others milestone this one.

**TODO**

- [x] Add change log when milestone is decided.