### PR TITLE
Optimize import time for fitsheader (and other fits scripts)

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -69,9 +69,6 @@ from .hdu.image import PrimaryHDU, ImageHDU
 from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
-from ...units import Unit
-from ...units.format.fits import UnitScaleError
-from ...units import Quantity
 from ...utils.exceptions import AstropyUserWarning
 from ...utils.decorators import deprecated_renamed_argument
 
@@ -453,8 +450,9 @@ def table_to_hdu(table, character_as_bytes=False):
     if table.has_mixin_columns:
         # Import is done here, in order to avoid it at build time as erfa is not
         # yet available then.
-        from ...table.column import BaseColumn, Column
+        from ...table.column import BaseColumn
         from ...time import Time
+        from ...units import Quantity
         from .fitstime import time_to_fits
 
         # Only those columns which are instances of BaseColumn, Quantity or Time can
@@ -512,6 +510,8 @@ def table_to_hdu(table, character_as_bytes=False):
 
         unit = table[col.name].unit
         if unit is not None:
+            from ...units import Unit
+            from ...units.format.fits import UnitScaleError
             try:
                 col.unit = unit.to_string(format='fits')
             except UnitScaleError:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -510,6 +510,8 @@ def table_to_hdu(table, character_as_bytes=False):
 
         unit = table[col.name].unit
         if unit is not None:
+            # Local imports to avoid importing units when it is not required,
+            # e.g. for command-line scripts
             from ...units import Unit
             from ...units.format.fits import UnitScaleError
             try:


### PR DESCRIPTION
Move units import that are needed only for `fits.table_to_hdu` but impact
the import time for command-line scripts (tested with `fitsheader`).

To measure import time, and plot with [tuna](https://github.com/nschloe/tuna):
```
❯ PYTHONPROFILEIMPORTTIME=1 fitsheader --help 2> import.log
❯ tuna import.log
```

In the development version, there are two significant contributors: `pkg_resources`, which can be avoided when installing from wheels (https://dev.to/methane/how-to-speed-up-python-application-startup-time-nkf), and `astropy.version` for the git versioning, so can be ignored.

Then, the slowest part is importing units, which is not needed for fits headers:

![astropy-dev-before](https://user-images.githubusercontent.com/311639/48867004-06a39180-edd5-11e8-861b-a31cba064e54.png)

Moving the `units` imports in `table_to_hdu`, I get this:

![astropy-dev-after](https://user-images.githubusercontent.com/311639/48867011-0acfaf00-edd5-11e8-84f1-15800cbcce2b.png)

And the last one is to show that `pkg_resources` and `astropy.version` disappear when installing from wheel, and here `units` represent 1/3 of the total import time.

![astropy-wheel-before](https://user-images.githubusercontent.com/311639/48867018-0f946300-edd5-11e8-9d07-6018affe73ef.png)
