### PR TITLE
Add wcs fitting function in wcs utils 

### DIFF
--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -577,10 +577,8 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
 
     return coords
 
-def _linear_transformation_fit(params, lon, lat, x, y, w_obj, proj = 'TAN'):	
-
+def _linear_transformation_fit(params, lon, lat, x, y, w_obj):	
 	""" Objective function for fitting linear terms."""   
-	
 	pc = params[0:4]
 	crpix = params[4:6]
 	
@@ -592,10 +590,10 @@ def _linear_transformation_fit(params, lon, lat, x, y, w_obj, proj = 'TAN'):
 	return resids
 
 def _sip_fit(params, lon, lat, u, v, w_obj, a_order, b_order, a_coeff_names, 
-			 b_coeff_names):	
-			 
+			 b_coeff_names):	 
 		""" Objective function for fitting SIP."""   
-		from ..modeling.models import SIP #here instead of top to avoid circular import
+		from ..modeling.models import SIP # here instead of top to avoid circular import
+		
 		crpix = params[0:2]
 		cdx = params[2:6].reshape((2,2))
 		a_params, b_params = params[6:6+len(a_coeff_names)],params[6+len(a_coeff_names):]
@@ -627,7 +625,7 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 	
 	Along with the matched coordinate pairs, users must provide the projection type 
 	(e.g. 'TAN'), celestial coordinate pair for the projection point (or 'center' to use 
-	the center of input coordinates), mode ('wcs' to fit only linear terms, or 'sip' ). 
+	the center of input coordinates), mode ('wcs' to fit only linear terms, or 'sip'). 
 	If a coordinate pair is passed to 'proj_point', it is assumed to be in the 
 	same units respectivley as the input (lon, lat) coordinates. Additionaly, if mode is 
 	set to 'sip', the polynomial order must be provided.
@@ -638,8 +636,8 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 	between keyword arguments passed to the function and values in the input WCS exist, 
 	the keyword argument will override, including the CD/PC convention. 
 		
-	NAXIS1 and NAXIS2 will returned as (0, 0). These can be set in the WCS output from 
-	this function (wcs._naxis1, wcs._naxis2). 
+	NAXIS1 and NAXIS2 will set as the span of the input points, unless an input WCS is 
+	provided. 
 	
 	All output will be in degrees. 
 	
@@ -672,8 +670,6 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 		
 	Notes
     -----
-    If passed an input wcs, please note this object will be modified. 
-    
     Please pay careful attention to the logic that applies when both an input WCS with
     keywords populated is passed in. For example, if no 'CUNIT' is set in this input
     WCS, the units of the CRVAL etc. are assumed to be the same as the input Skycoord.
@@ -684,49 +680,56 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 	from scipy.optimize import least_squares
 	from .wcs import Sip
 	import copy
-	
+	print('correct')
 	lon, lat = coords.data.lon.deg, coords.data.lat.deg
+	mode = mode.lower()
 	if mode not in ("wcs", "sip"): raise ValueError("mode must be 'wcs' or 'sip'")
 	if inwcs is not None: 
 		inwcs = copy.deepcopy(inwcs)
 	if projection is None:
 		if (inwcs is None) or ('' in inwcs.wcs.ctype):
 			raise ValueError("Must provide projection type or input WCS with CTYPE.")
-		projection = inwcs.wcs.ctype[0].replace('-SIP','').split('-')[-1] 
+		projection = inwcs.wcs.ctype[0].replace('-SIP','').split('-')[-1]
 		
+	### template wcs
 	wcs = celestial_frame_to_wcs(frame = coords.frame, projection = projection)
 
 	close = lambda l, p: p[np.where(np.abs(l) == min(np.abs(l)))[0][0]] 
 	if str(proj_point) == "center":
 		wcs.wcs.crval = ((max(lon)+min(lon))/2.,(max(lat)+min(lat))/2.)
-		wcs.wcs.crpix = ((max(xp)+min(xp))/2., (max(yp)+min(yp))/2.) #initial guess
+		wcs.wcs.crpix = ((max(xp)+min(xp))/2.,(max(yp)+min(yp))/2.) #initial guess
 	elif (proj_point is None) and (inwcs is None):
 		raise ValueError("Must give proj_point as argument or as CRVAL in input wcs.")
-	elif proj_point is not None: #convert units + rough initial guess for crpix for fitter
+	elif proj_point is not None: # convert units + rough initial guess for crpix for fit
 		lon_u, lat_u = u.Unit(coords.data.lon.unit), u.Unit(coords.data.lat.unit)
 		wcs.wcs.crval = (proj_point[0]*lon_u.to(u.deg), proj_point[1]*lat_u.to(u.deg))
 		wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp),close(lon-wcs.wcs.crval[0],yp))
 
 	if inwcs is not None: 
-		if inwcs.wcs.radesys == '': #no frame specified, use Skycoord's frame (warn???)
+		if inwcs.wcs.radesys == '': # no frame specified, use Skycoord's frame (warn???)
 			inwcs.wcs.radesys = coords.frame.name
 		wcs.wcs.radesys = inwcs.wcs.radesys
 		coords.transform_to(inwcs.wcs.radesys.lower()) #work in inwcs units
-		if proj_point is None: #crval, crpix from wcs. crpix used for initial guess. 
+		if proj_point is None: # crval, crpix from wcs. crpix used for initial guess. 
 			wcs.wcs.crval, wcs.wcs.crpix= inwcs.wcs.crval, inwcs.wcs.crpix 
-			if wcs.wcs.crpix[0] == wcs.wcs.crpix[1] == 0: #assume 0 wasn't intentional 
+			if wcs.wcs.crpix[0] == wcs.wcs.crpix[1] == 0: # assume 0 wasn't intentional 
 				wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp), \
-								 close(lon-wcs.wcs.crval[0],yp))
-		if inwcs.wcs.has_pc(): wcs.wcs.pc = inwcs.wcs.pc
+								 close(lon-wcs.wcs.crval[1],yp))
+		if inwcs.wcs.has_pc(): wcs.wcs.pc = inwcs.wcs.pc # work internally with pc
 		if inwcs.wcs.has_cd(): wcs.wcs.pc = inwcs.wcs.cd
+		### create dictionaries of both wcs (input and kwarg), merge them favoring kwargs
 		wcs_dict = dict(wcs.to_header(relax=False))
 		in_wcs_dict = dict(inwcs.to_header(relax=False)) 
 		wcs = WCS({**in_wcs_dict,**wcs_dict})
-
-	p0 = np.array((wcs.wcs.pc[0][0], wcs.wcs.pc[0][1], wcs.wcs.pc[1][0], 
-				   wcs.wcs.pc[1][1], wcs.wcs.crpix[0], wcs.wcs.crpix[1]))
-	fit = least_squares(_linear_transformation_fit, p0, 
-						args=(lon, lat, xp, yp, wcs, projection))
+		wcs._naxis1, wcs._naxis2 = inwcs._naxis1, inwcs._naxis2
+	else:	
+		wcs._naxis1, wcs._naxis2 = max(xp) - min(xp), max(yp) - min(yp)
+		
+	### fit 
+	p0 = np.concatenate((wcs.wcs.pc.flatten(),wcs.wcs.crpix.flatten()))
+	fit = least_squares(_linear_transformation_fit, p0, args=(lon, lat, xp, yp, wcs))
+	
+	### put fit values in wcs
 	wcs.wcs.crpix = np.array(fit.x[4:6])		
 	wcs.wcs.pc = np.array(fit.x[0:4].reshape((2,2)))
 	
@@ -738,16 +741,16 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 			a_order, b_order = order
 		else:
 			raise ValueError("Must provide integer or tuple (a_order, b_order) for SIP.")
-			
 		a_coef_names = ['{0}_{1}'.format(i,j) for i in range(a_order+1) \
 						for j in range(a_order+1) if (i+j) < (a_order+1) and (i+j) > 1]
 		b_coef_names = ['{0}_{1}'.format(i,j) for i in range(b_order+1) \
 						for j in range(b_order+1) if (i+j) < (b_order + 1) and (i+j) > 1]
-						
+		### fit				
 		p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.pc.flatten(), \
 							 np.zeros(len(a_coef_names)+len(b_coef_names))))
 		fit = least_squares(_sip_fit, p0, args = (lon, lat, xp, yp, wcs, a_order, b_order,
 												  a_coef_names, b_coef_names))
+		### put fit values in wcs										  
 		wcs.wcs.pc = fit.x[2:6].reshape((2,2))
 		wcs.wcs.crpix = fit.x[0:2]
 		coef_fit = (list(fit.x[6:6+len(a_coef_names)]),list(fit.x[6+len(b_coef_names):]))
@@ -758,7 +761,7 @@ def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None,
 			b_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[1].pop(0)
 		wcs.sip = Sip(a_vals, b_vals, a_vals * -1., b_vals * -1., wcs.wcs.crpix)
 		
-	if (inwcs is not None):
+	if (inwcs is not None): # maintain cd matrix if it was in input wcs
 		if inwcs.wcs.has_cd():
 			wcs.wcs.cd = wcs.wcs.pc
 			wcs.wcs.__delattr__('pc')

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -1,5 +1,3 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 import numpy as np
 
 from .. import units as u
@@ -13,13 +11,11 @@ __all__ = ['add_stokes_axis_to_wcs', 'celestial_frame_to_wcs',
            'proj_plane_pixel_area', 'is_proj_plane_distorted',
            'non_celestial_pixel_scales', 'skycoord_to_pixel',
            'pixel_to_skycoord', 'custom_wcs_to_frame_mappings',
-           'custom_frame_to_wcs_mappings']
-
+           'custom_frame_to_wcs_mappings','pixel_sky_to_wcs']
 
 def add_stokes_axis_to_wcs(wcs, add_before_ind):
     """
     Add a new Stokes axis that is uncorrelated with any other axes.
-
     Parameters
     ----------
     wcs : `~astropy.wcs.WCS`
@@ -28,7 +24,6 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
         Index of the WCS to insert the new Stokes axis in front of.
         To add at the end, do add_before_ind = wcs.wcs.naxis
         The beginning is at position 0.
-
     Returns
     -------
     A new `~astropy.wcs.WCS` instance with an additional axis
@@ -45,7 +40,7 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
 def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ..coordinates import FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
+    from ..coordinates import FK4, FK4NoETerms, FK5, ICRS, Galactic
 
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
     from ..time import Time
@@ -92,8 +87,6 @@ def _wcs_to_celestial_frame_builtin(wcs):
     else:
         if xcoord == 'GLON' and ycoord == 'GLAT':
             frame = Galactic()
-        elif xcoord == 'TLON' and ycoord == 'TLAT':
-            frame = ITRS(obstime=wcs.wcs.dateobs or None)
         else:
             frame = None
 
@@ -103,7 +96,7 @@ def _wcs_to_celestial_frame_builtin(wcs):
 def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ..coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
+    from ..coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, Galactic
 
     # Create a 2-dimensional WCS
     wcs = WCS(naxis=2)
@@ -128,11 +121,6 @@ def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
     elif isinstance(frame, Galactic):
         xcoord = 'GLON'
         ycoord = 'GLAT'
-    elif isinstance(frame, ITRS):
-        xcoord = 'TLON'
-        ycoord = 'TLAT'
-        wcs.wcs.radesys = 'ITRS'
-        wcs.wcs.dateobs = frame.obstime.utc.isot
     else:
         return None
 
@@ -179,30 +167,24 @@ def wcs_to_celestial_frame(wcs):
     """
     For a given WCS, return the coordinate frame that matches the celestial
     component of the WCS.
-
     Parameters
     ----------
     wcs : :class:`~astropy.wcs.WCS` instance
         The WCS to find the frame for
-
     Returns
     -------
     frame : :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass instance
         An instance of a :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame`
         subclass instance that best matches the specified WCS.
-
     Notes
     -----
-
     To extend this function to frames not defined in astropy.coordinates, you
     can write your own function which should take a :class:`~astropy.wcs.WCS`
     instance and should return either an instance of a frame, or `None` if no
     matching frame was found. You can register this function temporarily with::
-
         >>> from astropy.wcs.utils import wcs_to_celestial_frame, custom_wcs_to_frame_mappings
         >>> with custom_wcs_to_frame_mappings(my_function):
         ...     wcs_to_celestial_frame(...)
-
     """
     for mapping_set in WCS_FRAME_MAPPINGS:
         for func in mapping_set:
@@ -216,10 +198,8 @@ def wcs_to_celestial_frame(wcs):
 def celestial_frame_to_wcs(frame, projection='TAN'):
     """
     For a given coordinate frame, return the corresponding WCS object.
-
     Note that the returned WCS object has only the elements corresponding to
     coordinate frames set (e.g. ctype, equinox, radesys).
-
     Parameters
     ----------
     frame : :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass instance
@@ -227,17 +207,13 @@ def celestial_frame_to_wcs(frame, projection='TAN'):
         subclass instance for which to find the WCS
     projection : str
         Projection code to use in ctype, if applicable
-
     Returns
     -------
     wcs : :class:`~astropy.wcs.WCS` instance
         The corresponding WCS object
-
     Examples
     --------
-
     ::
-
         >>> from astropy.wcs.utils import celestial_frame_to_wcs
         >>> from astropy.coordinates import FK5
         >>> frame = FK5(equinox='J2010')
@@ -258,22 +234,17 @@ def celestial_frame_to_wcs(frame, projection='TAN'):
         LATPOLE =                  0.0 / [deg] Native latitude of celestial pole
         RADESYS = 'FK5'                / Equatorial coordinate system
         EQUINOX =               2010.0 / [yr] Equinox of equatorial coordinates
-
-
     Notes
     -----
-
     To extend this function to frames not defined in astropy.coordinates, you
     can write your own function which should take a
     :class:`~astropy.coordinates.baseframe.BaseCoordinateFrame` subclass
     instance and a projection (given as a string) and should return either a WCS
     instance, or `None` if the WCS could not be determined. You can register
     this function temporarily with::
-
         >>> from astropy.wcs.utils import celestial_frame_to_wcs, custom_frame_to_wcs_mappings
         >>> with custom_frame_to_wcs_mappings(my_function):
         ...     celestial_frame_to_wcs(...)
-
     """
     for mapping_set in FRAME_WCS_MAPPINGS:
         for func in mapping_set:
@@ -290,25 +261,21 @@ def proj_plane_pixel_scales(wcs):
     the ``CRPIX`` location once it is projected onto the
     "plane of intermediate world coordinates" as defined in
     `Greisen & Calabretta 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
-
     .. note::
         This function is concerned **only** about the transformation
         "image plane"->"projection plane" and **not** about the
         transformation "celestial sphere"->"projection plane"->"image plane".
         Therefore, this function ignores distortions arising due to
         non-linear nature of most projections.
-
     .. note::
         In order to compute the scales corresponding to celestial axes only,
         make sure that the input `~astropy.wcs.WCS` object contains
         celestial axes only, e.g., by passing in the
         `~astropy.wcs.WCS.celestial` WCS object.
-
     Parameters
     ----------
     wcs : `~astropy.wcs.WCS`
         A world coordinate system object.
-
     Returns
     -------
     scale : `~numpy.ndarray`
@@ -319,11 +286,9 @@ def proj_plane_pixel_scales(wcs):
         the celestial WCS and can be obtained by inquiring the value
         of `~astropy.wcs.Wcsprm.cunit` property of the input
         `~astropy.wcs.WCS` WCS object.
-
     See Also
     --------
     astropy.wcs.utils.proj_plane_pixel_area
-
     """
     return np.sqrt((wcs.pixel_scale_matrix**2).sum(axis=0, dtype=float))
 
@@ -334,26 +299,22 @@ def proj_plane_pixel_area(wcs):
     area of the image pixel at the ``CRPIX`` location once it is projected
     onto the "plane of intermediate world coordinates" as defined in
     `Greisen & Calabretta 2002, A&A, 395, 1061 <http://adsabs.harvard.edu/abs/2002A%26A...395.1061G>`_.
-
     .. note::
         This function is concerned **only** about the transformation
         "image plane"->"projection plane" and **not** about the
         transformation "celestial sphere"->"projection plane"->"image plane".
         Therefore, this function ignores distortions arising due to
         non-linear nature of most projections.
-
     .. note::
         In order to compute the area of pixels corresponding to celestial
         axes only, this function uses the `~astropy.wcs.WCS.celestial` WCS
         object of the input ``wcs``.  This is different from the
         `~astropy.wcs.utils.proj_plane_pixel_scales` function
         that computes the scales for the axes of the input WCS itself.
-
     Parameters
     ----------
     wcs : `~astropy.wcs.WCS`
         A world coordinate system object.
-
     Returns
     -------
     area : float
@@ -363,25 +324,20 @@ def proj_plane_pixel_area(wcs):
         and `~astropy.wcs.Wcsprm.cd` for the celestial WCS and can be
         obtained by inquiring the value of `~astropy.wcs.Wcsprm.cunit`
         property of the `~astropy.wcs.WCS.celestial` WCS object.
-
     Raises
     ------
     ValueError
         Pixel area is defined only for 2D pixels. Most likely the
         `~astropy.wcs.Wcsprm.cd` matrix of the `~astropy.wcs.WCS.celestial`
         WCS is not a square matrix of second order.
-
     Notes
     -----
-
     Depending on the application, square root of the pixel area can be used to
     represent a single pixel scale of an equivalent square pixel
     whose area is equal to the area of a generally non-square pixel.
-
     See Also
     --------
     astropy.wcs.utils.proj_plane_pixel_scales
-
     """
     psm = wcs.celestial.pixel_scale_matrix
     if psm.shape != (2, 2):
@@ -398,41 +354,34 @@ def is_proj_plane_distorted(wcs, maxerr=1.0e-5):
     It will return `True` if transformation from image (detector) coordinates
     to the focal plane coordinates is non-orthogonal or if WCS contains
     non-linear (e.g., SIP) distortions.
-
     .. note::
         Since this function is concerned **only** about the transformation
         "image plane"->"focal plane" and **not** about the transformation
         "celestial sphere"->"focal plane"->"image plane",
         this function ignores distortions arising due to non-linear nature
         of most projections.
-
     Let's denote by *C* either the original or the reconstructed
     (from ``PC`` and ``CDELT``) CD matrix. `is_proj_plane_distorted`
     verifies that the transformation from image (detector) coordinates
     to the focal plane coordinates is orthogonal using the following
     check:
-
     .. math::
         \left \| \frac{C \cdot C^{\mathrm{T}}}
         {| det(C)|} - I \right \|_{\mathrm{max}} < \epsilon .
-
     Parameters
     ----------
     wcs : `~astropy.wcs.WCS`
         World coordinate system object
-
     maxerr : float, optional
         Accuracy to which the CD matrix, **normalized** such
         that :math:`|det(CD)|=1`, should be close to being an
         orthogonal matrix as described in the above equation
         (see :math:`\epsilon`).
-
     Returns
     -------
     distorted : bool
         Returns `True` if focal (projection) plane is distorted and `False`
         otherwise.
-
     """
     cwcs = wcs.celestial
     return (not _is_cd_orthogonal(cwcs.pixel_scale_matrix, maxerr) or
@@ -460,12 +409,10 @@ def non_celestial_pixel_scales(inwcs):
     """
     Calculate the pixel scale along each axis of a non-celestial WCS,
     for example one with mixed spectral and spatial axes.
-
     Parameters
     ----------
     inwcs : `~astropy.wcs.WCS`
         The world coordinate system object.
-
     Returns
     -------
     scale : `numpy.ndarray`
@@ -497,7 +444,6 @@ def _has_distortion(wcs):
 def skycoord_to_pixel(coords, wcs, origin=0, mode='all'):
     """
     Convert a set of SkyCoord coordinates into pixels.
-
     Parameters
     ----------
     coords : `~astropy.coordinates.SkyCoord`
@@ -509,12 +455,10 @@ def skycoord_to_pixel(coords, wcs, origin=0, mode='all'):
     mode : 'all' or 'wcs'
         Whether to do the transformation including distortions (``'all'``) or
         only including only the core WCS transformation (``'wcs'``).
-
     Returns
     -------
     xp, yp : `numpy.ndarray`
         The pixel coordinates
-
     See Also
     --------
     astropy.coordinates.SkyCoord.from_pixel
@@ -566,7 +510,6 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
     """
     Convert a set of pixel coordinates into a `~astropy.coordinates.SkyCoord`
     coordinate.
-
     Parameters
     ----------
     xp, yp : float or `numpy.ndarray`
@@ -582,12 +525,10 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
         The class of object to create.  Should be a
         `~astropy.coordinates.SkyCoord` subclass.  If None, defaults to
         `~astropy.coordinates.SkyCoord`.
-
     Returns
     -------
     coords : Whatever ``cls`` is (a subclass of `~astropy.coordinates.SkyCoord`)
         The celestial coordinates
-
     See Also
     --------
     astropy.coordinates.SkyCoord.from_pixel
@@ -635,3 +576,210 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
     coords = cls(frame.realize_frame(data))
 
     return coords
+
+def _linear_transformation_fit(params, ra, dec, x, y, w_obj, proj):
+	"""
+	Objective function for fitting linear terms
+	"""	   
+	pc = params[0:4]
+	crpix = params[4:6]
+	
+	w_obj.wcs.pc = ((pc[0],pc[1]),(pc[2],pc[3]))
+	w_obj.wcs.crpix = crpix
+	lon, lat = w_obj.wcs_pix2world(x,y,1)
+	resids = np.concatenate((ra-lon, dec-lat)) 
+	return resids
+	
+
+def _sip_fit(params, u, v, x, y, coeff_names):
+	"""
+	Objective function for fitting SIP coefficients
+	"""
+
+	crpix = params[0:2]
+	cdx = params[2:6].reshape((2,2))
+	a_params = params[6:6+len(coeff_names)]
+	b_params = params[6+len(coeff_names):]
+		
+	a_coeff = {}
+	b_coeff = {}
+	for i in range(len(coeff_names)):
+		a_coeff['A_' + coeff_names[i]] = a_params[i]
+		b_coeff['B_' + coeff_names[i]] = b_params[i]
+		
+	sip = SIP(crpix=crpix, a_order=4, b_order=4, a_coeff=a_coeff, b_coeff=b_coeff)
+	
+	fuv, guv = sip(u,v)
+	xo, yo = np.dot(cdx, np.array([u+fuv-crpix[0], v+guv-crpix[1]]))
+	resids = np.concatenate((x-xo, y-yo)) 
+	return resids	
+
+def _new_sip_fit(params, lon, lat, u, v, w_obj, coeff_names):	
+		from ..modeling.models import SIP #here instead of top to avoid circular import
+		crpix = params[0:2]
+		cdx = params[2:6].reshape((2,2))
+		a_params, b_params = params[6:6+len(coeff_names)],params[6+len(coeff_names):]
+		w_obj.wcs.pc = cdx
+		w_obj.wcs.crpix = crpix
+		x,y = w_obj.wcs_world2pix(lon,lat,1) #'intermediate world coordinates', x & y 
+		x,y = np.dot(w_obj.wcs.pc,(x - w_obj.wcs.crpix[0],y - w_obj.wcs.crpix[1]))
+		
+		a_params, b_params = params[6:6+len(coeff_names)], params[6+len(coeff_names):]
+		a_coeff, b_coeff = {}, {}
+
+		for i in range(len(coeff_names)):
+			a_coeff['A_' + coeff_names[i]] = a_params[i]
+			b_coeff['B_' + coeff_names[i]] = b_params[i]
+			
+		sip = SIP(crpix=crpix, a_order=4, b_order=4, a_coeff=a_coeff, b_coeff=b_coeff)
+	
+		fuv, guv = sip(u,v)
+		xo, yo = np.dot(cdx, np.array([u+fuv-crpix[0], v+guv-crpix[1]]))
+		resids = np.concatenate((x-xo, y-yo))
+		return resids	
+	
+def pixel_sky_to_wcs(xp, yp, coords, projection='TAN', proj_point=None, 
+					 mode='sip', order=None, inwcs=None):	 
+	"""
+	Given a set of matched x,y pixel positions and celestial coordinates, solves for
+	WCS parameters and returns a WCS with these best fit values and other keywords based 
+	on projection type, frame, and units. Optionally, a SIP may be fit. 
+	
+	Along with the matched coordinate pairs, users must provide the projection type 
+	(e.g. 'TAN'), celestial coordinate pair for the projection point (or 'center' to use 
+	the center of input coordinates), mode ('wcs' to fit only linear terms, or 'sip' ). 
+	If a coordinate pair is passed to 'proj_point', it is assumed to be in the 
+	same units respectivley as the input (lon, lat) coordinates. Additionaly, if mode is 
+	set to 'sip', the polynomial order must be provided.
+	
+	Optionally, an existing ~astropy.wcs.WCS object with some may be passed in. For 
+	example, this is useful if the user wishes to refit an existing WCS with better
+	astrometry, or are using a projection type with non-standard keywords. If any overlap 
+	between keyword arguments passed to the function and values in the input WCS exist, 
+	the keyword argument will override, including the CD/PC convention. 
+		
+	NAXIS1 and NAXIS2 will returned as (0, 0). These can be set in the WCS output from 
+	this function (wcs._naxis1, wcs._naxis2). 
+	
+	All output will be in degrees. 
+	
+	Parameters
+	----------
+	xp, yp : `numpy.ndarray`
+		X and Y pixel coordinates, respectivley. 
+	coords : `~astropy.coordinates.SkyCoord`
+		Skycoord object.
+	inwcs : `~astropy.wcs.WCS`
+		Optional input WCS object. Populated keyword values will be used. For any 
+		overlap between keyword arguments passed to the function and values in 'inwcs', 
+		the keyword argument will be used and replace the value in 'inwcs'.
+	projection : str
+		Three-letter projection code. Defaults to TAN.
+	proj_point: None, str, or tuple of int or float
+		Celestial coordinates of projection point (lat, lon). If None, the geometric
+		center of input pixel and sky coordinates will be used for the projection.
+	mode : 'all' or 'wcs'
+		Whether to do the transformation including distortions (``'all'``) or
+		only including only the core WCS transformation (``'wcs'``).
+	order : int
+		Order for SIP polynomial to be fit. 
+
+	Returns
+	-------
+	wcs : `~astropy.wcs.WCS`
+		WCS object with best fit coefficients given the matched set of X, Y pixel and 
+		sky positions of sources.
+		
+	Notes
+    -----
+    If passed an input wcs, please note this object will be modified. 
+    
+    Please pay careful attention to the logic that applies when both an input WCS with
+    keywords populated is passed in. For example, if no 'CUNIT' is set in this input
+    WCS, the units of the CRVAL etc. are assumed to be the same as the input Skycoord.
+    Additionally, if 'RADESYS' is not set in the input WCS, this will be taken from the
+    Skycoord as well. 
+
+	"""
+	from scipy.optimize import least_squares
+	from .wcs import Sip
+	
+	lon, lat = coords.data.lon.deg, coords.data.lat.deg
+
+	if mode not in ("wcs", "sip"): raise ValueError("mode must be 'wcs' or 'sip'")
+	if mode == 'sip':
+		if (order is None) or (type(order) != int):
+			raise ValueError("Must provide integer order for SIP if mode = 'sip'")
+
+	if projection is None:
+		if (inwcs is None) or ('' in inwcs.wcs.ctype):
+			raise ValueError("Must provide projection type or input WCS with CTYPE.")
+		projection = inwcs.wcs.ctype[0].replace('-SIP','').split('-')[-1] 
+		
+	wcs = celestial_frame_to_wcs(frame = coords.frame, projection = projection)
+
+	close = lambda l, p: p[np.where(np.abs(l) == min(np.abs(l)))[0][0]] 
+	if str(proj_point) == "center":
+		wcs.wcs.crval = ((max(lon) + min(lon))/2.,(max(lat) + min(lat))/2.)
+		wcs.wcs.crpix = ((max(xp) + min(xp))/ 2., (max(yp) + min(yp))/2.) #initial guess
+	elif (proj_point is None) and (inwcs is None):
+		raise ValueError("Must give proj_point as argument or as CRVAL in input wcs.")
+	elif proj_point is not None: #convert units + rough initial guess for crpix for fitter
+		lon_u, lat_u = u.Unit(coords.data.lon.unit), u.Unit(coords.data.lat.unit)
+		wcs.wcs.crval = (proj_point[0]*lon_u.to(u.deg), proj_point[1]*lat_u.to(u.deg))
+		wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp),close(lon-wcs.wcs.crval[0],yp))
+
+	if inwcs is not None: 
+		if inwcs.wcs.radesys == '': #no frame specified, use Skycoord's frame (warn???)
+			inwcs.wcs.radesys = coords.frame.name
+		wcs.wcs.radesys = inwcs.wcs.radesys
+		coords.transform_to(inwcs.wcs.radesys.lower()) #work in inwcs units
+		if proj_point is None: #crval, crpix from wcs. crpix used for initial guess. 
+			wcs.wcs.crval, wcs.wcs.crpix= inwcs.wcs.crval, inwcs.wcs.crpix 
+			if wcs.wcs.crpix[0] == wcs.wcs.crpix[1] == 0: #assume 0 wasn't intentional 
+				wcs.wcs.crpix = (close(lon-wcs.wcs.crval[0],xp), \
+								 close(lon-wcs.wcs.crval[0],yp))
+		if inwcs.wcs.has_pc():
+			wcs.wcs.pc = inwcs.wcs.pc
+		if inwcs.wcs.has_cd():
+			wcs.wcs.pc = inwcs.wcs.cd
+		wcs_dict = dict(wcs.to_header(relax=False))
+		in_wcs_dict = dict(inwcs.to_header(relax=False)) 
+		wcs = WCS({**in_wcs_dict,**wcs_dict})
+
+	p0 = np.array((wcs.wcs.pc[0][0], wcs.wcs.pc[0][1], wcs.wcs.pc[1][0], 
+				   wcs.wcs.pc[1][1], wcs.wcs.crpix[0], wcs.wcs.crpix[1]))
+	fit = least_squares(_linear_transformation_fit, p0, 
+						args = (lon, lat, xp, yp, wcs, projection))
+	wcs.wcs.crpix = np.array(fit.x[4:6])		
+	wcs.wcs.pc = np.array(fit.x[0:4].reshape((2,2)))
+	
+	if mode == "sip": 
+		wcs.wcs.ctype = [x + '-SIP' for x in wcs.wcs.ctype]
+
+		#x,y = wcs.wcs_world2pix(lon,lat,1) #'intermediate world coordinates', x & y 
+		#x,y = np.dot(wcs.wcs.pc,(x - wcs.wcs.crpix[0],y - wcs.wcs.crpix[1]))
+		
+		coef_names = ['{0}_{1}'.format(i,j) for i in range(order+1) \
+						for j in range(order+1) if (i+j) < 5 and (i+j) > 1]
+	
+		p0 = np.concatenate((np.array(wcs.wcs.crpix), wcs.wcs.pc.flatten(),\
+							 np.zeros(len(coef_names)*2)))
+		#fit = least_squares(_sip_fit, p0, args = (xp, yp, x, y, coef_names))
+		fit = least_squares(_new_sip_fit, p0, args = (lon, lat, xp, yp, wcs, coef_names))
+		wcs.wcs.pc = fit.x[2:6].reshape((2,2))
+		wcs.wcs.crpix = fit.x[0:2]
+
+		coef_fit = (list(fit.x[6:6+len(coef_names)]),list(fit.x[6+len(coef_names):]))
+		a_vals, b_vals = np.zeros((order+1,order+1)), np.zeros((order+1,order+1))
+		for coef_name in coef_names:
+			a_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[0].pop(0)
+			b_vals[int(coef_name[0])][int(coef_name[2])] = coef_fit[1].pop(0)
+
+		wcs.sip = Sip(a_vals, b_vals, a_vals * -1., b_vals * -1., wcs.wcs.crpix)
+		
+		if (inwcs is not None):
+			if inwcs.wcs.has_cd():
+				wcs.wcs.cd = wcs.wcs.pc
+				wcs.wcs.__delattr__('pc')
+	return wcs


### PR DESCRIPTION
This is my first contribution to astropy so if I have done the PR incorrectly let me know. I wrote a function that takes a matched set of pixel positions and sky positions and fits a WCS (linear terms, optional SIP, and keywords based on given projection type and celestial frame). This is similar to the IRAF task CCMAP. Users pass in arrays of X & Y pixel positions, and then a SkyCoord object with the celestial coordinates, as well as the celestial coordinate pair for the projection (or ‘center’), the projection type, and if they would like a SIP fit (and if so, which order for A and B). A WCS object with the best fit parameters as well as other necessary keywords based on the celestial frame and projection type is returned. Optionally, users may pass in an existing WCS object with some keywords already populated and fit or re-fit the linear/polynomial distortion terms with the matched input coordinates. 

I consider this somewhat of a WIP still - I need a few more test cases, especially for with less common projection types, and some feedback on usability and the choices I made for input. Just to note, I use fitters in scipy rather than astropy models and fitters because this was very clunky in my experience to use when fitting a SIP. I do have a notebook with some demonstrative examples that I can link as well. I will submit tests but I’d like feedback on this WIP first. Thanks!