### PR TITLE
Coordinate matching fails for unit-less distances

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1586,7 +1586,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # subtraction
         self_car = self.data.without_differentials().represent_as(r.CartesianRepresentation)
         other_car = other_in_self_system.data.without_differentials().represent_as(r.CartesianRepresentation)
-        return Distance((self_car - other_car).norm())
+        dist = (self_car - other_car).norm()
+        if dist.unit == u.one:
+            return dist
+        else:
+            return Distance(dist)
 
     @property
     def cartesian(self):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -504,6 +504,16 @@ def test_sep():
     sep3d = i5.separation_3d(i6)
     assert_allclose(sep3d.to(u.kpc), np.array([2, 2])*u.kpc)
 
+    # 3d separations of dimensionless distances should still work
+    i7 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.one)
+    i8 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=4*u.one)
+    sep3d = i7.separation_3d(i8)
+    assert_allclose(sep3d.to(u.one).value, [1])
+
+    # but should fail with non-dimensionless
+    with pytest.raises(ValueError):
+        i7.separation_3d(i3)
+
 def test_time_inputs():
     """
     Test validation and conversion of inputs for equinox and obstime attributes.

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -296,3 +296,14 @@ def test_match_catalog_empty():
     with pytest.raises(ValueError) as excinfo:
         sc1.match_to_catalog_3d(cat0)
     assert 'catalog' in str(excinfo.value)
+
+@pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
+def test_match_catalog_nounit():
+    from .. import ICRS, CartesianRepresentation
+    from ..matching import match_coordinates_sky
+
+    i1 = ICRS([[1], [2], [3]], representation_type=CartesianRepresentation)
+    i2 = ICRS([[1], [2], [4, 5]], representation_type=CartesianRepresentation)
+    i, sep, sep3d = match_coordinates_sky(i1, i2)
+    assert_allclose(sep3d, [1]*u.dimensionless_unscaled)


### PR DESCRIPTION
The Problem this PR is trying to solve is most easily shown in this snippet:
```python
from astropy.coordinates import ICRS, CartesianRepresentation, match_coordinates_sky
i1 = ICRS([[1], [2], [3]], representation_type=CartesianRepresentation)
i2 = ICRS([[1], [2], [4, 5]], representation_type=CartesianRepresentation)
i, sep, sep3d = match_coordinates_sky(i1, i2)
```
yields ``astropy.units.core.UnitTypeError: Distance instances require units equivalent to 'm', so cannot set it to ''.``.  

The problem is: it seems counter-intuitive in that it fails only in `match_coordinates_sky` and not in the `ICRS` constructor or similar. The root cause is really `separation_3d`, which fails if the inputs are dimensionless because the "3d" part of coordinates matching uses `Distance`, which is supposed to be, well, a distance (and have appropriate units).  Given we are now allowing dimensionless distances in the frame classes, arguably we should allow it in `separation_3d`... But that's sort of an API change (albiet a "relaxing" one) - should we allow this "3d distance" to sometimes be dimensionless?

One could argue this is a bug... but I'm not sure it is, so I'm not sure if this is a bugfix, or new feature, or "shouldn't do", so have not yet flagged it bug, milestoned it, or changelogged it.

Also marking as a WIP because there's question above whether we really want to do this or not. The code itself I think is done, but the "discussion" part is not.

cc @mhvk @adrn