### PR TITLE
Caching of some frame-static attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,10 @@ astropy.coordinates
 - Added a ``concatenate_representations`` function to combine coordinate
   representation data and any associated differentials. [#7922]
 
+- Some rarely-changed attributes of frame classes are now cached, resulting in
+  speedups (of order 50% in some cases) when creating new scalar frame or
+  ``SkyCoord`` objects. [#7949]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,7 @@ astropy.coordinates
   representation data and any associated differentials. [#7922]
 
 - Some rarely-changed attributes of frame classes are now cached, resulting in
-  speedups (of order 50% in some cases) when creating new scalar frame or
+  speedups (up to 50% in some cases) when creating new scalar frame or
   ``SkyCoord`` objects. [#7949]
 
 astropy.cosmology

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -774,6 +774,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # This exists as a class method only to support handling frame inputs
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
+        # note that if so moved, the cache should be acceessed as
+        # self.__class__._frame_class_cache
 
         if cls._frame_class_cache.get('last_reprdiff_hash', None) != r.get_reprdiff_cls_hash():
             repr_attrs = {}

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -770,43 +770,45 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
 
-        repr_attrs = {}
-        for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
-                              list(r.DIFFERENTIAL_CLASSES.values())):
-            repr_attrs[repr_diff_cls] = {'names': [], 'units': []}
-            for c, c_cls in repr_diff_cls.attr_classes.items():
-                repr_attrs[repr_diff_cls]['names'].append(c)
-                # TODO: when "recommended_units" is removed, just directly use
-                # the default part here.
-                rec_unit = repr_diff_cls._recommended_units.get(
-                    c, u.deg if issubclass(c_cls, Angle) else None)
-                repr_attrs[repr_diff_cls]['units'].append(rec_unit)
+        if not hasattr(cls, '_cached_representation_info'):
+            repr_attrs = {}
+            for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
+                                  list(r.DIFFERENTIAL_CLASSES.values())):
+                repr_attrs[repr_diff_cls] = {'names': [], 'units': []}
+                for c, c_cls in repr_diff_cls.attr_classes.items():
+                    repr_attrs[repr_diff_cls]['names'].append(c)
+                    # TODO: when "recommended_units" is removed, just directly use
+                    # the default part here.
+                    rec_unit = repr_diff_cls._recommended_units.get(
+                        c, u.deg if issubclass(c_cls, Angle) else None)
+                    repr_attrs[repr_diff_cls]['units'].append(rec_unit)
 
-        for repr_diff_cls, mappings in cls._frame_specific_representation_info.items():
+            for repr_diff_cls, mappings in cls._frame_specific_representation_info.items():
 
-            # take the 'names' and 'units' tuples from repr_attrs,
-            # and then use the RepresentationMapping objects
-            # to update as needed for this frame.
-            nms = repr_attrs[repr_diff_cls]['names']
-            uns = repr_attrs[repr_diff_cls]['units']
-            comptomap = dict([(m.reprname, m) for m in mappings])
-            for i, c in enumerate(repr_diff_cls.attr_classes.keys()):
-                if c in comptomap:
-                    mapp = comptomap[c]
-                    nms[i] = mapp.framename
+                # take the 'names' and 'units' tuples from repr_attrs,
+                # and then use the RepresentationMapping objects
+                # to update as needed for this frame.
+                nms = repr_attrs[repr_diff_cls]['names']
+                uns = repr_attrs[repr_diff_cls]['units']
+                comptomap = dict([(m.reprname, m) for m in mappings])
+                for i, c in enumerate(repr_diff_cls.attr_classes.keys()):
+                    if c in comptomap:
+                        mapp = comptomap[c]
+                        nms[i] = mapp.framename
 
-                    # need the isinstance because otherwise if it's a unit it
-                    # will try to compare to the unit string representation
-                    if not (isinstance(mapp.defaultunit, str) and
-                            mapp.defaultunit == 'recommended'):
-                        uns[i] = mapp.defaultunit
-                        # else we just leave it as recommended_units says above
+                        # need the isinstance because otherwise if it's a unit it
+                        # will try to compare to the unit string representation
+                        if not (isinstance(mapp.defaultunit, str) and
+                                mapp.defaultunit == 'recommended'):
+                            uns[i] = mapp.defaultunit
+                            # else we just leave it as recommended_units says above
 
-            # Convert to tuples so that this can't mess with frame internals
-            repr_attrs[repr_diff_cls]['names'] = tuple(nms)
-            repr_attrs[repr_diff_cls]['units'] = tuple(uns)
+                # Convert to tuples so that this can't mess with frame internals
+                repr_attrs[repr_diff_cls]['names'] = tuple(nms)
+                repr_attrs[repr_diff_cls]['units'] = tuple(uns)
 
-        return repr_attrs
+            cls._cached_representation_info = repr_attrs
+        return cls._cached_representation_info
 
     @lazyproperty
     def representation_info(self):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -775,7 +775,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
 
-        if '_representation_info' not in cls._frame_class_cache:
+        if cls._frame_class_cache.get('last_reprdiff_hash', None) != r.get_reprdiff_cls_hash():
             repr_attrs = {}
             for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
                                   list(r.DIFFERENTIAL_CLASSES.values())):
@@ -812,8 +812,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 repr_attrs[repr_diff_cls]['names'] = tuple(nms)
                 repr_attrs[repr_diff_cls]['units'] = tuple(uns)
 
-            cls._frame_class_cache['_representation_info'] = repr_attrs
-        return cls._frame_class_cache['_representation_info']
+            cls._frame_class_cache['representation_info'] = repr_attrs
+            cls._frame_class_cache['last_reprdiff_hash'] = r.get_reprdiff_cls_hash()
+        return cls._frame_class_cache['representation_info']
 
     @lazyproperty
     def representation_info(self):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -280,6 +280,11 @@ class FrameMeta(OrderedDescriptorContainer, abc.ABCMeta):
         if 'name' not in members:
             members['name'] = name.lower()
 
+         # A cache that *must be unique to each frame class* - it is
+         # insufficient to share them with superclasses, hence the need to put
+         # them in the meta
+        members['_frame_class_cache'] = {}
+
         return super().__new__(mcls, name, bases, members)
 
     @staticmethod
@@ -770,7 +775,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # without units, which are deprecated and will be removed.  This can be
         # moved into the representation_info property at that time.
 
-        if not hasattr(cls, '_cached_representation_info'):
+        if '_representation_info' not in cls._frame_class_cache:
             repr_attrs = {}
             for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +
                                   list(r.DIFFERENTIAL_CLASSES.values())):
@@ -807,8 +812,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 repr_attrs[repr_diff_cls]['names'] = tuple(nms)
                 repr_attrs[repr_diff_cls]['units'] = tuple(uns)
 
-            cls._cached_representation_info = repr_attrs
-        return cls._cached_representation_info
+            cls._frame_class_cache['_representation_info'] = repr_attrs
+        return cls._frame_class_cache['_representation_info']
 
     @lazyproperty
     def representation_info(self):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -55,6 +55,8 @@ def get_reprdiff_cls_hash():
         _REPRDIFF_HASH = (hash(tuple(REPRESENTATION_CLASSES.items())) +
                           hash(tuple(DIFFERENTIAL_CLASSES.items())) )
     return _REPRDIFF_HASH
+
+
 def _invalidate_reprdiff_cls_hash():
     global _REPRDIFF_HASH
     _REPRDIFF_HASH = None

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -42,6 +42,24 @@ __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
 REPRESENTATION_CLASSES = {}
 DIFFERENTIAL_CLASSES = {}
 
+# a hash for the content of the above two dicts, cached for speed.
+_REPRDIFF_HASH = None
+def get_reprdiff_cls_hash():
+    """
+    Returns a hash value that should be invariable if the
+    `REPRESENTATION_CLASSES` and `DIFFERENTIAL_CLASSES` dictionaries have not
+    changed.
+    """
+    global _REPRDIFF_HASH
+    if _REPRDIFF_HASH is None:
+        _REPRDIFF_HASH = (hash(tuple(REPRESENTATION_CLASSES.items())) +
+                          hash(tuple(DIFFERENTIAL_CLASSES.items())) )
+    return _REPRDIFF_HASH
+def _invalidate_reprdiff_cls_hash():
+    global _REPRDIFF_HASH
+    _REPRDIFF_HASH = None
+
+
 
 # recommended_units deprecation message; if the attribute is removed later,
 # also remove its use in BaseFrame._get_representation_info.
@@ -420,6 +438,7 @@ class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
                              .format(repr_name))
 
         REPRESENTATION_CLASSES[repr_name] = cls
+        _invalidate_reprdiff_cls_hash()
 
         # define getters for any component that does not yet have one.
         for component in cls.attr_classes:
@@ -1944,6 +1963,7 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
                              .format(repr_name))
 
         DIFFERENTIAL_CLASSES[repr_name] = cls
+        _invalidate_reprdiff_cls_hash()
 
         # If not defined explicitly, create properties for the components.
         for component in cls.attr_classes:

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -8,7 +8,8 @@ from collections import OrderedDict
 from astropy.coordinates import Longitude, Latitude
 from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                                                 SphericalRepresentation,
-                                                UnitSphericalRepresentation)
+                                                UnitSphericalRepresentation,
+                                                _invalidate_reprdiff_cls_hash)
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates import ICRS
@@ -33,6 +34,7 @@ def setup_function(func):
 def teardown_function(func):
     REPRESENTATION_CLASSES.clear()
     REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
+    _invalidate_reprdiff_cls_hash()
 
 
 def test_unit_representation_subclass():


### PR DESCRIPTION
This is an incomplete implementation of a potential hot-spot in the `SkyCoord` initializer.  Specifically, the frequent accessing of certain frame-specific attributes that really don't need to be recomputed a lot (see #7030 for some related disucssion).

The first two commit seems to *mostly* work, except for something I don't fully understand (but can probably figure out how to work around) with `SkyOffsetFrame`s.  Combined they seem to give a 50% speedup in certain `SkyCoord` initialization cases.

~However, the  last one is more mysterious: that one caches the `representation_component_names` at a frame-level.  I thought this is *supposed* to be frame-constant for any particular representation (and that is how the cache is implemented), but for some reason it is causing failures all over, I think at least in part due to either the differentials or some of the related changes in representations.  @adrn or @mhvk, do you have any idea what might be going on here?  To see the failure in question you can grab this branch and do `python setup.py test -P coordinates` - you get a bunch of similar failures that don't seem to have much obvious in common except that they are related to missing names of representation components...~
