### PR TITLE
Add support for tick_params in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -213,7 +213,7 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 astropy.visualization.wcsaxes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Add support for setting ``set_separator(None)`` to use default
   separators. [#7570]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -212,23 +212,42 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
-- Add support for setting ``set_separator(None)`` in WCSAxes to use default
+astropy.visualization.wcsaxes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Add support for setting ``set_separator(None)`` to use default
   separators. [#7570]
 
-- Added two keyword argument options to ``CoordinateHelper.set_format_unit``: ``decimal`` can
-  be used to specify whether to use decimal formatting for the labels (by default this is
-  False for degrees and hours and True otherwise), and ``show_decimal_unit`` can be used to
-  determine whether the units should be shown for decimal labels. [#7318]
+- Added two keyword argument options to ``CoordinateHelper.set_format_unit``:
+  ``decimal`` can be used to specify whether to use decimal formatting for the
+  labels (by default this is False for degrees and hours and True otherwise),
+  and ``show_decimal_unit`` can be used to determine whether the units should be
+  shown for decimal labels. [#7318]
 
 - Added documentation for ``transform=`` and ``coord_meta=``. [#7698]
 
-- Allow ``coord_meta=`` in WCSAxes to optionally include ``format_unit=``.
-  [#7848]
+- Allow ``coord_meta=`` to optionally include ``format_unit=``. [#7848]
 
-- WCSAxes now recognizes more rcParams related to the grid, ticks, and labels, and
+- Add support for more rcParams related to the grid, ticks, and labels, and
   should work with most built-in Matplotlib styles. [#7961]
 
-- Improved rendering of WCSAxes with outward-facing ticks. [#7961]
+- Improved rendering of outward-facing ticks. [#7961]
+
+- Add support for ``tick_params`` (which is a standard Matplotlib
+  function/method) on both the ``WCSAxes`` class and the individual
+  ``CoordinateHelper`` classes. Note that this is provided for compatibility
+  with Matplotlib syntax users may be familiar with, but it is not the
+  preferred way to change settings. Instead, methods such as ``set_ticks``
+  should be preferred. [#7969]
+
+- Moved the argument ``exclude_overlapping`` from ``set_ticks`` to
+  ``set_ticklabel``. [#7969]
+
+- Added a ``pad=`` argument to ``set_ticklabel`` to provide a way to control
+  the padding between ticks and tick labels. [#7969]
+
+- Added support for setting the tick direction in ``set_ticks`` using the
+  ``direction=`` keyword argument. [#7969]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -16,7 +16,7 @@ from matplotlib.patches import PathPatch
 from matplotlib import rcParams
 
 from ... import units as u
-from ...exceptions import AstropyDeprecationWarning
+from ...utils.exceptions import AstropyDeprecationWarning
 
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 from .ticks import Ticks

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -289,7 +289,8 @@ class CoordinateHelper:
         self._formatter_locator.show_decimal_unit = show_decimal_unit
 
     def set_ticks(self, values=None, spacing=None, number=None, size=None,
-                  width=None, color=None, alpha=None, exclude_overlapping=False):
+                  width=None, color=None, alpha=None, direction=None,
+                  exclude_overlapping=False):
         """
         Set the location and properties of the ticks.
 
@@ -306,8 +307,12 @@ class CoordinateHelper:
             The approximate number of ticks shown.
         size : float, optional
             The length of the ticks in points
-        color : str or tuple
+        color : str or tuple, optional
             A valid Matplotlib color for the ticks
+        alpha : float, optional
+            The alpha value (transparency) for the ticks.
+        direction : {'in','out'}, optional
+            Whether the ticks should point inwards or outwards.
         exclude_overlapping : bool, optional
             Whether to exclude tick labels that overlap over each other.
         """
@@ -334,6 +339,12 @@ class CoordinateHelper:
 
         if alpha is not None:
             self.ticks.set_alpha(alpha)
+
+        if direction is not None:
+            if direction in ('in', 'out'):
+                self.ticks.set_tick_out(direction == 'out')
+            else:
+                raise ValueError("direction should be 'in' or 'out'")
 
         self.ticklabels.set_exclude_overlapping(exclude_overlapping)
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -381,8 +381,8 @@ class CoordinateHelper:
         """
         self.ticks.set_visible(visible)
 
-    def set_ticklabel(self, color=None, size=None, exclude_overlapping=None,
-                      **kwargs):
+    def set_ticklabel(self, color=None, size=None, pad=None,
+                      exclude_overlapping=None, **kwargs):
         """
         Set the visual properties for the tick labels.
 
@@ -392,6 +392,8 @@ class CoordinateHelper:
             The size of the ticks labels in points
         color : str or tuple, optional
             A valid Matplotlib color for the tick labels
+        pad : float, optional
+            Distance in points between tick and label.
         exclude_overlapping : bool, optional
             Whether to exclude tick labels that overlap over each other.
         kwargs
@@ -403,6 +405,8 @@ class CoordinateHelper:
             self.ticklabels.set_size(size)
         if color is not None:
             self.ticklabels.set_color(color)
+        if pad is not None:
+            self.ticklabels.set_pad(pad)
         if exclude_overlapping is not None:
             self.ticklabels.set_exclude_overlapping(exclude_overlapping)
         self.ticklabels.set(**kwargs)
@@ -987,7 +991,8 @@ class CoordinateHelper:
 
         # Set the tick label arguments.
         self.set_ticklabel(color=kwargs.get('labelcolor'),
-                           size=kwargs.get('labelsize'))
+                           size=kwargs.get('labelsize'),
+                           pad=kwargs.get('pad'))
 
         # Set the tick label position
         position = None
@@ -998,11 +1003,6 @@ class CoordinateHelper:
                 position += arg[0]
         if position is not None:
             self.set_ticklabel_position(position)
-
-        # Set the tick label padding
-        # FIXME: should have getter/setter as for other properties
-        if 'pad' in kwargs:
-            self.ticklabels.pad = kwargs['pad']
 
         # And the grid settings
         if 'grid_color' in kwargs:

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -381,12 +381,17 @@ class CoordinateHelper:
         """
         self.ticks.set_visible(visible)
 
-    def set_ticklabel(self, exclude_overlapping=None, **kwargs):
+    def set_ticklabel(self, color=None, size=None, exclude_overlapping=None,
+                      **kwargs):
         """
         Set the visual properties for the tick labels.
 
         Parameters
         ----------
+        size : float, optional
+            The size of the ticks labels in points
+        color : str or tuple, optional
+            A valid Matplotlib color for the tick labels
         exclude_overlapping : bool, optional
             Whether to exclude tick labels that overlap over each other.
         kwargs
@@ -394,6 +399,10 @@ class CoordinateHelper:
             These can include keywords to set the ``color``, ``size``,
             ``weight``, and other text properties.
         """
+        if size is not None:
+            self.ticklabels.set_size(size)
+        if color is not None:
+            self.ticklabels.set_color(color)
         if exclude_overlapping is not None:
             self.ticklabels.set_exclude_overlapping(exclude_overlapping)
         self.ticklabels.set(**kwargs)
@@ -895,6 +904,45 @@ class CoordinateHelper:
         :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticks_position`,
         :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticklabel_position`,
         and :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.grid`.
+
+        Parameters
+        ----------
+        which : {'major', 'minor', 'both'}, optional
+            Which ticks to apply the settings to. By default, setting are
+            applied to both major and minor ticks. Note that if ``'minor'`` is
+            specified, only the length of the ticks can be set currently.
+        direction : {'in', 'out'}, optional
+            Puts ticks inside the axes, or outside the axes.
+        length : float, optional
+            Tick length in points.
+        width : float
+            Tick width in points.
+        color : color, optional
+            Tick color (accepts any valid Matplotlib color)
+        pad : float, optional
+            Distance in points between tick and label.
+        labelsize : float or str, optional
+            Tick label font size in points or as a string (e.g., 'large').
+        labelcolor : color, optional
+            Tick label color (accepts any valid Matplotlib color)
+        colors : color, optional
+            Changes the tick color and the label color to the same value
+             (accepts any valid Matplotlib color).
+        bottom, top, left, right : bool, optional
+            Where to draw the ticks. Note that this will not work correctly if
+            the frame is not rectangular.
+        labelbottom, labeltop, labelleft, labelright : bool, optional
+            Where to draw the tick labels. Note that this will not work
+            correctly if the frame is not rectangular.
+        grid_color : color, optional
+            The color of the grid lines (accepts any valid Matplotlib color).
+        grid_alpha : float, optional
+            Transparency of grid lines: 0 (transparent) to 1 (opaque).
+        grid_linewidth : float, optional
+            Width of grid lines in points.
+        grid_linestyle : string, optional
+            The style of the grid lines (accepts any valid Matplotlib line
+            style).
         """
 
         # First do some sanity checking on the keyword arguments
@@ -937,7 +985,7 @@ class CoordinateHelper:
         if position is not None:
             self.set_ticks_position(position)
 
-        # Set the tick label arguments
+        # Set the tick label arguments.
         self.set_ticklabel(color=kwargs.get('labelcolor'),
                            size=kwargs.get('labelsize'))
 

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -398,8 +398,6 @@ class CoordinateHelper:
             Whether to exclude tick labels that overlap over each other.
         kwargs
             Other keyword arguments are passed to :class:`matplotlib.text.Text`.
-            These can include keywords to set the ``color``, ``size``,
-            ``weight``, and other text properties.
         """
         if size is not None:
             self.ticklabels.set_size(size)
@@ -911,7 +909,7 @@ class CoordinateHelper:
 
         Parameters
         ----------
-        which : {'major', 'minor', 'both'}, optional
+        which : {'both', 'major', 'minor'}, optional
             Which ticks to apply the settings to. By default, setting are
             applied to both major and minor ticks. Note that if ``'minor'`` is
             specified, only the length of the ticks can be set currently.
@@ -919,7 +917,7 @@ class CoordinateHelper:
             Puts ticks inside the axes, or outside the axes.
         length : float, optional
             Tick length in points.
-        width : float
+        width : float, optional
             Tick width in points.
         color : color, optional
             Tick color (accepts any valid Matplotlib color)
@@ -962,7 +960,7 @@ class CoordinateHelper:
         # the length. In future we could consider having a separate Ticks instance
         # for minor ticks so that e.g. the color can be set separately.
         if which == 'minor':
-            if set(kwargs) - {'length'}:
+            if len(set(kwargs) - {'length'}) > 0:
                 raise ValueError("When setting which='minor', the only "
                                  "property that can be set at the moment is "
                                  "'length' (the minor tick length)")

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -6,6 +6,8 @@ This file defines the classes used to represent a 'coordinate', which includes
 axes, ticks, tick labels, and grid lines.
 """
 
+import warnings
+
 import numpy as np
 
 from matplotlib.ticker import Formatter
@@ -14,6 +16,7 @@ from matplotlib.patches import PathPatch
 from matplotlib import rcParams
 
 from ... import units as u
+from ...exceptions import AstropyDeprecationWarning
 
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 from .ticks import Ticks
@@ -290,7 +293,7 @@ class CoordinateHelper:
 
     def set_ticks(self, values=None, spacing=None, number=None, size=None,
                   width=None, color=None, alpha=None, direction=None,
-                  exclude_overlapping=False):
+                  exclude_overlapping=None):
         """
         Set the location and properties of the ticks.
 
@@ -313,8 +316,6 @@ class CoordinateHelper:
             The alpha value (transparency) for the ticks.
         direction : {'in','out'}, optional
             Whether the ticks should point inwards or outwards.
-        exclude_overlapping : bool, optional
-            Whether to exclude tick labels that overlap over each other.
         """
 
         if sum([values is None, spacing is None, number is None]) < 2:
@@ -346,7 +347,11 @@ class CoordinateHelper:
             else:
                 raise ValueError("direction should be 'in' or 'out'")
 
-        self.ticklabels.set_exclude_overlapping(exclude_overlapping)
+        if exclude_overlapping is not None:
+            warnings.warn("exclude_overlapping= should be passed to "
+                          "set_ticklabel instead of set_ticks",
+                          AstropyDeprecationWarning)
+            self.ticklabels.set_exclude_overlapping(exclude_overlapping)
 
     def set_ticks_position(self, position):
         """
@@ -374,17 +379,21 @@ class CoordinateHelper:
         """
         self.ticks.set_visible(visible)
 
-    def set_ticklabel(self, **kwargs):
+    def set_ticklabel(self, exclude_overlapping=None, **kwargs):
         """
         Set the visual properties for the tick labels.
 
         Parameters
         ----------
+        exclude_overlapping : bool, optional
+            Whether to exclude tick labels that overlap over each other.
         kwargs
-            Keyword arguments are passed to :class:`matplotlib.text.Text`. These
-            can include keywords to set the ``color``, ``size``, ``weight``, and
-            other text properties.
+            Other keyword arguments are passed to :class:`matplotlib.text.Text`.
+            These can include keywords to set the ``color``, ``size``,
+            ``weight``, and other text properties.
         """
+        if exclude_overlapping is not None:
+            self.ticklabels.set_exclude_overlapping(exclude_overlapping)
         self.ticklabels.set(**kwargs)
 
     def set_ticklabel_position(self, position):

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -129,6 +129,12 @@ class CoordinatesMap:
         else:
             return self._coords[item]
 
+    def __contains__(self, item):
+        if isinstance(item, str):
+            return item.lower() in self._aliases
+        else:
+            return 0 <= item < len(self._coords)
+
     def set_visible(self, visibility):
         raise NotImplementedError()
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -641,6 +641,56 @@ class WCSAxes(Axes):
         else:
             raise ValueError('axis should be one of x/y/both')
 
+    def tick_params(self, axis='both', **kwargs):
+        """
+        Method to set the tick and tick label parameters in the same way as the
+        :meth:`~matplotlib.axes.Axes.tick_params` method in Matplotlib.
+
+        This is provided for convenience, but the recommended API is to use
+        :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticks`,
+        :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticklabel`,
+        :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticks_position`,
+        :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.set_ticklabel_position`,
+        and :meth:`~astropy.visualization.wcsaxes.CoordinateHelper.grid`.
+
+        Parameters
+        ----------
+        axis : int or str, optional
+            Which axis to apply the parameters to. This defaults to 'both'
+            but this can also be set to an `int` or `str` that refers to the
+            axis to apply it to, following the valid values that can index
+            ``ax.coords``. Note that ``'x'`` and ``'y``' are also accepted in
+            the case of rectangular axes.
+        """
+
+        if not hasattr(self, 'coords'):
+            # Axes haven't been fully initialized yet, so just ignore, as
+            # Axes.__init__ calls this method
+            return
+
+        if axis == 'both':
+
+            for pos in ('bottom', 'left', 'top', 'right'):
+                if pos in kwargs:
+                    raise ValueError("Cannot specify {0}= when axis='both'".format(pos))
+                if 'label' + pos in kwargs:
+                    raise ValueError("Cannot specify label{0}= when axis='both'".format(pos))
+
+            for coord in self.coords:
+                coord.tick_params(**kwargs)
+
+        elif axis in self.coords:
+
+            self.coords[axis].tick_params(**kwargs)
+
+        elif axis in ('x', 'y'):
+
+            if self.frame_class is RectangularFrame:
+                for coord_index in range(len(self.slices)):
+                    if self.slices[coord_index] == axis:
+                        self.coords[coord_index].tick_params(**kwargs)
+
+
 # In the following, we put the generated subplot class in a temporary class and
 # we then inherit it - if we don't do this, the generated class appears to
 # belong in matplotlib, not in WCSAxes, from the API's point of view.

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -661,42 +661,42 @@ class WCSAxes(Axes):
             axis to apply it to, following the valid values that can index
             ``ax.coords``. Note that ``'x'`` and ``'y``' are also accepted in
             the case of rectangular axes.
-        which : {'major', 'minor', 'both'}, optional
+        which : {'both', 'major', 'minor'}, optional
             Which ticks to apply the settings to. By default, setting are
             applied to both major and minor ticks. Note that if ``'minor'`` is
             specified, only the length of the ticks can be set currently.
-        direction : {'in', 'out'}
+        direction : {'in', 'out'}, optional
             Puts ticks inside the axes, or outside the axes.
-        length : float
+        length : float, optional
             Tick length in points.
-        width : float
+        width : float, optional
             Tick width in points.
-        color : color
+        color : color, optional
             Tick color (accepts any valid Matplotlib color)
-        pad : float
+        pad : float, optional
             Distance in points between tick and label.
-        labelsize : float or str
+        labelsize : float or str, optional
             Tick label font size in points or as a string (e.g., 'large').
-        labelcolor : color
+        labelcolor : color, optional
             Tick label color (accepts any valid Matplotlib color)
-        colors : color
+        colors : color, optional
             Changes the tick color and the label color to the same value
              (accepts any valid Matplotlib color).
-        bottom, top, left, right : bool
+        bottom, top, left, right : bool, optional
             Where to draw the ticks. Note that this can only be given if a
             specific coordinate is specified via the ``axis`` argument, and it
             will not work correctly if the frame is not rectangular.
-        labelbottom, labeltop, labelleft, labelright : bool
+        labelbottom, labeltop, labelleft, labelright : bool, optional
             Where to draw the tick labels. Note that this can only be given if a
             specific coordinate is specified via the ``axis`` argument, and it
             will not work correctly if the frame is not rectangular.
-        grid_color : color
+        grid_color : color, optional
             The color of the grid lines (accepts any valid Matplotlib color).
-        grid_alpha : float
+        grid_alpha : float, optional
             Transparency of grid lines: 0 (transparent) to 1 (opaque).
-        grid_linewidth : float
+        grid_linewidth : float, optional
             Width of grid lines in points.
-        grid_linestyle : string
+        grid_linestyle : string, optional
             The style of the grid lines (accepts any valid Matplotlib line
             style).
         """

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -661,6 +661,44 @@ class WCSAxes(Axes):
             axis to apply it to, following the valid values that can index
             ``ax.coords``. Note that ``'x'`` and ``'y``' are also accepted in
             the case of rectangular axes.
+        which : {'major', 'minor', 'both'}, optional
+            Which ticks to apply the settings to. By default, setting are
+            applied to both major and minor ticks. Note that if ``'minor'`` is
+            specified, only the length of the ticks can be set currently.
+        direction : {'in', 'out'}
+            Puts ticks inside the axes, or outside the axes.
+        length : float
+            Tick length in points.
+        width : float
+            Tick width in points.
+        color : color
+            Tick color (accepts any valid Matplotlib color)
+        pad : float
+            Distance in points between tick and label.
+        labelsize : float or str
+            Tick label font size in points or as a string (e.g., 'large').
+        labelcolor : color
+            Tick label color (accepts any valid Matplotlib color)
+        colors : color
+            Changes the tick color and the label color to the same value
+             (accepts any valid Matplotlib color).
+        bottom, top, left, right : bool
+            Where to draw the ticks. Note that this can only be given if a
+            specific coordinate is specified via the ``axis`` argument, and it
+            will not work correctly if the frame is not rectangular.
+        labelbottom, labeltop, labelleft, labelright : bool
+            Where to draw the tick labels. Note that this can only be given if a
+            specific coordinate is specified via the ``axis`` argument, and it
+            will not work correctly if the frame is not rectangular.
+        grid_color : color
+            The color of the grid lines (accepts any valid Matplotlib color).
+        grid_alpha : float
+            Transparency of grid lines: 0 (transparent) to 1 (opaque).
+        grid_linewidth : float
+            Width of grid lines in points.
+        grid_linestyle : string
+            The style of the grid lines (accepts any valid Matplotlib line
+            style).
         """
 
         if not hasattr(self, 'coords'):

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -234,10 +234,11 @@ class TestBasic(BaseImageTests):
 
         ax.coords[2].set_axislabel('Velocity m/s')
 
-        ax.coords[1].set_ticks(spacing=0.2 * u.deg, width=1,
-                               exclude_overlapping=True)
-        ax.coords[2].set_ticks(spacing=400 * u.m / u.s, width=1,
-                               exclude_overlapping=True)
+        ax.coords[1].set_ticks(spacing=0.2 * u.deg, width=1)
+        ax.coords[2].set_ticks(spacing=400 * u.m / u.s, width=1)
+
+        ax.coords[1].set_ticklabel(exclude_overlapping=True)
+        ax.coords[2].set_ticklabel(exclude_overlapping=True)
 
         ax.coords[1].grid(grid_type='contours', color='red', linestyle='solid')
         ax.coords[2].grid(grid_type='contours', color='red', linestyle='solid')
@@ -329,8 +330,10 @@ class TestBasic(BaseImageTests):
         ax.coords[2].set_major_formatter('x.xx')
         ax.coords[2].set_format_unit(u.km / u.s)
         ax.coords[2].set_axislabel('Velocity km/s')
-        ax.coords[1].set_ticks(width=1, exclude_overlapping=True)
-        ax.coords[2].set_ticks(width=1, exclude_overlapping=True)
+        ax.coords[1].set_ticks(width=1)
+        ax.coords[2].set_ticks(width=1)
+        ax.coords[1].set_ticklabel(exclude_overlapping=True)
+        ax.coords[2].set_ticklabel(exclude_overlapping=True)
 
         return fig
 
@@ -345,8 +348,8 @@ class TestBasic(BaseImageTests):
                           slices=(50, 'y', 'x'), aspect='equal')
         ax.set_xlim(-0.5, 52.5)
         ax.set_ylim(-0.5, 106.5)
-        ax.coords[2].set_ticks(exclude_overlapping=True)
-        ax.coords[1].set_ticks(exclude_overlapping=True)
+        ax.coords[2].set_ticklabel(exclude_overlapping=True)
+        ax.coords[1].set_ticklabel(exclude_overlapping=True)
         ax.coords[2].display_minor_ticks(True)
         ax.coords[1].display_minor_ticks(True)
         ax.coords[2].set_minor_frequency(3)
@@ -424,8 +427,8 @@ class TestBasic(BaseImageTests):
             ax.grid()
             ax.set_xlabel('X label')
             ax.set_ylabel('Y label')
-            ax.coords[0].set_ticks(exclude_overlapping=True)
-            ax.coords[1].set_ticks(exclude_overlapping=True)
+            ax.coords[0].set_ticklabel(exclude_overlapping=True)
+            ax.coords[1].set_ticklabel(exclude_overlapping=True)
             return fig
 
     @pytest.mark.remote_data(source='astropy')
@@ -498,8 +501,8 @@ class TestBasic(BaseImageTests):
         ax.coords[1].set_coord_type('scalar')
         ax.coords[0].set_major_formatter('x.xxx')
         ax.coords[1].set_major_formatter('x.xxx')
-        ax.coords[0].set_ticks(exclude_overlapping=True)
-        ax.coords[1].set_ticks(exclude_overlapping=True)
+        ax.coords[0].set_ticklabel(exclude_overlapping=True)
+        ax.coords[1].set_ticklabel(exclude_overlapping=True)
         return fig
 
     @pytest.mark.remote_data(source='astropy')

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -670,3 +670,63 @@ class TestBasic(BaseImageTests):
         ax.set_ylim(-0.5, 0.5)
         ax.coords[0].set_ticks(spacing=0.2 * 15 * u.arcsec)
         return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
+    def test_tick_params(self):
+
+        # This is a test to make sure that tick_params works correctly. We try
+        # and test as much as possible with a single reference image.
+
+        wcs = WCS()
+        wcs.wcs.ctype = ['lon', 'lat']
+
+        fig = plt.figure(figsize=(6, 6))
+
+        # The first subplot tests:
+        # - that plt.tick_params works
+        # - that by default both axes are changed
+        # - changing the tick direction and appearance, the label appearance and padding
+        ax = fig.add_subplot(2, 2, 1, projection=wcs)
+        plt.tick_params(direction='in', length=20, width=5, pad=6, labelsize=6,
+                        color='red', labelcolor='blue')
+
+        # The second subplot tests:
+        # - that specifying grid parameters doesn't actually cause the grid to
+        #   be shown (as expected)
+        # - that axis= can be given integer coordinates or their string name
+        # - that the tick positioning works (bottom/left/top/right)
+        # Make sure that we can pass things that can index coords
+        ax = fig.add_subplot(2, 2, 2, projection=wcs)
+        plt.tick_params(axis=0, direction='in', length=20, width=5, pad=4, labelsize=6,
+                        color='red', labelcolor='blue', bottom=True, grid_color='purple')
+        plt.tick_params(axis='lat', direction='out', labelsize=8,
+                        color='blue', labelcolor='purple', left=True, right=True,
+                        grid_color='red')
+
+        # The third subplot tests:
+        # - that ax.tick_params works
+        # - that the grid has the correct settings once shown explicitly
+        # - that we can use axis='x' and axis='y'
+        ax = fig.add_subplot(2, 2, 3, projection=wcs)
+        ax.tick_params(axis='x', direction='in', length=20, width=5, pad=20, labelsize=6,
+                       color='red', labelcolor='blue', bottom=True,
+                       grid_color='purple')
+        ax.tick_params(axis='y', direction='out', labelsize=8,
+                       color='blue', labelcolor='purple', left=True, right=True,
+                       grid_color='red')
+        plt.grid()
+
+        # The final subplot tests:
+        # - that we can use tick_params on a specific coordinate
+        # - that the label positioning can be customized
+        # - that the colors argument works
+        # - that which='minor' works
+        ax = fig.add_subplot(2, 2, 4, projection=wcs)
+        ax.coords[0].tick_params(length=4, pad=2, colors='orange', labelbottom=True,
+                                 labeltop=True, labelsize=10)
+        ax.coords[1].display_minor_ticks(True)
+        ax.coords[1].tick_params(which='minor', length=6)
+
+        return fig

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -93,14 +93,14 @@ class TestTransformCoordMeta(BaseImageTests):
         overlay['lon'].grid(color='red', linestyle='solid', alpha=0.3)
         overlay['lat'].grid(color='blue', linestyle='solid', alpha=0.3)
 
-        overlay['lon'].set_ticklabel(size=7)
-        overlay['lat'].set_ticklabel(size=7)
+        overlay['lon'].set_ticklabel(size=7, exclude_overlapping=True)
+        overlay['lat'].set_ticklabel(size=7, exclude_overlapping=True)
 
         overlay['lon'].set_ticklabel_position('brtl')
         overlay['lat'].set_ticklabel_position('brtl')
 
-        overlay['lon'].set_ticks(spacing=10. * u.deg, exclude_overlapping=True)
-        overlay['lat'].set_ticks(spacing=10. * u.deg, exclude_overlapping=True)
+        overlay['lon'].set_ticks(spacing=10. * u.deg)
+        overlay['lat'].set_ticks(spacing=10. * u.deg)
 
         ax.set_xlim(-0.5, 1215.5)
         ax.set_ylim(-0.5, 1791.5)
@@ -151,14 +151,14 @@ class TestTransformCoordMeta(BaseImageTests):
         ax.coords['lon'].grid(color='red', linestyle='solid', alpha=0.3)
         ax.coords['lat'].grid(color='blue', linestyle='solid', alpha=0.3)
 
-        ax.coords['lon'].set_ticklabel(size=7)
-        ax.coords['lat'].set_ticklabel(size=7)
+        ax.coords['lon'].set_ticklabel(size=7, exclude_overlapping=True)
+        ax.coords['lat'].set_ticklabel(size=7, exclude_overlapping=True)
 
         ax.coords['lon'].set_ticklabel_position('brtl')
         ax.coords['lat'].set_ticklabel_position('brtl')
 
-        ax.coords['lon'].set_ticks(spacing=10. * u.deg, exclude_overlapping=True)
-        ax.coords['lat'].set_ticks(spacing=10. * u.deg, exclude_overlapping=True)
+        ax.coords['lon'].set_ticks(spacing=10. * u.deg)
+        ax.coords['lat'].set_ticks(spacing=10. * u.deg)
 
         ax.set_xlim(-400., 500.)
         ax.set_ylim(-300., 400.)

--- a/astropy/visualization/wcsaxes/ticklabels.py
+++ b/astropy/visualization/wcsaxes/ticklabels.py
@@ -21,7 +21,7 @@ class TickLabels(Text):
         super().__init__(*args, **kwargs)
         self.set_clip_on(True)
         self.set_visible_axes('all')
-        self.pad = rcParams['xtick.major.pad']
+        self.set_pad(rcParams['xtick.major.pad'])
         self._exclude_overlapping = False
 
         # Check rcParams
@@ -94,6 +94,12 @@ class TickLabels(Text):
                     if starts_dollar:
                         self.text[axis][i] = '$' + self.text[axis][i]
 
+    def set_pad(self, value):
+        self._pad = value
+
+    def get_pad(self):
+        return self._pad
+
     def set_visible_axes(self, visible_axes):
         self._visible_axes = visible_axes
 
@@ -129,7 +135,7 @@ class TickLabels(Text):
 
                 x, y = self.pixel[axis][i]
 
-                pad = renderer.points_to_pixels(self.pad + tick_out_size)
+                pad = renderer.points_to_pixels(self.get_pad() + tick_out_size)
 
                 if isinstance(self._frame, RectangularFrame):
 

--- a/docs/visualization/wcsaxes/slicing_datacubes.rst
+++ b/docs/visualization/wcsaxes/slicing_datacubes.rst
@@ -75,7 +75,7 @@ We then add the axes to the image and plot it using the method
    :include-source:
    :align: center
 
-    ax.coords[2].set_ticks(exclude_overlapping=True)
+    ax.coords[2].set_ticklabel(exclude_overlapping=True)
     ax.imshow(image_data[:, :, 50].transpose())
 
 Here, ``image_data`` is an :class:`~numpy.ndarray` object. In Numpy, the order

--- a/docs/visualization/wcsaxes/ticks_labels_grid.rst
+++ b/docs/visualization/wcsaxes/ticks_labels_grid.rst
@@ -204,9 +204,15 @@ In the case of angular axes, specifying the spacing as an Astropy
 :class:`~astropy.units.quantity.Quantity` avoids roundoff errors. The
 :meth:`~astropy.visualization.wcsaxes.coordinate_helpers.CoordinateHelper.set_ticks` method can also
 be used to set the appearance (color and size) of the ticks, using the
-``color=`` and ``size=`` options. There is also the option
-``exclude_overlapping=True`` to prevent overlapping tick labels from being
-displayed.
+``color=`` and ``size=`` options.
+
+The :meth:`~astropy.visualization.wcsaxes.coordinate_helpers.CoordinateHelper.set_ticklabel` method can be used
+to change settings for the tick labels, such as color, font, size, and so on::
+
+    lon.set_ticklabel(color='red', size=12)
+
+In addition, this method has an option ``exclude_overlapping=True`` to prevent
+overlapping tick labels from being displayed.
 
 We can apply this to the previous example:
 
@@ -216,8 +222,10 @@ We can apply this to the previous example:
    :align: center
 
     from astropy import units as u
-    lon.set_ticks(spacing=10 * u.arcmin, color='white', exclude_overlapping=True)
-    lat.set_ticks(spacing=10 * u.arcmin, color='white', exclude_overlapping=True)
+    lon.set_ticks(spacing=10 * u.arcmin, color='white')
+    lat.set_ticks(spacing=10 * u.arcmin, color='white')
+    lon.set_ticklabel(exclude_overlapping=True)
+    lat.set_ticklabel(exclude_overlapping=True)
 
 Minor ticks
 ***********


### PR DESCRIPTION
The main addition in this pull request is that ``WCSAxes`` now has a ``tick_params`` method which means that both ``ax.tick_params`` and ``plt.tick_params`` will work. In addition, there is a ``tick_params`` method on ``CoordinateHelper``. The idea here is not that these should become the recommended way to do it, but that we should at least support them since Matplotlib users will be familiar with that method. This explains why I've not documented it beyond the API docs.

In addition, this exposes a ``direction`` argument for the tick direction in ``set_ticks``, and a ``pad`` argument for the tick to tick label padding in ``set_ticklabel``. It also moves the ``exclude_overlapping`` option from ``set_ticks`` to ``set_ticklabel`` (with a deprecation warning) since I believe the new location makes more sense.

Finally, potentially of interest to @bsipocz is that I've added a new section in the changelog for ``astropy.visualization.wcsaxes`` since there are enough entries that it was becoming tiring to repeat 'in WSAxes' in each entry - hope that's ok?

Fixes https://github.com/astropy/astropy/issues/6735