### PR TITLE
TST: Fix io.ascii test warnings

### DIFF
--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -1,8 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 from ... import ascii
-from .common import (assert_equal, assert_almost_equal, has_isnan,
-                     setup_function, teardown_function)
+from .common import assert_equal, assert_almost_equal, has_isnan
+
+# setup/teardown function to have the tests run in the correct directory
+from .common import setup_function, teardown_function  # noqa
 
 
 def read_table1(readme, data):
@@ -141,11 +145,14 @@ def test_header_from_readme():
     if has_isnan:
         from .common import isnan
         for i, val in enumerate(table.field('Q')):
-            if isnan(val):
-                # text value for a missing value in that table
-                assert Q[i] == -9.999
-            else:
-                assert val == Q[i]
+            with warnings.catch_warnings():
+                # converting a masked element to nan -- only sometimes
+                warnings.simplefilter('ignore', UserWarning)
+                if isnan(val):
+                    # text value for a missing value in that table
+                    assert Q[i] == -9.999
+                else:
+                    assert val == Q[i]
 
 
 def test_cds_units():

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -19,9 +19,13 @@ from ....table import Table
 import pytest
 import numpy as np
 
-from .common import setup_function, teardown_function
+# setup/teardown function to have the tests run in the correct directory
+from .common import setup_function, teardown_function  # noqa
+
+# for skipif
+from ....utils.xml.writer import HAS_BLEACH  # noqa
+
 from ... import ascii
-from ....utils.xml.writer import HAS_BLEACH
 
 # Check to see if the BeautifulSoup dependency is present.
 try:
@@ -38,7 +42,8 @@ def test_soupstring():
     Test to make sure the class SoupString behaves properly.
     """
 
-    soup = BeautifulSoup('<html><head></head><body><p>foo</p></body></html>')
+    soup = BeautifulSoup('<html><head></head><body><p>foo</p></body></html>',
+                         "html5lib")
     soup_str = html.SoupString(soup)
     assert isinstance(soup_str, str)
     assert isinstance(soup_str, html.SoupString)
@@ -70,12 +75,12 @@ def test_identify_table():
     """
 
     # Should return False on non-<table> tags and None
-    soup = BeautifulSoup('<html><body></body></html>')
+    soup = BeautifulSoup('<html><body></body></html>', "html5lib")
     assert html.identify_table(soup, {}, 0) is False
     assert html.identify_table(None, {}, 0) is False
 
     soup = BeautifulSoup('<table id="foo"><tr><th>A</th></tr><tr>'
-                         '<td>B</td></tr></table>').table
+                         '<td>B</td></tr></table>', "html5lib").table
     assert html.identify_table(soup, {}, 2) is False
     assert html.identify_table(soup, {}, 1) is True  # Default index of 1
 
@@ -262,8 +267,8 @@ def test_htmlsplitter():
 
     splitter = html.HTMLSplitter()
 
-    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>').tr),
-            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>').tr)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>', "html5lib").tr),
+            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>', "html5lib").tr)]
     expected_data = [['Col 1', 'Col 2'], ['Data 1', 'Data 2']]
     assert list(splitter(lines)) == expected_data
 
@@ -306,8 +311,8 @@ def test_htmlheader_start():
            '<tr><th>C1</th><th>C2</th><th>C3</th></tr>'
 
     # start_line should return None if no valid header is found
-    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>').tr),
-             html.SoupString(BeautifulSoup('<p>Text</p>').p)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>', "html5lib").tr),
+             html.SoupString(BeautifulSoup('<p>Text</p>', "html5lib").p)]
     assert header.start_line(lines) is None
 
     # Should raise an error if a non-SoupString is present
@@ -354,8 +359,8 @@ def test_htmldata():
            '<tr><td>9</td><td>i</td><td>-125.0</td></tr>'
 
     # start_line should raise an error if no table data exists
-    lines = [html.SoupString(BeautifulSoup('<div></div>').div),
-             html.SoupString(BeautifulSoup('<p>Text</p>').p)]
+    lines = [html.SoupString(BeautifulSoup('<div></div>', "html5lib").div),
+             html.SoupString(BeautifulSoup('<p>Text</p>', "html5lib").p)]
     with pytest.raises(core.InconsistentTableError):
         data.start_line(lines)
 

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -43,7 +43,7 @@ def test_soupstring():
     """
 
     soup = BeautifulSoup('<html><head></head><body><p>foo</p></body></html>',
-                         "html5lib")
+                         "html.parser")
     soup_str = html.SoupString(soup)
     assert isinstance(soup_str, str)
     assert isinstance(soup_str, html.SoupString)
@@ -75,12 +75,12 @@ def test_identify_table():
     """
 
     # Should return False on non-<table> tags and None
-    soup = BeautifulSoup('<html><body></body></html>', "html5lib")
+    soup = BeautifulSoup('<html><body></body></html>', "html.parser")
     assert html.identify_table(soup, {}, 0) is False
     assert html.identify_table(None, {}, 0) is False
 
     soup = BeautifulSoup('<table id="foo"><tr><th>A</th></tr><tr>'
-                         '<td>B</td></tr></table>', "html5lib").table
+                         '<td>B</td></tr></table>', "html.parser").table
     assert html.identify_table(soup, {}, 2) is False
     assert html.identify_table(soup, {}, 1) is True  # Default index of 1
 
@@ -267,8 +267,8 @@ def test_htmlsplitter():
 
     splitter = html.HTMLSplitter()
 
-    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>', "html5lib").tr),
-            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>', "html5lib").tr)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>', "html.parser").tr),
+            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>', "html.parser").tr)]
     expected_data = [['Col 1', 'Col 2'], ['Data 1', 'Data 2']]
     assert list(splitter(lines)) == expected_data
 
@@ -311,8 +311,8 @@ def test_htmlheader_start():
            '<tr><th>C1</th><th>C2</th><th>C3</th></tr>'
 
     # start_line should return None if no valid header is found
-    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>', "html5lib").tr),
-             html.SoupString(BeautifulSoup('<p>Text</p>', "html5lib").p)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>', "html.parser").tr),
+             html.SoupString(BeautifulSoup('<p>Text</p>', "html.parser").p)]
     assert header.start_line(lines) is None
 
     # Should raise an error if a non-SoupString is present
@@ -359,8 +359,8 @@ def test_htmldata():
            '<tr><td>9</td><td>i</td><td>-125.0</td></tr>'
 
     # start_line should raise an error if no table data exists
-    lines = [html.SoupString(BeautifulSoup('<div></div>', "html5lib").div),
-             html.SoupString(BeautifulSoup('<p>Text</p>', "html5lib").p)]
+    lines = [html.SoupString(BeautifulSoup('<div></div>', "html.parser").div),
+             html.SoupString(BeautifulSoup('<p>Text</p>', "html.parser").p)]
     with pytest.raises(core.InconsistentTableError):
         data.start_line(lines)
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -18,11 +18,12 @@ from ....table import Table
 from .... import table
 from ....units import Unit
 from ....table.table_helpers import simple_table
+from ....utils.exceptions import AstropyWarning
 
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true)
 from .. import core
-from ..ui import _probably_html, get_read_trace, cparser
+from ..ui import _probably_html, get_read_trace
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import setup_function, teardown_function
@@ -46,8 +47,10 @@ def test_convert_overflow(fast_reader):
     return inf (kind 'f') for this.
     """
     expected_kind = 'U'
-    dat = ascii.read(['a', '1' * 10000], format='basic',
-                     fast_reader=fast_reader, guess=False)
+    with pytest.warns(AstropyWarning,
+                      match='OverflowError converting to IntType'):
+        dat = ascii.read(['a', '1' * 10000], format='basic',
+                         fast_reader=fast_reader, guess=False)
     assert dat['a'].dtype.kind == expected_kind
 
 

--- a/docs/io/ascii/write.rst
+++ b/docs/io/ascii/write.rst
@@ -16,7 +16,7 @@ formatted ASCII table.  For example::
   >>> from astropy.io import ascii
   >>> x = np.array([1, 2, 3])
   >>> y = x ** 2
-  >>> ascii.write([x, y], 'values.dat', names=['x', 'y'])
+  >>> ascii.write([x, y], 'values.dat', names=['x', 'y'], overwrite=True)
 
 The ``values.dat`` file will then contain::
 


### PR DESCRIPTION
This PR gets rid of *most* of the warnings seen when removing `addopts = -p no:warnings` in `setup.cfg` and then running `python setup.py test -P io.ascii --remote-data`.

These still exist because I am not sure how to handle them:

```
astropy/io/ascii/tests/test_connect.py::test_read_latex_noformat
  .../astropy/io/ascii/connect.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='.../astropy/io/ascii/tests/t/latex1.tex' encoding='UTF-8'>
    return read(filename, format=format, **kwargs)

astropy/io/ascii/tests/test_connect.py::test_read_rdb_noformat
  .../astropy/io/ascii/connect.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='.../astropy/io/ascii/tests/t/short.rdb' encoding='UTF-8'>
    return read(filename, format=format, **kwargs)

astropy/io/ascii/tests/test_connect.py::test_read_csv
  .../astropy/io/ascii/connect.py:80: ResourceWarning: unclosed file <_io.TextIOWrapper name='.../astropy/io/ascii/tests/t/simple_csv.csv' encoding='UTF-8'>
    return read(filename, **kwargs)

astropy/io/ascii/tests/test_connect.py::test_auto_identify_ecsv
  .../astropy/io/ascii/connect.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-lim/pytest-26/test_auto_identify_ecsv0/tmpFile.ecsv' encoding='UTF-8'>
    return read(filename, format=format, **kwargs)

astropy/io/ascii/tests/test_ecsv.py::test_round_trip_masked_table_default
  .../astropy/io/ascii/connect.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-lim/pytest-26/test_round_trip_masked_table_d0/test.ecsv' encoding='UTF-8'>
    return read(filename, format=format, **kwargs)

astropy/io/ascii/tests/test_ecsv.py::test_round_trip_masked_table_serialize_mask
  .../astropy/io/ascii/connect.py:37: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/pytest-of-lim/pytest-26/test_round_trip_masked_table_s0/test.ecsv' encoding='UTF-8'>
    return read(filename, format=format, **kwargs)

astropy/io/ascii/tests/test_read.py::test_from_filelike[True]
  .../astropy/io/ascii/tests/test_read.py:406: ResourceWarning: unclosed file <_io.TextIOWrapper name='t/simple.txt' encoding='UTF-8'>
    data = ascii.read(fd, fast_reader=fast_reader, **testfile['opts'])

astropy/io/ascii/tests/test_read.py::test_from_filelike[force]
  .../astropy/io/ascii/tests/test_read.py:406: ResourceWarning: unclosed file <_io.TextIOWrapper name='t/simple.txt' encoding='UTF-8'>
    data = ascii.read(fd, fast_reader=fast_reader, **testfile['opts'])

astropy/io/ascii/tests/test_read.py::test_guessing_file_object
  .../astropy/io/ascii/tests/test_read.py:992: ResourceWarning: unclosed file <_io.BufferedReader name='t/ipac.dat.bz2'>
    t = ascii.read(open('t/ipac.dat.bz2', 'rb'))

astropy/io/ascii/tests/test_read.py::test_read_chunks_input_types
  .../astropy/io/ascii/tests/test_read.py:1355: ResourceWarning: unclosed file <_io.TextIOWrapper name='t/test5.dat' mode='r' encoding='UTF-8'>
    for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
  .../astropy/io/ascii/tests/test_read.py:1369: ResourceWarning: unclosed file <_io.TextIOWrapper name='t/test5.dat' mode='r' encoding='UTF-8'>
    for fp in (fpath, open(fpath, 'r'), open(fpath, 'r').read()):
```

Also see #7928