### PR TITLE
Representation now can be compared to check if they are equivalent. solves issue #7793

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ astropy.coordinates
   more suitable for catalog matching, and results in 1000x speedup in some
   cases. [#7324]
 
+- ``representation`` can be compared to check equality. [#7837]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ astropy.coordinates
   more suitable for catalog matching, and results in 1000x speedup in some
   cases. [#7324]
 
-- ``representation`` can be compared to check equality. [#7837]
+- ``representation`` can be compared to check equality. [#7838]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -324,6 +324,17 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
     def __rsub__(self, other):
         return self._combine_operation(operator.sub, other, reverse=True)
 
+    # Required to check equality between representation and differential
+    # classes
+    def __eq__(self, other):
+        if self.__class__ != other.__class__:
+            return False
+
+        for component in self.components:
+            if getattr(self, component) != getattr(other, component):
+                return False
+        return True
+
     # The following are used for repr and str
     @property
     def _values(self):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -325,14 +325,21 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         return self._combine_operation(operator.sub, other, reverse=True)
 
     # Required to check equality between representation and differential
-    # classes
+    # classes.
     def __eq__(self, other):
         if self.__class__ != other.__class__:
             return False
 
+        if self.isscalar and other.isscalar:
+            for component in self.components:
+                if getattr(self, component) != getattr(other, component):
+                    return False
+            return True
+
         for component in self.components:
-            if getattr(self, component) != getattr(other, component):
+            if any(getattr(self, component) != getattr(other, component)):
                 return False
+
         return True
 
     # The following are used for repr and str

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1497,3 +1497,23 @@ def test_unitphysics(unitphysics):
     assert assph.lon == obj.phi
     assert assph.lat == 80*u.deg
     assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)
+
+
+def test_equality_representation_differential():
+    representation_1 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
+    representation_2 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
+    assert representation_1 == representation_2
+
+    differential_1 = CartesianDifferential(0*u.m, 1*u.m, 2*u.m)
+    differential_2 = CartesianDifferential(0*u.m, 1*u.m, 2*u.m)
+    assert differential_1 == differential_2
+
+
+def test_inequality_representation_differntial():
+    representation_1 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
+    representation_2 = CartesianRepresentation(0*u.m, 1*u.m, 3*u.m)
+    assert representation_1 != representation_2
+
+    differential_1 = CartesianDifferential(0*u.m, 1*u.m, 2*u.m)
+    differential_2 = CartesianDifferential(0*u.m, 1*u.m, 3*u.m)
+    assert differential_1 != differential_2

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1499,7 +1499,7 @@ def test_unitphysics(unitphysics):
     assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)
 
 
-def test_equality_representation_differential():
+def test_equality_representation_differential_scalar():
     representation_1 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
     representation_2 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
     assert representation_1 == representation_2
@@ -1509,11 +1509,31 @@ def test_equality_representation_differential():
     assert differential_1 == differential_2
 
 
-def test_inequality_representation_differntial():
+def test_inequality_representation_differential_scalar():
     representation_1 = CartesianRepresentation(0*u.m, 1*u.m, 2*u.m)
     representation_2 = CartesianRepresentation(0*u.m, 1*u.m, 3*u.m)
     assert representation_1 != representation_2
 
     differential_1 = CartesianDifferential(0*u.m, 1*u.m, 2*u.m)
     differential_2 = CartesianDifferential(0*u.m, 1*u.m, 3*u.m)
+    assert differential_1 != differential_2
+
+
+def test_equality_representation_differential_non_scalar():
+    representation_1 = CartesianRepresentation([0, 1]*u.m, [2, 3]*u.m, [4, 5]*u.m)
+    representation_2 = CartesianRepresentation([0, 1]*u.m, [2, 3]*u.m, [4, 5]*u.m)
+    assert representation_1 == representation_2
+
+    differential_1 = CartesianDifferential([0, 1]*u.m, [2, 3]*u.m, [4, 5]*u.m)
+    differential_2 = CartesianDifferential([0, 1]*u.m, [2, 3]*u.m, [4, 5]*u.m)
+    assert differential_1 == differential_2
+
+
+def test_inequality_representation_differential_non_scalar():
+    representation_1 = CartesianRepresentation([0, 1]*u.m, [1, 1]*u.m, [2, 3]*u.m)
+    representation_2 = CartesianRepresentation([0, 1]*u.m, [1, 2]*u.m, [3, 3]*u.m)
+    assert representation_1 != representation_2
+
+    differential_1 = CartesianDifferential([0, 1]*u.m, [1, 1]*u.m, [2, 3]*u.m)
+    differential_2 = CartesianDifferential([0, 1]*u.m, [1, 2]*u.m, [3, 3]*u.m)
     assert differential_1 != differential_2


### PR DESCRIPTION
Previously comparing equivalent frame may lead to wrong results since one cannot compare representation objects are equivalent. 
Previously 
```
>>> from astropy.coordinates import GCRS
>>> from astropy.time import Time
>>> epoch = Time.now()
>>> GCRS(obstime=epoch).is_equivalent_frame(GCRS(obstime=epoch))
>>> False
```
But now

```
>>> GCRS(obstime=epoch).is_equivalent_frame(GCRS(obstime=epoch))
True
```

EDIT: Fix #7793