### PR TITLE
Tabular models fail to serialize to asdf when used with units

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -60,18 +60,19 @@ class TransformType(AstropyAsdfType):
         if model.name is not None:
             node['name'] = model.name
 
-        try:
-            bb = model.bounding_box
-        except NotImplementedError:
-            bb = None
+        if 'bounding_box' not in node:
+            try:
+                bb = model.bounding_box
+            except NotImplementedError:
+                bb = None
 
-        if bb is not None:
-            if model.n_inputs == 1:
-                bb = list(bb)
-            else:
-                bb = [list(item) for item in model.bounding_box]
-            node['bounding_box'] = bb
-
+            if bb is not None:
+                if model.n_inputs == 1:
+                    bb = list(bb)
+                else:
+                    bb = [list(item) for item in model.bounding_box]
+                node['bounding_box'] = bb
+        return node
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
@@ -80,7 +81,8 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def to_tree(cls, model, ctx):
         node = cls.to_tree_transform(model, ctx)
-        cls._to_tree_base_transform_members(model, node, ctx)
+        node = cls._to_tree_base_transform_members(model, node, ctx)
+        yamlutil.custom_tree_to_tagged_tree(node, ctx)
         return node
 
     @classmethod

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
-from numpy.testing import assert_array_equal
+import astropy.units as u
 
 from asdf import yamlutil
 
@@ -56,12 +56,16 @@ class TabularType(TransformType):
         node["method"] = str(model.method)
         node["bounds_error"] = model.bounds_error
         node["name"] = model.name
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        # Do this little dance, so that TransformType does not save the
+        # bounding box
+        node = yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        node["bounding_box"] = None
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):
-        assert_array_equal(a.lookup_table, b.lookup_table)
-        assert_array_equal(a.points, b.points)
+        assert u.allclose(a.lookup_table, b.lookup_table)
+        assert u.allclose(a.points, b.points)
         assert (a.method == b.method)
         if a.fill_value is None:
             assert b.fill_value is None

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -112,12 +112,30 @@ def test_tabular_model(tmpdir):
     model = astmodels.Tabular1D(points=points, lookup_table=values)
     tree = {'model': model}
     helpers.assert_roundtrip_tree(tree, tmpdir)
-    table = np.array([[ 3.,  0.,  0.],
-                      [ 0.,  2.,  0.],
-                      [ 0.,  0.,  0.]])
+    table = np.array([[3.,  0.,  0.],
+                      [0.,  2.,  0.],
+                      [0.,  0.,  0.]])
     points = ([1, 2, 3], [1, 2, 3])
-    model2 = astmodels.Tabular2D(points, lookup_table=table, bounds_error=False,
-                                 fill_value=None, method='nearest')
+    model2 = astmodels.Tabular2D(points, lookup_table=table,
+                                 bounds_error=False, fill_value=None,
+                                 method='nearest')
+    tree = {'model': model2}
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_tabular_model_units(tmpdir):
+    points = np.arange(0, 5) * u.pix
+    values = [1., 10, 2, 45, -3] * u.nm
+    model = astmodels.Tabular1D(points=points, lookup_table=values)
+    tree = {'model': model}
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+    table = np.array([[3.,  0.,  0.],
+                      [0.,  2.,  0.],
+                      [0.,  0.,  0.]]) * u.nm
+    points = ([1, 2, 3], [1, 2, 3]) * u.pix
+    model2 = astmodels.Tabular2D(points, lookup_table=table,
+                                 bounds_error=False, fill_value=None,
+                                 method='nearest')
     tree = {'model': model2}
     helpers.assert_roundtrip_tree(tree, tmpdir)
 


### PR DESCRIPTION
This is a bug report in the form of a regression test.

It seems that when presented with a Tabular model where points and lookup_table are units the asdf tag fails. I am currently debugging this insanity.