### PR TITLE
Guard against ncoord=0, zero malloc size in pipeline_pix2foc() & pipeline_all_pixel2world()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1322,6 +1322,10 @@ astropy.wcs
 - Instead of raising an error ``astropy.wcs`` now returns the input when
   the input has zero size.                                       [#7746]
 
+- Fix ``malloc(0)`` bug in ``pipeline_all_pixel2world()`` and
+  ``pipeline_pix2foc()``. They now raise an exception for input with
+  zero coordinates, i.e. shape = (0, n). [#7806]
+
 Other Changes and Additions
 ---------------------------
 

--- a/astropy/wcs/src/pipeline.c
+++ b/astropy/wcs/src/pipeline.c
@@ -99,6 +99,13 @@ pipeline_all_pixel2world(
   }
 
   if (has_wcs) {
+    if (ncoord < 1) {
+      status = wcserr_set(
+        PIP_ERRMSG(WCSERR_BAD_PIX),
+        "The number of coordinates must be > 0");
+      goto exit;
+    }
+
     buffer = mem = malloc(
         ncoord * nelem * sizeof(double) + /* imgcrd */
         ncoord * sizeof(double) +         /* phi */
@@ -189,6 +196,13 @@ int pipeline_pix2foc(
   }
 
   err = &(pipeline->err);
+
+  if (ncoord < 1) {
+      status = wcserr_set(
+        PIP_ERRMSG(WCSERR_BAD_PIX),
+        "The number of coordinates must be > 0");
+      goto exit;
+    }
 
   has_det2im = pipeline->det2im[0] != NULL || pipeline->det2im[1] != NULL;
   has_sip    = pipeline->sip != NULL;


### PR DESCRIPTION
Resolves #7804

Signed-off-by: James Noss <jnoss@stsci.edu>