### PR TITLE
Add upper limit to number of bins in hist and refactor bin edge calculation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1497,6 +1497,10 @@ astropy.visualization
 - Fixed a bug that caused an error when plotting grids multiple times
   with grid_type='contours'. [#7927]
 
+- Put an upper limit on the number of bins in ``hist`` and ``histogram`` and
+  factor out calculation of bin edges into public function
+  ``calculate_bin_edges``. [#7991]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -31,7 +31,7 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
 
     range : tuple or None (optional)
         The minimum and maximum range for the histogram.  If not specified,
-        it will be (x.min(), x.max()). However, if bins is a list it is
+        it will be (a.min(), a.max()). However, if bins is a list it is
         returned unmodified regardless of the range argument.
 
     weights : array_like, optional

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -13,7 +13,32 @@ __all__ = ['histogram', 'scott_bin_width', 'freedman_bin_width',
            'knuth_bin_width']
 
 
-def _calculate_bin_edges(a, bins=10, range=None, weights=None):
+def calculate_bin_edges(a, bins=10, range=None, weights=None):
+    """
+    Calculate histogram bin edges like `numpy.histogram_bin_edges`.
+
+    Parameters
+    ----------
+
+    a : array_like
+        Input data. The bin edges are calculated over the flattened array.
+
+    bins : int or list or str (optional)
+        If ``bins`` is an int, it is the number of bins. If it is a list
+        it is taken to be the bin edges. If it is a string, it must be one
+        of  'blocks', 'knuth', 'scott' or 'freedman'. See
+        `~astropy.stats.histogram` for a description of each method.
+
+    range : tuple or None (optional)
+        the minimum and maximum range for the histogram.  If not specified,
+        it will be (x.min(), x.max())
+
+    weights : array_like, optional
+        An array the same shape as ``a``. If given, the histogram accumulates
+        the value of the weight corresponding to ``a`` instead of returning the
+        count of values. This argument does not affect determination of bin
+        edges.
+    """
     # if range is specified, we need to truncate the data for
     # the bin-finding routines
     if range is not None:
@@ -88,7 +113,10 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
         it will be (x.min(), x.max())
 
     weights : array_like, optional
-        Not Implemented
+        An array the same shape as ``a``. If given, the histogram accumulates
+        the value of the weight corresponding to ``a`` instead of returning the
+        count of values. This argument does not affect determination of bin
+        edges.
 
     other keyword arguments are described in numpy.histogram().
 

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -30,8 +30,9 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
         `~astropy.stats.histogram` for a description of each method.
 
     range : tuple or None (optional)
-        the minimum and maximum range for the histogram.  If not specified,
-        it will be (x.min(), x.max())
+        The minimum and maximum range for the histogram.  If not specified,
+        it will be (x.min(), x.max()). However, if bins is a list it is
+        returned unmodified regardless of the range argument.
 
     weights : array_like, optional
         An array the same shape as ``a``. If given, the histogram accumulates
@@ -64,6 +65,17 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
             da, bins = freedman_bin_width(a, True)
         else:
             raise ValueError("unrecognized bin code: '{}'".format(bins))
+
+        if range:
+            # Check that the upper and lower edges are what was requested.
+            # The current implementation of the bin width estimators does not
+            # guarantee this, it only ensures that data outside the range is
+            # excluded from calculation of the bin widths.
+            if bins[0] != range[0]:
+                bins[0] = range[0]
+            if bins[-1] != range[1]:
+                bins[-1] = range[1]
+
     elif np.ndim(bins) == 0:
         # Number of bins was given
         try:
@@ -80,16 +92,6 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
                 lower = a.min()
                 upper = a.max()
             bins = np.linspace(lower, upper, bins + 1, endpoint=True)
-
-    if range:
-        # Check that the upper and lower edges are what was requested.
-        # The current implementation of the bin width estimators does not
-        # guarantee this, it only ensures that data outside the range is
-        # excluded from calculation of the bin widths.
-        if bins[0] != range[0]:
-            bins[0] = range[0]
-        if bins[-1] != range[1]:
-            bins[-1] = range[1]
 
     return bins
 

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -38,7 +38,7 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
         An array the same shape as ``a``. If given, the histogram accumulates
         the value of the weight corresponding to ``a`` instead of returning the
         count of values. This argument does not affect determination of bin
-        edges.
+        edges, though they may be used in the future as new methods are added.
     """
     # if range is specified, we need to truncate the data for
     # the bin-finding routines

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -10,7 +10,7 @@ import numpy as np
 from . import bayesian_blocks
 
 __all__ = ['histogram', 'scott_bin_width', 'freedman_bin_width',
-           'knuth_bin_width']
+           'knuth_bin_width', 'calculate_bin_edges']
 
 
 def calculate_bin_edges(a, bins=10, range=None, weights=None):
@@ -133,7 +133,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     numpy.histogram
     """
 
-    bins = _calculate_bin_edges(a, bins=bins, range=range, weights=weights)
+    bins = calculate_bin_edges(a, bins=bins, range=range, weights=weights)
     # Now we call numpy's histogram with the resulting bin edges
     return np.histogram(a, bins=bins, range=range, weights=weights, **kwargs)
 

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -81,6 +81,16 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
                 upper = a.max()
             bins = np.linspace(lower, upper, bins + 1, endpoint=True)
 
+    if range:
+        # Check that the upper and lower edges are what was requested.
+        # The current implementation of the bin width estimators does not
+        # guarantee this, it only ensures that data outside the range is
+        # excluded from calculation of the bin widths.
+        if bins[0] != range[0]:
+            bins[0] = range[0]
+        if bins[-1] != range[1]:
+            bins[-1] = range[1]
+
     return bins
 
 

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -81,7 +81,10 @@ def test_knuth_histogram(N=1000, rseed=0):
     assert (len(counts) == len(bins) - 1)
 
 
-_bin_types_to_test = [30, 'scott', 'freedman', 'blocks', 'knuth']
+_bin_types_to_test = [30, 'scott', 'freedman', 'blocks']
+
+if HAS_SCIPY:
+    _bin_types_to_test += ['knuth']
 
 
 @pytest.mark.parametrize('bin_type',

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -4,7 +4,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import histogram, scott_bin_width, freedman_bin_width, knuth_bin_width
+from .. import (histogram, calculate_bin_edges,
+                scott_bin_width, freedman_bin_width, knuth_bin_width)
 
 try:
     import scipy  # pylint: disable=W0611
@@ -99,7 +100,7 @@ def test_histogram_range(bin_type, N=1000, rseed=0):
     x = rng.randn(N)
     range = (0.1, 0.8)
 
-    counts, bins = histogram(x, bin_type, range=range)
+    bins = calculate_bin_edges(x, bin_type, range=range)
     assert bins.max() == range[1]
     assert bins.min() == range[0]
 

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -91,13 +91,17 @@ def test_histogram(N=1000, rseed=0):
         assert (len(counts) == len(bins) - 1)
 
 
-def test_histogram_range(N=1000, rseed=0):
+@pytest.mark.parametrize('bin_type',
+                         ['scott', 'freedman', 'blocks', 'knuth', 10])
+def test_histogram_range(bin_type, N=1000, rseed=0):
+    # Regression test for #8010
     rng = np.random.RandomState(rseed)
     x = rng.randn(N)
     range = (0.1, 0.8)
 
-    for bins in ['scott', 'freedman', 'blocks']:
-        counts, bins = histogram(x, bins, range=range)
+    counts, bins = histogram(x, bin_type, range=range)
+    assert bins.max() == range[1]
+    assert bins.min() == range[0]
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 from inspect import signature
-from ..stats import histogram
+from ..stats.histogram import _calculate_bin_edges
 
 __all__ = ['hist']
 
 
-def hist(x, bins=10, ax=None, **kwargs):
+def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     """Enhanced histogram function
 
     This is a histogram function that enables the use of more sophisticated
@@ -38,6 +38,12 @@ def hist(x, bins=10, ax=None, **kwargs):
         specify the Axes on which to draw the histogram.  If not specified,
         then the current active axes will be used.
 
+    max_bins : int (optional)
+        Maximum number of bins allowed. With more than a few thousand bins
+        the performance of matplotlib will not be great. If the number of
+        bins is large *and* the number of input data points is large then
+        the it will take a very long time to compute the histogram.
+
     **kwargs :
         other keyword arguments are described in ``plt.hist()``.
 
@@ -49,10 +55,14 @@ def hist(x, bins=10, ax=None, **kwargs):
     --------
     astropy.stats.histogram
     """
-    # arguments of np.histogram should be passed to astropy.stats.histogram
-    arglist = list(signature(np.histogram).parameters.keys())[1:]
-    np_hist_kwds = dict((key, kwargs[key]) for key in arglist if key in kwargs)
-    hist, bins = histogram(x, bins, **np_hist_kwds)
+    # Note that we only the bin edges calculated...matplotlib will calculate
+    # the actual histogram.
+    bins = _calculate_bin_edges(x, bins, **kwargs)
+
+    if len(bins) > max_bins:
+        raise ValueError('Histogram has too many bins: '
+                         '{nbin}. Use max_bins to increase the number '
+                         'of allowed bins'.format(nbin=len(bins)))
 
     if ax is None:
         # optional dependency; only import if strictly needed.

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -55,14 +55,17 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     --------
     astropy.stats.histogram
     """
-    # Note that we only the bin edges calculated...matplotlib will calculate
+    # Note that we only calculate the bin edges...matplotlib will calculate
     # the actual histogram.
-    bins = _calculate_bin_edges(x, bins, **kwargs)
+    range = kwargs.get('range', None)
+    weights = kwargs.get('weights', None)
+    bins = _calculate_bin_edges(x, bins, range=range, weights=weights)
 
     if len(bins) > max_bins:
         raise ValueError('Histogram has too many bins: '
                          '{nbin}. Use max_bins to increase the number '
-                         'of allowed bins'.format(nbin=len(bins)))
+                         'of allowed bins or range to restrict '
+                         'the histogram range.'.format(nbin=len(bins)))
 
     if ax is None:
         # optional dependency; only import if strictly needed.

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 from inspect import signature
-from ..stats.histogram import _calculate_bin_edges
+from ..stats.histogram import calculate_bin_edges
 
 __all__ = ['hist']
 
@@ -59,7 +59,7 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     # the actual histogram.
     range = kwargs.get('range', None)
     weights = kwargs.get('weights', None)
-    bins = _calculate_bin_edges(x, bins, range=range, weights=weights)
+    bins = calculate_bin_edges(x, bins, range=range, weights=weights)
 
     if len(bins) > max_bins:
         raise ValueError('Histogram has too many bins: '

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -67,3 +67,16 @@ def test_hist_autobin(rseed=0):
             n2, bins2, patches = hist(x, bintype, range=range)
             assert_allclose(n1, n2)
             assert_allclose(bins1, bins2)
+
+
+def test_histogram_pathological_input():
+    # Regression test for https://github.com/astropy/astropy/issues/7758
+
+    # The key feature of the data below is that one of the points is very,
+    # very different than the rest. That leads to a large number of bins.
+    data = [9.99999914e+05, -8.31312483e-03, 6.52755852e-02, 1.43104653e-03,
+            -2.26311017e-02, 2.82660007e-03, 1.80307521e-02, 9.26294279e-03,
+            5.06606026e-02, 2.05418011e-03]
+
+    with pytest.raises(ValueError):
+        hist(data, bins='freedman', max_bins=10000)


### PR DESCRIPTION
This PR fixes #7758 by separating the calculation of the bin edges for a histogram from the calculation of the histogram and raising an exception if the number of bins is very large. The default value I chose for the maximum number of bins is ridiculously large (1e6) but I was afraid that setting a value too low (around 3-4000 one sees matplotlib slow down) might start to raise exceptions in code people are already running.

FWIW, I first hit #7758 when I tried to histogram the pixel values of a calibrated image which turned out to have some extreme values. That led to ~5e8 bins, followed by a computer freeze as all the memory was slowly consumed. That same image dropped into this fix generates an error instead.

**Edit**: Also fixes #8010.