### PR TITLE
Factor out np.matrix from wcs

### DIFF
--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3045,21 +3045,21 @@ reduce these to 2 dimensions using the naxis kwarg.
     def pixel_scale_matrix(self):
 
         try:
-            cdelt = np.matrix(np.diag(self.wcs.get_cdelt()))
-            pc = np.matrix(self.wcs.get_pc())
+            cdelt = np.diag(self.wcs.get_cdelt())
+            pc = self.wcs.get_pc()
         except InconsistentAxisTypesError:
             try:
                 # for non-celestial axes, get_cdelt doesn't work
-                cdelt = np.matrix(self.wcs.cd) * np.matrix(np.diag(self.wcs.cdelt))
+                cdelt = np.matmul(self.wcs.cd, np.diag(self.wcs.cdelt))
             except AttributeError:
-                cdelt = np.matrix(np.diag(self.wcs.cdelt))
+                cdelt = np.diag(self.wcs.cdelt)
 
             try:
-                pc = np.matrix(self.wcs.pc)
+                pc = self.wcs.pc
             except AttributeError:
                 pc = 1
 
-        pccd = np.array(cdelt * pc)
+        pccd = np.array(np.matmul(cdelt, pc))
 
         return pccd
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3050,7 +3050,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         except InconsistentAxisTypesError:
             try:
                 # for non-celestial axes, get_cdelt doesn't work
-                cdelt = np.matmul(self.wcs.cd, np.diag(self.wcs.cdelt))
+                cdelt = np.dot(self.wcs.cd, np.diag(self.wcs.cdelt))
             except AttributeError:
                 cdelt = np.diag(self.wcs.cdelt)
 
@@ -3059,7 +3059,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             except AttributeError:
                 pc = 1
 
-        pccd = np.array(np.matmul(cdelt, pc))
+        pccd = np.array(np.dot(cdelt, pc))
 
         return pccd
 


### PR DESCRIPTION
This warning:
```
PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.
```
implies we shouldn't be using the matrix class any more.  See also #5088.