### PR TITLE
TST: Ignore convolution test warnings

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -804,7 +804,10 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         return fftmult
 
     if interpolate_nan:
-        rifft = (ifftn(fftmult)) / bigimwt
+        with np.errstate(divide='ignore'):
+            # divide by zeros are expected here; if the weight is zero, we want
+            # the output to be nan or inf
+            rifft = (ifftn(fftmult)) / bigimwt
         if not np.isscalar(bigimwt):
             if min_wt > 0.:
                 rifft[bigimwt < min_wt] = np.nan

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import itertools
-import warnings
 
 import pytest
 import numpy as np
@@ -68,8 +67,14 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -87,8 +92,14 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -106,8 +117,14 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -147,8 +164,14 @@ class TestConvolve1D:
 
         y = np.array([0.5, 0.5, 0.5], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -190,9 +213,15 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel,
+                                 preserve_nan=preserve_nan)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -229,9 +258,15 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel,
+                                 preserve_nan=preserve_nan)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -257,8 +292,15 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel,
+                                 preserve_nan=preserve_nan)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -310,12 +352,8 @@ class TestConvolve1D:
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            result = convolve_fft(masked_array, kernel, boundary='fill',
-                                  fill_value=np.nan)
-
+        result = convolve_fft(masked_array, kernel, boundary='fill',
+                              fill_value=np.nan)
         assert_floatclose(result, [1, 2, 3])
 
     def test_masked_array(self):
@@ -327,24 +365,16 @@ class TestConvolve1D:
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            result = convolve_fft(masked_array, kernel, boundary='fill',
-                                  fill_value=np.nan)
-
+        result = convolve_fft(masked_array, kernel, boundary='fill',
+                              fill_value=np.nan)
         assert_floatclose(result, [1, 2, 3])
 
         # Test masked kernel
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', RuntimeWarning)
-            result = convolve_fft(masked_array, kernel, boundary='fill',
-                                  fill_value=np.nan)
-
+        result = convolve_fft(masked_array, kernel, boundary='fill',
+                              fill_value=np.nan)
         assert_floatclose(result, [1, 2, 3])
 
     def test_normalize_function(self):
@@ -402,8 +432,14 @@ class TestConvolve2D:
 
         y = np.array([[1.]], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -425,9 +461,14 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -449,9 +490,15 @@ class TestConvolve2D:
                       [1., 1., 1.],
                       [1., 1., 1.]], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 fill_value=np.nan if normalize_kernel else 0,
+                                 normalize_kernel=normalize_kernel)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              fill_value=np.nan if normalize_kernel else 0,
@@ -503,9 +550,15 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 normalize_kernel=normalize_kernel,
+                                 preserve_nan=preserve_nan)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -547,9 +600,16 @@ class TestConvolve2D:
         #                          )
         #     return
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', (AstropyUserWarning,
-                                             RuntimeWarning))
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary,
+                                 nan_treatment=nan_treatment,
+                                 fill_value=np.nan if normalize_kernel else 0,
+                                 normalize_kernel=normalize_kernel,
+                                 preserve_nan=preserve_nan)
+        else:
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              fill_value=np.nan if normalize_kernel else 0,
@@ -598,7 +658,7 @@ class TestConvolve2D:
         if nan_treatment == 'interpolate':
             answer_key += '_interpnan'
 
-        a = answer_dict[answer_key]
+        answer_dict[answer_key]
 
         # Skip the NaN at [1, 1] when preserve_nan=True
         posns = np.where(np.isfinite(z))
@@ -629,8 +689,13 @@ class TestConvolve2D:
                       [-1., 0., -1.],
                       [1., -1., 1.]], dtype='float')
 
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', AstropyUserWarning)
+        if boundary is None:
+            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                              "version of boundary=None is equivalent to the "
+                              "convolve boundary='fill'"):
+                z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
+                                 normalize_kernel=False)
+        else:
             z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
                              normalize_kernel=False)
 
@@ -657,8 +722,12 @@ def test_asymmetric_kernel(boundary):
 
     y = np.array([1, 2, 3], dtype='>f8')
 
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', AstropyUserWarning)
+    if boundary is None:
+        with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+                          "version of boundary=None is equivalent to the "
+                          "convolve boundary='fill'"):
+            z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
+    else:
         z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
 
     if boundary in (None, 'fill'):

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -1,12 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import itertools
+import warnings
 
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
 
 from ..convolve import convolve_fft
+from ...utils.exceptions import AstropyUserWarning
 
 
 VALID_DTYPES = []
@@ -66,9 +68,11 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         assert_floatclose(z, x)
 
@@ -83,9 +87,11 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         assert_floatclose(z, x)
 
@@ -100,9 +106,11 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         answer_key = (boundary, nan_treatment, normalize_kernel)
 
@@ -139,9 +147,11 @@ class TestConvolve1D:
 
         y = np.array([0.5, 0.5, 0.5], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         answer_dict = {
             'sum': np.array([0.5, 2.0, 1.5], dtype='float64'),
@@ -180,10 +190,13 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel,
-                         preserve_nan=preserve_nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel,
+                             preserve_nan=preserve_nan)
 
         if preserve_nan:
             assert np.isnan(z[1])
@@ -216,10 +229,13 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel,
-                         preserve_nan=preserve_nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel,
+                             preserve_nan=preserve_nan)
 
         if preserve_nan:
             assert np.isnan(z[1])
@@ -241,10 +257,12 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel,
-                         preserve_nan=preserve_nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel,
+                             preserve_nan=preserve_nan)
 
         if preserve_nan:
             assert np.isnan(z[1])
@@ -292,7 +310,12 @@ class TestConvolve1D:
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-        result = convolve_fft(masked_array, kernel, boundary='fill', fill_value=np.nan)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            result = convolve_fft(masked_array, kernel, boundary='fill',
+                                  fill_value=np.nan)
+
         assert_floatclose(result, [1, 2, 3])
 
     def test_masked_array(self):
@@ -304,14 +327,24 @@ class TestConvolve1D:
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-        result = convolve_fft(masked_array, kernel, boundary='fill', fill_value=np.nan)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            result = convolve_fft(masked_array, kernel, boundary='fill',
+                                  fill_value=np.nan)
+
         assert_floatclose(result, [1, 2, 3])
 
         # Test masked kernel
         array = np.array([1., np.nan, 3.], dtype='float64')
         kernel = np.array([1, 1, 1])
         masked_array = np.ma.masked_array(array, mask=[0, 1, 0])
-        result = convolve_fft(masked_array, kernel, boundary='fill', fill_value=np.nan)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            result = convolve_fft(masked_array, kernel, boundary='fill',
+                                  fill_value=np.nan)
+
         assert_floatclose(result, [1, 2, 3])
 
     def test_normalize_function(self):
@@ -369,9 +402,11 @@ class TestConvolve2D:
 
         y = np.array([[1.]], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         assert_floatclose(z, x)
 
@@ -390,9 +425,12 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel)
 
         assert_floatclose(z, x)
 
@@ -411,10 +449,13 @@ class TestConvolve2D:
                       [1., 1., 1.],
                       [1., 1., 1.]], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         fill_value=np.nan if normalize_kernel else 0,
-                         normalize_kernel=normalize_kernel)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             fill_value=np.nan if normalize_kernel else 0,
+                             normalize_kernel=normalize_kernel)
 
         w = np.array([[4., 6., 4.],
                       [6., 9., 6.],
@@ -462,10 +503,13 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         normalize_kernel=normalize_kernel,
-                         preserve_nan=preserve_nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             normalize_kernel=normalize_kernel,
+                             preserve_nan=preserve_nan)
 
         if preserve_nan:
             assert np.isnan(z[1, 1])
@@ -503,11 +547,14 @@ class TestConvolve2D:
         #                          )
         #     return
 
-        z = convolve_fft(x, y, boundary=boundary,
-                         nan_treatment=nan_treatment,
-                         fill_value=np.nan if normalize_kernel else 0,
-                         normalize_kernel=normalize_kernel,
-                         preserve_nan=preserve_nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', (AstropyUserWarning,
+                                             RuntimeWarning))
+            z = convolve_fft(x, y, boundary=boundary,
+                             nan_treatment=nan_treatment,
+                             fill_value=np.nan if normalize_kernel else 0,
+                             normalize_kernel=normalize_kernel,
+                             preserve_nan=preserve_nan)
 
         if preserve_nan:
             assert np.isnan(z[1, 1])
@@ -582,8 +629,10 @@ class TestConvolve2D:
                       [-1., 0., -1.],
                       [1., -1., 1.]], dtype='float')
 
-        z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
-                         normalize_kernel=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
+                             normalize_kernel=False)
 
         if boundary in (None, 'fill'):
             assert_floatclose(z, np.array([[1., -5., 2.],
@@ -596,6 +645,7 @@ class TestConvolve2D:
         else:
             raise ValueError("Invalid boundary specification")
 
+
 @pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
 def test_asymmetric_kernel(boundary):
     '''
@@ -607,7 +657,9 @@ def test_asymmetric_kernel(boundary):
 
     y = np.array([1, 2, 3], dtype='>f8')
 
-    z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', AstropyUserWarning)
+        z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
 
     if boundary in (None, 'fill'):
         assert_array_almost_equal_nulp(z, np.array([6., 10., 2.], dtype='float'), 10)

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -55,7 +55,7 @@ class Test2DConvolutions:
         shape = kernel.array.shape
 
         x = np.zeros(shape)
-        xslice = [slice(sh // 2, sh // 2 + 1) for sh in shape]
+        xslice = tuple([slice(sh // 2, sh // 2 + 1) for sh in shape])
         x[xslice] = 1.0
 
         c2 = convolve_fft(x, kernel, boundary='fill')
@@ -94,7 +94,7 @@ class Test2DConvolutions:
         kernel = np.ones([width, width])
 
         x = np.zeros(shape)
-        xslice = [slice(sh // 2, sh // 2 + 1) for sh in shape]
+        xslice = tuple([slice(sh // 2, sh // 2 + 1) for sh in shape])
         x[xslice] = 1.0
 
         c2 = convolve_fft(x, kernel, boundary='fill')
@@ -114,7 +114,7 @@ class Test2DConvolutions:
         kernel2 = Box2DKernel(width, mode='oversample', factor=10)
 
         x = np.zeros(shape)
-        xslice = [slice(sh // 2, sh // 2 + 1) for sh in shape]
+        xslice = tuple([slice(sh // 2, sh // 2 + 1) for sh in shape])
         x[xslice] = 1.0
 
         c2 = convolve_fft(x, kernel2, boundary='fill')

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import itertools
+import warnings
 
 import pytest
 import numpy as np
@@ -15,7 +16,7 @@ from ..kernels import (
 
 from ..utils import KernelSizeError
 from ...modeling.models import Box2D, Gaussian1D, Gaussian2D
-from ...utils.exceptions import AstropyDeprecationWarning
+from ...utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from ...tests.helper import catch_warnings
 
 try:
@@ -316,8 +317,12 @@ class TestKernels:
         sums to zero.
         """
         array = [-2, -1, 0, 1, 2]
-        custom = CustomKernel(array)
-        custom.normalize()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            custom = CustomKernel(array)
+            custom.normalize()
+
         assert custom.truncation == 0.
         assert custom._kernel_sum == 0.
 
@@ -327,8 +332,12 @@ class TestKernels:
         sums to zero.
         """
         array = [[0, -1, 0], [-1, 4, -1], [0, -1, 0]]
-        custom = CustomKernel(array)
-        custom.normalize()
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyUserWarning)
+            custom = CustomKernel(array)
+            custom.normalize()
+
         assert custom.truncation == 0.
         assert custom._kernel_sum == 0.
 

--- a/docs/convolution/kernels.rst
+++ b/docs/convolution/kernels.rst
@@ -243,10 +243,13 @@ Furthermore two kernels can be convolved with each other, which is useful when
 data is filtered with two different kinds of kernels or to create a new,
 special kernel:
 
+>>> import warnings
 >>> from astropy.convolution import Gaussian1DKernel, convolve
 >>> gauss_1 = Gaussian1DKernel(10)
 >>> gauss_2 = Gaussian1DKernel(16)
->>> broad_gaussian = convolve(gauss_2,  gauss_1)
+>>> with warnings.catch_warnings():
+...     warnings.simplefilter('ignore')  # Ignore warning for doctest
+...     broad_gaussian = convolve(gauss_2,  gauss_1)
 
 Or in case of multistage smoothing:
 
@@ -266,7 +269,9 @@ You would rather do the following:
 
 >>> gauss = Gaussian1DKernel(3)
 >>> box = Box1DKernel(5)
->>> smoothed_gauss_box = convolve(data_1D, convolve(box, gauss))
+>>> with warnings.catch_warnings():
+...     warnings.simplefilter('ignore')  # Ignore warning for doctest
+...     smoothed_gauss_box = convolve(data_1D, convolve(box, gauss))
 
 Which, in most cases, will also be faster than the first method, because only
 one convolution with the, most times, larger data array will be necessary.


### PR DESCRIPTION
This PR gets rid of *most* of the warnings seen when removing `addopts = -p no:warnings` in `setup.cfg` and then running `python setup.py test -P convolution --remote-data`.

These still exist because I am not sure how to handle them:
```
=============================== warnings summary ===============================
astropy/convolution/tests/test_convolve.py::TestConvolve1D::()::test_list
  .../importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
    return f(*args, **kwds)

astropy/convolution/tests/test_convolve.py::test_astropy_convolution_against_scipy
  .../importlib/_bootstrap.py:219: ImportWarning: can't resolve package from __spec__ or __package__, falling back on __name__ and __path__
    return f(*args, **kwds)

docs/convolution/kernels.rst
  .../re.py:212: FutureWarning: split() requires a non-empty pattern match.
    return _compile(pattern, flags).split(string, maxsplit)

-- Docs: http://doc.pytest.org/en/latest/warnings.html
======= 1078 passed, 2 skipped, 14 xfailed, 3 warnings in 10.65 seconds ========
```

The `ImportWarning` is probably same as #6025. As for the `re` warning, it is astropy/pytest-doctestplus#29.

Also see #7928 