### PR TITLE
parser for objects with J coordinates embedded in their names (renewed)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The ``SkyCoord.from_name`` constructor now has the ability to create 
+  coordinate objects by parsing object catalogue names that have embedded 
+  J-coordinates.  [#7830]
+  
 - The new function ``make_transform_graph_docs`` can be used to create a
   docstring graph from a custom ``TransformGraph`` object. [#7135]
 

--- a/astropy/coordinates/jparser.py
+++ b/astropy/coordinates/jparser.py
@@ -1,0 +1,64 @@
+"""
+Module for parsing astronomical object names to extract embedded coordinates
+eg: '2MASS J06495091-0737408'
+"""
+
+import re
+
+import numpy as np
+
+import astropy.units as u
+from astropy.coordinates import SkyCoord
+
+RA_REGEX = '()([0-2]\d)([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+DEC_REGEX = '([+-])(\d{1,2})([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+JCOORD_REGEX = '(.*?J)' + RA_REGEX + DEC_REGEX
+JPARSER = re.compile(JCOORD_REGEX)
+
+
+def _sexagesimal(g):
+    # convert matched regex groups to sexigesimal array
+    sign, h, m, s, frac = g
+    sign = -1 if (sign == '-') else 1
+    s = '.'.join((s, frac))
+    return sign * np.array([h, m, s], float)
+
+
+def search(name, raise_=False):
+    """Regex match for coordinates in name"""
+    # extract the coordinate data from name
+    match = JPARSER.search(name)
+    if match is None and raise_:
+        raise ValueError('No coordinate match found!')
+    return match
+
+
+def to_ra_dec_angles(name):
+    """get RA in hourangle and DEC in degrees by parsing name """
+    groups = search(name, True).groups()
+    prefix, hms, dms = np.split(groups, [1, 6])
+    ra = (_sexagesimal(hms) / (1, 60, 60 * 60) * u.hourangle).sum()
+    dec = (_sexagesimal(dms) * (u.deg, u.arcmin, u.arcsec)).sum()
+    return ra, dec
+
+
+def to_skycoord(name, frame='icrs'):
+    """Convert to `name` to `SkyCoords` object"""
+    return SkyCoord(*to_ra_dec_angles(name), frame=frame)
+
+
+def shorten(name):
+    """
+    Produce a shortened version of the full object name using: the prefix
+    (usually the survey name) and RA (hour, minute), DEC (deg, arcmin) parts.
+        e.g.: '2MASS J06495091-0737408' --> '2MASS J0649-0737'
+    Parameters
+    ----------
+    name : str
+        Full object name with J-coords embedded.
+    Returns
+    -------
+    shortName: str
+    """
+    match = search(name)
+    return ''.join(match.group(1, 3, 4, 7, 8, 9))

--- a/astropy/coordinates/jparser.py
+++ b/astropy/coordinates/jparser.py
@@ -10,8 +10,8 @@ import numpy as np
 import astropy.units as u
 from astropy.coordinates import SkyCoord
 
-RA_REGEX = '()([0-2]\d)([0-5]\d)([0-5]\d)\.?(\d{0,3})'
-DEC_REGEX = '([+-])(\d{1,2})([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+RA_REGEX = r'()([0-2]\d)([0-5]\d)([0-5]\d)\.?(\d{0,3})'
+DEC_REGEX = r'([+-])(\d{1,2})([0-5]\d)([0-5]\d)\.?(\d{0,3})'
 JCOORD_REGEX = '(.*?J)' + RA_REGEX + DEC_REGEX
 JPARSER = re.compile(JCOORD_REGEX)
 

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -86,7 +86,7 @@ def _parse_response(resp_data):
         return ra, dec
 
 
-def get_icrs_coordinates(name, use_parser=False):
+def get_icrs_coordinates(name, parse=False):
     """
     Retrieve an ICRS object by using an online name resolving service to
     retrieve coordinates for the specified name. By default, this will
@@ -105,7 +105,7 @@ def get_icrs_coordinates(name, use_parser=False):
     ----------
     name : str
         The name of the object to get coordinates for, e.g. ``'M42'``.
-    use_parser: bool
+    parse: bool
         Whether to attempt extracting the coordinates from the name by
         parsing with a regex. For objects catalog names that have
         J-coordinates embedded in their names eg:
@@ -124,13 +124,14 @@ def get_icrs_coordinates(name, use_parser=False):
 
     # if requested, first try extract coordinates embedded in the object name.
     # Do this first since it may be much faster than doing the sesame query
-    if use_parser:
+    if parse:
         from . import jparser
         if jparser.search(name):
             return jparser.to_skycoord(name)
         else:
             # if the parser failed, fall back to sesame query.
             pass
+            # maybe emit a warning instead of silently falling back to sesame?
 
     database = sesame_database.get()
     # The web API just takes the first letter of the database name

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -86,7 +86,7 @@ def _parse_response(resp_data):
         return ra, dec
 
 
-def get_icrs_coordinates(name):
+def get_icrs_coordinates(name, use_parser=False):
     """
     Retrieve an ICRS object by using an online name resolving service to
     retrieve coordinates for the specified name. By default, this will
@@ -105,6 +105,15 @@ def get_icrs_coordinates(name):
     ----------
     name : str
         The name of the object to get coordinates for, e.g. ``'M42'``.
+    use_parser: bool
+        Whether to attempt extracting the coordinates from the name by
+        parsing with a regex. For objects catalog names that have
+        J-coordinates embedded in their names eg:
+        'CRTS SSS100805 J194428-420209', this may be much faster than a
+        sesame query for the same object name. The coordinates extracted
+        in this way may differ from the database coordinates by a few
+        deci-arcseconds, so only use this option if you do not need
+        sub-arcsecond accuracy for coordinates.
 
     Returns
     -------
@@ -112,6 +121,16 @@ def get_icrs_coordinates(name):
         The object's coordinates in the ICRS frame.
 
     """
+
+    # if requested, first try extract coordinates embedded in the object name.
+    # Do this first since it may be much faster than doing the sesame query
+    if use_parser:
+        from . import jparser
+        if jparser.search(name):
+            return jparser.to_skycoord(name)
+        else:
+            # if the parser failed, fall back to sesame query.
+            pass
 
     database = sesame_database.get()
     # The web API just takes the first letter of the database name

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1665,7 +1665,7 @@ class SkyCoord(ShapedLikeNDArray):
 
     # Name resolve
     @classmethod
-    def from_name(cls, name, frame='icrs'):
+    def from_name(cls, name, frame='icrs', use_parser=False):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame
@@ -1680,6 +1680,15 @@ class SkyCoord(ShapedLikeNDArray):
             The name of the object to get coordinates for, e.g. ``'M42'``.
         frame : str or `BaseCoordinateFrame` class or instance
             The frame to transform the object to.
+        use_parser: bool
+            Whether to attempt extracting the coordinates from the name by
+            parsing with a regex. For objects catalog names that have
+            J-coordinates embedded in their names eg:
+            'CRTS SSS100805 J194428-420209', this may be much faster than a
+            sesame query for the same object name. The coordinates extracted
+            in this way may differ from the database coordinates by a few
+            deci-arcseconds, so only use this option if you do not need
+            sub-arcsecond accuracy for coordinates.
 
         Returns
         -------
@@ -1689,7 +1698,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         from .name_resolve import get_icrs_coordinates
 
-        icrs_coord = get_icrs_coordinates(name)
+        icrs_coord = get_icrs_coordinates(name, use_parser)
         icrs_sky_coord = cls(icrs_coord)
         if frame in ('icrs', icrs_coord.__class__):
             return icrs_sky_coord

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1665,7 +1665,7 @@ class SkyCoord(ShapedLikeNDArray):
 
     # Name resolve
     @classmethod
-    def from_name(cls, name, frame='icrs', use_parser=False):
+    def from_name(cls, name, frame='icrs', parse=False):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame
@@ -1680,7 +1680,7 @@ class SkyCoord(ShapedLikeNDArray):
             The name of the object to get coordinates for, e.g. ``'M42'``.
         frame : str or `BaseCoordinateFrame` class or instance
             The frame to transform the object to.
-        use_parser: bool
+        parse: bool
             Whether to attempt extracting the coordinates from the name by
             parsing with a regex. For objects catalog names that have
             J-coordinates embedded in their names eg:
@@ -1698,7 +1698,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         from .name_resolve import get_icrs_coordinates
 
-        icrs_coord = get_icrs_coordinates(name, use_parser)
+        icrs_coord = get_icrs_coordinates(name, parse)
         icrs_sky_coord = cls(icrs_coord)
         if frame in ('icrs', icrs_coord.__class__):
             return icrs_sky_coord

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -136,6 +136,20 @@ def test_names():
     np.testing.assert_almost_equal(icrs.dec.degree, icrs_true.dec.degree, 1)
 
 
+def test_names_parse():
+    # a few test cases for parsing embedded coordinates from object name
+    test_names = ['CRTS SSS100805 J194428-420209',
+                  'MASTER OT J061451.7-272535.5',
+                  '2MASS J06495091-0737408',
+                  '1RXS J042555.8-194534',
+                  'SDSS J132411.57+032050.5',
+                  'DENIS-P J203137.5-000511',
+                  '2QZ J142438.9-022739',
+                  'CXOU J141312.3-652013']
+    for name in test_names:
+        get_icrs_coordinates(name, use_parser=True)
+
+
 @pytest.mark.remote_data
 @pytest.mark.parametrize(("name", "db_dict"), [('NGC 3642', _cached_ngc3642),
                                                ('castor', _cached_castor)])

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -147,7 +147,7 @@ def test_names_parse():
                   '2QZ J142438.9-022739',
                   'CXOU J141312.3-652013']
     for name in test_names:
-        get_icrs_coordinates(name, use_parser=True)
+        sc = get_icrs_coordinates(name, parse=True)
 
 
 @pytest.mark.remote_data

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -236,6 +236,19 @@ for a particular named object::
     >>> SkyCoord.from_name("PSR J1012+5307")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
         (153.1393271, 53.117343)>
+        
+In some cases, the coordinates are embedded in the catalogue name of the object.
+For such object names, `~astropy.coordinates.SkyCoord.from_name` is able 
+to parse the coordinates from the name if given the ``parse=True`` option.  
+For slow connections, this may be much faster than a sesame query for the same 
+object name. It's worth noting, however, that the coordinates extracted in this 
+way may differ from the database coordinates by a few deci-arcseconds, so only 
+use this option if you do not need sub-arcsecond accuracy for your coordinates::
+
+    >>> SkyCoord.from_name("CRTS SSS100805 J194428-420209", parse=True)
+    <SkyCoord (ICRS): (ra, dec) in deg
+        (296.1167, -42.03583)>
+
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides
 a quick way to get an `~astropy.coordinates.EarthLocation`::

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -247,7 +247,7 @@ use this option if you do not need sub-arcsecond accuracy for your coordinates::
 
     >>> SkyCoord.from_name("CRTS SSS100805 J194428-420209", parse=True)
     <SkyCoord (ICRS): (ra, dec) in deg
-        (296.1167, -42.03583)>
+        (296.11666667, -42.03583333)>
 
 
 For sites (primarily observatories) on the Earth, `astropy.coordinates` provides


### PR DESCRIPTION
Copied from #7216 which got closed-by-bot since I was too slow with updating the PR.  This new PR is a rebased copy of the original and also incorporates the changes requested by @eteq.

This PR adds functionality to `SkyCoord.from_name` by enabling parsing of object names with embedded coordinates.  On slow connections, this typically leads to a large performance gain at the cost of a few tenths of arcsec in accuracy for coordinate positions.

```
from astropy.coordinates import SkyCoord

coords = SkyCoord.from_name('2MASS J06495091-0737408', parse=True)
print(coords)
```
which prints
```
<SkyCoord (ICRS): (ra, dec) in deg
    (102.462125, -7.628)>
```