### PR TITLE
Fix deprecationwarnings issued by old uses of the representation= kwarg in coordinates

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1023,7 +1023,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         <CartesianRepresentation (x, y, z) [dimensionless]
                 (1., 0., 0.)>
 
-        >>> coord.representation = CartesianRepresentation
+        >>> coord.representation_type = CartesianRepresentation
         >>> coord  # doctest: +FLOAT_CMP
         <SkyCoord (ICRS): (x, y, z) [dimensionless]
             (1., 0., 0.)>

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1303,12 +1303,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         if not self.has_data:
             return ''
 
-        if self.representation:
-            if (hasattr(self.representation, '_unit_representation') and
-                    isinstance(self.data, self.representation._unit_representation)):
+        if self.representation_type:
+            if (hasattr(self.representation_type, '_unit_representation') and
+                    isinstance(self.data, self.representation_type._unit_representation)):
                 rep_cls = self.data.__class__
             else:
-                rep_cls = self.representation
+                rep_cls = self.representation_type
 
             if 's' in self.data.differentials:
                 dif_cls = self.get_representation_cls('s')

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -767,6 +767,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def differential_type(self, value):
         self.set_representation_cls(s=value)
 
+    # TODO: remove these in a future version
     @property
     def representation(self):
         _representation_deprecation()

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -767,7 +767,6 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def differential_type(self, value):
         self.set_representation_cls(s=value)
 
-    # TODO: deprecate these?
     @property
     def representation(self):
         _representation_deprecation()

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -284,7 +284,7 @@ class SkyCoord(ShapedLikeNDArray):
     def representation_type(self, value):
         self.frame.representation_type = value
 
-    # TODO: deprecate these in future
+    # TODO: remove these in future
     @property
     def representation(self):
         return self.frame.representation

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -422,7 +422,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
         if coords.data.differentials and 's' in coords.data.differentials:
             orig_vel = coords.data.differentials['s']
-            vel = coords.data.represent_as(frame.representation, frame.get_representation_cls('s')).differentials['s']
+            vel = coords.data.represent_as(frame.representation_type, frame.get_representation_cls('s')).differentials['s']
             for frname, reprname in frame.get_representation_component_names('s').items():
                 if (reprname == 'd_distance' and not hasattr(orig_vel, reprname) and
                     'unit' in orig_vel.get_name()):

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -296,7 +296,7 @@ def _parse_coordinate_data(frame, args, kwargs):
 
             for arg, frame_attr_name, repr_attr_name, unit in zip(args, frame_attr_names,
                                                                   repr_attr_names, units):
-                attr_class = frame.representation.attr_classes[repr_attr_name]
+                attr_class = frame.representation_type.attr_classes[repr_attr_name]
                 _components[frame_attr_name] = attr_class(arg, unit=unit)
 
         else:
@@ -383,7 +383,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
 
     frame_attr_names = list(frame.representation_component_names.keys())
     repr_attr_names = list(frame.representation_component_names.values())
-    repr_attr_classes = list(frame.representation.attr_classes.values())
+    repr_attr_classes = list(frame.representation_type.attr_classes.values())
     n_attr_names = len(repr_attr_names)
 
     # Turn a single string into a list of strings for convenience
@@ -453,7 +453,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 repr_attr_classes.append(data.differentials['s'].attr_classes[reprname])
 
         else:
-            data = coords.represent_as(frame.representation)
+            data = coords.represent_as(frame.representation_type)
             values = [getattr(data, repr_attr_name) for repr_attr_name in repr_attr_names]
 
     elif (isinstance(coords, np.ndarray) and coords.dtype.kind in 'if'

--- a/astropy/coordinates/tests/conftest.py
+++ b/astropy/coordinates/tests/conftest.py
@@ -3,6 +3,7 @@ import warnings
 
 
 # autouse makes this an all-coordinates-tests fixture
+# this can be eliminated if/when warnings in pytest are all turned to errors (gh issue #7928)
 @pytest.fixture(autouse=True)
 def representation_deprecation_to_error():
     warnings.filterwarnings('error', 'The `representation` keyword/property name is deprecated in favor of `representation_type`')

--- a/astropy/coordinates/tests/conftest.py
+++ b/astropy/coordinates/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+import warnings
+
+
+# autouse makes this an all-coordinates-tests fixture
+@pytest.fixture(autouse=True)
+def representation_deprecation_to_error():
+    warnings.filterwarnings('error', 'The `representation` keyword/property name is deprecated in favor of `representation_type`')
+    filt = warnings.filters[0]
+    yield
+    try:
+        warnings.filters.remove(filt)
+    except ValueError:
+        pass  # already removed

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -200,7 +200,7 @@ def test_frame_api():
     assert_allclose(icrs.dec, 5*u.deg)
     assert_allclose(fk5.ra, 8*u.hourangle)
 
-    assert icrs.representation == SphericalRepresentation
+    assert icrs.representation_type == SphericalRepresentation
 
     # low-level classes can also be initialized with names valid for that representation
     # and frame:

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -368,7 +368,7 @@ def test_realizing():
 
     # Check that a nicer error message is returned:
     with pytest.raises(TypeError) as excinfo:
-        f.realize_frame(f.representation)
+        f.realize_frame(f.representation_type)
 
     assert ('Class passed as data instead of a representation' in
             excinfo.value.args[0])
@@ -586,9 +586,9 @@ def test_representation():
     icrs_spher = icrs.spherical
 
     # Testing when `_representation` set to `CartesianRepresentation`.
-    icrs.representation = r.CartesianRepresentation
+    icrs.representation_type = r.CartesianRepresentation
 
-    assert icrs.representation == r.CartesianRepresentation
+    assert icrs.representation_type == r.CartesianRepresentation
     assert icrs_cart.x == icrs.x
     assert icrs_cart.y == icrs.y
     assert icrs_cart.z == icrs.z
@@ -601,15 +601,15 @@ def test_representation():
         assert 'object has no attribute' in str(err)
 
     # Testing when `_representation` set to `CylindricalRepresentation`.
-    icrs.representation = r.CylindricalRepresentation
+    icrs.representation_type = r.CylindricalRepresentation
 
-    assert icrs.representation == r.CylindricalRepresentation
+    assert icrs.representation_type == r.CylindricalRepresentation
     assert icrs.data == data
 
     # Testing setter input using text argument for spherical.
-    icrs.representation = 'spherical'
+    icrs.representation_type = 'spherical'
 
-    assert icrs.representation is r.SphericalRepresentation
+    assert icrs.representation_type is r.SphericalRepresentation
     assert icrs_spher.lat == icrs.dec
     assert icrs_spher.lon == icrs.ra
     assert icrs_spher.distance == icrs.distance
@@ -622,17 +622,17 @@ def test_representation():
         assert 'object has no attribute' in str(err)
 
     # Testing setter input using text argument for cylindrical.
-    icrs.representation = 'cylindrical'
+    icrs.representation_type = 'cylindrical'
 
-    assert icrs.representation is r.CylindricalRepresentation
+    assert icrs.representation_type is r.CylindricalRepresentation
     assert icrs.data == data
 
     with pytest.raises(ValueError) as err:
-        icrs.representation = 'WRONG'
+        icrs.representation_type = 'WRONG'
     assert 'but must be a BaseRepresentation class' in str(err)
 
     with pytest.raises(ValueError) as err:
-        icrs.representation = ICRS
+        icrs.representation_type = ICRS
     assert 'but must be a BaseRepresentation class' in str(err)
 
 
@@ -825,7 +825,7 @@ def test_representation_subclass():
     # SphericalRepresentation.
     frame = FK5(representation_type=r.SphericalRepresentation, ra=32 * u.deg, dec=20 * u.deg)
     assert type(frame._data) == r.UnitSphericalRepresentation
-    assert frame.representation == r.SphericalRepresentation
+    assert frame.representation_type == r.SphericalRepresentation
 
     # If using a SphericalRepresentation class this used to not work, so we
     # test here that this is now fixed.
@@ -834,7 +834,7 @@ def test_representation_subclass():
 
     frame = FK5(representation_type=NewSphericalRepresentation, lon=32 * u.deg, lat=20 * u.deg)
     assert type(frame._data) == r.UnitSphericalRepresentation
-    assert frame.representation == NewSphericalRepresentation
+    assert frame.representation_type == NewSphericalRepresentation
 
     # A similar issue then happened in __repr__ with subclasses of
     # SphericalRepresentation.
@@ -865,8 +865,8 @@ def test_getitem_representation():
     """
     from ..builtin_frames import ICRS
     c = ICRS([1, 1] * u.deg, [2, 2] * u.deg)
-    c.representation = 'cartesian'
-    assert c[0].representation is r.CartesianRepresentation
+    c.representation_type = 'cartesian'
+    assert c[0].representation_type is r.CartesianRepresentation
 
 
 def test_component_error_useful():
@@ -984,7 +984,7 @@ def test_representation_arg_backwards_compatibility():
     assert c1.y == c3.y
     assert c1.z == c3.z
 
-    assert c1.representation == c1.representation_type
+    assert c1.representation_type == c1.representation_type
 
     with pytest.raises(ValueError):
         ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -989,7 +989,7 @@ def test_representation_arg_backwards_compatibility():
     with pytest.raises(ValueError):
         ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
              representation_type='cartesian',
-             representation_type='cartesian')
+             representation='cartesian')
 
 
 def test_missing_component_error_names():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -823,7 +823,7 @@ def test_representation_subclass():
     # Normally when instantiating a frame without a distance the frame will try
     # and use UnitSphericalRepresentation internally instead of
     # SphericalRepresentation.
-    frame = FK5(representation=r.SphericalRepresentation, ra=32 * u.deg, dec=20 * u.deg)
+    frame = FK5(representation_type=r.SphericalRepresentation, ra=32 * u.deg, dec=20 * u.deg)
     assert type(frame._data) == r.UnitSphericalRepresentation
     assert frame.representation == r.SphericalRepresentation
 
@@ -832,7 +832,7 @@ def test_representation_subclass():
     class NewSphericalRepresentation(r.SphericalRepresentation):
         attr_classes = r.SphericalRepresentation.attr_classes
 
-    frame = FK5(representation=NewSphericalRepresentation, lon=32 * u.deg, lat=20 * u.deg)
+    frame = FK5(representation_type=NewSphericalRepresentation, lon=32 * u.deg, lat=20 * u.deg)
     assert type(frame._data) == r.UnitSphericalRepresentation
     assert frame.representation == NewSphericalRepresentation
 
@@ -853,7 +853,7 @@ def test_representation_subclass():
             return "<NewUnitSphericalRepresentation: spam spam spam>"
 
     frame = FK5(NewUnitSphericalRepresentation(lon=32 * u.deg, lat=20 * u.deg),
-                representation=NewSphericalRepresentation)
+                representation_type=NewSphericalRepresentation)
 
     assert repr(frame) == "<FK5 Coordinate (equinox=J2000.000):  spam spam spam>"
 
@@ -971,10 +971,10 @@ def test_representation_arg_backwards_compatibility():
               representation_type=r.CartesianRepresentation)
 
     c2 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-              representation=r.CartesianRepresentation)
+              representation_type=r.CartesianRepresentation)
 
     c3 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-              representation='cartesian')
+              representation_type='cartesian')
 
     assert c1.x == c2.x
     assert c1.y == c2.y
@@ -988,7 +988,7 @@ def test_representation_arg_backwards_compatibility():
 
     with pytest.raises(ValueError):
         ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
-             representation='cartesian',
+             representation_type='cartesian',
              representation_type='cartesian')
 
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -214,7 +214,7 @@ def test_differential_type_arg():
     # specify both
     icrs = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
                 v_x=1*u.km/u.s, v_y=2*u.km/u.s, v_z=3*u.km/u.s,
-                representation=r.CartesianRepresentation,
+                representation_type=r.CartesianRepresentation,
                 differential_type=r.CartesianDifferential)
     assert icrs.x == 1*u.pc
     assert icrs.y == 2*u.pc

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -181,7 +181,7 @@ def test_gcrs_itrs():
 
     # also try with the cartesian representation
     gcrsc = gcrs.realize_frame(gcrs.data)
-    gcrsc.representation = CartesianRepresentation
+    gcrsc.representation_type = CartesianRepresentation
     gcrsc2 = gcrsc.transform_to(ITRS).transform_to(gcrsc)
     assert_allclose(gcrsc.spherical.lon.deg, gcrsc2.ra.deg)
     assert_allclose(gcrsc.spherical.lat, gcrsc2.dec)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -148,7 +148,7 @@ def test_cirs_to_altaz():
     ra, dec, dist = randomly_sample_sphere(200)
     cirs = CIRS(ra=ra, dec=dec, obstime='J2000')
     crepr = SphericalRepresentation(lon=ra, lat=dec, distance=dist)
-    cirscart = CIRS(crepr, obstime=cirs.obstime, representation=CartesianRepresentation)
+    cirscart = CIRS(crepr, obstime=cirs.obstime, representation_type=CartesianRepresentation)
 
     loc = EarthLocation(lat=0*u.deg, lon=0*u.deg, height=0*u.m)
     altazframe = AltAz(location=loc, obstime=Time('J2005'))

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -388,7 +388,7 @@ def test_regression_6236():
 
     class MySpecialFrame(MyFrame):
         def __init__(self, *args, **kwargs):
-            _rep_kwarg = kwargs.get('representation', None)
+            _rep_kwarg = kwargs.get('representation_type', None)
             super().__init__(*args, **kwargs)
             if not _rep_kwarg:
                 self.representation_type = self.default_representation

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -404,16 +404,16 @@ def test_regression_6236():
     # realize_frame should do the same. Just in case, check attrs are passed.
     assert mf1.data is rep1
     assert mf2.data is rep2
-    assert mf1.representation is CartesianRepresentation
-    assert mf2.representation is CartesianRepresentation
+    assert mf1.representation_type is CartesianRepresentation
+    assert mf2.representation_type is CartesianRepresentation
     assert mf2.my_attr == mf1.my_attr
     # It should be independent of whether I set the reprensentation explicitly
     mf3 = MyFrame(rep1, my_attr=1.*u.km, representation_type='unitspherical')
     mf4 = mf3.realize_frame(rep2)
     assert mf3.data is rep1
     assert mf4.data is rep2
-    assert mf3.representation is UnitSphericalRepresentation
-    assert mf4.representation is CartesianRepresentation
+    assert mf3.representation_type is UnitSphericalRepresentation
+    assert mf4.representation_type is CartesianRepresentation
     assert mf4.my_attr == mf3.my_attr
     # This should be enough to help sunpy, but just to be sure, a test
     # even closer to what is done there, i.e., transform the representation.
@@ -423,8 +423,8 @@ def test_regression_6236():
     assert msf2.data is not rep2
     assert type(msf1.data) is CartesianRepresentation
     assert type(msf2.data) is CartesianRepresentation
-    assert msf1.representation is CartesianRepresentation
-    assert msf2.representation is CartesianRepresentation
+    assert msf1.representation_type is CartesianRepresentation
+    assert msf2.representation_type is CartesianRepresentation
     assert msf2.my_attr == msf1.my_attr
     # And finally a test where the input is not transformed.
     msf3 = MySpecialFrame(rep1, my_attr=1.*u.km,
@@ -432,8 +432,8 @@ def test_regression_6236():
     msf4 = msf3.realize_frame(rep2)
     assert msf3.data is rep1
     assert msf4.data is not rep2
-    assert msf3.representation is UnitSphericalRepresentation
-    assert msf4.representation is CartesianRepresentation
+    assert msf3.representation_type is UnitSphericalRepresentation
+    assert msf4.representation_type is CartesianRepresentation
     assert msf4.my_attr == msf3.my_attr
 
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -391,8 +391,8 @@ def test_regression_6236():
             _rep_kwarg = kwargs.get('representation', None)
             super().__init__(*args, **kwargs)
             if not _rep_kwarg:
-                self.representation = self.default_representation
-                self._data = self.data.represent_as(self.representation)
+                self.representation_type = self.default_representation
+                self._data = self.data.represent_as(self.representation_type)
 
     rep1 = UnitSphericalRepresentation([0., 1]*u.deg, [2., 3.]*u.deg)
     rep2 = SphericalRepresentation([10., 11]*u.deg, [12., 13.]*u.deg,
@@ -408,7 +408,7 @@ def test_regression_6236():
     assert mf2.representation is CartesianRepresentation
     assert mf2.my_attr == mf1.my_attr
     # It should be independent of whether I set the reprensentation explicitly
-    mf3 = MyFrame(rep1, my_attr=1.*u.km, representation='unitspherical')
+    mf3 = MyFrame(rep1, my_attr=1.*u.km, representation_type='unitspherical')
     mf4 = mf3.realize_frame(rep2)
     assert mf3.data is rep1
     assert mf4.data is rep2
@@ -428,7 +428,7 @@ def test_regression_6236():
     assert msf2.my_attr == msf1.my_attr
     # And finally a test where the input is not transformed.
     msf3 = MySpecialFrame(rep1, my_attr=1.*u.km,
-                          representation='unitspherical')
+                          representation_type='unitspherical')
     msf4 = msf3.realize_frame(rep2)
     assert msf3.data is rep1
     assert msf4.data is not rep2
@@ -518,7 +518,7 @@ def test_gcrs_itrs_cartesian_repr():
     # issue 6436: transformation failed if coordinate representation was
     # Cartesian
     gcrs = GCRS(CartesianRepresentation((859.07256, -4137.20368,  5295.56871),
-                                        unit='km'), representation='cartesian')
+                                        unit='km'), representation_type='cartesian')
     gcrs.transform_to(ITRS)
 
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -986,7 +986,7 @@ def test_deepcopy():
     assert c5.frame.name == c4.frame.name
     assert c5.obstime == c4.obstime
     assert c5.equinox == c4.equinox
-    assert c5.representation == c4.representation
+    assert c5.representation_type == c4.representation_type
 
 
 def test_no_copy():
@@ -1240,8 +1240,8 @@ def test_getitem_representation():
     from data representation.
     """
     sc = SkyCoord([1, 1] * u.deg, [2, 2] * u.deg)
-    sc.representation = 'cartesian'
-    assert sc[0].representation is CartesianRepresentation
+    sc.representation_type = 'cartesian'
+    assert sc[0].representation_type is CartesianRepresentation
 
 
 def test_spherical_offsets():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -735,27 +735,27 @@ def test_skycoord_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
     and various representations.  Use weird units and Galactic frame.
     """
     sc = SkyCoord(c1, c2, c3, unit=(unit1, unit2, unit3),
-                  representation=representation,
+                  representation_type=representation,
                   frame=Galactic)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
     sc = SkyCoord(1000*c1*u.Unit(unit1/1000), cls2(c2, unit=unit2),
                   1000*c3*u.Unit(unit3/1000), frame=Galactic,
-                  unit=(unit1, unit2, unit3), representation=representation)
+                  unit=(unit1, unit2, unit3), representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
     kwargs = {attr3: c3}
     sc = SkyCoord(c1, c2, unit=(unit1, unit2, unit3),
                   frame=Galactic,
-                  representation=representation, **kwargs)
+                  representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
     kwargs = {attr1: c1, attr2: c2, attr3: c3}
     sc = SkyCoord(frame=Galactic, unit=(unit1, unit2, unit3),
-                  representation=representation, **kwargs)
+                  representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
@@ -770,19 +770,19 @@ def test_skycoord_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
     representations.  Use weird units and Galactic frame.
     """
     sc = SkyCoord(c1, c2, unit=(unit1, unit2), frame=Galactic,
-                  representation=representation)
+                  representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2),
                                (attr1, attr2))
 
     sc = SkyCoord(1000*c1*u.Unit(unit1/1000), cls2(c2, unit=unit2),
                   frame=Galactic,
-                  unit=(unit1, unit2, unit3), representation=representation)
+                  unit=(unit1, unit2, unit3), representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2),
                                (attr1, attr2))
 
     kwargs = {attr1: c1, attr2: c2}
     sc = SkyCoord(frame=Galactic, unit=(unit1, unit2),
-                  representation=representation, **kwargs)
+                  representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2),
                                (attr1, attr2))
 
@@ -796,18 +796,18 @@ def test_galactic_three_components(repr_name, unit1, unit2, unit3, cls2, attr1, 
     and various representations.  Use weird units and Galactic frame.
     """
     sc = Galactic(1000*c1*u.Unit(unit1/1000), cls2(c2, unit=unit2),
-                  1000*c3*u.Unit(unit3/1000), representation=representation)
+                  1000*c3*u.Unit(unit3/1000), representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
     kwargs = {attr3: c3*unit3}
     sc = Galactic(c1*unit1, c2*unit2,
-                  representation=representation, **kwargs)
+                  representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
     kwargs = {attr1: c1*unit1, attr2: c2*unit2, attr3: c3*unit3}
-    sc = Galactic(representation=representation, **kwargs)
+    sc = Galactic(representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2, c3*unit3),
                                (attr1, attr2, attr3))
 
@@ -822,14 +822,14 @@ def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
     representations.  Use weird units and Galactic frame.
     """
 
-    sc = Galactic(1000*c1*u.Unit(unit1/1000), cls2(c2, unit=unit2), representation=representation)
+    sc = Galactic(1000*c1*u.Unit(unit1/1000), cls2(c2, unit=unit2), representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2), (attr1, attr2))
 
-    sc = Galactic(c1*unit1, c2*unit2, representation=representation)
+    sc = Galactic(c1*unit1, c2*unit2, representation_type=representation)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2), (attr1, attr2))
 
     kwargs = {attr1: c1*unit1, attr2: c2*unit2}
-    sc = Galactic(representation=representation, **kwargs)
+    sc = Galactic(representation_type=representation, **kwargs)
     assert_quantities_allclose(sc, (c1*unit1, c2*unit2), (attr1, attr2))
 
 
@@ -837,50 +837,50 @@ def test_galactic_spherical_two_components(repr_name, unit1, unit2, unit3, cls2,
                          [x for x in base_unit_attr_sets if x[0] != 'unitspherical'])
 def test_skycoord_coordinate_input(repr_name, unit1, unit2, unit3, cls2, attr1, attr2, attr3):
     c1, c2, c3 = 1, 2, 3
-    sc = SkyCoord([(c1, c2, c3)], unit=(unit1, unit2, unit3), representation=repr_name,
+    sc = SkyCoord([(c1, c2, c3)], unit=(unit1, unit2, unit3), representation_type=repr_name,
                   frame='galactic')
     assert_quantities_allclose(sc, ([c1]*unit1, [c2]*unit2, [c3]*unit3), (attr1, attr2, attr3))
 
     c1, c2, c3 = 1*unit1, 2*unit2, 3*unit3
-    sc = SkyCoord([(c1, c2, c3)], representation=repr_name, frame='galactic')
+    sc = SkyCoord([(c1, c2, c3)], representation_type=repr_name, frame='galactic')
     assert_quantities_allclose(sc, ([1]*unit1, [2]*unit2, [3]*unit3), (attr1, attr2, attr3))
 
 
 def test_skycoord_string_coordinate_input():
-    sc = SkyCoord('01 02 03 +02 03 04', unit='deg', representation='unitspherical')
+    sc = SkyCoord('01 02 03 +02 03 04', unit='deg', representation_type='unitspherical')
     assert_quantities_allclose(sc, (Angle('01:02:03', unit='deg'),
                                     Angle('02:03:04', unit='deg')),
                                ('ra', 'dec'))
-    sc = SkyCoord(['01 02 03 +02 03 04'], unit='deg', representation='unitspherical')
+    sc = SkyCoord(['01 02 03 +02 03 04'], unit='deg', representation_type='unitspherical')
     assert_quantities_allclose(sc, (Angle(['01:02:03'], unit='deg'),
                                     Angle(['02:03:04'], unit='deg')),
                                ('ra', 'dec'))
 
 
 def test_units():
-    sc = SkyCoord(1, 2, 3, unit='m', representation='cartesian')  # All get meters
+    sc = SkyCoord(1, 2, 3, unit='m', representation_type='cartesian')  # All get meters
     assert sc.x.unit is u.m
     assert sc.y.unit is u.m
     assert sc.z.unit is u.m
 
-    sc = SkyCoord(1, 2*u.km, 3, unit='m', representation='cartesian')  # All get u.m
+    sc = SkyCoord(1, 2*u.km, 3, unit='m', representation_type='cartesian')  # All get u.m
     assert sc.x.unit is u.m
     assert sc.y.unit is u.m
     assert sc.z.unit is u.m
 
-    sc = SkyCoord(1, 2, 3, unit=u.m, representation='cartesian')  # All get u.m
+    sc = SkyCoord(1, 2, 3, unit=u.m, representation_type='cartesian')  # All get u.m
     assert sc.x.unit is u.m
     assert sc.y.unit is u.m
     assert sc.z.unit is u.m
 
-    sc = SkyCoord(1, 2, 3, unit='m, km, pc', representation='cartesian')
+    sc = SkyCoord(1, 2, 3, unit='m, km, pc', representation_type='cartesian')
     assert_quantities_allclose(sc, (1*u.m, 2*u.km, 3*u.pc), ('x', 'y', 'z'))
 
     with pytest.raises(u.UnitsError) as err:
-        SkyCoord(1, 2, 3, unit=(u.m, u.m), representation='cartesian')
+        SkyCoord(1, 2, 3, unit=(u.m, u.m), representation_type='cartesian')
     assert 'should have matching physical types' in str(err)
 
-    SkyCoord(1, 2, 3, unit=(u.m, u.km, u.pc), representation='cartesian')
+    SkyCoord(1, 2, 3, unit=(u.m, u.km, u.pc), representation_type='cartesian')
     assert_quantities_allclose(sc, (1*u.m, 2*u.km, 3*u.pc), ('x', 'y', 'z'))
 
 
@@ -888,7 +888,7 @@ def test_units():
 def test_units_known_fail():
     # should fail but doesn't => corner case oddity
     with pytest.raises(u.UnitsError):
-        SkyCoord(1, 2, 3, unit=u.deg, representation='spherical')
+        SkyCoord(1, 2, 3, unit=u.deg, representation_type='spherical')
 
 
 def test_nodata_failure():
@@ -979,7 +979,7 @@ def test_deepcopy():
     c2 = copy.copy(c1)
     c3 = copy.deepcopy(c1)
 
-    c4 = SkyCoord([1, 2] * u.m, [2, 3] * u.m, [3, 4] * u.m, representation='cartesian', frame='fk5',
+    c4 = SkyCoord([1, 2] * u.m, [2, 3] * u.m, [3, 4] * u.m, representation_type='cartesian', frame='fk5',
                   obstime='J1999.9', equinox='J1988.8')
     c5 = copy.deepcopy(c4)
     assert np.all(c5.x == c4.x)  # and y and z
@@ -1107,7 +1107,7 @@ def test_guess_from_table():
     tabcart = Table([x, y, z], names=('x', 'y', 'z'))
     tabgal = Table([b, l], names=('b', 'l'))
 
-    sc_cart = SkyCoord.guess_from_table(tabcart, representation='cartesian')
+    sc_cart = SkyCoord.guess_from_table(tabcart, representation_type='cartesian')
     npt.assert_array_equal(sc_cart.x, x)
     npt.assert_array_equal(sc_cart.y, y)
     npt.assert_array_equal(sc_cart.z, z)

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -90,7 +90,7 @@ def test_skyoffset_functional_dec():
                       np.sin(dec_rad) * np.cos(input_ra_rad) * np.cos(input_dec_rad))
         expected = SkyCoord(x=expected_x,
                             y=expected_y,
-                            z=expected_z, unit='kpc', representation='cartesian')
+                            z=expected_z, unit='kpc', representation_type='cartesian')
         expected_xyz = expected.cartesian.xyz
 
         # actual transformation to the frame
@@ -136,7 +136,7 @@ def test_skyoffset_functional_ra_dec():
                           np.sin(dec_rad) * np.sin(ra_rad) * np.sin(input_ra_rad) * np.cos(input_dec_rad))
             expected = SkyCoord(x=expected_x,
                                 y=expected_y,
-                                z=expected_z, unit='kpc', representation='cartesian')
+                                z=expected_z, unit='kpc', representation_type='cartesian')
             expected_xyz = expected.cartesian.xyz
 
             # actual transformation to the frame

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -258,7 +258,7 @@ el = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
 scc = sc.copy()
-scc.representation = 'cartesian'
+scc.representation_type = 'cartesian'
 tm = Time([51000.5, 51001.5], format='mjd', scale='tai', precision=5, location=el[0])
 tm2 = Time(tm, format='iso')
 tm3 = Time(tm, location=el)
@@ -291,9 +291,9 @@ compare_attrs = {
     'tm2': time_attrs,
     'tm3': time_attrs,
     'dt': ['shape', 'value', 'format', 'scale'],
-    'sc': ['ra', 'dec', 'representation', 'frame.name'],
-    'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
-    'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
+    'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
+    'scc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
     'q': ['value', 'unit'],
     'lon': ['value', 'unit', 'wrap_angle'],
     'lat': ['value', 'unit'],

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -473,7 +473,7 @@ el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
 scc = sc.copy()
-scc.representation = 'cartesian'
+scc.representation_type = 'cartesian'
 tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
 
 
@@ -497,9 +497,9 @@ compare_attrs = {
     'c2': ['data'],
     'tm': time_attrs,
     'dt': ['shape', 'value', 'format', 'scale'],
-    'sc': ['ra', 'dec', 'representation', 'frame.name'],
-    'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
-    'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
+    'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
+    'scc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
     'q': ['value', 'unit'],
     'lon': ['value', 'unit', 'wrap_angle'],
     'lat': ['value', 'unit'],

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -631,7 +631,7 @@ el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
 scc = sc.copy()
-scc.representation = 'cartesian'
+scc.representation_type = 'cartesian'
 tm = Time([2450814.5, 2450815.5], format='jd', scale='tai', location=el)
 
 
@@ -655,9 +655,9 @@ compare_attrs = {
     'c2': ['data'],
     'tm': time_attrs,
     'dt': ['shape', 'value', 'format', 'scale'],
-    'sc': ['ra', 'dec', 'representation', 'frame.name'],
-    'scc': ['x', 'y', 'z', 'representation', 'frame.name'],
-    'scd': ['ra', 'dec', 'distance', 'representation', 'frame.name'],
+    'sc': ['ra', 'dec', 'representation_type', 'frame.name'],
+    'scc': ['x', 'y', 'z', 'representation_type', 'frame.name'],
+    'scd': ['ra', 'dec', 'distance', 'representation_type', 'frame.name'],
     'q': ['value', 'unit'],
     'lon': ['value', 'unit', 'wrap_angle'],
     'lat': ['value', 'unit'],

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -611,13 +611,13 @@ def test_skycoord_representation():
                            '-----------',
                            '0.0,1.0,0.0']
 
-    t['col0'].representation = 'unitspherical'
+    t['col0'].representation_type = 'unitspherical'
     assert t.pformat() == ['  col0  ',
                            'deg,deg ',
                            '--------',
                            '90.0,0.0']
 
-    t['col0'].representation = 'cylindrical'
+    t['col0'].representation_type = 'cylindrical'
     assert t.pformat() == ['    col0    ',
                            '  m,deg,m   ',
                            '------------',

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -596,7 +596,7 @@ def test_skycoord_representation():
     values are output and in changing the frame representation.
     """
     # With no unit we get "None" in the unit row
-    c = coordinates.SkyCoord([0], [1], [0], representation='cartesian')
+    c = coordinates.SkyCoord([0], [1], [0], representation_type='cartesian')
     t = Table([c])
     assert t.pformat() == ['     col0     ',
                            'None,None,None',
@@ -604,7 +604,7 @@ def test_skycoord_representation():
                            '   0.0,1.0,0.0']
 
     # Test that info works with a dynamically changed representation
-    c = coordinates.SkyCoord([0], [1], [0], unit='m', representation='cartesian')
+    c = coordinates.SkyCoord([0], [1], [0], unit='m', representation_type='cartesian')
     t = Table([c])
     assert t.pformat() == ['    col0   ',
                            '   m,m,m   ',

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -24,7 +24,7 @@ def sort_eq(list1, list2):
 def skycoord_equal(sc1, sc2):
     if not sc1.is_equivalent_frame(sc2):
         return False
-    if sc1.representation is not sc2.representation:  # Will be representation_type..
+    if sc1.representation_type is not sc2.representation_type:
         return False
     if sc1.shape != sc2.shape:
         return False  # Maybe raise ValueError corresponding to future numpy behavior


### PR DESCRIPTION
This fixes #8139.