### PR TITLE
deprecate _naxis1/2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -283,6 +283,9 @@ astropy.wcs
 
 - Added a new property ``WCS.has_distortion``. [#7326]
 
+- Deprecated ``_naxis1`` and ``_naxis2`` in favor of ``pixel_shape``. [#7973]
+
+
 API Changes
 -----------
 

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -17,6 +17,7 @@ from .. import _wcs
 from ...utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
 from ...utils.misc import NumpyRNGContext
+from ...utils.exceptions import AstropyUserWarning
 from ...io import fits
 
 
@@ -593,11 +594,12 @@ def test_footprint_to_file(tmpdir):
     From github issue #1912
     """
     # Arbitrary keywords from real data
-    w = wcs.WCS({'CTYPE1': 'RA---ZPN', 'CRUNIT1': 'deg',
-                 'CRPIX1': -3.3495999e+02, 'CRVAL1': 3.185790700000e+02,
-                 'CTYPE2': 'DEC--ZPN', 'CRUNIT2': 'deg',
-                 'CRPIX2': 3.0453999e+03, 'CRVAL2': 4.388538000000e+01,
-                 'PV2_1': 1., 'PV2_3': 220.})
+    hdr = {'CTYPE1': 'RA---ZPN', 'CRUNIT1': 'deg',
+           'CRPIX1': -3.3495999e+02, 'CRVAL1': 3.185790700000e+02,
+           'CTYPE2': 'DEC--ZPN', 'CRUNIT2': 'deg',
+           'CRPIX2': 3.0453999e+03, 'CRVAL2': 4.388538000000e+01,
+           'PV2_1': 1., 'PV2_3': 220., 'NAXIS1': 2048, 'NAXIS2': 1024}
+    w = wcs.WCS(hdr)
 
     testfile = str(tmpdir.join('test.txt'))
     w.footprint_to_file(testfile)
@@ -620,6 +622,12 @@ def test_footprint_to_file(tmpdir):
 
     with pytest.raises(ValueError):
         w.footprint_to_file(testfile, coordsys='FOO')
+
+    del hdr['NAXIS1']
+    del hdr['NAXIS2']
+    w = wcs.WCS(hdr)
+    with pytest.warns(AstropyUserWarning):
+        w.footprint_to_file(testfile)
 
 
 def test_validate_faulty_wcs():

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -72,7 +72,7 @@ __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
 
 __doctest_skip__ = ['WCS.all_world2pix']
 
-naxis_deprecated_message = """
+NAXIS_DEPRECATE_MESSAGE = """
 Private attributes "_naxis1" and "naxis2" have been deprecated since v3.1.
 Instead use the "pixel_shape" property which returns a list of NAXISj keyword values.
 """
@@ -2679,22 +2679,22 @@ reduce these to 2 dimensions using the naxis kwarg.
 
     @property
     def _naxis1(self):
-        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
+        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
         return self._naxis[0]
 
     @_naxis1.setter
     def _naxis1(self, value):
-        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
+        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
         self._naxis[0] = value
 
     @property
     def _naxis2(self):
-        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
+        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
         return self._naxis[1]
 
     @_naxis2.setter
     def _naxis2(self, value):
-        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
+        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
         self._naxis[1] = value
 
     def _get_naxis(self, header=None):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -72,6 +72,10 @@ __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
 
 __doctest_skip__ = ['WCS.all_world2pix']
 
+naxis_deprecated_message = """
+Private attributes "_naxis1" and "naxis2" have been deprecated since v3.1.
+Instead use the "pixel_shape" property which returns a list of NAXISj keyword values.
+"""
 
 if _wcs is not None:
     _parsed_version = _wcs.__version__.split('.')
@@ -698,8 +702,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 try:
                     # classes that inherit from WCS and define naxis1/2
                     # do not require a header parameter
-                    naxis1 = self._naxis1
-                    naxis2 = self._naxis2
+                    naxis1, naxis2 = self.pixel_shape
                 except AttributeError:
                     warnings.warn("Need a valid header in order to calculate footprint\n", AstropyUserWarning)
                     return None
@@ -2674,18 +2677,22 @@ reduce these to 2 dimensions using the naxis kwarg.
 
     @property
     def _naxis1(self):
+        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
         return self._naxis[0]
 
     @_naxis1.setter
     def _naxis1(self, value):
+        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
         self._naxis[0] = value
 
     @property
     def _naxis2(self):
+        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
         return self._naxis[1]
 
     @_naxis2.setter
     def _naxis2(self, value):
+        warnings.warn(naxis_deprecated_message, AstropyDeprecationWarning)
         self._naxis[1] = value
 
     def _get_naxis(self, header=None):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -703,7 +703,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     # classes that inherit from WCS and define naxis1/2
                     # do not require a header parameter
                     naxis1, naxis2 = self.pixel_shape
-                except AttributeError:
+                except (AttributeError, TypeError):
                     warnings.warn("Need a valid header in order to calculate footprint\n", AstropyUserWarning)
                     return None
             else:
@@ -2672,8 +2672,10 @@ reduce these to 2 dimensions using the naxis kwarg.
             f.write(comments)
             f.write('{}\n'.format(coordsys))
             f.write('polygon(')
-            self.calc_footprint().tofile(f, sep=',')
-            f.write(') # color={0}, width={1:d} \n'.format(color, width))
+            ftpr = self.calc_footprint()
+            if ftpr is not None:
+                ftpr.tofile(f, sep=',')
+                f.write(') # color={0}, width={1:d} \n'.format(color, width))
 
     @property
     def _naxis1(self):


### PR DESCRIPTION
Note: This depends on #7962 and astrofrog/astropy#75.

This deprecates `Wcs._naxis1` and `Wcs._naxis2` in favor of `WCS.pixel_shape`.
Resolves #5461 and #4669 where there's a description of the problem. 