### PR TITLE
Cache frame component names/units

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -829,10 +829,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def get_representation_component_names(self, which='base'):
         repr_or_diff_cls = self.get_representation_cls(which)
 
+        # Caching happens on the class object, *not* on a per-instance basis
         cls = self.__class__
+
+        # first check that the cache hasn't been invalidated by a new
+        # representation/differential class getting added
         if cls._frame_class_cache.get('representation_component_names_hash', None) != r.get_reprdiff_cls_hash():
             cls._frame_class_cache['representation_component_names'] = {}
             cls._frame_class_cache['representation_component_names_hash'] = r.get_reprdiff_cls_hash()
+
+        # now check if the representation/differential class we need here
+        # already has its component names cached. Only generate them if not
         if repr_or_diff_cls not in cls._frame_class_cache['representation_component_names']:
             out = OrderedDict()
             if repr_or_diff_cls is None:
@@ -847,10 +854,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def get_representation_component_units(self, which='base'):
         repr_or_diff_cls = self.get_representation_cls(which)
 
+        # Caching happens on the class object, *not* on a per-instance basis
         cls = self.__class__
+
+        # first check that the cache hasn't been invalidated by a new
+        # representation/differential class getting added
         if cls._frame_class_cache.get('representation_component_units_hash', None) != r.get_reprdiff_cls_hash():
             cls._frame_class_cache['representation_component_units'] = {}
             cls._frame_class_cache['representation_component_units_hash'] = r.get_reprdiff_cls_hash()
+
+        # now check if the representation/differential class we need here
+        # already has its component units cached. Only generate them if not
         if repr_or_diff_cls not in cls._frame_class_cache['representation_component_units']:
             out = OrderedDict()
             if repr_or_diff_cls is None:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -860,7 +860,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 if repr_unit:
                     out[repr_name] = repr_unit
                 cls._frame_class_cache['representation_component_units'][which] = out
-            return cls._frame_class_cache['representation_component_units'][which]
+        return cls._frame_class_cache['representation_component_units'][which]
 
     representation_component_names = property(get_representation_component_names)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -777,6 +777,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # note that if so moved, the cache should be acceessed as
         # self.__class__._frame_class_cache
 
+        # Check that the cache hasn't been invalidated by a new
+        # representation/differential class getting added. If it's good, then
+        # only re-generate the representation info if it's not already cached
         if cls._frame_class_cache.get('last_reprdiff_hash', None) != r.get_reprdiff_cls_hash():
             repr_attrs = {}
             for repr_diff_cls in (list(r.REPRESENTATION_CLASSES.values()) +

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -844,17 +844,23 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return cls._frame_class_cache['representation_component_names'][which]
 
     def get_representation_component_units(self, which='base'):
-        out = OrderedDict()
-        repr_or_diff_cls = self.get_representation_cls(which)
-        if repr_or_diff_cls is None:
-            return out
-        repr_attrs = self.representation_info[repr_or_diff_cls]
-        repr_names = repr_attrs['names']
-        repr_units = repr_attrs['units']
-        for repr_name, repr_unit in zip(repr_names, repr_units):
-            if repr_unit:
-                out[repr_name] = repr_unit
-        return out
+        cls = self.__class__
+        if cls._frame_class_cache.get('representation_component_units_hash', None) != r.get_reprdiff_cls_hash():
+            cls._frame_class_cache['representation_component_units'] = {}
+            cls._frame_class_cache['representation_component_units_hash'] = r.get_reprdiff_cls_hash()
+        if which not in cls._frame_class_cache['representation_component_units']:
+            out = OrderedDict()
+            repr_or_diff_cls = self.get_representation_cls(which)
+            if repr_or_diff_cls is None:
+                return out
+            repr_attrs = self.representation_info[repr_or_diff_cls]
+            repr_names = repr_attrs['names']
+            repr_units = repr_attrs['units']
+            for repr_name, repr_unit in zip(repr_names, repr_units):
+                if repr_unit:
+                    out[repr_name] = repr_unit
+                cls._frame_class_cache['representation_component_units'][which] = out
+            return cls._frame_class_cache['representation_component_units'][which]
 
     representation_component_names = property(get_representation_component_names)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -827,30 +827,32 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return self._get_representation_info()
 
     def get_representation_component_names(self, which='base'):
+        repr_or_diff_cls = self.get_representation_cls(which)
+
         cls = self.__class__
         if cls._frame_class_cache.get('representation_component_names_hash', None) != r.get_reprdiff_cls_hash():
             cls._frame_class_cache['representation_component_names'] = {}
             cls._frame_class_cache['representation_component_names_hash'] = r.get_reprdiff_cls_hash()
-        if which not in cls._frame_class_cache['representation_component_names']:
+        if repr_or_diff_cls not in cls._frame_class_cache['representation_component_names']:
             out = OrderedDict()
-            repr_or_diff_cls = self.get_representation_cls(which)
             if repr_or_diff_cls is None:
                 return out
             data_names = repr_or_diff_cls.attr_classes.keys()
             repr_names = self.representation_info[repr_or_diff_cls]['names']
             for repr_name, data_name in zip(repr_names, data_names):
                 out[repr_name] = data_name
-            cls._frame_class_cache['representation_component_names'][which] = out
-        return cls._frame_class_cache['representation_component_names'][which]
+            cls._frame_class_cache['representation_component_names'][repr_or_diff_cls] = out
+        return cls._frame_class_cache['representation_component_names'][repr_or_diff_cls]
 
     def get_representation_component_units(self, which='base'):
+        repr_or_diff_cls = self.get_representation_cls(which)
+
         cls = self.__class__
         if cls._frame_class_cache.get('representation_component_units_hash', None) != r.get_reprdiff_cls_hash():
             cls._frame_class_cache['representation_component_units'] = {}
             cls._frame_class_cache['representation_component_units_hash'] = r.get_reprdiff_cls_hash()
-        if which not in cls._frame_class_cache['representation_component_units']:
+        if repr_or_diff_cls not in cls._frame_class_cache['representation_component_units']:
             out = OrderedDict()
-            repr_or_diff_cls = self.get_representation_cls(which)
             if repr_or_diff_cls is None:
                 return out
             repr_attrs = self.representation_info[repr_or_diff_cls]
@@ -859,8 +861,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             for repr_name, repr_unit in zip(repr_names, repr_units):
                 if repr_unit:
                     out[repr_name] = repr_unit
-                cls._frame_class_cache['representation_component_units'][which] = out
-        return cls._frame_class_cache['representation_component_units'][which]
+                cls._frame_class_cache['representation_component_units'][repr_or_diff_cls] = out
+        return cls._frame_class_cache['representation_component_units'][repr_or_diff_cls]
 
     representation_component_names = property(get_representation_component_names)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -827,15 +827,21 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return self._get_representation_info()
 
     def get_representation_component_names(self, which='base'):
-        out = OrderedDict()
-        repr_or_diff_cls = self.get_representation_cls(which)
-        if repr_or_diff_cls is None:
-            return out
-        data_names = repr_or_diff_cls.attr_classes.keys()
-        repr_names = self.representation_info[repr_or_diff_cls]['names']
-        for repr_name, data_name in zip(repr_names, data_names):
-            out[repr_name] = data_name
-        return out
+        cls = self.__class__
+        if cls._frame_class_cache.get('representation_component_names_hash', None) != r.get_reprdiff_cls_hash():
+            cls._frame_class_cache['representation_component_names'] = {}
+            cls._frame_class_cache['representation_component_names_hash'] = r.get_reprdiff_cls_hash()
+        if which not in cls._frame_class_cache['representation_component_names']:
+            out = OrderedDict()
+            repr_or_diff_cls = self.get_representation_cls(which)
+            if repr_or_diff_cls is None:
+                return out
+            data_names = repr_or_diff_cls.attr_classes.keys()
+            repr_names = self.representation_info[repr_or_diff_cls]['names']
+            for repr_name, data_name in zip(repr_names, data_names):
+                out[repr_name] = data_name
+            cls._frame_class_cache['representation_component_names'][which] = out
+        return cls._frame_class_cache['representation_component_names'][which]
 
     def get_representation_component_units(self, which='base'):
         out = OrderedDict()


### PR DESCRIPTION
This extends the machinery developed in #7949 for caching frame attributes to also cache the component names and units of coordinate frames.

Note that this is *not* the factor of 2x or so speedup we had initially thought it might be.  I'm not sure if it was some other speedup in components used by these methods, or something else appearing as a new bottleneck, but I see only something in the realm of a 0-10% speedup here (in the scalar coordinate case) depending on exactly what `SkyCoord` or frame object input we are talking about.

That raises the questions of whether this is "worth it" - caches can be notoriously tricky to get right - I think I have here (#7949, which had a more measureable speedup, is essentially the same machinery), but I've certainly been wrong before... And for that reason I'm not milestoning 3.1, although if we agree there's no harm in this we can probably backport it since it's not really a "feature" per se (nor is it a bug fix... not sure what to call it, so I'm calling it "affects-dev" even though it isn't exactly a bug).

cc @adrn @mhvk @astrofrog


Oh, and I think we could say this closes #7030 in that I think it now hits all of the points that have been highlighted there... But maybe @adrn doesn't think so if it's still in the plan to build some more performant classmethods (which is one of the strategies mentioned in #7030)?