### PR TITLE
serialize model equivalencies

### DIFF
--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -24,6 +24,7 @@ from .tags.transform.projections import *
 from .tags.transform.tabular import *
 from .tags.unit.quantity import *
 from .tags.unit.unit import *
+from .tags.unit.equivalency import *
 from .types import _astropy_types, _astropy_asdf_types
 
 

--- a/astropy/io/misc/asdf/tags/unit/equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/equivalency.py
@@ -1,0 +1,47 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from astropy.units.equivalencies import Equivalency
+from astropy.units import equivalencies
+from astropy.units.quantity import Quantity
+from asdf.yamlutil import custom_tree_to_tagged_tree
+
+from astropy.io.misc.asdf.types import AstropyAsdfType
+
+
+class EquivalencyType(AstropyAsdfType):
+    name = "unit/equivalency"
+    types = [Equivalency]
+    requires = ['astropy']
+    version = '1.1.0'
+
+    @classmethod
+    def to_tree(cls, equiv, ctx):
+        node = {}
+        if isinstance(equiv, Equivalency):
+            eqs = []
+            for i, e in enumerate(equiv.name):
+                args = equiv.args[i]
+                args = [custom_tree_to_tagged_tree(i, ctx) if isinstance(i, Quantity) \
+                        else i for i in args]
+                kwargs = equiv.kwargs[i]
+                eq = {'name': e, 'args': args,  'kwargs_names': list(kwargs.keys()),
+                      'kwargs_values': list(kwargs.values())}
+                eqs.append(eq)
+        else:
+            raise TypeError("'{0}' is not a valid Equivalency".format(equiv))
+        node['equivalencies'] = eqs
+        return node
+     
+
+
+    @classmethod
+    def from_tree(cls, node, ctx):
+        import operator
+        e = []
+        for eq in node['equivalencies']:
+            equiv = getattr(equivalencies, eq['name'])
+            args = eq['args']
+            kwargs = dict(zip(eq['kwargs_names'], eq['kwargs_values']))
+            e.append(equiv(*args, **kwargs))
+        return operator.add(*e)

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -39,11 +39,23 @@ class Equivalency(UserList):
     kwargs: `dict`
         Any keyword arguments used to make the equivalency.
     """
-    def __init__(self, equiv_list, name, args=None, kwargs=None):
+    def __init__(self, equiv_list, name='', args=None, kwargs=None):
         self.data = equiv_list
-        self.name = name
-        self.args = args if args is not None else tuple()
-        self.kwargs = kwargs if kwargs is not None else dict()
+        self.name = [name]
+        self.args = [args] if args is not None else [tuple()]
+        self.kwargs = [kwargs] if kwargs is not None else [dict()]
+
+
+    def __add__(self, other):
+        new = super().__add__(other)
+        new.name = self.name
+        new.args = self.args
+        new.kwargs = self.kwargs
+        if isinstance(other, Equivalency):
+            new.name = other.name
+            new.args += other.args
+            new.kwargs += other.kwargs
+        return new
 
 
 def dimensionless_angles():

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """A set of standard astronomical equivalencies."""
 
+from collections import UserList
+
 # THIRD-PARTY
 import numpy as np
 import warnings
@@ -24,6 +26,26 @@ __all__ = ['parallax', 'spectral', 'spectral_density', 'doppler_radio',
            'pixel_scale', 'plate_scale', 'with_H0']
 
 
+class Equivalency(UserList):
+    """
+    A container for a units equivalency.
+
+    Attributes
+    ----------
+    name: `str`
+        The name of the equivalency.
+    args: `tuple`
+        Any arguments used to make the equivalency.
+    kwargs: `dict`
+        Any keyword arguments used to make the equivalency.
+    """
+    def __init__(self, equiv_list, name, args=None, kwargs=None):
+        self.data = equiv_list
+        self.name = name
+        self.args = args if args is not None else tuple()
+        self.kwargs = kwargs if kwargs is not None else dict()
+
+
 def dimensionless_angles():
     """Allow angles to be equivalent to dimensionless (with 1 rad = 1 m/m = 1).
 
@@ -31,15 +53,15 @@ def dimensionless_angles():
     allows this independent of the power to which the angle is raised,
     and independent of whether it is part of a more complicated unit.
     """
-    return [(si.radian, None)]
+    return Equivalency([(si.radian, None)], "dimensionless_angles")
 
 
 def logarithmic():
     """Allow logarithmic units to be converted to dimensionless fractions"""
-    return [
+    return Equivalency([
         (dimensionless_unscaled, function_units.dex,
          np.log10, lambda x: 10.**x)
-    ]
+    ], "logarithmic")
 
 
 def parallax():
@@ -62,9 +84,9 @@ def parallax():
             else:
                 return d
 
-    return [
+    return Equivalency([
         (si.arcsecond, astrophys.parsec, parallax_converter)
-    ]
+    ], "parallax")
 
 
 def spectral():
@@ -86,7 +108,7 @@ def spectral():
     inv_m_spec = si.m ** -1
     inv_m_ang = si.radian / si.m
 
-    return [
+    return Equivalency([
         (si.m, si.Hz, lambda x: _si.c.value / x),
         (si.m, si.J, lambda x: hc / x),
         (si.Hz, si.J, lambda x: _si.h.value * x, lambda x: x / _si.h.value),
@@ -99,7 +121,7 @@ def spectral():
         (si.Hz, inv_m_ang, lambda x: two_pi * x / _si.c.value,
          lambda x: _si.c.value * x / two_pi),
         (si.J, inv_m_ang, lambda x: x * two_pi / hc, lambda x: hc * x / two_pi)
-    ]
+    ], "spectral")
 
 
 def spectral_density(wav, factor=None):
@@ -210,7 +232,7 @@ def spectral_density(wav, factor=None):
     converter_phot_L_nu_to_L_la = converter_phot_f_nu_to_f_la
     iconverter_phot_L_nu_to_L_la = iconverter_phot_f_nu_to_f_la
 
-    return [
+    return Equivalency([
         # flux
         (f_la, f_nu, converter, iconverter),
         (f_nu, nu_f_nu, converter_f_nu_to_nu_f_nu, iconverter_f_nu_to_nu_f_nu),
@@ -229,7 +251,7 @@ def spectral_density(wav, factor=None):
         (phot_L_la, phot_L_nu, converter_phot_L_la_phot_L_nu, iconverter_phot_L_la_phot_L_nu),
         (phot_L_nu, L_nu, converter_phot_L_nu_to_L_nu, iconverter_phot_L_nu_to_L_nu),
         (phot_L_nu, L_la, converter_phot_L_nu_to_L_la, iconverter_phot_L_nu_to_L_la),
-    ]
+    ], "spectral_density", (wav,), {'factor': factor})
 
 
 def doppler_radio(rest):
@@ -291,10 +313,10 @@ def doppler_radio(rest):
         voverc = x/ckms
         return resten * (1-voverc)
 
-    return [(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
+    return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
             (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ]
+            ], "doppler_radio", (rest,))
 
 
 def doppler_optical(rest):
@@ -357,10 +379,10 @@ def doppler_optical(rest):
         voverc = x/ckms
         return resten / (1+voverc)
 
-    return [(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
+    return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
             (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ]
+            ], "doppler_optical", (rest,))
 
 
 def doppler_relativistic(rest):
@@ -430,19 +452,19 @@ def doppler_relativistic(rest):
         voverc = x/ckms
         return resten * ((1-voverc) / (1+(voverc)))**0.5
 
-    return [(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
+    return Equivalency([(si.Hz, si.km/si.s, to_vel_freq, from_vel_freq),
             (si.AA, si.km/si.s, to_vel_wav, from_vel_wav),
             (si.eV, si.km/si.s, to_vel_en, from_vel_en),
-            ]
+            ], "doppler_relativistic", (rest,))
 
 
 def molar_mass_amu():
     """
     Returns the equivalence between amu and molar mass.
     """
-    return [
+    return Equivalency([
         (si.g/si.mol, astrophys.u)
-    ]
+    ], "molar_mass_amu")
 
 
 def mass_energy():
@@ -451,7 +473,7 @@ def mass_energy():
     between mass and energy.
     """
 
-    return [(si.kg, si.J, lambda x: x * _si.c.value ** 2,
+    return Equivalency([(si.kg, si.J, lambda x: x * _si.c.value ** 2,
              lambda x: x / _si.c.value ** 2),
             (si.kg / si.m ** 2, si.J / si.m ** 2,
              lambda x: x * _si.c.value ** 2,
@@ -461,7 +483,7 @@ def mass_energy():
              lambda x: x / _si.c.value ** 2),
             (si.kg / si.s, si.J / si.s, lambda x: x * _si.c.value ** 2,
              lambda x: x / _si.c.value ** 2),
-    ]
+    ], "mass_energy")
 
 
 def brightness_temperature(frequency, beam_area=None):
@@ -555,7 +577,8 @@ def brightness_temperature(frequency, beam_area=None):
             factor = (astrophys.Jy / (2 * _si.k_B * nu**2 / _si.c**2)).to(si.K).value
             return (x_K / factor) # multiplied by 1x for 1 steradian
 
-        return [(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr)]
+        return Equivalency([(astrophys.Jy/si.sr, si.K, convert_JySr_to_K, convert_K_to_JySr)],
+                           "brightness_temperature", (frequency,), {'beam_area': beam_area})
 
 
 def beam_angular_area(beam_area):
@@ -570,10 +593,10 @@ def beam_angular_area(beam_area):
     beam_area : angular area equivalent
         The area of the beam in angular area units (e.g., steradians)
     """
-    return [(astrophys.beam, Unit(beam_area)),
-            (astrophys.beam**-1, Unit(beam_area)**-1),
-            (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),
-           ]
+    return Equivalency([(astrophys.beam, Unit(beam_area)),
+                        (astrophys.beam**-1, Unit(beam_area)**-1),
+                        (astrophys.Jy/astrophys.beam, astrophys.Jy/Unit(beam_area)),],
+                       "beam_angular_area", (beam_area,))
 
 
 def thermodynamic_temperature(frequency, T_cmb=None):
@@ -635,7 +658,8 @@ def thermodynamic_temperature(frequency, T_cmb=None):
         factor = (astrophys.Jy / (f(nu) * 2 * _si.k_B * nu**2 / _si.c**2)).to_value(si.K)
         return x_K / factor
 
-    return [(astrophys.Jy/si.sr, si.K, convert_Jy_to_K, convert_K_to_Jy)]
+    return Equivalency([(astrophys.Jy/si.sr, si.K, convert_Jy_to_K, convert_K_to_Jy)],
+                       "thermodynamic_temperature", (frequency,), {"T_cmb": T_cmb})
 
 
 def temperature():
@@ -643,18 +667,18 @@ def temperature():
     Unit and CompositeUnit cannot do addition or subtraction properly.
     """
     from .imperial import deg_F
-    return [
+    return Equivalency([
         (si.K, si.deg_C, lambda x: x - 273.15, lambda x: x + 273.15),
         (si.deg_C, deg_F, lambda x: x * 1.8 + 32.0, lambda x: (x - 32.0) / 1.8),
         (si.K, deg_F, lambda x: (x - 273.15) * 1.8 + 32.0,
-         lambda x: ((x - 32.0) / 1.8) + 273.15)]
+         lambda x: ((x - 32.0) / 1.8) + 273.15)], "temperature")
 
 
 def temperature_energy():
     """Convert between Kelvin and keV(eV) to an equivalent amount."""
-    return [
+    return Equivalency([
         (si.K, si.eV, lambda x: x / (_si.e.value / _si.k_B.value),
-         lambda x: x * (_si.e.value / _si.k_B.value))]
+         lambda x: x * (_si.e.value / _si.k_B.value))], "temperature_energy")
 
 
 def assert_is_spectral_unit(value):
@@ -663,7 +687,6 @@ def assert_is_spectral_unit(value):
     except (AttributeError, UnitsError) as ex:
         raise UnitsError("The 'rest' value must be a spectral equivalent "
                          "(frequency, wavelength, or energy).")
-
 
 def pixel_scale(pixscale):
     """
@@ -683,7 +706,9 @@ def pixel_scale(pixscale):
         raise UnitsError("The pixel scale must be in angle/pixel or "
                          "pixel/angle")
 
-    return [(astrophys.pix, si.radian, lambda px: px*pixscale_val, lambda rad: rad/pixscale_val)]
+    return Equivalency([(astrophys.pix, si.radian,
+                         lambda px: px*pixscale_val, lambda rad: rad/pixscale_val)],
+                       "pixel_scale", (pixel_scale,), {})
 
 
 def plate_scale(platescale):
@@ -704,7 +729,8 @@ def plate_scale(platescale):
         raise UnitsError("The pixel scale must be in angle/distance or "
                          "distance/angle")
 
-    return [(si.m, si.radian, lambda d: d*platescale_val, lambda rad: rad/platescale_val)]
+    return Equivalency([(si.m, si.radian, lambda d: d*platescale_val, lambda rad: rad/platescale_val)],
+                       "plate_scale", (platescale,))
 
 
 def with_H0(H0=None):
@@ -730,4 +756,4 @@ def with_H0(H0=None):
 
     h100_val_unit = Unit(H0.to((si.km/si.s)/astrophys.Mpc).value/100 * astrophys.littleh)
 
-    return [(h100_val_unit, None)]
+    return Equivalency([(h100_val_unit, None)], "with_H0", kwargs={"H0": H0})

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -52,7 +52,7 @@ class Equivalency(UserList):
         new.args = self.args
         new.kwargs = self.kwargs
         if isinstance(other, Equivalency):
-            new.name = other.name
+            new.name += other.name
             new.args += other.args
             new.kwargs += other.kwargs
         return new
@@ -720,7 +720,7 @@ def pixel_scale(pixscale):
 
     return Equivalency([(astrophys.pix, si.radian,
                          lambda px: px*pixscale_val, lambda rad: rad/pixscale_val)],
-                       "pixel_scale", (pixel_scale,), {})
+                       "pixel_scale", (pixscale,), {})
 
 
 def plate_scale(platescale):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose
 
 # LOCAL
 from astropy import units as u
+from astropy.units.equivalencies import Equivalency
 from astropy import constants, cosmology
 from astropy.tests.helper import assert_quantity_allclose
 
@@ -770,3 +771,27 @@ def test_littleh():
     # Then M - 5*log_10(h)  = M + 5 = 17
     withlittlehmag = 17 * (u.mag + u.MagUnit(u.littleh**2))
     assert_quantity_allclose(withlittlehmag.to(u.mag, u.with_H0(H0_10)), 12*u.mag)
+
+
+def test_equivelency():
+    ps = u.pixel_scale(10*u.arcsec/u.pix)
+    assert isinstance(ps, Equivalency)
+    assert isinstance(ps.name, list)
+    assert len(ps.name) == 1
+    assert ps.name[0] == "pixel_scale"
+    assert isinstance(ps.args, list)
+    assert len(ps.args) == 1
+    assert ps.args[0][0] == 10*u.arcsec/u.pix
+    assert isinstance(ps.kwargs, list)
+    assert len(ps.kwargs) == 1
+    assert ps.kwargs[0] == dict()
+
+def test_add_equivelencies():
+    e1 = u.pixel_scale(10*u.arcsec/u.pixel) + u.temperature_energy()
+    assert isinstance(e1, Equivalency)
+    assert e1.name == ["pixel_scale", "temperature_energy"]
+    assert isinstance(e1.args, list)
+    assert len(e1.args) == 2
+    assert e1.args[0][0] == 10*u.arcsec/u.pix
+    assert isinstance(e1.kwargs, list)
+    assert e1.kwargs == [dict(), dict()]


### PR DESCRIPTION
This is an implementation of the suggested API change in #8059.
The interface can be improved by not requiring the equivalencies tuple to include empty args and kwargs, I just wanted to show how it looks. Any thoughts?

@Cadair @perrygreenfield @astrofrog 