### PR TITLE
Added robots.txt and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ sdist
 develop-eggs
 .installed.cfg
 distribute-*.tar.gz
+.venv
+venv
 
 # Other
 .cache

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -241,3 +241,8 @@ except ImportError:
                  'to this.')
 
 linkcheck_anchors = False
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+html_extra_path = ['robots.txt']

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /*/stable/
+Allow: /en/stable/   # Fallback for bots that don't understand wildcards
+Disallow: /

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
+Allow: /*/latest/
+Allow: /en/latest/   # Fallback for bots that don't understand wildcards
 Allow: /*/stable/
 Allow: /en/stable/   # Fallback for bots that don't understand wildcards
 Disallow: /


### PR DESCRIPTION
- Added `venv` and `.venv` to `.gitignore`

- Added `robots.txt` to only allow `stable` docs to be crawled. I got some help from this [Stack overflow thread](https://stackoverflow.com/questions/19869004/robots-txt-to-disallow-all-pages-except-one-do-they-override-and-cascade). After ruing `python setup.py build_docs` robots.txt is in `docs/_build/html/`.

- I updated `docs/conf.py` to include this RTD github [comment](https://github.com/rtfd/readthedocs.org/issues/2430#issuecomment-285196933)