### PR TITLE
Limit doc build to use matplotlib < 3 

### DIFF
--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -9,7 +9,7 @@ pytz
 beautifulsoup4
 ipython
 mpmath
-matplotlib
+matplotlib<3
 scipy
 pillow
 jplephem


### PR DESCRIPTION
See if this fixes the `html-doc` CircleCI failure first before a more permanent fix can be made.