### PR TITLE
Visual improvements in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,9 @@ astropy.visualization
 - Allow ``coord_meta=`` in WCSAxes to optionally include ``format_unit=``.
   [#7848]
 
+- WCSAxes now recognizes more rcParams related to the grid, ticks, and labels, and
+  should work with most built-in Matplotlib styles.
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,10 +19,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- The ``SkyCoord.from_name`` constructor now has the ability to create 
-  coordinate objects by parsing object catalogue names that have embedded 
+- The ``SkyCoord.from_name`` constructor now has the ability to create
+  coordinate objects by parsing object catalogue names that have embedded
   J-coordinates.  [#7830]
-  
+
 - The new function ``make_transform_graph_docs`` can be used to create a
   docstring graph from a custom ``TransformGraph`` object. [#7135]
 
@@ -217,7 +217,9 @@ astropy.visualization
   [#7848]
 
 - WCSAxes now recognizes more rcParams related to the grid, ticks, and labels, and
-  should work with most built-in Matplotlib styles.
+  should work with most built-in Matplotlib styles. [#7961]
+
+- Improved rendering of WCSAxes with outward-facing ticks. [#7961]
 
 astropy.wcs
 ^^^^^^^^^^^
@@ -1747,11 +1749,6 @@ Other Changes and Additions
 ---------------------------
 
 - Fixed broken links in the documentation. [#6745]
-- Fixed a bug which meant that rcParams were not taken into account
-  for axis labels.
-
-astropy.vo
-^^^^^^^^^^
 
 - Substantial performance improvement (potentially >1000x for some cases) when
   converting non-scalar ``coordinates.Angle`` objects to strings. [#7004]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1744,6 +1744,11 @@ Other Changes and Additions
 ---------------------------
 
 - Fixed broken links in the documentation. [#6745]
+- Fixed a bug which meant that rcParams were not taken into account
+  for axis labels.
+
+astropy.vo
+^^^^^^^^^^
 
 - Substantial performance improvement (potentially >1000x for some cases) when
   converting non-scalar ``coordinates.Angle`` objects to strings. [#7004]

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -5,7 +5,7 @@ from ..utils.decorators import wraps
 
 MPL_VERSION = matplotlib.__version__
 
-ROOT = "http://{server}/testing/astropy/2018-03-27T18:38:34.793133/{mpl_version}/"
+ROOT = "http://{server}/testing/astropy/2018-10-24T12:38:34.134556/{mpl_version}/"
 IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x') + ',' +
                        ROOT.format(server='www.astropy.org/astropy-data', mpl_version=MPL_VERSION[:3] + '.x'))
 

--- a/astropy/visualization/wcsaxes/axislabels.py
+++ b/astropy/visualization/wcsaxes/axislabels.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 
+from matplotlib import rcParams
 from matplotlib.text import Text
 import matplotlib.transforms as mtransforms
 
@@ -12,6 +13,15 @@ from .frame import RectangularFrame
 class AxisLabels(Text):
 
     def __init__(self, frame, minpad=1, *args, **kwargs):
+
+        # Use rcParams if the following parameters were not specified explicitly
+        if 'weight' not in kwargs:
+            kwargs['weight'] = rcParams['axes.labelweight']
+        if 'size' not in kwargs:
+            kwargs['size'] = rcParams['axes.labelsize']
+        if 'color' not in kwargs:
+            kwargs['color'] = rcParams['axes.labelcolor']
+
         self._frame = frame
         super().__init__(*args, **kwargs)
         self.set_clip_on(True)

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -87,7 +87,7 @@ class CoordinateHelper:
         self.ticklabels = TickLabels(self.frame,
                                      transform=None,  # display coordinates
                                      figure=parent_axes.get_figure())
-        self.ticks.display_minor_ticks(False)
+        self.ticks.display_minor_ticks(rcParams['xtick.minor.visible'])
         self.minor_frequency = 5
 
         # Initialize axis labels
@@ -116,7 +116,7 @@ class CoordinateHelper:
                                   'edgecolor': rcParams['grid.color'],
                                   'linestyle': lines_to_patches_linestyle[rcParams['grid.linestyle']],
                                   'linewidth': rcParams['grid.linewidth'],
-                                  'alpha': rcParams.get('grid.alpha', 1.0),
+                                  'alpha': rcParams['grid.alpha'],
                                   'transform': self.parent_axes.transData}
 
     def grid(self, draw_grid=True, grid_type=None, **kwargs):
@@ -521,7 +521,8 @@ class CoordinateHelper:
 
         self.ticks.draw(renderer, ticks_locs)
         self.ticklabels.draw(renderer, bboxes=bboxes,
-                             ticklabels_bbox=ticklabels_bbox)
+                             ticklabels_bbox=ticklabels_bbox,
+                             tick_out_size=self.ticks.out_size)
 
         renderer.close_group('ticks')
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import numpy as np
 
+from matplotlib import rcParams
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
@@ -391,6 +392,9 @@ class WCSAxes(Axes):
                     self.coords[coord_index].set_axislabel_position('')
                     self.coords[coord_index].set_ticklabel_position('')
                     self.coords[coord_index].set_ticks_position('')
+
+        if rcParams['axes.grid']:
+            self.grid()
 
     def draw_wcsaxes(self, renderer):
 

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import numpy as np
 
 
+from matplotlib import rcParams
 from matplotlib.lines import Line2D, Path
 from matplotlib.patches import PathPatch
 
@@ -97,8 +98,8 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
 
         self.parent_axes = parent_axes
         self._transform = transform
-        self._linewidth = 1
-        self._color = 'black'
+        self._linewidth = rcParams['axes.linewidth']
+        self._color = rcParams['axes.edgecolor']
         self._path = path
 
         for axis in self.spine_names:
@@ -137,7 +138,7 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
     def patch(self):
         self._update_patch_path()
         return PathPatch(self._path, transform=self.parent_axes.transData,
-                         facecolor='white', edgecolor='white')
+                         facecolor=rcParams['axes.facecolor'], edgecolor='white')
 
     def draw(self, renderer):
         for axis in self:

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -38,7 +38,6 @@ class TestFrame(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='custom_frame.png',
                                    tolerance=0, style={})
     def test_custom_frame(self):
 
@@ -80,7 +79,6 @@ class TestFrame(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='update_clip_path_rectangular.png',
                                    tolerance=0, style={})
     def test_update_clip_path_rectangular(self, tmpdir):
 
@@ -104,7 +102,6 @@ class TestFrame(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='update_clip_path_nonrectangular.png',
                                    tolerance=0, style={})
     def test_update_clip_path_nonrectangular(self, tmpdir):
 
@@ -129,7 +126,6 @@ class TestFrame(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='update_clip_path_change_wcs.png',
                                    tolerance=0, style={})
     def test_update_clip_path_change_wcs(self, tmpdir):
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -59,7 +59,7 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   tolerance=1.5)
+                                   tolerance=1.5, style={})
     @pytest.mark.parametrize('axisbelow', [True, False, 'line'])
     def test_axisbelow(self, axisbelow):
         # Test that tick marks, labels, and gridlines are drawn with the

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -387,21 +387,43 @@ class TestBasic(BaseImageTests):
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
                                    tolerance=0, style={})
     def test_rcparams(self):
-        # Test default style (matplotlib.rcParams) for ticks and gridlines
+
+        # Test custom rcParams
+
         with rc_context({
+
+                'axes.labelcolor': 'purple',
+                'axes.labelsize': 14,
+                'axes.labelweight': 'bold',
+
+                'axes.linewidth': 3,
+                'axes.facecolor': '0.5',
+                'axes.edgecolor': 'green',
+
                 'xtick.color': 'red',
+                'xtick.labelsize': 8,
+                'xtick.direction': 'in',
+
+                'xtick.minor.visible': True,
+                'xtick.minor.size': 5,
+
                 'xtick.major.size': 20,
-                'xtick.major.width': 2,
+                'xtick.major.width': 3,
+                'xtick.major.pad': 10,
+
                 'grid.color': 'blue',
                 'grid.linestyle': ':',
                 'grid.linewidth': 1,
                 'grid.alpha': 0.5}):
+
             fig = plt.figure(figsize=(6, 6))
-            ax = WCSAxes(fig, [0.1, 0.1, 0.7, 0.7], wcs=None)
+            ax = WCSAxes(fig, [0.15, 0.1, 0.7, 0.7], wcs=None)
             fig.add_axes(ax)
             ax.set_xlim(-0.5, 2)
             ax.set_ylim(-0.5, 2)
             ax.grid()
+            ax.set_xlabel('X label')
+            ax.set_ylabel('Y label')
             ax.coords[0].set_ticks(exclude_overlapping=True)
             ax.coords[1].set_ticks(exclude_overlapping=True)
             return fig

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -47,7 +47,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='image_plot.png',
                                    tolerance=0, style={})
     def test_image_plot(self):
         # Test for plotting image and also setting values of ticks
@@ -87,7 +86,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='contour_overlay.png',
                                    tolerance=0, style={})
     def test_contour_overlay(self):
         # Test for overlaying contours on images
@@ -119,7 +117,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='contourf_overlay.png',
                                    tolerance=0, style={})
     def test_contourf_overlay(self):
         # Test for overlaying contours on images
@@ -151,7 +148,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='overlay_features_image.png',
                                    tolerance=0, style={})
     def test_overlay_features_image(self):
 
@@ -190,7 +186,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='curvlinear_grid_patches_image.png',
                                    tolerance=0, style={})
     def test_curvilinear_grid_patches_image(self):
 
@@ -224,7 +219,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='cube_slice_image.png',
                                    tolerance=0, style={})
     def test_cube_slice_image(self):
 
@@ -252,7 +246,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='cube_slice_image_lonlat.png',
                                    tolerance=0, style={})
     def test_cube_slice_image_lonlat(self):
 
@@ -324,7 +317,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='changed_axis_units.png',
                                    tolerance=0, style={})
     def test_changed_axis_units(self):
         # Test to see if changing the units of axis works
@@ -344,7 +336,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='minor_ticks_image.png',
                                    tolerance=0, style={})
     def test_minor_ticks(self):
         # Test for drawing minor ticks
@@ -365,7 +356,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='ticks_labels.png',
                                    tolerance=0, style={})
     def test_ticks_labels(self):
         fig = plt.figure(figsize=(6, 6))
@@ -395,7 +385,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='rcparams.png',
                                    tolerance=0, style={})
     def test_rcparams(self):
         # Test default style (matplotlib.rcParams) for ticks and gridlines
@@ -419,7 +408,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='tick_angles.png',
                                    tolerance=0, style={})
     def test_tick_angles(self):
         # Test that tick marks point in the correct direction, even when the
@@ -447,7 +435,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='tick_angles_non_square_axes.png',
                                    tolerance=0, style={})
     def test_tick_angles_non_square_axes(self):
         # Test that tick marks point in the correct direction, even when the
@@ -476,7 +463,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='set_coord_type.png',
                                    tolerance=0, style={})
     def test_set_coord_type(self):
         # Test for setting coord_type
@@ -496,7 +482,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='test_ticks_regression_1.png',
                                    tolerance=0, style={})
     def test_ticks_regression(self):
         # Regression test for a bug that caused ticks aligned exactly with a
@@ -521,7 +506,6 @@ class TestBasic(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='test_axislabels_regression.png',
                                    savefig_kwargs={'bbox_inches': 'tight'},
                                    tolerance=0, style={})
     def test_axislabels_regression(self):

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -60,7 +60,6 @@ class TestTransformCoordMeta(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='coords_overlay.png',
                                    tolerance=0, style={})
     def test_coords_overlay(self):
 
@@ -110,7 +109,6 @@ class TestTransformCoordMeta(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='coords_overlay_auto_coord_meta.png',
                                    tolerance=0, style={})
     def test_coords_overlay_auto_coord_meta(self):
 
@@ -135,7 +133,6 @@ class TestTransformCoordMeta(BaseImageTests):
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   filename='direct_init.png',
                                    tolerance=0, style={})
     def test_direct_init(self):
 

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -139,18 +139,18 @@ class TickLabels(Text):
                     if np.abs(self.angle[axis][i]) < 45.:
                         ha = 'right'
                         va = 'bottom'
-                        dx = - pad
-                        dy = - text_size * 0.5
+                        dx = -pad
+                        dy = -text_size * 0.5
                     elif np.abs(self.angle[axis][i] - 90.) < 45:
                         ha = 'center'
                         va = 'bottom'
                         dx = 0
-                        dy = - text_size - pad
+                        dy = -text_size - pad
                     elif np.abs(self.angle[axis][i] - 180.) < 45:
                         ha = 'left'
                         va = 'bottom'
                         dx = pad
-                        dy = - text_size * 0.5
+                        dy = -text_size * 0.5
                     else:
                         ha = 'center'
                         va = 'bottom'

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 
+from matplotlib import rcParams
 from matplotlib.text import Text
 
 from .frame import RectangularFrame
@@ -20,8 +21,16 @@ class TickLabels(Text):
         super().__init__(*args, **kwargs)
         self.set_clip_on(True)
         self.set_visible_axes('all')
-        self.pad = 0.3
+        self.pad = rcParams['xtick.major.pad']
         self._exclude_overlapping = False
+
+        # Check rcParams
+
+        if 'color' not in kwargs:
+            self.set_color(rcParams['xtick.color'])
+
+        if 'size' not in kwargs:
+            self.set_size(rcParams['xtick.labelsize'])
 
     def clear(self):
         self.world = {}
@@ -97,7 +106,7 @@ class TickLabels(Text):
     def set_exclude_overlapping(self, exclude_overlapping):
         self._exclude_overlapping = exclude_overlapping
 
-    def draw(self, renderer, bboxes, ticklabels_bbox):
+    def draw(self, renderer, bboxes, ticklabels_bbox, tick_out_size):
 
         if not self.get_visible():
             return
@@ -120,6 +129,8 @@ class TickLabels(Text):
 
                 x, y = self.pixel[axis][i]
 
+                pad = renderer.points_to_pixels(self.pad + tick_out_size)
+
                 if isinstance(self._frame, RectangularFrame):
 
                     # This is just to preserve the current results, but can be
@@ -128,23 +139,23 @@ class TickLabels(Text):
                     if np.abs(self.angle[axis][i]) < 45.:
                         ha = 'right'
                         va = 'bottom'
-                        dx = - text_size * 0.5
+                        dx = - pad
                         dy = - text_size * 0.5
                     elif np.abs(self.angle[axis][i] - 90.) < 45:
                         ha = 'center'
                         va = 'bottom'
                         dx = 0
-                        dy = - text_size * 1.5
+                        dy = - text_size - pad
                     elif np.abs(self.angle[axis][i] - 180.) < 45:
                         ha = 'left'
                         va = 'bottom'
-                        dx = text_size * 0.5
+                        dx = pad
                         dy = - text_size * 0.5
                     else:
                         ha = 'center'
                         va = 'bottom'
                         dx = 0
-                        dy = text_size * 0.2
+                        dy = pad
 
                     self.set_position((x + dx, y + dy))
                     self.set_ha(ha)
@@ -194,8 +205,8 @@ class TickLabels(Text):
                     ddx = dx / dist
                     ddy = dy / dist
 
-                    dx += ddx * text_size * self.pad
-                    dy += ddy * text_size * self.pad
+                    dx += ddx * pad
+                    dy += ddy * pad
 
                     self.set_position((x - dx, y - dy))
                     self.set_ha('center')

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -35,12 +35,10 @@ class Ticks(Line2D):
         if ticksize is None:
             ticksize = rcParams['xtick.major.size']
         self.set_ticksize(ticksize)
-        self.set_tick_out(rcParams.get('xtick.direction', 'in') == 'out')
+        self.set_tick_out(rcParams['xtick.direction'] == 'out')
         self.clear()
         line2d_kwargs = {'color': rcParams['xtick.color'],
-                         # For the linewidth we need to set a default since old versions of
-                         # matplotlib don't have this.
-                         'linewidth': rcParams.get('xtick.major.width', 1)}
+                         'linewidth': rcParams['xtick.major.width']}
         line2d_kwargs.update(kwargs)
         Line2D.__init__(self, [0.], [0.], **line2d_kwargs)
         self.set_visible_axes('all')
@@ -69,6 +67,13 @@ class Ticks(Line2D):
         set length of the ticks in points.
         """
         self._ticksize = ticksize
+
+    @property
+    def out_size(self):
+        if self._tick_out:
+            return self._ticksize
+        else:
+            return 0.
 
     def get_ticksize(self):
         """

--- a/astropy/visualization/wcsaxes/ticks.py
+++ b/astropy/visualization/wcsaxes/ticks.py
@@ -28,6 +28,7 @@ class Ticks(Line2D):
     * `xtick.direction`
     * `xtick.major.size`
     * `xtick.major.width`
+    * `xtick.minor.size`
     * `xtick.color`
     """
 
@@ -35,6 +36,7 @@ class Ticks(Line2D):
         if ticksize is None:
             ticksize = rcParams['xtick.major.size']
         self.set_ticksize(ticksize)
+        self.set_minor_ticksize(rcParams['xtick.minor.size'])
         self.set_tick_out(rcParams['xtick.direction'] == 'out')
         self.clear()
         line2d_kwargs = {'color': rcParams['xtick.color'],
@@ -68,18 +70,30 @@ class Ticks(Line2D):
         """
         self._ticksize = ticksize
 
+    def get_ticksize(self):
+        """
+        Return length of the ticks in points.
+        """
+        return self._ticksize
+
+    def set_minor_ticksize(self, ticksize):
+        """
+        set length of the minor ticks in points.
+        """
+        self._minor_ticksize = ticksize
+
+    def get_minor_ticksize(self):
+        """
+        Return length of the minor ticks in points.
+        """
+        return self._minor_ticksize
+
     @property
     def out_size(self):
         if self._tick_out:
             return self._ticksize
         else:
             return 0.
-
-    def get_ticksize(self):
-        """
-        Return length of the ticks in points.
-        """
-        return self._ticksize
 
     def set_visible_axes(self, visible_axes):
         self._visible_axes = visible_axes
@@ -144,7 +158,7 @@ class Ticks(Line2D):
         offset = renderer.points_to_pixels(self.get_ticksize())
         self._draw_ticks(renderer, self.pixel, self.angle, offset, ticks_locs)
         if self._display_minor_ticks:
-            offset = offset * 0.5  # for minor ticksize
+            offset = renderer.points_to_pixels(self.get_minor_ticksize())
             self._draw_ticks(renderer, self.minor_pixel, self.minor_angle, offset, ticks_locs)
 
     def _draw_ticks(self, renderer, pixel_array, angle_array, offset, ticks_locs):

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -721,7 +721,7 @@ installed Docker, to run the Astropy tests with the image comparison inside a
 Docker container, make sure you are inside the Astropy repository (or the
 repository of the package you are testing) then do::
 
-    docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl153:1.0 /bin/bash
+    docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl300:1.3 /bin/bash
 
 This will start up a bash prompt in the Docker container, and you should see
 something like::
@@ -765,7 +765,7 @@ Generating reference images
 Once you have a test for which you want to (re-)generate reference images,
 start up one of the Docker containers using e.g.::
 
-  docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl153:1.0 /bin/bash
+  docker run -it -v ${PWD}:/repo astropy/image-tests-py35-mpl300:1.3 /bin/bash
 
 then run the tests inside ``/repo`` with the ``--mpl-generate-path`` argument, e.g::
 


### PR DESCRIPTION
### rcParams and styles

This adds support for enough rcParams that styles now look reasonable:

**Before (I'll just show once since you'll get the idea)**

![seaborn](https://user-images.githubusercontent.com/314716/47435109-ca601f80-d79b-11e8-9d69-92393533c4d9.png)



**After**

![seaborn](https://user-images.githubusercontent.com/314716/47434948-82d99380-d79b-11e8-9a80-e44317dd69b7.png)

![seaborn-notebook](https://user-images.githubusercontent.com/314716/47434967-8a993800-d79b-11e8-8c5d-a7073c6497ed.png)

![dark_background](https://user-images.githubusercontent.com/314716/47435049-b1576e80-d79b-11e8-9288-df9709df1269.png)

### Tick label placement

Since ticks now face outwards by default, we need to be smarter about how we place the tick labels:

**Before**

![ticks](https://user-images.githubusercontent.com/314716/47435259-2460e500-d79c-11e8-94a8-09dbac7a6fb7.png)

**After**

![ticks](https://user-images.githubusercontent.com/314716/47435295-35a9f180-d79c-11e8-880f-177014f0d714.png)

### Other changes

Since I had to regenerate all reference images, I've removed the custom filenames, going instead with the pytest-mpl default, and I've ensured that we always use the default initial style.

Fixes https://github.com/astropy/astropy/issues/7485