### PR TITLE
Fixes #7877; Converting np.asscalar to .item()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,6 +118,8 @@ astropy.modeling
 - Add a ``separability_matrix`` function which returns the correlation matrix
   of inputs and outputs. [#7803]
 
+- Convert np.asscalar(a) to a.item() [#7880]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -118,8 +118,6 @@ astropy.modeling
 - Add a ``separability_matrix`` function which returns the correlation matrix
   of inputs and outputs. [#7803]
 
-- Convert np.asscalar(a) to a.item() [#7880]
-
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3288,7 +3288,7 @@ def _prepare_outputs_single_model(model, outputs, format_info):
         if broadcast_shape is not None:
             if not broadcast_shape:
                 # Shape is (), i.e. a scalar should be returned
-                outputs[idx] = np.asscalar(output)
+                outputs[idx] = output.item()
             else:
                 outputs[idx] = output.reshape(broadcast_shape)
 

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -46,7 +46,7 @@ class _EulerRotation:
         for angle, axis in zip([phi, theta, psi], axes_order):
             if isinstance(angle, u.Quantity):
                 angle = angle.value
-            angle = np.asscalar(angle)
+            angle = angle.item()
             matrices.append(rotation_matrix(angle, axis, unit=u.rad))
         result = matrix_product(*matrices[::-1])
         return result


### PR DESCRIPTION
With reference to #7877, this PR replaces np.asscalar() (to be deprecated by numpy) to .item()
I am a beginner and don't know if anything else has to be done. Please let me know.