### PR TITLE
TST: Skip segfault test case instead of xfail

### DIFF
--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -263,8 +263,8 @@ def test_exception_logging_origin():
     assert log_list[0].origin == 'astropy.utils.collections'
 
 
-@pytest.mark.xfail(True, reason="Infinite recursion on Python 3.5+, probably a real issue")
-@pytest.mark.xfail(str("ip is not None"))
+@pytest.mark.skip(reason="Infinite recursion on Python 3.5+, probably a real issue")
+#@pytest.mark.xfail(str("ip is not None"))
 def test_exception_logging_argless_exception():
     """
     Regression test for a crash that occurred on Python 3 when logging an


### PR DESCRIPTION
Fix #8148

I am very perplexed on why this only happens to me. But given that this particular test has a known recursion problem, it really does not matter whether we skip or xfail, but unfortunately the latter gives me seg fault.