### PR TITLE
Update version requirement for pytest in v2.0.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup_requires = ['numpy>=' + astropy.__minimum_numpy_version__]
 if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
     setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
 
-install_requires = ['pytest>=2.8,<4.0', 'numpy>=' + astropy.__minimum_numpy_version__]
+install_requires = ['pytest>=2.8,<3.7', 'numpy>=' + astropy.__minimum_numpy_version__]
 # Avoid installing setup_requires dependencies if the user just
 # queries for information
 if is_distutils_display_option():


### PR DESCRIPTION
Tests are not correctly collected for pytest 3.7+ (see https://github.com/astropy/astropy/issues/8177)