### PR TITLE
TST: Fix warnings in utils tests

### DIFF
--- a/astropy/utils/tests/test_timer.py
+++ b/astropy/utils/tests/test_timer.py
@@ -8,7 +8,6 @@
 
 """
 
-
 # STDLIB
 import time
 
@@ -17,6 +16,7 @@ import pytest
 import numpy as np
 
 # LOCAL
+from ..exceptions import AstropyUserWarning
 from ..timer import RunTimePredictor
 from ...modeling.fitting import ModelsError
 
@@ -48,7 +48,9 @@ def test_timer():
 
     # --- These must run next to set up data points. ---
 
-    p.time_func([2.02, 2.04, 2.1, 'a', 2.3])
+    with pytest.warns(AstropyUserWarning, match="ufunc 'multiply' did not "
+                      "contain a loop with signature matching types"):
+        p.time_func([2.02, 2.04, 2.1, 'a', 2.3])
     p.time_func(2.2)  # Test OrderedDict
 
     assert p._funcname == 'func_to_time'


### PR DESCRIPTION
This PR gets rid of *some* of the warnings seen when removing `addopts = -p no:warnings` in `setup.cfg` and then running `python setup.py test -P utils --remote-data`.

The following are not addressed:

* Deprecation warnings from doctest examples (similar problem as FITS over at #7998). These happen in 3 different places.
* Deprecation warning straight out of `astropy.utils.compat.funcsigs` import during test collection. Maybe this will be a non-issue when we remove that deprecated module.
* Other warnings outside our control (e.g., #6025)

Also see #7928