### PR TITLE
MNT: Replace bintrees with sortedcontainers in pip requirements

### DIFF
--- a/pip-requirements-dev
+++ b/pip-requirements-dev
@@ -1,5 +1,5 @@
 -r pip-requirements-doc
-bintrees
+sortedcontainers
 bleach
 
 # below here are used only for tests


### PR DESCRIPTION
Address https://github.com/astropy/astropy/issues/6539#issuecomment-434048779 . Note that both `bintrees` and `sortedcontainers` are installed for CI in `.travis.yml`. This simply discourages users from using the unmaintained `bintrees`. Deprecating that option altogether and updating relevant doc is beyond the scope of this PR.