### PR TITLE
Compatibility with Numpy 1.15.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1361,6 +1361,8 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fixed ``IERS_Auto.open`` compatibility with Numpy 1.15.3. [#7946]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -88,6 +88,8 @@ def _table_group_by(table, keys):
 
     # Finally do the actual sort of table_keys values
     table_keys = table_keys[idx_sort]
+    if hasattr(table_keys, 'filled'):
+        table_keys = table_keys.filled()
 
     # Get all keys
     diffs = np.concatenate(([True], table_keys[1:] != table_keys[:-1], [True]))

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1372,7 +1372,8 @@ def test_equality_masked():
     assert np.all(t == t)
 
     # Assert no rows are different
-    assert not np.any(t != t)
+    t_filled = t.filled()
+    assert not np.any(t_filled != t_filled)
 
     # Check equality result for a given row
     assert np.all((t == t[3]) == np.array([0, 0, 0, 1, 0, 0, 0, 0], dtype=bool))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -462,7 +462,8 @@ class IERS_A(IERS):
         #              Bull. A polar motion values
         # UT1Flag_A    IERS (I) or Prediction (P) flag for
         #              Bull. A UT1-UTC values
-        is_predictive = (table['UT1Flag_A'] == 'P') | (table['PolPMFlag_A'] == 'P')
+        is_predictive = ((table['UT1Flag_A'].filled() == 'P') |
+                         (table['PolPMFlag_A'].filled() == 'P'))
         table.meta['predictive_index'] = np.min(np.flatnonzero(is_predictive))
         table.meta['predictive_mjd'] = table['MJD'][table.meta['predictive_index']]
 


### PR DESCRIPTION
Fix #7943 -- Someone familiar with IERS API please review to make sure this is the proper fix.
Also fix #7956 (hopefully).

Unfortunately, I think Numpy 1.15.3 also broke something else in `astropy.table`. Log of `python setup.py test --remote-data` attached:

[zlog.txt](https://github.com/astropy/astropy/files/2503320/zlog.txt)
