### PR TITLE
Fix Moffat2DKernel's FWHM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -856,7 +856,7 @@ astropy.io.misc
   unicode strings.  Now those columns are first encoded to UTF-8 and
   written as byte strings. [#7024, #8017]
 
-- Fixed a bug with serializing the bounding_box of models initialized 
+- Fixed a bug with serializing the bounding_box of models initialized
   with ``Quantities`` . [#8052]
 
 astropy.io.fits
@@ -878,7 +878,7 @@ astropy.modeling
 - Fix behaviour of certain models with units, by making certain unit-related
   attributes readonly. [#7210]
 
-- Fixed an issue with validating a ``bounding_box`` whose items are 
+- Fixed an issue with validating a ``bounding_box`` whose items are
   ``Quantities``. [#8052]
 
 astropy.nddata
@@ -1714,6 +1714,9 @@ astropy.constants
 
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
+
+- Fix Moffat2DKernel's FWHM computation, which has an influence on the default
+  size of the kernel when no size is given. [#8105]
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -801,8 +801,10 @@ class Moffat2DKernel(Kernel2D):
     _is_bool = False
 
     def __init__(self, gamma, alpha, **kwargs):
-        self._model = models.Moffat2D((alpha - 1.0) / (np.pi * gamma * gamma),
-                                      0, 0, gamma, alpha)
+        # Compute amplitude, from
+        # https://en.wikipedia.org/wiki/Moffat_distribution
+        amplitude = (alpha - 1.0) / (np.pi * gamma * gamma)
+        self._model = models.Moffat2D(amplitude, 0, 0, gamma, alpha)
         self._default_size = _round_up_to_odd_integer(4.0 * self._model.fwhm)
         super().__init__(**kwargs)
         self.normalize()

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -801,10 +801,9 @@ class Moffat2DKernel(Kernel2D):
     _is_bool = False
 
     def __init__(self, gamma, alpha, **kwargs):
-        self._model = models.Moffat2D((gamma - 1.0) / (np.pi * alpha * alpha),
+        self._model = models.Moffat2D((alpha - 1.0) / (np.pi * gamma * gamma),
                                       0, 0, gamma, alpha)
-        fwhm = 2.0 * alpha * (2.0 ** (1.0 / gamma) - 1.0) ** 0.5
-        self._default_size = _round_up_to_odd_integer(4.0 * fwhm)
+        self._default_size = _round_up_to_odd_integer(4.0 * self._model.fwhm)
         super().__init__(**kwargs)
         self.normalize()
         self._truncation = None

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -12,12 +12,13 @@ from ..kernels import Moffat2DKernel
 
 
 SHAPES_ODD = [[15, 15], [31, 31]]
-SHAPES_EVEN = [[8, 8], [16, 16], [32, 32]]
+SHAPES_EVEN = [[8, 8], [16, 16], [32, 32]]  # FIXME: not used ?!
+NOSHAPE = [[None, None]]
 WIDTHS = [2, 3, 4, 5]
 
 KERNELS = []
 
-for shape in SHAPES_ODD:
+for shape in SHAPES_ODD + NOSHAPE:
     for width in WIDTHS:
 
         KERNELS.append(Gaussian2DKernel(width,


### PR DESCRIPTION
Fix #8095, thanks to @ycopin. gamma and alpha were inverted in the FWHM
and amplitude computations.