### PR TITLE
Add bitmask module to nddata for manipulating (DQ) bit fields and creating masks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -147,6 +147,9 @@ astropy.nddata
 - ``NDUncertainty`` objects now have a ``quantity`` attribute for simple
   conversion to quantities. [#7704]
 
+- Add a ``bitmask`` module that provides functions for manipulating bitmasks
+  and data quality (DQ) arrays. [#7943]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,7 +148,7 @@ astropy.nddata
   conversion to quantities. [#7704]
 
 - Add a ``bitmask`` module that provides functions for manipulating bitmasks
-  and data quality (DQ) arrays. [#7943]
+  and data quality (DQ) arrays. [#7944]
 
 astropy.samp
 ^^^^^^^^^^^^

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -23,6 +23,7 @@ from .mixins.ndio import *
 from .compat import *
 from .utils import *
 from .ccddata import *
+from .bitmask import *
 
 from .. import config as _config
 

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -1,0 +1,411 @@
+"""
+A module that provides functions for manipulating bitmasks and data quality
+(DQ) arrays.
+
+"""
+
+import sys
+import warnings
+import six
+import numpy as np
+
+
+__all__ = ['bitfield_to_boolean_mask', 'interpret_bit_flags', 'is_bit_flag']
+
+
+INT_TYPE = (int, long,) if sys.version_info < (3,) else (int,)
+MAX_UINT_TYPE = np.maximum_sctype(np.uint)
+SUPPORTED_FLAGS = int(np.bitwise_not(
+    0, dtype=MAX_UINT_TYPE, casting='unsafe'
+))
+
+
+def is_bit_flag(n):
+    """
+    Verifies if the input number is a bit flag (i.e., an integer number that is
+    an integer power of 2).
+
+    Parameters
+    ----------
+    n : int
+        A positive integer number. Non-positive integers are considered not to
+        be "flags".
+
+    Returns
+    -------
+    bool
+        ``True`` if input ``n`` is a bit flag and ``False`` if it is not.
+
+    """
+    if n < 1:
+        return False
+
+    return bin(n).count('1') == 1
+
+
+def _is_int(n):
+    return (
+        (isinstance(n, INT_TYPE) and not isinstance(n, bool)) or
+        (isinstance(n, np.generic) and np.issubdtype(n, np.integer))
+    )
+
+
+def interpret_bit_flags(bit_flags, flip_bits=None):
+    """
+    Converts input bit flags to a single integer value (bitmask) or `None`.
+
+    When input is a list of flags (either a Python list of integer flags or a
+    sting of comma- or '+'-separated list of flags), the returned bitmask
+    is obtained by summing input flags.
+
+    .. note::
+        In order to flip the bits of the returned bitmask,
+        for input of `str` type, prepend '~' to the input string. '~' must
+        be prepended to the *entire string* and not to each bit flag! For
+        input that is already a bitmask or a Python list of bit flags, set
+        `flip_bits` for `True` in order to flip the bits of the returned
+        bitmask.
+
+    Parameters
+    ----------
+    bit_flags : int, str, list, None
+        An integer bitmask or flag, `None`, a string of comma- or
+        '+'-separated list of integer bit flags, or a Python list of integer
+        bit flags. If `bit_flags` is a `str` and if it is prepended with '~',
+        then the output bitmask will have its bits flipped (compared to simple
+        sum of input flags). For input `bit_flags` that is already a bitmask
+        or a Python list of bit flags, bit-flipping can be controlled through
+        `flip_bits` parameter.
+
+    flip_bits : bool, None
+        Indicates whether or not to flip the bits of the returned bitmask
+        obtained from input bit flags. This parameter must be set to `None`
+        when input `bit_flags` is either `None` or a Python list of flags.
+
+    Returns
+    -------
+    bitmask : int or None
+        Returns and integer bit mask formed from the input bit value
+        or `None` if input `bit_flags` parameter is `None` or an empty string.
+        If input string value was prepended with '~' (or `flip_bits` was
+        set to `True`), then returned value will have its bits flipped
+        (inverse mask).
+
+    Examples
+    --------
+        >>> from astropy.nddata.bitmask import interpret_bit_flags
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags(28))
+        '0000000000011100'
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags('4,8,16'))
+        '0000000000011100'
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags('~4,8,16'))
+        '1111111111100011'
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags('~(4+8+16)'))
+        '1111111111100011'
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags([4, 8, 16]))
+        '0000000000011100'
+        >>> "{0:016b}".format(0xFFFF & interpret_bit_flags([4, 8, 16], flip_bits=True))
+        '1111111111100011'
+
+    """
+    has_flip_bits = flip_bits is not None
+    flip_bits = bool(flip_bits)
+    allow_non_flags = False
+
+    if _is_int(bit_flags):
+        return (~int(bit_flags) if flip_bits else int(bit_flags))
+
+    elif bit_flags is None:
+        if has_flip_bits:
+            raise TypeError(
+                "Keyword argument 'flip_bits' must be set to 'None' when "
+                "input 'bit_flags' is None."
+            )
+        return None
+
+    elif isinstance(bit_flags, six.string_types):
+        if has_flip_bits:
+            raise TypeError(
+                "Keyword argument 'flip_bits' is not permitted for "
+                "comma-separated string lists of bit flags. Prepend '~' to "
+                "the string to indicate bit-flipping."
+            )
+
+        bit_flags = str(bit_flags).strip()
+
+        if bit_flags.upper() in ['', 'NONE', 'INDEF']:
+            return None
+
+        # check whether bitwise-NOT is present and if it is, check that it is
+        # in the first position:
+        bitflip_pos = bit_flags.find('~')
+        if bitflip_pos == 0:
+            flip_bits = True
+            bit_flags = bit_flags[1:].lstrip()
+        else:
+            if bitflip_pos > 0:
+                raise ValueError("Bitwise-NOT must precede bit flag list.")
+            flip_bits = False
+
+        # basic check for correct use of parenthesis:
+        while True:
+            nlpar = bit_flags.count('(')
+            nrpar = bit_flags.count(')')
+
+            if nlpar == 0 and nrpar == 0:
+                break
+
+            if nlpar != nrpar:
+                raise ValueError("Unbalanced parantheses in bit flag list.")
+
+            lpar_pos = bit_flags.find('(')
+            rpar_pos = bit_flags.rfind(')')
+            if lpar_pos > 0 or rpar_pos < (len(bit_flags) - 1):
+                raise ValueError("Incorrect syntax (incorrect use of "
+                                 "parenthesis) in bit flag list.")
+
+            bit_flags = bit_flags[1:-1].strip()
+
+        if ',' in bit_flags:
+            bit_flags = bit_flags.split(',')
+
+        elif '+' in bit_flags:
+            bit_flags = bit_flags.split('+')
+
+        else:
+            if bit_flags == '':
+                raise ValueError(
+                    "Empty bit flag lists not allowed when either bitwise-NOT "
+                    "or parenthesis are present."
+                )
+            bit_flags = [bit_flags]
+
+        allow_non_flags = len(bit_flags) == 1
+
+    elif hasattr(bit_flags, '__iter__'):
+        if not all([_is_int(flag) for flag in bit_flags]):
+            raise TypeError("Each bit flag in a list must be an integer.")
+
+    else:
+        raise TypeError("Unsupported type for argument 'bit_flags'.")
+
+    bitset = set(map(int, bit_flags))
+    if len(bitset) != len(bit_flags):
+        warnings.warn("Duplicate bit flags will be ignored")
+
+    bitmask = 0
+    for v in bitset:
+        if not is_bit_flag(v) and not allow_non_flags:
+            raise ValueError("Input list contains invalid (not powers of two) "
+                             "bit flags")
+        bitmask += v
+
+    if flip_bits:
+        bitmask = ~bitmask
+
+    return bitmask
+
+
+def bitfield_to_boolean_mask(bitfield, ignore_flags=0, flip_bits=None,
+                             good_mask_value=True, dtype=np.bool_):
+    """
+    bitfield_to_boolean_mask(bitfield, ignore_flags=None, flip_bits=None, \
+good_mask_value=True, dtype=numpy.bool\_)
+    Converts an array of bit fields to a boolean (or integer) mask array
+    according to a bitmask constructed from the supplied bit flags (see
+    ``ignore_flags`` parameter).
+
+    This function is particularly useful to convert data quality arrays to
+    boolean masks with selective filtering of DQ flags.
+
+    Parameters
+    ----------
+    bitfield : numpy.ndarray
+        An array of bit flags. By default, values different from zero are
+        interpreted as "bad" values and values equal to zero are considered
+        as "good" values. However, see ``ignore_flags`` parameter on how to
+        selectively ignore some bits in the ``bitfield`` array data.
+
+    ignore_flags : int, str, list, None (Default = 0)
+        An integer bitmask, a Python list of bit flags, a comma- or
+        '+'-separated string list of integer bit flags that indicate what
+        bits in the input ``bitfield`` should be *ignored* (i.e., zeroed), or
+        `None`.
+
+        | Setting ``ignore_flags`` to `None` effectively will make
+          `bitfield_to_boolean_mask` interpret all ``bitfield`` elements
+          as "good" regardless of their value.
+
+        | When ``ignore_flags`` argument is an integer bitmask, it will be
+          combined using bitwise-NOT and bitwise-AND with each element of the
+          input ``bitfield`` array (``~ignore_flags & bitfield``). If the
+          resultant bitfield element is non-zero, that element will be
+          interpreted as a "bad" in the output boolean mask and it will be
+          interpreted as "good" otherwise. ``flip_bits`` parameter may be used
+          to flip the bits (``bitwise-NOT``) of the bitmask thus effectively
+          changing the meaning of the ``ignore_flags`` parameter from "ignore"
+          to "use only" these flags.
+
+        .. note::
+
+            Setting ``ignore_flags`` to 0 effectively will assume that all
+            non-zero elements in the input ``bitfield`` array are to be
+            interpreted as "bad".
+
+        | When ``ignore_flags`` argument is an Python list of integer bit
+          flags, these flags are added together to create an integer bitmask.
+          Each item in the list must be a flag, i.e., an integer that is an
+          integer power of 2. In order to flip the bits of the resultant
+          bitmask, use ``flip_bits`` parameter.
+
+        | Alternatively, ``ignore_flags`` may be a string of comma- or
+          '+'-separated list of integer bit flags that should be added together
+          to create an integer bitmask. For example, both ``'4,8'`` and
+          ``'4+8'`` are equivalent and indicate that bit flags 4 and 8 in
+          the input ``bitfield`` array should be ignored when generating
+          boolean mask.
+
+        .. note::
+
+            ``'None'``, ``'INDEF'``, and empty (or all white space) strings
+            are special values of string ``ignore_flags`` that are
+            interpreted as `None`.
+
+        .. note::
+
+            Each item in the list must be a flag, i.e., an integer that is an
+            integer power of 2. In addition, for convenience, an arbitrary
+            **single** integer is allowed and it will be interpretted as an
+            integer bitmask. For example, instead of ``'4,8'`` one could
+            simply provide string ``'12'``.
+
+        .. note::
+
+            When ``ignore_flags`` is a `str` and when it is prepended with
+            '~', then the meaning of ``ignore_flags`` parameters will be
+            reversed: now it will be interpreted as a list of bit flags to be
+            *used* (or *not ignored*) when deciding which elements of the
+            input ``bitfield`` array are "bad". Following this convention,
+            an ``ignore_flags`` string value of ``'~0'`` would be equivalent
+            to setting ``ignore_flags=None``.
+
+        .. warning::
+
+            Because prepending '~' to a string ``ignore_flags`` is equivalent
+            to setting ``flip_bits`` to `True`, ``flip_bits`` cannot be used
+            with string ``ignore_flags`` and it must be set to `None`.
+
+    flip_bits : bool, None (Default = None)
+        Specifies whether or not to invert the bits of the bitmask either
+        supplied directly through ``ignore_flags`` parameter or built from the
+        bit flags passed through ``ignore_flags`` (only when bit flags are
+        passed as Python lists of integer bit flags). Occasionally, it may be
+        useful to *consider only specific bit flags* in the ``bitfield``
+        array when creating a boolean mask as opposite to *ignoring* specific
+        bit flags as ``ignore_flags`` behaves by default. This can be achieved
+        by inverting/flipping the bits of the bitmask created from
+        ``ignore_flags`` flags which effectively changes the meaning of the
+        ``ignore_flags`` parameter from "ignore" to "use only" these flags.
+        Setting ``flip_bits`` to `None` means that no bit flipping will be
+        performed. Bit flipping for string lists of bit flags must be
+        specified by prepending '~' to string bit flag lists
+        (see documentation for ``ignore_flags`` for more details).
+
+        .. warning::
+            This parameter can be set to either `True` or `False` **ONLY** when
+            ``ignore_flags`` is either an integer bitmask or a Python
+            list of integer bit flags. When ``ignore_flags`` is either
+            `None` or a string list of flags, ``flip_bits`` **MUST** be set
+            to `None`.
+
+    good_mask_value : int, bool (Default = True)
+        This parameter is used to derive the values that will be assigned to
+        the elements in the output boolean mask array that correspond to the
+        "good" bit fields (that are 0 after zeroing bits specified by
+        ``ignore_flags``) in the input ``bitfield`` array. When
+        ``good_mask_value`` is non-zero or `True` then values in the output
+        boolean mask array corresponding to "good" bit fields in ``bitfield``
+        will be `True` (if ``dtype`` is `numpy.bool_`) or 1 (if ``dtype`` is
+        of numerical type) and values of corresponding to "bad" flags will be
+        `False` (or 0). When ``good_mask_value`` is zero or `False` then the
+        values in the output boolean mask array corresponding to "good" bit
+        fields in ``bitfield`` will be `False` (if ``dtype`` is `numpy.bool_`)
+        or 0 (if ``dtype`` is of numerical type) and values of corresponding
+        to "bad" flags will be `True` (or 1).
+
+    dtype : data-type (Default = numpy.bool\_)
+        The desired data-type for the output binary mask array.
+
+    Returns
+    -------
+    mask : numpy.ndarray
+        Returns an array of the same dimensionality as the input ``bitfield``
+        array whose elements can have two possible values,
+        e.g., `True` or `False` (or 1 or 0 for integer ``dtype``) according to
+        values of to the input ``bitfield`` elements, ``ignore_flags``
+        parameter, and the ``good_mask_value`` parameter.
+
+    Examples
+    --------
+        >>> from astropy.nddata import bitmask
+        >>> import numpy as np
+        >>> dqbits = np.asarray([[0, 0, 1, 2, 0, 8, 12, 0],
+        ...                      [10, 4, 0, 0, 0, 16, 6, 0]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
+        ...                                  dtype=int)
+        array([[1, 1, 0, 0, 1, 0, 0, 1],
+               [0, 0, 1, 1, 1, 0, 0, 1]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
+        ...                                  dtype=bool)
+        array([[ True,  True, False, False,  True, False, False,  True],
+               [False, False,  True,  True,  True, False, False,  True]]...)
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6,
+        ...                                  good_mask_value=0, dtype=int)
+        array([[0, 0, 1, 0, 0, 1, 1, 0],
+               [1, 0, 0, 0, 0, 1, 0, 0]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=~6,
+        ...                                  good_mask_value=0, dtype=int)
+        array([[0, 0, 0, 1, 0, 0, 1, 0],
+               [1, 1, 0, 0, 0, 0, 1, 0]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6, dtype=int,
+        ...                                  flip_bits=True, good_mask_value=0)
+        array([[0, 0, 0, 1, 0, 0, 1, 0],
+               [1, 1, 0, 0, 0, 0, 1, 0]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags='~(2+4)',
+        ...                                  good_mask_value=0, dtype=int)
+        array([[0, 0, 0, 1, 0, 0, 1, 0],
+               [1, 1, 0, 0, 0, 0, 1, 0]])
+        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=[2, 4],
+        ...                                  flip_bits=True, good_mask_value=0,
+        ...                                  dtype=int)
+        array([[0, 0, 0, 1, 0, 0, 1, 0],
+               [1, 1, 0, 0, 0, 0, 1, 0]])
+
+    """
+    bitfield = np.asarray(bitfield)
+    if not np.issubdtype(bitfield.dtype, np.integer):
+        raise TypeError("Input bitfield array must be of integer type.")
+
+    ignore_mask = interpret_bit_flags(ignore_flags, flip_bits=flip_bits)
+
+    if ignore_mask is None:
+        if good_mask_value:
+            mask = np.ones_like(bitfield, dtype=dtype)
+        else:
+            mask = np.zeros_like(bitfield, dtype=dtype)
+        return mask
+
+    # filter out bits beyond the maximum supported by the data type:
+    ignore_mask = ignore_mask & SUPPORTED_FLAGS
+
+    # invert the "ignore" mask:
+    ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype,
+                                 casting='unsafe')
+
+    mask = np.empty_like(bitfield, dtype=np.bool_)
+    np.bitwise_and(bitfield, ignore_mask, out=mask, casting='unsafe')
+
+    if good_mask_value:
+        np.logical_not(mask, out=mask)
+
+    return mask.astype(dtype=dtype, subok=False, copy=False)

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -1,25 +1,25 @@
 """
-A module that provides functions for manipulating bitmasks and data quality
+A module that provides functions for manipulating bit masks and data quality
 (DQ) arrays.
 
 """
 
 import sys
 import warnings
+import numbers
 import numpy as np
 
 
-__all__ = ['bitfield_to_boolean_mask', 'interpret_bit_flags', 'is_bit_flag']
+__all__ = ['bitfield_to_boolean_mask', 'interpret_bit_flags']
 
 
-INT_TYPE = (int, long,) if sys.version_info < (3,) else (int,)
-MAX_UINT_TYPE = np.maximum_sctype(np.uint)
-SUPPORTED_FLAGS = int(np.bitwise_not(
-    0, dtype=MAX_UINT_TYPE, casting='unsafe'
+_MAX_UINT_TYPE = np.maximum_sctype(np.uint)
+_SUPPORTED_FLAGS = int(np.bitwise_not(
+    0, dtype=_MAX_UINT_TYPE, casting='unsafe'
 ))
 
 
-def is_bit_flag(n):
+def _is_bit_flag(n):
     """
     Verifies if the input number is a bit flag (i.e., an integer number that is
     an integer power of 2).
@@ -44,47 +44,47 @@ def is_bit_flag(n):
 
 def _is_int(n):
     return (
-        (isinstance(n, INT_TYPE) and not isinstance(n, bool)) or
+        (isinstance(n, numbers.Integral) and not isinstance(n, bool)) or
         (isinstance(n, np.generic) and np.issubdtype(n, np.integer))
     )
 
 
 def interpret_bit_flags(bit_flags, flip_bits=None):
     """
-    Converts input bit flags to a single integer value (bitmask) or `None`.
+    Converts input bit flags to a single integer value (bit mask) or `None`.
 
     When input is a list of flags (either a Python list of integer flags or a
-    sting of comma- or '+'-separated list of flags), the returned bitmask
+    sting of comma- or '+'-separated list of flags), the returned bit mask
     is obtained by summing input flags.
 
     .. note::
-        In order to flip the bits of the returned bitmask,
+        In order to flip the bits of the returned bit mask,
         for input of `str` type, prepend '~' to the input string. '~' must
         be prepended to the *entire string* and not to each bit flag! For
-        input that is already a bitmask or a Python list of bit flags, set
+        input that is already a bit mask or a Python list of bit flags, set
         ``flip_bits`` for `True` in order to flip the bits of the returned
-        bitmask.
+        bit mask.
 
     Parameters
     ----------
     bit_flags : int, str, list, None
-        An integer bitmask or flag, `None`, a string of comma- or
+        An integer bit mask or flag, `None`, a string of comma- or
         '+'-separated list of integer bit flags, or a Python list of integer
         bit flags. If ``bit_flags`` is a `str` and if it is prepended with '~',
-        then the output bitmask will have its bits flipped (compared to simple
-        sum of input flags). For input ``bit_flags`` that is already a bitmask
+        then the output bit mask will have its bits flipped (compared to simple
+        sum of input flags). For input ``bit_flags`` that is already a bit mask
         or a Python list of bit flags, bit-flipping can be controlled through
         ``flip_bits`` parameter.
 
     flip_bits : bool, None
-        Indicates whether or not to flip the bits of the returned bitmask
+        Indicates whether or not to flip the bits of the returned bit mask
         obtained from input bit flags. This parameter must be set to `None`
         when input ``bit_flags`` is either `None` or a Python list of flags.
 
     Returns
     -------
     bitmask : int or None
-        Returns and integer bit mask formed from the input bit value or `None`
+        Returns an integer bit mask formed from the input bit value or `None`
         if input ``bit_flags`` parameter is `None` or an empty string.
         If input string value was prepended with '~' (or ``flip_bits`` was set
         to `True`), then returned value will have its bits flipped
@@ -194,9 +194,9 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
 
     bitmask = 0
     for v in bitset:
-        if not is_bit_flag(v) and not allow_non_flags:
+        if not _is_bit_flag(v) and not allow_non_flags:
             raise ValueError("Input list contains invalid (not powers of two) "
-                             "bit flags")
+                             "bit flag: {:d}".format(v))
         bitmask += v
 
     if flip_bits:
@@ -211,7 +211,7 @@ def bitfield_to_boolean_mask(bitfield, ignore_flags=0, flip_bits=None,
     bitfield_to_boolean_mask(bitfield, ignore_flags=None, flip_bits=None, \
 good_mask_value=False, dtype=numpy.bool_)
     Converts an array of bit fields to a boolean (or integer) mask array
-    according to a bitmask constructed from the supplied bit flags (see
+    according to a bit mask constructed from the supplied bit flags (see
     ``ignore_flags`` parameter).
 
     This function is particularly useful to convert data quality arrays to
@@ -226,7 +226,7 @@ good_mask_value=False, dtype=numpy.bool_)
         selectively ignore some bits in the ``bitfield`` array data.
 
     ignore_flags : int, str, list, None (Default = 0)
-        An integer bitmask, a Python list of bit flags, a comma- or
+        An integer bit mask, a Python list of bit flags, a comma- or
         '+'-separated string list of integer bit flags that indicate what
         bits in the input ``bitfield`` should be *ignored* (i.e., zeroed), or
         `None`.
@@ -235,13 +235,13 @@ good_mask_value=False, dtype=numpy.bool_)
           `bitfield_to_boolean_mask` interpret all ``bitfield`` elements
           as "good" regardless of their value.
 
-        | When ``ignore_flags`` argument is an integer bitmask, it will be
+        | When ``ignore_flags`` argument is an integer bit mask, it will be
           combined using bitwise-NOT and bitwise-AND with each element of the
           input ``bitfield`` array (``~ignore_flags & bitfield``). If the
           resultant bitfield element is non-zero, that element will be
           interpreted as a "bad" in the output boolean mask and it will be
           interpreted as "good" otherwise. ``flip_bits`` parameter may be used
-          to flip the bits (``bitwise-NOT``) of the bitmask thus effectively
+          to flip the bits (``bitwise-NOT``) of the bit mask thus effectively
           changing the meaning of the ``ignore_flags`` parameter from "ignore"
           to "use only" these flags.
 
@@ -252,14 +252,14 @@ good_mask_value=False, dtype=numpy.bool_)
             interpreted as "bad".
 
         | When ``ignore_flags`` argument is a Python list of integer bit
-          flags, these flags are added together to create an integer bitmask.
+          flags, these flags are added together to create an integer bit mask.
           Each item in the list must be a flag, i.e., an integer that is an
           integer power of 2. In order to flip the bits of the resultant
-          bitmask, use ``flip_bits`` parameter.
+          bit mask, use ``flip_bits`` parameter.
 
         | Alternatively, ``ignore_flags`` may be a string of comma- or
           '+'-separated list of integer bit flags that should be added together
-          to create an integer bitmask. For example, both ``'4,8'`` and
+          to create an integer bit mask. For example, both ``'4,8'`` and
           ``'4+8'`` are equivalent and indicate that bit flags 4 and 8 in
           the input ``bitfield`` array should be ignored when generating
           boolean mask.
@@ -275,7 +275,7 @@ good_mask_value=False, dtype=numpy.bool_)
             Each item in the list must be a flag, i.e., an integer that is an
             integer power of 2. In addition, for convenience, an arbitrary
             **single** integer is allowed and it will be interpretted as an
-            integer bitmask. For example, instead of ``'4,8'`` one could
+            integer bit mask. For example, instead of ``'4,8'`` one could
             simply provide string ``'12'``.
 
         .. note::
@@ -295,14 +295,14 @@ good_mask_value=False, dtype=numpy.bool_)
             with string ``ignore_flags`` and it must be set to `None`.
 
     flip_bits : bool, None (Default = None)
-        Specifies whether or not to invert the bits of the bitmask either
+        Specifies whether or not to invert the bits of the bit mask either
         supplied directly through ``ignore_flags`` parameter or built from the
         bit flags passed through ``ignore_flags`` (only when bit flags are
         passed as Python lists of integer bit flags). Occasionally, it may be
         useful to *consider only specific bit flags* in the ``bitfield``
         array when creating a boolean mask as opposite to *ignoring* specific
         bit flags as ``ignore_flags`` behaves by default. This can be achieved
-        by inverting/flipping the bits of the bitmask created from
+        by inverting/flipping the bits of the bit mask created from
         ``ignore_flags`` flags which effectively changes the meaning of the
         ``ignore_flags`` parameter from "ignore" to "use only" these flags.
         Setting ``flip_bits`` to `None` means that no bit flipping will be
@@ -312,7 +312,7 @@ good_mask_value=False, dtype=numpy.bool_)
 
         .. warning::
             This parameter can be set to either `True` or `False` **ONLY** when
-            ``ignore_flags`` is either an integer bitmask or a Python
+            ``ignore_flags`` is either an integer bit mask or a Python
             list of integer bit flags. When ``ignore_flags`` is either
             `None` or a string list of flags, ``flip_bits`` **MUST** be set
             to `None`.
@@ -341,8 +341,8 @@ good_mask_value=False, dtype=numpy.bool_)
     mask : numpy.ndarray
         Returns an array of the same dimensionality as the input ``bitfield``
         array whose elements can have two possible values,
-        e.g., ``numpy.True_`` or ``numpy.False_`` (or 1 or 0 for integer ``dtype``)
-        according to values of to the input ``bitfield`` elements,
+        e.g., ``numpy.True_`` or ``numpy.False_`` (or 1 or 0 for integer
+        ``dtype``) according to values of to the input ``bitfield`` elements,
         ``ignore_flags`` parameter, and the ``good_mask_value`` parameter.
 
     Examples
@@ -396,7 +396,7 @@ good_mask_value=False, dtype=numpy.bool_)
         return mask
 
     # filter out bits beyond the maximum supported by the data type:
-    ignore_mask = ignore_mask & SUPPORTED_FLAGS
+    ignore_mask = ignore_mask & _SUPPORTED_FLAGS
 
     # invert the "ignore" mask:
     ignore_mask = np.bitwise_not(ignore_mask, dtype=bitfield.dtype,

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -353,12 +353,12 @@ good_mask_value=False, dtype=numpy.bool_)
         ...                      [10, 4, 0, 0, 0, 16, 6, 0]])
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
         ...                                  dtype=int)
-        array([[1, 1, 0, 0, 1, 0, 0, 1],
-               [0, 0, 1, 1, 1, 0, 0, 1]])
+        array([[0, 0, 1, 1, 0, 1, 1, 0],
+               [1, 1, 0, 0, 0, 1, 1, 0]])
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
         ...                                  dtype=bool)
-        array([[ True,  True, False, False,  True, False, False,  True],
-               [False, False,  True,  True,  True, False, False,  True]]...)
+        array([[False, False,  True,  True, False,  True,  True, False],
+               [ True,  True, False, False, False,  True,  True, False]])
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6,
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 1, 0, 0, 1, 1, 0],

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -349,10 +349,6 @@ good_mask_value=False, dtype=numpy.bool_)
     --------
         >>> from astropy.nddata import bitmask
         >>> import numpy as np
-        >>> try: # OPTIONAL (used to preserve numpy 1.13 array formatting)
-        ...     np.set_printoptions(legacy='1.13')
-        ... except TypeError:
-        ...     pass
         >>> dqbits = np.asarray([[0, 0, 1, 2, 0, 8, 12, 0],
         ...                      [10, 4, 0, 0, 0, 16, 6, 0]])
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
@@ -362,7 +358,7 @@ good_mask_value=False, dtype=numpy.bool_)
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
         ...                                  dtype=bool)
         array([[False, False,  True,  True, False,  True,  True, False],
-               [ True,  True, False, False, False,  True,  True, False]], dtype=bool)
+               [ True,  True, False, False, False,  True,  True, False]]...)
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6,
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 1, 0, 0, 1, 1, 0],

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -300,7 +300,7 @@ good_mask_value=False, dtype=numpy.bool_)
         bit flags passed through ``ignore_flags`` (only when bit flags are
         passed as Python lists of integer bit flags). Occasionally, it may be
         useful to *consider only specific bit flags* in the ``bitfield``
-        array when creating a boolean mask as opposited to *ignoring* specific
+        array when creating a boolean mask as opposed to *ignoring* specific
         bit flags as ``ignore_flags`` behaves by default. This can be achieved
         by inverting/flipping the bits of the bit mask created from
         ``ignore_flags`` flags which effectively changes the meaning of the

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -300,7 +300,7 @@ good_mask_value=False, dtype=numpy.bool_)
         bit flags passed through ``ignore_flags`` (only when bit flags are
         passed as Python lists of integer bit flags). Occasionally, it may be
         useful to *consider only specific bit flags* in the ``bitfield``
-        array when creating a boolean mask as opposite to *ignoring* specific
+        array when creating a boolean mask as opposited to *ignoring* specific
         bit flags as ``ignore_flags`` behaves by default. This can be achieved
         by inverting/flipping the bits of the bit mask created from
         ``ignore_flags`` flags which effectively changes the meaning of the
@@ -349,6 +349,10 @@ good_mask_value=False, dtype=numpy.bool_)
     --------
         >>> from astropy.nddata import bitmask
         >>> import numpy as np
+        >>> try: # OPTIONAL (used to preserve numpy 1.13 array formatting)
+        ...     np.set_printoptions(legacy='1.13')
+        ... except TypeError:
+        ...     pass
         >>> dqbits = np.asarray([[0, 0, 1, 2, 0, 8, 12, 0],
         ...                      [10, 4, 0, 0, 0, 16, 6, 0]])
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
@@ -358,7 +362,7 @@ good_mask_value=False, dtype=numpy.bool_)
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
         ...                                  dtype=bool)
         array([[False, False,  True,  True, False,  True,  True, False],
-               [ True,  True, False, False, False,  True,  True, False]])
+               [ True,  True, False, False, False,  True,  True, False]], dtype=bool)
         >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6,
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 1, 0, 0, 1, 1, 0],

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -6,7 +6,6 @@ A module that provides functions for manipulating bitmasks and data quality
 
 import sys
 import warnings
-import six
 import numpy as np
 
 
@@ -63,7 +62,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
         for input of `str` type, prepend '~' to the input string. '~' must
         be prepended to the *entire string* and not to each bit flag! For
         input that is already a bitmask or a Python list of bit flags, set
-        `flip_bits` for `True` in order to flip the bits of the returned
+        ``flip_bits`` for `True` in order to flip the bits of the returned
         bitmask.
 
     Parameters
@@ -71,24 +70,24 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
     bit_flags : int, str, list, None
         An integer bitmask or flag, `None`, a string of comma- or
         '+'-separated list of integer bit flags, or a Python list of integer
-        bit flags. If `bit_flags` is a `str` and if it is prepended with '~',
+        bit flags. If ``bit_flags`` is a `str` and if it is prepended with '~',
         then the output bitmask will have its bits flipped (compared to simple
-        sum of input flags). For input `bit_flags` that is already a bitmask
+        sum of input flags). For input ``bit_flags`` that is already a bitmask
         or a Python list of bit flags, bit-flipping can be controlled through
-        `flip_bits` parameter.
+        ``flip_bits`` parameter.
 
     flip_bits : bool, None
         Indicates whether or not to flip the bits of the returned bitmask
         obtained from input bit flags. This parameter must be set to `None`
-        when input `bit_flags` is either `None` or a Python list of flags.
+        when input ``bit_flags`` is either `None` or a Python list of flags.
 
     Returns
     -------
     bitmask : int or None
-        Returns and integer bit mask formed from the input bit value
-        or `None` if input `bit_flags` parameter is `None` or an empty string.
-        If input string value was prepended with '~' (or `flip_bits` was
-        set to `True`), then returned value will have its bits flipped
+        Returns and integer bit mask formed from the input bit value or `None`
+        if input ``bit_flags`` parameter is `None` or an empty string.
+        If input string value was prepended with '~' (or ``flip_bits`` was set
+        to `True`), then returned value will have its bits flipped
         (inverse mask).
 
     Examples
@@ -123,7 +122,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
             )
         return None
 
-    elif isinstance(bit_flags, six.string_types):
+    elif isinstance(bit_flags, str):
         if has_flip_bits:
             raise TypeError(
                 "Keyword argument 'flip_bits' is not permitted for "
@@ -207,10 +206,10 @@ def interpret_bit_flags(bit_flags, flip_bits=None):
 
 
 def bitfield_to_boolean_mask(bitfield, ignore_flags=0, flip_bits=None,
-                             good_mask_value=True, dtype=np.bool_):
+                             good_mask_value=False, dtype=np.bool_):
     """
     bitfield_to_boolean_mask(bitfield, ignore_flags=None, flip_bits=None, \
-good_mask_value=True, dtype=numpy.bool\_)
+good_mask_value=False, dtype=numpy.bool_)
     Converts an array of bit fields to a boolean (or integer) mask array
     according to a bitmask constructed from the supplied bit flags (see
     ``ignore_flags`` parameter).
@@ -252,7 +251,7 @@ good_mask_value=True, dtype=numpy.bool\_)
             non-zero elements in the input ``bitfield`` array are to be
             interpreted as "bad".
 
-        | When ``ignore_flags`` argument is an Python list of integer bit
+        | When ``ignore_flags`` argument is a Python list of integer bit
           flags, these flags are added together to create an integer bitmask.
           Each item in the list must be a flag, i.e., an integer that is an
           integer power of 2. In order to flip the bits of the resultant
@@ -318,22 +317,23 @@ good_mask_value=True, dtype=numpy.bool\_)
             `None` or a string list of flags, ``flip_bits`` **MUST** be set
             to `None`.
 
-    good_mask_value : int, bool (Default = True)
+    good_mask_value : int, bool (Default = False)
         This parameter is used to derive the values that will be assigned to
         the elements in the output boolean mask array that correspond to the
         "good" bit fields (that are 0 after zeroing bits specified by
         ``ignore_flags``) in the input ``bitfield`` array. When
-        ``good_mask_value`` is non-zero or `True` then values in the output
-        boolean mask array corresponding to "good" bit fields in ``bitfield``
-        will be `True` (if ``dtype`` is `numpy.bool_`) or 1 (if ``dtype`` is
-        of numerical type) and values of corresponding to "bad" flags will be
-        `False` (or 0). When ``good_mask_value`` is zero or `False` then the
-        values in the output boolean mask array corresponding to "good" bit
-        fields in ``bitfield`` will be `False` (if ``dtype`` is `numpy.bool_`)
-        or 0 (if ``dtype`` is of numerical type) and values of corresponding
-        to "bad" flags will be `True` (or 1).
+        ``good_mask_value`` is non-zero or ``numpy.True_`` then values in the
+        output boolean mask array corresponding to "good" bit fields in
+        ``bitfield`` will be ``numpy.True_`` (if ``dtype`` is ``numpy.bool_``)
+        or 1 (if ``dtype`` is of numerical type) and values of corresponding
+        to "bad" flags will be ``numpy.False_`` (or 0). When
+        ``good_mask_value`` is zero or ``numpy.False_`` then the values
+        in the output boolean mask array corresponding to "good" bit fields
+        in ``bitfield`` will be ``numpy.False_`` (if ``dtype`` is
+        ``numpy.bool_``) or 0 (if ``dtype`` is of numerical type) and values
+        of corresponding to "bad" flags will be ``numpy.True_`` (or 1).
 
-    dtype : data-type (Default = numpy.bool\_)
+    dtype : data-type (Default = ``numpy.bool_``)
         The desired data-type for the output binary mask array.
 
     Returns
@@ -341,9 +341,9 @@ good_mask_value=True, dtype=numpy.bool\_)
     mask : numpy.ndarray
         Returns an array of the same dimensionality as the input ``bitfield``
         array whose elements can have two possible values,
-        e.g., `True` or `False` (or 1 or 0 for integer ``dtype``) according to
-        values of to the input ``bitfield`` elements, ``ignore_flags``
-        parameter, and the ``good_mask_value`` parameter.
+        e.g., ``numpy.True_`` or ``numpy.False_`` (or 1 or 0 for integer ``dtype``)
+        according to values of to the input ``bitfield`` elements,
+        ``ignore_flags`` parameter, and the ``good_mask_value`` parameter.
 
     Examples
     --------

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -1,81 +1,182 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+A module containing unit tests for the `bitmask` modue.
 
+Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+"""
+import warnings
 import numpy as np
 import pytest
 
-from ...tests.helper import catch_warnings
-from ..bitmask import bitfield_to_boolean_mask
+from .. import bitmask
 
 
-def test_bitfield_not_integer():
+MAX_INT_TYPE = np.maximum_sctype(np.int)
+MAX_UINT_TYPE = np.maximum_sctype(np.uint)
+MAX_UINT_FLAG = np.left_shift(
+    MAX_UINT_TYPE(1),
+    MAX_UINT_TYPE(np.iinfo(MAX_UINT_TYPE).bits - 1)
+)
+MAX_INT_FLAG = np.left_shift(
+    MAX_INT_TYPE(1),
+    MAX_INT_TYPE(np.iinfo(MAX_INT_TYPE).bits - 2)
+)
+SUPER_LARGE_FLAG = 1 << np.iinfo(MAX_UINT_TYPE).bits
+EXTREME_TEST_DATA = np.array([
+        0, 1, 1 + 1 << 2, MAX_INT_FLAG, ~0, MAX_INT_TYPE(MAX_UINT_FLAG),
+        1 + MAX_INT_TYPE(MAX_UINT_FLAG)
+], dtype=MAX_INT_TYPE)
+
+
+@pytest.mark.parametrize('flag', [0, -1])
+def test_nonpositive_not_a_bit_flag(flag):
+    assert not bitmask._is_bit_flag(n=flag)
+
+
+@pytest.mark.parametrize('flag', [
+    1, MAX_UINT_FLAG, int(MAX_UINT_FLAG), SUPER_LARGE_FLAG
+])
+def test_is_bit_flag(flag):
+    assert bitmask._is_bit_flag(n=flag)
+
+
+@pytest.mark.parametrize('number', [0, 1, MAX_UINT_FLAG, SUPER_LARGE_FLAG])
+def test_is_int(number):
+    assert bitmask._is_int(number)
+
+
+@pytest.mark.parametrize('number', ['1', True, 1.0])
+def test_nonint_is_not_an_int(number):
+    assert not bitmask._is_int(number)
+
+
+@pytest.mark.parametrize('flag,flip,expected', [
+    (3, None, 3),
+    (3, True, -4),
+    (3, False, 3),
+    ([1, 2], False, 3),
+    ([1, 2], True, -4)
+])
+def test_interpret_valid_int_bit_flags(flag, flip, expected):
+    assert(
+        bitmask.interpret_bit_flags(bit_flags=flag, flip_bits=flip) == expected
+    )
+
+
+@pytest.mark.parametrize('flag', [None, ' ', 'None', 'Indef'])
+def test_interpret_none_bit_flags_as_None(flag):
+    assert bitmask.interpret_bit_flags(bit_flags=flag) is None
+
+
+@pytest.mark.parametrize('flag,expected', [
+    ('1', 1),
+    ('~-1', ~(-1)),
+    ('~1', ~1),
+    ('1,2', 3),
+    ('1+2', 3),
+    ('(1,2)', 3),
+    ('(1+2)', 3),
+    ('~1,2', ~3),
+    ('~1+2', ~3),
+    ('~(1,2)', ~3),
+    ('~(1+2)', ~3)
+])
+def test_interpret_valid_str_bit_flags(flag, expected):
+    assert(
+        bitmask.interpret_bit_flags(bit_flags=flag) == expected
+    )
+
+
+@pytest.mark.parametrize('flag,flip', [
+    (None, True),
+    (' ', True),
+    ('None', True),
+    ('Indef', True),
+    (None, False),
+    (' ', False),
+    ('None', False),
+    ('Indef', False),
+    ('1', True),
+    ('1', False)
+])
+def test_interpret_None_or_str_and_flip_incompatibility(flag, flip):
     with pytest.raises(TypeError):
-        bitfield_to_boolean_mask(np.random.random((10, 10)))
+        bitmask.interpret_bit_flags(bit_flags=flag, flip_bits=flip)
 
 
-def test_bitfield_negative_flags():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, [-1])
-
-
-def test_bitfield_non_poweroftwo_flags():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, [3])
-
-
-def test_bitfield_flipbits_when_no_bits():
-    bm = np.random.randint(0, 10, (10, 10))
+@pytest.mark.parametrize('flag', [True, 1.0, [1.0], object])
+def test_interpret_wrong_flag_type(flag):
     with pytest.raises(TypeError):
-        bitfield_to_boolean_mask(bm, None, flip_bits=1)
+        bitmask.interpret_bit_flags(bit_flags=flag)
 
 
-def test_bitfield_flipbits_when_stringbits():
-    bm = np.random.randint(0, 10, (10, 10))
+@pytest.mark.parametrize('flag', ['SOMETHING', '1.0,2,3'])
+def test_interpret_wrong_string_int_format(flag):
+    with pytest.raises(ValueError):
+        bitmask.interpret_bit_flags(bit_flags=flag)
+
+
+def test_interpret_duplicate_flag_warning():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert bitmask.interpret_bit_flags([2, 4, 4]) == 6
+        assert len(w)
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Duplicate" in str(w[-1].message)
+
+
+@pytest.mark.parametrize('flag', [[1, 2, 3], '1, 2, 3'])
+def test_interpret_non_flag(flag):
+    with pytest.raises(ValueError):
+        bitmask.interpret_bit_flags(bit_flags=flag)
+
+
+def test_interpret_allow_single_value_str_nonflags():
+    assert bitmask.interpret_bit_flags(bit_flags=str(3)) == 3
+
+
+@pytest.mark.parametrize('flag', [
+    '~',
+    '( )',
+    '(~1,2)',
+    '~(1,2',
+    '1,~2',
+    '1,(2,4)',
+    '1,2+4',
+    '1+4,2'
+])
+def test_interpret_bad_str_syntax(flag):
+    with pytest.raises(ValueError):
+        bitmask.interpret_bit_flags(bit_flags=flag)
+
+
+def test_bitfield_must_be_integer_check():
     with pytest.raises(TypeError):
-        bitfield_to_boolean_mask(bm, '3', flip_bits=1)
+        bitmask.bitfield_to_boolean_mask(1.0, 1)
 
 
-def test_bitfield_string_flag_flip_not_start_of_string():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, '1, ~4')
+@pytest.mark.parametrize('data,flags,flip,goodval,dtype,ref', [
+    (EXTREME_TEST_DATA, None, None, True, np.bool_,
+     EXTREME_TEST_DATA.size * [1]),
+    (EXTREME_TEST_DATA, None, None, False, np.bool_,
+     EXTREME_TEST_DATA.size * [0]),
+    (EXTREME_TEST_DATA, [1, MAX_UINT_FLAG], False, True, np.bool_,
+     [1, 1, 0, 0, 0, 1, 1]),
+    (EXTREME_TEST_DATA, None, None, True, np.bool_,
+     EXTREME_TEST_DATA.size * [1]),
+    (EXTREME_TEST_DATA, [1, MAX_UINT_FLAG], False, False, np.bool_,
+     [0, 0, 1, 1, 1, 0, 0]),
+    (EXTREME_TEST_DATA, [1, MAX_UINT_FLAG], True, True, np.int8,
+     [1, 0, 1, 1, 0, 0, 0])
+])
+def test_bitfield_to_boolean_mask(data, flags, flip, goodval, dtype, ref):
+    mask = bitmask.bitfield_to_boolean_mask(
+        bitfield=data,
+        ignore_flags=flags,
+        flip_bits=flip,
+        good_mask_value=goodval,
+        dtype=dtype
+    )
 
-
-def test_bitfield_string_flag_unbalanced_parens():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, '(1, 4))')
-
-
-def test_bitfield_string_flag_wrong_positioned_parens():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, '((1, )4)')
-
-
-def test_bitfield_string_flag_empty():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(ValueError):
-        bitfield_to_boolean_mask(bm, '~')
-
-
-def test_bitfield_flag_non_integer():
-    bm = np.random.randint(0, 10, (10, 10))
-    with pytest.raises(TypeError):
-        bitfield_to_boolean_mask(bm, [1.3])
-
-
-def test_bitfield_duplicate_flag_throws_warning():
-    bm = np.random.randint(0, 10, (10, 10))
-    with catch_warnings(UserWarning) as w:
-        bitfield_to_boolean_mask(bm, [1, 1])
-    assert len(w)
-
-
-def test_bitfield_none_identical_to_strNone():
-    bm = np.random.randint(0, 10, (10, 10))
-    m1 = bitfield_to_boolean_mask(bm, None)
-    m2 = bitfield_to_boolean_mask(bm, 'None')
-    np.testing.assert_array_equal(m1, m2)
-
+    assert(mask.dtype == dtype)
+    assert np.all(mask == ref)

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -1,0 +1,81 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+import pytest
+
+from ...tests.helper import catch_warnings
+from ..bitmask import bitfield_to_boolean_mask
+
+
+def test_bitfield_not_integer():
+    with pytest.raises(TypeError):
+        bitfield_to_boolean_mask(np.random.random((10, 10)))
+
+
+def test_bitfield_negative_flags():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, [-1])
+
+
+def test_bitfield_non_poweroftwo_flags():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, [3])
+
+
+def test_bitfield_flipbits_when_no_bits():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(TypeError):
+        bitfield_to_boolean_mask(bm, None, flip_bits=1)
+
+
+def test_bitfield_flipbits_when_stringbits():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(TypeError):
+        bitfield_to_boolean_mask(bm, '3', flip_bits=1)
+
+
+def test_bitfield_string_flag_flip_not_start_of_string():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, '1, ~4')
+
+
+def test_bitfield_string_flag_unbalanced_parens():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, '(1, 4))')
+
+
+def test_bitfield_string_flag_wrong_positioned_parens():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, '((1, )4)')
+
+
+def test_bitfield_string_flag_empty():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(ValueError):
+        bitfield_to_boolean_mask(bm, '~')
+
+
+def test_bitfield_flag_non_integer():
+    bm = np.random.randint(0, 10, (10, 10))
+    with pytest.raises(TypeError):
+        bitfield_to_boolean_mask(bm, [1.3])
+
+
+def test_bitfield_duplicate_flag_throws_warning():
+    bm = np.random.randint(0, 10, (10, 10))
+    with catch_warnings(UserWarning) as w:
+        bitfield_to_boolean_mask(bm, [1, 1])
+    assert len(w)
+
+
+def test_bitfield_none_identical_to_strNone():
+    bm = np.random.randint(0, 10, (10, 10))
+    m1 = bitfield_to_boolean_mask(bm, None)
+    m2 = bitfield_to_boolean_mask(bm, 'None')
+    np.testing.assert_array_equal(m1, m2)
+

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -1,8 +1,178 @@
+.. _bitmask_details:
+
 *********************************************************
 Utility functions for handling bit masks and mask arrays.
 *********************************************************
 
-.. currentmodule:: astropy.nddata.bitmask
+It is common to use `bit fields <https://en.wikipedia.org/wiki/Bit_field>`_ - \
+e.g., integer variables whose individual bits
+represent some attributes - to characterize the state of data. For example,
+HST uses arrays of bit fields to characterize data quality (DQ) of HST images,
+see, e.g., DQ field values for
+`WFPC2 image data <http://documents.stsci.edu/hst/wfpc2/documents/handbooks/dhb/wfpc2_ch34.html#1971480>`_
+and `WFC3 image data <http://www.stsci.edu/hst/wfc3/documents/handbooks/currentDHB/Chapter2_data_structure3.html#567105>`_.
+As one can see, the meaning assigned to various *bit flags* in for the two
+instruments is generally different.
 
-.. automodule:: astropy.nddata.bitmask
-   :members:
+Bit fields can be thought of as tightly packed collections of bit flags. Using
+`masking <https://en.wikipedia.org/wiki/Mask_(computing)>`_ we can "inspect"
+the status of individual bits.
+
+One common operation performed on bit field arrays is their conversion to
+boolean masks, for example by simply assigning boolean `True` (in the boolean
+mask) to those elements that correspond to non-zero-valued bit fields
+(bit fields with at least one bit set to ``1``) or, oftentimes, by assigning
+`True` to elements whose corresponding bit fields have only *specific fields*
+set (to ``1``). This more sophisticated analysis of bit fields can be
+accomplished using *bit masks* and the aforementioned masking operation.
+
+The `~astropy.nddata.bitmask` module provides two functions that facilitate
+conversion of bit field arrays (i.e., DQ arrays) to boolean masks:
+`~astropy.nddata.bitmask.bitfield_to_boolean_mask` to convert an input bit
+fields array to a boolean mask using an input bit mask (or list of individual
+bit flags) and `~astropy.nddata.bitmask.interpret_bit_flags` to create bit mask
+from input list of individual bit flags.
+
+Creating boolean masks
+**********************
+
+
+Overview
+========
+
+`~astropy.nddata.bitmask.bitfield_to_boolean_mask` by default assumes that
+all input bit fields that have at least one bit turned "ON" correspond to
+"bad" data (i.e., pixels) and converts them to boolean `True` in the output
+boolean mask (otherwise output boolean mask values are set to `False`).
+
+Often, for specific algorithms and situations, some bit flags are OK and
+can be ignored. `~astropy.nddata.bitmask.bitfield_to_boolean_mask` accepts
+lists of bit flags that *by default must be ignored* in the input bit fields
+when creating boolean masks.
+
+Fundamentally, *by default*, `~astropy.nddata.bitmask.bitfield_to_boolean_mask`
+performs the following operation:
+
+.. _main_eq:
+
+``(1)    boolean_mask = (bitfield & ~bit_mask) != 0``
+
+(here ``&`` is bitwise ``AND`` and ``~`` is the bitwise ``NOT`` operations).
+In the previous formula, ``bit_mask`` is a bit mask created from individual
+bit flags that need to be ignored in the bit field.
+
+.. _table1:
+
+.. table:: Table 1: Examples of Boolean Mask Computations \
+           (default parameters and 8-bit data type)
+
+    +--------------+--------------+--------------+--------------+------------+
+    | Bit Field    |  Bit Mask    | ~(Bit Mask)  | Bit Field &  |Boolean Mask|
+    |              |              |              | ~(Bit Mask)  |            |
+    +==============+==============+==============+==============+============+
+    |11011001 (217)|01010000 (80) |10101111 (175)|10001001 (137)|   True     |
+    +--------------+--------------+--------------+--------------+------------+
+    |11011001 (217)|10101111 (175)|01010000 (80) |01010000 (80) |   True     |
+    +--------------+--------------+--------------+--------------+------------+
+    |00001001 (9)  |01001001 (73) |10110110 (182)|00000000 (0)  |   False    |
+    +--------------+--------------+--------------+--------------+------------+
+    |00001001 (9)  |00000000 (0)  |11111111 (255)|00001001 (9)  |   True     |
+    +--------------+--------------+--------------+--------------+------------+
+    |00001001 (9)  |11111111 (255)|00000000 (0)  |00000000 (0)  |   False    |
+    +--------------+--------------+--------------+--------------+------------+
+
+
+Specifying bit flags
+====================
+
+`~astropy.nddata.bitmask.bitfield_to_boolean_mask` accepts either an integer
+bit mask or lists of bit flags. Lists of bit flags will be combined into a
+bit mask and can be provided either as a Python list of
+**integer bit flag values** or as a comma-separated (or ``+``-separated)
+list of integer bit flag values. Consider the bit mask from the first example
+in `Table 1 <table1_>`_. In this case ``ignore_flags`` can be set either to:
+
+    - an integer value bit mask 80, or
+    - a Python list indicating individual non-zero
+      *bit flag values:* ``[16, 64]``, or
+    - a string of comma-separated *bit flag values*: ``'16,64'``, or
+    - a string of ``+``-separated *bit flag values*: ``'16+64'``
+
+For example,
+
+    >>> from astropy.nddata import bitmask
+    >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=80)
+    array(True)
+    >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags='16,64')
+    array(True)
+    >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=[16, 64])
+    array(True)
+    >>> bitmask.bitfield_to_boolean_mask(9, ignore_flags=[1, 8, 64])
+    array(False)
+    >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='1,8,64')
+    array([False,  True, False,  True])
+
+It is also possible to specify the type of the output mask:
+
+    >>> import numpy as np
+    >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='1,8,64', dtype=np.uint8)
+    array([0, 1, 0, 1], dtype=uint8)
+
+
+Tweaking Main Formula
+=====================
+
+`~astropy.nddata.bitmask.bitfield_to_boolean_mask` provides several parameters
+that can be used to modify the formula used to create boolean masks.
+
+
+Inverting Bit Mask
+------------------
+
+Sometimes it is more convenient to be able to specify those bit
+flags that *must be considered* when creating the boolean mask and all other
+flags should be ignored. In `~astropy.nddata.bitmask.bitfield_to_boolean_mask`
+this can be accomplished by setting parameter ``flip_bits`` to `True`.
+This effectively modifies `equation (1) <main_eq_>`_ to:
+
+.. _modif_eq2:
+
+``(2)    boolean_mask = (bitfield & bit_mask) != 0``
+
+So, instead of
+
+    >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64])
+    array([False,  True, False,  True])
+
+one can obtain the same result as
+
+    >>> bitmask.bitfield_to_boolean_mask(
+    ...     [9, 10, 73, 217], ignore_flags=[2, 4, 16, 32, 128], flip_bits=True
+    ... )
+    array([False,  True, False,  True])
+
+Note however, when ``ignore_flags`` is a comma-separated list of bit flag
+values, ``flip_bits`` cannot be set to neither `True` or `False`. Instead,
+to flip bits of the bit mask formed from a string list of comma-separated
+bit flag values, one can prepend a single ``~`` to the list:
+
+    >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='~2+4+16+32+128')
+    array([False,  True, False,  True])
+
+
+Inverting Boolean Mask
+----------------------
+
+Other times, it may be more convenient to obtain an opposite mask in which
+flagged data are converted to `False` instead of `True`:
+
+.. _modif_eq3:
+
+``(3)    boolean_mask = (bitfield & ~bit_mask) == 0``
+
+This can be accomplished by changing ``good_mask_value`` parameter from
+its default value (`False`) to `True`. For example,
+
+    >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64],
+    ...                                  good_mask_value=True)
+    array([ True, False,  True, False])

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -57,7 +57,7 @@ performs the following operation:
 
 ``(1)    boolean_mask = (bitfield & ~bit_mask) != 0``
 
-(here ``&`` is bitwise ``AND`` and ``~`` is the bitwise ``NOT`` operations).
+(here ``&`` is bitwise ``and`` and ``~`` is the bitwise ``not`` operations).
 In the previous formula, ``bit_mask`` is a bit mask created from individual
 bit flags that need to be ignored in the bit field.
 
@@ -101,20 +101,24 @@ in `Table 1 <table1_>`_. In this case ``ignore_flags`` can be set either to:
 For example,
 
     >>> from astropy.nddata import bitmask
+    >>> import numpy as np
+    >>> try: # OPTIONAL (used to preserve numpy 1.13 array formatting)
+    ...     np.set_printoptions(legacy='1.13')
+    ... except TypeError:
+    ...     pass
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=80)
-    array(True)
+    array(True, dtype=bool)
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags='16,64')
-    array(True)
+    array(True, dtype=bool)
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=[16, 64])
-    array(True)
+    array(True, dtype=bool)
     >>> bitmask.bitfield_to_boolean_mask(9, ignore_flags=[1, 8, 64])
-    array(False)
+    array(False, dtype=bool)
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='1,8,64')
-    array([False,  True, False,  True])
+    array([False,  True, False,  True], dtype=bool)
 
 It is also possible to specify the type of the output mask:
 
-    >>> import numpy as np
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='1,8,64', dtype=np.uint8)
     array([0, 1, 0, 1], dtype=uint8)
 
@@ -142,14 +146,14 @@ This effectively modifies `equation (1) <main_eq_>`_ to:
 So, instead of
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64])
-    array([False,  True, False,  True])
+    array([False,  True, False,  True], dtype=bool)
 
 one can obtain the same result as
 
     >>> bitmask.bitfield_to_boolean_mask(
     ...     [9, 10, 73, 217], ignore_flags=[2, 4, 16, 32, 128], flip_bits=True
     ... )
-    array([False,  True, False,  True])
+    array([False,  True, False,  True], dtype=bool)
 
 Note however, when ``ignore_flags`` is a comma-separated list of bit flag
 values, ``flip_bits`` cannot be set to neither `True` or `False`. Instead,
@@ -157,13 +161,13 @@ to flip bits of the bit mask formed from a string list of comma-separated
 bit flag values, one can prepend a single ``~`` to the list:
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='~2+4+16+32+128')
-    array([False,  True, False,  True])
+    array([False,  True, False,  True], dtype=bool)
 
 
 Inverting Boolean Mask
 ----------------------
 
-Other times, it may be more convenient to obtain an opposite mask in which
+Other times, it may be more convenient to obtain an inverted mask in which
 flagged data are converted to `False` instead of `True`:
 
 .. _modif_eq3:
@@ -175,4 +179,4 @@ its default value (`False`) to `True`. For example,
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64],
     ...                                  good_mask_value=True)
-    array([ True, False,  True, False])
+    array([ True, False,  True, False], dtype=bool)

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -102,20 +102,16 @@ For example,
 
     >>> from astropy.nddata import bitmask
     >>> import numpy as np
-    >>> try: # OPTIONAL (used to preserve numpy 1.13 array formatting)
-    ...     np.set_printoptions(legacy='1.13')
-    ... except TypeError:
-    ...     pass
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=80)
-    array(True, dtype=bool)
+    array(True...)
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags='16,64')
-    array(True, dtype=bool)
+    array(True...)
     >>> bitmask.bitfield_to_boolean_mask(217, ignore_flags=[16, 64])
-    array(True, dtype=bool)
+    array(True...)
     >>> bitmask.bitfield_to_boolean_mask(9, ignore_flags=[1, 8, 64])
-    array(False, dtype=bool)
+    array(False...)
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='1,8,64')
-    array([False,  True, False,  True], dtype=bool)
+    array([False,  True, False,  True]...)
 
 It is also possible to specify the type of the output mask:
 
@@ -146,14 +142,14 @@ This effectively modifies `equation (1) <main_eq_>`_ to:
 So, instead of
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64])
-    array([False,  True, False,  True], dtype=bool)
+    array([False,  True, False,  True]...)
 
 one can obtain the same result as
 
     >>> bitmask.bitfield_to_boolean_mask(
     ...     [9, 10, 73, 217], ignore_flags=[2, 4, 16, 32, 128], flip_bits=True
     ... )
-    array([False,  True, False,  True], dtype=bool)
+    array([False,  True, False,  True]...)
 
 Note however, when ``ignore_flags`` is a comma-separated list of bit flag
 values, ``flip_bits`` cannot be set to neither `True` or `False`. Instead,
@@ -161,7 +157,7 @@ to flip bits of the bit mask formed from a string list of comma-separated
 bit flag values, one can prepend a single ``~`` to the list:
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags='~2+4+16+32+128')
-    array([False,  True, False,  True], dtype=bool)
+    array([False,  True, False,  True]...)
 
 
 Inverting Boolean Mask
@@ -179,4 +175,4 @@ its default value (`False`) to `True`. For example,
 
     >>> bitmask.bitfield_to_boolean_mask([9, 10, 73, 217], ignore_flags=[1, 8, 64],
     ...                                  good_mask_value=True)
-    array([ True, False,  True, False], dtype=bool)
+    array([ True, False,  True, False]...)

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -1,0 +1,8 @@
+*********************************************************
+Utility functions for handling bit masks and mask arrays.
+*********************************************************
+
+.. currentmodule:: astropy.nddata.bitmask
+
+.. automodule:: astropy.nddata.bitmask
+   :members:

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -440,7 +440,6 @@ Reference/API
     :no-inheritance-diagram:
 
 .. automodapi:: astropy.nddata.bitmask
-    :members:
     :no-inheritance-diagram:
 
 .. automodapi:: astropy.nddata.utils

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -439,6 +439,10 @@ Reference/API
 .. automodapi:: astropy.nddata
     :no-inheritance-diagram:
 
+.. automodapi:: astropy.nddata.bitmask
+    :members:
+    :no-inheritance-diagram:
+
 .. automodapi:: astropy.nddata.utils
     :no-inheritance-diagram:
 

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -424,6 +424,7 @@ Using ``nddata``
    utils.rst
    decorator.rst
    nddata.rst
+   bitmask.rst
    mixins/index.rst
    subclassing.rst
 


### PR DESCRIPTION
This PR adds a `bitmask` module to `nddata` that provides utilities for handling DQ data and creating boolean masks. The purpose of this PR is to make this code available to the wider community. Currently this code lives in three locations: [`stsci.tools`](https://github.com/spacetelescope/stsci.tools/blob/5f25467705f592a5ba1487ba6d9eb9deff9f33d6/lib/stsci/tools/bitmask.py) (original), [`ccdproc`](https://github.com/astropy/ccdproc/blob/503968ebc67373ae8e4e2ff4759bf76998ed987a/ccdproc/extern/bitfield.py) (ported there), and [`jwst` pipeline](https://github.com/spacetelescope/jwst/blob/92f9b6f36694d6db18e5037a6c54d43983d5e671/jwst/resample/bitmask.py) (also ported there). This is an attempt to reduce all these copies to a single common location available to most users.