### PR TITLE
Limit pytest version for LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
+        - PYTEST_VERSION="<3.10"
 
         # PEP8 errors/warnings:
         # E101 - mix of tabs and spaces

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1804,6 +1804,8 @@ Other Changes and Additions
 - Fixing ``astropy.__citation__`` to provide the full bibtex entry of the 2018
   paper. [#8110]
 
+- Pytest 4.0 is not supported by the 2.0.x LTS releases. [#8173]
+
 
 2.0.9 (2018-10-14)
 ==================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,9 +17,11 @@ environment:
 
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
+          PYTEST_VERSION: "<3.10"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
           ASTROPY_USE_SYSTEM_PYTEST: 1
+          PYTEST_VERSION: "<3.10"
 
 matrix:
     fast_finish: true
@@ -42,4 +44,3 @@ build: false
 
 test_script:
     - "%CMD_IN_ENV% python setup.py test"
-

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,7 +17,7 @@ Astropy has the following strict requirements:
 
 - `Numpy`_ |minimum_numpy_version| or later
 
-- `pytest`_ 2.8 or later
+- `pytest`_ 2.8 or later but earlier than 4.0.
 
 Astropy also depends on other packages for optional features:
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
     setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
 
-install_requires = ['pytest>=2.8', 'numpy>=' + astropy.__minimum_numpy_version__]
+install_requires = ['pytest>=2.8,<4.0', 'numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information
 if is_distutils_display_option():


### PR DESCRIPTION
Pytest 4.0 is not compatible with LTS as we can't really do much about it as we cannot remove API from this branch, so the workaround has to be to add an upper limit to the version dependency.

See: https://github.com/astropy/astropy/issues/7782#issuecomment-441330102