### PR TITLE
Changed _array_to_file check to allow HDUList to be written to stream

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1276,6 +1276,8 @@ astropy.io.fits
 - ``HDUList.__contains__()`` now works with ``HDU`` arguments. That is,
   ``hdulist[0] in hdulist`` now works as expected. [#7282]
 
+- ``HDUList`` s can now be written to streams in Python 3 [#7850]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -635,7 +635,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
     def _writeto(self, fileobj, inplace=False, copy=False):
         try:
             dirname = os.path.dirname(fileobj._file.name)
-        except AttributeError:
+        except (AttributeError, TypeError):
             dirname = None
 
         with _free_space_check(self, dirname):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -920,7 +920,7 @@ class HDUList(list, _Verify):
         hdulist = self.fromfile(fileobj)
         try:
             dirname = os.path.dirname(hdulist._file.name)
-        except AttributeError:
+        except (AttributeError, TypeError):
             dirname = None
 
         with _free_space_check(self, dirname=dirname):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1048,4 +1048,3 @@ class TestHDUListFunctions(FitsTestCase):
         with open(self.temp('test.fits'), 'wb') as fout:
             p = subprocess.Popen(["cat"], stdin=subprocess.PIPE, stdout=fout)
             hdulist.writeto(p.stdin)
-

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -6,6 +6,7 @@ import os
 import platform
 import sys
 import copy
+import subprocess
 
 import pytest
 import numpy as np
@@ -1034,3 +1035,17 @@ class TestHDUListFunctions(FitsTestCase):
         hdu_popped = hdul.pop('SCI')
         assert len(hdul) == 5
         assert hdu_popped is hdu1
+
+    def test_write_hdulist_to_stream(self):
+        """
+        Unit test for https://github.com/astropy/astropy/issues/7435
+        Ensure that an HDUList can be written to a stream in Python 2
+        """
+        data = np.array([[1,2,3],[4,5,6]])
+        hdu = fits.PrimaryHDU(data)
+        hdulist = fits.HDUList([hdu])
+
+        with open(self.temp('test.fits'), 'wb') as fout:
+            p = subprocess.Popen(["cat"], stdin=subprocess.PIPE, stdout=fout)
+            hdulist.writeto(p.stdin)
+

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -610,7 +610,7 @@ def _array_to_file(arr, outfile):
     `ndarray.tofile`.  Otherwise a slower Python implementation is used.
     """
 
-    if isfile(outfile):
+    if isfile(outfile) and not isinstance(outfile, io.BufferedIOBase):
         write = lambda a, f: a.tofile(f)
     else:
         write = _array_to_file_like


### PR DESCRIPTION
I implemented @saimn 's fix from this [post](https://github.com/astropy/astropy/issues/7435#issuecomment-386853456) and added @rmjarvis 's [minimal test](https://github.com/astropy/astropy/issues/7435#issue-320135895) as a unit test. This fixes #7435. 