### PR TITLE
Planck15

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,6 +278,8 @@ astropy.coordinates
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
+- The default cosmology has been changed from ``WMAP9`` to ``Planck15``
+  [#8003]
 
 - Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
   are now 20x faster by using elliptic integrals for non-flat cases

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,7 +279,7 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 - The default cosmology has been changed from ``WMAP9`` to ``Planck15``
-  [#8003]
+  [#8123]
 
 - Distance calculations with ``LambaCDM`` with no radiation (T_CMB0=0)
   are now 20x faster by using elliptic integrals for non-flat cases

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -3337,7 +3337,7 @@ class default_cosmology(ScienceState):
         >>> with default_cosmology.set('WMAP7'):
         ...     # WMAP7 cosmology in effect
     """
-    _value = 'WMAP9'
+    _value = 'Planck15'
 
     @staticmethod
     def get_cosmology_from_string(arg):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -582,17 +582,6 @@ def test_beam():
 
 def test_thermodynamic_temperature():
     nu = 143 * u.GHz
-    tb = 0.00263251540546396 * u.K
-    np.testing.assert_almost_equal(
-        tb.value, (1 * u.MJy/u.sr).to_value(
-            u.K, equivalencies=u.thermodynamic_temperature(nu, T_cmb=2.725)))
-    np.testing.assert_almost_equal(
-        1.0, tb.to_value(
-            u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu)))
-
-
-def test_thermodynamic_temperature_w_tcmb():
-    nu = 143 * u.GHz
     tb = 0.0026320518775281975 * u.K
     np.testing.assert_almost_equal(
         tb.value, (1 * u.MJy/u.sr).to_value(

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -585,7 +585,7 @@ def test_thermodynamic_temperature():
     tb = 0.00263251540546396 * u.K
     np.testing.assert_almost_equal(
         tb.value, (1 * u.MJy/u.sr).to_value(
-            u.K, equivalencies=u.thermodynamic_temperature(nu)))
+            u.K, equivalencies=u.thermodynamic_temperature(nu, T_cmb=2.725)))
     np.testing.assert_almost_equal(
         1.0, tb.to_value(
             u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu)))

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -302,7 +302,7 @@ temperature", :math:`T_{CMB}`, in Kelvins. Example::
 
     >>> import astropy.units as u
     >>> nu = 143 * u.GHz
-    >>> t_k = 0.00263251540546396 * u.K
+    >>> t_k = 0.002632051878 * u.K
     >>> t_k.to(u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu))  # doctest: +FLOAT_CMP
     <Quantity 1. MJy / sr>
 
@@ -310,9 +310,9 @@ By default, this will use the :math:`T_{CMB}` value for the 'default cosmology'
 in astropy, but it is possible to specify a custom :math:`T_{CMB}` value for a
 specific cosmology as the second argument to the equivalency::
 
-    >>> from astropy.cosmology import Planck13
-    >>> t_k.to(u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu, T_cmb=Planck13.Tcmb0))  # doctest: +FLOAT_CMP
-    <Quantity 1.00017611 MJy / sr>
+    >>> from astropy.cosmology import WMAP9
+    >>> t_k.to(u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu, T_cmb=WMAP9.Tcmb0))  # doctest: +FLOAT_CMP
+    <Quantity 0.99982392 MJy / sr>
 
 Molar Mass AMU Equivalency
 --------------------------
@@ -401,7 +401,7 @@ the ``H0`` from the current default cosmology:
 
     >>> distance = 100 * (u.Mpc/u.littleh)
     >>> distance.to(u.Mpc, u.with_H0())  # doctest: +FLOAT_CMP
-    <Quantity 69.32 Mpc>
+    <Quantity 67.74 Mpc>
 
 This equivalency also allows the common magnitude formulation of little h
 scaling:

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -22,7 +22,8 @@ In particular, this release includes:
 * :ref:`whatsnew-3.1-nocopy-unit`
 * :ref:`whatsnew-3.1-tcmb`
 * :ref:`whatsnew-3.1-littleh`
-* :ref:`whatsnew-3.1-cosmology`
+* :ref:`whatsnew-3.1-default-cosmology`
+* :ref:`whatsnew-3.1-faster-cosmology`
 * :ref:`whatsnew-3.1-wcsaxes`
 * :ref:`whatsnew-3.1-imshow-norm`
 * :ref:`whatsnew-3.1-fits`
@@ -322,8 +323,26 @@ See :ref:`H0-equivalency` for more details.
 
 .. _whatsnew-3.1-cosmology:
 
+Improvements for Cosmology
+==========================
+
+.. _whatsnew-3.1-default-cosmology:
+
+Change in default cosmology
+---------------------------
+
+The default cosmology returned by the ``astropy.cosmology.default_cosmology``
+configuration item has been changed from the WMAP 9 year results to the Planck
+2015 results - as a result, you may see small changes in results of calculations
+where the cosmology was not explicitly specified. The default cosmology
+infrastructure is only provided for convenience and should be expected to
+change over time - as a result, for reproducibility it is always best to use
+an explicit cosmology rather than rely on the default.
+
+.. _whatsnew-3.1-faster-cosmology:
+
 Faster Cosmological Calculations
-================================
+--------------------------------
 
 There are now significant speedups (up to 100x) for distance and age
 calculations for FlatLambdaCDM cosmologies with no radiation or neutrinos,

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -293,7 +293,7 @@ equivalency allows conversion between Jy/beam and "thermodynamic temperature",
 
     >>> import astropy.units as u
     >>> nu = 143 * u.GHz
-    >>> t_k = 0.00263251540546396 * u.K
+    >>> t_k = 0.002632051878 * u.K
     >>> t_k.to(u.MJy / u.sr, equivalencies=u.thermodynamic_temperature(nu))  # doctest: +FLOAT_CMP
     <Quantity 1. MJy / sr>
 


### PR DESCRIPTION
Make Planck 2015 the default cosmology.

This breaks a test in units which depended on the default cosmology
rather than specifying parameters.  Removed that test, since such
dependencies are an antipattern.

Fixes [#8003]

