### PR TITLE
Remove deprecated usage of AsdfFile.open in io.misc.asdf

### DIFF
--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -115,7 +115,7 @@ table: !core/table
     buff = helpers.yaml_to_asdf(yaml)
 
     with pytest.raises(ValueError):
-        with asdf.AsdfFile.open(buff) as ff:
+        with asdf.open(buff) as ff:
             pass
 
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_quantity.py
@@ -12,13 +12,13 @@ from asdf.tests import helpers
 
 def roundtrip_quantity(yaml, quantity):
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.AsdfFile.open(buff) as ff:
+    with asdf.open(buff) as ff:
         assert (ff.tree['quantity'] == quantity).all()
         buff2 = io.BytesIO()
         ff.write_to(buff2)
 
     buff2.seek(0)
-    with asdf.AsdfFile.open(buff2) as ff:
+    with asdf.open(buff2) as ff:
         assert (ff.tree['quantity'] == quantity).all()
 
 def test_value_scalar(tmpdir):

--- a/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_unit.py
@@ -18,12 +18,12 @@ unit: !unit/unit-1.0.0 "2.1798721  10-18kg m2 s-2"
     """
 
     buff = helpers.yaml_to_asdf(yaml)
-    with asdf.AsdfFile.open(buff) as ff:
+    with asdf.open(buff) as ff:
         assert ff.tree['unit'].is_equivalent(u.Ry)
 
         buff2 = io.BytesIO()
         ff.write_to(buff2)
 
     buff2.seek(0)
-    with asdf.AsdfFile.open(buff2) as ff:
+    with asdf.open(buff2) as ff:
         assert ff.tree['unit'].is_equivalent(u.Ry)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -60,6 +60,9 @@ Astropy also depends on other packages for optional features:
 
 - `objgraph <https://mg.pov.lt/objgraph/>`_: Used only in tests to test for reference leaks.
 
+- `asdf <https://github.com/spacetelescope/asdf>`_ 2.0 or later: Enables the
+  serialization of various Astropy classes into a portable, hierarchical,
+  human-readable representation.
 
 
 However, note that these only need to be installed if those particular features


### PR DESCRIPTION
This deprecation is pending in https://github.com/spacetelescope/asdf/pull/579, but there's no harm in making this change now.

Any chance this could sneak into 3.1? It's not a big deal either way.