### PR TITLE
MNT: Simplify CCDData test

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1268,7 +1268,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
-- Fixed the bug in CCData.read when the HDU is not specified and the first one is empty so the function searches for the first HDU with data which may not have an image extension. [#7739]
+- Fixed the bug in CCData.read when the HDU is not specified and the first one
+  is empty so the function searches for the first HDU with data which may not
+  have an image extension. [#7739]
 
 astropy.samp
 ^^^^^^^^^^^^

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -500,7 +500,8 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
         # the primary header is empty.
         if hdu == 0 and hdus[hdu].data is None:
             for i in range(len(hdus)):
-                if hdus.info(hdu)[i][3] == 'ImageHDU' and hdus.fileinfo(i)['datSpan'] > 0:
+                if (hdus.info(hdu)[i][3] == 'ImageHDU' and
+                        hdus.fileinfo(i)['datSpan'] > 0):
                     hdu = i
                     comb_hdr = hdus[hdu].header.copy()
                     # Add header values from the primary header that aren't

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -883,14 +883,17 @@ def test_stddevuncertainty_compat_descriptor_no_weakref():
     assert uncert.parent_nddata is ccd
     uncert._parent_nddata = None
 
-def test_CCDataread_returns_image(ccd_data, tmpdir):
+
+# https://github.com/astropy/astropy/issues/7595
+def test_read_returns_image(tmpdir):
     # Test if CCData.read returns a image when reading a fits file containing
-    #a table and image, in that order.
-    tbl = Table([np.random.rand(10) for _ in range(20)])
-    img = np.random.rand(100, 100)
-    hdul = fits.HDUList(hdus=[fits.PrimaryHDU(), fits.TableHDU(tbl.as_array()), fits.ImageHDU(img)])
+    # a table and image, in that order.
+    tbl = Table(np.ones(10).reshape(5, 2))
+    img = np.ones((5, 5))
+    hdul = fits.HDUList(hdus=[fits.PrimaryHDU(), fits.TableHDU(tbl.as_array()),
+                              fits.ImageHDU(img)])
     filename = tmpdir.join('table_image.fits').strpath
     hdul.writeto(filename)
     ccd = CCDData.read(filename, unit='adu')
-    # Expecting to get (100, 100), the size of the image
-    assert ccd.data.shape == (100,100)
+    # Expecting to get (5, 5), the size of the image
+    assert ccd.data.shape == (5, 5)


### PR DESCRIPTION
Simplify CCDData test and minor formatting. This is a follow-up of #7739, which I was planning to review but arrived to the party too late. The test was adapted from example provided in #7595 but could be made lighter for performance.

Note: This should be milestoned the same as #7739.