### PR TITLE
[WIP] Fix issue with VLA columns and multi-dimensional arrays

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1576,7 +1576,7 @@ class ColDefs(NotifierMixin):
                 # filled with undefined values.
                 offsets.append(offsets[-1] + dt.itemsize)
 
-            if dim:
+            if dim and format_.format not in 'PQ':
                 if format_.format == 'A':
                     dt = np.dtype((dt.char + str(dim[-1]), dim[:-1]))
                 else:


### PR DESCRIPTION
Should fix #7810.

For variable-length array the table field is an array descriptor
containing two 32-bit signed integer values (for P). This can also be
used with TDIM, but in this case the code was changing the dtype of the
column, containing the array descriptor, though the TDIM keyword should
apply only the data array contained in the heap.

So the fix here is just to skip the dtype change for columns with TDIM
if the column contains VLA.
