### PR TITLE
Work around memory errors when using memory mapping on large files in io.fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,11 @@ astropy.io.fits
 - The ``fitsheader`` command line tool now supports a ``dfits+fitsort`` mode,
   and the dotted notation for keywords (e.g. ``ESO.INS.ID``). [#7240]
 
+- Fall back to reading arrays using mode='denywrite' if mode='readonly' fails
+  when using memory-mapping. This solves cases on some platforms when the
+  available address space was less than the file size (even when using memory
+  mapping). [#7926]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1017,6 +1017,7 @@ class TestFileFunctions(FitsTestCase):
             mmap.mmap = old_mmap
             _File.__dict__['_mmap_available']._cache.clear()
 
+    @pytest.mark.openfiles_ignore
     def test_mmap_allocate_error(self):
         """
         Regression test for https://github.com/astropy/astropy/issues/1380

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1045,6 +1045,8 @@ class TestFileFunctions(FitsTestCase):
             hdulist[1].data[:] = 1
         assert exc.value.args[0] == 'assignment destination is read-only'
 
+        hdulist.close()
+
     def test_mmap_closing(self):
         """
         Tests that the mmap reference is closed/removed when there aren't any


### PR DESCRIPTION
This is a workaround for https://github.com/astropy/astropy/issues/1380, which @Cadair and I ran into while trying to memory map a 30Gb file. The issue is that the available memory address space is less than the size of the file, the OS can in some cases raise a '[Errno 12] Cannot allocate memory' OSError **even if it's not actually allocating all the memory** (it's just testing if it would work preemptively).

Specifically, ``mode='readonly'`` results in the memory-mapping using the ACCESS_COPY mode in mmap so that users can modify arrays (without writing the values back to disk). The solution as described in #1380 is to open the file in ``mode='denywrite'``, which at least allows the file to be opened even if the resulting arrays will be truly read-only.

The change here is to modify ``readarray`` so that if this specific memory error occurs, it will fall back to reading the arrays as read-only arrays. This also will show a warning so that the user knows what's happening. There is no other way to access the data anyway in this case, so better to have read-only than not at all.

This change should be backward-compatible, as it won't affect anything for cases that worked already. It simply means that some cases that crashed before won't anymore.

Of course, this is io.fits, so who knows ``¯\_(ツ)_/¯`` - let's see what the CI says.

I'm not sure if this is a bug fix as such, so tentatively milestoning for 3.1, but let me know what you think.

also cc-ing @keflavich and @embray (because of #1380)