### PR TITLE
Update status of units to mature.

### DIFF
--- a/docs/stability.rst
+++ b/docs/stability.rst
@@ -257,10 +257,10 @@ The current planned and existing sub-packages are:
                 astropy.units
             </td>
             <td align='center'>
-                <span class="stable"></span>
+                <span class="mature"></span>
             </td>
             <td>
-                New in v0.2. Current functionality stable with intent to maintain backwards compatibility. Significant new functionality, in particular to allow dealing with uncertainties, is likely to be added in future versions.
+                Incremental improvements since v0.4. Functionality mature and unlikely to change. Efforts focused on performance and increased interoperability with Numpy functions.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
What was holding it back was the idea that quantities would start to have associated uncertainties, but this has now moved to the new `uncertainty` sub-module.

p.s. I perhaps should have, but didn't check the status of all other submodules carefully.

@adrn - do you agree units can be transitioned from stable to mature?

@bsipocz - I think it would make sense to have this in 3.1 still...