### PR TITLE
Add millibar unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -182,6 +182,8 @@ astropy.units
 - Add ``thermodynamic_temperature`` equivalency to convert between
   Jy/beam and "thermodynamic temperature" for cosmology. [#7054]
 
+- Add millibar unit. [#7863]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -159,6 +159,7 @@ def_unit(['eV', 'electronvolt'], _si.e.value * J, namespace=_ns, prefixes=True,
 def_unit(['Pa', 'Pascal', 'pascal'], J * m ** -3, namespace=_ns, prefixes=True,
          doc="Pascal: pressure")
 def_unit(['bar'], 1e5 * Pa, namespace=_ns,
+         prefixes=[(['m'], ['milli'], 1.e-3)],
          doc="bar: pressure")
 
 


### PR DESCRIPTION
mbar is a common weather unit. Mbar and kbar are not widely used so do not turn on all prefixes.

This PR relates to #7861.  I'm not entirely sure where to put a test for this so advice is welcomed.