### PR TITLE
Added CircleCI job with developer version of Matplotlib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,21 @@ jobs:
           command: |
             python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
+  image-tests-mpldev:
+    docker:
+      - image: astropy/image-tests-py35-base:1.0
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies, including developer version of Matplotlib
+          command: |
+            pip3 install pytest pytest-mpl pytest-astropy numpy scipy
+            pip3 install git+https://github.com/matplotlib/matplotlib.git
+      - run:
+          name: Run tests
+          command: |
+            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+
   html-docs:
     docker:
       - image: circleci/python:3.6
@@ -107,6 +122,7 @@ workflows:
       - image-tests-mpl212
       - image-tests-mpl222
       - image-tests-mpl300
+      - image-tests-mpldev
 
 notify:
   webhooks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ jobs:
       - run:
           name: Install dependencies, including developer version of Matplotlib
           command: |
+            apt-get install -y libfreetype6-dev libpng12-dev pkg-config
             pip3 install pytest pytest-mpl pytest-astropy numpy scipy
             pip3 install git+https://github.com/matplotlib/matplotlib.git
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: |
-            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
   image-tests-mpl212:
     docker:
@@ -50,8 +49,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: |
-            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
   image-tests-mpl222:
     docker:
@@ -60,8 +58,7 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: |
-            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
   image-tests-mpl300:
     docker:
@@ -69,9 +66,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Temporarily downgrade pytest
+          command: pip3 install "pytest<3.7"
+      - run:
           name: Run tests
-          command: |
-            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
   image-tests-mpldev:
     docker:
@@ -79,15 +78,14 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install dependencies, including developer version of Matplotlib
-          command: |
-            apt-get install -y libfreetype6-dev libpng12-dev pkg-config
-            pip3 install pytest pytest-mpl pytest-astropy numpy scipy
-            pip3 install git+https://github.com/matplotlib/matplotlib.git
+          name: Install apt dependencies
+          command: apt-get install -y libfreetype6-dev libpng12-dev pkg-config
+      - run:
+          name: Install Python dependencies, including developer version of Matplotlib
+          command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
       - run:
           name: Run tests
-          command: |
-            python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
   html-docs:
     docker:


### PR DESCRIPTION
This adds a CircleCI job with the latest developer version of Matplotlib. This is not currently an allowed failure, but at least it will appear as a separate result in the list below. We might want to consider something like this for Numpy dev to give more visibility to dev failures while still making it easy to ignore if the issues are known. Anyway, this is just an idea, and may already uncover some issues.