### PR TITLE
Explicitly disallow bad versions of pytest when using test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
-        - PYTEST_VERSION="<3.10"
+        - PYTEST_VERSION="<3.7"
 
         # PEP8 errors/warnings:
         # E101 - mix of tabs and spaces
@@ -91,16 +91,13 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'
-               PYTEST_VERSION=3.7
         - os: linux
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14
                SETUP_CMD='test --open-files'
-               PYTEST_VERSION=3.8
         - os: linux
           env: NUMPY_VERSION=1.12
                SETUP_CMD='test --open-files -a "--durations=50"'
                PYTEST_VERSION='>3.2'
-               PYTEST_VERSION=3.8
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy). We also test the two latest matplotlib versions

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,6 @@ matrix:
         - os: linux
           env: NUMPY_VERSION=1.12
                SETUP_CMD='test --open-files -a "--durations=50"'
-               PYTEST_VERSION='>3.2'
 
         # Now try with all optional dependencies the latest 3.x and on 2.7.
         # (with latest numpy). We also test the two latest matplotlib versions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1766,6 +1766,9 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- Explicitly disallow incompatible versions of ``pytest`` when using the test
+  runner. [#8188]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,11 +17,11 @@ environment:
 
         - PYTHON_VERSION: "2.7"
           NUMPY_VERSION: "stable"
-          PYTEST_VERSION: "<3.10"
+          PYTEST_VERSION: "<3.7"
         - PYTHON_VERSION: "3.6"
           NUMPY_VERSION: "stable"
           ASTROPY_USE_SYSTEM_PYTEST: 1
-          PYTEST_VERSION: "<3.10"
+          PYTEST_VERSION: "<3.7"
 
 matrix:
     fast_finish: true

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -11,8 +11,8 @@ import tempfile
 import warnings
 from collections import OrderedDict
 
-from ..config.paths import set_temp_config, set_temp_cache
 from ..extern import six
+from ..config.paths import set_temp_config, set_temp_cache
 from ..utils import wraps, find_current_module
 from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
@@ -183,6 +183,15 @@ class TestRunnerBase(object):
 
         # Don't import pytest until it's actually needed to run the tests
         import pytest
+        if pytest.__version__ > '3.7' and pytest.__version__ < '4':
+            from astropy.version import version as astropy_version
+            # These versions of pytest are known to be problematic and are not
+            # supported by Astropy LTS.
+            pytest.exit(
+                'This version of Astropy ({}) is incompatible with this version of '
+                'pytest ({}). Use pytest<3.7 or pytest>=4.'.format(
+                    astropy_version, pytest.__version__)
+            )
 
         # Raise error for undefined kwargs
         allowed_kwargs = set(self.keywords.keys())

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -186,7 +186,7 @@ class TestRunnerBase(object):
         from distutils.version import LooseVersion
 
         pytest_version = LooseVersion(pytest.__version__)
-        if pytest_version >= '3.7':
+        if pytest_version >= LooseVersion('3.7'):
             from astropy.version import version as astropy_version
             # These versions of pytest are known to be problematic and are not
             # supported by Astropy LTS.

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -183,14 +183,17 @@ class TestRunnerBase(object):
 
         # Don't import pytest until it's actually needed to run the tests
         import pytest
-        if pytest.__version__ > '3.7' and pytest.__version__ < '4':
+        from distutils.version import LooseVersion
+
+        pytest_version = LooseVersion(pytest.__version__)
+        if pytest_version >= '3.7':
             from astropy.version import version as astropy_version
             # These versions of pytest are known to be problematic and are not
             # supported by Astropy LTS.
             pytest.exit(
                 'This version of Astropy ({}) is incompatible with this version of '
-                'pytest ({}). Use pytest<3.7 or pytest>=4.'.format(
-                    astropy_version, pytest.__version__)
+                'pytest ({}). Use pytest<3.7.'.format(
+                    astropy_version, pytest_version)
             )
 
         # Raise error for undefined kwargs


### PR DESCRIPTION
This partially resolves #8177.