### PR TITLE
Alternative fix for Numpy 1.15.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1353,6 +1353,8 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fixed masked table comparisons with Numpy 1.15.3. [#7953]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -1367,6 +1369,8 @@ astropy.utils
 
 - Fixed the spelling of the 'luminous emittance/illuminance' physical
   property. [#7942]
+
+- Fixed ``IERS_Auto.open`` with Numpy 1.15.3. [#7946]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,6 +17,7 @@ from ..units import Quantity, QuantityInfo
 from ..utils import isiterable, ShapedLikeNDArray
 from ..utils.console import color_print
 from ..utils.metadata import MetaData
+from ..utils.masked import masked_arrays_equal
 from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
 from ..utils.exceptions import AstropyDeprecationWarning, NoValue
 
@@ -2642,7 +2643,8 @@ class Table:
 
         if self.masked:
             if isinstance(other, np.ma.MaskedArray):
-                result = self.as_array() == other
+                # We use a special function that deals correctly with the mask
+                result = masked_arrays_equal(self.as_array(), other)
             else:
                 # If mask is True, then by definition the row doesn't match
                 # because the other array is not masked.

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -462,7 +462,7 @@ class IERS_A(IERS):
         #              Bull. A polar motion values
         # UT1Flag_A    IERS (I) or Prediction (P) flag for
         #              Bull. A UT1-UTC values
-        is_predictive = (table['UT1Flag_A'] == 'P') | (table['PolPMFlag_A'] == 'P')
+        is_predictive = (table['UT1Flag_A'] == 'P').filled(False) | (table['PolPMFlag_A'] == 'P').filled(False)
         table.meta['predictive_index'] = np.min(np.flatnonzero(is_predictive))
         table.meta['predictive_mjd'] = table['MJD'][table.meta['predictive_index']]
 

--- a/astropy/utils/masked.py
+++ b/astropy/utils/masked.py
@@ -1,0 +1,33 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+__all__ = ['masked_arrays_equal']
+
+
+def masked_arrays_equal(array1, array2):
+    """
+    Check if two masked arrays are equal.
+
+    The rules are as follows:
+
+    * If an entry is masked in both arrays, this returns `True`
+    * If an entry is masked in only one array, this returns `False`
+    * If an entry is masked in neither array, this returns `True` if the
+      values are equal
+
+    This differs from Numpy, which returns masked values in the boolean array
+    if an entry is masked in either or both arrays, with a fill value of `True`.
+    """
+
+    # First use the standard Numpy comparison, using the default fill values
+    # on the arrays.
+    equal = array1.filled() == array2.filled()
+
+    # We need to now adjust the results - we want entries masked in both arrays
+    # to be considered equal (even if the fill value is different) and we want
+    # entries masked in one array and not in the other to not match, even if
+    # the fill values would make them match. We need to use equality instead of
+    # boolean comparisons as these don't work with structured arrays.
+    equal[(array1.mask == True) & (array2.mask == True)] = True
+    equal[array1.mask != array2.mask] = False
+
+    return equal

--- a/astropy/utils/tests/test_masked.py
+++ b/astropy/utils/tests/test_masked.py
@@ -1,0 +1,19 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from ..masked import masked_arrays_equal
+
+
+def test_masked_arrays_equal():
+
+    assert masked_arrays_equal(np.ma.array([1, 2, 3]),
+                               np.ma.array([1, 3, 3])).tolist() == [True, False, True]
+
+    assert masked_arrays_equal(np.ma.array([1, 2, 3], mask=[1, 0, 0]),
+                               np.ma.array([1, 3, 3])).tolist() == [False, False, True]
+
+    assert masked_arrays_equal(np.ma.array([1, 2, 3], mask=[0, 1, 0]),
+                               np.ma.array([1, 3, 3], mask=[0, 1, 0])).tolist() == [True, True, True]
+
+    assert masked_arrays_equal(np.ma.array([1, 2, 3], mask=[0, 1, 0], dtype=[('a', '?')]),
+                               np.ma.array([1, 3, 3], mask=[0, 1, 0], dtype=[('a', '?')])).tolist() == [True, True, True]


### PR DESCRIPTION
This is a variant on https://github.com/astropy/astropy/pull/7946 - fundamentally there are issues (in my mind) with how Numpy approaches equality comparisons of masked arrays - for starters, these comparisons return masked boolean arrays, which I don't think is what we want. Specifically, in the following case:

```python
In [4]: np.ma.array([1,2,3], mask=[1,0,0]) == np.ma.array([3,2,3], mask=[0,0,0])
Out[4]: 
masked_array(data=[--, True, True],
             mask=[ True, False, False],
       fill_value=True)
```

I would say that the final array should just be ``[False, True, True]`` while in the following example:

```python
In [5]: np.ma.array([1,2,3], mask=[1,0,0]) == np.ma.array([3,2,3], mask=[1,0,0])
Out[5]: 
masked_array(data=[--, True, True],
             mask=[ True, False, False],
       fill_value=True)
```

It should be ``[True, True, True]`` (i.e. to me ``--`` should be equal to ``--`` - even if the fill values are different. So my approach here is to define a convenience function for doing the logic of comparing masked arrays 'correctly' so that we don't have to rely on the Numpy behavior (which is currently causing test failures in astropy). For the above examples:

```
>>> masked_arrays_equal(np.ma.array([1,2,3], mask=[1,0,0]), np.ma.array([3,2,3], mask=[0,0,0]))
array([False,  True,  True])
>>> masked_arrays_equal(np.ma.array([1,2,3], mask=[1,0,0]), np.ma.array([3,2,3], mask=[1,0,0]))
array([ True,  True,  True])
```

@taldcroft - this modifies ``Table.__eq__``, so please take a careful look!