### PR TITLE
MNT: Remove build_sphinx from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[build_sphinx]
-source-dir = docs
-build-dir = docs/_build
-all_files = 1
-
 [build_docs]
 source-dir = docs
 build-dir = docs/_build


### PR DESCRIPTION
We don't need it anymore, right? 