### PR TITLE
Fix errors in kuiper_false_positive_probability

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -558,6 +558,8 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fix errors in ``kuiper_false_positive_probability``. [#7975]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1265,12 +1265,21 @@ def kuiper_false_positive_probability(D, N):
     fpp : float
         The probability of a score this large arising from the null hypothesis.
 
+    Notes
+    -----
+    Eq 7 of Paltani 2004 appears to incorrectly quote the original formula
+    (Stephens 1965). This function implements the original formula, as it
+    produces a result closer to Monte Carlo simulations.
+
     References
     ----------
 
     .. [1] Paltani, S., "Searching for periods in X-ray observations using
            Kuiper's test. Application to the ROSAT PSPC archive",
            Astronomy and Astrophysics, v.240, p.789-790, 2004.
+
+    .. [2] Stephens, M. A., "The goodness-of-fit statistic VN: distribution
+           and significance points", Biometrika, v.52, p.309, 1965.
 
     """
     try:
@@ -1292,9 +1301,6 @@ def kuiper_false_positive_probability(D, N):
         return 1. - factorial(N - 1) * (b**(N - 1.) * (1. - a) -
                                         a**(N - 1.) * (1. - b)) / float(N)**(N - 2) / (b - a)
     elif (D > 0.5 and N % 2 == 0) or (D > (N - 1.) / (2. * N) and N % 2 == 1):
-        # NOTE: eq 7 of Paltani 2004 appears to contain a typo with respect
-        # to the same equation in Stephens 1965. The latter is closer to
-        # Monte Carlo simulations, and is the version implemented here
         def T(t):
             y = D + t / float(N)
             return y**(t - 3) * (y**3 * N - y**2 * t * (3. - 2. /

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1290,7 +1290,7 @@ def kuiper_false_positive_probability(D, N):
         r = np.sqrt(k**2 - (N * D - 2.) / 2.)
         a, b = -k + r, -k - r
         return 1. - factorial(N - 1) * (b**(N - 1.) * (1. - a) -
-                                        a**(N - 1.) * (1. - b)) / float(N)**(N - 2) * (b - a)
+                                        a**(N - 1.) * (1. - b)) / float(N)**(N - 2) / (b - a)
     elif (D > 0.5 and N % 2 == 0) or (D > (N - 1.) / (2. * N) and N % 2 == 1):
         def T(t):
             y = D + t / float(N)
@@ -1322,7 +1322,7 @@ def kuiper_false_positive_probability(D, N):
             if np.abs(S2 - so) / (np.abs(S2) + np.abs(so)
                                   ) < term_eps or np.abs(S1 - so) < abs_eps:
                 break
-        return S1 - 8 * D / (3. * np.sqrt(N)) * S2
+        return S1 - 8 * D / 3. * S2
 
 
 def kuiper(data, cdf=lambda x: x, args=()):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1287,15 +1287,18 @@ def kuiper_false_positive_probability(D, N):
         return 1. - factorial(N) * (D - 1. / N)**(N - 1)
     elif D < 3. / N:
         k = -(N * D - 1.) / 2.
-        r = np.sqrt(k**2 - (N * D - 2.) / 2.)
+        r = np.sqrt(k**2 - (N * D - 2.)**2 / 2.)
         a, b = -k + r, -k - r
         return 1. - factorial(N - 1) * (b**(N - 1.) * (1. - a) -
                                         a**(N - 1.) * (1. - b)) / float(N)**(N - 2) / (b - a)
     elif (D > 0.5 and N % 2 == 0) or (D > (N - 1.) / (2. * N) and N % 2 == 1):
+        # NOTE: eq 7 of Paltani 2004 appears to contain a typo with respect
+        # to the same equation in Stephens 1965. The latter is closer to
+        # Monte Carlo simulations, and is the version implemented here
         def T(t):
             y = D + t / float(N)
             return y**(t - 3) * (y**3 * N - y**2 * t * (3. - 2. /
-                                                        N) / N - t * (t - 1) * (t - 2) / float(N)**2)
+                                                        N) + y * t * (t - 1) * (3. - 2. / N) / N - t * (t - 1) * (t - 2) / float(N)**2)
         s = 0.
         # NOTE: the upper limit of this sum is taken from Stephens 1965
         for t in range(int(np.floor(N * (1 - D))) + 1):

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -732,6 +732,7 @@ def test_histogram_intervals_known(ii, rr):
                                    pytest.param(300, 10000, 0.001,
                                                 marks=pytest.mark.skip('Test too slow')),
                                    (10, 10000, 0.001),
+                                   (3, 10000, 0.001),
                                    ])
 def test_uniform_binomial(N, m, p):
     """Check that the false positive probability is right
@@ -743,8 +744,10 @@ def test_uniform_binomial(N, m, p):
 
     """
     with NumpyRNGContext(1234):
-        fpps = [funcs.kuiper(np.random.random(N))[1]
-                for i in range(m)]
-        assert (scipy.stats.binom(n=m, p=p).ppf(0.01) <
-                len([fpp for fpp in fpps if fpp < p]) <
-                scipy.stats.binom(n=m, p=p).ppf(0.99))
+        fpps = np.array([funcs.kuiper(np.random.random(N))[1]
+                         for i in range(m)])
+        assert (fpps >= 0).all()
+        assert (fpps <= 1).all()
+        low = scipy.stats.binom(n=m, p=p).ppf(0.01)
+        high = scipy.stats.binom(n=m, p=p).ppf(0.99)
+        assert (low < sum(fpps < p) < high)


### PR DESCRIPTION
This addresses issue #7968. The current implementation of `kuiper_false_positive_probability` seems to differ from the corresponding equations in Paltani 2004 (cited in the docstring). In addition, one of the equations in that paper appears to be an incorrect copy of an equation from previous work (Stephens 1965), and `kuiper_false_positive_probability` implements the incorrect version. Some of these typos cause `kuiper_false_positive_probability` to return probabilities smaller than zero or larger than one for some values of the arguments, and in general the returned probabilities do not closely match Monte Carlo simulations.

Here are a few comparisons of the result of `kuiper_false_positive_probability` (orange) with a Monte Carlo (blue) before the fix:
![kuiper_p_003](https://user-images.githubusercontent.com/11317236/47563019-76198480-d8ee-11e8-9bbc-366f1bce1dca.png)
![kuiper_p_010](https://user-images.githubusercontent.com/11317236/47563020-76198480-d8ee-11e8-8d1f-bc65cc36c78a.png)
![kuiper_p_030](https://user-images.githubusercontent.com/11317236/47563021-76b21b00-d8ee-11e8-97c4-8e302e53bcb3.png)

Here is the same comparison after this patch:
![kuiper_p_003](https://user-images.githubusercontent.com/11317236/47563083-a06b4200-d8ee-11e8-8f01-c725a0ddde74.png)
![kuiper_p_010](https://user-images.githubusercontent.com/11317236/47563084-a06b4200-d8ee-11e8-91dc-bb7feaccbf9e.png)
![kuiper_p_030](https://user-images.githubusercontent.com/11317236/47563085-a06b4200-d8ee-11e8-973d-4aa1b1c1256b.png)

And here is a before/after comparison of the results of the function for a wider choices of N:
![astropy_fpp](https://user-images.githubusercontent.com/11317236/47563222-0bb51400-d8ef-11e8-8081-4a7234320314.png)
![astropy_fpp](https://user-images.githubusercontent.com/11317236/47563225-0f489b00-d8ef-11e8-8b8e-67d4303ef93b.png)
