### PR TITLE
Fix bug with grid_type='contours' and custom transforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1341,9 +1341,8 @@ astropy.visualization
 
 - Fix compatibility with Matplotlib 3.0. [#7839]
 
-- Fix an issue that meant that transform objects passed to WCSAxes needed to
-  have a method called ``get_coord_slice`` in order for
-  ``grid_type='contours'`` to work. [#7846]
+- Fix an issue that caused a crash when using WCSAxes with a custom Transform
+  object and when using ``grid_type='contours'`` to plot a grid. [#7846]
 
 astropy.vo
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1341,6 +1341,10 @@ astropy.visualization
 
 - Fix compatibility with Matplotlib 3.0. [#7839]
 
+- Fix an issue that meant that transform objects passed to WCSAxes needed to
+  have a method called ``get_coord_slice`` in order for
+  ``grid_type='contours'`` to work. [#7846]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -34,5 +34,8 @@ class Conf(_config.ConfigNamespace):
     grid_samples = _config.ConfigItem(1000,
         'How many points to sample along grid lines.')
 
+    contour_grid_samples = _config.ConfigItem(200,
+        'The grid size to use when drawing a grid using contours')
+
 
 conf = Conf()

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -817,13 +817,18 @@ class CoordinateHelper:
         xmin, xmax = self.parent_axes.get_xlim()
         ymin, ymax = self.parent_axes.get_ylim()
 
-        x, y, field = self.transform.get_coord_slices(xmin, xmax, ymin, ymax, 200, 200)
+        from . import conf
+        res = conf.contour_grid_samples
+        
+        x, y = np.meshgrid(np.linspace(xmin, xmax, res),
+                           np.linspace(ymin, ymax, res))
+        pixel = np.array([x.ravel(), y.ravel()]).T
+        world = self.transform.transform(pixel)
+        field = world[:, self.coord_index].reshape(res, res).T
 
         coord_range = self.parent_map.get_coord_range()
 
         tick_world_coordinates, spacing = self.locator(*coord_range[self.coord_index])
-
-        field = field[self.coord_index]
 
         # tick_world_coordinates is a Quantities array and we only needs its values
         tick_world_coordinates_values = tick_world_coordinates.value

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -819,7 +819,7 @@ class CoordinateHelper:
 
         from . import conf
         res = conf.contour_grid_samples
-        
+
         x, y = np.meshgrid(np.linspace(xmin, xmax, res),
                            np.linspace(ymin, ymax, res))
         pixel = np.array([x.ravel(), y.ravel()]).T

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -49,11 +49,9 @@ class CurvedTransform(Transform, metaclass=abc.ABCMeta):
 
     transform_path_non_affine = transform_path
 
-    @abc.abstractmethod
     def transform(self, input):
         raise NotImplementedError("")
 
-    @abc.abstractmethod
     def inverted(self):
         raise NotImplementedError("")
 

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -142,17 +142,6 @@ class WCSPixel2WorldTransform(CurvedTransform):
     def output_dims(self):
         return self.wcs.wcs.naxis
 
-    def get_coord_slices(self, xmin, xmax, ymin, ymax, nx, ny):
-        """
-        Get a coordinate slice
-        """
-        x = np.linspace(xmin, xmax, nx)
-        y = np.linspace(ymin, ymax, ny)
-        Y, X = np.meshgrid(y, x)
-        pixel = np.array([X.ravel(), Y.ravel()]).transpose()
-        world = self.transform(pixel)
-        return X, Y, [world[:, i].reshape(nx, ny).transpose() for i in range(self.wcs.wcs.naxis)]
-
     def transform(self, pixel):
         """
         Transform pixel to world coordinates. You should pass in a Nx2 array


### PR DESCRIPTION
Using WCSAxes with a custom transform object (not a WCS object), and using ``grid_type='contours'`` when drawing a grid, resulted in the following error:

```
E       AttributeError: 'CustomTransform' object has no attribute 'get_coord_slices'
```

This PR fixes that bug.