### PR TITLE
TST: Fix warnings in visualization

### DIFF
--- a/astropy/visualization/lupton_rgb.py
+++ b/astropy/visualization/lupton_rgb.py
@@ -154,7 +154,8 @@ class Mapping:
         image_rgb = [image_r, image_g, image_b]
         for c in image_rgb:
             c *= fac
-            c[c < 0] = 0                # individual bands can still be < 0, even if fac isn't
+            with np.errstate(invalid='ignore'):
+                c[c < 0] = 0                # individual bands can still be < 0, even if fac isn't
 
         pixmax = self._uint8Max
         r0, g0, b0 = image_rgb           # copies -- could work row by row to minimise memory usage

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -18,32 +18,31 @@ except ImportError:
 class TestFits2Bitmap:
     def setup_class(self):
         self.filename = 'test.fits'
+        self.array = np.arange(16384).reshape((128, 128))
 
     def test_function(self, tmpdir):
         filename = tmpdir.join(self.filename).strpath
-        fits.writeto(filename, np.ones((128, 128)))
+        fits.writeto(filename, self.array)
         fits2bitmap(filename)
 
     def test_script(self, tmpdir):
         filename = tmpdir.join(self.filename).strpath
-        fits.writeto(filename, np.ones((128, 128)))
+        fits.writeto(filename, self.array)
         main([filename, '-e', '0'])
 
     def test_exten_num(self, tmpdir):
         filename = tmpdir.join(self.filename).strpath
-        data = np.ones((100, 100))
         hdu1 = fits.PrimaryHDU()
-        hdu2 = fits.ImageHDU(data)
+        hdu2 = fits.ImageHDU(self.array)
         hdulist = fits.HDUList([hdu1, hdu2])
         hdulist.writeto(filename)
         main([filename, '-e', '1'])
 
     def test_exten_name(self, tmpdir):
         filename = tmpdir.join(self.filename).strpath
-        data = np.ones((100, 100))
         hdu1 = fits.PrimaryHDU()
         extname = 'SCI'
-        hdu2 = fits.ImageHDU(data)
+        hdu2 = fits.ImageHDU(self.array)
         hdu2.header['EXTNAME'] = extname
         hdulist = fits.HDUList([hdu1, hdu2])
         hdulist.writeto(filename)
@@ -52,7 +51,7 @@ class TestFits2Bitmap:
     @pytest.mark.parametrize('file_exten', ['.gz', '.bz2'])
     def test_compressed_fits(self, tmpdir, file_exten):
         filename = tmpdir.join('test.fits' + file_exten).strpath
-        fits.writeto(filename, np.ones((128, 128)))
+        fits.writeto(filename, self.array)
         main([filename, '-e', '0'])
 
     def test_orientation(self, tmpdir):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -109,7 +109,8 @@ class SqrtStretch(BaseStretch):
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)
-        np.sqrt(values, out=values)
+        with np.errstate(invalid='ignore'):
+            np.sqrt(values, out=values)
         return values
 
     @property

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -56,7 +56,7 @@ class BaseFormatterLocator:
 
     def __init__(self, values=None, number=None, spacing=None, format=None):
 
-        if (values, number, spacing).count(None) < 2:
+        if len([x for x in (values, number, spacing) if x is None]) < 2:
             raise ValueError("At most one of values/number/spacing can be specifed")
 
         if values is not None:

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -264,7 +264,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
 
 UCDS_FILE = os.path.join(os.path.dirname(__file__), 'ucds.txt')
-VALID_UCDS = set([x.strip() for x in open(UCDS_FILE).read().splitlines()[1:]])
+with open(UCDS_FILE) as f:
+    VALID_UCDS = set([x.strip() for x in f.read().splitlines()[1:]])
 
 
 def validate_physical_types(physical_types):


### PR DESCRIPTION
This fixes most warnings in astropy.visualization (and one in astropy.wcs.wcsapi). There are a few warnings that we should catch at the source since it doesn't really make sense to show them to users.