### PR TITLE
Fix bug in setting `TimeDelta` array item with pure floats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -204,6 +204,7 @@ astropy.time
 
 - Added ``datetime64`` format to the ``Time`` class to support working with
   ``numpy.datetime64`` dtype arrays. [#7361]
+
 - Add fractional second support for ``strftime`` and ``strptime`` methods
   of ``Time`` class. [#7705]
 
@@ -611,6 +612,10 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
+
+- Fix a bug when setting a ``TimeDelta`` array item with plain float value(s).
+  This was always interpreted as a JD (day) value regardless of the
+  ``TimeDelta`` format. [#7990]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2025,13 +2025,10 @@ class TimeDelta(Time):
         """Coerce setitem value into an equivalent TimeDelta object"""
         if not isinstance(value, TimeDelta):
             try:
-                value = self.__class__(value, scale=self.scale)
-            except Exception:
-                try:
-                    value = self.__class__(value, scale=self.scale, format=self.format)
-                except Exception as err:
-                    raise ValueError('cannot convert value to a compatible TimeDelta '
-                                     'object: {}'.format(err))
+                value = self.__class__(value, scale=self.scale, format=self.format)
+            except Exception as err:
+                raise ValueError('cannot convert value to a compatible TimeDelta '
+                                 'object: {}'.format(err))
         return value
 
 

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -504,6 +504,26 @@ def test_timedelta_setitem():
     assert 'cannot convert value to a compatible TimeDelta' in str(err)
 
 
+def test_timedelta_setitem_sec():
+    t = TimeDelta([1, 2, 3], format='sec')
+
+    t[0] = 0.5
+    assert allclose_jd(t.value, [0.5, 2, 3])
+
+    t[1:] = 4.5
+    assert allclose_jd(t.value, [0.5, 4.5, 4.5])
+
+    t[:] = 1 * u.day
+    assert allclose_jd(t.value, [86400, 86400, 86400])
+
+    t[1] = TimeDelta(2, format='jd')
+    assert allclose_jd(t.value, [86400, 86400 * 2, 86400])
+
+    with pytest.raises(ValueError) as err:
+        t[1] = 1 * u.m
+    assert 'cannot convert value to a compatible TimeDelta' in str(err)
+
+
 def test_timedelta_mask():
     t = TimeDelta([1, 2] * u.d, format='jd')
     t[1] = np.ma.masked


### PR DESCRIPTION
Previously:
```
tm = TimeDelta([2, 3], format='sec')
tm[0] = 1  # According to docs this should be 1 sec, but it got taken as 1 day
```
Now that plain `1` is taken in accord with the format of the object.  This is consistent with behavior for `Time` objects (e.g. for `unix` or `cxcsec` or `jd` formats).