### PR TITLE
Fix bug in show_in_notebook, not supporting mixin columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -856,7 +856,7 @@ astropy.io.misc
   unicode strings.  Now those columns are first encoded to UTF-8 and
   written as byte strings. [#7024, #8017]
 
-- Fixed a bug with serializing the bounding_box of models initialized 
+- Fixed a bug with serializing the bounding_box of models initialized
   with ``Quantities`` . [#8052]
 
 astropy.io.fits
@@ -878,7 +878,7 @@ astropy.modeling
 - Fix behaviour of certain models with units, by making certain unit-related
   attributes readonly. [#7210]
 
-- Fixed an issue with validating a ``bounding_box`` whose items are 
+- Fixed an issue with validating a ``bounding_box`` whose items are
   ``Quantities``. [#8052]
 
 astropy.nddata
@@ -1750,6 +1750,8 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fix ``Table.show_in_notebook`` failure when mixin columns are present. [#8069]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1026,7 +1026,7 @@ class Table:
 
         columns = display_table.columns.values()
         sortable_columns = [i for i, col in enumerate(columns)
-                            if col.dtype.kind in 'iufc']
+                            if col.info.dtype.kind in 'iufc']
         html += jsv.ipynb(tableid, css=css, sort_columns=sortable_columns)
         return HTML(html)
 


### PR DESCRIPTION
This is a trivial fix for #8067.  For general support of mixins all code needs to use `obj.info.dtype` not `obj.dtype`.  `Obj.info.dtype` is guaranteed to exist.

Not sure about milestone or where to put a changelog entry or how to add a test.  I confirm that for me it fixes the problem shown in #8067.

@mwcraig 