### PR TITLE
Added robots meta tags and updated docs/conf.py

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,19 @@
+{# This extension of the 'layout.html' is useful if the docs
+   are built and hosted on readthedocs.org
+
+   The readthedocs app passes additional variables to the template context.
+
+   The variable 'version_slug' passed by the RTD app  is a string computed
+   from the version control tags. It can be 'latest', 'stable' or the
+   version number as a string.
+
+   Check out '/readthedocs/builds/version_slug.py' in 'github.com/rtfd/readthedocs.org'
+#}
+
+{% extends "!layout.html" %}
+{%- block extrahead %} 
+  {% if version_slug != "stable" or version_slug != "latest"  %}
+  <meta name="robots" content="noindex, nofollow">
+  {% endif %}
+  {{ super()  }}
+{% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,19 +1,25 @@
-{# This extension of the 'layout.html' is useful if the docs
-   are built and hosted on readthedocs.org
+{# This extension of the 'layout.html' prevents documentation for previous
+   versions of Astropy to be indexed by bots, e.g. googlebot or bing bot,
+   by inserting a robots meta tag into pages that are not in the stable or
+   latest branch.
 
-   The readthedocs app passes additional variables to the template context.
+   It assumes that the documentation is built by and hosted on readthedocs.org:
+   1. Readthedocs.org has a global robots.txt and no option for a custom one.
+   2. The readthedocs app passes additional variables to the template context,
+   one of them being `version_slug`. This variable is a string computed from
+   the tags of the branches that are selected to be built. It can be 'latest',
+   'stable' or even a unique stringified version number.
 
-   The variable 'version_slug' passed by the RTD app  is a string computed
-   from the version control tags. It can be 'latest', 'stable' or the
-   version number as a string.
-
-   Check out '/readthedocs/builds/version_slug.py' in 'github.com/rtfd/readthedocs.org'
+   For more information, please refer to:
+   https://github.com/astropy/astropy/pull/7874
+   http://www.robotstxt.org/meta.html
+   https://github.com/rtfd/readthedocs.org/blob/master/readthedocs/builds/version_slug.py
 #}
 
 {% extends "!layout.html" %}
-{%- block extrahead %} 
-  {% if version_slug != "stable" or version_slug != "latest"  %}
+{%- block extrahead %}
+  {% if not version_slug in to_be_indexed  %}
   <meta name="robots" content="noindex, nofollow">
   {% endif %}
-  {{ super()  }}
+  {{ super() }}
 {% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,10 @@ html_title = '{0} v{1}'.format(project, release)
 # Output file base name for HTML help builder.
 htmlhelp_basename = project + 'doc'
 
+# A dictionary of values to pass into the template engine’s context for all pages.
+html_context = {
+    'to_be_indexed': ['stable', 'latest']
+}
 
 # -- Options for LaTeX output --------------------------------------------------
 


### PR DESCRIPTION
I added an extension to `layouts.html` to include meta robots text it the documentation version is not `latest` or `stable` and added a variable to Sphinx's [html_context](http://www.sphinx-doc.org/en/master/usage/configuration.html): a list of version that should not include the robots meta tag.

More about this in the discussion on pull request [#7874](https://github.com/astropy/astropy/pull/7874)