### PR TITLE
Warn if nan_treatment='interpolate' and NaN values persist post convolution

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -578,6 +578,9 @@ astropy.convolution
   however, someone may interpret this as an API change not realising that nothing has actually
   changed. [#7293]
 
+- ``interpolate_replace_nans()`` can no longer accept the keyword argument
+  ``preserve_nan``. It is explicitly set to ``False``. [#8088]
+
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,6 +236,9 @@ astropy.convolution
 - ``convolve`` now accepts any array-like input, not just ``numpy.ndarray`` or
   lists. [#7303]
 
+- ``convolve`` Now raises AstropyUserWarning if nan_treatment='interpolate' and
+  preserve_nan=False and NaN values are present post convolution. [#8088]
+
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -352,6 +352,12 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         if nan_interpolate:
             result *= kernel_sum
 
+    if nan_interpolate and not preserve_nan and np.isnan(result.sum()):
+        warnings.warn("nan_treatment='interpolate', however, NaN values detected "
+                     "post convolution. A contiguous region of NaN values, larger "
+                     "than the kernel size, are present in the input array. "
+                     "Increase the kernel size to avoid this.", AstropyUserWarning)
+
     if preserve_nan:
         result[initially_nan] = np.nan
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -849,7 +849,7 @@ def interpolate_replace_nans(array, kernel, convolve=convolve, **kwargs):
     newarray = array.copy()
 
     convolved = convolve(array, kernel, nan_treatment='interpolate',
-                         normalize_kernel=True, **kwargs)
+                         normalize_kernel=True, preserve_nan=False, **kwargs)
 
     isnan = np.isnan(array)
     newarray[isnan] = convolved[isnan]

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -942,12 +942,14 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
     nan_centroid = np.full(kernel.shape, np.nan)
     image = np.pad(nan_centroid, pad_width=kernel.shape[0]*2, mode='constant',
                    constant_values=1)
-    try:
+    with pytest.warns(AstropyUserWarning,
+                      match="nan_treatment='interpolate', however, NaN values detected "
+                      "post convolution. A contiguous region of NaN values, larger "
+                      "than the kernel size, are present in the input array. "
+                      "Increase the kernel size to avoid this."):
         result = convolve(image, kernel, boundary=boundary, nan_treatment='interpolate',
                           normalize_kernel=normalize_kernel)
-    except AstropyUserWarning:
-        pass
-    assert(np.isnan(result.sum()))
+        assert(np.any(np.isnan(result)))
 
     # Test case: kernel.shape > NaN_region.shape
     nan_centroid = np.full((kernel.shape[0]-1, kernel.shape[1]-1), np.nan) # 1 smaller than kerenel
@@ -955,4 +957,4 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
                    constant_values=1)
     result = convolve(image, kernel, boundary=boundary, nan_treatment='interpolate',
                       normalize_kernel=normalize_kernel)
-    assert(~np.isnan(result.sum())) # Note: negation
+    assert(~np.any(np.isnan(result))) # Note: negation

--- a/docs/convolution/index.rst
+++ b/docs/convolution/index.rst
@@ -252,6 +252,12 @@ Some contexts in which you might want to use kernel-based interpolation include:
    the imaged area, but an approximation of the extended sky emission can still
    be constructed.
 
+.. note::
+    Care must be taken to ensure that the kernel is large enough to completely
+    cover potential contiguous regions of ``NaN`` values.
+    An ``AstropyUserWarning`` is raised if ``NaN`` values are detected post
+    convolution, in which case the kernel size should be increased.
+
 The script below shows an example of kernel interpolation to fill in
 flagged-out pixels:
 


### PR DESCRIPTION
Resolves #8086

Warning inactive if preserve_nan=True

This will occur when a contiguous region of NaN values, larger
than the kernel size, are present in the input array.
Increasing the size of the kernel will avoid this.

Resolves #8092 

Signed-off-by: James Noss <jnoss@stsci.edu>