### PR TITLE
Skipping slow tests in test_uniform_binomial

### DIFF
--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -727,8 +727,10 @@ def test_histogram_intervals_known(ii, rr):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.parametrize('N,m,p', [(100, 10000, 0.01),
-                                   (300, 10000, 0.001),
+@pytest.mark.parametrize('N,m,p', [pytest.param(100, 10000, 0.01,
+                                                marks=pytest.mark.skip('Test too slow')),
+                                   pytest.param(300, 10000, 0.001,
+                                                marks=pytest.mark.skip('Test too slow')),
                                    (10, 10000, 0.001),
                                    ])
 def test_uniform_binomial(N, m, p):


### PR DESCRIPTION
This skips the slowest tests in test_uniform_binomial but does still keep one test to make sure the function does perform as expected

Fixes #6979