### PR TITLE
Remove arguments for super

### DIFF
--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -25,14 +25,14 @@ from ...table.pprint import get_auto_format_func
 class IpacFormatErrorDBMS(Exception):
     def __str__(self):
         return '{0}\nSee {1}'.format(
-            super(Exception, self).__str__(),
+            super().__str__(),
             'http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/DBMSrestriction.html')
 
 
 class IpacFormatError(Exception):
     def __str__(self):
         return '{0}\nSee {1}'.format(
-            super(Exception, self).__str__(),
+            super().__str__(),
             'http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html')
 
 

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -445,7 +445,7 @@ class AASTex(Latex):
     data_class = AASTexData
 
     def __init__(self, **kwargs):
-        super(AASTex, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # check if tabletype was explicitly set by the user
         if not (('latexdict' in kwargs) and ('tabletype' in kwargs['latexdict'])):
             self.latex['tabletype'] = 'deluxetable'

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -549,7 +549,7 @@ class HDUList(list, _Verify):
         # Make sure that HDUs are loaded before attempting to pop
         self.readall()
         list_index = self.index_of(index)
-        return super(HDUList, self).pop(list_index)
+        return super().pop(list_index)
 
     def insert(self, index, hdu):
         """

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -146,7 +146,7 @@ class DomainType(AstropyAsdfType):
 class GenericModel(mappings.Mapping):
     def __init__(self, n_inputs, n_outputs):
         mapping = tuple(range(n_inputs))
-        super(GenericModel, self).__init__(mapping)
+        super().__init__(mapping)
         self._outputs = tuple('x' + str(idx) for idx in range(self.n_outputs + 1))
 
 

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -19,7 +19,7 @@ class AstropyTypeMeta(ExtensionTypeMeta):
     be stored automatically by astropy extensions for ASDF.
     """
     def __new__(mcls, name, bases, attrs):
-        cls = super(AstropyTypeMeta, mcls).__new__(mcls, name, bases, attrs)
+        cls = super().__new__(mcls, name, bases, attrs)
         # Classes using this metaclass are automatically added to the list of
         # astropy extensions
         if cls.organization == 'astropy.org' and cls.standard == 'astropy':

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -389,8 +389,7 @@ class Chebyshev1D(PolynomialModel):
         return np.rollaxis(v, 0, v.ndim)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(PolynomialModel, self).prepare_inputs(x, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 
@@ -496,8 +495,7 @@ class Hermite1D(PolynomialModel):
         return np.rollaxis(v, 0, v.ndim)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(PolynomialModel, self).prepare_inputs(x, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 
@@ -701,8 +699,7 @@ class Legendre1D(PolynomialModel):
             name=name, meta=meta, **params)
 
     def prepare_inputs(self, x, **kwargs):
-        inputs, format_info = \
-                super(PolynomialModel, self).prepare_inputs(x, **kwargs)
+        inputs, format_info = super().prepare_inputs(x, **kwargs)
 
         x = inputs[0]
 

--- a/astropy/stats/bls/core.py
+++ b/astropy/stats/bls/core.py
@@ -719,7 +719,7 @@ class BoxLeastSquaresResults(dict):
 
     """
     def __init__(self, *args):
-        super(BoxLeastSquaresResults, self).__init__(zip(
+        super().__init__(zip(
             ("objective", "period", "power", "depth", "depth_err",
              "duration", "transit_time", "depth_snr", "log_likelihood"),
             args

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -57,7 +57,7 @@ class FixRemoteDataOption(type):
         else:
             sys.argv[idx] = '-R=any'
 
-        return super(FixRemoteDataOption, cls).__init__(name, bases, dct)
+        return super().__init__(name, bases, dct)
 
 
 class AstropyTest(Command, metaclass=FixRemoteDataOption):

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -300,11 +300,11 @@ class catch_warnings(warnings.catch_warnings):
     """
 
     def __init__(self, *classes):
-        super(catch_warnings, self).__init__(record=True)
+        super().__init__(record=True)
         self.classes = classes
 
     def __enter__(self):
-        warning_list = super(catch_warnings, self).__enter__()
+        warning_list = super().__enter__()
         treat_deprecations_as_exceptions()
         if len(self.classes) == 0:
             warnings.simplefilter('always')
@@ -328,7 +328,7 @@ class ignore_warnings(catch_warnings):
     """
 
     def __init__(self, category=None):
-        super(ignore_warnings, self).__init__()
+        super().__init__()
 
         if isinstance(category, type) and issubclass(category, Warning):
             self.category = [category]
@@ -347,7 +347,7 @@ class ignore_warnings(catch_warnings):
         return wrapper
 
     def __enter__(self):
-        retval = super(ignore_warnings, self).__enter__()
+        retval = super().__enter__()
         if self.category is not None:
             for category in self.category:
                 warnings.simplefilter('ignore', category)

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -131,7 +131,7 @@ class TestRunnerBase:
 
         cls.run_tests.__doc__ = cls.RUN_TESTS_DOCSTRING.format(keywords=doc_keywords)
 
-        return super(TestRunnerBase, cls).__new__(cls)
+        return super().__new__(cls)
 
     def _generate_args(self, **kwargs):
         # Update default values with passed kwargs
@@ -601,4 +601,4 @@ class TestRunner(TestRunnerBase):
         # own.
         from ..table import Table  # pylint: disable=W0611
 
-        return super(TestRunner, self).run_tests(**kwargs)
+        return super().run_tests(**kwargs)

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -222,7 +222,7 @@ class WCSAxes(Axes):
 
         transform = kwargs.pop('transform', None)
 
-        cset = super(WCSAxes, self).contour(*args, **kwargs)
+        cset = super().contour(*args, **kwargs)
 
         if transform is not None:
             # The transform passed to self.contour will normally include
@@ -248,7 +248,7 @@ class WCSAxes(Axes):
 
         transform = kwargs.pop('transform', None)
 
-        cset = super(WCSAxes, self).contourf(*args, **kwargs)
+        cset = super().contourf(*args, **kwargs)
 
         if transform is not None:
             # The transform passed to self.contour will normally include


### PR DESCRIPTION
Most of the cases here were added after the last cleanup (see https://github.com/astropy/astropy/issues/6630). But I've also removed a few cases where the first argument was not the same class. In the `io.ascii` case the behaviour is the same, while for modeling I'm fairly certain it was a copy-pasting mistake (while I'm also fairly certain the behaviour is the same).

Closes #6630 