### PR TITLE
Update Cutout2D to use pixel_shape instead of _naxis

### DIFF
--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -560,8 +560,7 @@ class TestCutout2D:
         xsize = 2
         ysize = 3
         c = Cutout2D(self.data, self.position, (ysize, xsize), wcs=self.wcs)
-        assert c.wcs._naxis[0] == xsize
-        assert c.wcs._naxis[1] == ysize
+        assert c.wcs.array_shape == (ysize, xsize)
 
     def test_crpix_maps_to_crval(self):
         w = Cutout2D(self.data, (0, 0), (3, 3), wcs=self.sipwcs,

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -714,7 +714,7 @@ class Cutout2D:
         if wcs is not None:
             self.wcs = deepcopy(wcs)
             self.wcs.wcs.crpix -= self._origin_original_true
-            self.wcs._naxis = [self.data.shape[1], self.data.shape[0]]
+            self.wcs.array_shape = self.data.shape
             if wcs.sip is not None:
                 self.wcs.sip = Sip(wcs.sip.a, wcs.sip.b,
                                    wcs.sip.ap, wcs.sip.bp,


### PR DESCRIPTION
`_naxis1/2` was deprecated in #7973.  `pixel_shape` was added in #7962.