### PR TITLE
Support differential/velocity data in frame concatenate() function 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ astropy.coordinates
 - Additional information about a site loaded from the Astropy sites registry is
   now available in ``EarthLocation.info.meta``. [#7857]
 
+- Added a ``concatenate_representations`` function to combine coordinate
+  representation data and any associated differentials. [#7922]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -242,6 +245,9 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- Fixed ``astropy.coordinates.concatenate`` to also concatenate velocity (i.e.
+  differential) data along with positional data. [#7922]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,8 +246,8 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- Fixed ``astropy.coordinates.concatenate`` to also concatenate velocity (i.e.
-  differential) data along with positional data. [#7922]
+- Fixed ``astropy.coordinates.concatenate`` to include velocity data in the
+  concatenation. [#7922]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -358,4 +358,16 @@ def concatenate(coords):
     """
     if getattr(coords, 'isscalar', False) or not isiterable(coords):
         raise TypeError('The argument to concatenate must be iterable')
-    return SkyCoord(coords)
+
+    scs = [SkyCoord(coord) for coord in coords]
+
+    # Check that all frames are equivalent
+    for sc in scs[1:]:
+        if not sc.is_equivalent_frame(scs[0]):
+            raise ValueError("All inputs must have equivalent frames: "
+                             "{0} != {1}".format(sc, scs[0]))
+
+    # TODO: this can be changed to SkyCoord.from_representation() for a speed
+    # boost when we switch to using classmethods
+    return SkyCoord(concatenate_representations([c.data for c in coords]),
+                    frame=scs[0].frame)

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -23,7 +23,7 @@ from .representation import SphericalRepresentation, CartesianRepresentation
 from .builtin_frames.utils import get_jd12
 
 __all__ = ['cartesian_to_spherical', 'spherical_to_cartesian', 'get_sun',
-           'concatenate', 'get_constellation']
+           'get_constellation', 'concatenate_representations', 'concatenate']
 
 
 def cartesian_to_spherical(x, y, z):

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -313,14 +313,18 @@ def concatenate_representations(reps):
                                      rep_type.attr_classes.keys())
     new_rep = rep_type(*values)
 
-    has_diff = 's' in reps[0].differentials
+    has_diff = any('s' in rep.differentials for rep in reps)
+    if has_diff and any('s' not in rep.differentials for rep in reps):
+        raise ValueError('Input representations must either all contain '
+                         'differentials, or not contain differentials.')
+
     if has_diff:
         dif_type = type(reps[0].differentials['s'])
 
         if any('s' not in r.differentials or
                 type(r.differentials['s']) != dif_type
                for r in reps):
-            raise TypeError('Input representations must all have the same '
+            raise TypeError('All input representations must have the same '
                             'differential type.')
 
         values = _concatenate_components([r.differentials['s'] for r in reps],

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -305,7 +305,7 @@ def concatenate_representations(reps):
     # concatenate all of the positional data:
     rep_type = type(reps[0])
     if any(type(r) != rep_type for r in reps):
-        raise ValueError('Input representations must all have the same type.')
+        raise TypeError('Input representations must all have the same type.')
 
     # Construct the new representation with the concatenated data from the
     # representations passed in
@@ -320,8 +320,8 @@ def concatenate_representations(reps):
         if any('s' not in r.differentials or
                 type(r.differentials['s']) != dif_type
                for r in reps):
-            raise ValueError('Input representations must all have the same '
-                             'differential type.')
+            raise TypeError('Input representations must all have the same '
+                            'differential type.')
 
         values = _concatenate_components([r.differentials['s'] for r in reps],
                                          dif_type.attr_classes.keys())

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -8,6 +8,7 @@ framework, but it is useful for some users who are used to more functional
 interfaces.
 """
 
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -168,32 +169,6 @@ def get_sun(time):
     return SkyCoord(cartrep, frame=GCRS(obstime=time))
 
 
-def concatenate(coords):
-    """
-    Combine multiple coordinate objects into a single
-    `~astropy.coordinates.SkyCoord`.
-
-    "Coordinate objects" here mean frame objects with data,
-    `~astropy.coordinates.SkyCoord`, or representation objects.  Currently,
-    they must all be in the same frame, but in a future version this may be
-    relaxed to allow inhomogenous sequences of objects.
-
-    Parameters
-    ----------
-    coords : sequence of coordinate objects
-        The objects to concatenate
-
-    Returns
-    -------
-    cskycoord : SkyCoord
-        A single sky coordinate with its data set to the concatenation of all
-        the elements in ``coords``
-    """
-    if getattr(coords, 'isscalar', False) or not isiterable(coords):
-        raise TypeError('The argument to concatenate must be iterable')
-    return SkyCoord(coords)
-
-
 # global dictionary that caches repeatedly-needed info for get_constellation
 _constellation_data = {}
 
@@ -279,3 +254,104 @@ def get_constellation(coord, short_name=False, constellation_list='iau'):
         return names[0]
     else:
         return names
+
+
+def _concatenate_components(reps_difs, names):
+    """ Helper function for the concatenate function below. Gets and
+    concatenates all of the individual components for an iterable of
+    representations or differentials.
+    """
+    values = []
+    for name in names:
+        data_vals = []
+        for x in reps_difs:
+            data_val = getattr(x, name)
+            data_vals.append(data_val.reshape(1, ) if x.isscalar else data_val)
+        concat_vals = np.concatenate(data_vals)
+
+        # Hack because np.concatenate doesn't fully work with Quantity
+        if isinstance(concat_vals, u.Quantity):
+            concat_vals._unit = data_val.unit
+
+        values.append(concat_vals)
+
+    return values
+
+def concatenate_representations(reps):
+    """
+    Combine multiple representation objects into a single instance by
+    concatenating the data in each component.
+
+    Currently, all of the input representations have to be the same type. This
+    properly handles differential or velocity data, but all input objects must
+    have the same differential object type as well.
+
+    Parameters
+    ----------
+    reps : sequence of representation objects
+        The objects to concatenate
+
+    Returns
+    -------
+    rep : `~astropy.coordinates.BaseRepresentation` subclass
+        A single representation object with its data set to the concatenation of
+        all the elements of the input sequence of representations.
+    """
+    if not isinstance(reps, (Sequence, np.ndarray)):
+        raise TypeError('Input must be a list or iterable of representation '
+                        'objects.')
+
+    # First, validate that the represenations are the same, and
+    # concatenate all of the positional data:
+    rep_type = type(reps[0])
+    if any(type(r) != rep_type for r in reps):
+        raise ValueError('Input representations must all have the same type.')
+
+    # Construct the new representation with the concatenated data from the
+    # representations passed in
+    values = _concatenate_components(reps,
+                                     rep_type.attr_classes.keys())
+    new_rep = rep_type(*values)
+
+    has_diff = 's' in reps[0].differentials
+    if has_diff:
+        dif_type = type(reps[0].differentials['s'])
+
+        if any('s' not in r.differentials or
+                type(r.differentials['s']) != dif_type
+               for r in reps):
+            raise ValueError('Input representations must all have the same '
+                             'differential type.')
+
+        values = _concatenate_components([r.differentials['s'] for r in reps],
+                                         dif_type.attr_classes.keys())
+        new_dif = dif_type(*values)
+        new_rep = new_rep.with_differentials({'s': new_dif})
+
+    return new_rep
+
+
+def concatenate(coords):
+    """
+    Combine multiple coordinate objects into a single
+    `~astropy.coordinates.SkyCoord`.
+
+    "Coordinate objects" here mean frame objects with data,
+    `~astropy.coordinates.SkyCoord`, or representation objects.  Currently,
+    they must all be in the same frame, but in a future version this may be
+    relaxed to allow inhomogenous sequences of objects.
+
+    Parameters
+    ----------
+    coords : sequence of coordinate objects
+        The objects to concatenate
+
+    Returns
+    -------
+    cskycoord : SkyCoord
+        A single sky coordinate with its data set to the concatenation of all
+        the elements in ``coords``
+    """
+    if getattr(coords, 'isscalar', False) or not isiterable(coords):
+        raise TypeError('The argument to concatenate must be iterable')
+    return SkyCoord(coords)

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -359,7 +359,7 @@ def concatenate(coords):
     if getattr(coords, 'isscalar', False) or not isiterable(coords):
         raise TypeError('The argument to concatenate must be iterable')
 
-    scs = [SkyCoord(coord) for coord in coords]
+    scs = [SkyCoord(coord, copy=False) for coord in coords]
 
     # Check that all frames are equivalent
     for sc in scs[1:]:

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -117,6 +117,19 @@ def test_concatenate_representations():
         if 's' in rep.differentials:
             assert tmp.differentials['s'].shape == expected_shape
 
+    # Try combining 4, just for something different
+    for rep in reps:
+        if not rep.shape:
+            expected_shape = (4, )
+        else:
+            expected_shape = (4 * rep.shape[0], ) + rep.shape[1:]
+
+        tmp = concatenate_representations((rep, rep, rep, rep))
+        assert tmp.shape == expected_shape
+
+        if 's' in rep.differentials:
+            assert tmp.differentials['s'].shape == expected_shape
+
     # Test that combining pairs fails
     with pytest.raises(TypeError):
         concatenate_representations((reps[0], reps[1]))

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -86,8 +86,8 @@ def test_concatenate_representations():
             r.SphericalRepresentation(lon=1*u.deg, lat=2.*u.deg,
                                       distance=10*u.pc),
             r.UnitSphericalRepresentation(lon=1*u.deg, lat=2.*u.deg),
-            r.CartesianRepresentation(np.random.random((3, 100)) * u.kpc),
-            r.CartesianRepresentation(np.random.random((3, 16, 8)) * u.kpc)]
+            r.CartesianRepresentation(np.ones((3, 100)) * u.kpc),
+            r.CartesianRepresentation(np.ones((3, 16, 8)) * u.kpc)]
 
     reps.append(reps[0].with_differentials(
         r.CartesianDifferential([1, 2, 3.] * u.km/u.s)))
@@ -100,9 +100,9 @@ def test_concatenate_representations():
     reps.append(reps[2].with_differentials(
         {'s': r.RadialDifferential(1*u.km/u.s)}))
     reps.append(reps[3].with_differentials(
-        r.CartesianDifferential(*np.random.random((3, 100)) * u.km/u.s)))
+        r.CartesianDifferential(*np.ones((3, 100)) * u.km/u.s)))
     reps.append(reps[4].with_differentials(
-        r.CartesianDifferential(*np.random.random((3, 16, 8)) * u.km/u.s)))
+        r.CartesianDifferential(*np.ones((3, 16, 8)) * u.km/u.s)))
 
     # Test that combining all of the above with itself succeeds
     for rep in reps:

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -61,9 +61,10 @@ def test_constellations():
 
 
 def test_concatenate():
-    from .. import FK5, SkyCoord
+    from .. import FK5, SkyCoord, ICRS
     from ..funcs import concatenate
 
+    # Just positions
     fk5 = FK5(1*u.deg, 2*u.deg)
     sc = SkyCoord(3*u.deg, 4*u.deg, frame='fk5')
 
@@ -76,6 +77,23 @@ def test_concatenate():
 
     with pytest.raises(TypeError):
         concatenate(1*u.deg)
+
+    # positions and velocities
+    fr = ICRS(ra=10*u.deg, dec=11.*u.deg,
+              pm_ra_cosdec=12*u.mas/u.yr,
+              pm_dec=13*u.mas/u.yr)
+    sc = SkyCoord(ra=20*u.deg, dec=21.*u.deg,
+                  pm_ra_cosdec=22*u.mas/u.yr,
+                  pm_dec=23*u.mas/u.yr)
+
+    res = concatenate([fr, sc])
+
+    with pytest.raises(ValueError):
+        concatenate([fr, fk5])
+
+    fr2 = ICRS(ra=10*u.deg, dec=11.*u.deg)
+    with pytest.raises(ValueError):
+        concatenate([fr, fr2])
 
 
 def test_concatenate_representations():


### PR DESCRIPTION
This PR does two things:

1. Fixes #7506 - the `concatenate()` function now properly handles differential data in frames.
2. Adds a new function to concatenate raw `Representation` instances (with or without attached differentials), and offloads most of the work here.

Previously, all of the work in `concatenate()` happened in the `SkyCoord` initializer.