### PR TITLE
Fix failing tests on MIPS and PowerPC

### DIFF
--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -82,7 +82,11 @@ def test_str():
                     '             mask=[False,  True],',
                     "       fill_value='N/A',",
                     "            dtype='<U23')"]
-    assert repr(t.iso).splitlines() == expected
+
+    # Note that we need to take care to allow for big-endian platforms,
+    # for which the dtype will be >U23 instead of <U23, which we do with
+    # the call to replace().
+    assert repr(t.iso).replace('>U23', '<U23').splitlines() == expected
 
     # Assign value to unmask
     t[1] = '2000:111'

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -36,7 +36,8 @@ __all__ = ['data_info_factory', 'dtype_info_name', 'BaseColumnInfo',
 
 # Tuple of filterwarnings kwargs to ignore when calling info
 IGNORE_WARNINGS = (dict(category=RuntimeWarning, message='All-NaN|'
-                        'Mean of empty slice|Degrees of freedom <= 0'),)
+                        'Mean of empty slice|Degrees of freedom <= 0|'
+                        'invalid value encountered in sqrt'),)
 
 STRING_TYPE_NAMES = {(False, 'S'): 'str',  # not PY3
                      (False, 'U'): 'unicode',


### PR DESCRIPTION
This fixes a couple of tests that were failing in Debian on MIPS and PowerPC. Neither were critical, but this will hopefully make packaging of the v3.1 release smoother on Debian.

cc @olebole (just FYI)

For the record, the failures were:

```python
=================================== FAILURES ===================================
_____________________________ test_ignore_warnings _____________________________

    def test_ignore_warnings():
        t = table.Table([[np.nan, np.nan]])
        with warnings.catch_warnings(record=True) as warns:
            t.info('stats', out=None)
>           assert len(warns) == 0
E           assert 1 == 0
E            +  where 1 = len([<warnings.WarningMessage object at 0x6fca67d0>])

/usr/local/lib/python3.6/site-packages/astropy-3.2.dev1-py3.6-linux-mips64.egg/astropy/table/tests/test_info.py:239: AssertionError
___________________________________ test_str ___________________________________

    def test_str():
        t = Time(['2000:001', '2000:002'])
        t[1] = np.ma.masked
        assert str(t) == "['2000:001:00:00:00.000' --]"
        assert repr(t) == "<Time object: scale='utc' format='yday' value=['2000:001:00:00:00.000' --]>"
    
        if NUMPY_LT_1_14:
            expected = ["masked_array(data = ['2000-01-01 00:00:00.000' --],",
                        "             mask = [False  True],",
                        "       fill_value = N/A)"]
        else:
            expected = ["masked_array(data=['2000-01-01 00:00:00.000', --],",
                        '             mask=[False,  True],',
                        "       fill_value='N/A',",
                        "            dtype='<U23')"]
>       assert repr(t.iso).splitlines() == expected
E       assert ["masked_arra...type='>U23')"] == ["masked_array...type='<U23')"]
E         At index 3 diff: "            dtype='>U23')" != "            dtype='<U23')"
E         Use -v to get the full diff

/usr/local/lib/python3.6/site-packages/astropy-3.2.dev1-py3.6-linux-mips64.egg/astropy/time/tests/test_mask.py:85: AssertionError
```