### PR TITLE
Interpolate NaN values only if they exist and nan_treatment='interpolate'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -763,10 +763,11 @@ astropy.convolution
   hoisting, and vectorization, etc. Compiler optimization level ``-O2`` required for
   hoisting and ``-O3`` for vectorization. [#7293]
 
-- ``convolve()``: ``nan_treatment=‘interpolate’`` was slow to compute irrespective of
-  whether any NaN values exist within the array. The input array is now
-  checked for NaN values and interpolation is disabled if non are found. This is a
-  significant performance boost for arrays without NaN values. [#7293]
+- ``convolve()`` and ``convolve_fft()``: ``nan_treatment=‘interpolate’`` was
+  slow to compute irrespective of whether any NaN values exist within the array.
+  The input array is now checked for NaN values and interpolation is disabled
+  if non are found. This is a significant performance boost for arrays without
+  NaN values. [#7293] [#8101]
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -614,6 +614,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     # NaN and inf catching
     nanmaskarray = np.isnan(array) | np.isinf(array)
     array[nanmaskarray] = 0
+    interpolate_nan = (nan_treatment == 'interpolate') and nanmaskarray.any()
     nanmaskkernel = np.isnan(kernel) | np.isinf(kernel)
     kernel[nanmaskkernel] = 0
 
@@ -751,7 +752,6 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     kernfft = fftn(np.fft.ifftshift(bigkernel))
     fftmult = arrayfft * kernfft
 
-    interpolate_nan = (nan_treatment == 'interpolate')
     if interpolate_nan:
         if not np.isfinite(fill_value):
             bigimwt = np.zeros(newshape, dtype=complex_dtype)

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -634,7 +634,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     else:
         kernel_scale = kernel.sum()
         if np.abs(kernel_scale) < normalization_zero_tol:
-            if nan_treatment == 'interpolate':
+            if interpolate_nan:
                 raise ValueError('Cannot interpolate NaNs with an unnormalizable kernel')
             else:
                 # the kernel's sum is near-zero, so it can't be scaled


### PR DESCRIPTION
I know we're way past the feature freeze for 3.1 but here's a one-liner for a major perf boost to convolution.convolve_fft().

![figure_1](https://user-images.githubusercontent.com/5013975/48279935-0e038c00-e420-11e8-8bd7-abea0151af08.png)


Signed-off-by: James Noss <jnoss@stsci.edu>