### PR TITLE
Expand documentation for now APE14 WCS API

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1042,13 +1042,18 @@ def test_naxis():
     w.wcs.cdelt = [0.1, 0.1]
     w.wcs.crpix = [1, 1]
     w._naxis = [1000, 500]
+    assert w.pixel_shape == (1000, 500)
+    assert w.array_shape == (500, 1000)
 
-    assert w._naxis1 == 1000
-    assert w._naxis2 == 500
-
-    w._naxis1 = 99
-    w._naxis2 = 59
+    w.pixel_shape = (99, 59)
     assert w._naxis == [99, 59]
+
+    w.array_shape = (45, 23)
+    assert w._naxis == [23, 45]
+    assert w.pixel_shape == (23, 45)
+
+    w.pixel_shape = None
+    assert w.pixel_bounds is None
 
 
 def test_sip_with_altkey():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -511,6 +511,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         for fd in close_fds:
             fd.close()
 
+        self._pixel_bounds = None
+
     def __copy__(self):
         new_copy = self.__class__()
         WCSBase.__init__(new_copy, self.sip,

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -128,12 +128,49 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         else:
             return tuple(self._naxis[::-1])
 
+    @array_shape.setter
+    def array_shape(self, value):
+        if value is None:
+            self._naxis = [0, 0]
+        else:
+            if len(value) != self.naxis:
+                raise ValueError("The number of data axes, "
+                                 "{}, does not equal the "
+                                 "shape {}.".format(self.naxis, len(value)))
+            self._naxis = list(value)[::-1]
+
     @property
     def pixel_shape(self):
         if self._naxis == [0, 0]:
             return None
         else:
             return tuple(self._naxis)
+
+    @pixel_shape.setter
+    def pixel_shape(self, value):
+        if value is None:
+            self._naxis = [0, 0]
+        else:
+            if len(value) != self.naxis:
+                raise ValueError("The number of data axes, "
+                                 "{}, does not equal the "
+                                 "shape {}.".format(self.naxis, len(value)))
+            self._naxis = list(value)
+
+    @property
+    def pixel_bounds(self):
+        return self._pixel_bounds
+
+    @pixel_bounds.setter
+    def pixel_bounds(self, value):
+        if value is None:
+            self._pixel_bounds = value
+        else:
+            if len(value) != self.naxis:
+                raise ValueError("The number of data axes, "
+                                 "{}, does not equal the number of "
+                                 "pixel bounds {}.".format(self.naxis, len(value)))
+            self._pixel_bounds = list(value)
 
     @property
     def world_axis_physical_types(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -126,7 +126,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         if self._naxis == [0, 0]:
             return None
         else:
-            return self._naxis[::-1]
+            return tuple(self._naxis[::-1])
 
     @property
     def world_axis_physical_types(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -123,7 +123,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def array_shape(self):
-        return self._naxis
+        if self._naxis == [0, 0]:
+            return None
+        else:
+            return self._naxis[::-1]
 
     @property
     def world_axis_physical_types(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -195,10 +195,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
     def world_to_array_index_values(self, *world_arrays):
         pixel_arrays = self.all_world2pix(*world_arrays, 0)[::-1]
         array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int) for pixel in pixel_arrays)
-        if len(array_indices) == 1:
-            return array_indices[0]
-        else:
-            return array_indices
+        return array_indices
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -122,6 +122,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return len(self.wcs.ctype)
 
     @property
+    def array_shape(self):
+        return self._naxis
+
+    @property
     def world_axis_physical_types(self):
         types = []
         for axis_type in self.axis_type_names:

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -129,6 +129,13 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             return tuple(self._naxis[::-1])
 
     @property
+    def pixel_shape(self):
+        if self._naxis == [0, 0]:
+            return None
+        else:
+            return tuple(self._naxis)
+
+    @property
     def world_axis_physical_types(self):
         types = []
         for axis_type in self.axis_type_names:

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -218,4 +218,4 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         return self.pixel_to_world(*index_arrays[::-1])
 
     def world_to_array_index(self, *world_objects):
-        return np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int)
+        return tuple(np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int).tolist())

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -195,8 +195,25 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
     @property
     def array_shape(self):
         """
-        The shape of the data that the WCS applies to as a tuple of
-        length `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`.
+        The shape of the data that the WCS applies to as a tuple of length
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` in ``(row, column)``
+        order (the convention for arrays in Python).
+
+        If the WCS is valid in the context of a dataset with a particular
+        shape, then this property can be used to store the shape of the
+        data. This can be used for example if implementing slicing of WCS
+        objects. This is an optional property, and it should return `None`
+        if a shape is not known or relevant.
+        """
+        return None
+
+    @property
+    def pixel_shape(self):
+        """
+        The shape of the data that the WCS applies to as a tuple of length
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` in ``(x, y)``
+        order (where for an image, ``x`` is the horizontal coordinate and ``y``
+        is the vertical coordinate).
 
         If the WCS is valid in the context of a dataset with a particular
         shape, then this property can be used to store the shape of the
@@ -204,8 +221,9 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         objects. This is an optional property, and it should return `None`
         if a shape is not known or relevant.
 
-        The shape should be given in ``(row, column)`` order (the convention
-        for arrays in Python).
+        If you are interested in getting a shape that is comparable to that of
+        a Numpy array, you should use
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.array_shape` instead.
         """
         return None
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -48,7 +48,7 @@ def test_empty():
     assert_allclose(wcs.array_index_to_world_values(29), 29)
 
     assert_allclose(wcs.world_to_pixel_values(29), 29)
-    assert_equal(wcs.world_to_array_index_values(29), 29)
+    assert_equal(wcs.world_to_array_index_values(29), (29,))
 
     # High-level API
 
@@ -61,7 +61,7 @@ def test_empty():
     assert_allclose(x, 15.)
 
     i = wcs.world_to_array_index(coord)
-    assert_equal(i, 15)
+    assert_equal(i, (15,))
 
 
 ###############################################################################

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -33,6 +33,7 @@ def test_empty():
 
     assert wcs.pixel_n_dim == 1
     assert wcs.world_n_dim == 1
+    assert wcs.array_shape is None
     assert wcs.world_axis_physical_types == [None]
     assert wcs.world_axis_units == ['']
 
@@ -94,6 +95,7 @@ def test_simple_celestial():
 
     assert wcs.pixel_n_dim == 2
     assert wcs.world_n_dim == 2
+    assert wcs.array_shape is None
     assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
     assert wcs.world_axis_units == ['deg', 'deg']
 
@@ -187,6 +189,7 @@ def test_spectral_cube():
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
+    assert wcs.array_shape is None
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
 
@@ -339,6 +342,7 @@ def test_time_cube():
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
+    assert wcs.array_shape == [11, 2048, 2048]
     assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
     assert wcs.world_axis_units == ['deg', 'deg', 's']
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -34,6 +34,7 @@ def test_empty():
     assert wcs.pixel_n_dim == 1
     assert wcs.world_n_dim == 1
     assert wcs.array_shape is None
+    assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == [None]
     assert wcs.world_axis_units == ['']
 
@@ -96,6 +97,7 @@ def test_simple_celestial():
     assert wcs.pixel_n_dim == 2
     assert wcs.world_n_dim == 2
     assert wcs.array_shape is None
+    assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
     assert wcs.world_axis_units == ['deg', 'deg']
 
@@ -202,6 +204,7 @@ def test_spectral_cube():
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
     assert wcs.array_shape is None
+    assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
 
@@ -355,6 +358,7 @@ def test_time_cube():
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == [11, 2048, 2048]
+    assert wcs.pixel_shape == [2048, 2048, 11]
     assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
     assert wcs.world_axis_units == ['deg', 'deg', 's']
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -152,6 +152,18 @@ def test_simple_celestial():
     assert_equal(i, 39)
     assert_equal(j, 29)
 
+    # Check that we can actually index the array
+
+    data = np.arange(3600).reshape((60, 60))
+
+    coord = SkyCoord(10, 20, unit='deg', frame='icrs')
+    index = wcs.world_to_array_index(coord)
+    assert_equal(data[index], 2369)
+
+    coord = SkyCoord([10, 12], [20, 22], unit='deg', frame='icrs')
+    index = wcs.world_to_array_index(coord)
+    assert_equal(data[index], [2369, 3550])
+
 
 ###############################################################################
 # The following example is a spectral cube with axes in an unusual order

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -357,8 +357,8 @@ def test_time_cube():
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
-    assert wcs.array_shape == [11, 2048, 2048]
-    assert wcs.pixel_shape == [2048, 2048, 11]
+    assert wcs.array_shape == (11, 2048, 2048)
+    assert wcs.pixel_shape == (2048, 2048, 11)
     assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
     assert wcs.world_axis_units == ['deg', 'deg', 's']
 

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -87,7 +87,7 @@ transform directly to astropy objects::
 
     >>> celestial, spectral = wcs.pixel_to_world([1, 2], [4, 3], [2, 3])
     >>> celestial
-    <SkyCoord (FK4: equinox=B1950.000, obstime=B1950.000): (ra, dec) in deg
+    <SkyCoord (ICRS): (ra, dec) in deg
         [(51.73115731, 30.32750025), (51.72414268, 30.32111136)]>
     >>> spectral
     <Quantity [2661.04211695, 2727.46572695] m / s>
@@ -96,10 +96,10 @@ Similarly, we can transform astropy objects back::
 
     >>> from astropy.coordinates import SkyCoord
     >>> from astropy import units as u
-    >>> coord = SkyCoord('03h27m36.4901s +30d45m22.2012s')
+    >>> coord = SkyCoord('03h26m36.4901s +30d45m22.2012s')
     >>> pixels = wcs.world_to_pixel(coord, 3000 * u.m / u.s)
     >>> pixels
-    [array(79.61020554), array(43.98304923), array(7.10297292)]
+    [array(8.11341207), array(71.0956641), array(7.10297292)]
 
 If you are looking to index the original data using these pixel coordinates,
 be sure to instead use
@@ -109,11 +109,11 @@ the nearest integer values::
 
     >>> index = wcs.world_to_array_index(coord, 3000 * u.m / u.s)
     >>> index
-    (7, 44, 80)
+    (7, 71, 8)
     >>> from astropy.io import fits
     >>> data = fits.getdata(filename)
     >>> data[index]  # doctest +FLOAT_CMP
-    0.38972738
+    0.22262384
 
 If you are interested in converting to/from world values as simple Python scalars
 or Numpy arrays without using high-level astropy objects, there are methods

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -48,9 +48,9 @@ cube (two celestial axes and one spectral axis)::
 
     >>> from astropy.wcs import WCS
     >>> from astropy.utils.data import get_pkg_data_filename
-    >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')
-    >>> wcs = WCS(filename)
-    >>> wcs
+    >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
+    >>> wcs = WCS(filename)  # doctest: +REMOTE_DATA
+    >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
     Number of WCS axes: 3
     CTYPE : 'RA---SFL'  'DEC--SFL'  'VOPT'
@@ -65,16 +65,16 @@ cube (two celestial axes and one spectral axis)::
 We can check how many pixel and world axes are in the transformation as well
 as the shape of the data the WCS applies to::
 
-    >>> wcs.pixel_n_dim
+    >>> wcs.pixel_n_dim  # doctest: +REMOTE_DATA
     3
-    >>> wcs.world_n_dim
+    >>> wcs.world_n_dim  # doctest: +REMOTE_DATA
     3
-    >>> wcs.array_shape
+    >>> wcs.array_shape  # doctest: +REMOTE_DATA
     [53, 105, 105]
 
 Let's now check what the physical type of each axis is::
 
-    >>> wcs.world_axis_physical_types
+    >>> wcs.world_axis_physical_types  # doctest: +REMOTE_DATA
     ['pos.eq.ra', 'pos.eq.dec', 'spect.dopplerVeloc.opt']
 
 This is indeed a spectral cube, with RA/Dec and a velocity axis.
@@ -85,11 +85,11 @@ coordinates. The most convenience way is to use the high-level methods
 :meth:`~astropy.wcs.fitswcs.BaseHighLevelWCS.world_to_pixel`, which can
 transform directly to astropy objects::
 
-    >>> celestial, spectral = wcs.pixel_to_world([1, 2], [4, 3], [2, 3])
-    >>> celestial
+    >>> celestial, spectral = wcs.pixel_to_world([1, 2], [4, 3], [2, 3])  # doctest: +REMOTE_DATA
+    >>> celestial  # doctest: +REMOTE_DATA
     <SkyCoord (ICRS): (ra, dec) in deg
         [(51.73115731, 30.32750025), (51.72414268, 30.32111136)]>
-    >>> spectral
+    >>> spectral  # doctest: +REMOTE_DATA
     <Quantity [2661.04211695, 2727.46572695] m / s>
 
 Similarly, we can transform astropy objects back::
@@ -97,8 +97,8 @@ Similarly, we can transform astropy objects back::
     >>> from astropy.coordinates import SkyCoord
     >>> from astropy import units as u
     >>> coord = SkyCoord('03h26m36.4901s +30d45m22.2012s')
-    >>> pixels = wcs.world_to_pixel(coord, 3000 * u.m / u.s)
-    >>> pixels
+    >>> pixels = wcs.world_to_pixel(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
+    >>> pixels  # doctest: +REMOTE_DATA
     [array(8.11341207), array(71.0956641), array(7.10297292)]
 
 If you are looking to index the original data using these pixel coordinates,
@@ -107,12 +107,12 @@ be sure to instead use
 the coordinates in the correct order to index Numpy arrays, and also rounds to
 the nearest integer values::
 
-    >>> index = wcs.world_to_array_index(coord, 3000 * u.m / u.s)
-    >>> index
+    >>> index = wcs.world_to_array_index(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
+    >>> index  # doctest: +REMOTE_DATA
     (7, 71, 8)
     >>> from astropy.io import fits
-    >>> data = fits.getdata(filename)
-    >>> data[index]  # doctest +FLOAT_CMP
+    >>> data = fits.getdata(filename)  # doctest: +REMOTE_DATA
+    >>> data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
     0.22262384
 
 If you are interested in converting to/from world values as simple Python scalars

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -24,7 +24,7 @@ The core astropy package provides base classes that define the low- and high-
 level APIs described in APE 14 in the :mod:`astropy.wcs.wcsapi` module, and
 these are listed in the `Reference/API`_ section below.
 
-Pixel conventions
+Pixel conventions and definitions
 =================
 
 This API assumes that integer pixel values fall at the center of pixels (as

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -70,7 +70,7 @@ as the shape of the data the WCS applies to::
     >>> wcs.world_n_dim
     3
     >>> wcs.array_shape
-    [105, 105, 53]
+    [53, 105, 105]
 
 Let's now check what the physical type of each axis is::
 

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -108,8 +108,16 @@ Note that the array shape should match that of the data::
     (720, 721)
 
 As mentioned in `Pixel conventions and definitions`_, what would normally be
-considered the 'y-axis' of the image (when looking at it visually) is the
-first dimension, while the 'x-axis' of the image is the second dimension.
+considered the 'y-axis' of the image (when looking at it visually) is the first
+dimension, while the 'x-axis' of the image is the second dimension. Thus
+:attr:`~astropy.wcs.WCS.array_shape` returns the shape in the *opposite* order
+to the NAXIS keywords in the FITS header (in the case of FITS-WCS). If you are
+interested in the data shape in the reverse order (which would match the NAXIS
+order in the case of FITS-WCS), then you can use
+:attr:`~astropy.wcs.WCS.pixel_shape`::
+
+    >>> wcs.pixel_shape  # doctest: +REMOTE_DATA
+    (721, 720)
 
 Let's now check what the physical type of each axis is::
 

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -26,12 +26,27 @@ these are listed in the `Reference/API`_ section below.
 
 Overview
 ========
-While the full  details and motivation for the API are detailed in APE 14, 
-this documentation summarizes the elements that are implemented directly in the `astropy` core package.  The high-level interface is likely of most interest to the average user.  In particular, the most important methods are the `world_to_pixel` and `pixel_to_world` methods. These provide the essential elements of WCS: mapping to and from world coordinates. The remainder generally provide information about the *kind* of world coordinates or similar information about the structure of the WCS.
 
-In a bit more detail, the key classes implemented here are a high-level that provides the main user interface (`~astropy.wcs.wcsapi.BaseHighLevelWCS` and subclasses), and a lower-level interface (`~astropy.wcs.wcsapi.BaseLowLevelWCS` and subclasses).  These can be distinct objects *or* the same one.  For FITS-WCS, the `~astropy.wcs.WCS` object meant for FITS-WCS follows both interfaces, allowing immediate use of this API with files that already contain FITS-WCS.  More concrete examples are outlined below.
+While the full  details and motivation for the API are detailed in APE 14,  this
+documentation summarizes the elements that are implemented directly in the
+`astropy` core package.  The high-level interface is likely of most interest to
+the average user.  In particular, the most important methods are the
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel` methods. These
+provide the essential elements of WCS: mapping to and from world coordinates.
+The remainder generally provide information about the *kind* of world
+coordinates or similar information about the structure of the WCS.
+
+In a bit more detail, the key classes implemented here are a high-level that
+provides the main user interface (:class:`~astropy.wcs.wcsapi.BaseHighLevelWCS` and
+subclasses), and a lower-level interface (:class:`~astropy.wcs.wcsapi.BaseLowLevelWCS`
+and subclasses).  These can be distinct objects *or* the same one.  For
+FITS-WCS, the `~astropy.wcs.WCS` object meant for FITS-WCS follows both
+interfaces, allowing immediate use of this API with files that already contain
+FITS-WCS. More concrete examples are outlined below.
+
 Pixel conventions and definitions
-=================
+=================================
 
 This API assumes that integer pixel values fall at the center of pixels (as
 assumed in the FITS-WCS standard, see Section 2.1.4 of `Greisen et al., 2002,
@@ -40,20 +55,107 @@ time matching the Python 0-index philosophy.  That is, the first pixel is
 considered pixel ``0``, but pixel coordinates ``(0, 0)`` are the *center* of
 that pixel.  Hence the first pixel spans pixel values ``-0.5`` to ``0.5``.
 
-The order of the pixel coordinates (``(x, y)`` vs ``(row, column)``) depends on
-the method or property used, and this can normally be determined from the
-property or method name. Properties and methods containing ``pixel`` assume
-``(x, y)`` ordering, while properties and methods containing ``array`` assume
-``(row, column)`` ordering.
+There are two main conventions for ordering pixel coordinates. In the context of
+2-dimensional imaging data/arrays, one can either think of the pixel coordinates
+as traditional Cartesian coordinates (which we call ``x`` and ``y`` here), which
+are usually given with the horizontal coordinate (``x``) first, and the vertical
+coordinate (``y``) second, meaning that pixel coordinates would be given as
+``(x, y)``. Alternatively, one can give the coordinates by first giving the row
+in the data, then the column, i.e. ``(row, column)``. While the former is a more
+common convention when e.g. plotting (think for example of the Matplotlib
+``scatter(x, y)`` method), the latter is the convention used when accessing
+values from e.g. Numpy arrays that represent images (``image[row, column]``).
+
+The order of the pixel coordinates (``(x, y)`` vs ``(row, column)``) in the API
+discussed here depends on the method or property used, and this can normally be
+determined from the property or method name. Properties and methods containing
+``pixel`` assume ``(x, y)`` ordering, while properties and methods containing
+``array`` assume ``(row, column)`` ordering.
 
 Basic usage
 ===========
 
-Let's take a look at the shared Python interface for WCS by using a spectral
-cube (two celestial axes and one spectral axis)::
+Let's start off by looking at the shared Python interface for WCS by using a
+simple image with two celestial axes (Right Ascension and Declination)::
 
     >>> from astropy.wcs import WCS
     >>> from astropy.utils.data import get_pkg_data_filename
+    >>> from astropy.io import fits
+    >>> filename = get_pkg_data_filename('galactic_center/gc_2mass_k.fits')  # doctest: +REMOTE_DATA
+    >>> hdu = fits.open(filename)[0]
+    >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
+    >>> wcs  # doctest: +REMOTE_DATA
+    WCS Keywords
+    Number of WCS axes: 2
+    CTYPE : 'RA---TAN'  'DEC--TAN'
+    CRVAL : 266.4  -28.93333
+    CRPIX : 361.0  360.5
+    NAXIS : 721  720
+
+We can check how many pixel and world axes are in the transformation as well
+as the shape of the data the WCS applies to::
+
+    >>> wcs.pixel_n_dim  # doctest: +REMOTE_DATA
+    2
+    >>> wcs.world_n_dim  # doctest: +REMOTE_DATA
+    2
+    >>> wcs.array_shape  # doctest: +REMOTE_DATA
+    (720, 721)
+
+Note that the array shape should match that of the data::
+
+    >>> hdu.data.shape  # doctest: +REMOTE_DATA
+    (720, 721)
+
+As mentioned in `Pixel conventions and definitions`_, what would normally be
+considered the 'y-axis' of the image (when looking at it visually) is the
+first dimension, while the 'x-axis' of the image is the second dimension.
+
+Let's now check what the physical type of each axis is::
+
+    >>> wcs.world_axis_physical_types  # doctest: +REMOTE_DATA
+    ['pos.eq.ra', 'pos.eq.dec']
+
+This is indeed an image with two celestial axes.
+
+The main part of the new interface defines standard methods for transforming
+coordinates. The most convenient way is to use the high-level methods
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel`, which can
+transform directly to astropy objects::
+
+    >>> coord = wcs.pixel_to_world([1, 2], [4, 3])  # doctest: +REMOTE_DATA
+    >>> coord  # doctest: +REMOTE_DATA
+    <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg
+        [(266.97242993, -29.42584415), (266.97084321, -29.42723968)]>
+
+Similarly, we can transform astropy objects back - we can test this by creating
+Galactic coordinates and these will automatically be converted::
+
+    >>> from astropy.coordinates import SkyCoord
+    >>> coord = SkyCoord('00h00m00s +00d00m00s', frame='galactic')
+    >>> pixels = wcs.world_to_pixel(coord)  # doctest: +REMOTE_DATA
+    >>> pixels  # doctest: +REMOTE_DATA
+    [array(356.85179997), array(357.45340331)]
+
+If you are looking to index the original data using these pixel coordinates,
+be sure to instead use
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_array_index` which returns
+the coordinates in the correct order to index Numpy arrays, and also rounds to
+the nearest integer values::
+
+    >>> index = wcs.world_to_array_index(coord)  # doctest: +REMOTE_DATA
+    >>> index  # doctest: +REMOTE_DATA
+    (357, 357)
+    >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
+    563.7532
+
+Advanced usage
+==============
+
+Let's now take a look at a WCS for a spectral cube (two celestial axes and one
+spectral axis)::
+
     >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
     >>> wcs = WCS(filename)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
@@ -68,28 +170,22 @@ cube (two celestial axes and one spectral axis)::
     CDELT : -0.006388889  0.006388889  66.42361
     NAXIS : 105  105  53
 
-We can check how many pixel and world axes are in the transformation as well
-as the shape of the data the WCS applies to::
+As before we can check how many pixel and world axes are in the transformation
+as well as the shape of the data the WCS applies to, as well as the physical
+types of each axis::
 
     >>> wcs.pixel_n_dim  # doctest: +REMOTE_DATA
     3
     >>> wcs.world_n_dim  # doctest: +REMOTE_DATA
     3
     >>> wcs.array_shape  # doctest: +REMOTE_DATA
-    [53, 105, 105]
-
-Let's now check what the physical type of each axis is::
-
+    (53, 105, 105)
     >>> wcs.world_axis_physical_types  # doctest: +REMOTE_DATA
     ['pos.eq.ra', 'pos.eq.dec', 'spect.dopplerVeloc.opt']
 
 This is indeed a spectral cube, with RA/Dec and a velocity axis.
 
-The main part of the new interface defines standard methods for transforming
-coordinates. The most convenient way is to use the high-level methods
-:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
-:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel`, which can
-transform directly to astropy objects::
+As before, we can convert between pixels and high-level Astropy objects::
 
     >>> celestial, spectral = wcs.pixel_to_world([1, 2], [4, 3], [2, 3])  # doctest: +REMOTE_DATA
     >>> celestial  # doctest: +REMOTE_DATA
@@ -98,25 +194,19 @@ transform directly to astropy objects::
     >>> spectral  # doctest: +REMOTE_DATA
     <Quantity [2661.04211695, 2727.46572695] m / s>
 
-Similarly, we can transform astropy objects back::
+and back::
 
-    >>> from astropy.coordinates import SkyCoord
     >>> from astropy import units as u
     >>> coord = SkyCoord('03h26m36.4901s +30d45m22.2012s')
     >>> pixels = wcs.world_to_pixel(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
     >>> pixels  # doctest: +REMOTE_DATA
     [array(8.11341207), array(71.0956641), array(7.10297292)]
 
-If you are looking to index the original data using these pixel coordinates,
-be sure to instead use
-:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_array_index` which returns
-the coordinates in the correct order to index Numpy arrays, and also rounds to
-the nearest integer values::
+And as before we can index array values using::
 
     >>> index = wcs.world_to_array_index(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
     >>> index  # doctest: +REMOTE_DATA
     (7, 71, 8)
-    >>> from astropy.io import fits
     >>> data = fits.getdata(filename)  # doctest: +REMOTE_DATA
     >>> data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
     0.22262384

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -81,8 +81,8 @@ This is indeed a spectral cube, with RA/Dec and a velocity axis.
 
 The main part of the new interface defines standard methods for transforming
 coordinates. The most convenience way is to use the high-level methods
-:meth:`~astropy.wcs.fitswcs.BaseHighLevelWCS.pixel_to_world` and
-:meth:`~astropy.wcs.fitswcs.BaseHighLevelWCS.world_to_pixel`, which can
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel`, which can
 transform directly to astropy objects::
 
     >>> celestial, spectral = wcs.pixel_to_world([1, 2], [4, 3], [2, 3])  # doctest: +REMOTE_DATA
@@ -103,7 +103,7 @@ Similarly, we can transform astropy objects back::
 
 If you are looking to index the original data using these pixel coordinates,
 be sure to instead use
-:meth:`~astropy.wcs.fitswcs.BaseHighLevelWCS.world_to_array_index` which returns
+:meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_array_index` which returns
 the coordinates in the correct order to index Numpy arrays, and also rounds to
 the nearest integer values::
 
@@ -117,7 +117,7 @@ the nearest integer values::
 
 If you are interested in converting to/from world values as simple Python scalars
 or Numpy arrays without using high-level astropy objects, there are methods
-such as :meth:`~astropy.wcs.fitswcs.BaseLowLevelWCS.pixel_to_world_values` to
+such as :meth:`~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values` to
 do this - see `Reference/API`_ for more details.
 
 Extending the physical types in FITS-WCS

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -80,7 +80,7 @@ Let's now check what the physical type of each axis is::
 This is indeed a spectral cube, with RA/Dec and a velocity axis.
 
 The main part of the new interface defines standard methods for transforming
-coordinates. The most convenience way is to use the high-level methods
+coordinates. The most convenient way is to use the high-level methods
 :meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
 :meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel`, which can
 transform directly to astropy objects::

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -24,6 +24,12 @@ The core astropy package provides base classes that define the low- and high-
 level APIs described in APE 14 in the :mod:`astropy.wcs.wcsapi` module, and
 these are listed in the `Reference/API`_ section below.
 
+Overview
+========
+While the full  details and motivation for the API are detailed in APE 14, 
+this documentation summarizes the elements that are implemented directly in the `astropy` core package.  The high-level interface is likely of most interest to the average user.  In particular, the most important methods are the `world_to_pixel` and `pixel_to_world` methods. These provide the essential elements of WCS: mapping to and from world coordinates. The remainder generally provide information about the *kind* of world coordinates or similar information about the structure of the WCS.
+
+In a bit more detail, the key classes implemented here are a high-level that provides the main user interface (`~astropy.wcs.wcsapi.BaseHighLevelWCS` and subclasses), and a lower-level interface (`~astropy.wcs.wcsapi.BaseLowLevelWCS` and subclasses).  These can be distinct objects *or* the same one.  For FITS-WCS, the `~astropy.wcs.WCS` object meant for FITS-WCS follows both interfaces, allowing immediate use of this API with files that already contain FITS-WCS.  More concrete examples are outlined below.
 Pixel conventions and definitions
 =================
 

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -29,7 +29,7 @@ Overview
 
 While the full  details and motivation for the API are detailed in APE 14,  this
 documentation summarizes the elements that are implemented directly in the
-`astropy` core package.  The high-level interface is likely of most interest to
+astropy core package.  The high-level interface is likely of most interest to
 the average user.  In particular, the most important methods are the
 :meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.pixel_to_world` and
 :meth:`~astropy.wcs.wcsapi.BaseHighLevelWCS.world_to_pixel` methods. These

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -82,7 +82,7 @@ simple image with two celestial axes (Right Ascension and Declination)::
     >>> from astropy.utils.data import get_pkg_data_filename
     >>> from astropy.io import fits
     >>> filename = get_pkg_data_filename('galactic_center/gc_2mass_k.fits')  # doctest: +REMOTE_DATA
-    >>> hdu = fits.open(filename)[0]
+    >>> hdu = fits.open(filename)[0]  # doctest: +REMOTE_DATA
     >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
@@ -165,7 +165,8 @@ Let's now take a look at a WCS for a spectral cube (two celestial axes and one
 spectral axis)::
 
     >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
-    >>> wcs = WCS(filename)  # doctest: +REMOTE_DATA
+    >>> hdu = fits.open(filename)[0]  # doctest: +REMOTE_DATA
+    >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
     >>> wcs  # doctest: +REMOTE_DATA
     WCS Keywords
     Number of WCS axes: 3
@@ -215,8 +216,7 @@ And as before we can index array values using::
     >>> index = wcs.world_to_array_index(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
     >>> index  # doctest: +REMOTE_DATA
     (7, 71, 8)
-    >>> data = fits.getdata(filename)  # doctest: +REMOTE_DATA
-    >>> data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> hdu.data[index]  # doctest: +REMOTE_DATA +FLOAT_CMP
     0.22262384
 
 If you are interested in converting to/from world values as simple Python scalars


### PR DESCRIPTION
This adds some basic usage docs for the new WCS APE 14 API

One important addition - it implements ``WCS.array_shape`` which means that we'll finally be able to close e.g. https://github.com/astropy/astropy/issues/5461 or https://github.com/astropy/astropy/issues/4669 - at least I think.

Hey @drdavella - I really could do with https://github.com/astropy/pytest-doctestplus/issues/2 here :wink: (not critical for the PR as I've just put ``+REMOTE_DATA`` everywhere, just pointing out a good use case!)

Once the CI runs, there will be a link to preview the docs (from 'giles') in the status checks below.

[Direct link to docs preview](https://13279-2081289-gh.circle-artifacts.com/0/home/circleci/project/docs/_build/html/wcs/wcsapi.html)