### PR TITLE
Adding __all__ for pytest_plugins to avoid issues when using pytest 3.7+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1796,6 +1796,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Explicitely adding public objects to ``pytest_plugins`` to avoid
+  complications when using pytest version 3.7+. [#8180]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -15,6 +15,9 @@ from ..utils.exceptions import AstropyDeprecationWarning
 from .helper import enable_deprecations_as_exceptions
 from .plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 
+__all__ = ['TESTED_VERSIONS', 'PYTEST_HEADER_MODULES',
+           'enable_deprecations_as_exceptions']
+
 # This makes sure that this module is not collected when running the test
 # suite. This is necessary in order to get the test suite to run without errors
 # using pytest>=3.7


### PR DESCRIPTION
Alternative fix for #8177, this PR is needed to avoid opening PRs similar to #8179 as an urgency to all packages that use the package-template (long term we need to update them not to use `pytest_plugins` at all.