### PR TITLE
Change ImageNormalize default to clip=True

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -351,6 +351,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- In ``ImageNormalize``, the default for ``clip`` is set to ``True``.
+  [#7800]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -57,7 +57,7 @@ class ImageNormalize(Normalize):
     """
 
     def __init__(self, data=None, interval=None, vmin=None, vmax=None,
-                 stretch=LinearStretch(), clip=False):
+                 stretch=LinearStretch(), clip=True):
         # this super call checks for matplotlib
         super().__init__(vmin=vmin, vmax=vmax, clip=clip)
 


### PR DESCRIPTION
I just noticed that the `ImageNormalize` docstring says the default is `clip=True`, but the init call default is `clip=False`.  This PR changes the default to `clip=True`, since I *think* that should be the default.  Setting `clip=False` doesn't make much sense to me and can give results that are not useful (e.g. an array with negative values when using a square-root or log stretch).

CC: @astrofrog