### PR TITLE
Interpolate NaN values only if they exist and nan_treatment='interpolate'

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -614,6 +614,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     # NaN and inf catching
     nanmaskarray = np.isnan(array) | np.isinf(array)
     array[nanmaskarray] = 0
+    interpolate_nan = (nan_treatment == 'interpolate') and nanmaskarray.any()
     nanmaskkernel = np.isnan(kernel) | np.isinf(kernel)
     kernel[nanmaskkernel] = 0
 
@@ -751,7 +752,6 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     kernfft = fftn(np.fft.ifftshift(bigkernel))
     fftmult = arrayfft * kernfft
 
-    interpolate_nan = (nan_treatment == 'interpolate')
     if interpolate_nan:
         if not np.isfinite(fill_value):
             bigimwt = np.zeros(newshape, dtype=complex_dtype)


### PR DESCRIPTION
I know we're way past the feature freeze for 3.1 but here's a one liner for a major perf boost to ``convolution.convolve_fft()``.

![pr 8100](https://user-images.githubusercontent.com/5013975/48277367-751d4280-e418-11e8-971e-065e2c6b732b.png)

Signed-off-by: James Noss <jnoss@stsci.edu>