### PR TITLE
asdftypes is deprecated, use asdf.types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
@@ -79,7 +80,7 @@ matrix:
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES="$CONDA_ALL_DEPENDENCIES clang"
-               PIP_DEPENDENCIES='jplephem asdf'
+               PIP_DEPENDENCIES="jplephem $ASDF_PIP_DEP"
                CCOMPILER=clang
                EVENT_TYPE='cron'
 
@@ -104,14 +105,14 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='test --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="jplephem asdf"
+               PIP_DEPENDENCIES="jplephem $ASDF_PIP_DEP"
                LC_CTYPE=C.ascii LC_ALL=C
                PYTEST_VERSION=3.7
 
         - os: linux
           stage: Initial tests
           env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="asdf"
+               PIP_DEPENDENCIES=$ASDF_PIP_DEP
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
 
@@ -119,7 +120,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="codecov objgraph jplephem bintrees sortedcontainers asdf"
+               PIP_DEPENDENCIES="codecov objgraph jplephem bintrees sortedcontainers $ASDF_PIP_DEP"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='--coverage -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0
@@ -142,7 +143,7 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="asdf"
+               PIP_DEPENDENCIES=$ASDF_PIP_DEP
                MATPLOTLIB_VERSION=dev
 
         # We check numpy-dev also in a job that only runs from cron, so that
@@ -152,13 +153,13 @@ matrix:
           stage: Cron tests
           env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="asdf"
+               PIP_DEPENDENCIES=$ASDF_PIP_DEP
 
     allow_failures:
       - os: linux
         env: NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-             PIP_DEPENDENCIES="asdf"
+             PIP_DEPENDENCIES=$ASDF_PIP_DEP
              MATPLOTLIB_VERSION=dev
 
 before_install:

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -3,7 +3,7 @@
 
 import six
 
-from asdf.asdftypes import CustomType, ExtensionTypeMeta
+from asdf.types import CustomType, ExtensionTypeMeta
 
 
 __all__ = ['AstropyType', 'AstropyAsdfType']


### PR DESCRIPTION
@drdavella Can this go in the 3.1 release?
Is astropy tested with asdf and if so which version?