### PR TITLE
Migrate to using pytest-cov

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -725,6 +725,11 @@ astropy.tests
 - Added an option ``--readonly`` to the test command to change the
   permissions on the temporary installation location to read-only. [#7598]
 
+- Changed the way coverage is handled in the test runner, to be based on
+  pytest-cov. This enables support for calculating covergae under parallel
+  buils as well as specifying ``--cov-report`` to the test command to customise
+  the reporting of the coverage statistics.
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -728,7 +728,7 @@ astropy.tests
 - Changed the way coverage is handled in the test runner, to be based on
   pytest-cov. This enables support for calculating covergae under parallel
   buils as well as specifying ``--cov-report`` to the test command to customise
-  the reporting of the coverage statistics.
+  the reporting of the coverage statistics. [#7851]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -329,7 +329,5 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         if self.cov_report and (isinstance(self.cov_report, bool) or "html" in self.cov_report):
             html_cov = os.path.join(os.path.abspath("."), "htmlcov")
             self.cov_report = 'html:{html_cov}'.format(html_cov=html_cov)
-        else:
-            self.cov_report = self.cov_report
 
         return cmd_pre, cmd_post

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -321,13 +321,13 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         cmd_post = ('from astropy.tests.helper import _patch_coverage; '
                     'import os; '
                     'test_dir = os.path.abspath("."); '
-                    f'_patch_coverage(test_dir, "{cwd}"); ')
+                    '_patch_coverage(test_dir, "{cwd}"); '.format(cwd=cwd))
 
         # Make html report the default and make pytest-cov save it to the
         # source directory not the temporary directory.
         if self.cov_report and (isinstance(self.cov_report, bool) or "html" in self.cov_report):
             html_cov = os.path.join(os.path.abspath("."), "htmlcov")
-            self.cov_report = f'html:{html_cov}'
+            self.cov_report = 'html:{html_cov}'.format(html_cov=html_cov)
         else:
             self.cov_report = self.cov_report
 

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -130,6 +130,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
         self.pep8 = False
         self.pdb = False
         self.coverage = False
+        self.cov_report = True
         self.open_files = False
         self.parallel = 0
         self.docs_path = None

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -504,7 +504,6 @@ def _patch_coverage(testdir, sourcedir):  # pragma: no cover
     dfs.filename = os.path.join(sourcedir, ".coverage")
 
     # Replace the testdir with source dir
-    # Lovingly borrowed from astropy (see licences directory)
     lines = cov.data._lines
     for key in list(lines.keys()):
         new_path = os.path.relpath(

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -317,15 +317,22 @@ class TestRunner(TestRunnerBase):
 
         return paths
 
-    # Increase priority so this warning is displayed first.
-    @keyword(priority=1000)
+    @keyword()
     def coverage(self, coverage, kwargs):
         if coverage:
-            warnings.warn(
-                "The coverage option is ignored on run_tests, since it "
-                "can not be made to work in that context.  Use "
-                "'python setup.py test --coverage' instead.",
-                AstropyWarning)
+            coveragerc = os.path.join(self.base_path, "tests", "coveragerc")
+            ret = []
+            for path in self.package_path:
+                ret += ["--cov", path, "--cov-config", coveragerc]
+            return ret
+
+        return []
+
+    @keyword()
+    def cov_report(self, cov_report, kwargs):
+        if kwargs['coverage'] and cov_report:
+            a = [cov_report] if isinstance(cov_report, str) else []
+            return ['--cov-report'] + a
 
         return []
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -323,7 +323,9 @@ class TestRunner(TestRunnerBase):
             coveragerc = os.path.join(self.base_path, "tests", "coveragerc")
             ret = []
             for path in self.package_path:
-                ret += ["--cov", path, "--cov-config", coveragerc]
+                ret += ["--cov", path]
+            ret += ["--cov-config", coveragerc]
+            print(ret)
             return ret
 
         return []

--- a/astropy/tests/tests/test_runner.py
+++ b/astropy/tests/tests/test_runner.py
@@ -1,11 +1,24 @@
+import imp
+
 import pytest
 
 # Renamed these imports so that them being in the namespace will not
 # cause pytest 3 to discover them as tests and then complain that
 # they have __init__ defined.
+import astropy.tests.runner
 from astropy.tests.runner import TestRunner as _TestRunner
 from astropy.tests.runner import TestRunnerBase as _TestRunnerBase
 from astropy.tests.runner import keyword
+
+
+def test_import_runner():
+    """
+    When running the tests with setup.py, the test runner class is imported by
+    setup.py before coverage is watching. To ensure that the coverage for
+    astropy/tests/runner.py is correctly measured we force the interpreter to
+    reload it here while coverage is watching.
+    """
+    imp.reload(astropy.tests.runner)
 
 
 def test_disable_kwarg():


### PR DESCRIPTION
This is an upstreaming of sunpy/sunpy#2667 which allowed us to run coverage checks on our parallel builds.

It replaces the manual coverage calculation with a call to pytest-cov (which should probably be added to pytest-astropy) and just patches the paths in the resulting coverage file.