### PR TITLE
Add a note that the equivalencies default to exact-unit equivalence

### DIFF
--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -356,7 +356,9 @@ elements::
   (from_unit, to_unit, forward, backward)
 
 ``from_unit`` and ``to_unit`` are the equivalent units.  ``forward`` and
-``backward`` are functions that convert values between those units.
+``backward`` are functions that convert values between those units. ``forward``
+and ``backward`` are optional, and if ommited such an equivalency simply
+declares that the two units should be taken as equivalent.
 
 For example, until 1964 the metric liter was defined as the volume of
 1kg of water at 4°C at 760mm mercury pressure.  Volumes and masses are

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -357,7 +357,7 @@ elements::
 
 ``from_unit`` and ``to_unit`` are the equivalent units.  ``forward`` and
 ``backward`` are functions that convert values between those units. ``forward``
-and ``backward`` are optional, and if ommited such an equivalency simply
+and ``backward`` are optional, and if omitted such an equivalency simply
 declares that the two units should be taken as equivalent.
 
 For example, until 1964 the metric liter was defined as the volume of


### PR DESCRIPTION
This was prompted by https://github.com/astropy/astropy/pull/7891#discussion_r224919440, where @mhvk pointed out that the default forward/backwards functions for equivalencies is a unity-mapping.  But it doesn't say that in the description of the "Writing new equivalencies" section.  So this PR simply adds a sentence to that effect.