### PR TITLE
TST: Bump Python to 3.7 for some jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
         # location during testing. We also use this build to make sure that the
         # dependencies get correctly installed with pip.
         - os: linux
-          env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy --readonly'
+          env: SETUP_CMD='test --remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
                PYTEST_VERSION=3.7
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
@@ -145,7 +145,7 @@ matrix:
         # unstable, we combine them into a single unstable build that we can
         # mark as an allowed failure below.
         - os: linux
-          env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+          env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$ASDF_PIP_DEP
                MATPLOTLIB_VERSION=dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,7 +161,7 @@ matrix:
 
     allow_failures:
       - os: linux
-        env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+        env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
              PIP_DEPENDENCIES=$ASDF_PIP_DEP
              MATPLOTLIB_VERSION=dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
         PIP_DEPENDENCIES: "objgraph"
 
     matrix:
-        - PYTHON_VERSION: "3.6"
+        - PYTHON_VERSION: "3.7"
           NUMPY_VERSION: "stable"
 
 matrix:


### PR DESCRIPTION
Given that Python 3.7 is the "fastest Python yet", using this when we can might speed up testing? 🤞 
Also, as people move to it, it should be the common one to test against.