### PR TITLE
Fix failing travis test on master (due to doctest failure in coordinates)

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -236,16 +236,16 @@ for a particular named object::
     >>> SkyCoord.from_name("PSR J1012+5307")  # doctest: +REMOTE_DATA +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
         (153.1393271, 53.117343)>
-        
+
 In some cases, the coordinates are embedded in the catalogue name of the object.
-For such object names, `~astropy.coordinates.SkyCoord.from_name` is able 
-to parse the coordinates from the name if given the ``parse=True`` option.  
-For slow connections, this may be much faster than a sesame query for the same 
-object name. It's worth noting, however, that the coordinates extracted in this 
-way may differ from the database coordinates by a few deci-arcseconds, so only 
+For such object names, `~astropy.coordinates.SkyCoord.from_name` is able
+to parse the coordinates from the name if given the ``parse=True`` option.
+For slow connections, this may be much faster than a sesame query for the same
+object name. It's worth noting, however, that the coordinates extracted in this
+way may differ from the database coordinates by a few deci-arcseconds, so only
 use this option if you do not need sub-arcsecond accuracy for your coordinates::
 
-    >>> SkyCoord.from_name("CRTS SSS100805 J194428-420209", parse=True)
+    >>> SkyCoord.from_name("CRTS SSS100805 J194428-420209", parse=True)  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
         (296.11666667, -42.03583333)>
 


### PR DESCRIPTION
In a rather obscure failure mode, #7830 seems to have made master start failing on travis despite the tests passing.  I think this is because the failure is a floating point rounding difference in a doctest (only failing on the py3.5 matrix element).  I think this slipped through the tests due to it being a py 3.5-only problem that manifests only in a doctest (and @ astromancer quite reasonably used ``[docs only] for the relevant commit`` since it was indeed only a doc change).  Not sure if this suggests any change to the ``[docs only]`` parsing or not given that this seems a pretty obscure failure mode...

At any rate, I think the fix is trivial - just the ``# doctest: +FLOAT_CMP`` should do the job.  Assuming travis actually passes, I think this can be approved/merged ASAP to get master passing again.