### PR TITLE
TST: Fix MarkInfo object in pytest 4

### DIFF
--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -34,11 +34,11 @@ DEFAULT_DATA_SCALE = 1.0
 
 
 def value_from_markers(key, request):
-    try:
-        val = request.keywords[key].args[0]
-    except KeyError:
-        val = DEFAULTS[key]
-    return val
+    m = request.node.get_closest_marker(key)
+    if m is not None:
+        return m.args[0]
+    else:
+        return DEFAULTS[key]
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix #8144 . Credit goes to @nicoddemus (thank you)!