### PR TITLE
Fix a bug that caused writing to FITS of Table objects that had index columns to fail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ astropy.io.fits
 - Changed the ``fitscheck`` and ``fitsdiff`` script to use the ``argparse``
   module instead of ``optparse``. [#9148]
 
+- Allow writing of ``Table`` objects with ``Time`` columns that are also table
+  indices to FITS files. [#8077]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
@@ -1842,139 +1845,6 @@ astropy.io.misc
   the mask was being silently dropped.  If the ``serialize_meta`` option is
   enabled the data mask will now be written as an additional column and the
   masked columns will round-trip correctly. [#7481]
-
-- Fixed a bug where writing to HDF5 failed for for tables with columns of
-  unicode strings.  Now those columns are first encoded to UTF-8 and
-  written as byte strings. [#7024, #8017]
-
-- Fixed a bug with serializing the bounding_box of models initialized 
-  with ``Quantities`` . [#8052]
-
-astropy.io.fits
-^^^^^^^^^^^^^^^
-
-- Added support for ``copy.copy`` and ``copy.deepcopy`` for ``HDUList``. [#7218]
-
-- Override ``HDUList.copy()`` to return a shallow HDUList instance. [#7218]
-
-- Fix writing of ``Table`` objects with ``Time`` columns that are also table
-  indices to FITS files. [#8077]
-
-astropy.io.registry
-^^^^^^^^^^^^^^^^^^^
-
-astropy.io.votable
-^^^^^^^^^^^^^^^^^^
-
-astropy.modeling
-^^^^^^^^^^^^^^^^
-
-- Fix behaviour of certain models with units, by making certain unit-related
-  attributes readonly. [#7210]
-
-- Fixed an issue with validating a ``bounding_box`` whose items are 
-  ``Quantities``. [#8052]
-
-astropy.nddata
-^^^^^^^^^^^^^^
-
-- Fixed rounding behavior in ``overlap_slices`` for even-sized small
-  arrays. [#7859]
-
-astropy.samp
-^^^^^^^^^^^^
-
-astropy.stats
-^^^^^^^^^^^^^
-
-astropy.table
-^^^^^^^^^^^^^
-
-astropy.tests
-^^^^^^^^^^^^^
-
-- Fixing bug that prevented to run the doctests on only a single rst documentation
-  file rather than all of them. [#8055]
-
-astropy.time
-^^^^^^^^^^^^
-
-- Fix a bug when setting a ``TimeDelta`` array item with plain float value(s).
-  This was always interpreted as a JD (day) value regardless of the
-  ``TimeDelta`` format. [#7990]
-
-astropy.units
-^^^^^^^^^^^^^
-
-- To simplify fast creation of ``Quantity`` instances from arrays, one can now
-  write ``array << unit`` (equivalent to ``Quantity(array, unit, copy=False)``).
-  If ``array`` is already a ``Quantity``, this will convert the quantity to the
-  requested units; in-place conversion can be done with ``quantity <<= unit``.
-  [#7734]
-
-astropy.utils
-^^^^^^^^^^^^^
-
-- Fixed a bug due to which ``report_diff_values()`` was reporting incorrect
-  number of differences when comparing two ``numpy.ndarray``. [#7470]
-
-- The download progress bar is now only displayed in terminals, to avoid
-  polluting piped output. [#7577]
-
-astropy.visualization
-^^^^^^^^^^^^^^^^^^^^^
-
-- Right ascension coordinates are now shown in hours by default, and the
-  ``set_format_unit`` method on ``CoordinateHelper`` now works correctly
-  with angle coordinates. [#7215]
-
-astropy.wcs
-^^^^^^^^^^^
-
-Other Changes and Additions
----------------------------
-
-- The documentation build now uses the Sphinx configuration from sphinx-astropy
-  rather than from astropy-helpers. [#7139]
-
-- Versions of Numpy <1.13 are no longer supported. [#7058]
-
-- Running tests now suppresses the output of the installation stage by default,
-  to allow easier viewing of the test results. To re-enable the output as
-  before, use ``python setup.py test --verbose-install``. [#7512]
-
-- The ERFA functions are now wrapped in ufuncs instead of custom C code,
-  leading to some speed improvements, and setting the stage for allowing
-  overrides with ``__array_ufunc__``. [#7502]
-
-- Updated the bundled CFITSIO library to 3.450. See
-  ``cextern/cfitsio/docs/changes.txt`` for additional information. [#8014]
-
-
-
-3.0.6 (unreleased)
-==================
-
-Bug Fixes
----------
-
-astropy.config
-^^^^^^^^^^^^^^
-
-astropy.constants
-^^^^^^^^^^^^^^^^^
-
-astropy.convolution
-^^^^^^^^^^^^^^^^^^^
-
-astropy.coordinates
-^^^^^^^^^^^^^^^^^^^
-
-astropy.cosmology
-^^^^^^^^^^^^^^^^^
-
-astropy.extern
-^^^^^^^^^^^^^^
 
 - Fixed a bug where writing to HDF5 failed for for tables with columns of
   unicode strings.  Now those columns are first encoded to UTF-8 and

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1847,6 +1847,139 @@ astropy.io.misc
   unicode strings.  Now those columns are first encoded to UTF-8 and
   written as byte strings. [#7024, #8017]
 
+- Fixed a bug with serializing the bounding_box of models initialized 
+  with ``Quantities`` . [#8052]
+
+astropy.io.fits
+^^^^^^^^^^^^^^^
+
+- Added support for ``copy.copy`` and ``copy.deepcopy`` for ``HDUList``. [#7218]
+
+- Override ``HDUList.copy()`` to return a shallow HDUList instance. [#7218]
+
+- Fix writing of ``Table`` objects with ``Time`` columns that are also table
+  indices to FITS files. [#8077]
+
+astropy.io.registry
+^^^^^^^^^^^^^^^^^^^
+
+astropy.io.votable
+^^^^^^^^^^^^^^^^^^
+
+astropy.modeling
+^^^^^^^^^^^^^^^^
+
+- Fix behaviour of certain models with units, by making certain unit-related
+  attributes readonly. [#7210]
+
+- Fixed an issue with validating a ``bounding_box`` whose items are 
+  ``Quantities``. [#8052]
+
+astropy.nddata
+^^^^^^^^^^^^^^
+
+- Fixed rounding behavior in ``overlap_slices`` for even-sized small
+  arrays. [#7859]
+
+astropy.samp
+^^^^^^^^^^^^
+
+astropy.stats
+^^^^^^^^^^^^^
+
+astropy.table
+^^^^^^^^^^^^^
+
+astropy.tests
+^^^^^^^^^^^^^
+
+- Fixing bug that prevented to run the doctests on only a single rst documentation
+  file rather than all of them. [#8055]
+
+astropy.time
+^^^^^^^^^^^^
+
+- Fix a bug when setting a ``TimeDelta`` array item with plain float value(s).
+  This was always interpreted as a JD (day) value regardless of the
+  ``TimeDelta`` format. [#7990]
+
+astropy.units
+^^^^^^^^^^^^^
+
+- To simplify fast creation of ``Quantity`` instances from arrays, one can now
+  write ``array << unit`` (equivalent to ``Quantity(array, unit, copy=False)``).
+  If ``array`` is already a ``Quantity``, this will convert the quantity to the
+  requested units; in-place conversion can be done with ``quantity <<= unit``.
+  [#7734]
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- Fixed a bug due to which ``report_diff_values()`` was reporting incorrect
+  number of differences when comparing two ``numpy.ndarray``. [#7470]
+
+- The download progress bar is now only displayed in terminals, to avoid
+  polluting piped output. [#7577]
+
+astropy.visualization
+^^^^^^^^^^^^^^^^^^^^^
+
+- Right ascension coordinates are now shown in hours by default, and the
+  ``set_format_unit`` method on ``CoordinateHelper`` now works correctly
+  with angle coordinates. [#7215]
+
+astropy.wcs
+^^^^^^^^^^^
+
+Other Changes and Additions
+---------------------------
+
+- The documentation build now uses the Sphinx configuration from sphinx-astropy
+  rather than from astropy-helpers. [#7139]
+
+- Versions of Numpy <1.13 are no longer supported. [#7058]
+
+- Running tests now suppresses the output of the installation stage by default,
+  to allow easier viewing of the test results. To re-enable the output as
+  before, use ``python setup.py test --verbose-install``. [#7512]
+
+- The ERFA functions are now wrapped in ufuncs instead of custom C code,
+  leading to some speed improvements, and setting the stage for allowing
+  overrides with ``__array_ufunc__``. [#7502]
+
+- Updated the bundled CFITSIO library to 3.450. See
+  ``cextern/cfitsio/docs/changes.txt`` for additional information. [#8014]
+
+
+
+3.0.6 (unreleased)
+==================
+
+Bug Fixes
+---------
+
+astropy.config
+^^^^^^^^^^^^^^
+
+astropy.constants
+^^^^^^^^^^^^^^^^^
+
+astropy.convolution
+^^^^^^^^^^^^^^^^^^^
+
+astropy.coordinates
+^^^^^^^^^^^^^^^^^^^
+
+astropy.cosmology
+^^^^^^^^^^^^^^^^^
+
+astropy.extern
+^^^^^^^^^^^^^^
+
+- Fixed a bug where writing to HDF5 failed for for tables with columns of
+  unicode strings.  Now those columns are first encoded to UTF-8 and
+  written as byte strings. [#7024, #8017]
+
 - Fixed a bug with serializing the bounding_box of models initialized
   with ``Quantities`` . [#8052]
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -504,6 +504,12 @@ def time_to_fits(table):
     # Shallow copy of the input table
     newtable = table.copy(copy_data=False)
 
+    # Remove any existing indices since these can cause issues when trying to
+    # replace columns, and the indices are no longer useful here.
+    for index in newtable.indices:
+        for column in index.columns:
+            newtable.remove_indices(column.info.name)
+
     # Global time coordinate frame keywords
     hdr = Header([Card(keyword=key, value=val[0], comment=val[1])
                   for key, val in GLOBAL_TIME_INFO.items()])

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -11,6 +11,7 @@ from . import Header, Card
 from astropy import units as u
 from astropy.coordinates import EarthLocation
 from astropy.table import Column
+from astropy.table.column import col_copy
 from astropy.time import Time, TimeDelta
 from astropy.time.core import BARYCENTRIC_SCALES
 from astropy.time.formats import FITS_DEPRECATED_SCALES
@@ -500,15 +501,20 @@ def time_to_fits(table):
     hdr : `~astropy.io.fits.header.Header`
         Header containing global time reference frame FITS keywords
     """
-
-    # Shallow copy of the input table
-    newtable = table.copy(copy_data=False)
-
-    # Remove any existing indices since these can cause issues when trying to
-    # replace columns, and the indices are no longer useful here.
-    for index in newtable.indices:
-        for column in index.columns:
-            newtable.remove_indices(column.info.name)
+    # Make a light copy of table (to the extent possible) and clear any indices along
+    # the way. Indices are not serialized and cause problems later, but they are not
+    # needed here so just drop.  For Column subclasses take advantage of copy() method,
+    # but for others it is required to actually copy the data if there are attached
+    # indices.  See #8077 and #9009 for further discussion.
+    new_cols = []
+    for col in table.itercols():
+        if isinstance(col, Column):
+            new_col = col.copy(copy_data=False)  # Also drops any indices
+        else:
+            new_col = col_copy(col, copy_indices=False) if col.info.indices else col
+        new_cols.append(new_col)
+    newtable = table.__class__(new_cols, copy=False)
+    newtable.meta = table.meta
 
     # Global time coordinate frame keywords
     hdr = Header([Card(keyword=key, value=val[0], comment=val[1])

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -280,9 +280,12 @@ class TestFitsTime(FitsTestCase):
         """
         t = table_types()
         t['a'] = Time(self.time, format='isot', scale='utc')
+        t['b'] = [2, 1]
+        t['c'] = [3, 4]
 
         # Make it so that the time column is also an index
         t.add_index('a')
+        t.add_index('b')
 
         # Test for default write behavior (full precision) and read it
         # back using native astropy objects; thus, ensure its round-trip
@@ -291,6 +294,15 @@ class TestFitsTime(FitsTestCase):
                               astropy_native=True)
 
         assert isinstance(tm['a'], Time)
+
+        # Ensure that indices on original table are preserved but round-trip
+        # table has no indices.  (If indices are ever serialized the final two
+        # tests are expected to fail).
+        assert len(t.indices) == 2
+        assert len(tm.indices) == 0
+        for name in ('a', 'b'):
+            assert len(t[name].info.indices) == 1
+            assert len(tm[name].info.indices) == 0
 
     @pytest.mark.parametrize('table_types', (Table, QTable))
     def test_io_time_read_fits(self, table_types):

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -273,6 +273,26 @@ class TestFitsTime(FitsTestCase):
         assert tm['a'].location.z.value == t['a'].location.z.to_value(unit='m')
 
     @pytest.mark.parametrize('table_types', (Table, QTable))
+    def test_fits_to_time_index(self, table_types):
+        """
+        Ensure that fits_to_time works correctly if the time column is also
+        an index.
+        """
+        t = table_types()
+        t['a'] = Time(self.time, format='isot', scale='utc')
+
+        # Make it so that the time column is also an index
+        t.add_index('a')
+
+        # Test for default write behavior (full precision) and read it
+        # back using native astropy objects; thus, ensure its round-trip
+        t.write(self.temp('time.fits'), format='fits', overwrite=True)
+        tm = table_types.read(self.temp('time.fits'), format='fits',
+                              astropy_native=True)
+
+        assert isinstance(tm['a'], Time)
+
+    @pytest.mark.parametrize('table_types', (Table, QTable))
     def test_io_time_read_fits(self, table_types):
         """
         Test that FITS table with time columns (standard compliant)


### PR DESCRIPTION
Edit: THIS REQUIRES https://github.com/astropy/astropy/issues/9009, keep open while that is addressed.

Before this fix, the following failed:

```python
>>> from astropy.time import Time
>>> from astropy.table import Table
>>> time = Time(['2016-03-22T12:30:31', '2016-03-22T12:30:38', '2016-03-22T12:34:40'])
>>> table = Table()
>>> table['time'] = time
>>> table.add_index('time')
>>> table.write('test.fits', overwrite=True)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/table/table.py", line 2592, in write
    io_registry.write(self, *args, **kwargs)
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/io/registry.py", line 560, in write
    writer(data, *args, **kwargs)
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/io/fits/connect.py", line 388, in write_table_fits
    table_hdu = table_to_hdu(input, character_as_bytes=True)
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/io/fits/convenience.py", line 470, in table_to_hdu
    table, hdr = time_to_fits(table)
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/io/fits/fitstime.py", line 533, in time_to_fits
    newtable.replace_column(col.info.name, Column(jd12, unit='d'))
  File "/Users/tom/Dropbox/Code/Astropy/astropy/astropy/table/table.py", line 1796, in replace_column
    raise ValueError('cannot replace a table index column')
ValueError: cannot replace a table index column
```

The solution is to remove the index columns.

@taldcroft - is there a better way to just remove all indices from a table?