### PR TITLE
Importing explicitely to be compatible with pytest 3.7+ versions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1766,6 +1766,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Any imports form ``pytest_plugins`` should be explicit to be compatible
+  with pytest 3.7+. [#8179]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -7,7 +7,7 @@ making use of astropy's test runner).
 from .extern.six.moves import builtins
 
 from .tests.pytest_plugins import (enable_deprecations_as_exceptions,
-                                   PYTEST_HEADER_MODULES)
+                                   PYTEST_HEADER_MODULES, pytest_plugins)
 
 try:
     import matplotlib

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -6,7 +6,8 @@ making use of astropy's test runner).
 """
 from .extern.six.moves import builtins
 
-from .tests.pytest_plugins import *
+from .tests.pytest_plugins import (enable_deprecations_as_exceptions,
+                                   PYTEST_HEADER_MODULES)
 
 try:
     import matplotlib


### PR DESCRIPTION
Locally this fixed #8177 

To make this fix more easily compatible with downstream packages I suggest to add an ``__all__`` to the `pytest_plugins.py` file as well, so the wildcard imports keep working.
(I'll open a separate PR to add that to master and to be backported).


NOTE: this should only be merged after the travis runs has been double checked that the tests were actually picked up in addition to the doctests.


 