### PR TITLE
Add Planck 2018 cosmology.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,10 @@ astropy.coordinates
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
+- The pre-publication Planck 2018 cosmological parameters are included as the
+  ``Planck2018_arXiv_v2`` object.  Please note that the values are preliminary,
+  and when the paper is accepted a final version will be included as ``Planck18``.
+  [#8111]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -25,8 +25,8 @@ Each cosmology has the following parameters defined:
 The list of cosmologies available are given by the tuple
 `available`. Current cosmologies available:
 
-Planck 2018 (Planck18) parameters from Planck Collaboration 2018,
- arXiv:1807.06209 (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)
+Planck 2018 (Planck18_arXiv_v2) parameters from Planck Collaboration 2018,
+ arXiv:1807.06209v2 (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)
 
 Planck 2015 (Planck15) parameters from Planck Collaboration 2016, A&A, 594, A13
  (Paper XIII), Table 4 (TT, TE, EE + lowP + lensing + ext)
@@ -50,11 +50,13 @@ doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).
 # in addition to the list above.  You also need to add them to the 'available'
 # list at the bottom of this file.
 
-# Planck 2018 paper VI 
-Planck18 = dict(
+# Planck 2018 paper VI v2
+# Unlike Planck 2015, the paper includes massive neutrinos in Om0, which here
+# are included in m_nu.  Hence, the Om0 value differs slightly from the paper.
+Planck18_arXiv_v2 = dict(
     Oc0=0.2607,
     Ob0=0.04897,
-    Om0=0.30966,  # Note: paper value includes neutrinos, here tracked by m_nu.
+    Om0=0.30966,
     H0=67.66,
     n=0.9665,
     sigma8=0.8102,
@@ -65,8 +67,8 @@ Planck18 = dict(
     Neff=3.046,
     flat=True,
     m_nu=[0., 0., 0.06],
-    reference=("Planck Collaboration 2018, arXiv:1807.06209 (Paper VI),"
-               " Table 4 (TT, TE, EE + lowP + lensing + ext)")
+    reference=("Planck Collaboration 2018, arXiv:1807.06209 v2 (Paper VI),"
+               " Table 2 (TT, TE, EE + lowE + lensing + BAO)")
 )
 
 # Planck 2015 paper XII Table 4 final column (best fit)
@@ -166,4 +168,5 @@ WMAP5 = dict(
 )
 
 # If new parameters are added, this list must be updated
-available = ['Planck18', 'Planck15', 'Planck13', 'WMAP9', 'WMAP7', 'WMAP5']
+available = ['Planck18_arXiv_v2', 'Planck15', 'Planck13', 'WMAP9', 'WMAP7',
+             'WMAP5']

--- a/astropy/cosmology/parameters.py
+++ b/astropy/cosmology/parameters.py
@@ -14,6 +14,7 @@ Each cosmology has the following parameters defined:
     n           Density perturbation spectral index
     Tcmb0       Current temperature of the CMB
     Neff        Effective number of neutrino species
+    m_nu        Assumed mass of neutrino species, in eV.
     sigma8      Density perturbation amplitude
     tau         Ionisation optical depth
     z_reion     Redshift of hydrogen reionisation
@@ -23,6 +24,9 @@ Each cosmology has the following parameters defined:
 
 The list of cosmologies available are given by the tuple
 `available`. Current cosmologies available:
+
+Planck 2018 (Planck18) parameters from Planck Collaboration 2018,
+ arXiv:1807.06209 (Paper VI), Table 2 (TT, TE, EE + lowE + lensing + BAO)
 
 Planck 2015 (Planck15) parameters from Planck Collaboration 2016, A&A, 594, A13
  (Paper XIII), Table 4 (TT, TE, EE + lowP + lensing + ext)
@@ -45,6 +49,25 @@ doi: 10.1088/0067-0049/180/2/330. Table 1 (WMAP + BAO + SN ML).
 # in the 'Built-in Cosmologies' section of astropy/docs/cosmology/index.rst
 # in addition to the list above.  You also need to add them to the 'available'
 # list at the bottom of this file.
+
+# Planck 2018 paper VI 
+Planck18 = dict(
+    Oc0=0.2607,
+    Ob0=0.04897,
+    Om0=0.30966,  # Note: paper value includes neutrinos, here tracked by m_nu.
+    H0=67.66,
+    n=0.9665,
+    sigma8=0.8102,
+    tau=0.0561,
+    z_reion=7.82,
+    t0=13.787,
+    Tcmb0=2.7255,
+    Neff=3.046,
+    flat=True,
+    m_nu=[0., 0., 0.06],
+    reference=("Planck Collaboration 2018, arXiv:1807.06209 (Paper VI),"
+               " Table 4 (TT, TE, EE + lowP + lensing + ext)")
+)
 
 # Planck 2015 paper XII Table 4 final column (best fit)
 Planck15 = dict(
@@ -143,4 +166,4 @@ WMAP5 = dict(
 )
 
 # If new parameters are added, this list must be updated
-available = ['Planck15', 'Planck13', 'WMAP9', 'WMAP7', 'WMAP5']
+available = ['Planck18', 'Planck15', 'Planck13', 'WMAP9', 'WMAP7', 'WMAP5']


### PR DESCRIPTION
Note: unlike Planck 2015, they included massive neutrinos in the
quoted Om0.  So the value used looks slightly different than that
in the paper, even though it is really the same thing.  Noticed
because the ages didn't match the ones in the paper without
subtracting it out.

Fix #8006