### PR TITLE
Fix numpy-dev failure in WCSAxes

### DIFF
--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -176,7 +176,11 @@ def transform_contour_set_inplace(cset, transform):
     pos_level = np.cumsum(pos_level)[:-1]
 
     # Stack all the segments into a single (n, 2) array
-    vertices = np.vstack(path.vertices for paths in all_paths for path in paths)
+    vertices = [path.vertices for paths in all_paths for path in paths]
+    if len(vertices) > 0:
+        vertices = np.vstack(vertices)
+    else:
+        return
 
     # Transform all coordinates in one go
     vertices = transform.transform(vertices)

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -178,7 +178,7 @@ def transform_contour_set_inplace(cset, transform):
     # Stack all the segments into a single (n, 2) array
     vertices = [path.vertices for paths in all_paths for path in paths]
     if len(vertices) > 0:
-        vertices = np.vstack(vertices)
+        vertices = np.concatenate(vertices)
     else:
         return
 


### PR DESCRIPTION
This only affects code that was added in master recently. The issue is that in Numpy, vstack no longer accepts empty lists, and it looks like ``np.concatenate`` should be used instead of ``np.vstack`` (based on some commit messages in Numpy).