### PR TITLE
Suppress ERFA warning in get_constellation

### DIFF
--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -8,6 +8,7 @@ framework, but it is useful for some users who are used to more functional
 interfaces.
 """
 
+import warnings
 from collections.abc import Sequence
 
 import numpy as np
@@ -225,7 +226,13 @@ def get_constellation(coord, short_name=False, constellation_list='iau'):
 
     # if it is geocentric, we reproduce the frame but with the 1875 equinox,
     # which is where the constellations are defined
-    constel_coord = coord.transform_to(PrecessedGeocentric(equinox='B1875'))
+    # this yields a "dubious year" warning because ERFA considers the year 1875
+    # "dubious", probably because UTC isn't well-defined then and precession
+    # models aren't precisely calibrated back to then.  But it's plenty
+    # sufficient for constellations
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', erfa.ErfaWarning)
+        constel_coord = coord.transform_to(PrecessedGeocentric(equinox='B1875'))
     if isscalar:
         rah = constel_coord.ra.ravel().hour
         decd = constel_coord.dec.ravel().deg

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -39,9 +39,12 @@ def test_constellations(recwarn):
     from ..funcs import get_constellation
 
     inuma = ICRS(9*u.hour, 65*u.deg)
+
+    n_prewarn = len(recwarn)
     res = get_constellation(inuma)
-    assert recwarn.pop(ErfaWarning)
     res_short = get_constellation(inuma, short_name=True)
+    assert len(recwarn) == n_prewarn  # neither version should not make warnings
+
     assert res == 'Ursa Major'
     assert res_short == 'UMa'
     assert isinstance(res, str) or getattr(res, 'shape', None) == tuple()

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -13,6 +13,7 @@ from numpy import testing as npt
 
 from ... import units as u
 from ...time import Time
+from ..._erfa import ErfaWarning
 
 
 def test_sun():
@@ -33,12 +34,13 @@ def test_sun():
     assert np.all(np.abs(gcrs2.dec - [23.5, 0, -23.5]*u.deg) < 1*u.deg)
 
 
-def test_constellations():
+def test_constellations(recwarn):
     from .. import ICRS, FK5, SkyCoord
     from ..funcs import get_constellation
 
     inuma = ICRS(9*u.hour, 65*u.deg)
     res = get_constellation(inuma)
+    assert recwarn.pop(ErfaWarning)
     res_short = get_constellation(inuma, short_name=True)
     assert res == 'Ursa Major'
     assert res_short == 'UMa'


### PR DESCRIPTION
Prompted by https://github.com/astropy/astropy/pull/7989#discussion_r228675876, this minor PR suppresses the "dubious year" warning that get_constellation produces.

For a bit more back-story: There is an argument that this is indeed a "correct" warning. It stems from the fact that constellation boundaries were defined based on boundaries defined in 1875. So to compute the constellation of a coordinate we have to precess back to 1875... and ERFA considers 1875 to be a "dubious year" because UTC and I think also the precession models aren't really meant to be used that far back. It's not a big enough affect to matter much for constellations, though, so while I originally had thought to pass it through, for this application I now think it does make sense to block the warning.

I'm not sure if it's right no label it a "bug", but it's not a "feature", either really.  So I'm just considering it no-changelog-entry-needed but aiming it for 3.1

cc @pllim @adrn @astrofrog