### PR TITLE
Make astropy compatible with wcslib version 6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -555,6 +555,7 @@ astropy.wcs
 
 - Deprecated ``_naxis1`` and ``_naxis2`` in favor of ``pixel_shape``. [#7973]
 
+- Added compatibility to wcslib version 6 [#8093]
 
 API Changes
 -----------

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -838,6 +838,9 @@ PyWcsprm_fix(
   const struct message_map_entry message_map[NWCSFIX] = {
     {"cdfix", CDFIX},
     {"datfix", DATFIX},
+#if (NWCSFIX > 6)
+    {"obsfix", OBSFIX},
+#endif
     {"unitfix", UNITFIX},
     {"celfix", CELFIX},
     {"spcfix", SPCFIX},

--- a/astropy/wcs/tests/data/validate.6.txt
+++ b/astropy/wcs/tests/data/validate.6.txt
@@ -1,0 +1,17 @@
+HDU 1:
+  WCS key ' ':
+    - RADECSYS= 'ICRS ' / Astrometric system
+      the RADECSYS keyword is deprecated, use RADESYSa.
+    - The WCS transformation has more axes (2) than the image it is
+      associated with (0)
+    - Removed redundant SCAMP distortion parameters because SIP
+      parameters are also present
+
+HDU 2:
+  WCS key ' ':
+    - The WCS transformation has more axes (3) than the image it is
+      associated with (0)
+    - 'unitfix' made the change 'Changed units:
+        'HZ' -> 'Hz'.
+    - 'celfix' made the change 'In CUNIT3 : Mismatched units type
+      'length': have 'Hz', want 'm''.

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -392,7 +392,9 @@ def test_validate():
         results = wcs.validate(get_pkg_data_filename("data/validate.fits"))
         results_txt = repr(results)
         version = wcs._wcs.__version__
-        if version[0] == '5':
+        if version[0] == '6':
+            filename = 'data/validate.6.txt'
+        elif version[0] == '5':
             if version >= '5.13':
                 filename = 'data/validate.5.13.txt'
             else:

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -391,25 +391,36 @@ def test_equinox():
 
 def test_fix():
     w = _wcs.Wcsprm()
-    assert w.fix() == {
+    fix_ref = {
         'cdfix': 'No change',
         'cylfix': 'No change',
+        'obsfix': 'No change',
         'datfix': 'No change',
         'spcfix': 'No change',
         'unitfix': 'No change',
         'celfix': 'No change'}
+    version = wcs._wcs.__version__
+    if version[0] <= "5":
+        del fix_ref['obsfix']
+    assert w.fix() == fix_ref
 
 
 def test_fix2():
     w = _wcs.Wcsprm()
     w.dateobs = '31/12/99'
-    assert w.fix() == {
+    fix_ref = {
         'cdfix': 'No change',
         'cylfix': 'No change',
-        'datfix': "Changed '31/12/99' to '1999-12-31'",
+        'obsfix': 'No change',
+        'datfix': "Set MJD-OBS to 51543.000000 from DATE-OBS.\nChanged DATE-OBS from '31/12/99' to '1999-12-31'",
         'spcfix': 'No change',
         'unitfix': 'No change',
         'celfix': 'No change'}
+    version = wcs._wcs.__version__
+    if version[0] <= "5":
+        del fix_ref['obsfix']
+        fix_ref['datfix'] = "Changed '31/12/99' to '1999-12-31'"
+    assert w.fix() == fix_ref
     assert w.dateobs == '1999-12-31'
     assert w.mjdobs == 51543.0
 
@@ -417,13 +428,19 @@ def test_fix2():
 def test_fix3():
     w = _wcs.Wcsprm()
     w.dateobs = '31/12/F9'
-    assert w.fix() == {
+    fix_ref = {
         'cdfix': 'No change',
         'cylfix': 'No change',
-        'datfix': "Invalid parameter value: invalid date '31/12/F9'",
+        'obsfix': 'No change',
+        'datfix': "Invalid DATE-OBS format '31/12/F9'",
         'spcfix': 'No change',
         'unitfix': 'No change',
         'celfix': 'No change'}
+    version = wcs._wcs.__version__
+    if version[0] <= "5":
+        del fix_ref['obsfix']
+        fix_ref['datfix'] = "Invalid parameter value: invalid date '31/12/F9'"
+    assert w.fix() == fix_ref
     assert w.dateobs == '31/12/F9'
     assert np.isnan(w.mjdobs)
 


### PR DESCRIPTION
This is a follow-up to #7929, which I needed since I too optimistically uploaded wcslib 6.2 to Debian without checking compatibility first ;-)

Wcslib version 6 introduces one more wcsfix (obsfix) and slightly changes some messages, which are adjusted with this patch. This also removes the segfault mentiones in #7929.

As a side note, in the tarball the wcslib include files are replicated in `astropy/wcs/include/`, and they are also used when astropy is built with `use_system_libraries=True`. This fails when the ABI was changed.

The change in wcslib.h shows IMO an interface that should be provided directly by wcslib; maybe this could discussed with Mark Calabretta? 

I tested this with both 3.0.5 and the 2.0.9 legaacy version on Debian, with wcslib-6.2.