### PR TITLE
Fix bug in convolution for 2D arrays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           command: apt-get install -y libfreetype6-dev libpng12-dev pkg-config
       - run:
           name: Install Python dependencies, including developer version of Matplotlib
-          command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
+          command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy "numpy<1.15.3" scipy git+https://github.com/matplotlib/matplotlib.git
       - run:
           name: Run tests
           command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"

--- a/astropy/convolution/src/boundary_none.c
+++ b/astropy/convolution/src/boundary_none.c
@@ -308,7 +308,7 @@ FORCE_INLINE void convolve2d_boundary_none(DTYPE * const result,
         {omp_iter_var j;
         for (j = wky; j < ny_minus_wky; ++j)
         {
-            wky_minus_j = wkx - j; // wky - j
+            wky_minus_j = wky - j; // wky - j
             j_minus_wky = j - wky; // j - wky
             j_plus_wky_plus_1 = j + wky_plus_1; // j + wky + 1
             nky_minus_1_minus_wky_plus_j = nky_minus_1 - wky_minus_j; // nky - 1 - (wky - i)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -6,7 +6,9 @@ import numpy.ma as ma
 
 from ..convolve import convolve, convolve_fft
 
-from numpy.testing import assert_array_almost_equal_nulp, assert_array_almost_equal
+from numpy.testing import (assert_array_almost_equal_nulp,
+                           assert_array_almost_equal,
+                           assert_allclose)
 
 import itertools
 
@@ -894,6 +896,7 @@ def test_astropy_convolution_against_scipy():
     assert_array_almost_equal(fftconvolve(y, x, 'same'),
                               convolve_fft(y, x, normalize_kernel=False))
 
+
 @pytest.mark.skipif('not HAS_PANDAS')
 def test_regression_6099():
     wave = np.array((np.linspace(5000, 5100, 10)))
@@ -905,8 +908,19 @@ def test_regression_6099():
 
     assert_array_almost_equal(nonseries_result, series_result)
 
+
 def test_invalid_array_convolve():
     kernel = np.ones(3)/3.
 
     with pytest.raises(TypeError):
         convolve('glork', kernel)
+
+
+def test_non_square_kernel_asymmetric():
+    # Regression test for a bug that occurred when using non-square kernels in
+    # 2D when using boundary=None
+    kernel = np.array([[1, 2, 3, 2, 1], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]])
+    image = np.zeros((13, 13))
+    image[6, 6] = 1
+    result = convolve(image, kernel, normalize_kernel=False)
+    assert_allclose(result[5:8, 4:9], kernel)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -916,11 +916,12 @@ def test_invalid_array_convolve():
         convolve('glork', kernel)
 
 
-def test_non_square_kernel_asymmetric():
+@pytest.mark.parametrize(('boundary'), BOUNDARY_OPTIONS)
+def test_non_square_kernel_asymmetric(boundary):
     # Regression test for a bug that occurred when using non-square kernels in
     # 2D when using boundary=None
     kernel = np.array([[1, 2, 3, 2, 1], [0, 1, 2, 1, 0], [0, 0, 0, 0, 0]])
     image = np.zeros((13, 13))
     image[6, 6] = 1
-    result = convolve(image, kernel, normalize_kernel=False)
+    result = convolve(image, kernel, normalize_kernel=False, boundary=boundary)
     assert_allclose(result[5:8, 4:9], kernel)


### PR DESCRIPTION
I noticed a typo in the convolution code for the boundary=None 2D case - this fixes it and includes a regression test.

cc @jamienoss 