### PR TITLE
Disable codecov comments in pull requests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
The GitHub integration for codecov wasn't quite set up right, but now that it is, codecov has started commenting in PRs. I personally quite like the comments but I know some people don't, so this PR is to disable the comments if we think that's the way to go. If you have opinions, please 👍  or 👎  this PR so we can get an idea what people prefer (👎 = don't merge this PR/disable comments)