### PR TITLE
MNT: Pin max Numpy version to fix RTD build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,11 @@ entry_points['asdf_extensions'] = [
 ]
 
 min_numpy_version = 'numpy>=' + astropy.__minimum_numpy_version__
+
+# TODO: Remove this pinning when Numpy 1.15.4 is out.
+# https://github.com/astropy/astropy/issues/8039
+min_numpy_version += ',<1.15.3'
+
 setup_requires = [min_numpy_version]
 
 # Make sure to have the packages needed for building astropy, but do not require them


### PR DESCRIPTION
Fix #8039 (unless there is a better solution from rtfd/readthedocs.org#4822). If this is accepted, before merge, might need a change log since it affects installation.

**Note:** Check RTD build log on my fork first!

https://readthedocs.org/projects/astropy-pllim/builds/8024712/

**Update:** Looks like this works despite the timeout. See below.

```
Collecting numpy<1.15.3,>=1.13.0 (from astropy==3.2.dev23163)
  Downloading https://f.../numpy-1.15.2-cp36-cp36m-manylinux1_x86_64.whl (13.9MB)
Building wheels for collected packages: astropy
  Running setup.py bdist_wheel for astropy: started
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: still running...
  Running setup.py bdist_wheel for astropy: finished with status 'done'
  Stored in directory: ...
Successfully built astropy
Installing collected packages: numpy, astropy
Successfully installed astropy-3.2.dev23163 numpy-1.15.2
```

p.s. Milestoning to 3.1 since we might want updated docs to go with the release.