### PR TITLE
Adding new ``warning_type`` argument for the deprecating decorators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1834,7 +1834,7 @@ Other Changes and Additions
 - Fixing ``astropy.__citation__`` to provide the full bibtex entry of the 2018
   paper. [#8110]
 
-- Adding ``warning_type`` keyword argumentum to the deprecated decorators to
+- Adding ``warning_type`` keyword argument to the "deprecated" decorators to
   allow issuing custom warning types instead of the default
   ``AstropyDeprecationWarning``. [#8178]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1834,6 +1834,10 @@ Other Changes and Additions
 - Fixing ``astropy.__citation__`` to provide the full bibtex entry of the 2018
   paper. [#8110]
 
+- Adding ``warning_type`` keyword argumentum to the deprecated decorators to
+  allow issuing custom warning types instead of the default
+  ``AstropyDeprecationWarning``. [#8178]
+
 
 2.0.9 (2018-10-14)
 ==================

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -61,7 +61,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
     pending : bool, optional
         If True, uses a AstropyPendingDeprecationWarning instead of a
-        AstropyDeprecationWarning.
+        ``warning_type``.
 
     obj_type : str, optional
         The type of this object, if the automatically determined one
@@ -100,7 +100,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             func = func.__func__
         return func
 
-    def deprecate_function(func, message, warning_type):
+    def deprecate_function(func, message, warning_type=warning_type):
         """
         Returns a wrapped function that displays ``warning_type``
         when it is called.
@@ -135,7 +135,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
         return func_wrapper(deprecated_func)
 
-    def deprecate_class(cls, message, warning_type):
+    def deprecate_class(cls, message, warning_type=warning_type):
         """
         Update the docstring and wrap the ``__init__`` in-place (or ``__new__``
         if the class or any of the bases overrides ``__new__``) so it will give

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -316,7 +316,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
 
     warning_type : warning
         Warning to be issued.
-        Default is `~astropy.utils.AstropyDeprecationWarning`.
+        Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
 
     Raises
     ------

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -23,7 +23,7 @@ _NotFound = object()
 
 
 def deprecated(since, message='', name='', alternative='', pending=False,
-               obj_type=None):
+               obj_type=None, warning_type=AstropyDeprecationWarning):
     """
     Used to mark a function or class as deprecated.
 
@@ -66,6 +66,10 @@ def deprecated(since, message='', name='', alternative='', pending=False,
     obj_type : str, optional
         The type of this object, if the automatically determined one
         needs to be overridden.
+
+    warning_tyoe : warning
+        Warning to be issued.
+        Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
     """
 
     method_types = (classmethod, staticmethod, types.MethodType)
@@ -96,10 +100,10 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             func = func.__func__
         return func
 
-    def deprecate_function(func, message):
+    def deprecate_function(func, message, warning_type):
         """
-        Returns a wrapped function that displays an
-        ``AstropyDeprecationWarning`` when it is called.
+        Returns a wrapped function that displays ``warning_type``
+        when it is called.
         """
 
         if isinstance(func, method_types):
@@ -113,7 +117,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             if pending:
                 category = AstropyPendingDeprecationWarning
             else:
-                category = AstropyDeprecationWarning
+                category = warning_type
 
             warnings.warn(message, category, stacklevel=2)
 
@@ -131,7 +135,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
         return func_wrapper(deprecated_func)
 
-    def deprecate_class(cls, message):
+    def deprecate_class(cls, message, warning_type):
         """
         Update the docstring and wrap the ``__init__`` in-place (or ``__new__``
         if the class or any of the bases overrides ``__new__``) so it will give
@@ -148,13 +152,15 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         """
         cls.__doc__ = deprecate_doc(cls.__doc__, message)
         if cls.__new__ is object.__new__:
-            cls.__init__ = deprecate_function(get_function(cls.__init__), message)
+            cls.__init__ = deprecate_function(get_function(cls.__init__),
+                                              message, warning_type)
         else:
-            cls.__new__ = deprecate_function(get_function(cls.__new__), message)
+            cls.__new__ = deprecate_function(get_function(cls.__new__),
+                                             message, warning_type)
         return cls
 
     def deprecate(obj, message=message, name=name, alternative=alternative,
-                  pending=pending):
+                  pending=pending, warning_type=warning_type):
         if obj_type is None:
             if isinstance(obj, type):
                 obj_type_name = 'class'
@@ -189,9 +195,9 @@ def deprecated(since, message='', name='', alternative='', pending=False,
             altmessage)
 
         if isinstance(obj, type):
-            return deprecate_class(obj, message)
+            return deprecate_class(obj, message, warning_type)
         else:
-            return deprecate_function(obj, message)
+            return deprecate_function(obj, message, warning_type)
 
     if type(message) is type(deprecate):
         return deprecate(message)
@@ -200,7 +206,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
 
 
 def deprecated_attribute(name, since, message=None, alternative=None,
-                         pending=False):
+                         pending=False, warning_type=AstropyDeprecationWarning):
     """
     Used to mark a public attribute as deprecated.  This creates a
     property that will warn when the given attribute name is accessed.
@@ -230,8 +236,12 @@ def deprecated_attribute(name, since, message=None, alternative=None,
         user about this alternative if provided.
 
     pending : bool, optional
-        If True, uses a AstropyPendingDeprecationWarning instead of a
-        AstropyDeprecationWarning.
+        If True, uses a AstropyPendingDeprecationWarning instead of
+        ``warning_type``.
+
+    warning_type : warning
+        Warning to be issued.
+        Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
 
     Examples
     --------
@@ -247,15 +257,15 @@ def deprecated_attribute(name, since, message=None, alternative=None,
     """
     private_name = '_' + name
 
-    @deprecated(since, name=name, obj_type='attribute')
+    @deprecated(since, name=name, obj_type='attribute', warning_type=warning_type)
     def get(self):
         return getattr(self, private_name)
 
-    @deprecated(since, name=name, obj_type='attribute')
+    @deprecated(since, name=name, obj_type='attribute', warning_type=warning_type)
     def set(self, val):
         setattr(self, private_name, val)
 
-    @deprecated(since, name=name, obj_type='attribute')
+    @deprecated(since, name=name, obj_type='attribute', warning_type=warning_type)
     def delete(self):
         delattr(self, private_name)
 
@@ -264,7 +274,8 @@ def deprecated_attribute(name, since, message=None, alternative=None,
 
 def deprecated_renamed_argument(old_name, new_name, since,
                                 arg_in_kwargs=False, relax=False,
-                                pending=False):
+                                pending=False,
+                                warning_type=AstropyDeprecationWarning):
     """Deprecate a _renamed_ function argument.
 
     The decorator assumes that the argument with the ``old_name`` was removed
@@ -302,6 +313,10 @@ def deprecated_renamed_argument(old_name, new_name, since,
         If ``True`` this will hide the deprecation warning and ignore the
         corresponding ``relax`` parameter value.
         Default is ``False``.
+
+    warning_type : warning
+        Warning to be issued.
+        Default is `~astropy.utils.AstropyDeprecationWarning`.
 
     Raises
     ------
@@ -460,7 +475,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                             'and will be removed in a future version. '
                             'Use argument "{2}" instead.'
                             ''.format(old_name[i], since[i], new_name[i]),
-                            AstropyDeprecationWarning, stacklevel=2)
+                            warning_type, stacklevel=2)
 
                     # Check if the newkeyword was given as well.
                     newarg_in_args = (position[i] is not None and

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -67,7 +67,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
         The type of this object, if the automatically determined one
         needs to be overridden.
 
-    warning_tyoe : warning
+    warning_type : warning
         Warning to be issued.
         Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
     """

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -120,7 +120,7 @@ def test_deprecated_attribute():
     dummy = DummyClass()
 
     with catch_warnings(AstropyDeprecationWarning) as wfoo:
-        xfoo = dummy.foo
+        dummy.foo
 
     with catch_warnings(AstropyDeprecationWarning) as wbar:
         dummy.bar

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -13,6 +13,13 @@ from ..exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from ...tests.helper import catch_warnings
 
 
+class NewDeprecationWarning(AstropyDeprecationWarning):
+    """
+    New Warning subclass to be used to test the deprecated decorator's
+    ``warning_type`` parameter.
+    """
+
+
 def test_wraps():
     """
     Tests the compatibility replacement for functools.wraps which supports
@@ -99,20 +106,34 @@ def test_deprecated_attribute():
     class DummyClass:
         def __init__(self):
             self._foo = 42
+            self._bar = 4242
 
         def set_private(self):
             self._foo = 100
+            self._bar = 1000
 
         foo = deprecated_attribute('foo', '0.2')
 
+        bar = deprecated_attribute('bar', '0.2',
+                                   warning_type=NewDeprecationWarning)
+
     dummy = DummyClass()
 
-    with catch_warnings(AstropyDeprecationWarning) as w:
-        x = dummy.foo
+    with catch_warnings(AstropyDeprecationWarning) as wfoo:
+        xfoo = dummy.foo
 
-    assert len(w) == 1
-    assert str(w[0].message) == ("The foo attribute is deprecated and may be "
-                                 "removed in a future version.")
+    with catch_warnings(AstropyDeprecationWarning) as wbar:
+        xbar = dummy.bar
+
+    assert len(wfoo) == 1
+    assert str(wfoo[0].message) == ("The foo attribute is deprecated and may "
+                                    "be removed in a future version.")
+    assert wfoo[0].category == AstropyDeprecationWarning
+
+    assert len(wbar) == 1
+    assert str(wbar[0].message) == ("The bar attribute is deprecated and may "
+                                    "be removed in a future version.")
+    assert wbar[0].category == NewDeprecationWarning
 
     with catch_warnings() as w:
         dummy.set_private()
@@ -144,6 +165,14 @@ class TB(metaclass=TMeta):
     pass
 
 
+@deprecated('100.0', warning_type=NewDeprecationWarning)
+class TC:
+    """
+    This class has the custom warning.
+    """
+    pass
+
+
 def test_deprecated_class():
     orig_A = TA.__bases__[0]
 
@@ -167,6 +196,12 @@ def test_deprecated_class():
 
     # Make sure the object is picklable
     pickle.dumps(TA)
+
+    with catch_warnings(NewDeprecationWarning) as w:
+        TC()
+
+    assert len(w) == 1
+    assert w[0].category == NewDeprecationWarning
 
 
 def test_deprecated_class_with_new_method():
@@ -202,7 +237,7 @@ def test_deprecated_class_with_new_method():
 
 def test_deprecated_class_with_super():
     """
-    Regression test for an issue where classes that used `super()` in their
+    Regression test for an issue where classes that used ``super()`` in their
     ``__init__`` did not actually call the correct class's ``__init__`` in the
     MRO.
     """
@@ -292,11 +327,16 @@ def test_deprecated_argument():
         def test3(self, overwrite):
             return overwrite
 
+        @deprecated_renamed_argument('clobber', 'overwrite', '1.3',
+                                     warning_type=NewDeprecationWarning)
+        def test4(self, overwrite):
+            return overwrite
+
     @deprecated_renamed_argument('clobber', 'overwrite', '1.3', relax=False)
     def test1(overwrite):
         return overwrite
 
-    for method in [Test().test1, Test().test2, Test().test3, test1]:
+    for method in [Test().test1, Test().test2, Test().test3, Test().test4, test1]:
         # As positional argument only
         assert method(1) == 1
 
@@ -309,6 +349,9 @@ def test_deprecated_argument():
             assert len(w) == 1
             assert '1.3' in str(w[0].message)
             assert 'test_decorators.py' in str(w[0].filename)
+
+            if method.__name__ == 'test4':
+                w[0].category == NewDeprecationWarning
 
         # Using both. Both keyword
         with pytest.raises(TypeError):

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -123,7 +123,7 @@ def test_deprecated_attribute():
         xfoo = dummy.foo
 
     with catch_warnings(AstropyDeprecationWarning) as wbar:
-        xbar = dummy.bar
+        dummy.bar
 
     assert len(wfoo) == 1
     assert str(wfoo[0].message) == ("The foo attribute is deprecated and may "


### PR DESCRIPTION
I've tried to wrap our `deprecated` decorator, catching the warning and issue another one instead. However all attempts for this have failed at one point or another, either my not being able to catch the warning (for contexting warnings.catch_warning within the new decorator, the actual warning was always out of scope and using astropy.tests.helper.catch_warnings messed up the whole warnings system and no other warnings could be issues after its usage). 

So rather than going deeper in this rabbit whole, I open this PR with the hope that it can go into LTS given that no behaviour has been changed just a tiny addition for a utility function.

This is to address https://github.com/astropy/astropy/issues/8078. 

I'm adding tests and changelog shortly.