### PR TITLE
Automatically pick grid_type in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -363,6 +363,9 @@ astropy.visualization
 - Changed ``AsymmetricPercentileInterval`` and ``MinMaxInterval`` to
   ignore NaN values in arrays. [#7360]
 
+- Automatically default to using ``grid_type='contours'`` in WCSAxes when using
+  a custom ``Transform`` object if the transform has no inverse. [#7847]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -119,7 +119,7 @@ class CoordinateHelper:
                                   'alpha': rcParams.get('grid.alpha', 1.0),
                                   'transform': self.parent_axes.transData}
 
-    def grid(self, draw_grid=True, grid_type='lines', **kwargs):
+    def grid(self, draw_grid=True, grid_type=None, **kwargs):
         """
         Plot grid lines for this coordinate.
 
@@ -137,8 +137,16 @@ class CoordinateHelper:
             positions in the image and then drawing contours
             (``'contours'``). The first is recommended for 2-d images, while
             for 3-d (or higher dimensional) cubes, the ``'contours'`` option
-            is recommended.
+            is recommended. By default, 'lines' is used if the transform has
+            an inverse, otherwise 'contours' is used.
         """
+
+        if grid_type == 'lines' and not self.transform.has_inverse:
+            raise ValueError('The specified transform has no inverse, so the '
+                             'grid cannot be drawn using grid_type=\'lines\'')
+
+        if grid_type is None:
+            grid_type = 'lines' if self.transform.has_inverse else 'contours'
 
         if grid_type in ('lines', 'contours'):
             self._grid_type = grid_type

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -131,7 +131,7 @@ class CoordinatesMap:
         for coord in self._coords:
             yield coord
 
-    def grid(self, draw_grid=True, grid_type='lines', **kwargs):
+    def grid(self, draw_grid=True, grid_type=None, **kwargs):
         """
         Plot gridlines for both coordinates.
 
@@ -149,7 +149,8 @@ class CoordinatesMap:
             positions in the image and then drawing contours
             (``'contours'``). The first is recommended for 2-d images, while
             for 3-d (or higher dimensional) cubes, the ``'contours'`` option
-            is recommended.
+            is recommended. By default, 'lines' is used if the transform has
+            an inverse, otherwise 'contours' is used.
         """
         for coord in self:
             coord.grid(draw_grid=draw_grid, grid_type=grid_type, **kwargs)

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -19,6 +19,8 @@ from ....tests.image_tests import IMAGE_REFERENCE_DIR
 
 class DistanceToLonLat(CurvedTransform):
 
+    has_inverse = True
+
     def __init__(self, R=6e3):
         super().__init__()
         self.R = R

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -49,11 +49,9 @@ class CurvedTransform(Transform, metaclass=abc.ABCMeta):
 
     transform_path_non_affine = transform_path
 
-    @abc.abstractmethod
     def transform(self, input):
         raise NotImplementedError("")
 
-    @abc.abstractmethod
     def inverted(self):
         raise NotImplementedError("")
 


### PR DESCRIPTION
When transforms have no inverse, only ``grid_type='contours'`` works, so we might as well be smart about this. Milestoning as 3.1 since this is an API change in a way. 