### PR TITLE
Better error message for CSV writer in the presence of comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -307,6 +307,9 @@ astropy.table
 - No values provided to stack will now raise ``ValueError`` rather than
   ``TypeError``. [#7674]
 
+- Better error message when writing out a table with comments to CSV format.
+  [#7801]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -199,6 +199,20 @@ class FastCsv(FastBasic):
         Override the default write method of `FastBasic` to
         output masked values as empty fields.
         """
+        # https://github.com/astropy/astropy/issues/7357
+        if 'comments' in table.meta:
+            errs = []
+
+            if isinstance(table.meta['comments'], str):
+                errs.append("'comments' must be a list of str.")
+
+            if self.comment != '#':
+                errs.append("Use comment='#' option to enable comments in "
+                            "metadata.")
+
+            if len(errs) > 0:
+                raise ValueError(' '.join(errs))
+
         self._write(table, output, {'fill_values': [(core.masked, '')]})
 
 

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -532,9 +532,28 @@ def test_write_comments(fast_writer):
 
     # setting comment=False should disable comment writing
     out = StringIO()
-    ascii.write(data, out, format='basic', comment=False, fast_writer=fast_writer)
+    ascii.write(data, out, format='basic', comment=False,
+                fast_writer=fast_writer)
     expected = ['a b c', '1 2 3']
     assert out.getvalue().splitlines() == expected
+
+    # CSV: https://github.com/astropy/astropy/issues/7357
+    with pytest.raises(ValueError) as exc:
+        out = StringIO()
+        ascii.write(data, out, format='csv')
+    assert "Use comment='#' option to enable comments in metadata." in str(exc)
+
+    out = StringIO()
+    ascii.write(data, out, format='csv', comment='#')
+    expected = ['#c1', '#c2', '#c3', 'a,b,c', '1,2,3']
+    assert out.getvalue().splitlines() == expected
+
+    tab = table.Table(data={'a': [1, 2]}, meta={'comments': 'spam'})
+    with pytest.raises(ValueError) as exc:
+        out = StringIO()
+        tab.write(out, format='ascii.csv')
+    assert ("'comments' must be a list of str. Use comment='#' option "
+            "to enable comments in metadata.") in str(exc)
 
 
 @pytest.mark.parametrize("fast_writer", [True, False])


### PR DESCRIPTION
Fix #7357 

Might be painful to backport, especially to v2, so milestoning to 3.1, but please let me know if this needs to be re-milestoned.