### PR TITLE
Fixes to new convolution code

### DIFF
--- a/astropy/convolution/__init__.py
+++ b/astropy/convolution/__init__.py
@@ -1,13 +1,13 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from .core import *
-from .kernels import *
-from .utils import discretize_model
+from .core import *  # noqa
+from .kernels import *  # noqa
+from .utils import discretize_model  # noqa
 
 try:
     # Not guaranteed available at setup time
-    from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models
+    from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models  # noqa
 except ImportError:
     if not _ASTROPY_SETUP_:
         raise

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -21,12 +21,15 @@ from ..modeling.core import _CompoundModelMeta
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 
 # Find and load C convolution library
-lib_path = glob.glob(os.path.join(os.path.dirname(__file__), 'lib_convolve*'))[0]
-if sys.platform.startswith('win'):
-    libConvolve = ctypes.windll.LoadLibrary(lib_path)
+lib_paths = glob.glob(os.path.join(os.path.dirname(__file__), 'lib_convolve*'))
+if len(lib_paths) > 0:
+    lib_path = lib_paths[0]
+    if sys.platform.startswith('win'):
+        libConvolve = ctypes.windll.LoadLibrary(lib_path)
+    else:
+        libConvolve = ctypes.cdll.LoadLibrary(lib_path)
 else:
-    libConvolve = ctypes.cdll.LoadLibrary(lib_path)
-
+    raise Exception("Compiled convolution code is missing, try re-building astropy")
 
 # The GIL is automatically released by default when calling functions imported
 # from libaries loaded by ctypes.cdll.LoadLibrary(<path>)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -23,20 +23,20 @@ from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 # Find and load C convolution library
 lib_paths = glob.glob(os.path.join(os.path.dirname(__file__), 'lib_convolve*'))
 if len(lib_paths) > 0:
-    lib_path = lib_paths[0]
     if sys.platform.startswith('win'):
-        libConvolve = ctypes.windll.LoadLibrary(lib_path)
+        lib_convolve = ctypes.windll.LoadLibrary(lib_paths[0])
     else:
-        libConvolve = ctypes.cdll.LoadLibrary(lib_path)
+        lib_convolve = ctypes.cdll.LoadLibrary(lib_paths[0])
 else:
     raise Exception("Compiled convolution code is missing, try re-building astropy")
+del lib_paths
 
 # The GIL is automatically released by default when calling functions imported
 # from libaries loaded by ctypes.cdll.LoadLibrary(<path>)
 
 # Declare prototypes
 # Boundary None
-_convolveNd_boundary_none_c = libConvolve.convolveNd_boundary_none_c
+_convolveNd_boundary_none_c = lib_convolve.convolveNd_boundary_none_c
 _convolveNd_boundary_none_c.restype = None
 _convolveNd_boundary_none_c.argtypes = [ndpointer(ctypes.c_double, flags={"C_CONTIGUOUS", "WRITEABLE"}), # return array
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"), # input array
@@ -48,7 +48,7 @@ _convolveNd_boundary_none_c.argtypes = [ndpointer(ctypes.c_double, flags={"C_CON
             ctypes.c_uint] # n_threads
 
 # Padded boundaries ['fill', 'extend', 'wrap']
-_convolveNd_padded_boundary_c = libConvolve.convolveNd_padded_boundary_c
+_convolveNd_padded_boundary_c = lib_convolve.convolveNd_padded_boundary_c
 _convolveNd_padded_boundary_c.restype = None
 _convolveNd_padded_boundary_c.argtypes = [ndpointer(ctypes.c_double, flags={"C_CONTIGUOUS", "WRITEABLE"}), # return array
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"), # input array

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -6,7 +6,7 @@ import os
 import sys
 import glob
 import ctypes
-import faulthandler
+
 import numpy as np
 from numpy.ctypeslib import ndpointer
 from functools import partial
@@ -19,10 +19,6 @@ from ..nddata import support_nddata
 from ..modeling.core import _make_arithmetic_operator, BINARY_OPERATORS
 from ..modeling.core import _CompoundModelMeta
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
-
-# Turn the faulthandler ON to help catch any signals, e.g. segfaults
-# or asserts. This doesn't, currently, work with Jupyter Notebook.
-faulthandler.enable()
 
 # Find and load C convolution library
 lib_path = glob.glob(os.path.join(os.path.dirname(__file__), 'lib_convolve*'))[0]


### PR DESCRIPTION
This fixes #8032 

If developers updated to the latest master version of astropy and were in develop mode, and did not rebuild extensions, they would get:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/bsipocz/munka/devel/astropy/astropy/convolution/__init__.py", line 10, in <module>
    from .convolve import convolve, convolve_fft, interpolate_replace_nans, convolve_models
  File "/Users/bsipocz/munka/devel/astropy/astropy/convolution/convolve.py", line 28, in <module>
    lib_path = glob.glob(os.path.join(os.path.dirname(__file__), 'lib_convolve*'))[0]
IndexError: list index out of range
```

so this PR makes the error message cleaner. For anyone curious, you can reproduce this error with:

```
python setup.py build_ext --inplace
rm astropy/convolution/lib_convolve.cpython-37m-darwin.so 
python -c 'import astropy.convolution'
```

Secondly it seems that importing faulthandler doesn't always work (see #8032) - so we should just not import it by default (it's easy for developers to import it in test scripts they are using, or in pytest using pytest-faulthandler).

cc @jamienoss