### PR TITLE
MNT: Replace deprecated PyUnicode_GetSize with PyUnicode_GetLength

### DIFF
--- a/astropy/io/votable/src/tablewriter.c
+++ b/astropy/io/votable/src/tablewriter.c
@@ -271,7 +271,7 @@ write_tabledata(PyObject* self, PyObject *args, PyObject *kwds)
                     goto exit;
                 }
 
-                str_len = PyUnicode_GetSize(str_val);
+                str_len = PyUnicode_GetLength(str_val);
                 if (str_len) {
                     if (_write_cstring(&buf, &buf_size, &x, "  <TD>", 6) ||
                         _write_string(&buf, &buf_size, &x, str_tmp, str_len) ||

--- a/astropy/utils/xml/src/iterparse.c
+++ b/astropy/utils/xml/src/iterparse.c
@@ -1184,7 +1184,7 @@ _escape_xml(PyObject* self, PyObject *args, const char** escapes)
             return NULL;
         }
 
-        input_len = PyUnicode_GetSize(input_coerce);
+        input_len = PyUnicode_GetLength(input_coerce);
 
         for (i = 0; i < input_len; ++i) {
             for (esc = escapes; ; esc += 2) {


### PR DESCRIPTION
Fix #8113 . I don't think this is critical enough to backport but feel free to remilestone if you disagree. The replacement was new in 3.3, so this should not go into Astropy 2.x series.

Hopefully CI would catch any unintended behavior change cause by this switch. According to https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_GetSize , this should be sufficient but both docstrings are slightly different.