### PR TITLE
TST: Ignore coordinates test warnings

### DIFF
--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -8,7 +8,8 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from ..angles import Longitude, Latitude, Angle
 from ... import units as u
-from ..errors import IllegalSecondError, IllegalMinuteError, IllegalHourError
+from ..errors import (IllegalSecondError, IllegalMinuteError, IllegalHourError,
+                      IllegalSecondWarning, IllegalMinuteWarning)
 
 
 def test_create_angles():
@@ -458,48 +459,56 @@ def test_negative_zero_hm():
 
 def test_negative_sixty_hm():
     # Test for HM parser
-    a = Angle('-00:60', u.hour)
+    with pytest.warns(IllegalMinuteWarning):
+        a = Angle('-00:60', u.hour)
     assert_allclose(a.hour, -1.)
 
 
 def test_plus_sixty_hm():
     # Test for HM parser
-    a = Angle('00:60', u.hour)
+    with pytest.warns(IllegalMinuteWarning):
+        a = Angle('00:60', u.hour)
     assert_allclose(a.hour, 1.)
 
 
 def test_negative_fifty_nine_sixty_dms():
     # Test for DMS parser
-    a = Angle('-00:59:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('-00:59:60', u.deg)
     assert_allclose(a.degree, -1.)
 
 
 def test_plus_fifty_nine_sixty_dms():
     # Test for DMS parser
-    a = Angle('+00:59:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('+00:59:60', u.deg)
     assert_allclose(a.degree, 1.)
 
 
 def test_negative_sixty_dms():
     # Test for DMS parser
-    a = Angle('-00:00:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('-00:00:60', u.deg)
     assert_allclose(a.degree, -1. / 60.)
 
 
 def test_plus_sixty_dms():
     # Test for DMS parser
-    a = Angle('+00:00:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('+00:00:60', u.deg)
     assert_allclose(a.degree, 1. / 60.)
 
 
 def test_angle_to_is_angle():
-    a = Angle('00:00:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('00:00:60', u.deg)
     assert isinstance(a, Angle)
     assert isinstance(a.to(u.rad), Angle)
 
 
 def test_angle_to_quantity():
-    a = Angle('00:00:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('00:00:60', u.deg)
     q = u.Quantity(a)
     assert isinstance(q, u.Quantity)
     assert q.unit is u.deg
@@ -518,7 +527,8 @@ def test_quantity_to_angle():
 
 
 def test_angle_string():
-    a = Angle('00:00:60', u.deg)
+    with pytest.warns(IllegalSecondWarning):
+        a = Angle('00:00:60', u.deg)
     assert str(a) == '0d01m00s'
     a = Angle('-00:00:10', u.hour)
     assert str(a) == '-0h00m10s'
@@ -843,6 +853,7 @@ def test_wrap_at_without_new():
     l = np.concatenate([l1, l2])
     assert l._wrap_angle is not None
 
+
 def test__str__():
     """
     Check the __str__ method used in printing the Angle
@@ -862,6 +873,7 @@ def test__str__():
     # summarizing for large arrays, ... should appear
     bigarrangle = Angle(np.ones(10000), u.deg)
     assert '...' in bigarrangle.__str__()
+
 
 def test_repr_latex():
     """

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
-
 """
 This includes tests for the Distance class and related calculations
 """
@@ -129,10 +127,10 @@ def test_distances_scipy():
     npt.assert_allclose(d6.value, 3.5417046898762366e+22)
 
     with pytest.raises(ValueError):
-        d7 = Distance(cosmology=WMAP5, unit=u.km)
+        Distance(cosmology=WMAP5, unit=u.km)
 
     with pytest.raises(ValueError):
-        d8 = Distance()
+        Distance()
 
 
 def test_distance_change():

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -131,7 +131,8 @@ def test_python_kdtree(monkeypatch):
     ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 2, 3, 4]*u.kpc)
 
     monkeypatch.delattr("scipy.spatial.cKDTree")
-    matching.match_coordinates_sky(cmatch, ccatalog)
+    with pytest.warns(UserWarning, match='C-based KD tree not found'):
+        matching.match_coordinates_sky(cmatch, ccatalog)
 
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1043,13 +1043,10 @@ def test_subclass_representation():
                                    **kwargs)
             return self
 
-    with pytest.warns(AstropyDeprecationWarning,
-                      match="'recommended_units' attribute is deprecated"):
-        class SphericalWrap180Representation(SphericalRepresentation):
-            attr_classes = OrderedDict([('lon', Longitude180),
-                                        ('lat', Latitude),
-                                        ('distance', u.Quantity)])
-            recommended_units = {'lon': u.deg, 'lat': u.deg}
+    class SphericalWrap180Representation(SphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude),
+                                    ('distance', u.Quantity)])
 
     class ICRSWrap180(ICRS):
         frame_specific_representation_info = ICRS._frame_specific_representation_info.copy()

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1043,11 +1043,13 @@ def test_subclass_representation():
                                    **kwargs)
             return self
 
-    class SphericalWrap180Representation(SphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude),
-                                    ('distance', u.Quantity)])
-        recommended_units = {'lon': u.deg, 'lat': u.deg}
+    with pytest.warns(AstropyDeprecationWarning,
+                      match="'recommended_units' attribute is deprecated"):
+        class SphericalWrap180Representation(SphericalRepresentation):
+            attr_classes = OrderedDict([('lon', Longitude180),
+                                        ('lat', Latitude),
+                                        ('distance', u.Quantity)])
+            recommended_units = {'lon': u.deg, 'lat': u.deg}
 
     class ICRSWrap180(ICRS):
         frame_specific_representation_info = ICRS._frame_specific_representation_info.copy()

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -1,9 +1,10 @@
 """
 This file tests the behavior of subclasses of Representation and Frames
 """
-
 from copy import deepcopy
 from collections import OrderedDict
+
+import pytest
 
 from astropy.coordinates import Longitude, Latitude
 from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
@@ -14,8 +15,7 @@ from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates import ICRS
 from astropy.coordinates.baseframe import RepresentationMapping
-
-from .. import representation as r
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 import astropy.units as u
 
@@ -45,18 +45,20 @@ def test_unit_representation_subclass():
                                    **kwargs)
             return self
 
-    class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude)])
-        recommended_units = {'lon': u.deg, 'lat': u.deg}
+    with pytest.warns(AstropyDeprecationWarning,
+                      match="The 'recommended_units' attribute is deprecated"):
+        class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
+            attr_classes = OrderedDict([('lon', Longitude180),
+                                        ('lat', Latitude)])
+            recommended_units = {'lon': u.deg, 'lat': u.deg}
 
-    class SphericalWrap180Representation(SphericalRepresentation):
-        attr_classes = OrderedDict([('lon', Longitude180),
-                                    ('lat', Latitude),
-                                    ('distance', u.Quantity)])
-        recommended_units = {'lon': u.deg, 'lat': u.deg}
+        class SphericalWrap180Representation(SphericalRepresentation):
+            attr_classes = OrderedDict([('lon', Longitude180),
+                                        ('lat', Latitude),
+                                        ('distance', u.Quantity)])
+            recommended_units = {'lon': u.deg, 'lat': u.deg}
 
-        _unit_representation = UnitSphericalWrap180Representation
+            _unit_representation = UnitSphericalWrap180Representation
 
     class MyFrame(ICRS):
         default_representation = SphericalWrap180Representation

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -4,8 +4,6 @@ This file tests the behavior of subclasses of Representation and Frames
 from copy import deepcopy
 from collections import OrderedDict
 
-import pytest
-
 from astropy.coordinates import Longitude, Latitude
 from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                                                 SphericalRepresentation,
@@ -15,7 +13,6 @@ from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates import ICRS
 from astropy.coordinates.baseframe import RepresentationMapping
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 import astropy.units as u
 
@@ -45,20 +42,16 @@ def test_unit_representation_subclass():
                                    **kwargs)
             return self
 
-    with pytest.warns(AstropyDeprecationWarning,
-                      match="The 'recommended_units' attribute is deprecated"):
-        class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
-            attr_classes = OrderedDict([('lon', Longitude180),
-                                        ('lat', Latitude)])
-            recommended_units = {'lon': u.deg, 'lat': u.deg}
+    class UnitSphericalWrap180Representation(UnitSphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude)])
 
-        class SphericalWrap180Representation(SphericalRepresentation):
-            attr_classes = OrderedDict([('lon', Longitude180),
-                                        ('lat', Latitude),
-                                        ('distance', u.Quantity)])
-            recommended_units = {'lon': u.deg, 'lat': u.deg}
+    class SphericalWrap180Representation(SphericalRepresentation):
+        attr_classes = OrderedDict([('lon', Longitude180),
+                                    ('lat', Latitude),
+                                    ('distance', u.Quantity)])
 
-            _unit_representation = UnitSphericalWrap180Representation
+        _unit_representation = UnitSphericalWrap180Representation
 
     class MyFrame(ICRS):
         default_representation = SphericalWrap180Representation


### PR DESCRIPTION
This PR gets rid of *most* of the warnings seen when removing `addopts = -p no:warnings` in `setup.cfg` and then running `python setup.py test -P coordinates --remote-data`.

These still exist because I am not sure how to handle them:

* `ImportWarning` that is probably same as #6025
* `re` warning from astropy/pytest-doctestplus#29
* `ResourceWarning` as reported in https://github.com/astropy/astropy/issues/7913#issuecomment-433523946

Also see #7928