### PR TITLE
MNT: Remove duplicate pip req entries

### DIFF
--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -1,19 +1,10 @@
--r pip-requirements
 -r pip-requirements-doc
-Cython>=0.21
-jinja2>=2.7
-pyyaml
-pandas
-h5py
-beautifulsoup4
 bintrees
 bleach
-scikit-image
 
 # below here are used only for tests
 pytest-astropy
 coverage
 skyfield
-mpmath
 pytest-xdist
 pytest-mpl

--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -1,7 +1,7 @@
 -r pip-requirements
-cython
+Cython>=0.21
+jinja2>=2.7
 pyyaml
-jinja2
 h5py
 scikit-image
 pandas
@@ -16,5 +16,3 @@ jplephem
 sphinx<1.7
 sphinx-astropy
 sphinx-gallery
-pyyaml
-scikit-image


### PR DESCRIPTION
It was reported on Slack that `pip install -r pip-requirements-dev` resulted in error due to duplicated package specifications. The reported error got stuck at Cython, but I went ahead to clean all the duplicates that I found.

The following test with this patch was successful locally:
```
conda create -n tmp1 python=3.7
conda activate tmp1
cd astropy_source_checkout
pip install -r pip-requirements-dev
```

Bonus: I also did this successfully
```
python setup.py install
```

*However*, running `python setup.py test` got stuck at `astropy/tests/test_logger.py ............` and then it exited right there without any further log nor error message. But this is not related to this change, is it?
```
platform linux -- Python 3.7.0, pytest-3.9.3, py-1.7.0, pluggy-0.8.0

Running tests with Astropy version 3.2.dev23151.
Running tests in astropy docs.

Date: 2018-10-29T16:03:54

Platform: Linux-3.10.0-862.14.4.el7.x86_64-x86_64-with-redhat-7.5-Maipo

Executable: .../anaconda/envs/tmp1/bin/python

Full Python Version: 
3.7.0 | packaged by conda-forge | (default, Sep 30 2018, 14:56:18) 
[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.15.2
Scipy: 1.1.0
Matplotlib: 3.0.1
h5py: 2.8.0
Pandas: 0.23.4
Cython: 0.29
astropy_helpers: 2.0.6
Using Astropy options: remote_data: none.

Matplotlib: 3.0.1
Freetype: 2.6.1
rootdir: /tmp/astropy-test-4gkl_dqf/lib/python3.7/site-packages, inifile: setup.cfg
plugins: xdist-1.23.2, remotedata-0.3.1, openfiles-0.3.0, mpl-0.10, forked-0.2, doctestplus-0.1.3, arraydiff-0.2
collected 12313 items / 19 skipped
```