### PR TITLE
Fix bug in BLS when times are negative

### DIFF
--- a/astropy/stats/bls/core.py
+++ b/astropy/stats/bls/core.py
@@ -54,14 +54,14 @@ class BoxLeastSquares(object):
     >>> model = BoxLeastSquares(t, y)
     >>> results = model.autopower(0.16)
     >>> results.period[np.argmax(results.power)]  # doctest: +FLOAT_CMP
-    2.005441310651872
+    1.9923406038842544
 
     Compute the periodogram on a user-specified period grid:
 
     >>> periods = np.linspace(1.9, 2.1, 5)
     >>> results = model.power(periods, 0.16)
     >>> results.power  # doctest: +FLOAT_CMP
-    array([0.01479464, 0.03804835, 0.09640946, 0.05199547, 0.01970484])
+    array([0.01421067, 0.02842475, 0.10867671, 0.05117755, 0.01783253])
 
     If the inputs are AstroPy Quantities with units, the units will be
     validated and the outputs will also be Quantities with appropriate units:

--- a/astropy/stats/bls/methods.py
+++ b/astropy/stats/bls/methods.py
@@ -99,6 +99,7 @@ def _bls_slow_one(t, y, ivar, duration, oversample, use_likelihood, period):
     """A private function to compute the brute force periodogram result"""
     best = (-np.inf, None)
     hp = 0.5*period
+    min_t = np.min(t)
     for dur in duration:
 
         # Compute the phase grid (this is set by the duration and oversample).
@@ -107,7 +108,7 @@ def _bls_slow_one(t, y, ivar, duration, oversample, use_likelihood, period):
 
         for t0 in phase:
             # Figure out which data points are in and out of transit.
-            m_in = np.abs((t-t0+hp) % period - hp) < 0.5*dur
+            m_in = np.abs((t-min_t-t0+hp) % period - hp) < 0.5*dur
             m_out = ~m_in
 
             # Compute the estimates of the in and out-of-transit flux.
@@ -135,7 +136,8 @@ def _bls_slow_one(t, y, ivar, duration, oversample, use_likelihood, period):
             if depth > 0 and objective > best[0]:
                 best = (
                     objective,
-                    (objective, depth, depth_err, dur, t0, snr, loglike)
+                    (objective, depth, depth_err, dur, (t0+min_t) % period,
+                     snr, loglike)
                 )
 
     return best[1]

--- a/astropy/stats/bls/tests/test_bls.py
+++ b/astropy/stats/bls/tests/test_bls.py
@@ -346,11 +346,4 @@ def test_negative_times(data):
     # Shift the transit times back into the unshifted coordinates
     results2.transit_time = (results2.transit_time + mu) % results2.period
 
-    # Make sure that the period and phase for the top 50 peaks match
-    inds = np.argsort(results1.power)[-50:]
-    mean_duration = 0.5 * (results1.duration[inds] + results2.duration[inds])
-    delta = np.abs(results1.transit_time[inds] - results2.transit_time[inds])
-    assert np.all(delta / mean_duration < 0.5)
-
-    delta = np.abs(results1.period[inds] - results2.period[inds])
-    assert np.all(delta / mean_duration < 0.5)
+    assert_allclose_blsresults(results1, results2)

--- a/astropy/stats/bls/tests/test_bls.py
+++ b/astropy/stats/bls/tests/test_bls.py
@@ -35,7 +35,6 @@ def assert_allclose_blsresults(blsresult, other, **kwargs):
         assert_quantity_allclose(v, other[k], **kwargs)
 
 
-
 @pytest.fixture
 def data():
     rand = np.random.RandomState(123)
@@ -63,12 +62,12 @@ def test_32bit_bug():
     model = BoxLeastSquares(t, y)
     results = model.autopower(0.16)
     assert np.allclose(results.period[np.argmax(results.power)],
-                       2.005441310651872)
+                       1.9923406038842544)
     periods = np.linspace(1.9, 2.1, 5)
     results = model.power(periods, 0.16)
     assert np.allclose(
         results.power,
-        np.array([0.01479464, 0.03804835, 0.09640946, 0.05199547, 0.01970484])
+        np.array([0.01421067, 0.02842475, 0.10867671, 0.05117755, 0.01783253])
     )
 
 
@@ -330,3 +329,28 @@ def test_compute_stats(data, with_units, with_err):
     for f, k in zip((1.0, 1.0, 1.0, 0.0),
                     ("depth", "depth_even", "depth_odd", "depth_phased")):
         assert np.abs((stats[k][0]-f*params["depth"]) / stats[k][1]) < 1.0
+
+
+def test_negative_times(data):
+    t, y, dy, params = data
+    mu = np.mean(t)
+    duration = params["duration"] + np.linspace(-0.1, 0.1, 3)
+
+    model1 = BoxLeastSquares(t, y, dy)
+    results1 = model1.autopower(duration)
+
+    # Compute the periodogram with offset (negative) times
+    model2 = BoxLeastSquares(t - mu, y, dy)
+    results2 = model2.autopower(duration)
+
+    # Shift the transit times back into the unshifted coordinates
+    results2.transit_time = (results2.transit_time + mu) % results2.period
+
+    # Make sure that the period and phase for the top 50 peaks match
+    inds = np.argsort(results1.power)[-50:]
+    mean_duration = 0.5 * (results1.duration[inds] + results2.duration[inds])
+    delta = np.abs(results1.transit_time[inds] - results2.transit_time[inds])
+    assert np.all(delta / mean_duration < 0.5)
+
+    delta = np.abs(results1.period[inds] - results2.period[inds])
+    assert np.all(delta / mean_duration < 0.5)


### PR DESCRIPTION
There was a bug in the way that BLS handled negative times because of the way `fmod` handles negative arguments. This pull requests adds a test for this and fixes the bug.