### PR TITLE
Removing unused, legacy python compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -368,6 +368,9 @@ astropy.utils
 - ``diff_values()``, ``report_diff_values()``, and ``where_not_allclose()``
   utility functions are moved from ``astropy.io.fits.diff``. [#7444]
 
+- ``invalidate_caches()`` has been removed from the
+  ``astropy.utils.compat`` namespace, use it directly from ``importlib``. [#7872]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -9,10 +9,9 @@ be accessed from there.
 import sys
 import functools
 from contextlib import suppress
-from importlib import invalidate_caches
 
 
-__all__ = ['invalidate_caches', 'override__dir__', 'suppress',
+__all__ = ['override__dir__', 'suppress',
            'possible_filename', 'namedtuple_asdict']
 
 


### PR DESCRIPTION
Over time the code has been removed for this python <3.3 compatibility workaround, time to remove it from the namespace, too.