### PR TITLE
Fix compatibility of WCSAxes with Matplotlib 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
 
   image-tests-mpl202:
     docker:
-      - image: astropy/image-tests-py35-mpl202:1.2
+      - image: astropy/image-tests-py35-mpl202:1.3
     steps:
       - checkout
       - run:
@@ -45,7 +45,27 @@ jobs:
 
   image-tests-mpl212:
     docker:
-      - image: astropy/image-tests-py35-mpl212:1.2
+      - image: astropy/image-tests-py35-mpl212:1.3
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+
+  image-tests-mpl222:
+    docker:
+      - image: astropy/image-tests-py35-mpl222:1.3
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+
+  image-tests-mpl300:
+    docker:
+      - image: astropy/image-tests-py35-mpl300:1.3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ workflows:
       - 32bit
       - image-tests-mpl202
       - image-tests-mpl212
+      - image-tests-mpl222
+      - image-tests-mpl300
 
 notify:
   webhooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1328,6 +1328,8 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fix compatibility with Matplotlib 3.0. [#7839]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -394,7 +394,7 @@ class CoordinateHelper:
         """
         self.ticklabels.set_visible(visible)
 
-    def set_axislabel(self, text, minpad=1, **kwargs):
+    def set_axislabel(self, text, minpad=1, fontdict=None, **kwargs):
         """
         Set the text and optionally visual properties for the axis label.
 
@@ -404,6 +404,8 @@ class CoordinateHelper:
             The axis label text.
         minpad : float, optional
             The padding for the label in terms of axis label font size.
+        fontdict : dict, optional
+            Dictionary of settings to pass to the label
         kwargs
             Keywords are passed to :class:`matplotlib.text.Text`. These
             can include keywords to set the ``color``, ``size``, ``weight``, and
@@ -412,6 +414,8 @@ class CoordinateHelper:
         self.axislabels.set_text(text)
         self.axislabels.set_minpad(minpad)
         self.axislabels.set(**kwargs)
+        if fontdict is not None:
+            self.axislabels.update(fontdict)
 
     def get_axislabel(self):
         """

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -394,7 +394,7 @@ class CoordinateHelper:
         """
         self.ticklabels.set_visible(visible)
 
-    def set_axislabel(self, text, minpad=1, fontdict=None, **kwargs):
+    def set_axislabel(self, text, minpad=1, **kwargs):
         """
         Set the text and optionally visual properties for the axis label.
 
@@ -404,19 +404,24 @@ class CoordinateHelper:
             The axis label text.
         minpad : float, optional
             The padding for the label in terms of axis label font size.
-        fontdict : dict, optional
-            Dictionary of settings to pass to the label
         kwargs
             Keywords are passed to :class:`matplotlib.text.Text`. These
             can include keywords to set the ``color``, ``size``, ``weight``, and
             other text properties.
         """
-        self.axislabels.set_text(text)
+
+        fontdict = kwargs.pop('fontdict', None)
+
         # NOTE: When using plt.xlabel/plt.ylabel, minpad can get set explicitly
         # to None so we need to make sure that in that case we change to a
-        # default numerical value, which we do in the line below.
-        self.axislabels.set_minpad(minpad or 1)
+        # default numerical value.
+        if minpad is None:
+            minpad = 1
+
+        self.axislabels.set_text(text)
+        self.axislabels.set_minpad(minpad)
         self.axislabels.set(**kwargs)
+
         if fontdict is not None:
             self.axislabels.update(fontdict)
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -412,7 +412,10 @@ class CoordinateHelper:
             other text properties.
         """
         self.axislabels.set_text(text)
-        self.axislabels.set_minpad(minpad)
+        # NOTE: When using plt.xlabel/plt.ylabel, minpad can get set explicitly
+        # to None so we need to make sure that in that case we change to a
+        # default numerical value, which we do in the line below.
+        self.axislabels.set_minpad(minpad or 1)
         self.axislabels.set(**kwargs)
         if fontdict is not None:
             self.axislabels.update(fontdict)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -572,7 +572,7 @@ class WCSAxes(Axes):
                 else:
                     return pixel2world + CoordinateTransform(self.wcs, frame)
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer, **kwargs):
 
         if not self.get_visible():
             return

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -2,9 +2,11 @@
 
 from functools import partial
 from collections import defaultdict
+from distutils.version import LooseVersion
 
 import numpy as np
 
+from matplotlib import __version__
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
@@ -20,6 +22,8 @@ from .utils import get_coord_meta, transform_contour_set_inplace
 from .frame import EllipticalFrame, RectangularFrame
 
 __all__ = ['WCSAxes', 'WCSAxesSubplot']
+
+MATPLOTLIB_LT_30 = LooseVersion(__version__) < LooseVersion('3.0')
 
 VISUAL_PROPERTIES = ['facecolor', 'edgecolor', 'linewidth', 'alpha', 'linestyle']
 
@@ -451,11 +455,21 @@ class WCSAxes(Axes):
 
         self._drawn = True
 
-    def set_xlabel(self, label, labelpad=1, **kwargs):
-        self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
+    if MATPLOTLIB_LT_30:
 
-    def set_ylabel(self, label, labelpad=1, **kwargs):
-        self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
+        def set_xlabel(self, label, labelpad=1, **kwargs):
+            self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
+
+        def set_ylabel(self, label, labelpad=1, **kwargs):
+            self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
+
+    else:
+
+        def set_xlabel(self, xlabel, labelpad=1, **kwargs):
+            self.coords[self._x_index].set_axislabel(xlabel, minpad=labelpad, **kwargs)
+
+        def set_ylabel(self, ylabel, labelpad=1, **kwargs):
+            self.coords[self._y_index].set_axislabel(ylabel, minpad=labelpad, **kwargs)
 
     def get_xlabel(self):
         return self.coords[self._x_index].get_axislabel()

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -460,14 +460,14 @@ class WCSAxes(Axes):
         if xlabel is None:
             xlabel = kwargs.pop('label', None)
             if xlabel is None:
-                raise ValueError('xlabel should be set')
+                raise TypeError("set_xlabel() missing 1 required positional argument: 'xlabel'")
         self.coords[self._x_index].set_axislabel(xlabel, minpad=labelpad, **kwargs)
 
     def set_ylabel(self, ylabel=None, labelpad=1, **kwargs):
         if ylabel is None:
             ylabel = kwargs.pop('label', None)
             if ylabel is None:
-                raise ValueError('ylabel should be set')
+                raise TypeError("set_ylabel() missing 1 required positional argument: 'ylabel'")
         self.coords[self._y_index].set_axislabel(ylabel, minpad=labelpad, **kwargs)
 
     def get_xlabel(self):

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -455,21 +455,20 @@ class WCSAxes(Axes):
 
         self._drawn = True
 
-    if MATPLOTLIB_LT_30:
+    # The label=None, xlabel=None (and similarly for ylabel) is to ensure
+    # compatibility with Matplotlib 2.x (which has label) and 3.x (which has
+    # xlabel). While these are meant to be a single positional argument,
+    # Matplotlib internally sometimes specifies e.g. set_xlabel(xlabel=...).
 
-        def set_xlabel(self, label, labelpad=1, **kwargs):
-            self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
+    def set_xlabel(self, label=None, xlabel=None, labelpad=1, **kwargs):
+        if label is None and xlabel is not None:
+            label = xlabel
+        self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
 
-        def set_ylabel(self, label, labelpad=1, **kwargs):
-            self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
-
-    else:
-
-        def set_xlabel(self, xlabel, labelpad=1, **kwargs):
-            self.coords[self._x_index].set_axislabel(xlabel, minpad=labelpad, **kwargs)
-
-        def set_ylabel(self, ylabel, labelpad=1, **kwargs):
-            self.coords[self._y_index].set_axislabel(ylabel, minpad=labelpad, **kwargs)
+    def set_ylabel(self, label=None, ylabel=None, labelpad=1, **kwargs):
+        if label is None and ylabel is not None:
+            label = ylabel
+        self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
 
     def get_xlabel(self):
         return self.coords[self._x_index].get_axislabel()

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -2,11 +2,9 @@
 
 from functools import partial
 from collections import defaultdict
-from distutils.version import LooseVersion
 
 import numpy as np
 
-from matplotlib import __version__
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
@@ -22,8 +20,6 @@ from .utils import get_coord_meta, transform_contour_set_inplace
 from .frame import EllipticalFrame, RectangularFrame
 
 __all__ = ['WCSAxes', 'WCSAxesSubplot']
-
-MATPLOTLIB_LT_30 = LooseVersion(__version__) < LooseVersion('3.0')
 
 VISUAL_PROPERTIES = ['facecolor', 'edgecolor', 'linewidth', 'alpha', 'linestyle']
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -451,20 +451,24 @@ class WCSAxes(Axes):
 
         self._drawn = True
 
-    # The label=None, xlabel=None (and similarly for ylabel) is to ensure
+    # MATPLOTLIB_LT_30: The ``kwargs.pop('label', None)`` is to ensure
     # compatibility with Matplotlib 2.x (which has label) and 3.x (which has
     # xlabel). While these are meant to be a single positional argument,
     # Matplotlib internally sometimes specifies e.g. set_xlabel(xlabel=...).
 
-    def set_xlabel(self, label=None, xlabel=None, labelpad=1, **kwargs):
-        if label is None and xlabel is not None:
-            label = xlabel
-        self.coords[self._x_index].set_axislabel(label, minpad=labelpad, **kwargs)
+    def set_xlabel(self, xlabel=None, labelpad=1, **kwargs):
+        if xlabel is None:
+            xlabel = kwargs.pop('label', None)
+            if xlabel is None:
+                raise ValueError('xlabel should be set')
+        self.coords[self._x_index].set_axislabel(xlabel, minpad=labelpad, **kwargs)
 
-    def set_ylabel(self, label=None, ylabel=None, labelpad=1, **kwargs):
-        if label is None and ylabel is not None:
-            label = ylabel
-        self.coords[self._y_index].set_axislabel(label, minpad=labelpad, **kwargs)
+    def set_ylabel(self, ylabel=None, labelpad=1, **kwargs):
+        if ylabel is None:
+            ylabel = kwargs.pop('label', None)
+            if ylabel is None:
+                raise ValueError('ylabel should be set')
+        self.coords[self._y_index].set_axislabel(ylabel, minpad=labelpad, **kwargs)
 
     def get_xlabel(self):
         return self.coords[self._x_index].get_axislabel()

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -572,7 +572,7 @@ class WCSAxes(Axes):
                 else:
                     return pixel2world + CoordinateTransform(self.wcs, frame)
 
-    def get_tightbbox(self, renderer, **kwargs):
+    def get_tightbbox(self, renderer, *args, **kwargs):
 
         if not self.get_visible():
             return

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -583,6 +583,10 @@ class WCSAxes(Axes):
 
     def get_tightbbox(self, renderer, *args, **kwargs):
 
+        # FIXME: we should determine what to do with the extra arguments here.
+        # Note that the expected signature of this method is different in
+        # Matplotlib 3.x compared to 2.x.
+
         if not self.get_visible():
             return
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -197,3 +197,14 @@ def test_slicing_warnings(tmpdir):
         print(warning)
 
     assert len(warning_lines) == 0
+
+
+def test_plt_xlabel_ylabel(tmpdir):
+
+    # Regression test for a bug that happened when using plt.xlabel
+    # and plt.ylabel with Matplotlib 3.0
+
+    plt.subplot(projection=WCS())
+    plt.xlabel('Galactic Longitude')
+    plt.ylabel('Galactic Latitude')
+    plt.savefig(tmpdir.join('test.png').strpath)

--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -9,7 +9,7 @@ pytz
 beautifulsoup4
 ipython
 mpmath
-matplotlib<3
+matplotlib
 scipy
 pillow
 jplephem


### PR DESCRIPTION
This is a quick fix for the get_tightbbox issue that is causing the docs build to fail. In future I'll need to look in detail at how to correctly interpret the extra arguments, but for now this should at least be backward-compatible.

This also undoes https://github.com/astropy/astropy/pull/7836 (no longer needed) - sorry @pllim :)