### PR TITLE
Fix test runner: allow single doc paths to be tested again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -891,6 +891,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Fixing bug that prevented to run the doctests on only a single rst documentation
+  file rather than all of them. [#8055]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -564,7 +564,7 @@ class TestRunner(TestRunnerBase):
                                    "docs path ({path}) does not exist.")
                 paths = self.packages_path(kwargs['package'], docs_path,
                                            warning=warning_message)
-            else:
+            elif not kwargs['test_path']:
                 paths = [docs_path, ]
 
             if len(paths) and not kwargs['test_path']:


### PR DESCRIPTION
This fixes #8030.

Not sure whether this requires a change log update or not.