### PR TITLE
EXP: Try using pytest 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - checkout
       - run:
           name: Install dependencies
-          command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.15.3" scipy "pytest<3.7" pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.15.3" scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -V -a "--durations=50"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
         # Set defaults to avoid repeating in most cases
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
+        - PYTEST_VERSION=3.9
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach asdf bottleneck'
@@ -104,14 +105,12 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="jplephem"
                LC_CTYPE=C.ascii LC_ALL=C
-               PYTEST_VERSION=3.7
 
 
         - os: linux
           stage: Initial tests
           env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                SETUP_CMD='test -a "--durations=50"'
-               PYTEST_VERSION=3.8
           compiler: clang
 
         # Full tests with coverage checks.

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,7 @@ matrix:
                INSTALL_CMD='python setup.py build_ext --inplace'
                PIP_DEPENDENCIES='pytest-astropy'
                TEST_CMD='pytest --open-files --doctest-rst'
+               PYTEST_VERSION=3.7
           script:
             - $INSTALL_CMD
             - $TEST_CMD
@@ -105,7 +106,7 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="jplephem"
                LC_CTYPE=C.ascii LC_ALL=C
-
+               PYTEST_VERSION=3.7
 
         - os: linux
           stage: Initial tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ env:
         # Set defaults to avoid repeating in most cases
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
-        - PYTEST_VERSION=3.9
+        - PYTEST_VERSION=3.10
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach asdf bottleneck'


### PR DESCRIPTION
Just want to see if up-ping `pytest` to 3.9 would succeed. `pytest` 3.9.3 was released on Oct 27, 2018 (https://docs.pytest.org/en/latest/changelog.html).