### PR TITLE
Additions to convolution.convolve as per #8057

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -38,11 +38,14 @@ _convolveNd_c.restype = None
 _convolveNd_c.argtypes = [ndpointer(ctypes.c_double, flags={"C_CONTIGUOUS", "WRITEABLE"}), # return array
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"), # input array
             ctypes.c_uint, # N dim
-            ndpointer(ctypes.c_size_t, flags="C_CONTIGUOUS"), # size array for return & input
+            ndpointer(ctypes.c_size_t, flags="C_CONTIGUOUS"), # size array for input and result unless
+                                                              # assume_results_array_padded_by_half_kernel_size is True,
+                                                              # in which case the result array is assumed to be
+                                                              # input.shape + 2*(kernel.shape//2). Note: integer division.
             ndpointer(ctypes.c_double, flags="C_CONTIGUOUS"), # kernel array
             ndpointer(ctypes.c_size_t, flags="C_CONTIGUOUS"), # size array for kernel
             ctypes.c_bool, # nan_interpolate
-            ctypes.c_bool, # padded
+            ctypes.c_bool, # assume_results_array_padded_by_half_kernel_size
             ctypes.c_uint] # n_threads
 
 # Disabling all doctests in this module until a better way of handling warnings
@@ -297,10 +300,10 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     # here and pass through instead.
     result = np.zeros(array_internal.shape, dtype=float, order='C')
 
-    is_array_padded = False
+    results_array_padded_by_half_kernel_size = True
     array_to_convolve = array_internal
     if boundary in ('fill', 'extend', 'wrap'):
-        is_array_padded = True
+        results_array_padded_by_half_kernel_size = False
         if boundary == 'fill':
             # This method is faster than using numpy.pad(..., mode='constant')
             array_to_convolve = np.full(array_shape + 2*pad_width, fill_value=fill_value, dtype=float, order='C')
@@ -335,7 +338,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
                   np.array(array_to_convolve.shape, dtype=ctypes.c_size_t, order='C'),
                   kernel_internal,
                   np.array(kernel_shape, dtype=ctypes.c_size_t, order='C'),
-                  nan_interpolate, is_array_padded,
+                  nan_interpolate, results_array_padded_by_half_kernel_size,
                   n_threads
                   )
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -26,7 +26,7 @@ LIBRARY_PATH = os.path.dirname(__file__)
 try:
     _convolve = load_library("_convolve", LIBRARY_PATH)
 except Exception:
-    raise Exception("Convolution C extension is missing. Try re-building astropy.")
+    raise ImportError("Convolution C extension is missing. Try re-building astropy.")
 
 # The GIL is automatically released by default when calling functions imported
 # from libaries loaded by ctypes.cdll.LoadLibrary(<path>)

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -236,7 +236,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        i_minus_wkx = i - wkx; //i - wkx
+        i_minus_wkx = i - wkx;
 
         top = 0.;
         if (nan_interpolate) // compile time constant
@@ -337,12 +337,12 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        i_minus_wkx = i - wkx; //i - wkx
+        i_minus_wkx = i - wkx;
 
         {omp_iter_var j;
         for (j = wky; j < ny_minus_wky; ++j)
         {
-            j_minus_wky = j - wky; // j - wky
+            j_minus_wky = j - wky;
 
             top = 0.;
             if (nan_interpolate) // compile time constant
@@ -454,17 +454,17 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        i_minus_wkx = i - wkx; //i - wkx
+        i_minus_wkx = i - wkx;
 
         {omp_iter_var j;
         for (j = wky; j < ny_minus_wky; ++j)
         {
-            j_minus_wky = j - wky; // j - wky
+            j_minus_wky = j - wky;
 
             {omp_iter_var k;
             for (k = wkz; k < nz_minus_wkz; ++k)
             {
-                k_minus_wkz = k - wkz; // k - wkz
+                k_minus_wkz = k - wkz;
 
                 top = 0.;
                 if (nan_interpolate) // compile time constant

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -217,13 +217,14 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
     // when threaded. Without these, compile time constant conditionals may
     // not be optimized away.
     const size_t nx = _nx;
+    const size_t nkx = _nkx;
+    const size_t nkx_minus_1 = nkx - 1;
     const bool nan_interpolate = _nan_interpolate;
     const bool padded = _padded;
 
     // Thread locals
     const size_t wkx = _wkx;
     size_t wkx_plus_i;
-    size_t ker_i;
     const omp_iter_var nx_minus_wkx = nx - wkx;
     size_t i_minus_wkx;
     omp_iter_var i_plus_wkx_plus_1;
@@ -245,11 +246,10 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
         if (nan_interpolate) // compile time constant
             bot = 0.;
         {omp_iter_var ii;
-        for (ii = i_minus_wkx; ii < i_plus_wkx_plus_1; ++ii)
+        for (ii = 0; ii < nkx; ++ii)
         {
-            ker_i = wkx_plus_i - ii; // nkx - 1 - (wkx + ii - i)
-            val = f[ii];
-            ker = g[ker_i];
+            val = f[i_minus_wkx + ii];
+            ker = g[nkx_minus_1 - ii];
             if (nan_interpolate) // compile time constant
             {
                 if (!isnan(val))
@@ -319,7 +319,8 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
     // when threaded. Without these, compile time constant conditionals may
     // not be optimized away.
     const size_t nx = _nx, ny = _ny;
-    const size_t nky = _nky;
+    const size_t nkx = _nkx, nky = _nky;
+    const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1;
     const bool nan_interpolate = _nan_interpolate;
     const bool padded = _padded;
 
@@ -327,7 +328,6 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
     const size_t wkx = _wkx;
     const size_t wky = _wky;
     size_t wkx_plus_i, wky_plus_j;
-    size_t ker_i, ker_j;
     const omp_iter_var nx_minus_wkx = nx - wkx;
     const omp_iter_var ny_minus_wky = ny - wky;
     const size_t ny_minus_2wky = ny - 2 * wky;
@@ -358,15 +358,13 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
             if (nan_interpolate) // compile time constant
                 bot = 0.;
             {omp_iter_var ii;
-            for (ii = i_minus_wkx; ii < i_plus_wkx_plus_1; ++ii)
+            for (ii = 0; ii < nkx; ++ii)
             {
-                ker_i = wkx_plus_i - ii; // nkx - 1 - (wkx + ii - i)
                 {omp_iter_var jj;
-                for (jj = j_minus_wky; jj < j_plus_wky_plus_1; ++jj)
+                for (jj = 0; jj < nky; ++jj)
                 {
-                    ker_j = wky_plus_j - jj; // nky - 1 - (wky + jj - j)
-                    val = f[ii*ny + jj]; //[ii, jj];
-                    ker = g[ker_i*nky + ker_j]; // [ker_i, ker_j];
+                    val = f[(i_minus_wkx+ii)*ny + (j_minus_wky+jj)];
+                    ker = g[(nkx_minus_1 - ii)*nky + (nky_minus_1 - jj)];
                     if (nan_interpolate) // compile time constant
                     {
                         if (!isnan(val))
@@ -440,7 +438,8 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     // when threaded. Without these, compile time constant conditionals may
     // not be optimized away.
     const size_t nx = _nx, ny = _ny, nz = _nz;
-    const size_t nky = _nky, nkz = _nkz;
+    const size_t nkx = _nkx, nky = _nky, nkz = _nkz;
+    const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1, nkz_minus_1 = nkz - 1;
     const bool nan_interpolate = _nan_interpolate;
     const bool padded = _padded;
 
@@ -449,7 +448,6 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     const size_t wky = _wky;
     const size_t wkz = _wkz;
     size_t wkx_plus_i, wky_plus_j, wkz_plus_k;
-    size_t ker_i, ker_j, ker_k;
     const size_t nx_minus_wkx = nx - wkx;
     const omp_iter_var ny_minus_wky = ny - wky;
     const omp_iter_var nz_minus_wkz = nz - wkz;
@@ -490,20 +488,16 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
                 if (nan_interpolate) // compile time constant
                     bot = 0.;
                 {omp_iter_var ii;
-                for (ii = i_minus_wkx; ii < i_plus_wkx_plus_1; ++ii)
+                for (ii = 0; ii < nkx; ++ii)
                 {
-                    ker_i = wkx_plus_i - ii; // nkx - 1 - (wkx + ii - i)
                     {omp_iter_var jj;
-                    for (jj = j_minus_wky; jj < j_plus_wky_plus_1; ++jj)
+                    for (jj = 0; jj < nky; ++jj)
                     {
-                        ker_j = wky_plus_j - jj; // nky - 1 - (wky + jj - j)
                         {omp_iter_var kk;
-                        for (kk = k_minus_wkz; kk < k_plus_wkz_plus_1; ++kk)
+                        for (kk = 0; kk < nkz; ++kk)
                         {
-                            ker_k = wkz_plus_k - kk; // nkz - 1 - (wkz + kk - k)
-
-                            val = f[(ii*ny + jj)*nz + kk]; //[ii, jj, kk];
-                            ker = g[(ker_i*nky + ker_j)*nkz + ker_k]; // [ker_i, ker_j, ker_k];
+                            val = f[((i_minus_wkx + ii)*ny + (j_minus_wky + jj))*nz + (k_minus_wkz + kk)];
+                            ker = g[((nkx_minus_1 - ii)*nky + (nky_minus_1 - jj))*nkz + (nkz_minus_1 - kk)];
                             if (nan_interpolate) // compile time constant
                             {
                                 if (!isnan(val))

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -224,10 +224,8 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
 
     // Thread locals
     const size_t wkx = _wkx;
-    size_t wkx_plus_i;
     const omp_iter_var nx_minus_wkx = nx - wkx;
     size_t i_minus_wkx;
-    omp_iter_var i_plus_wkx_plus_1;
     size_t result_index;
 
     DTYPE top, bot=0., ker, val;
@@ -238,9 +236,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        wkx_plus_i = wkx + i; // wkx + i
         i_minus_wkx = i - wkx; //i - wkx
-        i_plus_wkx_plus_1 = wkx_plus_i + 1; // i + wkx + 1
 
         top = 0.;
         if (nan_interpolate) // compile time constant
@@ -327,12 +323,10 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
     // Thread locals
     const size_t wkx = _wkx;
     const size_t wky = _wky;
-    size_t wkx_plus_i, wky_plus_j;
     const omp_iter_var nx_minus_wkx = nx - wkx;
     const omp_iter_var ny_minus_wky = ny - wky;
     const size_t ny_minus_2wky = ny - 2 * wky;
     size_t i_minus_wkx, j_minus_wky;
-    omp_iter_var i_plus_wkx_plus_1, j_plus_wky_plus_1;
     size_t result_index;
 
     DTYPE top, bot=0., ker, val;
@@ -343,16 +337,12 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        wkx_plus_i = wkx + i; // wkx + 1
         i_minus_wkx = i - wkx; //i - wkx
-        i_plus_wkx_plus_1 = wkx_plus_i + 1; // i + wkx + 1
 
         {omp_iter_var j;
         for (j = wky; j < ny_minus_wky; ++j)
         {
-            wky_plus_j = wky + j; // wky + j
             j_minus_wky = j - wky; // j - wky
-            j_plus_wky_plus_1 = wky_plus_j + 1; // j + wky + 1
 
             top = 0.;
             if (nan_interpolate) // compile time constant
@@ -447,7 +437,6 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     const size_t wkx = _wkx;
     const size_t wky = _wky;
     const size_t wkz = _wkz;
-    size_t wkx_plus_i, wky_plus_j, wkz_plus_k;
     const size_t nx_minus_wkx = nx - wkx;
     const omp_iter_var ny_minus_wky = ny - wky;
     const omp_iter_var nz_minus_wkz = nz - wkz;
@@ -455,7 +444,6 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     const size_t nz_minus_2wkz = nz - 2 * wkz;
 
     size_t i_minus_wkx, j_minus_wky, k_minus_wkz;
-    omp_iter_var i_plus_wkx_plus_1, j_plus_wky_plus_1, k_plus_wkz_plus_1;
     size_t result_index;
 
     DTYPE top, bot=0., ker, val;
@@ -466,23 +454,17 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
 #endif
     for (i = wkx; i < nx_minus_wkx; ++i)
     {
-        wkx_plus_i = wkx + i; // wkx + i
         i_minus_wkx = i - wkx; //i - wkx
-        i_plus_wkx_plus_1 = wkx_plus_i + 1; // i + wkx + 1
 
         {omp_iter_var j;
         for (j = wky; j < ny_minus_wky; ++j)
         {
-            wky_plus_j = wky + j; // wky + j
             j_minus_wky = j - wky; // j - wky
-            j_plus_wky_plus_1 = wky_plus_j + 1; // j + wky + 1
 
             {omp_iter_var k;
             for (k = wkz; k < nz_minus_wkz; ++k)
             {
-                wkz_plus_k = wkz + k; // wkz + k
                 k_minus_wkz = k - wkz; // k - wkz
-                k_plus_wkz_plus_1 = wkz_plus_k + 1; // k + wkz + 1
 
                 top = 0.;
                 if (nan_interpolate) // compile time constant

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -20,7 +20,7 @@
  * index when accessing the results array - for example in the 1D case we shift
  * the index in the results array compared to the input array by half the kernel
  * size. This is done via the 'result_index' variable, and this behavior is
- * triggered by the 'padded' setting.
+ * triggered by the 'assume_results_array_padded_by_half_kernel_size' setting.
  *
  */
 
@@ -54,7 +54,7 @@ void convolveNd_c(DTYPE * const result,
         const DTYPE * const g,
         const size_t * const kernel_shape,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -72,17 +72,23 @@ void convolveNd_c(DTYPE * const result,
         convolve1d_c(result, f,
                 image_shape[0],
                 g, kernel_shape[0],
-                nan_interpolate, padded, n_threads);
+                nan_interpolate,
+                assume_results_array_padded_by_half_kernel_size,
+                n_threads);
     else if (n_dim == 2)
         convolve2d_c(result, f,
                 image_shape[0], image_shape[1],
                 g, kernel_shape[0], kernel_shape[1],
-                nan_interpolate, padded, n_threads);
+                nan_interpolate,
+                assume_results_array_padded_by_half_kernel_size,
+                n_threads);
     else if (n_dim == 3)
         convolve3d_c(result, f,
                         image_shape[0], image_shape[1], image_shape[2],
                         g, kernel_shape[0], kernel_shape[1], kernel_shape[2],
-                        nan_interpolate, padded, n_threads);
+                        nan_interpolate,
+                        assume_results_array_padded_by_half_kernel_size,
+                        n_threads);
     else
         assert(0); // Unimplemented: n_dim > 3
 }
@@ -101,7 +107,8 @@ void convolveNd_c(DTYPE * const result,
 void convolve1d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
-        const bool nan_interpolate, const bool padded,
+        const bool nan_interpolate,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -114,12 +121,12 @@ void convolve1d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve1d(result, f, nx, g, nkx, true, true, n_threads);
       else
         convolve1d(result, f, nx, g, nkx, true, false, n_threads);
     } else {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve1d(result, f, nx, g, nkx, false, true, n_threads);
       else
         convolve1d(result, f, nx, g, nkx, false, false, n_threads);
@@ -129,7 +136,8 @@ void convolve1d_c(DTYPE * const result,
 void convolve2d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
-        const bool nan_interpolate, const bool padded,
+        const bool nan_interpolate,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -142,12 +150,12 @@ void convolve2d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve2d(result, f, nx, ny, g, nkx, nky, true, true, n_threads);
       else
         convolve2d(result, f, nx, ny, g, nkx, nky, true, false, n_threads);
     } else {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve2d(result, f, nx, ny, g, nkx, nky, false, true, n_threads);
       else
         convolve2d(result, f, nx, ny, g, nkx, nky, false, false, n_threads);
@@ -157,7 +165,8 @@ void convolve2d_c(DTYPE * const result,
 void convolve3d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
-        const bool nan_interpolate, const bool padded,
+        const bool nan_interpolate,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -170,12 +179,12 @@ void convolve3d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, true, true, n_threads);
       else
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, true, false, n_threads);
     } else {
-      if (padded)
+      if (assume_results_array_padded_by_half_kernel_size)
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, false, true, n_threads);
       else
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, false, false, n_threads);
@@ -186,7 +195,8 @@ void convolve3d_c(DTYPE * const result,
 FORCE_INLINE void convolve1d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx,
         const DTYPE * const g, const size_t _nkx,
-        const bool _nan_interpolate, const bool _padded,
+        const bool _nan_interpolate,
+        const bool _assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -220,7 +230,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
     const size_t nkx = _nkx;
     const size_t nkx_minus_1 = nkx - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool padded = _padded;
+    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -258,10 +268,10 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
                 top += val * ker;
         }}
 
-        if (padded) { // compile time constant
-          result_index = i_minus_wkx;
+        if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
+            result_index = i;
         } else {
-          result_index = i;
+            result_index = i_minus_wkx;
         }
 
         if (nan_interpolate) // compile time constant
@@ -283,7 +293,8 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
 FORCE_INLINE void convolve2d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx, const size_t _ny,
         const DTYPE * const g, const size_t _nkx, const size_t _nky,
-        const bool _nan_interpolate, const bool _padded,
+        const bool _nan_interpolate,
+        const bool _assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -318,7 +329,7 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
     const size_t nkx = _nkx, nky = _nky;
     const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool padded = _padded;
+    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -374,10 +385,10 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
                 }}
             }}
 
-            if (padded) { // compile time constant
-              result_index = i_minus_wkx * ny_minus_2wky + j_minus_wky;
+            if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
+                result_index = result_cursor + j;
             } else {
-              result_index = result_cursor + j;
+                result_index = i_minus_wkx * ny_minus_2wky + j_minus_wky;
             }
 
             if (nan_interpolate) // compile time constant
@@ -400,7 +411,8 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
 FORCE_INLINE void convolve3d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx, const size_t _ny, const size_t _nz,
         const DTYPE * const g, const size_t _nkx, const size_t _nky, const size_t _nkz,
-        const bool _nan_interpolate, const bool _padded,
+        const bool _nan_interpolate,
+        const bool _assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -437,7 +449,7 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     const size_t nkx = _nkx, nky = _nky, nkz = _nkz;
     const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1, nkz_minus_1 = nkz - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool padded = _padded;
+    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -509,10 +521,10 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
                     }}
                 }}
 
-                if (padded) { // compile time constant
-                    result_index = (i_minus_wkx*ny_minus_2wky + j_minus_wky)*nz_minus_2wkz + k_minus_wkz;
-                } else {
+                if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
                     result_index = array_cursor + k;
+                } else {
+                    result_index = (i_minus_wkx*ny_minus_2wky + j_minus_wky)*nz_minus_2wkz + k_minus_wkz;
                 }
 
                 if (nan_interpolate) // compile time constant

--- a/astropy/convolution/src/convolve.c
+++ b/astropy/convolution/src/convolve.c
@@ -20,7 +20,7 @@
  * index when accessing the results array - for example in the 1D case we shift
  * the index in the results array compared to the input array by half the kernel
  * size. This is done via the 'result_index' variable, and this behavior is
- * triggered by the 'assume_results_array_padded_by_half_kernel_size' setting.
+ * triggered by the 'embed_result_within_padded_region' setting.
  *
  */
 
@@ -54,7 +54,7 @@ void convolveNd_c(DTYPE * const result,
         const DTYPE * const g,
         const size_t * const kernel_shape,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -73,21 +73,21 @@ void convolveNd_c(DTYPE * const result,
                 image_shape[0],
                 g, kernel_shape[0],
                 nan_interpolate,
-                assume_results_array_padded_by_half_kernel_size,
+                embed_result_within_padded_region,
                 n_threads);
     else if (n_dim == 2)
         convolve2d_c(result, f,
                 image_shape[0], image_shape[1],
                 g, kernel_shape[0], kernel_shape[1],
                 nan_interpolate,
-                assume_results_array_padded_by_half_kernel_size,
+                embed_result_within_padded_region,
                 n_threads);
     else if (n_dim == 3)
         convolve3d_c(result, f,
                         image_shape[0], image_shape[1], image_shape[2],
                         g, kernel_shape[0], kernel_shape[1], kernel_shape[2],
                         nan_interpolate,
-                        assume_results_array_padded_by_half_kernel_size,
+                        embed_result_within_padded_region,
                         n_threads);
     else
         assert(0); // Unimplemented: n_dim > 3
@@ -108,7 +108,7 @@ void convolve1d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -121,12 +121,12 @@ void convolve1d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve1d(result, f, nx, g, nkx, true, true, n_threads);
       else
         convolve1d(result, f, nx, g, nkx, true, false, n_threads);
     } else {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve1d(result, f, nx, g, nkx, false, true, n_threads);
       else
         convolve1d(result, f, nx, g, nkx, false, false, n_threads);
@@ -137,7 +137,7 @@ void convolve2d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -150,12 +150,12 @@ void convolve2d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve2d(result, f, nx, ny, g, nkx, nky, true, true, n_threads);
       else
         convolve2d(result, f, nx, ny, g, nkx, nky, true, false, n_threads);
     } else {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve2d(result, f, nx, ny, g, nkx, nky, false, true, n_threads);
       else
         convolve2d(result, f, nx, ny, g, nkx, nky, false, false, n_threads);
@@ -166,7 +166,7 @@ void convolve3d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -179,12 +179,12 @@ void convolve3d_c(DTYPE * const result,
 #endif
 
     if (nan_interpolate) {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, true, true, n_threads);
       else
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, true, false, n_threads);
     } else {
-      if (assume_results_array_padded_by_half_kernel_size)
+      if (embed_result_within_padded_region)
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, false, true, n_threads);
       else
         convolve3d(result, f, nx, ny, nz, g, nkx, nky, nkz, false, false, n_threads);
@@ -196,7 +196,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx,
         const DTYPE * const g, const size_t _nkx,
         const bool _nan_interpolate,
-        const bool _assume_results_array_padded_by_half_kernel_size,
+        const bool _embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -230,7 +230,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
     const size_t nkx = _nkx;
     const size_t nkx_minus_1 = nkx - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
+    const bool embed_result_within_padded_region = _embed_result_within_padded_region;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -268,7 +268,7 @@ FORCE_INLINE void convolve1d(DTYPE * const result,
                 top += val * ker;
         }}
 
-        if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
+        if (embed_result_within_padded_region) { // compile time constant
             result_index = i;
         } else {
             result_index = i_minus_wkx;
@@ -294,7 +294,7 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx, const size_t _ny,
         const DTYPE * const g, const size_t _nkx, const size_t _nky,
         const bool _nan_interpolate,
-        const bool _assume_results_array_padded_by_half_kernel_size,
+        const bool _embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -329,7 +329,7 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
     const size_t nkx = _nkx, nky = _nky;
     const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
+    const bool embed_result_within_padded_region = _embed_result_within_padded_region;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -385,7 +385,7 @@ FORCE_INLINE void convolve2d(DTYPE * const result,
                 }}
             }}
 
-            if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
+            if (embed_result_within_padded_region) { // compile time constant
                 result_index = result_cursor + j;
             } else {
                 result_index = i_minus_wkx * ny_minus_2wky + j_minus_wky;
@@ -412,7 +412,7 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
         const DTYPE * const f, const size_t _nx, const size_t _ny, const size_t _nz,
         const DTYPE * const g, const size_t _nkx, const size_t _nky, const size_t _nkz,
         const bool _nan_interpolate,
-        const bool _assume_results_array_padded_by_half_kernel_size,
+        const bool _embed_result_within_padded_region,
         const unsigned n_threads)
 {
 #ifdef NDEBUG
@@ -449,7 +449,7 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
     const size_t nkx = _nkx, nky = _nky, nkz = _nkz;
     const size_t nkx_minus_1 = nkx - 1, nky_minus_1 = nky - 1, nkz_minus_1 = nkz - 1;
     const bool nan_interpolate = _nan_interpolate;
-    const bool assume_results_array_padded_by_half_kernel_size = _assume_results_array_padded_by_half_kernel_size;
+    const bool embed_result_within_padded_region = _embed_result_within_padded_region;
 
     // Thread locals
     const size_t wkx = _wkx;
@@ -521,7 +521,7 @@ FORCE_INLINE void convolve3d(DTYPE * const result,
                     }}
                 }}
 
-                if (assume_results_array_padded_by_half_kernel_size) { // compile time constant
+                if (embed_result_within_padded_region) { // compile time constant
                     result_index = array_cursor + k;
                 } else {
                     result_index = (i_minus_wkx*ny_minus_2wky + j_minus_wky)*nz_minus_2wkz + k_minus_wkz;

--- a/astropy/convolution/src/convolve.h
+++ b/astropy/convolution/src/convolve.h
@@ -50,7 +50,7 @@ LIB_CONVOLVE_EXPORT void convolveNd_c(DTYPE * const result,
         const DTYPE * const g,
         const size_t * const kernel_shape,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 
 // 1D
@@ -58,13 +58,13 @@ void convolve1d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 FORCE_INLINE void convolve1d(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 
 // 2D
@@ -72,13 +72,13 @@ void convolve2d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 FORCE_INLINE void convolve2d(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 
 // 3D
@@ -86,13 +86,13 @@ void convolve3d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 FORCE_INLINE void convolve3d(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
         const bool nan_interpolate,
-        const bool padded,
+        const bool assume_results_array_padded_by_half_kernel_size,
         const unsigned n_threads);
 
 

--- a/astropy/convolution/src/convolve.h
+++ b/astropy/convolution/src/convolve.h
@@ -50,7 +50,7 @@ LIB_CONVOLVE_EXPORT void convolveNd_c(DTYPE * const result,
         const DTYPE * const g,
         const size_t * const kernel_shape,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 
 // 1D
@@ -58,13 +58,13 @@ void convolve1d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 FORCE_INLINE void convolve1d(DTYPE * const result,
         const DTYPE * const f, const size_t nx,
         const DTYPE * const g, const size_t nkx,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 
 // 2D
@@ -72,13 +72,13 @@ void convolve2d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 FORCE_INLINE void convolve2d(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny,
         const DTYPE * const g, const size_t nkx, const size_t nky,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 
 // 3D
@@ -86,13 +86,13 @@ void convolve3d_c(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 FORCE_INLINE void convolve3d(DTYPE * const result,
         const DTYPE * const f, const size_t nx, const size_t ny, const size_t nz,
         const DTYPE * const g, const size_t nkx, const size_t nky, const size_t nkz,
         const bool nan_interpolate,
-        const bool assume_results_array_padded_by_half_kernel_size,
+        const bool embed_result_within_padded_region,
         const unsigned n_threads);
 
 


### PR DESCRIPTION
This PR contains various changes that were mentioned during the review of #8057 that, however, were not included in it.

Regarding the following comment https://github.com/astropy/astropy/pull/8057#issuecomment-435147378 in relation to the func param ``padded`` - I decided to stick with a bool rather than allow for arbitrary offsets. Arbitrary offsets imply nothing about the total size of the results array and therefore the shape of the results array must also be passed through, i.e. the stride can't be assumed to be expanded by only twice half the kernel size. I briefly started on this path but it significantly explodes the function interface so decided against it.

@astrofrog suggested something along the lines of _offset the results index by half a kernel_, however, the semantics of offset still implies nothing about the total size and therefore the shape of the results array should still be passed through to accurately account for the stride in the index computation. Some notion of the semantics of "padding" should alleviate this issue. FYI: I'm open to other slight variants on ``assume_results_array_padded_by_half_kernel_size``.