### PR TITLE
BUG: Ignore mirror caching when no internet

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1805,6 +1805,8 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Ignore URL mirror caching when there is no internet. [#8163]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1001,9 +1001,11 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
     # Check if URL is Astropy data server, which has alias, and cache it.
     if (url_key.startswith(conf.dataurl) and
             conf.dataurl not in _dataurls_to_alias):
-        with urllib.request.urlopen(conf.dataurl, timeout=timeout) as remote:
-            _dataurls_to_alias[conf.dataurl] = [conf.dataurl, remote.geturl()]
-
+        try:
+            with urllib.request.urlopen(conf.dataurl, timeout=timeout) as remote:
+                _dataurls_to_alias[conf.dataurl] = [conf.dataurl, remote.geturl()]
+        except urllib.error.URLError:  # Host unreachable
+            pass
     try:
         if cache:
             # We don't need to acquire the lock here, since we are only reading

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1005,7 +1005,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
             with urllib.request.urlopen(conf.dataurl, timeout=timeout) as remote:
                 _dataurls_to_alias[conf.dataurl] = [conf.dataurl, remote.geturl()]
         except urllib.error.URLError:  # Host unreachable
-            pass
+            _dataurls_to_alias[conf.dataurl] = [conf.dataurl]
     try:
         if cache:
             # We don't need to acquire the lock here, since we are only reading


### PR DESCRIPTION
Address a bug reported by @parejkoj in #7653 where obtaining cached download fails when there is no internet. This _does not_ address the original feature request in #7653 (i.e., providing a user-defined `sites.json`).

@eteq , can you please review, given you also reviewed #6987 that introduced this bug?

@bsipocz , not sure if this can be cleanly backported to 2.x though #6987 was put in 2.0.4. What should I milestone this to? Do you need a separate PR straight to 2.x branch? Please advise.

Thanks!