### PR TITLE
deprecate representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -970,7 +970,7 @@ Other Changes and Additions
 
 - The ``representation`` keywords in coordinate frames are now deprecated in
   favor of the ``representation_type`` keywords (which are less
-  ambiguous). [#8119]
+  ambiguously named). [#8119]
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -968,6 +968,10 @@ Other Changes and Additions
 - Updated the bundled CFITSIO library to 3.450. See
   ``cextern/cfitsio/docs/changes.txt`` for additional information. [#8014]
 
+- The ``representation`` keywords in coordinate frames are now deprecated in
+  favor of the ``representation_type`` keywords (which are less
+  ambiguous). [#8119]
+
 
 
 3.0.6 (unreleased)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -125,7 +125,7 @@ def _representation_deprecation():
     Raises a deprecation warning for the "representation" keyword
     """
     warnings.warn('The `representation` keyword/property name is deprecated in '
-                  'favor of `representation_type`', AstropyWarning)
+                  'favor of `representation_type`', AstropyDeprecationWarning)
 
 def _normalize_representation_type(kwargs):
     """ This is added for backwards compatibility: if the user specifies the

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -120,6 +120,13 @@ def _get_repr_classes(base, **differentials):
     return repr_classes
 
 
+def _representation_deprecation():
+    """
+    Raises a deprecation warning for the "representation" keyword
+    """
+    warnings.warn('The `representation` keyword/property name is deprecated in '
+                  'favor of `representation_type`', AstropyWarning)
+
 def _normalize_representation_type(kwargs):
     """ This is added for backwards compatibility: if the user specifies the
     old-style argument ``representation``, add it back in to the kwargs dict
@@ -131,6 +138,7 @@ def _normalize_representation_type(kwargs):
                              "were passed to a frame initializer. Please use "
                              "only `representation_type` (`representation` is "
                              "now pending deprecation).")
+        _representation_deprecation()
         kwargs['representation_type'] = kwargs.pop('representation')
 
 
@@ -763,10 +771,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     # TODO: deprecate these?
     @property
     def representation(self):
+        _representation_deprecation()
         return self.representation_type
 
     @representation.setter
     def representation(self, value):
+        _representation_deprecation()
         self.representation_type = value
 
     @classmethod

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -19,7 +19,7 @@ import numpy as np
 # Project
 from ..utils.compat.misc import override__dir__
 from ..utils.decorators import lazyproperty, format_doc
-from ..utils.exceptions import AstropyWarning
+from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from .. import units as u
 from ..utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
                      check_broadcast)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -417,7 +417,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         # This is here for backwards compatibility. It should be possible
         # to use either the kwarg representation_type, or representation.
-        # TODO: In future versions, we will raise a deprecation warning here:
         if representation_type is not None:
             kwargs['representation_type'] = representation_type
         _normalize_representation_type(kwargs)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -391,13 +391,18 @@ def test_time_cube():
     # High-level API
 
     # Make sure that we get a FutureWarning about the time column
-    with warnings.catch_warnings(record=True) as warning_lines:
+    with warnings.catch_warnings(record=True) as warning_entries:
         warnings.resetwarnings()
         coord, time = wcs.pixel_to_world(29, 39, 44)
 
-    assert len(warning_lines) == 1
-    assert warning_lines[0].category is FutureWarning
-    assert str(warning_lines[0].message).startswith('In future, times will be represented by the Time class')
+    # Check that there's at least one warning of the right category/message
+    assert len(warning_entries) > 0
+    found_warning = False
+    for w in warning_entries:
+        msg = 'In future, times will be represented by the Time class'
+        if w.category is FutureWarning and str(w.message).startswith(msg):
+            found_warning = True
+    assert found_warning
 
     assert isinstance(coord, SkyCoord)
     assert isinstance(time, Quantity)


### PR DESCRIPTION
As detailed in #7032, this implements the plan to deprecate the "representation" keyword in coordinates.

Closes #7032 (although we should open a "remove it" issue for 3.2 presumably?)