### PR TITLE
Fix confusing argument name in realize_frame

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -603,6 +603,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Changed the name of the single argument to ``Frame.realize_frame()`` from the
+  (incorrect) ``representation_type`` back to its pre-3.0 name
+  ``representation``. [#7923]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -275,6 +275,9 @@ astropy.coordinates
 - Fixed ``astropy.coordinates.concatenate`` to include velocity data in the
   concatenation. [#7922]
 
+- Changed the name of the single argument to ``Frame.realize_frame()`` from the
+  (incorrect) ``representation_type`` to ``data``. [#7923]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -602,10 +605,6 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-
-- Changed the name of the single argument to ``Frame.realize_frame()`` from the
-  (incorrect) ``representation_type`` back to its pre-3.0 name
-  ``representation``. [#7923]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -942,7 +942,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         return self._replicate(None, copy=copy, **kwargs)
 
-    def realize_frame(self, representation_type):
+    def realize_frame(self, representation):
         """
         Generates a new frame *with new data* from another frame (which may or
         may not have data). Roughly speaking, the converse of
@@ -950,7 +950,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         Parameters
         ----------
-        representation_type : `BaseRepresentation`
+        representation : `BaseRepresentation`
             The representation to use as the data for the new frame.
 
         Returns
@@ -959,7 +959,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             A new object with the same frame attributes as this one, but
             with the ``representation`` as the data.
         """
-        return self._replicate(representation_type)
+        return self._replicate(representation)
 
     def represent_as(self, base, s='base', in_frame_units=False):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -944,7 +944,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     def realize_frame(self, data):
         """
-        Generates a new frame *with new data from another frame (which may or
+        Generates a new frame with new data from another frame (which may or
         may not have data). Roughly speaking, the converse of
         `replicate_without_data`.
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -942,24 +942,24 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         return self._replicate(None, copy=copy, **kwargs)
 
-    def realize_frame(self, representation):
+    def realize_frame(self, data):
         """
-        Generates a new frame *with new data* from another frame (which may or
+        Generates a new frame *with new data from another frame (which may or
         may not have data). Roughly speaking, the converse of
         `replicate_without_data`.
 
         Parameters
         ----------
-        representation : `BaseRepresentation`
+        data : `BaseRepresentation`
             The representation to use as the data for the new frame.
 
         Returns
         -------
         frameobj : same as this frame
             A new object with the same frame attributes as this one, but
-            with the ``representation`` as the data.
+            with the ``data`` as the coordinate data.
         """
-        return self._replicate(representation)
+        return self._replicate(data)
 
     def represent_as(self, base, s='base', in_frame_units=False):
         """


### PR DESCRIPTION
As a result of a large copy-pasta for v3.0 (or 2.0?), I renamed a bunch of things `representation` -> `representation_type`. Well, this one was changed by accident: `realize_frame` expects a representation *with data*, not a representation type. I've changed the name now to make this more clear...but this is kind of an API change, even though it's fixing an unintentional previous API change.