### PR TITLE
Fix #5159 - Supports rename_columns in Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,8 @@ astropy.table
   columns.  ``Time`` and ``TimeDelta`` columns get converted to
   corresponding pandas date or time delta types.  The ``DataFrame``
   index is now handled in the conversion methods. [#8247]
+- Added ``rename_columns`` method to rename multiple columns in one call. [#5159, #8070]
+
 
 - Improved Table performance by reducing unnecessary calls to copy and deepcopy,
   especially as related to the table and column ``meta`` attributes.  Changed the

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2249,6 +2249,52 @@ class Table:
 
         self.columns[name].info.name = new_name
 
+    def rename_columns(self, names, new_names):
+        '''
+        Rename multiple columns.
+
+        Parameters
+        ----------
+        names: list, tuple
+            A list or tuple of existing column names.
+        new_names: list, tuple
+            A list or tuple of new column names.
+
+        Examples
+        --------
+        Create a table with three columns 'a', 'b', 'c'::
+
+            >>> t = Table([[1,2],[3,4],[5,6]], names=('a','b','c'))
+            >>> print(t)
+              a   b   c
+             --- --- ---
+              1   3   5
+              2   4   6
+
+        Renaming columns 'a' to 'aa' and 'b' to 'bb'::
+
+            >>> names = ('a','b')
+            >>> new_names = ('aa','bb')
+            >>> t.rename_columns(names, new_names)
+            >>> print(t)
+             aa  bb   c
+            --- --- ---
+              1   3   5
+              2   4   6
+        '''
+
+        if not self._is_list_or_tuple_of_str(names):
+            raise TypeError("input 'names' must be a tuple or a list of column names")
+
+        if not self._is_list_or_tuple_of_str(new_names):
+            raise TypeError("input 'new_names' must be a tuple or a list of column names")
+
+        if len(names) != len(new_names):
+            raise ValueError("input 'names' and 'new_names' list arguments must be the same length")
+
+        for name, new_name in zip(names, new_names):
+            self.rename_column(name, new_name)
+
     def _set_row(self, idx, colnames, vals):
         try:
             assert len(vals) == len(colnames)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2255,9 +2255,9 @@ class Table:
 
         Parameters
         ----------
-        names: list, tuple
+        names : list, tuple
             A list or tuple of existing column names.
-        new_names: list, tuple
+        new_names : list, tuple
             A list or tuple of new column names.
 
         Examples

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1022,7 +1022,7 @@ class TestRename(SetupData):
         self._setup(table_types)
         t = table_types.Table([self.a, self.b, self.c])
         t.rename_columns(('a', 'b', 'c'), ('aa', 'bb', 'cc'))
-        assert t.columns.keys() == ['aa', 'bb', 'cc']
+        assert t.colnames == ['aa', 'bb', 'cc']
         t.rename_columns(['bb', 'cc'], ['b', 'c'])
         assert t.colnames == ['aa', 'b', 'c']
         with pytest.raises(TypeError):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1018,6 +1018,18 @@ class TestRename(SetupData):
         assert np.all(t['c'] == np.array([1, 2, 3]))
         assert np.all(t['a'] == np.array([4, 5, 6]))
 
+    def test_rename_columns(self, table_types):
+        self._setup(table_types)
+        t = table_types.Table([self.a, self.b, self.c])
+        t.rename_columns(('a', 'b', 'c'), ('aa', 'bb', 'cc'))
+        assert t.columns.keys() == ['aa', 'bb', 'cc']
+        t.rename_columns(['bb', 'cc'], ['b', 'c'])
+        assert t.colnames == ['aa', 'b', 'c']
+        with pytest.raises(TypeError):
+            t.rename_columns(('aa'), ['a'])
+        with pytest.raises(ValueError):
+            t.rename_columns(['a'], ['b', 'c'])
+
 
 @pytest.mark.usefixtures('table_types')
 class TestSort():


### PR DESCRIPTION
- Implements a rename_columns method in Table which takes in
  two lists as parameters to rename.
- Adds relevant test cases for both passing and failures

EDIT: Fix #5159 