### PR TITLE
Fix WCSAxes image tests in v2.0.x branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Temporarily downgrade pytest
+          command: pip3 install "pytest<3.7"
+      - run:
           name: Run tests
           command: |
             python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"


### PR DESCRIPTION
This PR is to get the Matplotlib 2.2.2 and 3.0.0 image tests working in the v2.0.x branch.

In fact, the main change has been to update the baseline images on data.astropy.org but this PR still has a small change to the v2.0.x branch.