### PR TITLE
Remove timescale from FITS format time strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,12 @@ astropy.uncertainty
 
 - This sub-package was added as a "preview" (i.e. API unstable), containing
   the ``Distribution`` class and associated convenience functions. [#6945]
+- Remove timescale from string version of FITS format time string.
+  The timescale is not part of the FITS standard and should not be included.
+  This change may cause some compatibility issues for code that relies on
+  round-tripping a FITS format string with a timescale. Strings generated
+  from previous versions of this package are still understood but a
+  DeprecationWarning will be issued. [#7870]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -183,7 +183,7 @@ class TestFitsTime(FitsTestCase):
 
         # Test DATE
         assert isinstance(tm.meta['DATE'], Time)
-        assert tm.meta['DATE'].value == t.meta['DATE'] + '(UTC)'
+        assert tm.meta['DATE'].value == t.meta['DATE']
         assert tm.meta['DATE'].format == 'fits'
         # Default time scale according to the FITS standard is UTC
         assert tm.meta['DATE'].scale == 'utc'
@@ -203,7 +203,7 @@ class TestFitsTime(FitsTestCase):
 
         # Test DATE
         assert isinstance(tm.meta['DATE'], Time)
-        assert tm.meta['DATE'].value == t.meta['DATE'] + '(UTC)'
+        assert tm.meta['DATE'].value == t.meta['DATE']
         assert tm.meta['DATE'].scale == 'utc'
 
         # Test MJD-xxx

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1036,8 +1036,6 @@ class TimeFITS(TimeString):
         (subfmt[0],
          subfmt[1] + r'(\((?P<scale>\w+)(\((?P<realization>\w+)\))?\))?',
          subfmt[2]) for subfmt in subfmts)
-    _fits_scale = None
-    _fits_realization = None
 
     def parse_string(self, timestr, subfmts):
         """Read time and deprecated scale if present"""
@@ -1063,17 +1061,12 @@ class TimeFITS(TimeString):
                 raise ValueError("Scale {0!r} is not in the allowed scales {1}"
                                  .format(scale, sorted(TIME_SCALES)))
             # If no scale was given in the initialiser, set the scale to
-            # that given in the string.  Also store a possible realization,
-            # so we can round-trip (as long as no scale changes are made).
-            fits_realization = (tm['realization'].upper()
-                                if tm['realization'] else None)
-            if self._fits_scale is None:
-                self._fits_scale = fits_scale
-                self._fits_realization = fits_realization
-                if self._scale is None:
-                    self._scale = scale
-            if (scale != self.scale or fits_scale != self._fits_scale or
-                    fits_realization != self._fits_realization):
+            # that given in the string.  Realization is ignored
+            # and is only supported to allow old-style strings to be
+            # parsed.
+            if self._scale is None:
+                self._scale = scale
+            if scale != self.scale:
                 raise ValueError("Input strings for {0} class must all "
                                  "have consistent time scales."
                                  .format(self.name))

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1002,13 +1002,7 @@ class TimeFITS(TimeString):
     """
     FITS format: "[±Y]YYYY-MM-DD[THH:MM:SS[.sss]]".
 
-    ISOT with one extension:
-    - Can give signed five-digit year (mostly for negative years);
-
-    Note: FITS supports some deprecated names for timescales; these are
-    translated to the formal names upon initialization.  Furthermore, any
-    specific realization information is stored only as long as the time scale
-    is not changed.
+    ISOT but can give signed five-digit year (mostly for negative years);
 
     The allowed subformats are:
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -701,10 +701,28 @@ class TestSubFormat():
         """Test that the previous FITS-string formatting can still be handled
         but with a DeprecationWarning."""
         for inputs in (("2000-01-02(TAI)", "tai"),
-                       ("1999-01-01T00:00:00.123(ET(NIST))", "tt")):
+                       ("1999-01-01T00:00:00.123(ET(NIST))", "tt"),
+                       ("2014-12-12T01:00:44.1(UTC)", "utc")):
             with catch_warnings(AstropyDeprecationWarning):
                 t = Time(inputs[0])
             assert t.scale == inputs[1]
+
+            # Create Time using normal ISOT syntax and compare with FITS
+            t2 = Time(inputs[0][:inputs[0].index("(")], format="isot",
+                      scale=inputs[1])
+            assert t == t2
+
+        # Explicit check that conversions still work despite warning
+        with catch_warnings(AstropyDeprecationWarning):
+            t = Time('1999-01-01T00:00:00.123456789(UTC)')
+        t = t.tai
+        assert t.isot == '1999-01-01T00:00:32.123'
+
+        with catch_warnings(AstropyDeprecationWarning):
+            t = Time('1999-01-01T00:00:32.123456789(TAI)')
+        t = t.utc
+        assert t.isot == '1999-01-01T00:00:00.123'
+
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -723,6 +723,15 @@ class TestSubFormat():
         t = t.utc
         assert t.isot == '1999-01-01T00:00:00.123'
 
+        # Check scale consistency
+        with catch_warnings(AstropyDeprecationWarning):
+            t = Time('1999-01-01T00:00:32.123456789(TAI)', scale="tai")
+        assert t.scale == "tai"
+        with catch_warnings(AstropyDeprecationWarning):
+            t = Time('1999-01-01T00:00:32.123456789(ET)', scale="tt")
+        assert t.scale == "tt"
+        with pytest.raises(ValueError):
+            t = Time('1999-01-01T00:00:32.123456789(TAI)', scale="utc")
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -208,7 +208,7 @@ class TestBasic():
         assert allclose_jd(t.jd, 2455197.5)
         assert t.iso == '2010-01-01 00:00:00.000'
         assert t.tt.iso == '2010-01-01 00:01:06.184'
-        assert t.tai.fits == '2010-01-01T00:00:34.000(TAI)'
+        assert t.tai.fits == '2010-01-01T00:00:34.000'
         assert allclose_jd(t.utc.jd, 2455197.5)
         assert allclose_jd(t.ut1.jd, 2455197.500003867)
         assert t.tcg.isot == '2010-01-01T00:01:06.910'
@@ -347,7 +347,6 @@ class TestBasic():
         Time('2000-01-01T12:23:34.0Z', format='isot', scale='utc')
         Time('2000-01-01T12:23:34.0', format='fits')
         Time('2000-01-01T12:23:34.0', format='fits', scale='tdb')
-        Time('2000-01-01T12:23:34.0(TDB)', format='fits')
         Time(2400000.5, 51544.0333981, format='jd', scale='tai')
         Time(0.0, 51544.0333981, format='mjd', scale='tai')
         Time('2000:001:12:23:34.0', format='yday', scale='tai')
@@ -372,7 +371,7 @@ class TestBasic():
         assert t.datetime == datetime.datetime(2006, 1, 15, 21, 24, 37, 500000)
         assert t.isot == '2006-01-15T21:24:37.500'
         assert t.yday == '2006:015:21:24:37.500'
-        assert t.fits == '2006-01-15T21:24:37.500(LOCAL)'
+        assert t.fits == '2006-01-15T21:24:37.500'
         assert_allclose(t.byear, 2006.04217888831, atol=0.001/3600./24./365., rtol=0.)
         assert_allclose(t.jyear, 2006.0407723496082, atol=0.001/3600./24./365., rtol=0.)
         assert t.byear_str == 'B2006.042'
@@ -645,26 +644,26 @@ class TestSubFormat():
         # Heterogeneous input formats with in_subfmt='*' (default)
         times = ['2000-01-01', '2000-01-01T01:01:01', '2000-01-01T01:01:01.123']
         t = Time(times, format='fits', scale='tai')
-        assert np.all(t.fits == np.array(['2000-01-01T00:00:00.000(TAI)',
-                                          '2000-01-01T01:01:01.000(TAI)',
-                                          '2000-01-01T01:01:01.123(TAI)']))
+        assert np.all(t.fits == np.array(['2000-01-01T00:00:00.000',
+                                          '2000-01-01T01:01:01.000',
+                                          '2000-01-01T01:01:01.123']))
         # Explicit long format for output, default scale is UTC.
         t2 = Time(times, format='fits', out_subfmt='long*')
-        assert np.all(t2.fits == np.array(['+02000-01-01T00:00:00.000(UTC)',
-                                           '+02000-01-01T01:01:01.000(UTC)',
-                                           '+02000-01-01T01:01:01.123(UTC)']))
+        assert np.all(t2.fits == np.array(['+02000-01-01T00:00:00.000',
+                                           '+02000-01-01T01:01:01.000',
+                                           '+02000-01-01T01:01:01.123']))
         # Implicit long format for output, because of negative year.
         times[2] = '-00594-01-01'
         t3 = Time(times, format='fits', scale='tai')
-        assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
-                                           '+02000-01-01T01:01:01.000(TAI)',
-                                           '-00594-01-01T00:00:00.000(TAI)']))
+        assert np.all(t3.fits == np.array(['+02000-01-01T00:00:00.000',
+                                           '+02000-01-01T01:01:01.000',
+                                           '-00594-01-01T00:00:00.000']))
         # Implicit long format for output, because of large positive year.
         times[2] = '+10594-01-01'
         t4 = Time(times, format='fits', scale='tai')
-        assert np.all(t4.fits == np.array(['+02000-01-01T00:00:00.000(TAI)',
-                                           '+02000-01-01T01:01:01.000(TAI)',
-                                           '+10594-01-01T00:00:00.000(TAI)']))
+        assert np.all(t4.fits == np.array(['+02000-01-01T00:00:00.000',
+                                           '+02000-01-01T01:01:01.000',
+                                           '+10594-01-01T00:00:00.000']))
 
     def test_yday_format(self):
         """Year:Day_of_year format"""
@@ -696,36 +695,6 @@ class TestSubFormat():
         # Check that bad scale is caught when format is auto-determined
         with pytest.raises(ScaleValueError):
             Time('2000:001:00:00:00', scale='bad scale')
-
-    def test_fits_scale(self):
-        """Test that scale gets interpreted correctly for FITS strings."""
-        t = Time('2000-01-02(TAI)')
-        assert t.scale == 'tai'
-        # Test deprecated scale.
-        t = Time('2000-01-02(IAT)')
-        assert t.scale == 'tai'
-        # Test with scale and FITS string scale
-        t = Time('2045-11-08T00:00:00.000(UTC)', scale='utc')
-        assert t.scale == 'utc'
-        # Test with local time scale and FITS string scale
-        t = Time('2045-11-08T00:00:00.000(LOCAL)')
-        assert t.scale == 'local'
-        # Check that inconsistent scales lead to errors.
-        with pytest.raises(ValueError):
-            Time('2000-01-02(TAI)', scale='utc')
-        with pytest.raises(ValueError):
-            Time(['2000-01-02(TAI)', '2001-02-03(UTC)'])
-        # Check that inconsistent FITS string scales lead to errors.
-        with pytest.raises(ValueError):
-            Time(['2000-01-02(TAI)', '2001-02-03(IAT)'])
-        # Check that inconsistent realizations lead to errors.
-        with pytest.raises(ValueError):
-            Time(['2000-01-02(ET(NIST))', '2001-02-03(ET)'])
-
-    def test_fits_scale_representation(self):
-        t = Time('1960-01-02T03:04:05.678(ET(NIST))')
-        assert t.scale == 'tt'
-        assert t.value == '1960-01-02T03:04:05.678(ET(NIST))'
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""
@@ -929,20 +898,20 @@ def test_decimalyear():
 
 def test_fits_year0():
     t = Time(1721425.5, format='jd')
-    assert t.fits == '0001-01-01T00:00:00.000(UTC)'
+    assert t.fits == '0001-01-01T00:00:00.000'
     t = Time(1721425.5 - 366., format='jd')
-    assert t.fits == '+00000-01-01T00:00:00.000(UTC)'
+    assert t.fits == '+00000-01-01T00:00:00.000'
     t = Time(1721425.5 - 366. - 365., format='jd')
-    assert t.fits == '-00001-01-01T00:00:00.000(UTC)'
+    assert t.fits == '-00001-01-01T00:00:00.000'
 
 
 def test_fits_year10000():
     t = Time(5373484.5, format='jd', scale='tai')
-    assert t.fits == '+10000-01-01T00:00:00.000(TAI)'
+    assert t.fits == '+10000-01-01T00:00:00.000'
     t = Time(5373484.5 - 365., format='jd', scale='tai')
-    assert t.fits == '9999-01-01T00:00:00.000(TAI)'
+    assert t.fits == '9999-01-01T00:00:00.000'
     t = Time(5373484.5, -1./24./3600., format='jd', scale='tai')
-    assert t.fits == '9999-12-31T23:59:59.000(TAI)'
+    assert t.fits == '9999-12-31T23:59:59.000'
 
 
 def test_dir():
@@ -1078,7 +1047,7 @@ def test_set_format_does_not_share_subfmt():
 
     t.format = 'fits'
     assert t.out_subfmt == '*'
-    assert t.value == '2000-02-03T00:00:00.000(UTC)'  # date_hms
+    assert t.value == '2000-02-03T00:00:00.000'  # date_hms
 
 
 def test_replicate_value_error():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -10,6 +10,7 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from ...tests.helper import catch_warnings, pytest
+from ...utils.exceptions import AstropyDeprecationWarning
 from ...utils import isiterable
 from .. import Time, ScaleValueError, STANDARD_TIME_SCALES, TimeString, TimezoneInfo
 from ...coordinates import EarthLocation
@@ -695,6 +696,15 @@ class TestSubFormat():
         # Check that bad scale is caught when format is auto-determined
         with pytest.raises(ScaleValueError):
             Time('2000:001:00:00:00', scale='bad scale')
+
+    def test_fits_scale(self):
+        """Test that the previous FITS-string formatting can still be handled
+        but with a DeprecationWarning."""
+        for inputs in (("2000-01-02(TAI)", "tai"),
+                       ("1999-01-01T00:00:00.123(ET(NIST))", "tt")):
+            with catch_warnings(AstropyDeprecationWarning):
+                t = Time(inputs[0])
+            assert t.scale == inputs[1]
 
     def test_scale_default(self):
         """Test behavior when no scale is provided"""

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -73,8 +73,8 @@ The default representation can be changed by setting the `format` attribute::
 
   >>> t.format = 'fits'
   >>> t
-  <Time object: scale='utc' format='fits' value=['1999-01-01T00:00:00.123(UTC)'
-                                                 '2010-01-01T00:00:00.000(UTC)']>
+  <Time object: scale='utc' format='fits' value=['1999-01-01T00:00:00.123'
+                                                 '2010-01-01T00:00:00.000']>
   >>> t.format = 'isot'
 
 We can also convert to a different time scale, for instance from UTC to
@@ -93,7 +93,7 @@ course, from the numbers or strings one could not tell; one format in which
 this information is kept is the ``fits`` format::
 
   >>> print(t2.fits)
-  ['1999-01-01T00:01:04.307(TT)' '2010-01-01T00:01:06.184(TT)']
+  ['1999-01-01T00:01:04.307' '2010-01-01T00:01:06.184']
 
 One can set the time values in-place using the usual numpy array setting
 item syntax::
@@ -165,7 +165,7 @@ byear_str    :class:`~astropy.time.TimeBesselianEpochString`    'B1950.0'
 cxcsec       :class:`~astropy.time.TimeCxcSec`                  63072064.184
 datetime     :class:`~astropy.time.TimeDatetime`                datetime(2000, 1, 2, 12, 0, 0)
 decimalyear  :class:`~astropy.time.TimeDecimalYear`             2000.45
-fits         :class:`~astropy.time.TimeFITS`                    '2000-01-01T00:00:00.000(TAI)'
+fits         :class:`~astropy.time.TimeFITS`                    '2000-01-01T00:00:00.000'
 gps          :class:`~astropy.time.TimeGPS`                     630720013.0
 iso          :class:`~astropy.time.TimeISO`                     '2000-01-01 00:00:00.000'
 isot         :class:`~astropy.time.TimeISOT`                    '2000-01-01T00:00:00.000'
@@ -203,13 +203,13 @@ preserved::
 
   >>> t = Time('2000-01-02', format='fits', out_subfmt='longdate')
   >>> t.value
-  '+02000-01-02(UTC)'
+  '+02000-01-02'
   >>> t.format = 'iso'
   >>> t.out_subfmt
   u'*'
   >>> t.format = 'fits'
   >>> t.value
-  '2000-01-02T00:00:00.000(UTC)'
+  '2000-01-02T00:00:00.000'
 
 
 Subformat
@@ -234,9 +234,9 @@ Format    Subformat    Input / output
 ``iso``   date_hms     2001-01-02 03:04:05.678
 ``iso``   date_hm      2001-01-02 03:04
 ``iso``   date         2001-01-02
-``fits``  date_hms     2001-01-02T03:04:05.678(UTC)
-``fits``  longdate_hms +02001-01-02T03:04:05.678(UTC)
-``fits``  longdate     +02001-01-02(UTC)
+``fits``  date_hms     2001-01-02T03:04:05.678
+``fits``  longdate_hms +02001-01-02T03:04:05.678
+``fits``  longdate     +02001-01-02
 ``yday``  date_hms     2001:032:03:04:05.678
 ``yday``  date_hm      2001:032:03:04
 ``yday``  date         2001:032


### PR DESCRIPTION
As discussed in #7781 and #5329.

It might be better to retain the parsing support for timescale but no longer include the timescale when converting to a string.