### PR TITLE
Use OpenStreetMap in EarthLocation.of_address() by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -434,6 +434,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- ``EarthLocation.of_address`` now uses the OpenStreetMap geocoding API by
+  default to retrieve coordinates, with the Google API (which now requires an
+  API key) as an option. [#7918]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -371,8 +371,11 @@ class EarthLocation(u.Quantity):
         the OpenStreetMap Nominatim tool [1]_ (default) or the Google geocoding
         API [2]_, which requires a specified API key.
 
-        This is intended as a quick convenience function to get fast access to
-        locations. In the background, this just issues a web query to either of
+        This is intended as a quick convenience function to get easy access to
+        locations. If you need to specify a precise location, you should use the
+        initializer directly and pass in a longitude, latitude, and elevation.
+
+        In the background, this just issues a web query to either of
         the APIs noted above. This is not meant to be abused! Both
         OpenStreetMap and Google use IP-based query limiting and will ban your
         IP if you send more than a few thousand queries per hour [2]_.

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -75,7 +75,7 @@ def _get_json_result(url, err_str, use_google):
 
     if use_google:
         results = resp_data.get('results', [])
-        
+
         if resp_data.get('status', None) != 'OK':
             raise NameResolveError(err_str.format(msg="unknown failure with "
                                                   "Google API"))
@@ -394,6 +394,8 @@ class EarthLocation(u.Quantity):
             the Google maps elevation API to retrieve the height of the input
             address [3]_.
         google_api_key : str (optional)
+            A Google API key with the Geocoding API and (optionally) the
+            elevation API enabled. See [4]_ for more information.
 
 
         Returns
@@ -406,6 +408,7 @@ class EarthLocation(u.Quantity):
         .. [1] https://nominatim.openstreetmap.org/
         .. [2] https://developers.google.com/maps/documentation/geocoding/start
         .. [3] https://developers.google.com/maps/documentation/elevation/
+        .. [4] https://developers.google.com/maps/documentation/geocoding/get-api-key
 
         """
 

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -293,6 +293,9 @@ def test_of_address(google_api_key):
     NYC_lon = -74.0 * u.deg
     NYC_lat = 40.7 * u.deg
     # ~10 km tolerance to address difference between OpenStreetMap and Google
+    # for "New York, NY". This doesn't matter in practice because this test is
+    # only used to verify that the query succeeded, not that the returned
+    # position is precise.
     NYC_tol = 0.1 * u.deg
 
     # just a location

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -303,7 +303,6 @@ def test_of_address(google_api_key):
         if 'unknown failure with' not in str(e):
             pytest.xfail(str(e))
     else:
-        # Tolerance below is a MAGIC NUMBER
         assert quantity_allclose(loc.lat, NYC_lat, atol=NYC_tol)
         assert quantity_allclose(loc.lon, NYC_lon, atol=NYC_tol)
         assert np.allclose(loc.height.value, 0.)

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -285,16 +285,27 @@ def test_repr_latex():
 
 
 @pytest.mark.remote_data
-def test_of_address():
+# TODO: this parametrize should include a second option with a valid Google API
+# key. For example, we should make an API key for Astropy, and add it to Travis
+# as an environment variable (for security).
+@pytest.mark.parametrize('google_api_key', [None])
+def test_of_address(google_api_key):
+    NYC_lon = -74.0 * u.deg
+    NYC_lat = 40.7 * u.deg
+    # ~10 km tolerance to address difference between OpenStreetMap and Google
+    NYC_tol = 0.1 * u.deg
+
     # just a location
     try:
         loc = EarthLocation.of_address("New York, NY")
     except NameResolveError as e:
-        # Google map API limit might surface even here in Travis CI.
-        pytest.xfail(str(e))
+        # API limit might surface even here in Travis CI.
+        if 'unknown failure with' not in str(e):
+            pytest.xfail(str(e))
     else:
-        assert quantity_allclose(loc.lat, 40.7128*u.degree)
-        assert quantity_allclose(loc.lon, -74.0059*u.degree)
+        # Tolerance below is a MAGIC NUMBER
+        assert quantity_allclose(loc.lat, NYC_lat, atol=NYC_tol)
+        assert quantity_allclose(loc.lon, NYC_lon, atol=NYC_tol)
         assert np.allclose(loc.height.value, 0.)
 
     # Put this one here as buffer to get around Google map API limit per sec.
@@ -302,18 +313,19 @@ def test_of_address():
     with pytest.raises(NameResolveError):
         EarthLocation.of_address("lkjasdflkja")
 
-    # a location and height
-    try:
-        loc = EarthLocation.of_address("New York, NY", get_height=True)
-    except NameResolveError as e:
-        # Buffer above sometimes insufficient to get around API limit but
-        # we also do not want to drag things out with time.sleep(0.195),
-        # where 0.195 was empirically determined on some physical machine.
-        pytest.xfail(str(e))
-    else:
-        assert quantity_allclose(loc.lat, 40.7128*u.degree)
-        assert quantity_allclose(loc.lon, -74.0059*u.degree)
-        assert quantity_allclose(loc.height, 10.438659669*u.meter, atol=1.*u.cm)
+    if google_api_key is not None:
+        # a location and height
+        try:
+            loc = EarthLocation.of_address("New York, NY", get_height=True)
+        except NameResolveError as e:
+            # Buffer above sometimes insufficient to get around API limit but
+            # we also do not want to drag things out with time.sleep(0.195),
+            # where 0.195 was empirically determined on some physical machine.
+            pytest.xfail(str(e))
+        else:
+            assert quantity_allclose(loc.lat, NYC_lat, atol=NYC_tol)
+            assert quantity_allclose(loc.lon, NYC_lon, atol=NYC_tol)
+            assert quantity_allclose(loc.height, 10.438*u.meter, atol=1.*u.cm)
 
 
 def test_geodetic_tuple():


### PR DESCRIPTION
This adds the OpenStreetMap geocoding API as the default service for `EarthLocation.of_address`, and provides the option to use the old Google API with a provided key.

This fixes #7867 

cc @eteq 
