### PR TITLE
Add Cython compilation directive to pyx for language_level=3

### DIFF
--- a/astropy/cosmology/scalar_inv_efuncs.pyx
+++ b/astropy/cosmology/scalar_inv_efuncs.pyx
@@ -1,5 +1,5 @@
+#cython: language_level=3, boundscheck=False
 """ Cython inverse efuncs for cosmology integrals"""
-#cython boundcheck=False
 
 cimport cython
 from libc.math cimport exp, pow

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 
 import csv
 import os

--- a/astropy/stats/bls/_impl.pyx
+++ b/astropy/stats/bls/_impl.pyx
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+#cython: language_level=3
 
 import numpy as np
 cimport numpy as np

--- a/astropy/stats/lombscargle/implementations/cython_impl.pyx
+++ b/astropy/stats/lombscargle/implementations/cython_impl.pyx
@@ -1,3 +1,5 @@
+#cython: language_level=3
+
 import numpy as np
 cimport numpy as np
 

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 """
 This module provides mixin bases classes for the Column and MaskedColumn
 classes to provide those classes with their custom __getitem__ implementations.
@@ -20,7 +21,6 @@ applies the subclass to those arrays, so they are returned as Column instances
 behavior in the case where the element returned from a single row of the
 Column is itself an array.
 """
-
 
 import sys
 import numpy as np

--- a/astropy/table/_np_utils.pyx
+++ b/astropy/table/_np_utils.pyx
@@ -1,3 +1,4 @@
+#cython: language_level=3
 """
 Cython utilities for numpy structured arrays.
 


### PR DESCRIPTION
Add Cython compilation directive to `*.pyx` to avoid `language_level` `FutureWarning`. Not sure how to prove that this works other than reporting I don't see those warnings anymore after installing with this patch. Those warnings should be pretty obvious if you want to test it yourself, as they are the last stuff to appear in the installation log (right before you get your prompt back).

p.s. I am not brave enough to mess with `setup.py`, so I'd rather add some harmless looking comment lines. 😬 

p.p.s. Milestone set to what @bsipocz mentioned but feel free to re-milestone if needed.

Fix #8102 