### PR TITLE
better error message for to_pandas()

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2878,9 +2878,12 @@ class Table:
 
         tbl = _encode_mixins(self)
 
-        if any(getattr(col, 'ndim', 1) > 1 for col in tbl.columns.values()):
-            raise ValueError("Cannot convert a table with multi-dimensional "
-                             "columns to a pandas DataFrame")
+        badcols = [name for name, col in self.columns.items()
+                   if (getattr(col, 'ndim', 1) > 1)]
+        if badcols:
+            raise ValueError(
+                "Cannot convert a table with multi-dimensional columns to a "
+                "pandas DataFrame. Offending columns are: {}".format(badcols))
 
         out = OrderedDict()
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1666,7 +1666,9 @@ class TestPandas:
 
         with pytest.raises(ValueError) as exc:
             t.to_pandas()
-        assert exc.value.args[0] == "Cannot convert a table with multi-dimensional columns to a pandas DataFrame"
+        assert (exc.value.args[0] ==
+            "Cannot convert a table with multi-dimensional columns "
+            "to a pandas DataFrame. Offending columns are: ['b']")
 
     def test_mixin_pandas(self):
         t = table.QTable()
@@ -1705,8 +1707,8 @@ class TestPandas:
         import pandas as pd
         row_index = pd.RangeIndex(0, 2, 1)
         tm_index = pd.DatetimeIndex(['1998-01-01', '2002-01-01'],
-                                                   dtype='datetime64[ns]',
-                                                   name='tm', freq=None)
+                                    dtype='datetime64[ns]',
+                                    name='tm', freq=None)
 
         tm = Time([1998, 2002], format='jyear')
         x = [1, 2]
@@ -1732,7 +1734,6 @@ class TestPandas:
         with pytest.raises(ValueError) as err:
             t.to_pandas(index='not a column')
         assert 'index must be None, False' in str(err)
-
 
     def test_mixin_pandas_masked(self):
         tm = Time([1, 2, 3], format='cxcsec')


### PR DESCRIPTION
I've added a more helpful error message to to_pandas, that says which are the offending (multidimensionsal) columns that are making to_pandas() fail.

   @eteq 