### PR TITLE
models inputs, outputs correlation matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,9 @@ astropy.modeling
 - Add a ``uses_quantity`` property to ``Model`` which allows introspection of if
   the ``Model`` can accept ``Quantity`` objects. [#7417]
 
+- Add a ``separability_matrix`` function which returns the correlation matrix
+  of inputs and outputs. [#7803]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 
@@ -596,7 +599,6 @@ astropy.wcs
 
 Other Changes and Additions
 ---------------------------
-
 
 3.0.4 (2018-08-02)
 ==================

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -21,7 +21,7 @@ from .core import Model, _CompoundModel, ModelDefinitionError
 from .mappings import Mapping
 
 
-__all__ = ["is_separable"]
+__all__ = ["is_separable", "separability_matrix"]
 
 
 def is_separable(transform):
@@ -39,6 +39,12 @@ def is_separable(transform):
         A boolean array with size ``transform.n_outputs`` where
         each element indicates whether the output is independent
         and the result of a separable transform.
+    separable_matrix : ndarray
+        A boolean correlation matrix of shape (n_outputs, n_inputs).
+        Indicates the dependence of outputs on inputs. For completely
+        independent outputs, the diagonal elements are True and
+        off-diagonal elements are False.
+
 
     Examples
     --------
@@ -61,6 +67,46 @@ def is_separable(transform):
     is_separable = separable_matrix.sum(1)
     is_separable = np.where(is_separable != 1, False, True)
     return is_separable
+
+
+def separability_matrix(transform):
+    """
+    Compute the correlation between outputs and inputs.
+
+    Parameters
+    ----------
+    transform : `~astropy.modeling.core.Model`
+        A (compound) model.
+
+    Returns
+    -------
+    separable_matrix : ndarray
+        A boolean correlation matrix of shape (n_outputs, n_inputs).
+        Indicates the dependence of outputs on inputs. For completely
+        independent outputs, the diagonal elements are True and
+        off-diagonal elements are False.
+
+
+    Examples
+    --------
+    >>> from astropy.modeling.models import Shift, Scale, Rotation2D, Polynomial2D
+    >>> separability_matrix(Shift(1) & Shift(2) | Scale(1) & Scale(2))
+        array([[ True, False], [False,  True]]...)
+    >>> separability_matrix(Shift(1) & Shift(2) | Rotation2D(2))
+        array([[ True,  True], [ True,  True]]...)
+    >>> separability_matrix(Shift(1) & Shift(2) | Mapping([0, 1, 0, 1]) | \
+        Polynomial2D(1) & Polynomial2D(2))
+        array([[ True,  True], [ True,  True]]...)
+    >>> separability_matrix(Shift(1) & Shift(2) | Mapping([0, 1, 0, 1]))
+        array([[ True, False], [False,  True], [ True, False], [False,  True]]...)
+
+    """
+    if transform.n_inputs == 1 and transform.n_outputs > 1:
+        return np.ones((transform.n_outputs, transform.n_inputs),
+                       dtype=np.bool)
+    separable_matrix = _separable(transform)
+    separable_matrix = np.where(separable_matrix != 0, True, False)
+    return separable_matrix
 
 
 def _compute_n_outputs(left, right):

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -39,12 +39,6 @@ def is_separable(transform):
         A boolean array with size ``transform.n_outputs`` where
         each element indicates whether the output is independent
         and the result of a separable transform.
-    separable_matrix : ndarray
-        A boolean correlation matrix of shape (n_outputs, n_inputs).
-        Indicates the dependence of outputs on inputs. For completely
-        independent outputs, the diagonal elements are True and
-        off-diagonal elements are False.
-
 
     Examples
     --------
@@ -85,7 +79,6 @@ def separability_matrix(transform):
         Indicates the dependence of outputs on inputs. For completely
         independent outputs, the diagonal elements are True and
         off-diagonal elements are False.
-
 
     Examples
     --------

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_allclose
 from .. import models
 from ..models import Mapping
 from .. separable import (_coord_matrix, is_separable, _cdot,
-                          _cstack, _arith_oper)
+                          _cstack, _arith_oper, separability_matrix)
 
 
 sh1 = models.Shift(1, name='shift1')
@@ -28,22 +28,28 @@ p1 = models.Polynomial1D(1, name='p1')
 
 compound_models = {
     'cm1': (map3 & sh1 | rot & sh1 | sh1 & sh2 & sh1,
-            np.array([False, False, True])
+            (np.array([False, False, True]),
+             np.array([[True, False], [True, False], [False, True]]))
             ),
     'cm2': (sh1 & sh2 | rot | map1 | p2 & p22,
-            np.array([False, False])
+            (np.array([False, False]),
+             np.array([[True, True], [True, True]]))
             ),
     'cm3': (map2 | rot & scl1,
-            np.array([False, False, True])
+            (np.array([False, False, True]),
+            np.array([[True, False], [True, False], [False, True]]))
             ),
     'cm4': (sh1 & sh2 | map2 | rot & scl1,
-            np.array([False, False, True])
+            (np.array([False, False, True]),
+            np.array([[True, False], [True, False], [False, True]]))
             ),
     'cm5': (map3 | sh1 & sh2 | scl1 & scl2,
-            np.array([False, False])
+            (np.array([False, False]),
+            np.array([[True], [True]]))
             ),
     'cm7': (map2 | p2 & sh1,
-            np. array([False, True])
+            (np.array([False, True]),
+            np.array([[True, False], [False, True]]))
             )
 }
 
@@ -110,4 +116,5 @@ def test_arith_oper():
 
 @pytest.mark.parametrize(('compound_model', 'result'), compound_models.values())
 def test_separable(compound_model, result):
-    assert_allclose(is_separable(compound_model), result)
+    assert_allclose(is_separable(compound_model), result[0])
+    assert_allclose(separability_matrix(compound_model), result[1])


### PR DESCRIPTION
This modifies `is_separable` to return the correlation matrix of inputs and outputs. 
Motivation for this is the WCS APE.