### PR TITLE
TST: Use matplotlib dev with numpy dev for cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ matrix:
         # that gives too many false positives due to URL timeouts.
         - os: linux
           stage: Cron tests
-          env: NUMPY_VERSION=dev EVENT_TYPE='cron'
+          env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="asdf==2.1.0"
 


### PR DESCRIPTION
In order to fix failure like this: https://travis-ci.org/astropy/astropy/builds/451820941
Related: #7954

Not sure how to test this except to merge and check the next cron run. :woman_shrugging: 