### PR TITLE
change default lomb scargle method to 'slow' when fit_mean is False…

### DIFF
--- a/astropy/stats/lombscargle/implementations/main.py
+++ b/astropy/stats/lombscargle/implementations/main.py
@@ -87,7 +87,7 @@ def validate_method(method, dy, fit_mean, nterms,
     methods = available_methods()
     prefer_fast = (len(frequency) > 200
                    and (assume_regular_frequency or _is_regular(frequency)))
-    prefer_scipy = 'scipy' in methods and dy is None and not fit_mean
+    prefer_scipy = 'scipy' in methods and dy is None and fit_mean
 
     # automatically choose the appropriate method
     if method == 'auto':
@@ -101,6 +101,8 @@ def validate_method(method, dy, fit_mean, nterms,
             method = 'fast'
         elif prefer_scipy:
             method = 'scipy'
+        elif not fit_mean:
+            method = 'slow'
         else:
             method = 'cython'
 


### PR DESCRIPTION
...and few frequencies are evaluated.

Addressing Issue https://github.com/astropy/astropy/issues/7875, which will help the default Lomb Scargle 'auto' method to be successful in returning results when fit_mean = False.