### PR TITLE
Prevent pytest from picking up test function as a test

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -272,6 +272,7 @@ class TestRunnerBase:
         if hasattr(test, '__wrapped__'):
             del test.__wrapped__
 
+        test.__test__ = False
         return test
 
 


### PR DESCRIPTION
This one-line change prevents pytest from picking up test function as a test.
Fixes #8169

It's probably best to apply this both here and in https://github.com/astropy/package-template/issues/372 to minimise the number of users / affiliated package maintainers that will have to deal with this. I don't think there's any concern having the line in both places.