### PR TITLE
Add workaround for running test suite with newer version of pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,8 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="jplephem"
                LC_CTYPE=C.ascii LC_ALL=C
+               PYTEST_VERSION=3.7
+
 
         - os: linux
           stage: Initial tests
@@ -119,6 +121,7 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=prerelease
                EVENT_TYPE='push pull_request cron'
+               PYTEST_VERSION=3.8
 
         # Do a PEP8/pyflakes test with flake8
         - os: linux

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -4,6 +4,7 @@ This file contains pytest configuration settings that are astropy-specific
 (i.e.  those that would not necessarily be shared by affiliated packages
 making use of astropy's test runner).
 """
+import builtins
 from importlib.util import find_spec
 
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
@@ -36,6 +37,7 @@ matplotlibrc_cache = {}
 
 
 def pytest_configure(config):
+    builtins._pytest_running = True
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:
         matplotlibrc_cache.update(matplotlib.rcParams)
@@ -43,6 +45,7 @@ def pytest_configure(config):
 
 
 def pytest_unconfigure(config):
+    builtins._pytest_running = False
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:
         matplotlib.rcParams.update(matplotlibrc_cache)

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -14,6 +14,11 @@ from ..utils.exceptions import AstropyDeprecationWarning
 from .helper import enable_deprecations_as_exceptions
 from .plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
+# This makes sure that this module is not collected when running the test
+# suite. This is necessary in order to get the test suite to run without errors
+# using pytest>=3.7
+import pytest
+pytest.skip()
 
 _warning_message = "The module `astropy.tests.pytest_plugins has been " \
     "deprecated. The variables `PYTEST_HEADER_MODULES` and `TESTED_VERSIONS`" \

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -8,6 +8,7 @@ configure them within setup.cfg).
 TODO: This entire module should eventually be removed once backwards
 compatibility is no longer supported.
 """
+import builtins
 import warnings
 from ..utils.exceptions import AstropyDeprecationWarning
 
@@ -17,8 +18,9 @@ from .plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 # This makes sure that this module is not collected when running the test
 # suite. This is necessary in order to get the test suite to run without errors
 # using pytest>=3.7
-import pytest
-pytest.skip()
+if getattr(builtins, '_pytest_running', False):
+    import pytest
+    pytest.skip()
 
 _warning_message = "The module `astropy.tests.pytest_plugins has been " \
     "deprecated. The variables `PYTEST_HEADER_MODULES` and `TESTED_VERSIONS`" \


### PR DESCRIPTION
This update appears to be necessary (and is hopefully sufficient) to allow us to run with newer versions of pytest (i.e. >3.7).