### PR TITLE
Fix reading big csv files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
           command: /opt/python/cp36-cp36m/bin/pip install numpy scipy "pytest<3.7" pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests
-          command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4
+          command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -V -a "--durations=50"
 
   image-tests-mpl202:
     docker:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1287,6 +1287,8 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fix reading of big files with the fast reader. [#7885]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -324,7 +324,7 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
     // Allocate memory for structures used during tokenization
     self->output_cols = (char **) malloc(self->num_cols * sizeof(char *));
     self->col_ptrs = (char **) malloc(self->num_cols * sizeof(char *));
-    self->output_len = (int *) malloc(self->num_cols * sizeof(int));
+    self->output_len = (size_t *) malloc(self->num_cols * sizeof(size_t));
 
     for (i = 0; i < self->num_cols; ++i)
     {

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -63,7 +63,7 @@ typedef struct
     char expchar;          // exponential character in scientific notation
     char **output_cols;    // array of output strings for each column
     char **col_ptrs;       // array of pointers to current output position for each col
-    int *output_len;       // length of each output column string
+    size_t *output_len;    // length of each output column string
     int num_cols;          // number of table columns
     int num_rows;          // number of table rows
     int fill_extra_cols;   // represents whether or not to fill rows with too few values

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -959,6 +959,35 @@ def test_read_big_table(tmpdir):
     assert len(t) == NB_ROWS
 
 
+@pytest.mark.skipif(not os.getenv('TEST_READ_HUGE_FILE'),
+                    reason='Environment variable TEST_READ_HUGE_FILE must be '
+                    'defined to run this test')
+def test_read_big_table2(tmpdir):
+    """Test reading of a file with a huge column.
+    """
+    # (2**32 // 2) : max value for int
+    # // 10 : we use a value for rows that have 10 chars (1e9)
+    # + 5 : add a few lines so the length cannot be stored by an int
+    NB_ROWS = (2**32 // 2) // 10 + 5
+    filename = str(tmpdir.join("big_table.csv"))
+
+    print("Creating a {} rows table.".format(NB_ROWS))
+    data = np.full(2**32 // 2 // 10 + 5, int(1e9), dtype=np.int32)
+    t = Table(data=[data], names=['a'], copy=False)
+
+    print("Saving the table to {}".format(filename))
+    t.write(filename, format='ascii.csv', overwrite=True)
+    t = None
+
+    print("Counting the number of lines in the csv, it should be {}"
+          " + 1 (header).".format(NB_ROWS))
+    assert sum(1 for line in open(filename)) == NB_ROWS + 1
+
+    print("Reading the file with astropy.")
+    t = Table.read(filename, format='ascii.csv', fast_reader=True)
+    assert len(t) == NB_ROWS
+
+
 # Test these both with guessing turned on and off
 @pytest.mark.parametrize("guess", [True, False])
 # fast_reader configurations: False| 'use_fast_converter'=False|True


### PR DESCRIPTION
Fix  #7871. 
This is quite similar to #5319, it just reached another limitation with the size of the columns (number of rows times the number of chars for the values). So as for the #5319 the test run only when setting an environment variable (and yes it runs locally ;)).