### PR TITLE
Fix how coordinates handles negative or nan parallaxes/distances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -315,9 +315,13 @@ astropy.coordinates
 
 - Changed the name of the single argument to ``Frame.realize_frame()`` from the
   (incorrect) ``representation_type`` to ``data``. [#7923]
+
 - Negative parallaxes passed to ``Distance()`` now raise an error by default
   (``allow_negative=False``), or are converted to NaN values with a warning
   (``allow_negative=True``). [#7988]
+
+- Negating a ``SphericalRepresentation`` object now changes the angular
+  coordinates (by rotating 180º) instead of negating the distance. [#7988]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -315,6 +315,9 @@ astropy.coordinates
 
 - Changed the name of the single argument to ``Frame.realize_frame()`` from the
   (incorrect) ``representation_type`` to ``data``. [#7923]
+- Negative parallaxes passed to ``Distance()`` now raise an error by default
+  (``allow_negative=False``), or are converted to NaN values with a warning
+  (``allow_negative=True``). [#7988]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
@@ -436,6 +439,9 @@ astropy.units
   ``units``, the default for ``include_prefix_units`` is set to
   `True`, so that no units get ignored. [#6957]
 
+- Negative parallaxes are now converted to NaN values when using the
+  ``parallax`` equivalency. [#7988]
+
 astropy.utils
 ^^^^^^^^^^^^^
 
@@ -541,6 +547,12 @@ astropy.coordinates
 - ``EarthLocation.of_address`` now uses the OpenStreetMap geocoding API by
   default to retrieve coordinates, with the Google API (which now requires an
   API key) as an option. [#7918]
+
+- Fixed a bug that caused frame objects with NaN distances to have NaN sky
+  positions, even if valid sky coordinates were specified. [#7988]
+
+- Fixed ``represent_as()`` to not round-trip through cartesian if the same
+  representation class as the instance is passed in. [#7988]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -161,10 +161,13 @@ class Distance(u.SpecificTypeQuantity):
                             "into distances. See discussion in this paper: "
                             "https://arxiv.org/abs/1507.02105", AstropyWarning)
                     else:
-                        raise ValueError("Negative parallaxes are not "
-                                         "interpretable as distances. If you "
-                                         "want to have these values turned "
-                                         "into NaN values, use the "
+                        raise ValueError("Some parallaxes are negative, which "
+                                         "are notinterpretable as distances. "
+                                         "See the discussion in this paper: "
+                                         "https://arxiv.org/abs/1507.02105 . "
+                                         "If you want parallaxes to pass "
+                                         "through, with negative parallaxes "
+                                         "instead becoming NaN, use the "
                                          "`allow_negative=True` argument.")
 
             elif value is None:

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -5,9 +5,12 @@ This module contains the classes and utility functions for distance and
 cartesian coordinates.
 """
 
+import warnings
+
 import numpy as np
 
 from .. import units as u
+from ..utils.exceptions import AstropyWarning
 from .angles import Angle
 
 __all__ = ['Distance']
@@ -142,12 +145,27 @@ class Distance(u.SpecificTypeQuantity):
                 copy = False
 
             elif parallax is not None:
-                value = parallax.to(u.pc, equivalencies=u.parallax()).value
+                value = parallax.to_value(u.pc, equivalencies=u.parallax())
                 unit = u.pc
 
                 # Continue on to take account of unit and other arguments
                 # but a copy is already made, so no longer necessary
                 copy = False
+
+                if np.any(parallax < 0) and not allow_negative:
+                    raise ValueError('Negative parallaxes are not interpretable'
+                                     ' as distances. If you want to have these '
+                                     'values turned into NaN values, use the '
+                                     '`allow_negative=True` argument.')
+
+                elif np.any(parallax < 0) and allow_negative:
+                    warnings.warn("Negative parallaxes are converted to NaN "
+                                  "distances even when `allow_negative=True`, "
+                                  "because negative parallaxes cannot be "
+                                  "transformed into distances. See discussion "
+                                  "in this paper: "
+                                  "https://arxiv.org/abs/1507.02105",
+                                  AstropyWarning)
 
             elif value is None:
                 raise ValueError('None of `value`, `z`, `distmod`, or '

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -152,20 +152,20 @@ class Distance(u.SpecificTypeQuantity):
                 # but a copy is already made, so no longer necessary
                 copy = False
 
-                if np.any(parallax < 0) and not allow_negative:
-                    raise ValueError('Negative parallaxes are not interpretable'
-                                     ' as distances. If you want to have these '
-                                     'values turned into NaN values, use the '
-                                     '`allow_negative=True` argument.')
-
-                elif np.any(parallax < 0) and allow_negative:
-                    warnings.warn("Negative parallaxes are converted to NaN "
-                                  "distances even when `allow_negative=True`, "
-                                  "because negative parallaxes cannot be "
-                                  "transformed into distances. See discussion "
-                                  "in this paper: "
-                                  "https://arxiv.org/abs/1507.02105",
-                                  AstropyWarning)
+                if np.any(parallax < 0):
+                    if allow_negative:
+                        warnings.warn(
+                            "Negative parallaxes are converted to NaN "
+                            "distances even when `allow_negative=True`, "
+                            "because negative parallaxes cannot be transformed "
+                            "into distances. See discussion in this paper: "
+                            "https://arxiv.org/abs/1507.02105", AstropyWarning)
+                    else:
+                        raise ValueError("Negative parallaxes are not "
+                                         "interpretable as distances. If you "
+                                         "want to have these values turned "
+                                         "into NaN values, use the "
+                                         "`allow_negative=True` argument.")
 
             elif value is None:
                 raise ValueError('None of `value`, `z`, `distmod`, or '

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1566,7 +1566,13 @@ class SphericalRepresentation(BaseRepresentation):
         super().__init__(lon, lat, distance, copy=copy,
                          differentials=differentials)
         if self._distance.unit.physical_type == 'length':
-            self._distance = self._distance.view(Distance)
+            try:
+                self._distance = Distance(self._distance, copy=False)
+            except ValueError:
+                raise ValueError("Distance must be >= 0. To allow negative "
+                                 "distance values, you must explicitly pass "
+                                 "in a `Distance` object with the the argument "
+                                 "'allow_negative=True'.")
 
     @property
     def _compatible_differentials(self):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1676,6 +1676,11 @@ class SphericalRepresentation(BaseRepresentation):
         """
         return np.abs(self.distance)
 
+    def __neg__(self):
+        self._raise_if_has_differentials('negation')
+        return self.__class__(self.lon + 180. * u.deg, -self.lat, self.distance,
+                              copy=False)
+
 
 class PhysicsSphericalRepresentation(BaseRepresentation):
     """

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -1568,11 +1568,14 @@ class SphericalRepresentation(BaseRepresentation):
         if self._distance.unit.physical_type == 'length':
             try:
                 self._distance = Distance(self._distance, copy=False)
-            except ValueError:
-                raise ValueError("Distance must be >= 0. To allow negative "
-                                 "distance values, you must explicitly pass "
-                                 "in a `Distance` object with the the argument "
-                                 "'allow_negative=True'.")
+            except ValueError as e:
+                if e.args[0].startswith('Distance must be >= 0'):
+                    raise ValueError("Distance must be >= 0. To allow negative "
+                                     "distance values, you must explicitly pass"
+                                     " in a `Distance` object with the the "
+                                     "argument 'allow_negative=True'.")
+                else:
+                    raise
 
     @property
     def _compatible_differentials(self):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -685,8 +685,11 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
                                  "must be a class, not a string. For "
                                  "strings, use frame objects")
 
-            # The default is to convert via cartesian coordinates
-            new_rep = other_class.from_cartesian(self.to_cartesian())
+            if other_class is not self.__class__:
+                # The default is to convert via cartesian coordinates
+                new_rep = other_class.from_cartesian(self.to_cartesian())
+            else:
+                new_rep = self
 
             new_rep._differentials = self._re_represent_differentials(
                 new_rep, differential_class)

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -14,6 +14,8 @@ from ... import units as u
 from ...units import allclose as quantity_allclose
 from .. import Longitude, Latitude, Distance, CartesianRepresentation
 from ..builtin_frames import ICRS, Galactic
+from ...tests.helper import catch_warnings
+from ...utils.exceptions import AstropyWarning
 
 try:
     import scipy  # pylint: disable=W0611
@@ -225,6 +227,21 @@ def test_parallax():
     d = Distance(parallax=plx)
     assert quantity_allclose(d.pc, [1000., 100., 10.])
     assert quantity_allclose(plx, d.parallax)
+
+    # check behavior for negative parallax
+    with pytest.raises(ValueError):
+        Distance(parallax=-1 * u.mas)
+
+    with pytest.raises(ValueError):
+        Distance(parallax=[10, 1, -1] * u.mas)
+
+    with catch_warnings(AstropyWarning) as w:
+        Distance(parallax=-1 * u.mas, allow_negative=True)
+    assert len(w) > 0
+
+    with catch_warnings(AstropyWarning) as w:
+        Distance(parallax=[10, 1, -1] * u.mas, allow_negative=True)
+    assert len(w) > 0
 
 def test_distance_in_coordinates():
     """

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -243,6 +243,7 @@ def test_parallax():
         Distance(parallax=[10, 1, -1] * u.mas, allow_negative=True)
     assert len(w) > 0
 
+
 def test_distance_in_coordinates():
     """
     test that distances can be created from quantities and that cartesian

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -281,3 +281,23 @@ def test_shorthand_attributes():
                  representation_type=r.CartesianRepresentation,
                  differential_type=r.CartesianDifferential)
     icrs4.radial_velocity
+
+
+def test_negative_distance():
+    """ Regression test: #7408
+    Make sure that negative parallaxes turned into distances are handled right
+    """
+
+    RA = 150 * u.deg
+    DEC = -11*u.deg
+    c = ICRS(ra=RA, dec=DEC,
+             distance=(-10*u.mas).to(u.pc, u.parallax()),
+             pm_ra_cosdec=10*u.mas/u.yr,
+             pm_dec=10*u.mas/u.yr)
+    assert quantity_allclose(c.ra, RA)
+    assert quantity_allclose(c.dec, DEC)
+
+    c = ICRS(ra=RA, dec=DEC,
+             distance=(-10*u.mas).to(u.pc, u.parallax()))
+    assert quantity_allclose(c.ra, RA)
+    assert quantity_allclose(c.dec, DEC)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -194,6 +194,23 @@ class TestSphericalRepresentation:
             len(s)
         assert not isiterable(s)
 
+    def test_nan_distance(self):
+        """ This is a regression test: calling represent_as() and passing in the
+            same class as the object shouldn't round-trip through cartesian.
+        """
+
+        sph = SphericalRepresentation(1*u.deg, 2*u.deg, np.nan*u.kpc)
+        new_sph = sph.represent_as(SphericalRepresentation)
+        assert_allclose_quantity(new_sph.lon, sph.lon)
+        assert_allclose_quantity(new_sph.lat, sph.lat)
+
+        dif = SphericalCosLatDifferential(1*u.mas/u.yr, 2*u.mas/u.yr,
+                                          3*u.km/u.s)
+        sph = sph.with_differentials(dif)
+        new_sph = sph.represent_as(SphericalRepresentation)
+        assert_allclose_quantity(new_sph.lon, sph.lon)
+        assert_allclose_quantity(new_sph.lat, sph.lat)
+
 
 class TestUnitSphericalRepresentation:
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1514,3 +1514,13 @@ def test_unitphysics(unitphysics):
     assert assph.lon == obj.phi
     assert assph.lat == 80*u.deg
     assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)
+
+
+def test_distance_warning(recwarn):
+    SphericalRepresentation(1*u.deg, 2*u.deg, 1*u.kpc)
+    with pytest.raises(ValueError) as excinfo:
+        SphericalRepresentation(1*u.deg, 2*u.deg, -1*u.kpc)
+    assert 'Distance must be >= 0' in str(excinfo.value)
+    # second check is because the "originating" ValueError says the above,
+    # while the representation one includes the below
+    assert 'you must explicitly pass' in str(excinfo.value)

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -15,7 +15,7 @@ from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 RadialRepresentation, RadialDifferential, Longitude, Latitude)
 from ..representation import DIFFERENTIAL_CLASSES
 from ..angle_utilities import angular_separation
-from ...tests.helper import assert_quantity_allclose
+from ...tests.helper import assert_quantity_allclose, quantity_allclose
 
 
 def assert_representation_allclose(actual, desired, rtol=1.e-7, atol=None,
@@ -120,9 +120,10 @@ class TestArithmetic():
         assert np.all(representation_equal(s3, s2))
         s4 = -self.spherical
         assert isinstance(s4, SphericalRepresentation)
-        assert np.all(s4.lon == self.spherical.lon)
-        assert np.all(s4.lat == self.spherical.lat)
-        assert np.all(s4.distance == -self.spherical.distance)
+        assert quantity_allclose(s4.to_cartesian().xyz,
+                                 -self.spherical.to_cartesian().xyz,
+                                 atol=1e-15*self.spherical.distance.unit)
+        assert np.all(s4.distance == self.spherical.distance)
         s5 = +self.spherical
         assert s5 is not self.spherical
         assert np.all(representation_equal(s5, self.spherical))

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -7,6 +7,7 @@ import warnings
 
 # LOCAL
 from ..constants import si as _si
+from ..utils.misc import isiterable
 from . import si
 from . import cgs
 from . import astrophys
@@ -46,8 +47,23 @@ def parallax():
     Returns a list of equivalence pairs that handle the conversion
     between parallax angle and distance.
     """
+
+    def parallax_converter(x):
+        x = np.asanyarray(x)
+        d = 1 / x
+
+        if isiterable(d):
+            d[d < 0] = np.nan
+            return d
+
+        else:
+            if d < 0:
+                return np.array(np.nan)
+            else:
+                return d
+
     return [
-        (si.arcsecond, astrophys.parsec, lambda x: 1. / x)
+        (si.arcsecond, astrophys.parsec, parallax_converter)
     ]
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -227,6 +227,12 @@ def test_parallax():
     b = u.au.to(u.arcminute, a, u.parallax())
     assert_allclose(b, 1)
 
+    val = (-1 * u.mas).to(u.pc, u.parallax())
+    assert np.isnan(val.value)
+
+    val = (-1 * u.mas).to_value(u.pc, u.parallax())
+    assert np.isnan(val)
+
 
 def test_parallax2():
     a = u.arcsecond.to(u.pc, [0.1, 2.5], u.parallax())


### PR DESCRIPTION
This addresses a few issues related to how negative parallaxes / distances are handled in coordinates.

### with master:

![image](https://user-images.githubusercontent.com/583379/47588378-04fcc000-d934-11e8-9693-7523fddaf4c5.png)

### with this PR:

![image](https://user-images.githubusercontent.com/583379/47588404-1645cc80-d934-11e8-8807-ea09212c81fa.png)

Fixes #7408 