### PR TITLE
Make number of cores in ProgressBar.map adjustable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -308,8 +308,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - It is now possible to control the number of cores used by ``ProgressBar.map``
-  by passing a nonzero integer as the ``multiprocess`` keyword argument.
-  [#8083]
+  by passing a positive integer as the ``multiprocess`` keyword argument. Use
+  ``True`` to use all cores. [#8083]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -307,6 +307,10 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- It is now possible to control the number of cores used by ``ProgressBar.map``
+  by passing a nonzero integer as the ``multiprocess`` keyword argument.
+  [#8083]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -809,14 +809,14 @@ class ProgressBar:
             else:
                 default_step = max(int(float(len(items)) / bar._bar_length), 1)
                 chunksize = min(default_step, step)
-            if not multiprocess:
+            if not multiprocess or multiprocess < 1:
                 for i, item in enumerate(items):
                     results.append(function(item))
                     if (i % chunksize) == 0:
                         bar.update(i)
             else:
                 p = multiprocessing.Pool(
-                    processes=(multiprocess if multiprocess > 1 else None))
+                    processes=(int(multiprocess) if multiprocess is not True else None))
                 for i, result in enumerate(
                     p.imap_unordered(function, items, chunksize=chunksize)):
                     bar.update(i)

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -714,9 +714,10 @@ class ProgressBar:
             Sequence where each element is a tuple of arguments to pass to
             *function*.
 
-        multiprocess : bool, optional
-            If `True`, use the `multiprocessing` module to distribute each
-            task to a different processor core.
+        multiprocess : bool, int, optional
+            If `True`, use the `multiprocessing` module to distribute each task
+            to a different processor core. If a number greater than 1, then use
+            that number of cores.
 
         ipython_widget : bool, optional
             If `True`, the progress bar will display as an IPython
@@ -774,9 +775,10 @@ class ProgressBar:
             Sequence where each element is a tuple of arguments to pass to
             *function*.
 
-        multiprocess : bool, optional
-            If `True`, use the `multiprocessing` module to distribute each
-            task to a different processor core.
+        multiprocess : bool, int, optional
+            If `True`, use the `multiprocessing` module to distribute each task
+            to a different processor core. If a number greater than 1, then use
+            that number of cores.
 
         ipython_widget : bool, optional
             If `True`, the progress bar will display as an IPython
@@ -813,7 +815,8 @@ class ProgressBar:
                     if (i % chunksize) == 0:
                         bar.update(i)
             else:
-                p = multiprocessing.Pool()
+                p = multiprocessing.Pool(
+                    processes=(multiprocess if multiprocess > 1 else None))
                 for i, result in enumerate(
                     p.imap_unordered(function, items, chunksize=chunksize)):
                     bar.update(i)

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -4,9 +4,7 @@
 
 import io
 
-import numpy as np
 import pytest
-
 
 from . import test_progress_bar_func
 from astropy.utils import console
@@ -164,6 +162,11 @@ def test_progress_bar_map():
     result = console.ProgressBar.map(test_progress_bar_func.func,
                                      items, step=10, multiprocess=True)
     assert items == result
+
+    result1 = console.ProgressBar.map(test_progress_bar_func.func,
+                                      items, step=10, multiprocess=2)
+
+    assert items == result1
 
 
 @pytest.mark.parametrize(("seconds", "string"),


### PR DESCRIPTION
It is now possible to control the number of cores used by `ProgressBar.map` by passing a nonzero integer as the `multiprocess` keyword argument.