### PR TITLE
Change all relative imports to absolute imports (except same-module imports)

### DIFF
--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from .. import core as erfa
-from ...tests.helper import catch_warnings
+from astropy._erfa import core as erfa
+from astropy.tests.helper import catch_warnings
 
 
 def test_erfa_wrapper():

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -16,11 +16,11 @@ from os import path
 import re
 from warnings import warn
 
-from ..extern.configobj import configobj, validate
-from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
-from ..utils import find_current_module
-from ..utils.introspection import resolve_name
-from ..utils.misc import InheritDocstrings
+from astropy.extern.configobj import configobj, validate
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils import find_current_module
+from astropy.utils.introspection import resolve_name
+from astropy.utils.misc import InheritDocstrings
 from .paths import get_config_dir
 
 
@@ -219,7 +219,7 @@ class ConfigItem(metaclass=InheritDocstrings):
 
     def __init__(self, defaultvalue='', description=None, cfgtype=None,
                  module=None, aliases=None):
-        from ..utils import isiterable
+        from astropy.utils import isiterable
 
         if module is None:
             module = find_current_module(2)

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -3,7 +3,7 @@
 data/cache files used by Astropy should be placed.
 """
 
-from ..utils.decorators import wraps
+from astropy.utils.decorators import wraps
 
 import os
 import shutil

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -8,12 +8,12 @@ import subprocess
 
 import pytest
 
-from ...tests.helper import catch_warnings
+from astropy.tests.helper import catch_warnings
 
-from ...utils.data import get_pkg_data_filename
-from .. import configuration
-from .. import paths
-from ...utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.data import get_pkg_data_filename
+from astropy.config import configuration
+from astropy.config import paths
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_paths():
@@ -72,7 +72,7 @@ def test_set_temp_cache(tmpdir, monkeypatch):
 
 
 def test_config_file():
-    from ..configuration import get_config, reload_config
+    from astropy.config.configuration import get_config, reload_config
 
     apycfg = get_config('astropy')
     assert apycfg.filename.endswith('astropy.cfg')
@@ -87,7 +87,7 @@ def test_config_file():
 
 def test_configitem():
 
-    from ..configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
 
     ci = ConfigItem(34, 'this is a Description')
 
@@ -118,7 +118,7 @@ def test_configitem():
 
 def test_configitem_types():
 
-    from ..configuration import ConfigNamespace, ConfigItem
+    from astropy.config.configuration import ConfigNamespace, ConfigItem
 
     cio = ConfigItem(['op1', 'op2', 'op3'])
 
@@ -146,7 +146,7 @@ def test_configitem_types():
 
 def test_configitem_options(tmpdir):
 
-    from ..configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
 
     cio = ConfigItem(['op1', 'op2', 'op3'])
 
@@ -214,7 +214,7 @@ def test_config_noastropy_fallback(monkeypatch):
 
 def test_configitem_setters():
 
-    from ..configuration import ConfigNamespace, ConfigItem
+    from astropy.config.configuration import ConfigNamespace, ConfigItem
 
     class Conf(ConfigNamespace):
         tstnm12 = ConfigItem(42, 'this is another Description')
@@ -243,7 +243,7 @@ def test_configitem_setters():
 
 
 def test_empty_config_file():
-    from ..configuration import is_unedited_config_file
+    from astropy.config.configuration import is_unedited_config_file
 
     def get_content(fn):
         with open(get_pkg_data_filename(fn), 'rt', encoding='latin-1') as fd:
@@ -288,7 +288,7 @@ class TestAliasRead:
 
 def test_configitem_unicode(tmpdir):
 
-    from ..configuration import ConfigNamespace, ConfigItem, get_config
+    from astropy.config.configuration import ConfigNamespace, ConfigItem, get_config
 
     cio = ConfigItem('ასტრონომიის')
 
@@ -307,7 +307,7 @@ def test_configitem_unicode(tmpdir):
 def test_warning_move_to_top_level():
     # Check that the warning about deprecation config items in the
     # file works.  See #2514
-    from ... import conf
+    from astropy import conf
 
     configuration._override_config_file = get_pkg_data_filename('data/deprecated.cfg')
 

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 
 # Hack to make circular imports with units work
 try:
-    from .. import units
+    from astropy import units
     del units
 except ImportError:
     pass

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -5,11 +5,11 @@ import types
 import warnings
 import numpy as np
 
-from ..units.core import Unit, UnitsError
-from ..units.quantity import Quantity
-from ..utils import lazyproperty
-from ..utils.exceptions import AstropyUserWarning
-from ..utils.misc import InheritDocstrings
+from astropy.units.core import Unit, UnitsError
+from astropy.units.quantity import Quantity
+from astropy.utils import lazyproperty
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.misc import InheritDocstrings
 
 __all__ = ['Constant', 'EMConstant']
 

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -6,13 +6,13 @@ import copy
 
 import pytest
 
-from .. import Constant
-from ...units import Quantity as Q
+from astropy.constants import Constant
+from astropy.units import Quantity as Q
 
 
 def test_c():
 
-    from .. import c
+    from astropy.constants import c
 
     # c is an exactly defined constant, so it shouldn't be changing
     assert c.value == 2.99792458e8  # default is S.I.
@@ -28,7 +28,7 @@ def test_c():
 
 def test_h():
 
-    from .. import h
+    from astropy.constants import h
 
     # check that the value is fairly close to what it should be (not exactly
     # checking because this might get updated in the future)
@@ -46,7 +46,7 @@ def test_h():
 def test_e():
     """Tests for #572 demonstrating how EM constants should behave."""
 
-    from .. import e
+    from astropy.constants import e
 
     # A test quantity
     E = Q(100, 'V/m')
@@ -72,7 +72,7 @@ def test_e():
 
 def test_g0():
     """Tests for #1263 demonstrating how g0 constant should behave."""
-    from .. import g0
+    from astropy.constants import g0
 
     # g0 is an exactly defined constant, so it shouldn't be changing
     assert g0.value == 9.80665  # default is S.I.
@@ -94,8 +94,8 @@ def test_b_wien():
     given blackbody temperature. The Sun is used in this test.
 
     """
-    from .. import b_wien
-    from ... import units as u
+    from astropy.constants import b_wien
+    from astropy import units as u
     t = 5778 * u.K
     w = (b_wien / t).to(u.nm)
     assert round(w.value) == 502
@@ -103,9 +103,9 @@ def test_b_wien():
 
 def test_unit():
 
-    from ... import units as u
+    from astropy import units as u
 
-    from ... import constants as const
+    from astropy import constants as const
 
     for key, val in vars(const).items():
         if isinstance(val, Constant):
@@ -116,7 +116,7 @@ def test_unit():
 
 
 def test_copy():
-    from ... import constants as const
+    from astropy import constants as const
     cc = copy.deepcopy(const.c)
     assert cc == const.c
 
@@ -126,7 +126,7 @@ def test_copy():
 
 def test_view():
     """Check that Constant and Quantity views can be taken (#3537, #3538)."""
-    from .. import c
+    from astropy.constants import c
     c2 = c.view(Constant)
     assert c2 == c
     assert c2.value == c.value

--- a/astropy/constants/tests/test_pickle.py
+++ b/astropy/constants/tests/test_pickle.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from ... import constants as const
-from ...tests.helper import pickle_protocol, check_pickling_recovery  # noqa
+from astropy import constants as const
+from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
 
 originals = [const.Constant('h_fake', 'Not Planck',
                             0.0, 'J s', 0.0, 'fakeref',

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -4,13 +4,13 @@ import copy
 
 import pytest
 
-from .. import Constant
-from ...units import Quantity as Q
+from astropy.constants import Constant
+from astropy.units import Quantity as Q
 
 
 def test_c():
 
-    from ..codata2010 import c
+    from astropy.constants.codata2010 import c
 
     # c is an exactly defined constant, so it shouldn't be changing
     assert c.value == 2.99792458e8  # default is S.I.
@@ -26,8 +26,8 @@ def test_c():
 
 def test_h():
 
-    from ..codata2010 import h
-    from .. import h as h_current
+    from astropy.constants.codata2010 import h
+    from astropy.constants import h as h_current
 
     # check that the value is the CODATA2010 value
     assert abs(h.value - 6.62606957e-34) < 1e-43
@@ -46,7 +46,7 @@ def test_h():
 
 def test_e():
 
-    from ..astropyconst13 import e
+    from astropy.constants.astropyconst13 import e
 
     # A test quantity
     E = Q(100.00000348276221, 'V/m')
@@ -66,7 +66,7 @@ def test_e():
 
 def test_g0():
     """Tests for #1263 demonstrating how g0 constant should behave."""
-    from ..astropyconst13 import g0
+    from astropy.constants.astropyconst13 import g0
 
     # g0 is an exactly defined constant, so it shouldn't be changing
     assert g0.value == 9.80665  # default is S.I.
@@ -88,8 +88,8 @@ def test_b_wien():
     given blackbody temperature. The Sun is used in this test.
 
     """
-    from ..astropyconst13 import b_wien
-    from ... import units as u
+    from astropy.constants.astropyconst13 import b_wien
+    from astropy import units as u
     t = 5778 * u.K
     w = (b_wien / t).to(u.nm)
     assert round(w.value) == 502
@@ -97,9 +97,9 @@ def test_b_wien():
 
 def test_unit():
 
-    from ... import units as u
+    from astropy import units as u
 
-    from .. import astropyconst13 as const
+    from astropy.constants import astropyconst13 as const
 
     for key, val in vars(const).items():
         if isinstance(val, Constant):
@@ -110,7 +110,7 @@ def test_unit():
 
 
 def test_copy():
-    from ... import constants as const
+    from astropy import constants as const
     cc = copy.deepcopy(const.c)
     assert cc == const.c
 
@@ -120,7 +120,7 @@ def test_copy():
 
 def test_view():
     """Check that Constant and Quantity views can be taken (#3537, #3538)."""
-    from .. import c
+    from astropy.constants import c
     c2 = c.view(Constant)
     assert c2 == c
     assert c2.value == c.value
@@ -156,7 +156,7 @@ def test_view():
 
 
 def test_context_manager():
-    from ... import constants as const
+    from astropy import constants as const
 
     with const.set_enabled_constants('astropyconst13'):
         assert const.h.value == 6.62606957e-34  # CODATA2010

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -12,13 +12,13 @@ import numpy as np
 from numpy.ctypeslib import ndpointer, load_library
 
 from .core import Kernel, Kernel1D, Kernel2D, MAX_NORMALIZATION
-from ..utils.exceptions import AstropyUserWarning
-from ..utils.console import human_file_size
-from ..utils.decorators import deprecated_renamed_argument
-from .. import units as u
-from ..nddata import support_nddata
-from ..modeling.core import _make_arithmetic_operator, BINARY_OPERATORS
-from ..modeling.core import _CompoundModelMeta
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.console import human_file_size
+from astropy.utils.decorators import deprecated_renamed_argument
+from astropy import units as u
+from astropy.nddata import support_nddata
+from astropy.modeling.core import _make_arithmetic_operator, BINARY_OPERATORS
+from astropy.modeling.core import _CompoundModelMeta
 from .utils import KernelSizeError, has_even_axis, raise_even_kernel_exception
 
 LIBRARY_PATH = os.path.dirname(__file__)

--- a/astropy/convolution/core.py
+++ b/astropy/convolution/core.py
@@ -19,7 +19,7 @@ import warnings
 import copy
 
 import numpy as np
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 from .utils import (discretize_model, add_kernel_arrays_1D,
                     add_kernel_arrays_2D)
 

--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -6,9 +6,9 @@ import numpy as np
 
 from .core import Kernel1D, Kernel2D, Kernel
 from .utils import has_even_axis, raise_even_kernel_exception
-from ..modeling import models
-from ..modeling.core import Fittable1DModel, Fittable2DModel
-from ..utils.decorators import deprecated_renamed_argument
+from astropy.modeling import models
+from astropy.modeling.core import Fittable1DModel, Fittable2DModel
+from astropy.utils.decorators import deprecated_renamed_argument
 
 __all__ = ['Gaussian1DKernel', 'Gaussian2DKernel', 'CustomKernel',
            'Box1DKernel', 'Box2DKernel', 'Tophat2DKernel',

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -4,9 +4,9 @@ import pytest
 import numpy as np
 import numpy.ma as ma
 
-from ..convolve import convolve, convolve_fft
-from ..kernels import Gaussian2DKernel
-from ...utils.exceptions import AstropyUserWarning
+from astropy.convolution.convolve import convolve, convolve_fft
+from astropy.convolution.kernels import Gaussian2DKernel
+from astropy.utils.exceptions import AstropyUserWarning
 
 from numpy.testing import (assert_array_almost_equal_nulp,
                            assert_array_almost_equal,

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -6,8 +6,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
 
-from ..convolve import convolve_fft, convolve
-from ...utils.exceptions import AstropyUserWarning
+from astropy.convolution.convolve import convolve_fft, convolve
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 VALID_DTYPES = ('>f4', '<f4', '>f8', '<f8')

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -6,9 +6,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from ..convolve import convolve, convolve_fft
-from ..kernels import Gaussian2DKernel, Box2DKernel, Tophat2DKernel
-from ..kernels import Moffat2DKernel
+from astropy.convolution.convolve import convolve, convolve_fft
+from astropy.convolution.kernels import Gaussian2DKernel, Box2DKernel, Tophat2DKernel
+from astropy.convolution.kernels import Moffat2DKernel
 
 
 SHAPES_ODD = [[15, 15], [31, 31]]

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -4,9 +4,9 @@ import math
 import numpy as np
 import pytest
 
-from ..convolve import convolve, convolve_fft, convolve_models
-from ...modeling import models, fitting
-from ...utils.misc import NumpyRNGContext
+from astropy.convolution.convolve import convolve, convolve_fft, convolve_models
+from astropy.modeling import models, fitting
+from astropy.utils.misc import NumpyRNGContext
 from numpy.testing import assert_allclose, assert_almost_equal
 
 try:

--- a/astropy/convolution/tests/test_convolve_nddata.py
+++ b/astropy/convolution/tests/test_convolve_nddata.py
@@ -3,9 +3,9 @@
 import pytest
 import numpy as np
 
-from ..convolve import convolve, convolve_fft
-from ..kernels import Gaussian2DKernel
-from ...nddata import NDData
+from astropy.convolution.convolve import convolve, convolve_fft
+from astropy.convolution.kernels import Gaussian2DKernel
+from astropy.nddata import NDData
 
 
 def test_basic_nddata():

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -6,11 +6,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ..utils import discretize_model
-from ...modeling.functional_models import (
+from astropy.convolution.utils import discretize_model
+from astropy.modeling.functional_models import (
     Gaussian1D, Box1D, MexicanHat1D, Gaussian2D, Box2D, MexicanHat2D)
-from ...modeling.tests.example_models import models_1D, models_2D
-from ...modeling.tests.test_models import create_model
+from astropy.modeling.tests.example_models import models_1D, models_2D
+from astropy.modeling.tests.test_models import create_model
 
 try:
     import scipy  # pylint: disable=W0611

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -6,16 +6,16 @@ import pytest
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_allclose
 
-from ..convolve import convolve, convolve_fft
-from ..kernels import (
+from astropy.convolution.convolve import convolve, convolve_fft
+from astropy.convolution.kernels import (
     Gaussian1DKernel, Gaussian2DKernel, Box1DKernel, Box2DKernel,
     Trapezoid1DKernel, TrapezoidDisk2DKernel, MexicanHat1DKernel,
     Tophat2DKernel, MexicanHat2DKernel, AiryDisk2DKernel, Ring2DKernel,
     CustomKernel, Model1DKernel, Model2DKernel, Kernel1D, Kernel2D)
 
-from ..utils import KernelSizeError
-from ...modeling.models import Box2D, Gaussian1D, Gaussian2D
-from ...utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.convolution.utils import KernelSizeError
+from astropy.modeling.models import Box2D, Gaussian1D, Gaussian2D
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 try:
     from scipy.ndimage import filters

--- a/astropy/convolution/tests/test_pickle.py
+++ b/astropy/convolution/tests/test_pickle.py
@@ -3,8 +3,8 @@
 import pytest
 import numpy as np
 
-from ... import convolution as conv
-from ...tests.helper import pickle_protocol, check_pickling_recovery  # noqa
+from astropy import convolution as conv
+from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
 
 
 @pytest.mark.parametrize(("name", "args", "kwargs", "xfail"),

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -2,7 +2,7 @@
 import ctypes
 import numpy as np
 
-from ..modeling.core import FittableModel, custom_model
+from astropy.modeling.core import FittableModel, custom_model
 
 __all__ = ['discretize_model']
 

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -25,8 +25,8 @@ import numpy as np
 from .errors import (IllegalHourWarning, IllegalHourError,
                      IllegalMinuteWarning, IllegalMinuteError,
                      IllegalSecondWarning, IllegalSecondError)
-from ..utils import format_exception
-from .. import units as u
+from astropy.utils import format_exception
+from astropy import units as u
 
 
 TAB_HEADER = """# -*- coding: utf-8 -*-
@@ -81,7 +81,7 @@ class _AngleParser:
 
     @classmethod
     def _make_parser(cls):
-        from ..extern.ply import lex, yacc
+        from astropy.extern.ply import lex, yacc
 
         # List of token names.
         tokens = (

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -11,9 +11,9 @@ from collections import namedtuple
 import numpy as np
 
 from . import angle_utilities as util
-from .. import units as u
-from ..utils import isiterable
-from ..utils.compat import NUMPY_LT_1_14_1, NUMPY_LT_1_14_2
+from astropy import units as u
+from astropy.utils import isiterable
+from astropy.utils.compat import NUMPY_LT_1_14_1, NUMPY_LT_1_14_2
 
 __all__ = ['Angle', 'Latitude', 'Longitude']
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -7,9 +7,9 @@ import numpy as np
 import warnings
 
 # Project
-from .. import units as u
-from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils import OrderedDescriptor, ShapedLikeNDArray
+from astropy import units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils import OrderedDescriptor, ShapedLikeNDArray
 
 __all__ = ['Attribute', 'TimeAttribute', 'QuantityAttribute',
            'EarthLocationAttribute', 'CoordinateAttribute',
@@ -169,7 +169,7 @@ class TimeAttribute(Attribute):
             If the input is not valid for this attribute.
         """
 
-        from ..time import Time
+        from astropy.time import Time
 
         if value is None:
             return None, False

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -17,11 +17,11 @@ import warnings
 import numpy as np
 
 # Project
-from ..utils.compat.misc import override__dir__
-from ..utils.decorators import lazyproperty, format_doc
-from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
-from .. import units as u
-from ..utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
+from astropy.utils.compat.misc import override__dir__
+from astropy.utils.decorators import lazyproperty, format_doc
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy import units as u
+from astropy.utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
                      check_broadcast)
 from .transformations import TransformGraph
 from . import representation as r

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -50,7 +50,7 @@ from . import cirs_observed_transforms
 from . import intermediate_rotation_transforms
 from . import ecliptic_transforms
 
-from ..baseframe import frame_transform_graph
+from astropy.coordinates.baseframe import frame_transform_graph
 
 # we define an __all__ because otherwise the transformation modules
 # get included
@@ -110,7 +110,7 @@ def make_transform_graph_docs(transform_graph):
     docstr = dedent(docstr) + '        ' + graphstr.replace('\n', '\n        ')
 
     # colors are in dictionary at the bottom of transformations.py
-    from ..transformations import trans_to_color
+    from astropy.coordinates.transformations import trans_to_color
     html_list_items = []
     for cls, color in trans_to_color.items():
         block = u"""

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -3,11 +3,11 @@
 
 import numpy as np
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
-from ..attributes import (Attribute, TimeAttribute,
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.coordinates.attributes import (Attribute, TimeAttribute,
                           QuantityAttribute, EarthLocationAttribute)
 
 __all__ = ['AltAz']

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.utils.decorators import format_doc
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 
 __all__ = ['BaseRADecFrame']
 

--- a/astropy/coordinates/builtin_frames/cirs.py
+++ b/astropy/coordinates/builtin_frames/cirs.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from ..attributes import TimeAttribute
-from ..baseframe import base_doc
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.baseframe import base_doc
 from .baseradec import doc_components, BaseRADecFrame
 from .utils import DEFAULT_OBSTIME
 

--- a/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
+++ b/astropy/coordinates/builtin_frames/cirs_observed_transforms.py
@@ -7,12 +7,12 @@ Currently that just means AltAz.
 
 import numpy as np
 
-from ... import units as u
-from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransformWithFiniteDifference
-from ..representation import (SphericalRepresentation,
+from astropy import units as u
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.coordinates.representation import (SphericalRepresentation,
                               UnitSphericalRepresentation)
-from ... import _erfa as erfa
+from astropy import _erfa as erfa
 
 from .cirs import CIRS
 from .altaz import AltAz

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
-from ..attributes import TimeAttribute
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy.coordinates.attributes import TimeAttribute
 from .utils import EQUINOX_J2000, DEFAULT_OBSTIME
 
 __all__ = ['GeocentricTrueEcliptic', 'BarycentricTrueEcliptic',

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -4,19 +4,19 @@
 Contains the transformation functions for getting to/from ecliptic systems.
 """
 
-from ... import units as u
-from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransformWithFiniteDifference, DynamicMatrixTransform
-from ..matrix_utilities import (rotation_matrix,
+from astropy import units as u
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference, DynamicMatrixTransform
+from astropy.coordinates.matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
-from ..representation import CartesianRepresentation
-from ... import _erfa as erfa
+from astropy.coordinates.representation import CartesianRepresentation
+from astropy import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
 from .ecliptic import GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
 from .utils import get_jd12
-from ..errors import UnitsError
+from astropy.coordinates.errors import UnitsError
 
 
 def _ecliptic_rotation_matrix(equinox):
@@ -80,7 +80,7 @@ def icrs_to_helioecliptic(from_coo, to_frame):
 
     # get barycentric sun coordinate
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric
+    from astropy.coordinates.solar_system import get_body_barycentric
     bary_sun_pos = get_body_barycentric('sun', to_frame.obstime)
 
     # offset to heliocentric
@@ -107,7 +107,7 @@ def helioecliptic_to_icrs(from_coo, to_frame):
     # now offset back to barycentric, which is the correct center for ICRS
 
     # this goes here to avoid circular import errors
-    from ..solar_system import get_body_barycentric
+    from astropy.coordinates.solar_system import get_body_barycentric
 
     # get barycentric sun coordinate
     bary_sun_pos = get_body_barycentric('sun', from_coo.obstime)

--- a/astropy/coordinates/builtin_frames/fk4.py
+++ b/astropy/coordinates/builtin_frames/fk4.py
@@ -3,15 +3,15 @@
 
 import numpy as np
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from ..baseframe import frame_transform_graph, base_doc
-from ..attributes import TimeAttribute
-from ..transformations import (FunctionTransformWithFiniteDifference,
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.baseframe import frame_transform_graph, base_doc
+from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.transformations import (FunctionTransformWithFiniteDifference,
                                FunctionTransform, DynamicMatrixTransform)
-from ..representation import (CartesianRepresentation,
+from astropy.coordinates.representation import (CartesianRepresentation,
                               UnitSphericalRepresentation)
-from .. import earth_orientation as earth
+from astropy.coordinates import earth_orientation as earth
 
 from .utils import EQUINOX_B1950
 from .baseradec import doc_components, BaseRADecFrame

--- a/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/fk4_fk5_transforms.py
@@ -4,9 +4,9 @@
 
 import numpy as np
 
-from ..baseframe import frame_transform_graph
-from ..transformations import DynamicMatrixTransform
-from ..matrix_utilities import matrix_product, matrix_transpose
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import DynamicMatrixTransform
+from astropy.coordinates.matrix_utilities import matrix_product, matrix_transpose
 
 
 from .fk4 import FK4NoETerms

--- a/astropy/coordinates/builtin_frames/fk5.py
+++ b/astropy/coordinates/builtin_frames/fk5.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from ..baseframe import frame_transform_graph, base_doc
-from ..attributes import TimeAttribute
-from ..transformations import DynamicMatrixTransform
-from .. import earth_orientation as earth
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.baseframe import frame_transform_graph, base_doc
+from astropy.coordinates.attributes import TimeAttribute
+from astropy.coordinates.transformations import DynamicMatrixTransform
+from astropy.coordinates import earth_orientation as earth
 
 from .baseradec import BaseRADecFrame, doc_components
 from .utils import EQUINOX_J2000

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from ..angles import Angle
-from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.angles import Angle
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 
 # these are needed for defining the NGP
 from .fk5 import FK5

--- a/astropy/coordinates/builtin_frames/galactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/galactic_transforms.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..matrix_utilities import (rotation_matrix,
+from astropy.coordinates.matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
-from ..baseframe import frame_transform_graph
-from ..transformations import DynamicMatrixTransform
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .fk4 import FK4NoETerms

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -5,19 +5,19 @@ import warnings
 
 import numpy as np
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from ...utils.exceptions import AstropyDeprecationWarning
-from ..angles import Angle
-from ..matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
-from .. import representation as r
-from ..baseframe import (BaseCoordinateFrame, frame_transform_graph,
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.coordinates.angles import Angle
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import (BaseCoordinateFrame, frame_transform_graph,
                          RepresentationMapping, base_doc)
-from ..attributes import (Attribute, CoordinateAttribute,
+from astropy.coordinates.attributes import (Attribute, CoordinateAttribute,
                           QuantityAttribute,
                           DifferentialAttribute)
-from ..transformations import AffineTransform
-from ..errors import ConvertError
+from astropy.coordinates.transformations import AffineTransform
+from astropy.coordinates.errors import ConvertError
 
 from .icrs import ICRS
 

--- a/astropy/coordinates/builtin_frames/gcrs.py
+++ b/astropy/coordinates/builtin_frames/gcrs.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from ..attributes import (TimeAttribute,
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.attributes import (TimeAttribute,
                           CartesianRepresentationAttribute)
 from .utils import DEFAULT_OBSTIME, EQUINOX_J2000
-from ..baseframe import base_doc
+from astropy.coordinates.baseframe import base_doc
 from .baseradec import BaseRADecFrame, doc_components
 
 __all__ = ['GCRS', 'PrecessedGeocentric']

--- a/astropy/coordinates/builtin_frames/hcrs.py
+++ b/astropy/coordinates/builtin_frames/hcrs.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from ..attributes import TimeAttribute
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.attributes import TimeAttribute
 from .utils import DEFAULT_OBSTIME
-from ..baseframe import base_doc
+from astropy.coordinates.baseframe import base_doc
 from .baseradec import BaseRADecFrame, doc_components
 
 __all__ = ['HCRS']

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from ..baseframe import base_doc
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.baseframe import base_doc
 from .baseradec import BaseRADecFrame, doc_components
 
 __all__ = ['ICRS']

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -7,12 +7,12 @@ anything in between (currently that means GCRS)
 
 import numpy as np
 
-from ... import units as u
-from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransformWithFiniteDifference, AffineTransform
-from ..representation import (SphericalRepresentation, CartesianRepresentation,
+from astropy import units as u
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference, AffineTransform
+from astropy.coordinates.representation import (SphericalRepresentation, CartesianRepresentation,
                               UnitSphericalRepresentation)
-from ... import _erfa as erfa
+from astropy import _erfa as erfa
 
 from .icrs import ICRS
 from .gcrs import GCRS
@@ -287,13 +287,13 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(hcrs_coo.__class__.__name__))
 
     if hcrs_coo.data.differentials:
-        from ..solar_system import get_body_barycentric_posvel
+        from astropy.coordinates.solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_coo.obstime)
         bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
     else:
-        from ..solar_system import get_body_barycentric
+        from astropy.coordinates.solar_system import get_body_barycentric
         bary_sun_pos = get_body_barycentric('sun', hcrs_coo.obstime)
         bary_sun_vel = None
 
@@ -307,13 +307,13 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
         raise u.UnitsError(_NEED_ORIGIN_HINT.format(icrs_coo.__class__.__name__))
 
     if icrs_coo.data.differentials:
-        from ..solar_system import get_body_barycentric_posvel
+        from astropy.coordinates.solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_frame.obstime)
         bary_sun_pos = -bary_sun_pos.with_differentials(-bary_sun_vel)
 
     else:
-        from ..solar_system import get_body_barycentric
+        from astropy.coordinates.solar_system import get_body_barycentric
         bary_sun_pos = -get_body_barycentric('sun', hcrs_frame.obstime)
         bary_sun_vel = None
 

--- a/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_fk5_transforms.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..matrix_utilities import (rotation_matrix,
+from astropy.coordinates.matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
-from ..baseframe import frame_transform_graph
-from ..transformations import DynamicMatrixTransform
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import DynamicMatrixTransform
 
 from .fk5 import FK5
 from .icrs import ICRS

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -8,10 +8,10 @@ rotations without aberration corrections or offsets.
 
 import numpy as np
 
-from ..baseframe import frame_transform_graph
-from ..transformations import FunctionTransformWithFiniteDifference
-from ..matrix_utilities import matrix_transpose
-from ... import _erfa as erfa
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference
+from astropy.coordinates.matrix_utilities import matrix_transpose
+from astropy import _erfa as erfa
 
 from .gcrs import GCRS, PrecessedGeocentric
 from .cirs import CIRS

--- a/astropy/coordinates/builtin_frames/itrs.py
+++ b/astropy/coordinates/builtin_frames/itrs.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ...utils.decorators import format_doc
-from ..representation import CartesianRepresentation, CartesianDifferential
-from ..baseframe import BaseCoordinateFrame, base_doc
-from ..attributes import TimeAttribute
+from astropy.utils.decorators import format_doc
+from astropy.coordinates.representation import CartesianRepresentation, CartesianDifferential
+from astropy.coordinates.baseframe import BaseCoordinateFrame, base_doc
+from astropy.coordinates.attributes import TimeAttribute
 from .utils import DEFAULT_OBSTIME
 
 __all__ = ['ITRS']
@@ -30,7 +30,7 @@ class ITRS(BaseCoordinateFrame):
         """
         The data in this frame as an `~astropy.coordinates.EarthLocation` class.
         """
-        from ..earth import EarthLocation
+        from astropy.coordinates.earth import EarthLocation
 
         cart = self.represent_as(CartesianRepresentation)
         return EarthLocation(x=cart.x, y=cart.y, z=cart.z)

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from ...time import Time
-from .. import representation as r
-from ..baseframe import (BaseCoordinateFrame, RepresentationMapping,
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.time import Time
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import (BaseCoordinateFrame, RepresentationMapping,
                          frame_transform_graph, base_doc)
-from ..transformations import AffineTransform
-from ..attributes import DifferentialAttribute
+from astropy.coordinates.transformations import AffineTransform
+from astropy.coordinates.attributes import DifferentialAttribute
 
 from .baseradec import BaseRADecFrame, doc_components as doc_components_radec
 from .icrs import ICRS

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ... import units as u
-from ...utils.compat import namedtuple_asdict
-from .. import representation as r
-from ..transformations import DynamicMatrixTransform, FunctionTransform
-from ..baseframe import (frame_transform_graph, RepresentationMapping,
+from astropy import units as u
+from astropy.utils.compat import namedtuple_asdict
+from astropy.coordinates import representation as r
+from astropy.coordinates.transformations import DynamicMatrixTransform, FunctionTransform
+from astropy.coordinates.baseframe import (frame_transform_graph, RepresentationMapping,
                          BaseCoordinateFrame)
-from ..attributes import CoordinateAttribute, QuantityAttribute
-from ..matrix_utilities import (rotation_matrix,
+from astropy.coordinates.attributes import CoordinateAttribute, QuantityAttribute
+from astropy.coordinates.matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
 
 _skyoffset_cache = {}

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import units as u
-from ...utils.decorators import format_doc
-from .. import representation as r
-from ..baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
+from astropy import units as u
+from astropy.utils.decorators import format_doc
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping, base_doc
 from .galactic import Galactic
 
 __all__ = ['Supergalactic']

--- a/astropy/coordinates/builtin_frames/supergalactic_transforms.py
+++ b/astropy/coordinates/builtin_frames/supergalactic_transforms.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..matrix_utilities import (rotation_matrix,
+from astropy.coordinates.matrix_utilities import (rotation_matrix,
                                 matrix_product, matrix_transpose)
-from ..baseframe import frame_transform_graph
-from ..transformations import StaticMatrixTransform
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.transformations import StaticMatrixTransform
 
 from .galactic import Galactic
 from .supergalactic import Supergalactic

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -9,11 +9,11 @@ import warnings
 
 import numpy as np
 
-from ... import units as u
-from ... import _erfa as erfa
-from ...time import Time
-from ...utils import iers
-from ...utils.exceptions import AstropyWarning
+from astropy import units as u
+from astropy import _erfa as erfa
+from astropy.time import Time
+from astropy.utils import iers
+from astropy.utils.exceptions import AstropyWarning
 
 
 # The UTC time scale is not properly defined prior to 1960, so Time('B1950',
@@ -279,7 +279,7 @@ def prepare_earth_position_vel(time):
         Heliocentric position of Earth in au
     """
     # this goes here to avoid circular import errors
-    from ..solar_system import (get_body_barycentric, get_body_barycentric_posvel)
+    from astropy.coordinates.solar_system import (get_body_barycentric, get_body_barycentric_posvel)
     # get barycentric position and velocity of earth
     earth_p, earth_v = get_body_barycentric_posvel('earth', time)
 

--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -10,8 +10,8 @@ from datetime import datetime
 from urllib.request import urlopen
 
 # Third-party
-from .. import time as atime
-from ..utils.console import color_print, _color_text
+from astropy import time as atime
+from astropy.utils.console import color_print, _color_text
 from . import get_sun
 
 __all__ = []

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -9,8 +9,8 @@ import warnings
 
 import numpy as np
 
-from .. import units as u
-from ..utils.exceptions import AstropyWarning
+from astropy import units as u
+from astropy.utils.exceptions import AstropyWarning
 from .angles import Angle
 
 __all__ = ['Distance']
@@ -105,7 +105,7 @@ class Distance(u.SpecificTypeQuantity):
                                  'or `distmod` in Distance constructor.')
 
             if cosmology is None:
-                from ..cosmology import default_cosmology
+                from astropy.cosmology import default_cosmology
                 cosmology = default_cosmology.get()
 
             value = cosmology.luminosity_distance(z)
@@ -209,10 +209,10 @@ class Distance(u.SpecificTypeQuantity):
         """
 
         if cosmology is None:
-            from ..cosmology import default_cosmology
+            from astropy.cosmology import default_cosmology
             cosmology = default_cosmology.get()
 
-        from ..cosmology import z_at_value
+        from astropy.cosmology import z_at_value
         return z_at_value(cosmology.luminosity_distance, self, ztol=1.e-10)
 
     @property

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -9,18 +9,18 @@ import urllib.error
 import urllib.parse
 
 import numpy as np
-from .. import units as u
-from .. import constants as consts
-from ..units.quantity import QuantityInfoBase
-from ..utils.exceptions import AstropyUserWarning
+from astropy import units as u
+from astropy import constants as consts
+from astropy.units.quantity import QuantityInfoBase
+from astropy.utils.exceptions import AstropyUserWarning
 from .angles import Longitude, Latitude
 from .representation import CartesianRepresentation, CartesianDifferential
 from .errors import UnknownSiteException
-from ..utils import data, deprecated
+from astropy.utils import data, deprecated
 
 try:
     # Not guaranteed available at setup time.
-    from .. import _erfa as erfa
+    from astropy import _erfa as erfa
 except ImportError:
     if not _ASTROPY_SETUP_:
         raise

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -11,8 +11,8 @@ is instead primarily for internal use in `coordinates`
 
 import numpy as np
 
-from ..time import Time
-from .. import units as u
+from astropy.time import Time
+from astropy import units as u
 from .matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 
 

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -4,7 +4,7 @@
 ''' This module defines custom errors and exceptions used in astropy.coordinates.
 '''
 
-from ..utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ['RangeError', 'BoundsError', 'IllegalHourError',
            'IllegalMinuteError', 'IllegalSecondError', 'ConvertError',

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -13,11 +13,11 @@ from collections.abc import Sequence
 
 import numpy as np
 
-from .. import units as u
-from ..constants import c
-from .. import _erfa as erfa
-from ..io import ascii
-from ..utils import isiterable, data
+from astropy import units as u
+from astropy.constants import c
+from astropy import _erfa as erfa
+from astropy.io import ascii
+from astropy.utils import isiterable, data
 from .sky_coordinate import SkyCoord
 from .builtin_frames import GCRS, PrecessedGeocentric
 from .representation import SphericalRepresentation, CartesianRepresentation

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -7,7 +7,7 @@ This module contains functions for matching coordinate catalogs.
 import numpy as np
 
 from .representation import UnitSphericalRepresentation
-from .. import units as u
+from astropy import units as u
 from . import Angle
 
 __all__ = ['match_coordinates_3d', 'match_coordinates_sky', 'search_around_3d',

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -7,7 +7,7 @@ This module contains utililies used for constructing rotation matrices.
 from functools import reduce
 import numpy as np
 
-from .. import units as u
+from astropy import units as u
 from .angles import Angle
 
 

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -17,10 +17,10 @@ import urllib.parse
 import urllib.error
 
 # Astropy
-from .. import units as u
+from astropy import units as u
 from .sky_coordinate import SkyCoord
-from ..utils import data
-from ..utils.state import ScienceState
+from astropy.utils import data
+from astropy.utils.state import ScienceState
 
 __all__ = ["get_icrs_coordinates"]
 

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -8,8 +8,8 @@ second edition, 1998, Willmann-Bell.
 import numpy as np
 from numpy.polynomial.polynomial import polyval
 
-from .. import units as u
-from .. import _erfa as erfa
+from astropy import units as u
+from astropy import _erfa as erfa
 from . import ICRS, SkyCoord, GeocentricTrueEcliptic
 from .builtin_frames.utils import get_jd12
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -17,13 +17,13 @@ import astropy.units as u
 
 from .angles import Angle, Longitude, Latitude
 from .distances import Distance
-from .._erfa import ufunc as erfa_ufunc
-from ..utils import ShapedLikeNDArray, classproperty
+from astropy._erfa import ufunc as erfa_ufunc
+from astropy.utils import ShapedLikeNDArray, classproperty
 
-from ..utils import deprecated_attribute
-from ..utils.exceptions import AstropyDeprecationWarning
-from ..utils.misc import InheritDocstrings
-from ..utils.compat import NUMPY_LT_1_14
+from astropy.utils import deprecated_attribute
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import InheritDocstrings
+from astropy.utils.compat import NUMPY_LT_1_14
 
 __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
            "CartesianRepresentation", "SphericalRepresentation",

--- a/astropy/coordinates/sites.py
+++ b/astropy/coordinates/sites.py
@@ -15,10 +15,10 @@ import json
 from difflib import get_close_matches
 from collections.abc import Mapping
 
-from ..utils.data import get_pkg_data_contents, get_file_contents
+from astropy.utils.data import get_pkg_data_contents, get_file_contents
 from .earth import EarthLocation
 from .errors import UnknownSiteException
-from .. import units as u
+from astropy import units as u
 
 
 class SiteRegistry(Mapping):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -4,14 +4,14 @@ import copy
 
 import numpy as np
 
-from .. import _erfa as erfa
-from ..utils.compat.misc import override__dir__
-from .. import units as u
-from ..constants import c as speed_of_light
-from ..wcs.utils import skycoord_to_pixel, pixel_to_skycoord
-from ..utils.data_info import MixinInfo
-from ..utils import ShapedLikeNDArray
-from ..time import Time
+from astropy import _erfa as erfa
+from astropy.utils.compat.misc import override__dir__
+from astropy import units as u
+from astropy.constants import c as speed_of_light
+from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
+from astropy.utils.data_info import MixinInfo
+from astropy.utils import ShapedLikeNDArray
+from astropy.time import Time
 
 from .distances import Distance
 from .angles import Angle

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -6,8 +6,8 @@ import inspect
 
 import numpy as np
 
-from ..units import Unit, IrreducibleUnit
-from .. import units as u
+from astropy.units import Unit, IrreducibleUnit
+from astropy import units as u
 
 from .baseframe import (BaseCoordinateFrame, frame_transform_graph,
                         _get_repr_cls, _get_diff_cls,

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -10,13 +10,13 @@ from collections import OrderedDict
 import numpy as np
 
 from .sky_coordinate import SkyCoord
-from ..utils.data import download_file
-from ..utils.decorators import classproperty
-from ..utils.state import ScienceState
-from ..utils import indent
-from .. import units as u
-from .. import _erfa as erfa
-from ..constants import c as speed_of_light
+from astropy.utils.data import download_file
+from astropy.utils.decorators import classproperty
+from astropy.utils.state import ScienceState
+from astropy.utils import indent
+from astropy import units as u
+from astropy import _erfa as erfa
+from astropy.constants import c as speed_of_light
 from .representation import CartesianRepresentation
 from .orbital_elements import calc_moon
 from .builtin_frames import GCRS, ICRS

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -8,7 +8,7 @@ import os
 
 import numpy as np
 
-from ....table import Table, Column
+from astropy.table import Table, Column
 
 
 def ref_fk4_no_e_fk4(fnout='fk4_no_e_fk4.csv'):

--- a/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
+++ b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
@@ -11,11 +11,11 @@ higher-precision checks on 64-bit machines.
 
 import pytest
 
-from .... import units as u
-from ....time import Time
-from ...builtin_frames import AltAz
-from ... import EarthLocation
-from ... import Angle, SkyCoord
+from astropy import units as u
+from astropy.time import Time
+from astropy.coordinates.builtin_frames import AltAz
+from astropy.coordinates import EarthLocation
+from astropy.coordinates import Angle, SkyCoord
 
 
 def test_against_hor2eq():

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -5,11 +5,11 @@ Accuracy tests for Ecliptic coordinate systems.
 
 import numpy as np
 
-from ....units import allclose as quantity_allclose
-from .... import units as u
-from ... import SkyCoord
-from ...builtin_frames import FK5, ICRS, GCRS, GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
-from ....constants import R_sun, R_earth
+from astropy.units import allclose as quantity_allclose
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.coordinates.builtin_frames import FK5, ICRS, GCRS, GeocentricTrueEcliptic, BarycentricTrueEcliptic, HeliocentricTrueEcliptic
+from astropy.constants import R_sun, R_earth
 
 
 def test_against_pytpm_doc_example():

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 
-from .... import units as u
-from ...builtin_frames import FK4NoETerms, FK4
-from ....time import Time
-from ....table import Table
-from ...angle_utilities import angular_separation
-from ....utils.data import get_pkg_data_contents
+from astropy import units as u
+from astropy.coordinates.builtin_frames import FK4NoETerms, FK4
+from astropy.time import Time
+from astropy.table import Table
+from astropy.coordinates.angle_utilities import angular_separation
+from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 
-from .... import units as u
-from ...builtin_frames import FK4NoETerms, FK5
-from ....time import Time
-from ....table import Table
-from ...angle_utilities import angular_separation
-from ....utils.data import get_pkg_data_contents
+from astropy import units as u
+from astropy.coordinates.builtin_frames import FK4NoETerms, FK5
+from astropy.time import Time
+from astropy.table import Table
+from astropy.coordinates.angle_utilities import angular_separation
+from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 
-from .... import units as u
-from ...builtin_frames import Galactic, FK4
-from ....time import Time
-from ....table import Table
-from ...angle_utilities import angular_separation
-from ....utils.data import get_pkg_data_contents
+from astropy import units as u
+from astropy.coordinates.builtin_frames import Galactic, FK4
+from astropy.time import Time
+from astropy.table import Table
+from astropy.coordinates.angle_utilities import angular_separation
+from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -3,12 +3,12 @@
 
 import numpy as np
 
-from .... import units as u
-from ...builtin_frames import ICRS, FK5
-from ....time import Time
-from ....table import Table
-from ...angle_utilities import angular_separation
-from ....utils.data import get_pkg_data_contents
+from astropy import units as u
+from astropy.coordinates.builtin_frames import ICRS, FK5
+from astropy.time import Time
+from astropy.table import Table
+from astropy.coordinates.angle_utilities import angular_separation
+from astropy.utils.data import get_pkg_data_contents
 
 # the number of tests to run
 from . import N_ACCURACY_TESTS

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -6,9 +6,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ..angles import Longitude, Latitude, Angle
-from ... import units as u
-from ..errors import (IllegalSecondError, IllegalMinuteError, IllegalHourError,
+from astropy.coordinates.angles import Longitude, Latitude, Angle
+from astropy import units as u
+from astropy.coordinates.errors import (IllegalSecondError, IllegalMinuteError, IllegalHourError,
                       IllegalSecondWarning, IllegalMinuteWarning)
 
 
@@ -902,9 +902,9 @@ def test_angle_with_cds_units_enabled():
     Especially the example in
     https://github.com/astropy/astropy/issues/5350#issuecomment-248770151
     """
-    from ...units import cds
+    from astropy.units import cds
     # the problem is with the parser, so remove it temporarily
-    from ..angle_utilities import _AngleParser
+    from astropy.coordinates.angle_utilities import _AngleParser
     del _AngleParser._parser
     with cds.enable():
         Angle('5d')

--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -9,10 +9,10 @@ Tests for the projected separation stuff
 import pytest
 import numpy as np
 
-from ...tests.helper import assert_quantity_allclose as assert_allclose
-from ... import units as u
-from ..builtin_frames import ICRS, FK5, Galactic
-from .. import Angle, Distance
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy import units as u
+from astropy.coordinates.builtin_frames import ICRS, FK5, Galactic
+from astropy.coordinates import Angle, Distance
 
 # lon1, lat1, lon2, lat2 in degrees
 coords = [(1, 0, 0, 0),
@@ -37,7 +37,7 @@ def test_angsep():
     """
     Tests that the angular separation object also behaves correctly.
     """
-    from ..angle_utilities import angular_separation
+    from astropy.coordinates.angle_utilities import angular_separation
 
     # check it both works with floats in radians, Quantities, or Angles
     for conv in (np.deg2rad,

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -16,11 +16,11 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 
-from ...tests.helper import raises, assert_quantity_allclose as assert_allclose
-from ... import units as u
-from ... import time
-from ... import coordinates as coords
-from ...units import allclose
+from astropy.tests.helper import raises, assert_quantity_allclose as assert_allclose
+from astropy import units as u
+from astropy import time
+from astropy import coordinates as coords
+from astropy.units import allclose
 
 try:
     import scipy  # pylint: disable=W0611
@@ -31,10 +31,10 @@ else:
 
 
 def test_representations_api():
-    from ..representation import SphericalRepresentation, \
+    from astropy.coordinates.representation import SphericalRepresentation, \
         UnitSphericalRepresentation, PhysicsSphericalRepresentation, \
         CartesianRepresentation
-    from ... coordinates import Angle, Longitude, Latitude, Distance
+    from astropy.coordinates import Angle, Longitude, Latitude, Distance
 
     # <-----------------Classes for representation of coordinate data-------------->
     # These classes inherit from a common base class and internally contain Quantity
@@ -145,9 +145,9 @@ def test_representations_api():
 
 
 def test_frame_api():
-    from ..representation import SphericalRepresentation, \
+    from astropy.coordinates.representation import SphericalRepresentation, \
                                  UnitSphericalRepresentation
-    from ..builtin_frames import ICRS, FK5
+    from astropy.coordinates.builtin_frames import ICRS, FK5
     # <--------------------Reference Frame/"Low-level" classes--------------------->
     # The low-level classes have a dual role: they act as specifiers of coordinate
     # frames and they *may* also contain data as one of the representation objects,
@@ -232,10 +232,10 @@ def test_frame_api():
 
 
 def test_transform_api():
-    from ..representation import UnitSphericalRepresentation
-    from ..builtin_frames import ICRS, FK5
-    from ..baseframe import frame_transform_graph, BaseCoordinateFrame
-    from ..transformations import DynamicMatrixTransform
+    from astropy.coordinates.representation import UnitSphericalRepresentation
+    from astropy.coordinates.builtin_frames import ICRS, FK5
+    from astropy.coordinates.baseframe import frame_transform_graph, BaseCoordinateFrame
+    from astropy.coordinates.transformations import DynamicMatrixTransform
     # <------------------------Transformations------------------------------------->
     # Transformation functionality is the key to the whole scheme: they transform
     # low-level classes from one frame to another.

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -7,13 +7,13 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 
-from ... import units as u
-from ...time import Time
-from ...tests.helper import assert_quantity_allclose as assert_allclose
+from astropy import units as u
+from astropy.time import Time
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
-from .. import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
+from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
                 CartesianRepresentation)
-from ..angle_utilities import dms_to_degrees, hms_to_hours
+from astropy.coordinates.angle_utilities import dms_to_degrees, hms_to_hours
 
 
 def test_angle_arrays():

--- a/astropy/coordinates/tests/test_atc_replacements.py
+++ b/astropy/coordinates/tests/test_atc_replacements.py
@@ -7,11 +7,11 @@ from itertools import product
 
 import pytest
 
-from ...tests.helper import assert_quantity_allclose as assert_allclose
-from ...time import Time
-from ... import _erfa as erfa
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.time import Time
+from astropy import _erfa as erfa
 from .utils import randomly_sample_sphere
-from ..builtin_frames.utils import get_jd12, atciqz, aticq
+from astropy.coordinates.builtin_frames.utils import get_jd12, atciqz, aticq
 
 times = [Time("2014-06-25T00:00"), Time(["2014-06-25T00:00", "2014-09-24"])]
 ra, dec, _ = randomly_sample_sphere(2)

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -4,15 +4,15 @@
 import pytest
 import numpy as np
 
-from ... import units as u
-from ..distances import Distance
-from ..builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
+from astropy import units as u
+from astropy.coordinates.distances import Distance
+from astropy.coordinates.builtin_frames import (ICRS, FK5, FK4, FK4NoETerms, Galactic,
                               Supergalactic, Galactocentric, HCRS, GCRS, LSR)
-from .. import SkyCoord
-from ...tests.helper import assert_quantity_allclose as assert_allclose
-from .. import EarthLocation, CartesianRepresentation
-from ...time import Time
-from ...units import allclose
+from astropy.coordinates import SkyCoord
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.coordinates import EarthLocation, CartesianRepresentation
+from astropy.time import Time
+from astropy.units import allclose
 
 # used below in the next parametrized test
 m31_sys = [ICRS, FK5, FK4, Galactic]

--- a/astropy/coordinates/tests/test_distance.py
+++ b/astropy/coordinates/tests/test_distance.py
@@ -8,12 +8,12 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 
-from ... import units as u
-from ...units import allclose as quantity_allclose
-from .. import Longitude, Latitude, Distance, CartesianRepresentation
-from ..builtin_frames import ICRS, Galactic
-from ...tests.helper import catch_warnings
-from ...utils.exceptions import AstropyWarning
+from astropy import units as u
+from astropy.units import allclose as quantity_allclose
+from astropy.coordinates import Longitude, Latitude, Distance, CartesianRepresentation
+from astropy.coordinates.builtin_frames import ICRS, Galactic
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyWarning
 
 try:
     import scipy  # pylint: disable=W0611
@@ -114,7 +114,7 @@ def test_distances_scipy():
     The distance-related tests that require scipy due to the cosmology
     module needing scipy integration routines
     """
-    from ...cosmology import WMAP5
+    from astropy.cosmology import WMAP5
 
     # try different ways to initialize a Distance
     d4 = Distance(z=0.23)  # uses default cosmology - as of writing, WMAP7

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -8,13 +8,13 @@ import pickle
 import pytest
 import numpy as np
 
-from ..earth import EarthLocation, ELLIPSOIDS
-from ..angles import Longitude, Latitude
-from ...units import allclose as quantity_allclose
-from ... import units as u
-from ...time import Time
-from ... import constants
-from ..name_resolve import NameResolveError
+from astropy.coordinates.earth import EarthLocation, ELLIPSOIDS
+from astropy.coordinates.angles import Longitude, Latitude
+from astropy.units import allclose as quantity_allclose
+from astropy import units as u
+from astropy.time import Time
+from astropy import constants
+from astropy.coordinates.name_resolve import NameResolveError
 
 
 def allclose_m14(a, b, rtol=1.e-14, atol=None):

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -4,15 +4,15 @@
 
 import pytest
 import numpy as np
-from ...units import allclose as quantity_allclose
+from astropy.units import allclose as quantity_allclose
 
-from ... import units as u
-from ... import constants
-from ...time import Time
-from ..builtin_frames import ICRS, AltAz, LSR, GCRS, Galactic, FK5
-from ..baseframe import frame_transform_graph
-from ..sites import get_builtin_sites
-from .. import (TimeAttribute,
+from astropy import units as u
+from astropy import constants
+from astropy.time import Time
+from astropy.coordinates.builtin_frames import ICRS, AltAz, LSR, GCRS, Galactic, FK5
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.coordinates.sites import get_builtin_sites
+from astropy.coordinates import (TimeAttribute,
                 FunctionTransformWithFiniteDifference, get_sun,
                 CartesianRepresentation, SphericalRepresentation,
                 CartesianDifferential, SphericalDifferential,
@@ -73,7 +73,7 @@ def test_faux_lsr(dt, symmetric):
 
 def test_faux_fk5_galactic():
 
-    from ..builtin_frames.galactic_transforms import fk5_to_gal, _gal_to_fk5
+    from astropy.coordinates.builtin_frames.galactic_transforms import fk5_to_gal, _gal_to_fk5
 
     class Galactic2(Galactic):
         pass

--- a/astropy/coordinates/tests/test_formatting.py
+++ b/astropy/coordinates/tests/test_formatting.py
@@ -7,8 +7,8 @@ test_sky_coord
 
 
 
-from ..angles import Angle
-from ... import units as u
+from astropy.coordinates.angles import Angle
+from astropy import units as u
 
 
 def test_to_string_precision():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -5,15 +5,15 @@
 from copy import deepcopy
 import numpy as np
 
-from ... import units as u
-from ...tests.helper import (catch_warnings, pytest,
+from astropy import units as u
+from astropy.tests.helper import (catch_warnings, pytest,
                              assert_quantity_allclose as assert_allclose)
-from ...utils import OrderedDescriptorContainer
-from ...utils.compat import NUMPY_LT_1_14
-from ...utils.exceptions import AstropyWarning
-from .. import representation as r
-from ..representation import REPRESENTATION_CLASSES
-from ...units import allclose
+from astropy.utils import OrderedDescriptorContainer
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.utils.exceptions import AstropyWarning
+from astropy.coordinates import representation as r
+from astropy.coordinates.representation import REPRESENTATION_CLASSES
+from astropy.units import allclose
 
 
 from .test_representation import unitphysics  # this fixture is used below
@@ -30,7 +30,7 @@ def teardown_function(func):
 
 def test_frame_attribute_descriptor():
     """ Unit tests of the Attribute descriptor """
-    from ..attributes import Attribute
+    from astropy.coordinates.attributes import Attribute
 
     class TestAttributes(metaclass=OrderedDescriptorContainer):
         attr_none = Attribute()
@@ -67,8 +67,8 @@ def test_frame_attribute_descriptor():
 
 
 def test_frame_subclass_attribute_descriptor():
-    from ..builtin_frames import FK4
-    from ..attributes import Attribute, TimeAttribute
+    from astropy.coordinates.builtin_frames import FK4
+    from astropy.coordinates.attributes import Attribute, TimeAttribute
     from astropy.time import Time
 
     _EQUINOX_B1980 = Time('B1980', scale='tai')
@@ -92,7 +92,7 @@ def test_frame_subclass_attribute_descriptor():
 
 
 def test_create_data_frames():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     # from repr
     i1 = ICRS(r.SphericalRepresentation(1*u.deg, 2*u.deg, 3*u.kpc))
@@ -119,7 +119,7 @@ def test_create_data_frames():
 
 
 def test_create_orderered_data():
-    from ..builtin_frames import ICRS, Galactic, AltAz
+    from astropy.coordinates.builtin_frames import ICRS, Galactic, AltAz
 
     TOL = 1e-10*u.deg
 
@@ -144,7 +144,7 @@ def test_create_orderered_data():
 
 
 def test_create_nodata_frames():
-    from ..builtin_frames import ICRS, FK4, FK5
+    from astropy.coordinates.builtin_frames import ICRS, FK4, FK5
 
     i = ICRS()
     assert len(i.get_frame_attr_names()) == 0
@@ -161,7 +161,7 @@ def test_create_nodata_frames():
 
 
 def test_no_data_nonscalar_frames():
-    from ..builtin_frames import AltAz
+    from astropy.coordinates.builtin_frames import AltAz
     from astropy.time import Time
     a1 = AltAz(obstime=Time('2012-01-01') + np.arange(10.) * u.day,
                temperature=np.ones((3, 1)) * u.deg_C)
@@ -175,7 +175,7 @@ def test_no_data_nonscalar_frames():
 
 
 def test_frame_repr():
-    from ..builtin_frames import ICRS, FK5
+    from astropy.coordinates.builtin_frames import ICRS, FK5
 
     i = ICRS()
     assert repr(i) == '<ICRS Frame>'
@@ -211,7 +211,7 @@ def test_frame_repr():
 
 
 def test_frame_repr_vels():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS(ra=1*u.deg, dec=2*u.deg,
              pm_ra_cosdec=1*u.marcsec/u.yr, pm_dec=2*u.marcsec/u.yr)
@@ -227,8 +227,8 @@ def test_frame_repr_vels():
 
 def test_converting_units():
     import re
-    from ..baseframe import RepresentationMapping
-    from ..builtin_frames import ICRS, FK5
+    from astropy.coordinates.baseframe import RepresentationMapping
+    from astropy.coordinates.builtin_frames import ICRS, FK5
 
     # this is a regular expression that with split (see below) removes what's
     # the decimal point  to fix rounding problems
@@ -278,8 +278,8 @@ def test_converting_units():
 
 
 def test_representation_info():
-    from ..baseframe import RepresentationMapping
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.baseframe import RepresentationMapping
+    from astropy.coordinates.builtin_frames import ICRS
 
     class NewICRS1(ICRS):
         frame_specific_representation_info = {
@@ -346,8 +346,8 @@ def test_representation_info():
 
 
 def test_realizing():
-    from ..builtin_frames import ICRS, FK5
-    from ...time import Time
+    from astropy.coordinates.builtin_frames import ICRS, FK5
+    from astropy.time import Time
 
     rep = r.SphericalRepresentation(1*u.deg, 2*u.deg, 3*u.kpc)
 
@@ -374,8 +374,8 @@ def test_realizing():
             excinfo.value.args[0])
 
 def test_replicating():
-    from ..builtin_frames import ICRS, AltAz
-    from ...time import Time
+    from astropy.coordinates.builtin_frames import ICRS, AltAz
+    from astropy.time import Time
 
     i = ICRS(ra=[1]*u.deg, dec=[2]*u.deg)
 
@@ -398,7 +398,7 @@ def test_replicating():
 
 
 def test_getitem():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     rep = r.SphericalRepresentation(
         [1, 2, 3]*u.deg, [4, 5, 6]*u.deg, [7, 8, 9]*u.kpc)
@@ -418,8 +418,8 @@ def test_transform():
     This test just makes sure the transform architecture works, but does *not*
     actually test all the builtin transforms themselves are accurate
     """
-    from ..builtin_frames import ICRS, FK4, FK5, Galactic
-    from ...time import Time
+    from astropy.coordinates.builtin_frames import ICRS, FK4, FK5, Galactic
+    from astropy.time import Time
 
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
     f = i.transform_to(FK5)
@@ -469,8 +469,8 @@ def test_transform():
 
 def test_transform_to_nonscalar_nodata_frame():
     # https://github.com/astropy/astropy/pull/5254#issuecomment-241592353
-    from ..builtin_frames import ICRS, FK5
-    from ...time import Time
+    from astropy.coordinates.builtin_frames import ICRS, FK5
+    from astropy.time import Time
     times = Time('2016-08-23') + np.linspace(0, 10, 12)*u.day
     coo1 = ICRS(ra=[[0.], [10.], [20.]]*u.deg,
                 dec=[[-30.], [30.], [60.]]*u.deg)
@@ -479,7 +479,7 @@ def test_transform_to_nonscalar_nodata_frame():
 
 
 def test_sep():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i1 = ICRS(ra=0*u.deg, dec=1*u.deg)
     i2 = ICRS(ra=0*u.deg, dec=2*u.deg)
@@ -508,8 +508,8 @@ def test_time_inputs():
     """
     Test validation and conversion of inputs for equinox and obstime attributes.
     """
-    from ...time import Time
-    from ..builtin_frames import FK4
+    from astropy.time import Time
+    from astropy.coordinates.builtin_frames import FK4
 
     c = FK4(1 * u.deg, 2 * u.deg, equinox='J2001.5', obstime='2000-01-01 12:00:00')
     assert c.equinox == Time('J2001.5')
@@ -535,8 +535,8 @@ def test_is_frame_attr_default():
     """
     Check that the `is_frame_attr_default` machinery works as expected
     """
-    from ...time import Time
-    from ..builtin_frames import FK5
+    from astropy.time import Time
+    from astropy.coordinates.builtin_frames import FK5
 
     c1 = FK5(ra=1*u.deg, dec=1*u.deg)
     c2 = FK5(ra=1*u.deg, dec=1*u.deg, equinox=FK5.get_frame_attr_names()['equinox'])
@@ -557,8 +557,8 @@ def test_is_frame_attr_default():
 
 
 def test_altaz_attributes():
-    from ...time import Time
-    from .. import EarthLocation, AltAz
+    from astropy.time import Time
+    from astropy.coordinates import EarthLocation, AltAz
 
     aa = AltAz(1*u.deg, 2*u.deg)
     assert aa.obstime is None
@@ -575,7 +575,7 @@ def test_representation():
     """
     Test the getter and setter properties for `representation`
     """
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     # Create the frame object.
     icrs = ICRS(ra=1*u.deg, dec=1*u.deg)
@@ -637,7 +637,7 @@ def test_representation():
 
 
 def test_represent_as():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     icrs = ICRS(ra=1*u.deg, dec=1*u.deg)
 
@@ -679,7 +679,7 @@ def test_represent_as():
 
 
 def test_shorthand_representations():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     rep = r.CartesianRepresentation([1, 2, 3]*u.pc)
     dif = r.CartesianDifferential([1, 2, 3]*u.km/u.s)
@@ -697,7 +697,7 @@ def test_shorthand_representations():
 
 
 def test_dynamic_attrs():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
     c = ICRS(1*u.deg, 2*u.deg)
     assert 'ra' in dir(c)
     assert 'dec' in dir(c)
@@ -715,7 +715,7 @@ def test_dynamic_attrs():
 
 
 def test_nodata_error():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS()
     with pytest.raises(ValueError) as excinfo:
@@ -725,7 +725,7 @@ def test_nodata_error():
 
 
 def test_len0_data():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS([]*u.deg, []*u.deg)
     assert i.has_data
@@ -733,7 +733,7 @@ def test_len0_data():
 
 
 def test_quantity_attributes():
-    from ..builtin_frames import GCRS
+    from astropy.coordinates.builtin_frames import GCRS
 
     # make sure we can create a GCRS frame with valid inputs
     GCRS(obstime='J2002', obsgeoloc=[1, 2, 3]*u.km, obsgeovel=[4, 5, 6]*u.km/u.s)
@@ -748,7 +748,7 @@ def test_quantity_attributes():
 
 
 def test_eloc_attributes():
-    from .. import AltAz, ITRS, GCRS, EarthLocation
+    from astropy.coordinates import AltAz, ITRS, GCRS, EarthLocation
 
     el = EarthLocation(lon=12.3*u.deg, lat=45.6*u.deg, height=1*u.km)
     it = ITRS(r.SphericalRepresentation(lon=12.3*u.deg, lat=45.6*u.deg, distance=1*u.km))
@@ -783,8 +783,8 @@ def test_eloc_attributes():
 
 
 def test_equivalent_frames():
-    from .. import SkyCoord
-    from ..builtin_frames import ICRS, FK4, FK5, AltAz
+    from astropy.coordinates import SkyCoord
+    from astropy.coordinates.builtin_frames import ICRS, FK4, FK5, AltAz
 
     i = ICRS()
     i2 = ICRS(1*u.deg, 2*u.deg)
@@ -818,7 +818,7 @@ def test_representation_subclass():
 
     # Regression test for #3354
 
-    from ..builtin_frames import FK5
+    from astropy.coordinates.builtin_frames import FK5
 
     # Normally when instantiating a frame without a distance the frame will try
     # and use UnitSphericalRepresentation internally instead of
@@ -863,7 +863,7 @@ def test_getitem_representation():
     Make sure current representation survives __getitem__ even if different
     from data representation.
     """
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
     c = ICRS([1, 1] * u.deg, [2, 2] * u.deg)
     c.representation_type = 'cartesian'
     assert c[0].representation_type is r.CartesianRepresentation
@@ -874,7 +874,7 @@ def test_component_error_useful():
     Check that a data-less frame gives useful error messages about not having
     data when the attributes asked for are possible coordinate components
     """
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS()
 
@@ -891,7 +891,7 @@ def test_component_error_useful():
 
 
 def test_cache_clear():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS(1*u.deg, 2*u.deg)
 
@@ -906,7 +906,7 @@ def test_cache_clear():
 
 
 def test_inplace_array():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS([[1, 2], [3, 4]]*u.deg, [[10, 20], [30, 40]]*u.deg)
 
@@ -928,7 +928,7 @@ def test_inplace_array():
 
 
 def test_inplace_change():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     i = ICRS(1*u.deg, 2*u.deg)
 
@@ -950,7 +950,7 @@ def test_inplace_change():
 
 
 def test_representation_with_multiple_differentials():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     dif1 = r.CartesianDifferential([1, 2, 3]*u.km/u.s)
     dif2 = r.CartesianDifferential([1, 2, 3]*u.km/u.s**2)
@@ -965,7 +965,7 @@ def test_representation_with_multiple_differentials():
 def test_representation_arg_backwards_compatibility():
     # TODO: this test can be removed when the `representation` argument is
     # removed from the BaseCoordinateFrame initializer.
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     c1 = ICRS(x=1*u.pc, y=2*u.pc, z=3*u.pc,
               representation_type=r.CartesianRepresentation)
@@ -1004,7 +1004,7 @@ def test_missing_component_error_names():
 
     TypeError: __init__() missing 1 required positional argument: 'dec'
     """
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     with pytest.raises(TypeError) as e:
         ICRS(ra=150 * u.deg)
@@ -1017,7 +1017,7 @@ def test_missing_component_error_names():
 
 
 def test_non_spherical_representation_unit_creation(unitphysics):
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     class PhysicsICRS(ICRS):
         default_representation = r.PhysicsSphericalRepresentation
@@ -1030,8 +1030,8 @@ def test_non_spherical_representation_unit_creation(unitphysics):
 
 
 def test_attribute_repr():
-    from ..attributes import Attribute
-    from ..baseframe import BaseCoordinateFrame
+    from astropy.coordinates.attributes import Attribute
+    from astropy.coordinates.baseframe import BaseCoordinateFrame
 
     class Spam:
         def _astropy_repr_in_frame(self):

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -5,12 +5,12 @@
 import pytest
 import numpy as np
 
-from ... import units as u
-from ..builtin_frames import ICRS, Galactic, Galactocentric
-from .. import builtin_frames as bf
-from ...units import allclose as quantity_allclose
-from ..errors import ConvertError
-from .. import representation as r
+from astropy import units as u
+from astropy.coordinates.builtin_frames import ICRS, Galactic, Galactocentric
+from astropy.coordinates import builtin_frames as bf
+from astropy.units import allclose as quantity_allclose
+from astropy.coordinates.errors import ConvertError
+from astropy.coordinates import representation as r
 
 def test_api():
     # transform observed Barycentric velocities to full-space Galactocentric
@@ -188,7 +188,7 @@ def test_differential_type_arg():
     Test passing in an explicit differential class to the initializer or
     changing the differential class via set_representation_cls
     """
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     icrs = ICRS(ra=1*u.deg, dec=60*u.deg,
                 pm_ra=10*u.mas/u.yr, pm_dec=-11*u.mas/u.yr,

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -11,16 +11,16 @@ import numpy as np
 from numpy import testing as npt
 
 
-from ... import units as u
-from ...time import Time
-from ..._erfa import ErfaWarning
+from astropy import units as u
+from astropy.time import Time
+from astropy._erfa import ErfaWarning
 
 
 def test_sun():
     """
     Test that `get_sun` works and it behaves roughly as it should (in GCRS)
     """
-    from ..funcs import get_sun
+    from astropy.coordinates.funcs import get_sun
 
     northern_summer_solstice = Time('2010-6-21')
     northern_winter_solstice = Time('2010-12-21')
@@ -35,8 +35,8 @@ def test_sun():
 
 
 def test_constellations(recwarn):
-    from .. import ICRS, FK5, SkyCoord
-    from ..funcs import get_constellation
+    from astropy.coordinates import ICRS, FK5, SkyCoord
+    from astropy.coordinates.funcs import get_constellation
 
     inuma = ICRS(9*u.hour, 65*u.deg)
 
@@ -66,8 +66,8 @@ def test_constellations(recwarn):
 
 
 def test_concatenate():
-    from .. import FK5, SkyCoord, ICRS
-    from ..funcs import concatenate
+    from astropy.coordinates import FK5, SkyCoord, ICRS
+    from astropy.coordinates.funcs import concatenate
 
     # Just positions
     fk5 = FK5(1*u.deg, 2*u.deg)
@@ -102,8 +102,8 @@ def test_concatenate():
 
 
 def test_concatenate_representations():
-    from ..funcs import concatenate_representations
-    from .. import representation as r
+    from astropy.coordinates.funcs import concatenate_representations
+    from astropy.coordinates import representation as r
 
     reps = [r.CartesianRepresentation([1, 2, 3.]*u.kpc),
             r.SphericalRepresentation(lon=1*u.deg, lat=2.*u.deg,

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -6,15 +6,15 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 
-from ... import units as u
-from ...time import Time
-from ..builtin_frames import ICRS, AltAz
-from ..builtin_frames.utils import get_jd12
-from .. import EarthLocation
-from .. import SkyCoord
-from ...tests.helper import catch_warnings
-from ... import _erfa as erfa
-from ...utils import iers
+from astropy import units as u
+from astropy.time import Time
+from astropy.coordinates.builtin_frames import ICRS, AltAz
+from astropy.coordinates.builtin_frames.utils import get_jd12
+from astropy.coordinates import EarthLocation
+from astropy.coordinates import SkyCoord
+from astropy.tests.helper import catch_warnings
+from astropy import _erfa as erfa
+from astropy.utils import iers
 from .utils import randomly_sample_sphere
 
 
@@ -151,11 +151,11 @@ def test_future_altaz():
     warning is raised when attempting to get to AltAz in the future (beyond
     IERS tables)
     """
-    from ...utils.exceptions import AstropyWarning
+    from astropy.utils.exceptions import AstropyWarning
 
     # this is an ugly hack to get the warning to show up even if it has already
     # appeared
-    from ..builtin_frames import utils
+    from astropy.coordinates.builtin_frames import utils
     if hasattr(utils, '__warningregistry__'):
         utils.__warningregistry__.clear()
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -6,21 +6,21 @@
 import pytest
 import numpy as np
 
-from ... import units as u
-from ...tests.helper import (assert_quantity_allclose as assert_allclose)
-from ...time import Time
-from .. import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
+from astropy import units as u
+from astropy.tests.helper import (assert_quantity_allclose as assert_allclose)
+from astropy.time import Time
+from astropy.coordinates import (EarthLocation, get_sun, ICRS, GCRS, CIRS, ITRS, AltAz,
                 PrecessedGeocentric, CartesianRepresentation, SkyCoord,
                 SphericalRepresentation, UnitSphericalRepresentation,
                 HCRS, HeliocentricTrueEcliptic)
 
 
-from ..._erfa import epv00
+from astropy._erfa import epv00
 
 from .utils import randomly_sample_sphere
-from ..builtin_frames.utils import get_jd12
-from .. import solar_system_ephemeris
-from ...units import allclose
+from astropy.coordinates.builtin_frames.utils import get_jd12
+from astropy.coordinates import solar_system_ephemeris
+from astropy.units import allclose
 
 try:
     import jplephem  # pylint: disable=W0611
@@ -143,7 +143,7 @@ def test_cirs_to_altaz():
     Check the basic CIRS<->AltAz transforms.  More thorough checks implicitly
     happen in `test_iau_fullstack`
     """
-    from .. import EarthLocation
+    from astropy.coordinates import EarthLocation
 
     ra, dec, dist = randomly_sample_sphere(200)
     cirs = CIRS(ra=ra, dec=dec, obstime='J2000')
@@ -236,7 +236,7 @@ def test_gcrs_altaz():
     """
     Check GCRS<->AltAz transforms for round-tripping.  Has multiple paths
     """
-    from .. import EarthLocation
+    from astropy.coordinates import EarthLocation
 
     ra, dec, _ = randomly_sample_sphere(1)
     gcrs = GCRS(ra=ra[0], dec=dec[0], obstime='J2000')

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -5,12 +5,12 @@ import pytest
 import numpy as np
 from numpy import testing as npt
 
-from ...tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
-from ... import units as u
-from ...utils import minversion
+from astropy import units as u
+from astropy.utils import minversion
 
-from .. import matching
+from astropy.coordinates import matching
 
 """
 These are the tests for coordinate matching.
@@ -32,8 +32,8 @@ else:
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_function():
-    from .. import ICRS
-    from ..matching import match_coordinates_3d
+    from astropy.coordinates import ICRS
+    from astropy.coordinates.matching import match_coordinates_3d
     # this only uses match_coordinates_3d because that's the actual implementation
 
     cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree)
@@ -52,8 +52,8 @@ def test_matching_function():
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_function_3d_and_sky():
-    from .. import ICRS
-    from ..matching import match_coordinates_3d, match_coordinates_sky
+    from astropy.coordinates import ICRS
+    from astropy.coordinates.matching import match_coordinates_3d, match_coordinates_sky
 
     cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
     ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 1, 1, 5] * u.kpc)
@@ -80,7 +80,7 @@ def test_matching_function_3d_and_sky():
                          ])
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
-    from .. import ICRS
+    from astropy.coordinates import ICRS
 
     def make_scs():
         cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 2]*u.kpc)
@@ -125,7 +125,7 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_python_kdtree(monkeypatch):
-    from .. import ICRS
+    from astropy.coordinates import ICRS
 
     cmatch = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 2]*u.kpc)
     ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 2, 3, 4]*u.kpc)
@@ -137,9 +137,9 @@ def test_python_kdtree(monkeypatch):
 
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 def test_matching_method():
-    from .. import ICRS, SkyCoord
-    from ...utils import NumpyRNGContext
-    from ..matching import match_coordinates_3d, match_coordinates_sky
+    from astropy.coordinates import ICRS, SkyCoord
+    from astropy.utils import NumpyRNGContext
+    from astropy.coordinates.matching import match_coordinates_3d, match_coordinates_sky
 
     with NumpyRNGContext(987654321):
         cmatch = ICRS(np.random.rand(20) * 360.*u.degree,
@@ -168,8 +168,8 @@ def test_matching_method():
 @pytest.mark.skipif(str('not HAS_SCIPY'))
 @pytest.mark.skipif(str('OLDER_SCIPY'))
 def test_search_around():
-    from .. import ICRS, SkyCoord
-    from ..matching import search_around_sky, search_around_3d
+    from astropy.coordinates import ICRS, SkyCoord
+    from astropy.coordinates.matching import search_around_sky, search_around_3d
 
     coo1 = ICRS([4, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
     coo2 = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 1, 1, 5] * u.kpc)

--- a/astropy/coordinates/tests/test_matrix_utilities.py
+++ b/astropy/coordinates/tests/test_matrix_utilities.py
@@ -3,8 +3,8 @@
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ... import units as u
-from ..matrix_utilities import rotation_matrix, angle_axis
+from astropy import units as u
+from astropy.coordinates.matrix_utilities import rotation_matrix, angle_axis
 
 
 def test_rotation_matrix():

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -10,10 +10,10 @@ import urllib.request
 import pytest
 import numpy as np
 
-from ..name_resolve import (get_icrs_coordinates, NameResolveError,
+from astropy.coordinates.name_resolve import (get_icrs_coordinates, NameResolveError,
                             sesame_database, _parse_response, sesame_url)
-from ..sky_coordinate import SkyCoord
-from ... import units as u
+from astropy.coordinates.sky_coordinate import SkyCoord
+from astropy import units as u
 
 _cached_ngc3642 = dict()
 _cached_ngc3642["simbad"] = """# NGC 3642    #Q22523669

--- a/astropy/coordinates/tests/test_pickle.py
+++ b/astropy/coordinates/tests/test_pickle.py
@@ -2,9 +2,9 @@ import pickle
 import pytest
 import numpy as np
 
-from ...coordinates import Longitude
-from ... import coordinates as coord
-from ...tests.helper import pickle_protocol, check_pickling_recovery  # noqa
+from astropy.coordinates import Longitude
+from astropy import coordinates as coord
+from astropy.tests.helper import pickle_protocol, check_pickling_recovery  # noqa
 
 # Can't test distances without scipy due to cosmology deps
 try:

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -12,20 +12,20 @@ import pytest
 import numpy as np
 
 
-from ... import units as u
-from .. import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
+from astropy import units as u
+from astropy.coordinates import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS, CIRS, ITRS,
                 GeocentricTrueEcliptic, Longitude, Latitude, GCRS, HCRS,
                 get_moon, FK4, FK4NoETerms, BaseCoordinateFrame,
                 QuantityAttribute, SphericalRepresentation,
                 UnitSphericalRepresentation, CartesianRepresentation)
-from ..sites import get_builtin_sites
-from ...time import Time
-from ...utils import iers
-from ...table import Table
+from astropy.coordinates.sites import get_builtin_sites
+from astropy.time import Time
+from astropy.utils import iers
+from astropy.table import Table
 
-from ...tests.helper import assert_quantity_allclose, catch_warnings
+from astropy.tests.helper import assert_quantity_allclose, catch_warnings
 from .test_matching import HAS_SCIPY, OLDER_SCIPY
-from ...units import allclose as quantity_allclose
+from astropy.units import allclose as quantity_allclose
 
 try:
     import yaml  # pylint: disable=W0611
@@ -159,7 +159,7 @@ def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082
     """
-    from .. import search_around_sky, search_around_3d
+    from astropy.coordinates import search_around_sky, search_around_3d
     cat = SkyCoord([10.076, 10.00455], [18.54746, 18.54896], unit='deg')
     search_around_sky(cat[0:1], cat, seplimit=u.arcsec * 60, storekdtree=False)
     # in the issue, this raises a TypeError
@@ -183,7 +183,7 @@ def test_regression_4210():
 
     # and for good measure, check the other ecliptic systems are all the same
     # names for their attributes
-    from ..builtin_frames import ecliptic
+    from astropy.coordinates.builtin_frames import ecliptic
     for frame_name in ecliptic.__all__:
         eclcls = getattr(ecliptic, frame_name)
         eclobj = eclcls(1*u.deg, 2*u.deg, 3*u.AU)
@@ -201,11 +201,11 @@ def test_regression_futuretimes_4302():
 
     Relevant comment: https://github.com/astropy/astropy/pull/4302#discussion_r44836531
     """
-    from ...utils.exceptions import AstropyWarning
+    from astropy.utils.exceptions import AstropyWarning
 
     # this is an ugly hack to get the warning to show up even if it has already
     # appeared
-    from ..builtin_frames import utils
+    from astropy.coordinates.builtin_frames import utils
     if hasattr(utils, '__warningregistry__'):
         utils.__warningregistry__.clear()
 
@@ -480,9 +480,9 @@ def test_regression_6300():
     """Check that importing old frame attribute names from astropy.coordinates
     still works. See comments at end of #6300
     """
-    from ...utils.exceptions import AstropyDeprecationWarning
-    from .. import CartesianRepresentation
-    from .. import (TimeFrameAttribute, QuantityFrameAttribute,
+    from astropy.utils.exceptions import AstropyDeprecationWarning
+    from astropy.coordinates import CartesianRepresentation
+    from astropy.coordinates import (TimeFrameAttribute, QuantityFrameAttribute,
                     CartesianRepresentationFrameAttribute)
 
     with catch_warnings() as found_warnings:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -8,15 +8,15 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ... import units as u
-from ...tests.helper import (assert_quantity_allclose as
+from astropy import units as u
+from astropy.tests.helper import (assert_quantity_allclose as
                              assert_allclose_quantity, catch_warnings)
-from ...utils import isiterable
-from ...utils.compat import NUMPY_LT_1_14
-from ...utils.exceptions import AstropyDeprecationWarning
-from ..angles import Longitude, Latitude, Angle
-from ..distances import Distance
-from ..representation import (REPRESENTATION_CLASSES,
+from astropy.utils import isiterable
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.coordinates.angles import Longitude, Latitude, Angle
+from astropy.coordinates.distances import Distance
+from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                               DIFFERENTIAL_CLASSES,
                               BaseRepresentation,
                               SphericalRepresentation,
@@ -1035,7 +1035,7 @@ def test_representation_str_multi_d():
 
 
 def test_subclass_representation():
-    from ..builtin_frames import ICRS
+    from astropy.coordinates.builtin_frames import ICRS
 
     class Longitude180(Longitude):
         def __new__(cls, angle, unit=None, wrap_angle=180 * u.deg, **kwargs):

--- a/astropy/coordinates/tests/test_representation_arithmetic.py
+++ b/astropy/coordinates/tests/test_representation_arithmetic.py
@@ -5,17 +5,17 @@ import functools
 import pytest
 import numpy as np
 
-from ... import units as u
-from .. import (PhysicsSphericalRepresentation, CartesianRepresentation,
+from astropy import units as u
+from astropy.coordinates import (PhysicsSphericalRepresentation, CartesianRepresentation,
                 CylindricalRepresentation, SphericalRepresentation,
                 UnitSphericalRepresentation, SphericalDifferential,
                 CartesianDifferential, UnitSphericalDifferential,
                 SphericalCosLatDifferential, UnitSphericalCosLatDifferential,
                 PhysicsSphericalDifferential, CylindricalDifferential,
                 RadialRepresentation, RadialDifferential, Longitude, Latitude)
-from ..representation import DIFFERENTIAL_CLASSES
-from ..angle_utilities import angular_separation
-from ...tests.helper import assert_quantity_allclose, quantity_allclose
+from astropy.coordinates.representation import DIFFERENTIAL_CLASSES
+from astropy.coordinates.angle_utilities import angular_separation
+from astropy.tests.helper import assert_quantity_allclose, quantity_allclose
 
 
 def assert_representation_allclose(actual, desired, rtol=1.e-7, atol=None,

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -4,8 +4,8 @@
 import pytest
 import numpy as np
 
-from ... import units as u
-from .. import (SphericalRepresentation, Longitude, Latitude,
+from astropy import units as u
+from astropy.coordinates import (SphericalRepresentation, Longitude, Latitude,
                 SphericalDifferential)
 
 

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -2,11 +2,11 @@
 
 import numpy as np
 
-from ... import units as u
-from .. import Longitude, Latitude, EarthLocation, SkyCoord
+from astropy import units as u
+from astropy.coordinates import Longitude, Latitude, EarthLocation, SkyCoord
 # test on frame with most complicated frame attributes.
-from ..builtin_frames import ICRS, AltAz, GCRS
-from ...time import Time
+from astropy.coordinates.builtin_frames import ICRS, AltAz, GCRS
+from astropy.time import Time
 
 
 class TestManipulation():

--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -1,11 +1,11 @@
 
 import pytest
 
-from ...tests.helper import assert_quantity_allclose
-from ...units import allclose as quantity_allclose
-from ... import units as u
-from .. import Longitude, Latitude, EarthLocation
-from ..sites import get_builtin_sites, get_downloaded_sites, SiteRegistry
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import allclose as quantity_allclose
+from astropy import units as u
+from astropy.coordinates import Longitude, Latitude, EarthLocation
+from astropy.coordinates.sites import get_builtin_sites, get_downloaded_sites, SiteRegistry
 
 
 def test_builtin_sites():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -12,23 +12,23 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 
-from ... import units as u
-from ...tests.helper import (catch_warnings,
+from astropy import units as u
+from astropy.tests.helper import (catch_warnings,
                              assert_quantity_allclose as assert_allclose)
-from ..representation import REPRESENTATION_CLASSES
-from ...coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
+from astropy.coordinates.representation import REPRESENTATION_CLASSES
+from astropy.coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                             SphericalRepresentation, CartesianRepresentation,
                             UnitSphericalRepresentation, AltAz,
                             BaseCoordinateFrame, Attribute,
                             frame_transform_graph, RepresentationMapping)
-from ...coordinates import Latitude, EarthLocation
-from ...time import Time
-from ...utils import minversion, isiterable
-from ...utils.compat import NUMPY_LT_1_14
-from ...utils.exceptions import AstropyDeprecationWarning
-from ...units import allclose as quantity_allclose
-from ...io import fits
-from ...wcs import WCS
+from astropy.coordinates import Latitude, EarthLocation
+from astropy.time import Time
+from astropy.utils import minversion, isiterable
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.units import allclose as quantity_allclose
+from astropy.io import fits
+from astropy.wcs import WCS
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -583,7 +583,7 @@ def test_position_angle():
 
 def test_position_angle_directly():
     """Regression check for #3800: position_angle should accept floats."""
-    from ..angle_utilities import position_angle
+    from astropy.coordinates.angle_utilities import position_angle
     result = position_angle(10., 20., 10., 20.)
     assert result.unit is u.radian
     assert result.value == 0.
@@ -677,7 +677,7 @@ def test_table_to_coord():
 
     (Regression test for #1762 )
     """
-    from ...table import Table, Column
+    from astropy.table import Table, Column
 
     t = Table()
     t.add_column(Column(data=[1, 2, 3], name='ra', unit=u.deg))
@@ -900,9 +900,9 @@ def test_nodata_failure():
                                           ('all', 0),
                                           ('all', 1)])
 def test_wcs_methods(mode, origin):
-    from ...wcs import WCS
-    from ...utils.data import get_pkg_data_contents
-    from ...wcs.utils import pixel_to_skycoord
+    from astropy.wcs import WCS
+    from astropy.utils.data import get_pkg_data_contents
+    from astropy.wcs.utils import pixel_to_skycoord
 
     header = get_pkg_data_contents('../../wcs/tests/maps/1904-66_TAN.hdr', encoding='binary')
     wcs = WCS(header)
@@ -1017,7 +1017,7 @@ def test_search_around():
     Here we don't actually test the values are right, just that the methods of
     SkyCoord work.  The accuracy tests are in ``test_matching.py``
     """
-    from ...utils import NumpyRNGContext
+    from astropy.utils import NumpyRNGContext
 
     with NumpyRNGContext(987654321):
         sc1 = SkyCoord(np.random.rand(20) * 360.*u.degree,
@@ -1058,8 +1058,8 @@ def test_init_with_frame_instance_keyword():
 
 
 def test_guess_from_table():
-    from ...table import Table, Column
-    from ...utils import NumpyRNGContext
+    from astropy.table import Table, Column
+    from astropy.utils import NumpyRNGContext
 
     tab = Table()
     with NumpyRNGContext(987654321):
@@ -1324,7 +1324,7 @@ def test_frame_attr_changes():
 
 
 def test_cache_clear_sc():
-    from .. import SkyCoord
+    from astropy.coordinates import SkyCoord
 
     i = SkyCoord(1*u.deg, 2*u.deg)
 
@@ -1537,7 +1537,7 @@ def test_none_differential_type():
     """
     This is a regression test for #8021
     """
-    from .. import BaseCoordinateFrame
+    from astropy.coordinates import BaseCoordinateFrame
 
     class MockHeliographicStonyhurst(BaseCoordinateFrame):
         default_representation = SphericalRepresentation

--- a/astropy/coordinates/tests/test_sky_coord_velocities.py
+++ b/astropy/coordinates/tests/test_sky_coord_velocities.py
@@ -12,9 +12,9 @@ import pytest
 
 import numpy as np
 
-from ... import units as u
-from ...tests.helper import assert_quantity_allclose
-from .. import (SkyCoord, ICRS, SphericalRepresentation, SphericalDifferential,
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.coordinates import (SkyCoord, ICRS, SphericalRepresentation, SphericalDifferential,
                 SphericalCosLatDifferential, CartesianRepresentation,
                 CartesianDifferential, Galactic, PrecessedGeocentric)
 

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -4,12 +4,12 @@
 import pytest
 import numpy as np
 
-from ... import units as u
-from ..distances import Distance
-from ..builtin_frames import ICRS, FK5, Galactic, AltAz, SkyOffsetFrame
-from .. import SkyCoord, EarthLocation
-from ...time import Time
-from ...tests.helper import assert_quantity_allclose as assert_allclose
+from astropy import units as u
+from astropy.coordinates.distances import Distance
+from astropy.coordinates.builtin_frames import ICRS, FK5, Galactic, AltAz, SkyOffsetFrame
+from astropy.coordinates import SkyCoord, EarthLocation
+from astropy.time import Time
+from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
 
 @pytest.mark.parametrize("inradec,expectedlatlon, tolsep", [

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -2,18 +2,18 @@
 import pytest
 import numpy as np
 
-from ...time import Time
-from ... import units as u
-from ...constants import c
-from ..builtin_frames import GCRS
-from ..earth import EarthLocation
-from ..sky_coordinate import SkyCoord
-from ..solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
+from astropy.time import Time
+from astropy import units as u
+from astropy.constants import c
+from astropy.coordinates.builtin_frames import GCRS
+from astropy.coordinates.earth import EarthLocation
+from astropy.coordinates.sky_coordinate import SkyCoord
+from astropy.coordinates.solar_system import (get_body, get_moon, BODY_NAME_TO_KERNEL_SPEC,
                             _apparent_position_in_true_coordinates,
                             get_body_barycentric, get_body_barycentric_posvel)
-from ..funcs import get_sun
-from ...tests.helper import assert_quantity_allclose
-from ...units import allclose as quantity_allclose
+from astropy.coordinates.funcs import get_sun
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import allclose as quantity_allclose
 
 try:
     import jplephem  # pylint: disable=W0611

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -5,15 +5,15 @@
 import numpy as np
 import pytest
 
-from ... import units as u
-from .. import transformations as t
-from ..builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, AltAz
-from .. import representation as r
-from ..baseframe import frame_transform_graph
-from ...tests.helper import (assert_quantity_allclose as assert_allclose,
+from astropy import units as u
+from astropy.coordinates import transformations as t
+from astropy.coordinates.builtin_frames import ICRS, FK5, FK4, FK4NoETerms, Galactic, AltAz
+from astropy.coordinates import representation as r
+from astropy.coordinates.baseframe import frame_transform_graph
+from astropy.tests.helper import (assert_quantity_allclose as assert_allclose,
                              catch_warnings)
-from ...time import Time
-from ...units import allclose as quantity_allclose
+from astropy.time import Time
+from astropy.units import allclose as quantity_allclose
 
 
 # Coordinates just for these tests.
@@ -138,8 +138,8 @@ def test_sphere_cart():
     """
     Tests the spherical <-> cartesian transform functions
     """
-    from ...utils import NumpyRNGContext
-    from .. import spherical_to_cartesian, cartesian_to_spherical
+    from astropy.utils import NumpyRNGContext
+    from astropy.coordinates import spherical_to_cartesian, cartesian_to_spherical
 
     x, y, z = spherical_to_cartesian(1, 0, 0)
     assert_allclose(x, 1)
@@ -392,7 +392,7 @@ def test_unit_spherical_with_differentials(rep):
 
 def test_vel_transformation_obstime_err():
     # TODO: replace after a final decision on PR #6280
-    from ..sites import get_builtin_sites
+    from astropy.coordinates.sites import get_builtin_sites
 
     diff = r.CartesianDifferential([.1, .2, .3]*u.km/u.s)
     rep = r.CartesianRepresentation([1, 2, 3]*u.au, differentials=diff)
@@ -438,8 +438,8 @@ def test_frame_override_component_with_attribute():
     It was previously possible to define a frame with an attribute with the
     same name as a component. We don't want to allow this!
     """
-    from ..baseframe import BaseCoordinateFrame
-    from ..attributes import Attribute
+    from astropy.coordinates.baseframe import BaseCoordinateFrame
+    from astropy.coordinates.attributes import Attribute
 
     class BorkedFrame(BaseCoordinateFrame):
         ra = Attribute(default=150)
@@ -464,8 +464,8 @@ def test_static_matrix_combine_paths():
 
     This is somewhat of a regression test for #7706
     """
-    from ..baseframe import BaseCoordinateFrame
-    from ..matrix_utilities import rotation_matrix
+    from astropy.coordinates.baseframe import BaseCoordinateFrame
+    from astropy.coordinates.matrix_utilities import rotation_matrix
 
     class AFrame(BaseCoordinateFrame):
         default_representation = r.SphericalRepresentation

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -3,11 +3,11 @@ import pytest
 
 import numpy as np
 
-from ...tests.helper import assert_quantity_allclose
-from ... import units as u
-from ...time import Time
-from .. import EarthLocation, SkyCoord, Angle
-from ..sites import get_builtin_sites
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
+from astropy.time import Time
+from astropy.coordinates import EarthLocation, SkyCoord, Angle
+from astropy.coordinates.sites import get_builtin_sites
 
 
 @pytest.mark.parametrize('kind', ['heliocentric', 'barycentric'])
@@ -248,7 +248,7 @@ def _get_barycorr_bvcs(coos, loc, injupyter=False):
     the tests.
     """
     import barycorr
-    from ...utils.console import ProgressBar
+    from astropy.utils.console import ProgressBar
 
     bvcs = []
     for ra, dec in ProgressBar(list(zip(coos.ra.deg, coos.dec.deg)),

--- a/astropy/coordinates/tests/utils.py
+++ b/astropy/coordinates/tests/utils.py
@@ -4,8 +4,8 @@
 
 import numpy as np
 
-from ... import units as u
-from ...utils import NumpyRNGContext
+from astropy import units as u
+from astropy.utils import NumpyRNGContext
 
 
 def randomly_sample_sphere(ntosample, randomseed=12345):

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -27,8 +27,8 @@ from inspect import signature
 
 import numpy as np
 
-from .. import units as u
-from ..utils.exceptions import AstropyWarning
+from astropy import units as u
+from astropy.utils.exceptions import AstropyWarning
 
 from .representation import REPRESENTATION_CLASSES
 from .matrix_utilities import matrix_product

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -10,10 +10,10 @@ import numpy as np
 
 from . import scalar_inv_efuncs
 
-from .. import constants as const
-from .. import units as u
-from ..utils import isiterable
-from ..utils.state import ScienceState
+from astropy import constants as const
+from astropy import units as u
+from astropy.utils import isiterable
+from astropy.utils.state import ScienceState
 
 from . import parameters
 

--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 
 from .core import CosmologyError
-from ..units import Quantity
+from astropy.units import Quantity
 
 __all__ = ['z_at_value']
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -5,10 +5,10 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from .. import core, funcs
-from ...units import allclose
-from ...utils.compat import NUMPY_LT_1_14
-from ... import units as u
+from astropy.cosmology import core, funcs
+from astropy.units import allclose
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy import units as u
 
 try:
     import scipy  # pylint: disable=W0611

--- a/astropy/cosmology/tests/test_pickle.py
+++ b/astropy/cosmology/tests/test_pickle.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from ...tests.helper import pickle_protocol, check_pickling_recovery
-from ... import cosmology as cosm
+from astropy.tests.helper import pickle_protocol, check_pickling_recovery
+from astropy import cosmology as cosm
 
 originals = [cosm.FLRW]
 xfails = [False]

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -18,7 +18,7 @@ from contextlib import suppress
 from . import core
 from . import fixedwidth
 
-from ...units import Unit
+from astropy.units import Unit
 
 
 __doctest_skip__ = ['*']

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -5,8 +5,8 @@
 import re
 import functools
 
-from .. import registry as io_registry
-from ...table import Table
+from astropy.io import registry as io_registry
+from astropy.table import Table
 
 __all__ = []
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -24,10 +24,10 @@ from io import StringIO
 
 import numpy
 
-from ...utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 
-from ...table import Table
-from ...utils.data import get_readable_fileobj
+from astropy.table import Table
+from astropy.utils.data import get_readable_fileobj
 from . import connect
 
 # Global dictionary mapping format arg to the corresponding Reader class

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -10,9 +10,9 @@ import contextlib
 import warnings
 
 from . import core, basic
-from ...table import meta, serialize
-from ...utils.data_info import serialize_context_as
-from ...utils.exceptions import AstropyWarning
+from astropy.table import meta, serialize
+from astropy.utils.data_info import serialize_context_as
+from astropy.utils.exceptions import AstropyWarning
 
 __doctest_requires__ = {'Ecsv': ['yaml']}
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -5,9 +5,9 @@ import copy
 from collections import OrderedDict
 
 from . import core
-from ...table import Table
+from astropy.table import Table
 from . import cparser
-from ...utils import set_locale
+from astropy.utils import set_locale
 
 
 class FastBasic(metaclass=core.MetaBaseReader):

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -14,8 +14,8 @@ import numpy
 
 
 from . import core
-from ...table import Column
-from ...utils.xml import writer
+from astropy.table import Column
+from astropy.utils.xml import writer
 
 from copy import deepcopy
 

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -18,8 +18,8 @@ from warnings import warn
 from . import core
 from . import fixedwidth
 from . import basic
-from ...utils.exceptions import AstropyUserWarning
-from ...table.pprint import get_auto_format_func
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.table.pprint import get_auto_format_func
 
 
 class IpacFormatErrorDBMS(Exception):

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -10,11 +10,11 @@ import pytest
 import numpy as np
 from numpy import ma
 
-from ....table import Table, MaskedColumn
-from ... import ascii
-from ...ascii.core import ParameterError, FastOptionsError, InconsistentTableError
-from ...ascii.cparser import CParserError
-from ..fastbasic import (
+from astropy.table import Table, MaskedColumn
+from astropy.io import ascii
+from astropy.io.ascii.core import ParameterError, FastOptionsError, InconsistentTableError
+from astropy.io.ascii.cparser import CParserError
+from astropy.io.ascii.fastbasic import (
     FastBasic, FastCsv, FastTab, FastCommentedHeader, FastRdb, FastNoHeader)
 from .common import assert_equal, assert_almost_equal, assert_true
 

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ... import ascii
+from astropy.io import ascii
 from .common import (assert_equal, assert_almost_equal, has_isnan,
                      setup_function, teardown_function)
 
@@ -149,7 +149,7 @@ def test_header_from_readme():
 
 
 def test_cds_units():
-    from .... import units
+    from astropy import units
     data_and_readme = 't/cds.dat'
     reader = ascii.get_reader(ascii.Cds)
     table = reader.read(data_and_readme)

--- a/astropy/io/ascii/tests/test_compressed.py
+++ b/astropy/io/ascii/tests/test_compressed.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 import numpy as np
 
-from .. import read
+from astropy.io.ascii import read
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -3,9 +3,9 @@ import os
 
 import pytest
 
-from ....table import Table, Column
+from astropy.table import Table, Column
 
-from ....table.table_helpers import simple_table
+from astropy.table.table_helpers import simple_table
 
 import numpy as np
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -14,17 +14,17 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from ....table import Table, Column, QTable, NdarrayMixin
-from ....table.table_helpers import simple_table
-from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
-from ....time import Time, TimeDelta
-from ....units import allclose as quantity_allclose
-from ....units import QuantityInfo
-from ....tests.helper import catch_warnings
+from astropy.table import Table, Column, QTable, NdarrayMixin
+from astropy.table.table_helpers import simple_table
+from astropy.coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from astropy.time import Time, TimeDelta
+from astropy.units import allclose as quantity_allclose
+from astropy.units import QuantityInfo
+from astropy.tests.helper import catch_warnings
 
-from ..ecsv import DELIMITERS
-from ... import ascii
-from .... import units as u
+from astropy.io.ascii.ecsv import DELIMITERS
+from astropy.io import ascii
+from astropy import units as u
 
 try:
     import yaml  # pylint: disable=W0611

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -5,8 +5,8 @@ from io import StringIO
 
 import pytest
 
-from ... import ascii
-from ..core import InconsistentTableError
+from astropy.io import ascii
+from astropy.io.ascii.core import InconsistentTableError
 from .common import (assert_equal, assert_almost_equal)
 
 

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -12,16 +12,16 @@ to be installed.
 
 from io import StringIO
 
-from .. import html
-from .. import core
-from ....table import Table
+from astropy.io.ascii import html
+from astropy.io.ascii import core
+from astropy.table import Table
 
 import pytest
 import numpy as np
 
 from .common import setup_function, teardown_function
-from ... import ascii
-from ....utils.xml.writer import HAS_BLEACH
+from astropy.io import ascii
+from astropy.utils.xml.writer import HAS_BLEACH
 
 # Check to see if the BeautifulSoup dependency is present.
 try:

--- a/astropy/io/ascii/tests/test_ipac_definitions.py
+++ b/astropy/io/ascii/tests/test_ipac_definitions.py
@@ -5,12 +5,12 @@ from io import StringIO
 
 import pytest
 
-from ..ui import read
-from ..ipac import Ipac, IpacFormatError, IpacFormatErrorDBMS
-from ....tests.helper import catch_warnings
-from ... import ascii
-from ....table import Table, Column
-from ..core import masked
+from astropy.io.ascii.ui import read
+from astropy.io.ascii.ipac import Ipac, IpacFormatError, IpacFormatErrorDBMS
+from astropy.tests.helper import catch_warnings
+from astropy.io import ascii
+from astropy.table import Table, Column
+from astropy.io.ascii.core import masked
 
 
 DATA = '''

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -13,16 +13,16 @@ import pathlib
 import pytest
 import numpy as np
 
-from ... import ascii
-from ....table import Table
-from .... import table
-from ....units import Unit
-from ....table.table_helpers import simple_table
+from astropy.io import ascii
+from astropy.table import Table
+from astropy import table
+from astropy.units import Unit
+from astropy.table.table_helpers import simple_table
 
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true)
-from .. import core
-from ..ui import _probably_html, get_read_trace, cparser
+from astropy.io.ascii import core
+from astropy.io.ascii.ui import _probably_html, get_read_trace, cparser
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import setup_function, teardown_function

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -2,7 +2,7 @@
 
 from io import StringIO
 
-from ... import ascii
+from astropy.io import ascii
 from .common import (assert_equal, assert_almost_equal)
 
 

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -5,7 +5,7 @@ from io import StringIO
 
 import numpy as np
 
-from ... import ascii
+from astropy.io import ascii
 
 from .common import assert_equal
 

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -10,12 +10,12 @@ from itertools import chain
 import pytest
 import numpy as np
 
-from ... import ascii
-from .... import table
-from ....table.table_helpers import simple_table
-from ....tests.helper import catch_warnings
-from ....utils.exceptions import AstropyWarning, AstropyDeprecationWarning
-from .... import units
+from astropy.io import ascii
+from astropy import table
+from astropy.table.table_helpers import simple_table
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy import units
 
 from .common import setup_function, teardown_function
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -34,9 +34,9 @@ from . import fastbasic
 from . import cparser
 from . import fixedwidth
 
-from ...table import Table, vstack, MaskedColumn
-from ...utils.data import get_readable_fileobj
-from ...utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.table import Table, vstack, MaskedColumn
+from astropy.utils.data import get_readable_fileobj
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 _read_trace = []
 

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -12,7 +12,7 @@ standard, see the NASA/Science Office of Standards and Technology
 publication, NOST 100-2.0.
 """
 
-from ... import config as _config
+from astropy import config as _config
 
 # Set module-global boolean variables
 # TODO: Make it possible to set these variables via environment variables

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -9,7 +9,7 @@ from .util import _str_to_num, _is_int, translate, _words_group
 from .verify import _Verify, _ErrList, VerifyError, VerifyWarning
 
 from . import conf
-from ...utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['Card', 'Undefined']

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -20,8 +20,8 @@ from .util import (pairwise, _is_int, _convert_array, encode_ascii, cmp,
                    NotifierMixin)
 from .verify import VerifyError, VerifyWarning
 
-from ...utils import lazyproperty, isiterable, indent
-from ...utils.exceptions import AstropyUserWarning
+from astropy.utils import lazyproperty, isiterable, indent
+from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ['Column', 'ColDefs', 'Delayed']
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -6,13 +6,13 @@ import re
 import warnings
 from collections import OrderedDict
 
-from .. import registry as io_registry
-from ... import units as u
-from ...table import Table, serialize, meta, Column, MaskedColumn
-from ...table.table import has_info_class
-from ...time import Time
-from ...utils.exceptions import AstropyUserWarning
-from ...utils.data_info import MixinInfo, serialize_context_as
+from astropy.io import registry as io_registry
+from astropy import units as u
+from astropy.table import Table, serialize, meta, Column, MaskedColumn
+from astropy.table.table import has_info_class
+from astropy.time import Time
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.data_info import MixinInfo, serialize_context_as
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES, ASCII_DEFAULT_WIDTHS, _fortran_to_python_format
 from .convenience import table_to_hdu

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -69,8 +69,8 @@ from .hdu.image import PrimaryHDU, ImageHDU
 from .hdu.table import BinTableHDU
 from .header import Header
 from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
-from ...utils.exceptions import AstropyUserWarning
-from ...utils.decorators import deprecated_renamed_argument
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
@@ -450,9 +450,9 @@ def table_to_hdu(table, character_as_bytes=False):
     if table.has_mixin_columns:
         # Import is done here, in order to avoid it at build time as erfa is not
         # yet available then.
-        from ...table.column import BaseColumn
-        from ...time import Time
-        from ...units import Quantity
+        from astropy.table.column import BaseColumn
+        from astropy.time import Time
+        from astropy.units import Quantity
         from .fitstime import time_to_fits
 
         # Only those columns which are instances of BaseColumn, Quantity or Time can
@@ -512,8 +512,8 @@ def table_to_hdu(table, character_as_bytes=False):
         if unit is not None:
             # Local imports to avoid importing units when it is not required,
             # e.g. for command-line scripts
-            from ...units import Unit
-            from ...units.format.fits import UnitScaleError
+            from astropy.units import Unit
+            from astropy.units.format.fits import UnitScaleError
             try:
                 col.unit = unit.to_string(format='fits')
             except UnitScaleError:

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -19,16 +19,16 @@ from itertools import islice
 
 import numpy as np
 
-from ... import __version__
+from astropy import __version__
 
 from .card import Card, BLANK_CARD
 from .header import Header
-from ...utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated_renamed_argument
 # HDUList is used in one of the doctests
 from .hdu.hdulist import fitsopen, HDUList  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
-from ...utils.exceptions import AstropyDeprecationWarning
-from ...utils.diff import (report_diff_values, fixed_width_indent,
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.diff import (report_diff_values, fixed_width_indent,
                            where_not_allclose, diff_values)
 
 __all__ = ['FITSDiff', 'HDUDiff', 'HeaderDiff', 'ImageDataDiff', 'RawDataDiff',

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -23,9 +23,9 @@ import numpy as np
 from .util import (isreadable, iswritable, isfile, fileobj_open, fileobj_name,
                    fileobj_closed, fileobj_mode, _array_from_file,
                    _array_to_file, _write_string)
-from ...utils.data import download_file, _is_url
-from ...utils.decorators import classproperty, deprecated_renamed_argument
-from ...utils.exceptions import AstropyUserWarning
+from astropy.utils.data import download_file, _is_url
+from astropy.utils.decorators import classproperty, deprecated_renamed_argument
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 # Maps astropy.io.fits-specific file mode names to the appropriate file

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -16,7 +16,7 @@ from .column import (ASCIITNULL, FITS2NUMPY, ASCII2NUMPY, ASCII2STR, ColDefs,
                      _AsciiColDefs, _FormatX, _FormatP, _VLF, _get_index,
                      _wrapx, _unwrapx, _makep, Delayed)
 from .util import decode_ascii, encode_ascii, _rstrip_inplace
-from ...utils import lazyproperty
+from astropy.utils import lazyproperty
 
 
 class FITS_record:

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -8,13 +8,13 @@ import numpy as np
 
 from . import Header, Card
 
-from ... import units as u
-from ...coordinates import EarthLocation
-from ...table import Column
-from ...time import Time, TimeDelta
-from ...time.core import BARYCENTRIC_SCALES
-from ...time.formats import FITS_DEPRECATED_SCALES
-from ...utils.exceptions import AstropyUserWarning
+from astropy import units as u
+from astropy.coordinates import EarthLocation
+from astropy.table import Column
+from astropy.time import Time, TimeDelta
+from astropy.time.core import BARYCENTRIC_SCALES
+from astropy.time.formats import FITS_DEPRECATED_SCALES
+from astropy.utils.exceptions import AstropyUserWarning
 
 # The following is based on the FITS WCS Paper IV, "Representations of time
 # coordinates in FITS".

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -11,17 +11,17 @@ from inspect import signature, Parameter
 
 import numpy as np
 
-from .. import conf
-from ..file import _File
-from ..header import Header, _pad_length
-from ..util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
+from astropy.io.fits import conf
+from astropy.io.fits.file import _File
+from astropy.io.fits.header import Header, _pad_length
+from astropy.io.fits.util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
                     itersubclasses, decode_ascii, _get_array_mmap, first,
                     _free_space_check, _extract_number)
-from ..verify import _Verify, _ErrList
+from astropy.io.fits.verify import _Verify, _ErrList
 
-from ....utils import lazyproperty
-from ....utils.exceptions import AstropyUserWarning
-from ....utils.decorators import deprecated_renamed_argument
+from astropy.utils import lazyproperty
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 class _Delayed:

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -14,20 +14,20 @@ import numpy as np
 from .base import DELAYED, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
 from .image import ImageHDU
 from .table import BinTableHDU
-from ..card import Card
-from ..column import Column, ColDefs, TDEF_RE
-from ..column import KEYWORD_NAMES as TABLE_KEYWORD_NAMES
-from ..fitsrec import FITS_rec
-from ..header import Header
-from ..util import (_is_pseudo_unsigned, _unsigned_zero, _is_int,
+from astropy.io.fits.card import Card
+from astropy.io.fits.column import Column, ColDefs, TDEF_RE
+from astropy.io.fits.column import KEYWORD_NAMES as TABLE_KEYWORD_NAMES
+from astropy.io.fits.fitsrec import FITS_rec
+from astropy.io.fits.header import Header
+from astropy.io.fits.util import (_is_pseudo_unsigned, _unsigned_zero, _is_int,
                     _get_array_mmap)
 
-from ....utils import lazyproperty
-from ....utils.exceptions import (AstropyPendingDeprecationWarning,
+from astropy.utils import lazyproperty
+from astropy.utils.exceptions import (AstropyPendingDeprecationWarning,
                                   AstropyUserWarning)
 
 try:
-    from .. import compression
+    from astropy.io.fits import compression
     COMPRESSION_SUPPORTED = COMPRESSION_ENABLED = True
 except ImportError:
     COMPRESSION_SUPPORTED = COMPRESSION_ENABLED = False

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -6,11 +6,11 @@ import numpy as np
 from .base import DTYPE2BITPIX
 from .image import PrimaryHDU
 from .table import _TableLikeHDU
-from ..column import Column, ColDefs, FITS2NUMPY
-from ..fitsrec import FITS_rec, FITS_record
-from ..util import _is_int, _is_pseudo_unsigned, _unsigned_zero
+from astropy.io.fits.column import Column, ColDefs, FITS2NUMPY
+from astropy.io.fits.fitsrec import FITS_rec, FITS_record
+from astropy.io.fits.util import _is_int, _is_pseudo_unsigned, _unsigned_zero
 
-from ....utils import lazyproperty
+from astropy.utils import lazyproperty
 
 
 class Group(FITS_record):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -15,14 +15,14 @@ from . import compressed
 from .base import _BaseHDU, _ValidHDU, _NonstandardHDU, ExtensionHDU
 from .groups import GroupsHDU
 from .image import PrimaryHDU, ImageHDU
-from ..file import _File, FILE_MODES
-from ..header import _pad_length
-from ..util import (_is_int, _tmp_name, fileobj_closed, ignore_sigint,
+from astropy.io.fits.file import _File, FILE_MODES
+from astropy.io.fits.header import _pad_length
+from astropy.io.fits.util import (_is_int, _tmp_name, fileobj_closed, ignore_sigint,
                     _get_array_mmap, _free_space_check, fileobj_mode, isfile)
-from ..verify import _Verify, _ErrList, VerifyError, VerifyWarning
-from ....utils import indent
-from ....utils.exceptions import AstropyUserWarning
-from ....utils.decorators import deprecated_renamed_argument
+from astropy.io.fits.verify import _Verify, _ErrList, VerifyError, VerifyWarning
+from astropy.utils import indent
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
@@ -127,7 +127,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
 
     """
 
-    from .. import conf
+    from astropy.io.fits import conf
 
     if memmap is None:
         # distinguish between True (kwarg explicitly set)

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -6,11 +6,11 @@ import warnings
 import numpy as np
 
 from .base import DELAYED, _ValidHDU, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
-from ..header import Header
-from ..util import _is_pseudo_unsigned, _unsigned_zero, _is_int
-from ..verify import VerifyWarning
+from astropy.io.fits.header import Header
+from astropy.io.fits.util import _is_pseudo_unsigned, _unsigned_zero, _is_int
+from astropy.io.fits.verify import VerifyWarning
 
-from ....utils import isiterable, lazyproperty
+from astropy.utils import isiterable, lazyproperty
 
 
 class _ImageBaseHDU(_ValidHDU):

--- a/astropy/io/fits/hdu/nonstandard.py
+++ b/astropy/io/fits/hdu/nonstandard.py
@@ -3,13 +3,13 @@
 import gzip
 import io
 
-from ..file import _File
+from astropy.io.fits.file import _File
 from .base import NonstandardExtHDU
 from .hdulist import HDUList
-from ..header import Header, _pad_length
-from ..util import fileobj_name
+from astropy.io.fits.header import Header, _pad_length
+from astropy.io.fits.util import fileobj_name
 
-from ....utils import lazyproperty
+from astropy.utils import lazyproperty
 
 
 class FitsHDU(NonstandardExtHDU):

--- a/astropy/io/fits/hdu/streaming.py
+++ b/astropy/io/fits/hdu/streaming.py
@@ -7,9 +7,9 @@ from .base import _BaseHDU, BITPIX2DTYPE
 from .hdulist import HDUList
 from .image import PrimaryHDU
 
-from ..file import _File
-from ..header import _pad_length
-from ..util import fileobj_name
+from astropy.io.fits.file import _File
+from astropy.io.fits.header import _pad_length
+from astropy.io.fits.util import fileobj_name
 
 
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -18,18 +18,18 @@ from .base import DELAYED, _ValidHDU, ExtensionHDU
 # This module may have many dependencies on astropy.io.fits.column, but
 # astropy.io.fits.column has fewer dependencies overall, so it's easier to
 # keep table/column-related utilities in astropy.io.fits.column
-from ..column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
+from astropy.io.fits.column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
                       ATTRIBUTE_TO_KEYWORD, TDEF_RE, Column, ColDefs,
                       _AsciiColDefs, _FormatP, _FormatQ, _makep,
                       _parse_tformat, _scalar_to_format, _convert_format,
                       _cmp_recformats)
-from ..fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
-from ..header import Header, _pad_length
-from ..util import _is_int, _str_to_num
+from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
+from astropy.io.fits.header import Header, _pad_length
+from astropy.io.fits.util import _is_int, _str_to_num
 
-from ....utils import lazyproperty
-from ....utils.exceptions import AstropyDeprecationWarning
-from ....utils.decorators import deprecated_renamed_argument
+from astropy.utils import lazyproperty
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 class FITSTableDumpDialect(csv.excel):
@@ -843,9 +843,9 @@ class BinTableHDU(_TableBaseHDU):
 
     def __init__(self, data=None, header=None, name=None, uint=False, ver=None,
                  character_as_bytes=False):
-        from ....table import Table
+        from astropy.table import Table
         if isinstance(data, Table):
-            from ..convenience import table_to_hdu
+            from astropy.io.fits.convenience import table_to_hdu
             hdu = table_to_hdu(data)
             if header is not None:
                 hdu.header.update(header)

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -10,9 +10,9 @@ from .card import Card, _pad, KEYWORD_LENGTH
 from .file import _File
 from .util import encode_ascii, decode_ascii, fileobj_closed, fileobj_is_binary
 
-from ...utils import isiterable
-from ...utils.exceptions import AstropyUserWarning
-from ...utils.decorators import deprecated_renamed_argument
+from astropy.utils import isiterable
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 BLOCK_SIZE = 2880  # the FITS block size

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -46,8 +46,8 @@ import os
 import sys
 import textwrap
 
-from ....tests.helper import catch_warnings
-from ... import fits
+from astropy.tests.helper import catch_warnings
+from astropy.io import fits
 
 
 log = logging.getLogger('fitscheck')

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -7,9 +7,9 @@ import sys
 import textwrap
 import warnings
 
-from ... import fits
-from ..util import fill
-from ....utils.exceptions import AstropyDeprecationWarning
+from astropy.io import fits
+from astropy.io.fits.util import fill
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 log = logging.getLogger('fitsdiff')

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -62,8 +62,8 @@ import argparse
 
 import numpy as np
 
-from ... import fits
-from .... import log
+from astropy.io import fits
+from astropy import log
 
 
 class ExtensionNotFoundException(Exception):
@@ -243,7 +243,7 @@ class TableHeaderFormatter(HeaderFormatter):
                 pass
 
         if tablerows:
-            from .... import table
+            from astropy import table
             return table.Table(tablerows)
         return None
 
@@ -294,7 +294,7 @@ def print_headers_as_table(args):
     elif len(tables) == 1:
         resulting_table = tables[0]
     else:
-        from .... import table
+        from astropy import table
         resulting_table = table.vstack(tables)
     # Print the string representation of the concatenated table
     resulting_table.write(sys.stdout, format=args.table)
@@ -310,7 +310,7 @@ def print_headers_as_comparison(args):
     args : argparse.Namespace
         Arguments passed from the command-line as defined below.
     """
-    from .... import table
+    from astropy import table
     tables = []
     # Create a Table object for each file
     for filename in args.filename:  # Support wildcards

--- a/astropy/io/fits/tests/__init__.py
+++ b/astropy/io/fits/tests/__init__.py
@@ -6,7 +6,7 @@ import stat
 import tempfile
 import time
 
-from ... import fits
+from astropy.io import fits
 
 
 class FitsTestCase:

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -7,8 +7,8 @@ import pytest
 import numpy as np
 
 from .test_table import comparerecords
-from ..hdu.base import _ValidHDU
-from ....io import fits
+from astropy.io.fits.hdu.base import _ValidHDU
+from astropy.io import fits
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_compression_failures.py
+++ b/astropy/io/fits/tests/test_compression_failures.py
@@ -3,8 +3,8 @@
 import pytest
 import numpy as np
 
-from ....io import fits
-from ..compression import compress_hdu
+from astropy.io import fits
+from astropy.io.fits.compression import compress_hdu
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -7,23 +7,23 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ..column import (_parse_tdisp_format, _fortran_to_python_format,
+from astropy.io.fits.column import (_parse_tdisp_format, _fortran_to_python_format,
                       python_to_tdisp)
 
-from .. import HDUList, PrimaryHDU, BinTableHDU
+from astropy.io.fits import HDUList, PrimaryHDU, BinTableHDU
 
-from ... import fits
+from astropy.io import fits
 
-from .... import units as u
-from ....table import Table, QTable, NdarrayMixin, Column
-from ....table.table_helpers import simple_table
-from ....tests.helper import catch_warnings
-from ....units.format.fits import UnitScaleError
-from ....utils.exceptions import AstropyUserWarning
+from astropy import units as u
+from astropy.table import Table, QTable, NdarrayMixin, Column
+from astropy.table.table_helpers import simple_table
+from astropy.tests.helper import catch_warnings
+from astropy.units.format.fits import UnitScaleError
+from astropy.utils.exceptions import AstropyUserWarning
 
-from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
-from ....time import Time, TimeDelta
-from ....units.quantity import QuantityInfo
+from astropy.coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from astropy.time import Time, TimeDelta
+from astropy.units.quantity import QuantityInfo
 
 try:
     import yaml  # pylint: disable=W0611

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -7,10 +7,10 @@ import warnings
 import pytest
 import numpy as np
 
-from ....io import fits
-from ....table import Table
-from .. import printdiff
-from ....tests.helper import catch_warnings
+from astropy.io import fits
+from astropy.table import Table
+from astropy.io.fits import printdiff
+from astropy.tests.helper import catch_warnings
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -16,15 +16,15 @@ import numpy as np
 
 from . import FitsTestCase
 
-from ..convenience import _getext
-from ..diff import FITSDiff
-from ..file import _File, GZIP_MAGIC
+from astropy.io.fits.convenience import _getext
+from astropy.io.fits.diff import FITSDiff
+from astropy.io.fits.file import _File, GZIP_MAGIC
 
-from ....io import fits
-from ....tests.helper import raises, catch_warnings, ignore_warnings
-from ....utils.data import conf, get_pkg_data_filename
-from ....utils.exceptions import AstropyUserWarning
-from ....utils import data
+from astropy.io import fits
+from astropy.tests.helper import raises, catch_warnings, ignore_warnings
+from astropy.utils.data import conf, get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils import data
 
 
 class TestCore(FitsTestCase):

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -2,16 +2,16 @@
 import pytest
 import numpy as np
 
-from ..column import Column
-from ..diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
+from astropy.io.fits.column import Column
+from astropy.io.fits.diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
                     HDUDiff)
-from ..hdu import HDUList, PrimaryHDU, ImageHDU
-from ..hdu.table import BinTableHDU
-from ..header import Header
+from astropy.io.fits.hdu import HDUList, PrimaryHDU, ImageHDU
+from astropy.io.fits.hdu.table import BinTableHDU
+from astropy.io.fits.header import Header
 
-from ....tests.helper import catch_warnings
-from ....utils.exceptions import AstropyDeprecationWarning
-from ....io import fits
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.io import fits
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -2,9 +2,9 @@
 
 import numpy as np
 
-from ....io import fits
+from astropy.io import fits
 from . import FitsTestCase
-from ....tests.helper import catch_warnings
+from astropy.tests.helper import catch_warnings
 
 
 class TestDivisionFunctions(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitscheck.py
+++ b/astropy/io/fits/tests/test_fitscheck.py
@@ -2,8 +2,8 @@
 
 import pytest
 from . import FitsTestCase
-from ..scripts import fitscheck
-from ... import fits
+from astropy.io.fits.scripts import fitscheck
+from astropy.io import fits
 
 
 class TestFitscheck(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -5,13 +5,13 @@ import pytest
 import os
 
 from . import FitsTestCase
-from ..convenience import writeto
-from ..hdu import PrimaryHDU, hdulist
-from .. import Header, ImageHDU, HDUList
-from ..scripts import fitsdiff
-from ....tests.helper import catch_warnings
-from ....utils.exceptions import AstropyDeprecationWarning
-from ....version import version
+from astropy.io.fits.convenience import writeto
+from astropy.io.fits.hdu import PrimaryHDU, hdulist
+from astropy.io.fits import Header, ImageHDU, HDUList
+from astropy.io.fits.scripts import fitsdiff
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.version import version
 
 
 class TestFITSDiff_script(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitsheader.py
+++ b/astropy/io/fits/tests/test_fitsheader.py
@@ -3,7 +3,7 @@
 import pytest
 
 from . import FitsTestCase
-from ..scripts import fitsheader
+from astropy.io.fits.scripts import fitsheader
 
 
 class TestFITSheader_script(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitsinfo.py
+++ b/astropy/io/fits/tests/test_fitsinfo.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from . import FitsTestCase
-from ..scripts import fitsinfo
+from astropy.io.fits.scripts import fitsinfo
 
 
 class TestFitsinfo(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -5,15 +5,15 @@ import numpy as np
 
 from . import FitsTestCase
 
-from ..fitstime import GLOBAL_TIME_INFO, time_to_fits, is_time_column_keyword
-from ....coordinates import EarthLocation
-from ....io import fits
-from ....table import Table, QTable
-from ....time import Time, TimeDelta
-from ....time.core import BARYCENTRIC_SCALES
-from ....time.formats import FITS_DEPRECATED_SCALES
-from ....tests.helper import catch_warnings
-from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.io.fits.fitstime import GLOBAL_TIME_INFO, time_to_fits, is_time_column_keyword
+from astropy.coordinates import EarthLocation
+from astropy.io import fits
+from astropy.table import Table, QTable
+from astropy.time import Time, TimeDelta
+from astropy.time.core import BARYCENTRIC_SCALES
+from astropy.time.formats import FITS_DEPRECATED_SCALES
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 
 class TestFitsTime(FitsTestCase):

--- a/astropy/io/fits/tests/test_groups.py
+++ b/astropy/io/fits/tests/test_groups.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from . import FitsTestCase
 from .test_table import comparerecords
-from ....io import fits
+from astropy.io import fits
 
 
 class TestGroupsFunctions(FitsTestCase):

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -11,10 +11,10 @@ import subprocess
 import pytest
 import numpy as np
 
-from ..verify import VerifyError
-from ....io import fits
-from ....tests.helper import raises, catch_warnings, ignore_warnings
-from ....utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.io.fits.verify import VerifyError
+from astropy.io import fits
+from astropy.tests.helper import raises, catch_warnings, ignore_warnings
+from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -10,15 +10,15 @@ from io import StringIO, BytesIO
 import pytest
 import numpy as np
 
-from ....io import fits
-from ....io.fits.verify import VerifyWarning
-from ....tests.helper import catch_warnings, ignore_warnings
-from ....utils.exceptions import AstropyUserWarning
+from astropy.io import fits
+from astropy.io.fits.verify import VerifyWarning
+from astropy.tests.helper import catch_warnings, ignore_warnings
+from astropy.utils.exceptions import AstropyUserWarning
 
 from . import FitsTestCase
-from ..card import _pad
-from ..header import _pad_length
-from ..util import encode_ascii
+from astropy.io.fits.card import _pad
+from astropy.io.fits.header import _pad_length
+from astropy.io.fits.util import encode_ascii
 
 
 def test_shallow_copy():
@@ -2678,7 +2678,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
 
     def test_fitsheader_script(self):
         """Tests the basic functionality of the `fitsheader` script."""
-        from ....io.fits.scripts import fitsheader
+        from astropy.io.fits.scripts import fitsheader
 
         # Can an extension by specified by the EXTNAME keyword?
         hf = fitsheader.HeaderFormatter(self.data('zerowidth.fits'))
@@ -2718,8 +2718,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
 
     def test_fitsheader_table_feature(self):
         """Tests the `--table` feature of the `fitsheader` script."""
-        from ....io import fits
-        from ....io.fits.scripts import fitsheader
+        from astropy.io import fits
+        from astropy.io.fits.scripts import fitsheader
         test_filename = self.data('zerowidth.fits')
         fitsobj = fits.open(test_filename)
         formatter = fitsheader.TableHeaderFormatter(test_filename)

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -12,10 +12,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from ....io import fits
-from ....utils.exceptions import AstropyPendingDeprecationWarning
-from ....tests.helper import raises, catch_warnings, ignore_warnings
-from ..hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
+from astropy.io import fits
+from astropy.utils.exceptions import AstropyPendingDeprecationWarning
+from astropy.tests.helper import raises, catch_warnings, ignore_warnings
+from astropy.io.fits.hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from .test_table import comparerecords
 
 from . import FitsTestCase

--- a/astropy/io/fits/tests/test_nonstandard.py
+++ b/astropy/io/fits/tests/test_nonstandard.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from ....io import fits
+from astropy.io import fits
 from . import FitsTestCase
 
 

--- a/astropy/io/fits/tests/test_structured.py
+++ b/astropy/io/fits/tests/test_structured.py
@@ -4,7 +4,7 @@ import sys
 
 import numpy as np
 
-from ....io import fits
+from astropy.io import fits
 from . import FitsTestCase
 
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -16,14 +16,14 @@ try:
 except ImportError:
     HAVE_OBJGRAPH = False
 
-from ....io import fits
-from ....tests.helper import catch_warnings, ignore_warnings
-from ....utils.compat import NUMPY_LT_1_14_1, NUMPY_LT_1_14_2
-from ....utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.io import fits
+from astropy.tests.helper import catch_warnings, ignore_warnings
+from astropy.utils.compat import NUMPY_LT_1_14_1, NUMPY_LT_1_14_2
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
-from ..column import Delayed, NUMPY2FITS
-from ..util import decode_ascii
-from ..verify import VerifyError
+from astropy.io.fits.column import Delayed, NUMPY2FITS
+from astropy.io.fits.util import decode_ascii
+from astropy.io.fits.verify import VerifyError
 from . import FitsTestCase
 
 
@@ -3113,7 +3113,7 @@ def test_regression_5383():
 
 
 def test_table_to_hdu():
-    from ....table import Table
+    from astropy.table import Table
     table = Table([[1, 2, 3], ['a', 'b', 'c'], [2.3, 4.5, 6.7]],
                     names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])
     table['a'].unit = 'm/s'

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -5,9 +5,9 @@ import platform
 import pytest
 import numpy as np
 
-from ....io import fits
+from astropy.io import fits
 from . import FitsTestCase
-from ....tests.helper import ignore_warnings
+from astropy.tests.helper import ignore_warnings
 
 
 class TestUintFunctions(FitsTestCase):

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -15,9 +15,9 @@ try:
 except ImportError:
     HAS_PIL = False
 
-from ....tests.helper import catch_warnings
-from .. import util
-from ..util import ignore_sigint, _rstrip_inplace
+from astropy.tests.helper import catch_warnings
+from astropy.io.fits import util
+from astropy.io.fits.util import ignore_sigint, _rstrip_inplace
 
 from . import FitsTestCase
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -16,14 +16,14 @@ import threading
 import warnings
 import weakref
 from contextlib import contextmanager, suppress
-from ...utils import data
+from astropy.utils import data
 
 from distutils.version import LooseVersion
 
 import numpy as np
 
-from ...utils import wraps
-from ...utils.exceptions import AstropyUserWarning
+from astropy.utils import wraps
+from astropy.utils.exceptions import AstropyUserWarning
 
 cmp = lambda a, b: (a > b) - (a < b)
 

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -3,8 +3,8 @@
 import operator
 import warnings
 
-from ...utils import indent
-from ...utils.exceptions import AstropyUserWarning
+from astropy.utils import indent
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 class VerifyError(Exception):

--- a/astropy/io/misc/asdf/tags/coordinates/angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/angle.py
@@ -4,7 +4,7 @@
 from asdf.yamlutil import custom_tree_to_tagged_tree
 from astropy.coordinates import Angle, Latitude, Longitude
 
-from ..unit.quantity import QuantityType
+from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
 
 
 __all__ = ['AngleType', 'LatitudeType', 'LongitudeType']

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -12,8 +12,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
 
-from ..unit.quantity import QuantityType
-from ...types import AstropyType
+from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
+from astropy.io.misc.asdf.types import AstropyType
 
 
 __all__ = ['CoordType']

--- a/astropy/io/misc/asdf/tags/coordinates/representation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/representation.py
@@ -4,7 +4,7 @@ import astropy.coordinates.representation
 from astropy.coordinates.representation import BaseRepresentationOrDifferential
 from astropy.tests.helper import assert_quantity_allclose
 
-from ...types import AstropyType
+from astropy.io.misc.asdf.types import AstropyType
 
 
 class RepresentationType(AstropyType):

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_angle.py
@@ -11,7 +11,7 @@ from asdf.tests.helpers import assert_roundtrip_tree
 
 from astropy.coordinates import Longitude, Latitude, Angle
 
-from ....extension import AstropyExtension
+from astropy.io.misc.asdf.extension import AstropyExtension
 
 
 def test_angle(tmpdir):

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_frames.py
@@ -9,7 +9,7 @@ from asdf.tests.helpers import assert_roundtrip_tree
 from astropy import units
 from astropy.coordinates import ICRS, FK5, Longitude, Latitude, Angle
 
-from ....extension import AstropyExtension
+from astropy.io.misc.asdf.extension import AstropyExtension
 
 
 def test_hcrs_basic(tmpdir):

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -8,7 +8,7 @@ from asdf import yamlutil
 
 from astropy import table
 from astropy.io import fits
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 
 
 class FitsType(AstropyAsdfType):

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -6,7 +6,7 @@ from asdf import yamlutil
 from asdf.tags.core.ndarray import NDArrayType
 
 from astropy import table
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 
 
 class TableType(AstropyAsdfType):

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -11,7 +11,7 @@ from astropy import time
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import EarthLocation
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 
 
 _guessable_formats = set(['iso', 'byear', 'jyear', 'yday'])

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -6,7 +6,7 @@ from asdf import tagged, yamlutil
 from astropy.modeling import mappings
 from astropy.utils import minversion
 from astropy.modeling import functional_models
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 
 
 __all__ = ['TransformType', 'IdentityType', 'ConstantType']

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -6,10 +6,10 @@ from numpy.testing import assert_array_equal
 
 from asdf import yamlutil
 
-from ...... import modeling
-from ...... import units as u
+from astropy import modeling
+from astropy import units as u
 from .basic import TransformType
-from ......tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 
 __all__ = ['TabularType']
 

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -7,7 +7,7 @@ from astropy.units import Quantity
 from asdf.yamlutil import custom_tree_to_tagged_tree
 from asdf.tags.core import NDArrayType
 
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 from .unit import UnitType
 
 

--- a/astropy/io/misc/asdf/tags/unit/unit.py
+++ b/astropy/io/misc/asdf/tags/unit/unit.py
@@ -4,7 +4,7 @@
 import six
 
 from astropy.units import Unit, UnitBase
-from ...types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyAsdfType
 
 
 class UnitType(AstropyAsdfType):

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -12,7 +12,7 @@ import numpy as np
 
 # NOTE: Do not import anything from astropy.table here.
 # https://github.com/astropy/astropy/issues/6604
-from ...utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
 
 HDF5_SIGNATURE = b'\x89HDF\r\n\x1a\n'
 META_KEY = '__table_column_meta__'
@@ -147,7 +147,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
     # convert to a Table.
 
     # Create a Table object
-    from ...table import Table, meta, serialize
+    from astropy.table import Table, meta, serialize
 
     table = Table(np.array(input))
 
@@ -192,10 +192,10 @@ def _encode_mixins(tbl):
     """Encode a Table ``tbl`` that may have mixin columns to a Table with only
     astropy Columns + appropriate meta-data to allow subsequent decoding.
     """
-    from ...table import serialize
-    from ...table.table import has_info_class
-    from ... import units as u
-    from ...utils.data_info import MixinInfo, serialize_context_as
+    from astropy.table import serialize
+    from astropy.table.table import has_info_class
+    from astropy import units as u
+    from astropy.utils.data_info import MixinInfo, serialize_context_as
 
     # If PyYAML is not available then check to see if there are any mixin cols
     # that *require* YAML serialization.  HDF5 already has support for
@@ -252,7 +252,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
         replaced; the file/group will not be overwritten.
     """
 
-    from ...table import meta
+    from astropy.table import meta
     try:
         import h5py
     except ImportError:
@@ -381,8 +381,8 @@ def register_hdf5():
     """
     Register HDF5 with Unified I/O.
     """
-    from .. import registry as io_registry
-    from ...table import Table
+    from astropy.io import registry as io_registry
+    from astropy.table import Table
 
     io_registry.register_reader('hdf5', Table, read_table_hdf5)
     io_registry.register_writer('hdf5', Table, write_table_hdf5)

--- a/astropy/io/misc/pickle_helpers.py
+++ b/astropy/io/misc/pickle_helpers.py
@@ -6,7 +6,7 @@ part of a larger framework or standard.
 
 import warnings
 
-from ...utils.exceptions import AstropyDeprecationWarning, NoValue
+from astropy.utils.exceptions import AstropyDeprecationWarning, NoValue
 
 __all__ = ['fnpickle', 'fnunpickle']
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -4,15 +4,15 @@
 import pytest
 import numpy as np
 
-from ....tests.helper import catch_warnings
-from ....table import Table, QTable, NdarrayMixin, Column
-from ....table.table_helpers import simple_table
+from astropy.tests.helper import catch_warnings
+from astropy.table import Table, QTable, NdarrayMixin, Column
+from astropy.table.table_helpers import simple_table
 
-from .... import units as u
+from astropy import units as u
 
-from ....coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
-from ....time import Time, TimeDelta
-from ....units.quantity import QuantityInfo
+from astropy.coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from astropy.time import Time, TimeDelta
+from astropy.units.quantity import QuantityInfo
 
 try:
     import h5py

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from .. import fnpickle, fnunpickle
-from ....tests.helper import catch_warnings
-from ....utils.exceptions import AstropyDeprecationWarning
+from astropy.io.misc import fnpickle, fnunpickle
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_fnpickling_simple(tmpdir):

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -11,13 +11,13 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from ....coordinates import SkyCoord, EarthLocation, Angle, Longitude, Latitude
-from .... import units as u
-from ....time import Time
-from ....table import QTable, SerializedColumn
+from astropy.coordinates import SkyCoord, EarthLocation, Angle, Longitude, Latitude
+from astropy import units as u
+from astropy.time import Time
+from astropy.table import QTable, SerializedColumn
 
 try:
-    from ..yaml import load, load_all, dump
+    from astropy.io.misc.yaml import load, load_all, dump
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -70,11 +70,11 @@ Example
 import base64
 import numpy as np
 
-from ...time import Time, TimeDelta
-from ... import units as u
-from ... import coordinates as coords
-from ...utils import minversion
-from ...table import SerializedColumn
+from astropy.time import Time, TimeDelta
+from astropy import units as u
+from astropy import coordinates as coords
+from astropy.utils import minversion
+from astropy.table import SerializedColumn
 
 
 try:

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -95,7 +95,7 @@ def get_formats(data_class=None, readwrite=None):
     format_table : Table
         Table of available I/O formats.
     """
-    from ..table import Table
+    from astropy.table import Table
 
     format_classes = sorted(set(_readers) | set(_writers), key=itemgetter(0))
     rows = []
@@ -492,7 +492,7 @@ def read(cls, *args, format=None, **kwargs):
 
             if len(args):
                 if isinstance(args[0], PATH_TYPES):
-                    from ..utils.data import get_readable_fileobj
+                    from astropy.utils.data import get_readable_fileobj
                     # path might be a pathlib.Path object
                     if isinstance(args[0], pathlib.Path):
                         args = (str(args[0]),) + args[1:]

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -7,10 +7,10 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from ..registry import _readers, _writers, _identifiers
-from .. import registry as io_registry
-from ...table import Table
-from ... import units as u
+from astropy.io.registry import _readers, _writers, _identifiers
+from astropy.io import registry as io_registry
+from astropy.table import Table
+from astropy import units as u
 
 _READERS_ORIGINAL = copy(_readers)
 _WRITERS_ORIGINAL = copy(_writers)

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -10,7 +10,7 @@ from .table import (
 from .exceptions import (
     VOWarning, VOTableChangeWarning, VOTableSpecWarning, UnimplementedWarning,
     IOWarning, VOTableSpecError)
-from ... import config as _config
+from astropy import config as _config
 
 __all__ = [
     'Conf', 'conf', 'parse', 'parse_single_table', 'validate',

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -6,10 +6,10 @@ import os
 
 from . import parse, from_table
 from .tree import VOTableFile, Table as VOTable
-from .. import registry as io_registry
-from ...table import Table
-from ...table.column import BaseColumn
-from ...units import Quantity
+from astropy.io import registry as io_registry
+from astropy.table import Table
+from astropy.table.column import BaseColumn
+from astropy.units import Quantity
 
 
 def is_votable(origin, filepath, fileobj, *args, **kwargs):

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -16,7 +16,7 @@ import numpy as np
 from numpy import ma
 
 # ASTROPY
-from ...utils.xml.writer import xml_escape_cdata
+from astropy.utils.xml.writer import xml_escape_cdata
 
 # LOCAL
 from .exceptions import (vo_raise, vo_warn, warn_or_raise, W01,

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -40,7 +40,7 @@ import re
 from textwrap import dedent
 from warnings import warn
 
-from ...utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning
 
 
 __all__ = [

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -15,8 +15,8 @@ import warnings
 # LOCAL
 from . import exceptions
 from . import tree
-from ...utils.xml import iterparser
-from ...utils import data
+from astropy.utils.xml import iterparser
+from astropy.utils import data
 
 
 __all__ = ['parse', 'parse_single_table', 'from_table', 'writeto', 'validate',
@@ -175,7 +175,7 @@ def writeto(table, file, tabledata_format=None):
         each ``table`` object as it was created or read in.  See
         :ref:`votable-serialization`.
     """
-    from ...table import Table
+    from astropy.table import Table
     if isinstance(table, Table):
         table = tree.VOTableFile.from_table(table)
     elif not isinstance(table, tree.VOTableFile):
@@ -217,7 +217,7 @@ def validate(source, output=None, xmllint=False, filename=None):
         `None`, the return value will be a string.
     """
 
-    from ...utils.console import print_code_line, color_print
+    from astropy.utils.console import print_code_line, color_print
 
     if output is None:
         output = sys.stdout

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -9,13 +9,13 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 # LOCAL
-from .. import converters
-from .. import exceptions
-from .. import tree
+from astropy.io.votable import converters
+from astropy.io.votable import exceptions
+from astropy.io.votable import tree
 
-from ..table import parse_single_table
-from ....tests.helper import raises, catch_warnings
-from ....utils.data import get_pkg_data_filename
+from astropy.io.votable.table import parse_single_table
+from astropy.tests.helper import raises, catch_warnings
+from astropy.utils.data import get_pkg_data_filename
 
 
 @raises(exceptions.E13)

--- a/astropy/io/votable/tests/exception_test.py
+++ b/astropy/io/votable/tests/exception_test.py
@@ -1,11 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # LOCAL
-from ....tests.helper import catch_warnings
+from astropy.tests.helper import catch_warnings
 
-from .. import converters
-from .. import exceptions
-from .. import tree
+from astropy.io.votable import converters
+from astropy.io.votable import exceptions
+from astropy.io.votable import tree
 
 
 def test_reraise():

--- a/astropy/io/votable/tests/resource_test.py
+++ b/astropy/io/votable/tests/resource_test.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # LOCAL
-from .. import parse
-from ....utils.data import get_pkg_data_filename
+from astropy.io.votable import parse
+from astropy.utils.data import get_pkg_data_filename
 
 
 def test_resource_groups():

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -8,9 +8,9 @@ import os
 import pathlib
 import numpy as np
 
-from ....utils.data import get_pkg_data_filename, get_pkg_data_fileobj
-from ..table import parse, writeto
-from .. import tree
+from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
+from astropy.io.votable.table import parse, writeto
+from astropy.io.votable import tree
 
 
 def test_table(tmpdir):
@@ -68,7 +68,7 @@ def test_table(tmpdir):
 
 
 def test_read_through_table_interface(tmpdir):
-    from ....table import Table
+    from astropy.table import Table
 
     with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable', table_id='main_table')
@@ -85,7 +85,7 @@ def test_read_through_table_interface(tmpdir):
 
 
 def test_read_through_table_interface2():
-    from ....table import Table
+    from astropy.table import Table
 
     with get_pkg_data_fileobj('data/regression.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable', table_id='last_table')
@@ -120,7 +120,7 @@ def test_table_read_with_unnamed_tables():
     """
     Issue #927
     """
-    from ....table import Table
+    from astropy.table import Table
 
     with get_pkg_data_fileobj('data/names.xml', encoding='binary') as fd:
         t = Table.read(fd, format='votable')
@@ -140,7 +140,7 @@ def test_votable_path_object():
 
 
 def test_from_table_without_mask():
-    from ....table import Table, Column
+    from astropy.table import Table, Column
     t = Table()
     c = Column(data=[1, 2, 3], name='a')
     t.add_column(c)
@@ -149,7 +149,7 @@ def test_from_table_without_mask():
 
 
 def test_write_with_format():
-    from ....table import Table, Column
+    from astropy.table import Table, Column
     t = Table()
     c = Column(data=[1, 2, 3], name='a')
     t.add_column(c)

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # LOCAL
-from .. import exceptions
-from .. import tree
-from ....tests.helper import raises
+from astropy.io.votable import exceptions
+from astropy.io.votable import tree
+from astropy.tests.helper import raises
 
 
 @raises(exceptions.W07)

--- a/astropy/io/votable/tests/ucd_test.py
+++ b/astropy/io/votable/tests/ucd_test.py
@@ -3,10 +3,10 @@
 
 
 
-from ....tests.helper import raises
+from astropy.tests.helper import raises
 
 # LOCAL
-from .. import ucd
+from astropy.io.votable import ucd
 
 
 def test_none():

--- a/astropy/io/votable/tests/util_test.py
+++ b/astropy/io/votable/tests/util_test.py
@@ -5,8 +5,8 @@ A set of tests for the util.py module
 
 
 # LOCAL
-from .. import util
-from ....tests.helper import raises
+from astropy.io.votable import util
+from astropy.tests.helper import raises
 
 
 def test_range_list():

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -21,12 +21,12 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 # LOCAL
-from ..table import parse, parse_single_table, validate
-from .. import tree
-from ..exceptions import VOTableSpecError, VOWarning
-from ..xmlutil import validate_schema
-from ....utils.data import get_pkg_data_filename, get_pkg_data_filenames
-from ....tests.helper import raises, catch_warnings
+from astropy.io.votable.table import parse, parse_single_table, validate
+from astropy.io.votable import tree
+from astropy.io.votable.exceptions import VOTableSpecError, VOWarning
+from astropy.io.votable.xmlutil import validate_schema
+from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
+from astropy.tests.helper import raises, catch_warnings
 
 # Determine the kind of float formatting in this build of Python
 if hasattr(sys, 'float_repr_style'):
@@ -693,7 +693,7 @@ class TestThroughBinary2(TestParse):
 
 
 def table_from_scratch():
-    from ..tree import VOTableFile, Resource, Table, Field
+    from astropy.io.votable.tree import VOTableFile, Resource, Table, Field
 
     # Create a new VOTable file...
     votable = VOTableFile()
@@ -864,7 +864,7 @@ def test_from_scratch_example():
 
 
 def _run_test_from_scratch_example():
-    from ..tree import VOTableFile, Resource, Table, Field
+    from astropy.io.votable.tree import VOTableFile, Resource, Table, Field
 
     # Create a new VOTable file...
     votable = VOTableFile()
@@ -896,7 +896,7 @@ def _run_test_from_scratch_example():
 def test_fileobj():
     # Assert that what we get back is a raw C file pointer
     # so it will be super fast in the C extension.
-    from ....utils.xml import iterparser
+    from astropy.utils.xml import iterparser
     filename = get_pkg_data_filename('data/regression.xml')
     with iterparser._convert_to_fd_or_read_function(filename) as fd:
         if sys.platform == 'win32':
@@ -906,7 +906,7 @@ def test_fileobj():
 
 
 def test_nonstandard_units():
-    from .... import units as u
+    from astropy import units as u
 
     votable = parse(
         get_pkg_data_filename('data/nonstandard_units.xml'),

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -16,12 +16,12 @@ import numpy as np
 from numpy import ma
 
 # LOCAL
-from .. import fits
-from ... import __version__ as astropy_version
-from ...utils.collections import HomogeneousList
-from ...utils.xml.writer import XMLWriter
-from ...utils.exceptions import AstropyDeprecationWarning
-from ...utils.misc import InheritDocstrings
+from astropy.io import fits
+from astropy import __version__ as astropy_version
+from astropy.utils.collections import HomogeneousList
+from astropy.utils.xml.writer import XMLWriter
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.misc import InheritDocstrings
 
 from . import converters
 from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
@@ -772,7 +772,7 @@ class Info(SimpleElementWithContent, _IDProperty, _XtypeProperty,
             self._unit = None
             return
 
-        from ... import units as u
+        from astropy import units as u
 
         if not self._config.get('version_1_2_or_later'):
             warn_or_raise(W28, W28, ('unit', 'INFO', '1.2'),
@@ -1379,7 +1379,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
             self._unit = None
             return
 
-        from ... import units as u
+        from astropy import units as u
 
         # First, parse the unit in the default way, so that we can
         # still emit a warning if the unit is not to spec.
@@ -2842,7 +2842,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
            identically when round-tripping through the
            `astropy.table.Table` instance.
         """
-        from ...table import Table
+        from astropy.table import Table
 
         meta = {}
         for key in ['ID', 'name', 'ref', 'ucd', 'utype', 'description']:

--- a/astropy/io/votable/ucd.py
+++ b/astropy/io/votable/ucd.py
@@ -8,7 +8,7 @@ This file contains routines to verify the correctness of UCD strings.
 import re
 
 # LOCAL
-from ...utils import data
+from astropy.utils import data
 
 __all__ = ['parse_ucd', 'check_ucd']
 

--- a/astropy/io/votable/validator/html.py
+++ b/astropy/io/votable/validator/html.py
@@ -7,11 +7,11 @@ import os
 import re
 
 # ASTROPY
-from ....utils.xml.writer import XMLWriter, xml_escape
-from .... import online_docs_root
+from astropy.utils.xml.writer import XMLWriter, xml_escape
+from astropy import online_docs_root
 
 # VO
-from .. import exceptions
+from astropy.io.votable import exceptions
 
 html_header = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html

--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -8,7 +8,7 @@ and generates a report as a directory tree of HTML files.
 import os
 
 # LOCAL
-from ....utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_filename
 from . import html
 from . import result
 
@@ -110,7 +110,7 @@ def make_validation_report(
     locally in *destdir*.  To refresh the cache, remove *destdir*
     first.
     """
-    from ....utils.console import (color_print, ProgressBar, Spinner)
+    from astropy.utils.console import (color_print, ProgressBar, Spinner)
 
     if stilts is not None:
         if not os.path.exists(stilts):

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -19,9 +19,9 @@ import urllib.error
 import http.client
 
 # VO
-from .. import table
-from .. import exceptions
-from .. import xmlutil
+from astropy.io.votable import table
+from astropy.io.votable import exceptions
+from astropy.io.votable import xmlutil
 
 
 class Result:

--- a/astropy/io/votable/xmlutil.py
+++ b/astropy/io/votable/xmlutil.py
@@ -5,10 +5,10 @@ Various XML-related utilities
 
 
 # ASTROPY
-from ...logger import log
-from ...utils import data
-from ...utils.xml import check as xml_check
-from ...utils.xml import validate
+from astropy.logger import log
+from astropy.utils import data
+from astropy.utils.xml import check as xml_check
+from astropy.utils.xml import validate
 
 # LOCAL
 from .exceptions import (warn_or_raise, vo_warn, W02, W03, W04, W05)

--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -96,9 +96,9 @@ import numpy as np
 
 from .core import Fittable1DModel
 from .parameters import Parameter
-from .. import constants as const
-from .. import units as u
-from ..utils.exceptions import AstropyUserWarning
+from astropy import constants as const
+from astropy import units as u
+from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ['BlackBody1D', 'blackbody_nu', 'blackbody_lambda']
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -31,19 +31,19 @@ from functools import partial
 
 import numpy as np
 
-from ..utils import indent, metadata
-from ..table import Table
-from ..units import Quantity, UnitsError, dimensionless_unscaled
-from ..units.utils import quantity_asanyarray
-from ..utils import (sharedmethod, find_current_module,
+from astropy.utils import indent, metadata
+from astropy.table import Table
+from astropy.units import Quantity, UnitsError, dimensionless_unscaled
+from astropy.units.utils import quantity_asanyarray
+from astropy.utils import (sharedmethod, find_current_module,
                      InheritDocstrings, OrderedDescriptorContainer,
                      check_broadcast, IncompatibleShapeError, isiterable)
-from ..utils.codegen import make_function_with_signature
-from ..utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.codegen import make_function_with_signature
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from .utils import (combine_labels, make_binary_operator_eval,
                     ExpressionTree, AliasDict, get_inputs_and_params,
                     _BoundingBox, _combine_equivalency_dict)
-from ..nddata.utils import add_array, extract_array
+from astropy.nddata.utils import add_array, extract_array
 
 from .parameters import Parameter, InputParameterError, param_repr_oneline
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -32,8 +32,8 @@ from functools import reduce, wraps
 import numpy as np
 
 from .utils import poly_map_domain, _combine_equivalency_dict
-from ..units import Quantity
-from ..utils.exceptions import AstropyUserWarning
+from astropy.units import Quantity
+from astropy.utils.exceptions import AstropyUserWarning
 from .optimizers import (SLSQP, Simplex)
 from .statistic import (leastsquare)
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -11,8 +11,8 @@ from .core import (Fittable1DModel, Fittable2DModel,
                    ModelDefinitionError)
 from .parameters import Parameter, InputParameterError
 from .utils import ellipse_extent
-from .. import units as u
-from ..units import Quantity, UnitsError
+from astropy import units as u
+from astropy.units import Quantity, UnitsError
 
 __all__ = ['AiryDisk2D', 'Moffat1D', 'Moffat2D', 'Box1D', 'Box2D', 'Const1D',
            'Const2D', 'Ellipse2D', 'Disk2D', 'Gaussian1D',

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -7,7 +7,7 @@ Optimization algorithms used in `~astropy.modeling.fitting`.
 import warnings
 import abc
 import numpy as np
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 __all__ = ["Optimization", "SLSQP", "Simplex"]
 

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -15,9 +15,9 @@ import operator
 
 import numpy as np
 
-from .. import units as u
-from ..units import Quantity, UnitsError
-from ..utils import isiterable, OrderedDescriptor
+from astropy import units as u
+from astropy.units import Quantity, UnitsError
+from astropy.utils import isiterable, OrderedDescriptor
 from .utils import array_repr_oneline
 
 from .utils import get_inputs_and_params

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -12,8 +12,8 @@ from .core import FittableModel, Model
 from .functional_models import Shift
 from .parameters import Parameter
 from .utils import poly_map_domain, comb
-from ..utils import indent, check_broadcast
-from ..units import Quantity
+from astropy.utils import indent, check_broadcast
+from astropy.units import Quantity
 
 __all__ = [
     'Chebyshev1D', 'Chebyshev2D', 'Hermite1D', 'Hermite2D',

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from .core import Fittable1DModel
 from .parameters import Parameter, InputParameterError
-from ..units import Quantity
+from astropy.units import Quantity
 
 __all__ = ['PowerLaw1D', 'BrokenPowerLaw1D', 'SmoothlyBrokenPowerLaw1D',
            'ExponentialCutoffPowerLaw1D', 'LogParabola1D']

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -21,7 +21,7 @@ import numpy as np
 from .core import Model
 from .parameters import Parameter, InputParameterError
 
-from .. import units as u
+from astropy import units as u
 
 from . import _projections
 from .utils import _to_radian, _to_orig_unit

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -25,9 +25,9 @@ import numpy as np
 
 from .core import Model
 from .parameters import Parameter
-from ..coordinates.matrix_utilities import rotation_matrix, matrix_product
-from .. import units as u
-from ..utils.decorators import deprecated
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
+from astropy import units as u
+from astropy.utils.decorators import deprecated
 from .utils import _to_radian, _to_orig_unit
 
 __all__ = ['RotateCelestial2Native', 'RotateNative2Celestial', 'Rotation2D',

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -22,8 +22,8 @@ import abc
 import numpy as np
 
 from .core import Model
-from .. import units as u
-from ..utils import minversion
+from astropy import units as u
+from astropy.utils import minversion
 
 try:
     import scipy

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -50,14 +50,14 @@ Explanation of keywords of the dictionaries:
 """
 
 
-from ..functional_models import (
+from astropy.modeling.functional_models import (
     Gaussian1D, Sine1D, Box1D, Linear1D, Lorentz1D,
     MexicanHat1D, Trapezoid1D, Const1D, Moffat1D,
     Gaussian2D, Const2D, Box2D, MexicanHat2D,
     TrapezoidDisk2D, AiryDisk2D, Moffat2D, Disk2D,
     Ring2D, Sersic1D, Sersic2D, Voigt1D, Planar2D)
-from ..polynomial import Polynomial1D, Polynomial2D
-from ..powerlaws import (
+from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
+from astropy.modeling.powerlaws import (
     PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D, ExponentialCutoffPowerLaw1D,
     LogParabola1D)
 import numpy as np

--- a/astropy/modeling/tests/irafutil.py
+++ b/astropy/modeling/tests/irafutil.py
@@ -4,7 +4,7 @@ This module provides functions to help with testing against iraf tasks
 """
 
 
-from ...logger import log
+from astropy.logger import log
 import numpy as np
 
 

--- a/astropy/modeling/tests/test_blackbody.py
+++ b/astropy/modeling/tests/test_blackbody.py
@@ -4,13 +4,13 @@
 import pytest
 import numpy as np
 
-from ..blackbody import BlackBody1D, blackbody_nu, blackbody_lambda, FNU
-from ..fitting import LevMarLSQFitter
+from astropy.modeling.blackbody import BlackBody1D, blackbody_nu, blackbody_lambda, FNU
+from astropy.modeling.fitting import LevMarLSQFitter
 
-from ...tests.helper import assert_quantity_allclose, catch_warnings
-from ... import constants as const
-from ... import units as u
-from ...utils.exceptions import AstropyUserWarning
+from astropy.tests.helper import assert_quantity_allclose, catch_warnings
+from astropy import constants as const
+from astropy import units as u
+from astropy.utils.exceptions import AstropyUserWarning
 
 try:
     from scipy import optimize, integrate  # noqa

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -10,10 +10,10 @@ import numpy as np
 
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ...utils import minversion
-from ..core import Model, ModelDefinitionError
-from ..parameters import Parameter
-from ..models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
+from astropy.utils import minversion
+from astropy.modeling.core import Model, ModelDefinitionError
+from astropy.modeling.parameters import Parameter
+from astropy.modeling.models import (Const1D, Shift, Scale, Rotation2D, Gaussian1D,
                       Gaussian2D, Polynomial1D, Polynomial2D,
                       Chebyshev2D, Legendre2D, Chebyshev1D, Legendre1D,
                       AffineTransformation2D, Identity, Mapping,

--- a/astropy/modeling/tests/test_constraints.py
+++ b/astropy/modeling/tests/test_constraints.py
@@ -7,10 +7,10 @@ import numpy as np
 from numpy.testing import assert_allclose
 from numpy.random import RandomState
 
-from ..core import Fittable1DModel
-from ..parameters import Parameter
-from .. import models
-from .. import fitting
+from astropy.modeling.core import Fittable1DModel
+from astropy.modeling.parameters import Parameter
+from astropy.modeling import models
+from astropy.modeling import fitting
 
 from .utils import ignore_non_integer_warning
 
@@ -489,7 +489,7 @@ def test_2d_model():
     z = gauss2d(x, y)
     w = np.ones(x.size)
     w.shape = x.shape
-    from ...utils import NumpyRNGContext
+    from astropy.utils import NumpyRNGContext
 
     with NumpyRNGContext(1234567890):
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -5,9 +5,9 @@ import numpy as np
 from inspect import signature
 from numpy.testing import assert_allclose
 
-from ..core import Model, custom_model
-from ..parameters import Parameter
-from .. import models
+from astropy.modeling.core import Model, custom_model
+from astropy.modeling.parameters import Parameter
+from astropy.modeling import models
 
 
 class NonFittableModel(Model):

--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -12,16 +12,16 @@ from numpy.testing import assert_allclose, assert_almost_equal
 from unittest import mock
 
 from . import irafutil
-from .. import models
-from ..core import Fittable2DModel, Parameter
-from ..fitting import *
-from ...utils import NumpyRNGContext
-from ...utils.data import get_pkg_data_filename
+from astropy.modeling import models
+from astropy.modeling.core import Fittable2DModel, Parameter
+from astropy.modeling.fitting import *
+from astropy.utils import NumpyRNGContext
+from astropy.utils.data import get_pkg_data_filename
 from .utils import ignore_non_integer_warning
-from ...stats import sigma_clip
+from astropy.stats import sigma_clip
 
-from ...utils.exceptions import AstropyUserWarning
-from ..fitting import populate_entry_points
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.modeling.fitting import populate_entry_points
 import warnings
 
 try:

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -5,11 +5,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from .. import models, InputParameterError
-from ...coordinates import Angle
-from .. import fitting
-from ...tests.helper import catch_warnings
-from ...utils.exceptions import AstropyDeprecationWarning
+from astropy.modeling import models, InputParameterError
+from astropy.coordinates import Angle
+from astropy.modeling import fitting
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 try:
     from scipy import optimize  # pylint: disable=W0611
@@ -25,8 +25,8 @@ def test_sigma_constant():
     it manually in astropy.modeling to avoid importing from
     astropy.stats.
     """
-    from ...stats.funcs import gaussian_sigma_to_fwhm
-    from ..functional_models import GAUSSIAN_SIGMA_TO_FWHM
+    from astropy.stats.funcs import gaussian_sigma_to_fwhm
+    from astropy.modeling.functional_models import GAUSSIAN_SIGMA_TO_FWHM
     assert gaussian_sigma_to_fwhm == GAUSSIAN_SIGMA_TO_FWHM
 
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -7,10 +7,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import models
-from .. import fitting
-from ..core import Model, FittableModel, Fittable1DModel
-from ..parameters import Parameter
+from astropy.modeling import models
+from astropy.modeling import fitting
+from astropy.modeling.core import Model, FittableModel, Fittable1DModel
+from astropy.modeling.parameters import Parameter
 
 try:
     from scipy import optimize  # pylint: disable=W0611

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -4,9 +4,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ..fitting import LevMarLSQFitter
-from ..models import Shift, Rotation2D, Gaussian1D, Identity, Mapping
-from ...utils import NumpyRNGContext
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.models import Shift, Rotation2D, Gaussian1D, Identity, Mapping
+from astropy.utils import NumpyRNGContext
 
 try:
     from scipy import optimize  # pylint: disable=W0611

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -6,10 +6,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ..models import Polynomial1D, Polynomial2D
-from ..fitting import LinearLSQFitter
-from ..core import Model
-from ..parameters import Parameter
+from astropy.modeling.models import Polynomial1D, Polynomial2D
+from astropy.modeling.fitting import LinearLSQFitter
+from astropy.modeling.core import Model
+from astropy.modeling.parameters import Parameter
 
 
 x = np.arange(4)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -11,13 +11,13 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from .example_models import models_1D, models_2D
-from .. import fitting, models
-from ..core import FittableModel
-from ..polynomial import PolynomialBase
-from ... import units as u
-from ...utils import minversion
-from ...tests.helper import assert_quantity_allclose
-from ...utils import NumpyRNGContext
+from astropy.modeling import fitting, models
+from astropy.modeling.core import FittableModel
+from astropy.modeling.polynomial import PolynomialBase
+from astropy import units as u
+from astropy.utils import minversion
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils import NumpyRNGContext
 
 try:
     import scipy

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -3,10 +3,10 @@ from collections import OrderedDict
 import pytest
 import numpy as np
 
-from ... import units as u
-from ...tests.helper import assert_quantity_allclose
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 
-from ..functional_models import (Gaussian1D,
+from astropy.modeling.functional_models import (Gaussian1D,
                                  Sersic1D, Sine1D, Linear1D,
                                  Lorentz1D, Voigt1D, Const1D,
                                  Box1D, Trapezoid1D, MexicanHat1D,
@@ -14,12 +14,12 @@ from ..functional_models import (Gaussian1D,
                                  Disk2D, Ring2D, Box2D, TrapezoidDisk2D,
                                  MexicanHat2D, AiryDisk2D, Moffat2D, Sersic2D)
 
-from ..powerlaws import (PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D,
+from astropy.modeling.powerlaws import (PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D,
                          ExponentialCutoffPowerLaw1D, LogParabola1D)
 
-from ..polynomial import Polynomial1D, Polynomial2D
+from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
 
-from ..fitting import LevMarLSQFitter
+from astropy.modeling.fitting import LevMarLSQFitter
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -11,10 +11,10 @@ from numpy.testing import (assert_allclose, assert_equal, assert_array_equal,
                            assert_almost_equal)
 
 from . import irafutil
-from .. import models, fitting
-from ..core import Model, FittableModel
-from ..parameters import Parameter, InputParameterError
-from ...utils.data import get_pkg_data_filename
+from astropy.modeling import models, fitting
+from astropy.modeling.core import Model, FittableModel
+from astropy.modeling.parameters import Parameter, InputParameterError
+from astropy.utils.data import get_pkg_data_filename
 
 
 def setter1(val):

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -11,15 +11,15 @@ import numpy as np
 
 from numpy.testing import assert_allclose
 
-from .. import fitting
-from ... import wcs
-from ...io import fits
-from ..polynomial import (Chebyshev1D, Hermite1D, Legendre1D, Polynomial1D,
+from astropy.modeling import fitting
+from astropy import wcs
+from astropy.io import fits
+from astropy.modeling.polynomial import (Chebyshev1D, Hermite1D, Legendre1D, Polynomial1D,
                           Chebyshev2D, Hermite2D, Legendre2D, Polynomial2D, SIP,
                           PolynomialBase, OrthoPolynomialBase)
-from ..functional_models import Linear1D
-from ..mappings import Identity
-from ...utils.data import get_pkg_data_filename
+from astropy.modeling.functional_models import Linear1D
+from astropy.modeling.mappings import Identity
+from astropy.utils.data import get_pkg_data_filename
 
 try:
     from scipy import optimize  # pylint: disable=W0611

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -8,14 +8,14 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal
 
-from .. import projections
-from ..parameters import InputParameterError
+from astropy.modeling import projections
+from astropy.modeling.parameters import InputParameterError
 
-from ... import units as u
-from ...io import fits
-from ... import wcs
-from ...utils.data import get_pkg_data_filename
-from ...tests.helper import assert_quantity_allclose
+from astropy import units as u
+from astropy.io import fits
+from astropy import wcs
+from astropy.utils.data import get_pkg_data_filename
+from astropy.tests.helper import assert_quantity_allclose
 
 
 def test_Projection_properties():

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -10,11 +10,11 @@ import pytest
 from numpy.testing import assert_allclose
 
 
-from ..core import Model
-from ..models import Gaussian1D, Shift, Scale, Pix2Sky_TAN
-from ... import units as u
-from ...units import UnitsError
-from ...tests.helper import assert_quantity_allclose
+from astropy.modeling.core import Model
+from astropy.modeling.models import Gaussian1D, Shift, Scale, Pix2Sky_TAN
+from astropy import units as u
+from astropy.units import UnitsError
+from astropy.tests.helper import assert_quantity_allclose
 
 
 # We start off by taking some simple cases where the units are defined by

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -8,12 +8,12 @@ Tests that relate to fitting models with quantity parameters
 import numpy as np
 import pytest
 
-from ..models import Gaussian1D
-from ... import units as u
-from ...units import UnitsError
-from ...tests.helper import assert_quantity_allclose
-from ...utils import NumpyRNGContext
-from .. import fitting
+from astropy.modeling.models import Gaussian1D
+from astropy import units as u
+from astropy.units import UnitsError
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils import NumpyRNGContext
+from astropy.modeling import fitting
 
 try:
     from scipy import optimize

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,8 +1,8 @@
 # Various tests of models not related to evaluation, fitting, or parameters
 import pytest
 
-from ...tests.helper import assert_quantity_allclose
-from ... import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
 
 from astropy.modeling.models import Mapping, Pix2Sky_TAN, Gaussian1D
 from astropy.modeling import models

--- a/astropy/modeling/tests/test_quantities_parameters.py
+++ b/astropy/modeling/tests/test_quantities_parameters.py
@@ -8,14 +8,14 @@ Tests that relate to using quantities/units on parameters of models.
 import numpy as np
 import pytest
 
-from ..core import Model, Fittable1DModel, InputParameterError
-from ..parameters import Parameter, ParameterDefinitionError
-from ..models import (Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial,
+from astropy.modeling.core import Model, Fittable1DModel, InputParameterError
+from astropy.modeling.parameters import Parameter, ParameterDefinitionError
+from astropy.modeling.models import (Gaussian1D, Pix2Sky_TAN, RotateNative2Celestial,
                       Rotation2D)
-from ... import units as u
-from ...units import UnitsError
-from ...tests.helper import assert_quantity_allclose
-from ... import coordinates as coord
+from astropy import units as u
+from astropy.units import UnitsError
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import coordinates as coord
 
 
 class BaseTestModel(Fittable1DModel):

--- a/astropy/modeling/tests/test_quantities_rotations.py
+++ b/astropy/modeling/tests/test_quantities_rotations.py
@@ -5,10 +5,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ...wcs import wcs
-from .. import models
-from ... import units as u
-from ...tests.helper import assert_quantity_allclose
+from astropy.wcs import wcs
+from astropy.modeling import models
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 
 @pytest.mark.parametrize(('inp'), [(0, 0), (4000, -20.56), (-2001.5, 45.9),

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -10,8 +10,8 @@ from numpy.testing import assert_allclose
 import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
-from .. import models
-from ...wcs import wcs
+from astropy.modeling import models
+from astropy.wcs import wcs
 
 
 @pytest.mark.parametrize(('inp'), [(0, 0), (4000, -20.56), (-2001.5, 45.9),

--- a/astropy/modeling/tests/test_separable.py
+++ b/astropy/modeling/tests/test_separable.py
@@ -7,10 +7,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import models
-from ..models import Mapping
-from .. separable import (_coord_matrix, is_separable, _cdot,
-                          _cstack, _arith_oper, separability_matrix)
+from astropy.modeling import models
+from astropy.modeling.models import Mapping
+from astropy.modeling.separable import (_coord_matrix, is_separable, _cdot,
+                                        _cstack, _arith_oper, separability_matrix)
 
 
 sh1 = models.Shift(1, name='shift1')

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -5,8 +5,8 @@ import operator
 
 import numpy as np
 
-from ..utils import ExpressionTree as ET, ellipse_extent
-from ..models import Ellipse2D
+from astropy.modeling.utils import ExpressionTree as ET, ellipse_extent
+from astropy.modeling.models import Ellipse2D
 
 
 def test_traverse_postorder_duplicate_subtrees():

--- a/astropy/modeling/tests/utils.py
+++ b/astropy/modeling/tests/utils.py
@@ -4,7 +4,7 @@
 
 import contextlib
 import warnings
-from ...tests.helper import catch_warnings
+from astropy.tests.helper import catch_warnings
 
 
 @contextlib.contextmanager

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -12,10 +12,10 @@ from inspect import signature
 import numpy as np
 
 
-from ..utils import isiterable, check_broadcast
-from ..utils.compat import NUMPY_LT_1_14
+from astropy.utils import isiterable, check_broadcast
+from astropy.utils.compat import NUMPY_LT_1_14
 
-from .. import units as u
+from astropy import units as u
 
 __all__ = ['ExpressionTree', 'AliasDict', 'check_broadcast',
            'poly_map_domain', 'comb', 'ellipse_extent']

--- a/astropy/nddata/__init__.py
+++ b/astropy/nddata/__init__.py
@@ -25,7 +25,7 @@ from .utils import *
 from .ccddata import *
 from .bitmask import *
 
-from .. import config as _config
+from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -6,11 +6,11 @@ import numpy as np
 from .compat import NDDataArray
 from .nduncertainty import (
     StdDevUncertainty, NDUncertainty, VarianceUncertainty, InverseVariance)
-from ..io import fits, registry
-from .. import units as u
-from .. import log
-from ..wcs import WCS
-from ..utils.decorators import sharedmethod
+from astropy.io import fits, registry
+from astropy import units as u
+from astropy import log
+from astropy.wcs import WCS
+from astropy.utils.decorators import sharedmethod
 
 
 __all__ = ['CCDData', 'fits_ccddata_reader', 'fits_ccddata_writer']

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -4,8 +4,8 @@
 
 import numpy as np
 
-from ..units import UnitsError, UnitConversionError, Unit
-from .. import log
+from astropy.units import UnitsError, UnitConversionError, Unit
+from astropy import log
 
 from .nddata import NDData
 from .nduncertainty import NDUncertainty

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -6,8 +6,8 @@ from inspect import signature
 from itertools import islice
 import warnings
 
-from ..utils import wraps
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils import wraps
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .nddata import NDData
 

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from ..utils.misc import isiterable
+from astropy.utils.misc import isiterable
 
 __all__ = ['FlagCollection']
 

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -6,9 +6,9 @@ from copy import deepcopy
 
 import numpy as np
 
-from ..nduncertainty import NDUncertainty
-from ...units import dimensionless_unscaled
-from ...utils import format_doc, sharedmethod
+from astropy.nddata.nduncertainty import NDUncertainty
+from astropy.units import dimensionless_unscaled
+from astropy.utils import format_doc, sharedmethod
 
 __all__ = ['NDArithmeticMixin']
 

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -2,7 +2,7 @@
 # This module implements the I/O mixin to the NDData class.
 
 
-from ...io import registry as io_registry
+from astropy.io import registry as io_registry
 
 __all__ = ['NDIOMixin']
 

--- a/astropy/nddata/mixins/ndslicing.py
+++ b/astropy/nddata/mixins/ndslicing.py
@@ -2,7 +2,7 @@
 # This module implements the Slicing mixin to the NDData class.
 
 
-from ... import log
+from astropy import log
 
 __all__ = ['NDSlicingMixin']
 

--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -6,15 +6,15 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from ...nduncertainty import (StdDevUncertainty, VarianceUncertainty,
+from astropy.nddata.nduncertainty import (StdDevUncertainty, VarianceUncertainty,
                               InverseVariance,
                               UnknownUncertainty,
                               IncompatibleUncertaintiesException)
-from ... import NDDataRef
-from ...nddata import NDData
+from astropy.nddata import NDDataRef
+from astropy.nddata.nddata import NDData
 
-from ....units import UnitsError, Quantity
-from .... import units as u
+from astropy.units import UnitsError, Quantity
+from astropy import units as u
 
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)

--- a/astropy/nddata/mixins/tests/test_ndio.py
+++ b/astropy/nddata/mixins/tests/test_ndio.py
@@ -1,5 +1,5 @@
 
-from ... import NDData, NDIOMixin, NDDataRef
+from astropy.nddata import NDData, NDIOMixin, NDDataRef
 
 
 # Alias NDDataAllMixins in case this will be renamed ... :-)

--- a/astropy/nddata/mixins/tests/test_ndslicing.py
+++ b/astropy/nddata/mixins/tests/test_ndslicing.py
@@ -6,9 +6,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ... import NDData, NDSlicingMixin
-from ...nduncertainty import NDUncertainty, StdDevUncertainty
-from .... import units as u
+from astropy.nddata import NDData, NDSlicingMixin
+from astropy.nddata.nduncertainty import NDUncertainty, StdDevUncertainty
+from astropy import units as u
 
 
 # Just add the Mixin to NDData

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -7,9 +7,9 @@ from copy import deepcopy
 
 from .nddata_base import NDDataBase
 from .nduncertainty import NDUncertainty, UnknownUncertainty
-from .. import log
-from ..units import Unit, Quantity
-from ..utils.metadata import MetaData
+from astropy import log
+from astropy.units import Unit, Quantity
+from astropy.utils.metadata import MetaData
 
 __all__ = ['NDData']
 

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -9,9 +9,9 @@ from copy import deepcopy
 import weakref
 
 
-# from ..utils.compat import ignored
-from .. import log
-from ..units import Unit, Quantity, UnitConversionError
+# from astropy.utils.compat import ignored
+from astropy import log
+from astropy.units import Unit, Quantity, UnitConversionError
 
 __all__ = ['MissingDataAssociationException',
            'IncompatibleUncertaintiesException', 'NDUncertainty',

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 import pytest
 
-from .. import bitmask
+from astropy.nddata import bitmask
 
 
 MAX_INT_TYPE = np.maximum_sctype(np.int)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -6,19 +6,19 @@ import textwrap
 import numpy as np
 import pytest
 
-from ...io import fits
-from ..nduncertainty import (
+from astropy.io import fits
+from astropy.nddata.nduncertainty import (
     StdDevUncertainty, MissingDataAssociationException, VarianceUncertainty,
     InverseVariance)
-from ... import units as u
-from ... import log
-from ...wcs import WCS, FITSFixedWarning
-from ...tests.helper import catch_warnings
-from ...utils import NumpyRNGContext
-from ...utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
+from astropy import units as u
+from astropy import log
+from astropy.wcs import WCS, FITSFixedWarning
+from astropy.tests.helper import catch_warnings
+from astropy.utils import NumpyRNGContext
+from astropy.utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
                            get_pkg_data_contents)
 
-from ..ccddata import CCDData
+from astropy.nddata.ccddata import CCDData
 from astropy.table import Table
 
 # If additional pytest markers are defined the key in the dictionary below
@@ -649,7 +649,7 @@ def test_wcs_keywords_removed_from_header():
     Test, for the file included with the nddata tests, that WCS keywords are
     properly removed from header.
     """
-    from ..ccddata import _KEEP_THESE_KEYWORDS_IN_HEADER
+    from astropy.nddata.ccddata import _KEEP_THESE_KEYWORDS_IN_HEADER
     keepers = set(_KEEP_THESE_KEYWORDS_IN_HEADER)
     data_file = get_pkg_data_filename('data/sip-wcs.fits')
     ccd = CCDData.read(data_file)
@@ -668,8 +668,8 @@ def test_wcs_keyword_removal_for_wcs_test_files():
     expected. Those cover a much broader range of WCS types than
     test_wcs_keywords_removed_from_header
     """
-    from ..ccddata import _generate_wcs_and_update_header
-    from ..ccddata import _KEEP_THESE_KEYWORDS_IN_HEADER
+    from astropy.nddata.ccddata import _generate_wcs_and_update_header
+    from astropy.nddata.ccddata import _KEEP_THESE_KEYWORDS_IN_HEADER
 
     keepers = set(_KEEP_THESE_KEYWORDS_IN_HEADER)
     wcs_headers = get_pkg_data_filenames('../../wcs/tests/data',

--- a/astropy/nddata/tests/test_compat.py
+++ b/astropy/nddata/tests/test_compat.py
@@ -5,10 +5,10 @@
 import pytest
 import numpy as np
 
-from ..nddata import NDData
-from ..compat import NDDataArray
-from ..nduncertainty import StdDevUncertainty
-from ... import units as u
+from astropy.nddata.nddata import NDData
+from astropy.nddata.compat import NDDataArray
+from astropy.nddata.nduncertainty import StdDevUncertainty
+from astropy import units as u
 
 
 NDDATA_ATTRIBUTES = ['mask', 'flags', 'uncertainty', 'unit', 'shape', 'size',

--- a/astropy/nddata/tests/test_decorators.py
+++ b/astropy/nddata/tests/test_decorators.py
@@ -5,12 +5,12 @@ import inspect
 import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings
-from ...utils.exceptions import AstropyUserWarning
-from ... import units as u
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy import units as u
 
-from ..nddata import NDData
-from ..decorators import support_nddata
+from astropy.nddata.nddata import NDData
+from astropy.nddata.decorators import support_nddata
 
 
 class CCDData(NDData):

--- a/astropy/nddata/tests/test_flag_collection.py
+++ b/astropy/nddata/tests/test_flag_collection.py
@@ -5,7 +5,7 @@
 import pytest
 import numpy as np
 
-from .. import FlagCollection
+from astropy.nddata import FlagCollection
 
 
 def test_init():

--- a/astropy/nddata/tests/test_nddata.py
+++ b/astropy/nddata/tests/test_nddata.py
@@ -9,10 +9,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ..nddata import NDData
-from ..nduncertainty import StdDevUncertainty
-from ... import units as u
-from ...utils import NumpyRNGContext
+from astropy.nddata.nddata import NDData
+from astropy.nddata.nduncertainty import StdDevUncertainty
+from astropy import units as u
+from astropy.utils import NumpyRNGContext
 
 from .test_nduncertainty import FakeUncertainty
 
@@ -391,7 +391,7 @@ def test_pickle_nddata_without_uncertainty():
 # Check that the meta descriptor is working as expected. The MetaBaseTest class
 # takes care of defining all the tests, and we simply have to define the class
 # and any minimal set of args to pass.
-from ...utils.tests.test_metadata import MetaBaseTest
+from astropy.utils.tests.test_metadata import MetaBaseTest
 
 
 class TestMetaNDData(MetaBaseTest):

--- a/astropy/nddata/tests/test_nddata_base.py
+++ b/astropy/nddata/tests/test_nddata_base.py
@@ -2,7 +2,7 @@
 # Tests of NDDataBase
 
 
-from ..nddata_base import NDDataBase
+from astropy.nddata.nddata_base import NDDataBase
 
 
 class MinimalSubclass(NDDataBase):

--- a/astropy/nddata/tests/test_nduncertainty.py
+++ b/astropy/nddata/tests/test_nduncertainty.py
@@ -6,17 +6,17 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from ..nduncertainty import (StdDevUncertainty,
+from astropy.nddata.nduncertainty import (StdDevUncertainty,
                              VarianceUncertainty,
                              InverseVariance,
                              NDUncertainty,
                              IncompatibleUncertaintiesException,
                              MissingDataAssociationException,
                              UnknownUncertainty)
-from ..nddata import NDData
-from ..compat import NDDataArray
-from ..ccddata import CCDData
-from ... import units as u
+from astropy.nddata.nddata import NDData
+from astropy.nddata.compat import NDDataArray
+from astropy.nddata.ccddata import CCDData
+from astropy import units as u
 
 # Regarding setter tests:
 # No need to test setters since the uncertainty is considered immutable after
@@ -240,7 +240,7 @@ def test_for_leak_with_uncertainty():
 
     # Same for NDDataArray:
 
-    from ..compat import NDDataArray
+    from astropy.nddata.compat import NDDataArray
 
     def non_leaker_nddataarray():
         NDDataArray(np.ones(100))

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -4,15 +4,15 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ...tests.helper import assert_quantity_allclose
-from ..utils import (extract_array, add_array, subpixel_indices,
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.nddata.utils import (extract_array, add_array, subpixel_indices,
                      block_reduce, block_replicate,
                      overlap_slices, NoOverlapError, PartialOverlapError,
                      Cutout2D)
-from ...wcs import WCS, Sip
-from ...wcs.utils import proj_plane_pixel_area
-from ...coordinates import SkyCoord
-from ... import units as u
+from astropy.wcs import WCS, Sip
+from astropy.wcs.utils import proj_plane_pixel_area
+from astropy.coordinates import SkyCoord
+from astropy import units as u
 
 try:
     import skimage  # pylint: disable=W0611

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -7,11 +7,11 @@ from copy import deepcopy
 import numpy as np
 
 from .decorators import support_nddata
-from .. import units as u
-from ..coordinates import SkyCoord
-from ..utils import lazyproperty
-from ..wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
-from ..wcs import Sip
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.utils import lazyproperty
+from astropy.wcs.utils import skycoord_to_pixel, proj_plane_pixel_scales
+from astropy.wcs import Sip
 
 
 __all__ = ['extract_array', 'add_array', 'subpixel_indices',

--- a/astropy/samp/__init__.py
+++ b/astropy/samp/__init__.py
@@ -18,7 +18,7 @@ from .integrated_client import *
 from .hub_proxy import *
 
 
-from .. import config as _config
+from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/samp/constants.py
+++ b/astropy/samp/constants.py
@@ -4,7 +4,7 @@ Defines constants used in `astropy.samp`.
 """
 
 
-from ..utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_filename
 
 __all__ = ['SAMP_STATUS_OK', 'SAMP_STATUS_WARNING', 'SAMP_STATUS_ERROR',
            'SAFE_MTYPES', 'SAMP_ICON']

--- a/astropy/samp/errors.py
+++ b/astropy/samp/errors.py
@@ -6,7 +6,7 @@ Defines custom errors and exceptions used in `astropy.samp`.
 
 import xmlrpc.client as xmlrpc
 
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['SAMPWarning', 'SAMPHubError', 'SAMPClientError', 'SAMPProxyError']

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -13,7 +13,7 @@ import queue
 import xmlrpc.client as xmlrpc
 from urllib.parse import urlunparse
 
-from .. import log
+from astropy import log
 
 from .constants import SAMP_STATUS_OK
 from .constants import __profile_version__

--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -6,7 +6,7 @@ import time
 import sys
 import argparse
 
-from .. import log, __version__
+from astropy import log, __version__
 
 from .hub import SAMPHubServer
 

--- a/astropy/samp/lockfile_helpers.py
+++ b/astropy/samp/lockfile_helpers.py
@@ -13,12 +13,12 @@ from contextlib import suppress
 from urllib.parse import urlparse
 import xmlrpc.client as xmlrpc
 
-from ..config.paths import _find_home
+from astropy.config.paths import _find_home
 
 
-from .. import log
+from astropy import log
 
-from ..utils.data import get_readable_fileobj
+from astropy.utils.data import get_readable_fileobj
 
 from .errors import SAMPHubError, SAMPWarning
 

--- a/astropy/samp/tests/test_client.py
+++ b/astropy/samp/tests/test_client.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-from ..hub_proxy import SAMPHubProxy
-from ..client import SAMPClient
-from ..integrated_client import SAMPIntegratedClient
-from ..hub import SAMPHubServer
+from astropy.samp.hub_proxy import SAMPHubProxy
+from astropy.samp.client import SAMPClient
+from astropy.samp.integrated_client import SAMPIntegratedClient
+from astropy.samp.hub import SAMPHubServer
 
 # By default, tests should not use the internet.
-from .. import conf
+from astropy.samp import conf
 
 
 def setup_module(module):

--- a/astropy/samp/tests/test_errors.py
+++ b/astropy/samp/tests/test_errors.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from ..errors import SAMPHubError, SAMPClientError, SAMPProxyError
+from astropy.samp.errors import SAMPHubError, SAMPClientError, SAMPProxyError
 
 # By default, tests should not use the internet.
-from .. import conf
+from astropy.samp import conf
 
 
 def setup_module(module):

--- a/astropy/samp/tests/test_helpers.py
+++ b/astropy/samp/tests/test_helpers.py
@@ -4,7 +4,7 @@ import pickle
 import random
 import string
 
-from .. import SAMP_STATUS_OK
+from astropy.samp import SAMP_STATUS_OK
 
 TEST_REPLY = {"samp.status": SAMP_STATUS_OK,
               "samp.result": {"txt": "test"}}

--- a/astropy/samp/tests/test_hub.py
+++ b/astropy/samp/tests/test_hub.py
@@ -2,9 +2,9 @@
 
 import time
 
-from ..hub import SAMPHubServer
+from astropy.samp.hub import SAMPHubServer
 
-from .. import conf
+from astropy.samp import conf
 
 
 def setup_module(module):

--- a/astropy/samp/tests/test_hub_proxy.py
+++ b/astropy/samp/tests/test_hub_proxy.py
@@ -1,7 +1,7 @@
-from ..hub_proxy import SAMPHubProxy
-from ..hub import SAMPHubServer
+from astropy.samp.hub_proxy import SAMPHubProxy
+from astropy.samp.hub import SAMPHubServer
 
-from .. import conf
+from astropy.samp import conf
 
 
 def setup_module(module):

--- a/astropy/samp/tests/test_hub_script.py
+++ b/astropy/samp/tests/test_hub_script.py
@@ -1,8 +1,8 @@
 import sys
 
-from ..hub_script import hub_script
+from astropy.samp.hub_script import hub_script
 
-from .. import conf
+from astropy.samp import conf
 
 
 def setup_module(module):

--- a/astropy/samp/tests/test_standard_profile.py
+++ b/astropy/samp/tests/test_standard_profile.py
@@ -3,14 +3,14 @@ import tempfile
 
 import pytest
 
-from ...utils.data import get_pkg_data_filename
+from astropy.utils.data import get_pkg_data_filename
 
-from ..hub import SAMPHubServer
-from ..integrated_client import SAMPIntegratedClient
-from ..errors import SAMPProxyError
+from astropy.samp.hub import SAMPHubServer
+from astropy.samp.integrated_client import SAMPIntegratedClient
+from astropy.samp.errors import SAMPProxyError
 
 # By default, tests should not use the internet.
-from .. import conf
+from astropy.samp import conf
 
 from .test_helpers import random_params, Receiver, assert_output, TEST_REPLY
 

--- a/astropy/samp/tests/test_web_profile.py
+++ b/astropy/samp/tests/test_web_profile.py
@@ -10,14 +10,14 @@ import threading
 import tempfile
 from urllib.request import Request, urlopen
 
-from ...utils.data import get_readable_fileobj
+from astropy.utils.data import get_readable_fileobj
 
-from .. import SAMPIntegratedClient, SAMPHubServer
+from astropy.samp import SAMPIntegratedClient, SAMPHubServer
 from .web_profile_test_helpers import (AlwaysApproveWebProfileDialog,
                                        SAMPIntegratedWebClient)
-from ..web_profile import CROSS_DOMAIN, CLIENT_ACCESS_POLICY
+from astropy.samp.web_profile import CROSS_DOMAIN, CLIENT_ACCESS_POLICY
 
-from .. import conf
+from astropy.samp import conf
 
 from .test_standard_profile import TestStandardProfile as BaseTestStandardProfile
 

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -2,12 +2,12 @@ import time
 import threading
 import xmlrpc.client as xmlrpc
 
-from ..hub import WebProfileDialog
-from ..hub_proxy import SAMPHubProxy
-from ..client import SAMPClient
-from ..integrated_client import SAMPIntegratedClient
-from ..utils import ServerProxyPool
-from ..errors import SAMPClientError, SAMPHubError
+from astropy.samp.hub import WebProfileDialog
+from astropy.samp.hub_proxy import SAMPHubProxy
+from astropy.samp.client import SAMPClient
+from astropy.samp.integrated_client import SAMPIntegratedClient
+from astropy.samp.utils import ServerProxyPool
+from astropy.samp.errors import SAMPClientError, SAMPHubError
 
 
 class AlwaysApproveWebProfileDialog(WebProfileDialog):

--- a/astropy/samp/web_profile.py
+++ b/astropy/samp/web_profile.py
@@ -4,7 +4,7 @@
 from urllib.parse import parse_qs
 from urllib.request import urlopen
 
-from ..utils.data import get_pkg_data_contents
+from astropy.utils.data import get_pkg_data_contents
 
 from .standard_profile import (SAMPSimpleXMLRPCRequestHandler,
                                ThreadingXMLRPCServer)

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -43,7 +43,7 @@ import warnings
 import numpy as np
 
 from inspect import signature
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 # TODO: implement other fitness functions from appendix B of Scargle 2012
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -8,7 +8,7 @@ Tukey's biweight function.
 import numpy as np
 
 from .funcs import median_absolute_deviation
-from ..utils.decorators import deprecated_renamed_argument
+from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['biweight_location', 'biweight_scale', 'biweight_midvariance',

--- a/astropy/stats/bls/core.py
+++ b/astropy/stats/bls/core.py
@@ -5,8 +5,8 @@ __all__ = ["BoxLeastSquares", "BoxLeastSquaresResults"]
 
 import numpy as np
 
-from ... import units
-from ..lombscargle.core import has_units, strip_units
+from astropy import units
+from astropy.stats.lombscargle.core import has_units, strip_units
 
 from . import methods
 

--- a/astropy/stats/bls/tests/test_bls.py
+++ b/astropy/stats/bls/tests/test_bls.py
@@ -5,10 +5,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .... import units
-from ....tests.helper import assert_quantity_allclose
-from .. import BoxLeastSquares
-from ...lombscargle.core import has_units
+from astropy import units
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.stats.bls import BoxLeastSquares
+from astropy.stats.lombscargle.core import has_units
 
 
 def assert_allclose_blsresults(blsresult, other, **kwargs):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -17,8 +17,8 @@ import numpy as np
 
 from warnings import warn
 
-from ..utils.decorators import deprecated_renamed_argument
-from ..utils import isiterable
+from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils import isiterable
 from . import _stats
 
 

--- a/astropy/stats/lombscargle/core.py
+++ b/astropy/stats/lombscargle/core.py
@@ -5,7 +5,7 @@ import numpy as np
 from .implementations import lombscargle, available_methods
 from .implementations.mle import periodic_fit
 from . import _statistics
-from ... import units
+from astropy import units
 
 
 def has_units(obj):

--- a/astropy/stats/lombscargle/implementations/tests/test_mle.py
+++ b/astropy/stats/lombscargle/implementations/tests/test_mle.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ..mle import design_matrix, periodic_fit
+from astropy.stats.lombscargle.implementations.mle import design_matrix, periodic_fit
 
 
 @pytest.fixture

--- a/astropy/stats/lombscargle/implementations/tests/test_utils.py
+++ b/astropy/stats/lombscargle/implementations/tests/test_utils.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
-from ..utils import extirpolate, bitceil, trig_sum
+from astropy.stats.lombscargle.implementations.utils import extirpolate, bitceil, trig_sum
 
 
 @pytest.mark.parametrize('N', 2 ** np.arange(1, 12))

--- a/astropy/stats/lombscargle/tests/test_lombscargle.py
+++ b/astropy/stats/lombscargle/tests/test_lombscargle.py
@@ -2,9 +2,9 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .... import units
-from ....tests.helper import assert_quantity_allclose
-from .. import LombScargle
+from astropy import units
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.stats.lombscargle import LombScargle
 
 
 ALL_METHODS = LombScargle.available_methods

--- a/astropy/stats/lombscargle/tests/test_statistics.py
+++ b/astropy/stats/lombscargle/tests/test_statistics.py
@@ -9,10 +9,10 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from .. import LombScargle
-from .._statistics import (cdf_single, pdf_single, fap_single, inv_fap_single,
+from astropy.stats.lombscargle import LombScargle
+from astropy.stats.lombscargle._statistics import (cdf_single, pdf_single, fap_single, inv_fap_single,
                            METHODS)
-from ..utils import convert_normalization, compute_chi2_ref
+from astropy.stats.lombscargle.utils import convert_normalization, compute_chi2_ref
 
 METHOD_KWDS = dict(bootstrap={'n_bootstraps': 20, 'random_seed': 42})
 NORMALIZATIONS = ['standard', 'psd', 'log', 'model']

--- a/astropy/stats/lombscargle/tests/test_utils.py
+++ b/astropy/stats/lombscargle/tests/test_utils.py
@@ -2,8 +2,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from ..utils import convert_normalization, compute_chi2_ref
-from ..core import LombScargle
+from astropy.stats.lombscargle.utils import convert_normalization, compute_chi2_ref
+from astropy.stats.lombscargle.core import LombScargle
 
 
 NORMALIZATIONS = ['standard', 'model', 'log', 'psd']

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -4,9 +4,9 @@ import warnings
 
 import numpy as np
 
-from ..utils import isiterable
-from ..utils.decorators import deprecated_renamed_argument
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils import isiterable
+from astropy.utils.decorators import deprecated_renamed_argument
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 try:

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import bayesian_blocks, RegularEvents
+from astropy.stats import bayesian_blocks, RegularEvents
 
 
 def test_single_change_point(rseed=0):

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -4,11 +4,11 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
 
-from ..biweight import (biweight_location, biweight_scale,
+from astropy.stats.biweight import (biweight_location, biweight_scale,
                         biweight_midvariance, biweight_midcovariance,
                         biweight_midcorrelation)
-from ...tests.helper import catch_warnings
-from ...utils.misc import NumpyRNGContext
+from astropy.tests.helper import catch_warnings
+from astropy.utils.misc import NumpyRNGContext
 
 
 def test_biweight_location():

--- a/astropy/stats/tests/test_circstats.py
+++ b/astropy/stats/tests/test_circstats.py
@@ -13,8 +13,8 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from ..circstats import _length, circmean, circvar, circmoment, circcorrcoef
-from ..circstats import rayleightest, vtest, vonmisesmle
+from astropy.stats.circstats import _length, circmean, circvar, circmoment, circcorrcoef
+from astropy.stats.circstats import rayleightest, vtest, vonmisesmle
 
 
 def test__length():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -19,10 +19,10 @@ except ImportError:
 else:
     HAS_MPMATH = True
 
-from .. import funcs
-from ... import units as u
-from ...tests.helper import catch_warnings
-from ...utils.misc import NumpyRNGContext
+from astropy.stats import funcs
+from astropy import units as u
+from astropy.tests.helper import catch_warnings
+from astropy.utils.misc import NumpyRNGContext
 
 
 def test_median_absolute_deviation():

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -4,7 +4,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .. import (histogram, calculate_bin_edges,
+from astropy.stats import (histogram, calculate_bin_edges,
                 scott_bin_width, freedman_bin_width, knuth_bin_width)
 
 try:

--- a/astropy/stats/tests/test_info_theory.py
+++ b/astropy/stats/tests/test_info_theory.py
@@ -1,8 +1,8 @@
 
 from numpy.testing import assert_allclose
 
-from ..info_theory import bayesian_info_criterion, bayesian_info_criterion_lsq
-from ..info_theory import akaike_info_criterion, akaike_info_criterion_lsq
+from astropy.stats.info_theory import bayesian_info_criterion, bayesian_info_criterion_lsq
+from astropy.stats.info_theory import akaike_info_criterion, akaike_info_criterion_lsq
 
 
 def test_bayesian_info_criterion():

--- a/astropy/stats/tests/test_jackknife.py
+++ b/astropy/stats/tests/test_jackknife.py
@@ -12,7 +12,7 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from ..jackknife import jackknife_resampling, jackknife_stats
+from astropy.stats.jackknife import jackknife_resampling, jackknife_stats
 
 
 def test_jackknife_resampling():

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -13,8 +13,8 @@ except ImportError:
 else:
     HAS_SCIPY = True
 
-from ..sigma_clipping import sigma_clip, SigmaClip, sigma_clipped_stats
-from ...utils.misc import NumpyRNGContext
+from astropy.stats.sigma_clipping import sigma_clip, SigmaClip, sigma_clipped_stats
+from astropy.utils.misc import NumpyRNGContext
 
 
 def test_sigma_clip():

--- a/astropy/stats/tests/test_spatial.py
+++ b/astropy/stats/tests/test_spatial.py
@@ -4,8 +4,8 @@ import pytest
 
 from numpy.testing import assert_allclose
 
-from ..spatial import RipleysKEstimator
-from ...utils.misc import NumpyRNGContext
+from astropy.stats.spatial import RipleysKEstimator
+from astropy.utils.misc import NumpyRNGContext
 
 
 a = np.array([[1, 4], [2, 5], [3, 6]])

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from .. import config as _config
+from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):
@@ -50,12 +50,12 @@ from .serialize import SerializedColumn
 
 # Finally import the formats for the read and write method but delay building
 # the documentation until all are loaded. (#5275)
-from ..io import registry
+from astropy.io import registry
 
 with registry.delay_doc_updates(Table):
     # Import routines that connect readers/writers to astropy.table
     from .jsviewer import JSViewer
-    from ..io.ascii import connect
-    from ..io.fits import connect
-    from ..io.misc import connect
-    from ..io.votable import connect
+    from astropy.io.ascii import connect
+    from astropy.io.fits import connect
+    from astropy.io.misc import connect
+    from astropy.io.votable import connect

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -18,11 +18,11 @@ except ImportError:
     # For Numpy versions that do not raise this warning.
     MaskedArrayFutureWarning = None
 
-from ..units import Unit, Quantity
-from ..utils.console import color_print
-from ..utils.metadata import MetaData
-from ..utils.data_info import BaseColumnInfo, dtype_info_name
-from ..utils.misc import dtype_bytes_or_chars
+from astropy.units import Unit, Quantity
+from astropy.utils.console import color_print
+from astropy.utils.metadata import MetaData
+from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
+from astropy.utils.misc import dtype_bytes_or_chars
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -866,7 +866,7 @@ class Column(BaseColumn):
         descr = '<' + ' '.join(descr_vals) + '>\n'
 
         if html:
-            from ..utils.xml.writer import xml_escape
+            from astropy.utils.xml.writer import xml_escape
             descr = xml_escape(descr)
 
         data_lines, outs = self._formatter._pformat_col(

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 from .index import get_index_by_names
 
-from ..utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 __all__ = ['TableGroups', 'ColumnGroups']

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from .bst import MinValue, MaxValue
 from .sorted_array import SortedArray
-from ..time import Time
+from astropy.time import Time
 
 
 class QueryError(ValueError):

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from inspect import isclass
 
 import numpy as np
-from ..utils.data_info import DataInfo
+from astropy.utils.data_info import DataInfo
 
 __all__ = ['table_info', 'TableInfo', 'serialize_method_as']
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -4,9 +4,9 @@ from os.path import abspath, dirname, join
 
 from .table import Table
 
-from ..io import registry as io_registry
-from .. import config as _config
-from .. import extern
+from astropy.io import registry as io_registry
+from astropy import config as _config
+from astropy import extern
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -234,7 +234,7 @@ def get_yaml_from_header(header):
         raise ImportError('`import yaml` failed, PyYAML package is '
                           'required for serializing mixin columns')
 
-    from ..io.misc.yaml import AstropyDumper
+    from astropy.io.misc.yaml import AstropyDumper
 
     class TableDumper(AstropyDumper):
         """
@@ -323,7 +323,7 @@ def get_header_from_yaml(lines):
         raise ImportError('`import yaml` failed, PyYAML package '
                           'is required for serializing mixin columns')
 
-    from ..io.misc.yaml import AstropyLoader
+    from astropy.io.misc.yaml import AstropyLoader
 
     class TableLoader(AstropyLoader):
         """

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -16,9 +16,9 @@ from collections.abc import Mapping, Sequence
 
 import numpy as np
 
-from ..utils import metadata
+from astropy.utils import metadata
 from .table import Table, QTable, Row, Column
-from ..units import Quantity
+from astropy.units import Quantity
 
 from . import _np_utils
 from .np_utils import fix_column_name, TableMergeError

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -6,9 +6,9 @@ import re
 
 import numpy as np
 
-from .. import log
-from ..utils.console import Getch, color_print, terminal_size, conf
-from ..utils.data_info import dtype_info_name
+from astropy import log
+from astropy.utils.console import Getch, color_print, terminal_size, conf
+from astropy.utils.data_info import dtype_info_name
 
 __all__ = []
 
@@ -247,7 +247,7 @@ class TableFormatter:
             col_width = max(len(x) for x in col_strs)
 
         if html:
-            from ..utils.xml.writer import xml_escape
+            from astropy.utils.xml.writer import xml_escape
             n_header = outs['n_header']
             for i, col_str in enumerate(col_strs):
                 # _pformat_col output has a header line '----' which is not needed here
@@ -568,7 +568,7 @@ class TableFormatter:
         # row-oriented list.
         rows = []
         if html:
-            from ..utils.xml.writer import xml_escape
+            from astropy.utils.xml.writer import xml_escape
 
             if tableid is None:
                 tableid = 'table{id}'.format(id=id(table))

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -3,10 +3,10 @@ import re
 from copy import deepcopy
 from collections import OrderedDict
 
-from ..utils.data_info import MixinInfo
+from astropy.utils.data_info import MixinInfo
 from .column import Column
 from .table import Table, QTable, has_info_class
-from ..units.quantity import QuantityInfo
+from astropy.units.quantity import QuantityInfo
 
 
 __construct_mixin_classes = ('astropy.time.core.Time',

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -11,14 +11,14 @@ from copy import deepcopy
 import numpy as np
 from numpy import ma
 
-from .. import log
-from ..io import registry as io_registry
-from ..units import Quantity, QuantityInfo
-from ..utils import isiterable, ShapedLikeNDArray
-from ..utils.console import color_print
-from ..utils.metadata import MetaData
-from ..utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
-from ..utils.exceptions import AstropyDeprecationWarning, NoValue
+from astropy import log
+from astropy.io import registry as io_registry
+from astropy.units import Quantity, QuantityInfo
+from astropy.utils import isiterable, ShapedLikeNDArray
+from astropy.utils.console import color_print
+from astropy.utils.metadata import MetaData
+from astropy.utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
+from astropy.utils.exceptions import AstropyDeprecationWarning, NoValue
 
 from . import groups
 from .pprint import TableFormatter
@@ -853,7 +853,7 @@ class Table:
 
         descr = ' '.join(descr_vals)
         if html:
-            from ..utils.xml.writer import xml_escape
+            from astropy.utils.xml.writer import xml_escape
             descr = '<i>{0}</i>\n'.format(xml_escape(descr))
         else:
             descr = '<{0}>\n'.format(descr)

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -11,7 +11,7 @@ import string
 import numpy as np
 
 from .table import Table, Column
-from ..utils.data_info import ParentDtypeInfo
+from astropy.utils.data_info import ParentDtypeInfo
 
 
 class TimingTables:
@@ -123,8 +123,8 @@ def complex_table():
     Return a masked table from the io.votable test set that has a wide variety
     of stressing types.
     """
-    from ..utils.data import get_pkg_data_filename
-    from ..io.votable.table import parse
+    from astropy.utils.data import get_pkg_data_filename
+    from astropy.io.votable.table import parse
     import warnings
 
     with warnings.catch_warnings():

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -22,12 +22,12 @@ import pickle
 import pytest
 import numpy as np
 
-from ... import table
-from ...table import table_helpers, Table, QTable
-from ... import time
-from ... import units as u
-from ... import coordinates
-from .. import pprint
+from astropy import table
+from astropy.table import table_helpers, Table, QTable
+from astropy import time
+from astropy import units as u
+from astropy import coordinates
+from astropy.table import pprint
 
 
 @pytest.fixture(params=[table.Column, table.MaskedColumn])

--- a/astropy/table/tests/test_array.py
+++ b/astropy/table/tests/test_array.py
@@ -3,8 +3,8 @@
 import pytest
 import numpy as np
 
-from ..sorted_array import SortedArray
-from ..table import Table
+from astropy.table.sorted_array import SortedArray
+from astropy.table.table import Table
 
 
 @pytest.fixture

--- a/astropy/table/tests/test_bst.py
+++ b/astropy/table/tests/test_bst.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from ..bst import BST
+from astropy.table.bst import BST
 
 
 def get_tree(TreeType):

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -7,9 +7,9 @@ import operator
 import pytest
 import numpy as np
 
-from ...tests.helper import assert_follows_unicode_guidelines, catch_warnings
-from ... import table
-from ... import units as u
+from astropy.tests.helper import assert_follows_unicode_guidelines, catch_warnings
+from astropy import table
+from astropy import units as u
 
 
 class TestColumn():
@@ -73,7 +73,7 @@ class TestColumn():
 
     def test_format(self, Column):
         """Show that the formatted output from str() works"""
-        from ... import conf
+        from astropy import conf
         with conf.set_temp('max_lines', 8):
             c1 = Column(np.arange(2000), name='a', dtype=float,
                         format='%6.2f')
@@ -438,7 +438,7 @@ class TestAttrEqual():
 # and any minimal set of args to pass.
 
 
-from ...utils.tests.test_metadata import MetaBaseTest
+from astropy.utils.tests.test_metadata import MetaBaseTest
 
 
 class TestMetaColumn(MetaBaseTest):

--- a/astropy/table/tests/test_groups.py
+++ b/astropy/table/tests/test_groups.py
@@ -4,12 +4,12 @@
 import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings
-from ...table import Table, Column, QTable, table_helpers, NdarrayMixin, unique
-from ...utils.exceptions import AstropyUserWarning
-from ... import time
-from ... import units as u
-from ... import coordinates
+from astropy.tests.helper import catch_warnings
+from astropy.table import Table, Column, QTable, table_helpers, NdarrayMixin, unique
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy import time
+from astropy import units as u
+from astropy import coordinates
 
 
 def sort_eq(list1, list2):

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -4,13 +4,13 @@ import pytest
 import numpy as np
 
 from .test_table import SetupData
-from ..bst import BST, FastRBT, FastBST
-from ..sorted_array import SortedArray
-from ..soco import SCEngine, HAS_SOCO
-from ..table import QTable, Row, Table
-from ... import units as u
-from ...time import Time
-from ..column import BaseColumn
+from astropy.table.bst import BST, FastRBT, FastBST
+from astropy.table.sorted_array import SortedArray
+from astropy.table.soco import SCEngine, HAS_SOCO
+from astropy.table.table import QTable, Row, Table
+from astropy import units as u
+from astropy.time import Time
+from astropy.table.column import BaseColumn
 
 try:
     import bintrees

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -10,13 +10,13 @@ from copy import deepcopy
 import numpy as np
 import pytest
 
-from ... import units as u
-from ... import time
-from ... import coordinates
-from ... import table
-from ..info import serialize_method_as
-from ...utils.data_info import data_info_factory, dtype_info_name
-from ..table_helpers import simple_table
+from astropy import units as u
+from astropy import time
+from astropy import coordinates
+from astropy import table
+from astropy.table.info import serialize_method_as
+from astropy.utils.data_info import data_info_factory, dtype_info_name
+from astropy.table.table_helpers import simple_table
 
 
 def test_table_info_attributes(table_types):

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 import pytest
 import numpy as np
 
-from ...table import Column, TableColumns
+from astropy.table import Column, TableColumns
 
 
 class TestTableColumnsInit():

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -3,9 +3,9 @@ import textwrap
 
 import pytest
 
-from ..table import Table
-from ... import extern
-from ...utils.xml.writer import HAS_BLEACH
+from astropy.table.table import Table
+from astropy import extern
+from astropy.utils.xml.writer import HAS_BLEACH
 
 try:
     import IPython  # pylint: disable=W0611

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -7,7 +7,7 @@ import pytest
 import numpy as np
 import numpy.ma as ma
 
-from ...table import Column, MaskedColumn, Table
+from astropy.table import Column, MaskedColumn, Table
 
 
 class SetupData:

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -21,14 +21,14 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from ...coordinates import EarthLocation
-from ...table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
-from ...table import serialize
-from ... import time
-from ... import coordinates
-from ... import units as u
-from ..column import BaseColumn
-from .. import table_helpers
+from astropy.coordinates import EarthLocation
+from astropy.table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
+from astropy.table import serialize
+from astropy import time
+from astropy import coordinates
+from astropy import units as u
+from astropy.table.column import BaseColumn
+from astropy.table import table_helpers
 from .conftest import MIXIN_COLS
 
 
@@ -100,7 +100,7 @@ def test_io_ascii_write():
     every pure Python writer.  No validation of the output is done,
     this just confirms no exceptions.
     """
-    from ...io.ascii.connect import _get_connectors_table
+    from astropy.io.ascii.connect import _get_connectors_table
     t = QTable(MIXIN_COLS)
     for fmt in _get_connectors_table():
         if fmt['Format'] == 'ascii.ecsv' and not HAS_YAML:

--- a/astropy/table/tests/test_np_utils.py
+++ b/astropy/table/tests/test_np_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .. import np_utils
+from astropy.table import np_utils
 
 
 def test_common_dtype():

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -6,15 +6,15 @@ from collections import OrderedDict
 import pytest
 import numpy as np
 
-from ...tests.helper import catch_warnings
-from ...table import Table, QTable, TableMergeError
-from ...table.operations import _get_out_class
-from ... import units as u
-from ...utils import metadata
-from ...utils.metadata import MergeConflictError
-from ... import table
-from ...time import Time
-from ...coordinates import SkyCoord
+from astropy.tests.helper import catch_warnings
+from astropy.table import Table, QTable, TableMergeError
+from astropy.table.operations import _get_out_class
+from astropy import units as u
+from astropy.utils import metadata
+from astropy.utils.metadata import MergeConflictError
+from astropy import table
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
 
 
 def sort_eq(list1, list2):

--- a/astropy/table/tests/test_pickle.py
+++ b/astropy/table/tests/test_pickle.py
@@ -2,11 +2,11 @@
 import numpy as np
 import pickle
 
-from ...table import Table, Column, MaskedColumn, QTable
-from ...table.table_helpers import simple_table
-from ...units import Quantity, deg
-from ...time import Time
-from ...coordinates import SkyCoord
+from astropy.table import Table, Column, MaskedColumn, QTable
+from astropy.table.table_helpers import simple_table
+from astropy.units import Quantity, deg
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
 
 
 def test_pickle_column(protocol):

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -5,11 +5,11 @@
 import pytest
 import numpy as np
 
-from ... import table
-from ...table import Table, QTable
-from ...table.table_helpers import simple_table
-from ... import units as u
-from ...utils import console
+from astropy import table
+from astropy.table import Table, QTable
+from astropy.table.table_helpers import simple_table
+from astropy import units as u
+from astropy.utils import console
 
 BIG_WIDE_ARR = np.arange(2000, dtype=np.float64).reshape(100, 20)
 SMALL_ARR = np.arange(18, dtype=np.int64).reshape(6, 3)
@@ -293,7 +293,7 @@ class TestFormat():
         assert t['a'].format == '%4.2f {0:}'  # format did not change
 
     def test_column_format_with_threshold(self, table_type):
-        from ... import conf
+        from astropy import conf
         with conf.set_temp('max_lines', 8):
             t = table_type([np.arange(20)], names=['a'])
             t['a'].format = '%{0:}'
@@ -413,7 +413,7 @@ class TestFormatWithMaskedElements():
         assert str(t['a']) == '   a   \n-------\n     --\n%4.2f 2\n     --'
 
     def test_column_format_with_threshold(self, table_type):
-        from ... import conf
+        from astropy import conf
         with conf.set_temp('max_lines', 8):
             t = table_type([np.arange(20)], names=['a'])
             t['a'].format = '%{0:}'

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -6,9 +6,9 @@ import sys
 import pytest
 import numpy as np
 
-from ... import table
-from ...table import Row
-from ... import units as u
+from astropy import table
+from astropy.table import Row
+from astropy import units as u
 from .conftest import MaskedTable
 
 

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -1,8 +1,8 @@
 import os
 import re
 
-from ..scripts import showtable
-from ...utils.compat import NUMPY_LT_1_14
+from astropy.table.scripts import showtable
+from astropy.utils.compat import NUMPY_LT_1_14
 
 ROOT = os.path.abspath(os.path.dirname(__file__))
 ASCII_ROOT = os.path.join(ROOT, '..', '..', 'io', 'ascii', 'tests')

--- a/astropy/table/tests/test_subclass.py
+++ b/astropy/table/tests/test_subclass.py
@@ -2,8 +2,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 
-from ... import table
-from .. import pprint
+from astropy import table
+from astropy.table import pprint
 
 
 class MyRow(table.Row):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -11,12 +11,12 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ...io import fits
-from ...tests.helper import (assert_follows_unicode_guidelines,
+from astropy.io import fits
+from astropy.tests.helper import (assert_follows_unicode_guidelines,
                              ignore_warnings, catch_warnings)
-from ...utils.data import get_pkg_data_filename
-from ... import table
-from ... import units as u
+from astropy.utils.data import get_pkg_data_filename
+from astropy import table
+from astropy import units as u
 from .conftest import MaskedTable
 
 
@@ -1445,7 +1445,7 @@ def test_equality_masked_bug():
 # takes care of defining all the tests, and we simply have to define the class
 # and any minimal set of args to pass.
 
-from ...utils.tests.test_metadata import MetaBaseTest
+from astropy.utils.tests.test_metadata import MetaBaseTest
 
 
 class TestMetaTable(MetaBaseTest):
@@ -1657,7 +1657,7 @@ class TestPandas:
 
     def test_mixin(self):
 
-        from ...coordinates import SkyCoord
+        from astropy.coordinates import SkyCoord
 
         t = table.Table()
         t['c'] = SkyCoord([1, 2, 3], [4, 5, 6], unit='deg')

--- a/astropy/tests/disable_internet.py
+++ b/astropy/tests/disable_internet.py
@@ -15,7 +15,7 @@ TODO: This module should eventually be removed once backwards compatibility
 is no longer supported.
 """
 from warnings import warn
-from ..utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 warn("The ``disable_internet`` module is no longer provided by astropy. It "

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -19,8 +19,8 @@ try:
 except ImportError:
     pass
 
-from ..units import allclose as quantity_allclose  # noqa
-from ..utils.exceptions import (AstropyDeprecationWarning,
+from astropy.units import allclose as quantity_allclose  # noqa
+from astropy.utils.exceptions import (AstropyDeprecationWarning,
                                 AstropyPendingDeprecationWarning)
 
 
@@ -53,7 +53,7 @@ def _save_coverage(cov, result, rootdir, testing_path):
     This method is called after the tests have been run in coverage mode
     to cleanup and then save the coverage data and report.
     """
-    from ..utils.console import color_print
+    from astropy.utils.console import color_print
 
     if result != 0:
         return
@@ -373,7 +373,7 @@ def assert_follows_unicode_guidelines(
         ensure that ``__bytes__(x)`` roundtrip.
         If not provided, no roundtrip testing will be performed.
     """
-    from .. import conf
+    from astropy import conf
 
     with conf.set_temp('unicode_output', False):
         bytes_x = bytes(x)
@@ -473,6 +473,6 @@ def assert_quantity_allclose(actual, desired, rtol=1.e-7, atol=None,
     :func:`numpy.testing.assert_allclose`.
     """
     import numpy as np
-    from ..units.quantity import _unquantify_allclose_arguments
+    from astropy.units.quantity import _unquantify_allclose_arguments
     np.testing.assert_allclose(*_unquantify_allclose_arguments(
         actual, desired, rtol, atol), **kwargs)

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -1,7 +1,7 @@
 import matplotlib
 from matplotlib import pyplot as plt
 
-from ..utils.decorators import wraps
+from astropy.utils.decorators import wraps
 
 MPL_VERSION = matplotlib.__version__
 

--- a/astropy/tests/plugins/config.py
+++ b/astropy/tests/plugins/config.py
@@ -11,9 +11,9 @@ from collections import OrderedDict
 
 import pytest
 
-from ...config.paths import set_temp_config, set_temp_cache
-from ...utils.argparse import writeable_directory
-from ..helper import treat_deprecations_as_exceptions
+from astropy.config.paths import set_temp_config, set_temp_cache
+from astropy.utils.argparse import writeable_directory
+from astropy.tests.helper import treat_deprecations_as_exceptions
 
 import importlib.machinery as importlib_machinery
 

--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -13,8 +13,8 @@ import locale
 import math
 from collections import OrderedDict
 
-from ..helper import ignore_warnings
-from ...utils.introspection import resolve_name
+from astropy.tests.helper import ignore_warnings
+from astropy.utils.introspection import resolve_name
 
 
 PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
@@ -24,7 +24,7 @@ PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
                                      ('Pandas', 'pandas')])
 
 # This always returns with Astropy's version
-from ... import __version__
+from astropy import __version__
 TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
 
 
@@ -99,7 +99,7 @@ def pytest_report_header(config):
         astropy_helpers_version = TESTED_VERSIONS['astropy_helpers']
     else:
         try:
-            from ...version import astropy_helpers_version
+            from astropy.version import astropy_helpers_version
         except ImportError:
             astropy_helpers_version = None
 

--- a/astropy/tests/pytest_plugins.py
+++ b/astropy/tests/pytest_plugins.py
@@ -10,7 +10,7 @@ compatibility is no longer supported.
 """
 import builtins
 import warnings
-from ..utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from .helper import enable_deprecations_as_exceptions
 from .plugins.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -12,9 +12,9 @@ import importlib
 from collections import OrderedDict
 from importlib.util import find_spec
 
-from ..config.paths import set_temp_config, set_temp_cache
-from ..utils import wraps, find_current_module
-from ..utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.config.paths import set_temp_config, set_temp_cache
+from astropy.utils import wraps, find_current_module
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 __all__ = ['TestRunner', 'TestRunnerBase', 'keyword']
 
@@ -600,6 +600,6 @@ class TestRunner(TestRunnerBase):
         # This prevents cyclical import problems that make it
         # impossible to test packages that define Table types on their
         # own.
-        from ..table import Table  # pylint: disable=W0611
+        from astropy.table import Table  # pylint: disable=W0611
 
         return super().run_tests(**kwargs)

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -8,9 +8,9 @@ import warnings
 import pytest
 
 from .helper import catch_warnings
-from .. import log
-from ..logger import LoggingError, conf
-from ..utils.exceptions import AstropyWarning, AstropyUserWarning
+from astropy import log
+from astropy.logger import LoggingError, conf
+from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning
 
 
 # Save original values of hooks. These are not the system values, but the
@@ -133,7 +133,7 @@ def test_warnings_logging_with_custom_class():
 
 
 def test_warning_logging_with_io_votable_warning():
-    from ..io.votable.exceptions import W02, vo_warn
+    from astropy.io.votable.exceptions import W02, vo_warn
 
     with catch_warnings() as warn_list:
         log.enable_warnings_logging()
@@ -243,7 +243,7 @@ def test_exception_logging_origin():
     # The point here is to get an exception raised from another location
     # and make sure the error's origin is reported correctly
 
-    from ..utils.collections import HomogeneousList
+    from astropy.utils.collections import HomogeneousList
 
     l = HomogeneousList(int)
     try:

--- a/astropy/tests/tests/test_imports.py
+++ b/astropy/tests/tests/test_imports.py
@@ -11,7 +11,7 @@ def test_imports():
     dependencies that sneak through
     """
 
-    from ...utils import find_current_module
+    from astropy.utils import find_current_module
 
     pkgornm = find_current_module(1).__name__.split('.')[0]
 

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -1,6 +1,6 @@
-from ... import units as u
+from astropy import units as u
 
-from ..helper import assert_quantity_allclose, pytest
+from astropy.tests.helper import assert_quantity_allclose, pytest
 
 
 def test_assert_quantity_allclose():

--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -11,9 +11,9 @@ from textwrap import dedent
 import pytest
 
 # test helper.run_tests function
-from ... import test as run_tests
+from astropy import test as run_tests
 
-from .. import helper
+from astropy.tests import helper
 
 
 # run_tests should raise ValueError when asked to run on a module it can't find

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -15,12 +15,12 @@ from time import strftime, strptime
 
 import numpy as np
 
-from .. import units as u, constants as const
-from .. import _erfa as erfa
-from ..units import UnitConversionError
-from ..utils import ShapedLikeNDArray
-from ..utils.compat.misc import override__dir__
-from ..utils.data_info import MixinInfo, data_info_factory
+from astropy import units as u, constants as const
+from astropy import _erfa as erfa
+from astropy.units import UnitConversionError
+from astropy.utils import ShapedLikeNDArray
+from astropy.utils.compat.misc import override__dir__
+from astropy.utils.data_info import MixinInfo, data_info_factory
 from .utils import day_frac
 from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
@@ -28,7 +28,7 @@ from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
 # making a custom timescale in the documentation.
 from .formats import TimeFromEpoch  # pylint: disable=W0611
 
-from ..extern import _strptime
+from astropy.extern import _strptime
 
 __all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
            'ScaleValueError', 'OperandTypeError', 'TimeInfo']
@@ -371,7 +371,7 @@ class Time(ShapedLikeNDArray):
                  location=None, copy=False):
 
         if location is not None:
-            from ..coordinates import EarthLocation
+            from astropy.coordinates import EarthLocation
             if isinstance(location, EarthLocation):
                 self.location = location
             else:
@@ -1050,7 +1050,7 @@ class Time(ShapedLikeNDArray):
                                  'corrections')
             location = self.location
 
-        from ..coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
+        from astropy.coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
                                    HCRS, ICRS, GCRS, solar_system_ephemeris)
 
         # ensure sky location is ICRS compatible
@@ -1115,7 +1115,7 @@ class Time(ShapedLikeNDArray):
             Sidereal time as a quantity with units of hourangle
         """  # docstring is formatted below
 
-        from ..coordinates import Longitude
+        from astropy.coordinates import Longitude
 
         if kind.lower() not in SIDEREAL_TIME_MODELS.keys():
             raise ValueError('The kind of sidereal time has to be {0}'.format(
@@ -1156,7 +1156,7 @@ class Time(ShapedLikeNDArray):
     def _erfa_sidereal_time(self, model):
         """Calculate a sidereal time using a IAU precession/nutation model."""
 
-        from ..coordinates import Longitude
+        from astropy.coordinates import Longitude
 
         erfa_function = model['function']
         erfa_parameters = [getattr(getattr(self, scale)._time, jd_part)
@@ -1621,7 +1621,7 @@ class Time(ShapedLikeNDArray):
             array([ True, False]...)
         """
         if iers_table is None:
-            from ..utils.iers import IERS
+            from astropy.utils.iers import IERS
             iers_table = IERS.open()
 
         return iers_table.ut1_utc(self.utc, return_status=return_status)
@@ -1637,7 +1637,7 @@ class Time(ShapedLikeNDArray):
         # Sec. 4.3.1: the arg DUT is the quantity delta_UT1 = UT1 - UTC in
         # seconds. It is obtained from tables published by the IERS.
         if not hasattr(self, '_delta_ut1_utc'):
-            from ..utils.iers import IERS_Auto
+            from astropy.utils.iers import IERS_Auto
             iers_table = IERS_Auto.open()
             # jd1, jd2 are normally set (see above), except if delta_ut1_utc
             # is access directly; ensure we behave as expected for that case
@@ -1699,7 +1699,7 @@ class Time(ShapedLikeNDArray):
             ut = day_frac(njd1 - 0.5, njd2)[1]
 
             if self.location is None:
-                from ..coordinates import EarthLocation
+                from astropy.coordinates import EarthLocation
                 location = EarthLocation.from_geodetic(0., 0., 0.)
             else:
                 location = self.location

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -10,10 +10,10 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
-from ..utils.decorators import lazyproperty
-from ..utils.exceptions import AstropyDeprecationWarning
-from .. import units as u
-from .. import _erfa as erfa
+from astropy.utils.decorators import lazyproperty
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy import units as u
+from astropy import _erfa as erfa
 from .utils import day_frac, quantity_day_frac, two_sum, two_product
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -9,14 +9,14 @@ from copy import deepcopy
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ...tests.helper import catch_warnings, pytest
-from ...utils.exceptions import AstropyDeprecationWarning
-from ...utils import isiterable
-from .. import Time, ScaleValueError, STANDARD_TIME_SCALES, TimeString, TimezoneInfo
-from ...coordinates import EarthLocation
-from ... import units as u
-from ... import _erfa as erfa
-from ...table import Column
+from astropy.tests.helper import catch_warnings, pytest
+from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils import isiterable
+from astropy.time import Time, ScaleValueError, STANDARD_TIME_SCALES, TimeString, TimezoneInfo
+from astropy.coordinates import EarthLocation
+from astropy import units as u
+from astropy import _erfa as erfa
+from astropy.table import Column
 try:
     import pytz
     HAS_PYTZ = True

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -5,7 +5,7 @@ import operator
 import pytest
 import numpy as np
 
-from .. import Time, TimeDelta
+from astropy.time import Time, TimeDelta
 
 
 class TestTimeComparisons():

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -1,9 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
-from ... import units as u
-from ...coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
-from .. import Time, TimeDelta
+from astropy import units as u
+from astropy.coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
+from astropy.time import Time, TimeDelta
 
 try:
     import jplephem  # pylint: disable=W0611

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -8,9 +8,9 @@ import pytest
 
 from datetime import timedelta
 
-from .. import (Time, TimeDelta, OperandTypeError, ScaleValueError,
+from astropy.time import (Time, TimeDelta, OperandTypeError, ScaleValueError,
                 TIME_SCALES, STANDARD_TIME_SCALES, TIME_DELTA_SCALES)
-from ... import units as u
+from astropy import units as u
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,

--- a/astropy/time/tests/test_guess.py
+++ b/astropy/time/tests/test_guess.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from .. import Time
+from astropy.time import Time
 
 
 class TestGuess():

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -3,10 +3,10 @@
 import functools
 import numpy as np
 
-from ...utils.compat import NUMPY_LT_1_14
-from ...tests.helper import pytest
-from .. import Time
-from ...table import Table
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.tests.helper import pytest
+from astropy.time import Time
+from astropy.table import Table
 
 try:
     import h5py  # pylint: disable=W0611

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -6,7 +6,7 @@ import copy
 import pytest
 import numpy as np
 
-from .. import Time
+from astropy.time import Time
 
 
 @pytest.fixture(scope="module", params=[True, False])

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -3,7 +3,7 @@
 import pickle
 import numpy as np
 
-from .. import Time
+from astropy.time import Time
 
 
 class TestPickle():

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -3,7 +3,7 @@ import functools
 import pytest
 import numpy as np
 
-from .. import Time, TimeDelta
+from astropy.time import Time, TimeDelta
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -4,9 +4,9 @@ import functools
 import pytest
 import numpy as np
 
-from .. import Time, TimeDelta
-from ... import units as u
-from ...table import Column
+from astropy.time import Time, TimeDelta
+from astropy import units as u
+from astropy.table import Column
 
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -5,8 +5,8 @@ import itertools
 import pytest
 import numpy as np
 
-from .. import Time
-from ..core import SIDEREAL_TIME_MODELS
+from astropy.time import Time
+from astropy.time.core import SIDEREAL_TIME_MODELS
 
 allclose_hours = functools.partial(np.allclose, rtol=1e-15, atol=3e-8)
 # 0.1 ms atol; IERS-B files change at that level.

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -4,8 +4,8 @@ import functools
 import pytest
 import numpy as np
 
-from .. import Time
-from ...utils.iers import iers  # used in testing
+from astropy.time import Time
+from astropy.utils.iers import iers  # used in testing
 
 allclose_jd = functools.partial(np.allclose, rtol=0, atol=1e-9)
 allclose_sec = functools.partial(np.allclose, rtol=1e-15, atol=1e-4)

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -8,7 +8,7 @@ Geometry 18(3):305-363 -- http://www.cs.berkeley.edu/~jrs/papers/robustr.pdf
 """
 
 import numpy as np
-from .. import units as u
+from astropy import units as u
 
 
 def day_frac(val1, val2, factor=1., divisor=1.):

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -7,9 +7,9 @@ Distribution class and associated machinery.
 
 import numpy as np
 
-from .. import units as u
-from .. import visualization
-from .. import stats
+from astropy import units as u
+from astropy import visualization
+from astropy import stats
 
 __all__ = ['Distribution']
 

--- a/astropy/uncertainty/distributions.py
+++ b/astropy/uncertainty/distributions.py
@@ -8,7 +8,7 @@ from warnings import warn
 
 import numpy as np
 
-from .. import units as u
+from astropy import units as u
 from .core import Distribution
 
 __all__ = ['normal', 'poisson', 'uniform']

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import, division, print_function
 
 import numpy as np
 
-from ... import units as u
-from ..core import Distribution
-from .. import distributions as ds
-from ...utils import NumpyRNGContext
-from ...tests.helper import assert_quantity_allclose, pytest
+from astropy import units as u
+from astropy.uncertainty.core import Distribution
+from astropy.uncertainty import distributions as ds
+from astropy.utils import NumpyRNGContext
+from astropy.tests.helper import assert_quantity_allclose, pytest
 
 try:
     from scipy.stats import norm  # pylint: disable=W0611

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -8,7 +8,7 @@ available in the `astropy.units` namespace.
 
 
 from . import si
-from ..constants import si as _si
+from astropy.constants import si as _si
 from .core import (UnitBase, def_unit, si_prefixes, binary_prefixes,
                    set_enabled_units)
 

--- a/astropy/units/cds.py
+++ b/astropy/units/cds.py
@@ -32,8 +32,8 @@ def _initialize_module():
     import numpy as np
 
     from . import core
-    from .. import units as u
-    from ..constants import si as _si
+    from astropy import units as u
+    from astropy.constants import si as _si
 
     # The CDS format also supports power-of-2 prefixes as defined here:
     # http://physics.nist.gov/cuu/Units/binary.html

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -13,9 +13,9 @@ import warnings
 
 import numpy as np
 
-from ..utils.decorators import lazyproperty
-from ..utils.exceptions import AstropyWarning
-from ..utils.misc import isiterable, InheritDocstrings
+from astropy.utils.decorators import lazyproperty
+from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.misc import isiterable, InheritDocstrings
 from .utils import (is_effectively_unity, sanitize_scale, validate_power,
                     resolve_fractions)
 from . import format as unit_format

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -4,8 +4,8 @@
 __all__ = ['quantity_input']
 
 import inspect
-from ..utils.decorators import wraps
-from ..utils.misc import isiterable
+from astropy.utils.decorators import wraps
+from astropy.utils.misc import isiterable
 
 from .core import Unit, UnitsError, add_enabled_equivalencies
 from .physical import _unit_physical_mapping

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -6,8 +6,8 @@ import numpy as np
 import warnings
 
 # LOCAL
-from ..constants import si as _si
-from ..utils.misc import isiterable
+from astropy.constants import si as _si
+from astropy.utils.misc import isiterable
 from . import si
 from . import cgs
 from . import astrophys
@@ -620,7 +620,7 @@ def thermodynamic_temperature(frequency, T_cmb=None):
     nu = frequency.to(si.GHz, spectral())
 
     if T_cmb is None:
-        from ..cosmology import default_cosmology
+        from astropy.cosmology import default_cosmology
         T_cmb = default_cosmology.get().Tcmb0
 
     def f(nu, T_cmb=T_cmb):
@@ -725,7 +725,7 @@ def with_H0(H0=None):
     """
 
     if H0 is None:
-        from .. import cosmology
+        from astropy import cosmology
         H0 = cosmology.default_cosmology.get().H0
 
     h100_val_unit = Unit(H0.to((si.km/si.s)/astrophys.Mpc).value/100 * astrophys.littleh)

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -2,7 +2,7 @@
 
 import os
 
-from ...utils.misc import InheritDocstrings
+from astropy.utils.misc import InheritDocstrings
 
 
 class _FormatterMeta(InheritDocstrings):

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -23,9 +23,9 @@ import re
 
 from .base import Base
 from . import core, utils
-from ..utils import is_effectively_unity
-from ...utils import classproperty
-from ...utils.misc import did_you_mean
+from astropy.units.utils import is_effectively_unity
+from astropy.utils import classproperty
+from astropy.utils.misc import did_you_mean
 
 
 # TODO: Support logarithmic units using bracketed syntax
@@ -66,8 +66,8 @@ class CDS(Base):
 
     @staticmethod
     def _generate_unit_names():
-        from .. import cds
-        from ... import units as u
+        from astropy.units import cds
+        from astropy import units as u
 
         names = {}
 
@@ -80,7 +80,7 @@ class CDS(Base):
     @classmethod
     def _make_lexer(cls):
 
-        from ...extern.ply import lex
+        from astropy.extern.ply import lex
 
         tokens = cls._tokens
 
@@ -149,7 +149,7 @@ class CDS(Base):
         <https://bitbucket.org/nxg/unity/>`_.
         """
 
-        from ...extern.ply import yacc
+        from astropy.extern.ply import yacc
 
         tokens = cls._tokens
 
@@ -159,7 +159,7 @@ class CDS(Base):
                  | combined_units
                  | factor
             '''
-            from ..core import Unit
+            from astropy.units.core import Unit
             if len(p) == 3:
                 p[0] = Unit(p[1] * p[2])
             else:

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -26,7 +26,7 @@ class Fits(generic.Generic):
 
     @staticmethod
     def _generate_unit_names():
-        from ... import units as u
+        from astropy import units as u
         names = {}
         deprecated_names = set()
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -20,8 +20,8 @@ import warnings
 
 from . import core, utils
 from .base import Base
-from ...utils import classproperty
-from ...utils.misc import did_you_mean
+from astropy.utils import classproperty
+from astropy.utils.misc import did_you_mean
 
 
 def _to_string(cls, unit):
@@ -104,7 +104,7 @@ class Generic(Base):
 
     @classmethod
     def _make_lexer(cls):
-        from ...extern.ply import lex
+        from astropy.extern.ply import lex
 
         tokens = cls._tokens
 
@@ -184,7 +184,7 @@ class Generic(Base):
         formats, the only difference being the set of available unit
         strings.
         """
-        from ...extern.ply import yacc
+        from astropy.extern.ply import yacc
 
         tokens = cls._tokens
 
@@ -201,7 +201,7 @@ class Generic(Base):
                  | factor product inverse_unit
                  | factor
             '''
-            from ..core import Unit
+            from astropy.units.core import Unit
             if len(p) == 2:
                 p[0] = Unit(p[1])
             elif len(p) == 3:
@@ -214,7 +214,7 @@ class Generic(Base):
             division_product_of_units : division_product_of_units division product_of_units
                                       | product_of_units
             '''
-            from ..core import Unit
+            from astropy.units.core import Unit
             if len(p) == 4:
                 p[0] = Unit(p[1] / p[3])
             else:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -52,7 +52,7 @@ class OGIP(generic.Generic):
     @staticmethod
     def _generate_unit_names():
 
-        from ... import units as u
+        from astropy import units as u
         names = {}
         deprecated_names = set()
 
@@ -111,7 +111,7 @@ class OGIP(generic.Generic):
 
     @classmethod
     def _make_lexer(cls):
-        from ...extern.ply import lex
+        from astropy.extern.ply import lex
 
         tokens = cls._tokens
 
@@ -186,7 +186,7 @@ class OGIP(generic.Generic):
         <https://bitbucket.org/nxg/unity/>`_.
         """
 
-        from ...extern.ply import yacc
+        from astropy.extern.ply import yacc
 
         tokens = cls._tokens
 
@@ -279,7 +279,7 @@ class OGIP(generic.Generic):
                 p[0] = p[1]
             # Can't use np.log10 here, because p[0] may be a Python long.
             if math.log10(p[0]) % 1.0 != 0.0:
-                from ..core import UnitsWarning
+                from astropy.units.core import UnitsWarning
                 warnings.warn(
                     "'{0}' scale should be a power of 10 in "
                     "OGIP format".format(p[0]), UnitsWarning)

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -8,7 +8,7 @@ Utilities shared by the different formats.
 import warnings
 from fractions import Fraction
 
-from ...utils.misc import did_you_mean
+from astropy.utils.misc import did_you_mean
 
 
 def get_grouped_by_powers(bases, powers):
@@ -94,7 +94,7 @@ def decompose_to_known_units(unit, func):
     unit : `~astropy.units.UnitBase` instance
         A flattened unit.
     """
-    from .. import core
+    from astropy.units import core
     if isinstance(unit, core.CompositeUnit):
         new_unit = core.Unit(unit.scale)
         for base, power in zip(unit.bases, unit.powers):
@@ -208,7 +208,7 @@ def unit_deprecation_warning(s, unit, standard_name, format_decomposed):
         A function to turn a decomposed version of the unit into a
         string.  Should return `None` if not possible
     """
-    from ..core import UnitsWarning
+    from astropy.units.core import UnitsWarning
 
     message = "The unit '{0}' has been deprecated in the {1} standard.".format(
         s, standard_name)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -27,8 +27,8 @@ class VOUnit(generic.Generic):
 
     @staticmethod
     def _generate_unit_names():
-        from ... import units as u
-        from ...units import required_by_vounit as uvo
+        from astropy import units as u
+        from astropy.units import required_by_vounit as uvo
 
         names = {}
         deprecated_names = set()
@@ -185,7 +185,7 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def to_string(cls, unit):
-        from .. import core
+        from astropy.units import core
 
         # Remove units that aren't known to the format
         unit = utils.decompose_to_known_units(unit, cls._get_unit_name)
@@ -222,7 +222,7 @@ class VOUnit(generic.Generic):
 
     @classmethod
     def _to_decomposed_alternative(cls, unit):
-        from .. import core
+        from astropy.units import core
 
         try:
             s = cls.to_string(unit)

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -6,7 +6,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 
-from .. import (Unit, UnitBase, UnitsError, UnitTypeError,
+from astropy.units import (Unit, UnitBase, UnitsError, UnitTypeError,
                 dimensionless_unscaled, Quantity)
 
 __all__ = ['FunctionUnitBase', 'FunctionQuantity']

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -2,7 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import numpy as np
 
-from .. import CompositeUnit, UnitsError, dimensionless_unscaled, photometric
+from astropy.units import CompositeUnit, UnitsError, dimensionless_unscaled, photometric
 from .core import FunctionUnitBase, FunctionQuantity
 from .units import dex, dB, mag
 

--- a/astropy/units/function/magnitude_zero_points.py
+++ b/astropy/units/function/magnitude_zero_points.py
@@ -7,8 +7,8 @@ names remain here for backwards compatibility.
 """
 from warnings import warn
 
-from ..photometric import AB, ST
-from ...utils import deprecated
+from astropy.units.photometric import AB, ST
+from astropy.utils import deprecated
 
 _ns = globals()
 
@@ -32,7 +32,7 @@ def enable():
     # manager
 
     # Local import to avoid cyclical import
-    from ..core import add_enabled_units
+    from astropy.units.core import add_enabled_units
     # Local import to avoid polluting namespace
     import inspect
     return add_enabled_units(inspect.getmodule(enable))

--- a/astropy/units/function/mixin.py
+++ b/astropy/units/function/mixin.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..core import IrreducibleUnit, Unit
+from astropy.units.core import IrreducibleUnit, Unit
 
 
 class FunctionMixin:

--- a/astropy/units/function/units.py
+++ b/astropy/units/function/units.py
@@ -6,7 +6,7 @@ If called, their arguments are used to initialize the corresponding function
 unit (e.g., ``u.mag(u.ct/u.s)``).  Note that the prefixed versions cannot be
 called, as it would be unclear what, e.g., ``u.mmag(u.ct/u.s)`` would mean.
 """
-from ..core import _add_prefixes
+from astropy.units.core import _add_prefixes
 from .mixin import RegularFunctionUnit, IrreducibleFunctionUnit
 
 
@@ -41,6 +41,6 @@ del IrreducibleFunctionUnit
 
 # This generates a docstring for this module that describes all of the
 # standard units defined here.
-from ..utils import generate_unit_summary as _generate_unit_summary
+from astropy.units.utils import generate_unit_summary as _generate_unit_summary
 if __doc__ is not None:
     __doc__ += _generate_unit_summary(globals())

--- a/astropy/units/photometric.py
+++ b/astropy/units/photometric.py
@@ -9,7 +9,7 @@ This module defines magnitude zero points and related photometric quantities.
 import numpy as _numpy
 from .core import UnitBase, def_unit, Unit
 
-from ..constants import si as _si
+from astropy.constants import si as _si
 from . import cgs, si, astrophys
 
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -20,12 +20,12 @@ from .core import (Unit, dimensionless_unscaled, get_current_unit_registry,
                    UnitBase, UnitsError, UnitConversionError, UnitTypeError)
 from .utils import is_effectively_unity
 from .format.latex import Latex
-from ..utils.compat import NUMPY_LT_1_14
-from ..utils.compat.misc import override__dir__
-from ..utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from ..utils.misc import isiterable, InheritDocstrings
-from ..utils.data_info import ParentDtypeInfo
-from .. import config as _config
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.utils.compat.misc import override__dir__
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy.utils.misc import isiterable, InheritDocstrings
+from astropy.utils.data_info import ParentDtypeInfo
+from astropy import config as _config
 from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
                               check_output)
 

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from ..core import (UnitsError, UnitConversionError, UnitTypeError,
+from astropy.units.core import (UnitsError, UnitConversionError, UnitTypeError,
                     dimensionless_unscaled)
 
 __all__ = ['can_have_arbitrary_unit', 'converters_and_unit',

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -3,7 +3,7 @@
 """Quantity helpers for the ERFA ufuncs."""
 
 
-from ..core import UnitsError, UnitTypeError, dimensionless_unscaled
+from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 from . import UFUNC_HELPERS
 from .helpers import get_converter, helper_invariant, helper_multiplication
 
@@ -12,7 +12,7 @@ erfa_ufuncs = ('s2c', 's2p', 'c2s', 'p2s', 'pm', 'pdp', 'pxp', 'rxp')
 
 
 def helper_s2c(f, unit1, unit2):
-    from ..si import radian
+    from astropy.units.si import radian
     try:
         return [get_converter(unit1, radian),
                 get_converter(unit2, radian)], dimensionless_unscaled
@@ -23,7 +23,7 @@ def helper_s2c(f, unit1, unit2):
 
 
 def helper_s2p(f, unit1, unit2, unit3):
-    from ..si import radian
+    from astropy.units.si import radian
     try:
         return [get_converter(unit1, radian),
                 get_converter(unit2, radian), None], unit3
@@ -34,17 +34,17 @@ def helper_s2p(f, unit1, unit2, unit3):
 
 
 def helper_c2s(f, unit1):
-    from ..si import radian
+    from astropy.units.si import radian
     return [None], (radian, radian)
 
 
 def helper_p2s(f, unit1):
-    from ..si import radian
+    from astropy.units.si import radian
     return [None], (radian, radian, unit1)
 
 
 def get_erfa_helpers():
-    from ..._erfa import ufunc as erfa_ufunc
+    from astropy._erfa import ufunc as erfa_ufunc
 
     ERFA_HELPERS = {}
     ERFA_HELPERS[erfa_ufunc.s2c] = helper_s2c

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -13,7 +13,7 @@ from fractions import Fraction
 import numpy as np
 
 from . import UFUNC_HELPERS, UNSUPPORTED_UFUNCS
-from ..core import (UnitsError, UnitConversionError, UnitTypeError,
+from astropy.units.core import (UnitsError, UnitConversionError, UnitTypeError,
                     dimensionless_unscaled, get_current_unit_registry)
 
 
@@ -152,7 +152,7 @@ def helper_dimensionless_to_dimensionless(f, unit):
 
 
 def helper_dimensionless_to_radian(f, unit):
-    from ..si import radian
+    from astropy.units.si import radian
     if unit is None:
         return [None], radian
 
@@ -165,7 +165,7 @@ def helper_dimensionless_to_radian(f, unit):
 
 
 def helper_degree_to_radian(f, unit):
-    from ..si import degree, radian
+    from astropy.units.si import degree, radian
     try:
         return [get_converter(unit, degree)], radian
     except UnitsError:
@@ -175,7 +175,7 @@ def helper_degree_to_radian(f, unit):
 
 
 def helper_radian_to_degree(f, unit):
-    from ..si import degree, radian
+    from astropy.units.si import degree, radian
     try:
         return [get_converter(unit, radian)], degree
     except UnitsError:
@@ -185,7 +185,7 @@ def helper_radian_to_degree(f, unit):
 
 
 def helper_radian_to_dimensionless(f, unit):
-    from ..si import radian
+    from astropy.units.si import radian
     try:
         return [get_converter(unit, radian)], dimensionless_unscaled
     except UnitsError:
@@ -280,7 +280,7 @@ def helper_twoarg_comparison(f, unit1, unit2):
 
 
 def helper_twoarg_invtrig(f, unit1, unit2):
-    from ..si import radian
+    from astropy.units.si import radian
     converters, _ = get_converters_and_unit(f, unit1, unit2)
     return converters, radian
 

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -6,7 +6,7 @@ Available ufuncs in this module are at
 https://docs.scipy.org/doc/scipy/reference/special.html
 """
 
-from ..core import UnitsError, UnitTypeError, dimensionless_unscaled
+from astropy.units.core import UnitsError, UnitTypeError, dimensionless_unscaled
 from . import UFUNC_HELPERS
 from .helpers import (get_converter,
                       helper_dimensionless_to_dimensionless,
@@ -38,7 +38,7 @@ scipy_special_ufuncs += ('cbrt', 'radian')
 
 
 def helper_degree_to_dimensionless(f, unit):
-    from ..si import degree
+    from astropy.units.si import degree
     try:
         return [get_converter(unit, degree)], dimensionless_unscaled
     except UnitsError:
@@ -48,7 +48,7 @@ def helper_degree_to_dimensionless(f, unit):
 
 
 def helper_degree_minute_second_to_radian(f, unit1, unit2, unit3):
-    from ..si import degree, arcmin, arcsec, radian
+    from astropy.units.si import degree, arcmin, arcsec, radian
     try:
         return [get_converter(unit1, degree),
                 get_converter(unit2, arcmin),

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -6,7 +6,7 @@ This package defines the SI units.  They are also available in the
 
 """
 
-from ..constants import si as _si
+from astropy.constants import si as _si
 from .core import UnitBase, Unit, def_unit
 
 import numpy as _numpy

--- a/astropy/units/tests/test_deprecated.py
+++ b/astropy/units/tests/test_deprecated.py
@@ -7,8 +7,8 @@ because they are required for VOUnit support but are not in common use."""
 
 import pytest
 
-from .. import deprecated, required_by_vounit
-from ... import units as u
+from astropy.units import deprecated, required_by_vounit
+from astropy import units as u
 
 
 def test_emu():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -9,9 +9,9 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 # LOCAL
-from ... import units as u
-from ... import constants, cosmology
-from ...tests.helper import assert_quantity_allclose
+from astropy import units as u
+from astropy import constants, cosmology
+from astropy.tests.helper import assert_quantity_allclose
 
 
 def test_dimensionless_angles():
@@ -461,7 +461,7 @@ def test_spectraldensity5():
 
 
 def test_equivalent_units():
-    from .. import imperial
+    from astropy.units import imperial
     with u.add_enabled_units(imperial):
         units = u.g.find_equivalent_units()
         units_set = set(units)
@@ -483,7 +483,7 @@ def test_equivalent_units2():
          u.jupiterRad])
     assert units == match
 
-    from .. import imperial
+    from astropy.units import imperial
     with u.add_enabled_units(imperial):
         units = set(u.Hz.find_equivalent_units(u.spectral()))
         match = set(
@@ -671,7 +671,7 @@ def test_equivalency_context_manager():
 
 
 def test_temperature():
-    from ..imperial import deg_F
+    from astropy.units.imperial import deg_F
     t_k = 0 * u.K
     assert_allclose(t_k.to_value(u.deg_C, u.temperature()), -273.15)
     assert_allclose(t_k.to_value(deg_F, u.temperature()), -459.67)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -8,12 +8,12 @@ Regression tests for the units.format package
 import pytest
 from numpy.testing import assert_allclose
 
-from ...tests.helper import catch_warnings
-from ... import units as u
-from ...constants import si
-from .. import core
-from .. import format as u_format
-from ..utils import is_effectively_unity
+from astropy.tests.helper import catch_warnings
+from astropy import units as u
+from astropy.constants import si
+from astropy.units import core
+from astropy.units import format as u_format
+from astropy.units.utils import is_effectively_unity
 
 
 @pytest.mark.parametrize('strings, unit', [
@@ -233,7 +233,7 @@ def test_cds_units_available():
 def test_cds_non_ascii_unit():
     """Regression test for #5350.  This failed with a decoding error as
     μas could not be represented in ascii."""
-    from .. import cds
+    from astropy.units import cds
     with cds.enable():
         u.radian.find_equivalent_units(include_prefix_units=True)
 

--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -11,8 +11,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ...tests.helper import assert_quantity_allclose
-from ... import units as u, constants as c
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u, constants as c
 
 lu_units = [u.dex, u.mag, u.decibel]
 

--- a/astropy/units/tests/test_photometric.py
+++ b/astropy/units/tests/test_photometric.py
@@ -7,10 +7,10 @@ might be expected because a lot of the relevant tests that deal
 with magnidues are in `test_logarithmic.py`
 """
 
-from ...tests.helper import assert_quantity_allclose
+from astropy.tests.helper import assert_quantity_allclose
 
-from .. import Magnitude, mgy, nmgy, ABflux, STflux, zero_point_flux, Jy
-from .. import erg, cm, s, AA
+from astropy.units import Magnitude, mgy, nmgy, ABflux, STflux, zero_point_flux, Jy
+from astropy.units import erg, cm, s, AA
 
 
 def test_maggies():

--- a/astropy/units/tests/test_physical.py
+++ b/astropy/units/tests/test_physical.py
@@ -7,10 +7,10 @@ Regression tests for the physical_type support in the units package
 
 
 
-from ... import units as u
-from ...units import physical
-from ...constants import hbar
-from ...tests.helper import raises
+from astropy import units as u
+from astropy.units import physical
+from astropy.constants import hbar
+from astropy.tests.helper import raises
 
 
 def test_simple():

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -14,12 +14,12 @@ import numpy as np
 from numpy.testing import (assert_allclose, assert_array_equal,
                            assert_array_almost_equal)
 
-from ...tests.helper import catch_warnings, raises
-from ...utils import isiterable, minversion
-from ...utils.compat import NUMPY_LT_1_14
-from ...utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from ... import units as u
-from ...units.quantity import _UNIT_NOT_INITIALISED
+from astropy.tests.helper import catch_warnings, raises
+from astropy.utils import isiterable, minversion
+from astropy.utils.compat import NUMPY_LT_1_14
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
+from astropy import units as u
+from astropy.units.quantity import _UNIT_NOT_INITIALISED
 
 try:
     import matplotlib
@@ -540,7 +540,7 @@ class TestQuantityOperations:
 
     def test_complicated_operation(self):
         """ Perform a more complicated test """
-        from .. import imperial
+        from astropy.units import imperial
 
         # Multiple units
         distance = u.Quantity(15., u.meter)
@@ -896,7 +896,7 @@ class TestQuantityDisplay:
         assert repr(bad_quantity).endswith(_UNIT_NOT_INITIALISED + '>')
 
     def test_repr_latex(self):
-        from ...units.quantity import conf
+        from astropy.units.quantity import conf
 
         q2scalar = u.Quantity(1.5e14, 'm/s')
         assert self.scalarintq._repr_latex_() == r'$1 \; \mathrm{m}$'
@@ -1366,7 +1366,7 @@ def test_quantity_from_table():
 
 def test_assign_slice_with_quantity_like():
     # Regression tests for gh-5961
-    from ... table import Table, Column
+    from astropy.table import Table, Column
     # first check directly that we can use a Column to assign to a slice.
     c = Column(np.arange(10.), unit=u.mm)
     q = u.Quantity(c)

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from ... import units as u  # pylint: disable=W0611
+from astropy import units as u  # pylint: disable=W0611
 
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -4,7 +4,7 @@
 import pytest
 import numpy as np
 
-from ... import units as u
+from astropy import units as u
 
 
 class TestQuantityArrayCopy:

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -3,7 +3,7 @@
 
 import pytest
 
-from ... import units as u
+from astropy import units as u
 
 # list of pairs (target unit/physical type, input unit)
 x_inputs = [(u.arcsec, u.deg), ('angle', u.deg),

--- a/astropy/units/tests/test_quantity_helpers.py
+++ b/astropy/units/tests/test_quantity_helpers.py
@@ -5,7 +5,7 @@ Test ``allclose`` and ``isclose``.
 import numpy as np
 import pytest
 
-from ... import units as u
+from astropy import units as u
 
 
 @pytest.mark.parametrize(

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytest
 
-from ... import units as u
+from astropy import units as u
 
 
 class TestQuantityLinAlgFuncs:

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -8,10 +8,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ... import units as u
-from .. import quantity_helper as qh
-from ..._erfa import ufunc as erfa_ufunc
-from ...tests.helper import raises
+from astropy import units as u
+from astropy.units import quantity_helper as qh
+from astropy._erfa import ufunc as erfa_ufunc
+from astropy.tests.helper import raises
 
 try:
     import scipy  # pylint: disable=W0611

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -10,18 +10,18 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ...tests.helper import raises, catch_warnings
+from astropy.tests.helper import raises, catch_warnings
 
-from ... import units as u
-from ... import constants as c
-from .. import utils
+from astropy import units as u
+from astropy import constants as c
+from astropy.units import utils
 
 
 def test_getting_started():
     """
     Corresponds to "Getting Started" section in the docs.
     """
-    from .. import imperial
+    from astropy.units import imperial
     with imperial.enable():
         speed_unit = u.cm / u.s
         x = speed_unit.to(imperial.mile / u.hour, 1)
@@ -282,8 +282,8 @@ def test_decompose_bases():
     From issue #576
     """
 
-    from .. import cgs
-    from ...constants import e
+    from astropy.units import cgs
+    from astropy.constants import e
 
     d = e.esu.unit.decompose(bases=cgs.bases)
     assert d._bases == [u.cm, u.g, u.s]
@@ -388,7 +388,7 @@ def test_to_cgs():
 
 
 def test_decompose_to_cgs():
-    from .. import cgs
+    from astropy.units import cgs
     assert u.m.decompose(bases=cgs.bases)._bases[0] is cgs.cm
 
 
@@ -568,7 +568,7 @@ def test_duplicate_define():
 
 
 def test_all_units():
-    from ...units.core import get_current_unit_registry
+    from astropy.units.core import get_current_unit_registry
     registry = get_current_unit_registry()
     assert len(registry.all_units) > len(registry.non_prefix_units)
 
@@ -595,7 +595,7 @@ def test_comparison():
 
 def test_compose_into_arbitrary_units():
     # Issue #1438
-    from ...constants import G
+    from astropy.constants import G
     G.decompose([u.kg, u.km, u.Unit("15 s")])
 
 
@@ -638,7 +638,7 @@ def test_composite_unit_get_format_name():
 
 
 def test_unicode_policy():
-    from ...tests.helper import assert_follows_unicode_guidelines
+    from astropy.tests.helper import assert_follows_unicode_guidelines
 
     assert_follows_unicode_guidelines(
         u.degree, roundtrip=u.__dict__)
@@ -774,12 +774,12 @@ def test_fractional_rounding_errors_simple():
 
 
 def test_enable_unit_groupings():
-    from ...units import cds
+    from astropy.units import cds
 
     with cds.enable():
         assert cds.geoMass in u.kg.find_equivalent_units()
 
-    from ...units import imperial
+    from astropy.units import imperial
     with imperial.enable():
         assert imperial.inch in u.m.find_equivalent_units()
 
@@ -792,7 +792,7 @@ def test_unit_summary_prefixes():
     Regression test for https://github.com/astropy/astropy/issues/3835
     """
 
-    from .. import astrophys
+    from astropy.units import astrophys
 
     for summary in utils._iter_unit_summary(astrophys.__dict__):
         unit, _, _, _, prefixes = summary

--- a/astropy/units/tests/test_utils.py
+++ b/astropy/units/tests/test_utils.py
@@ -5,9 +5,9 @@
 """
 import numpy as np
 from numpy import finfo
-from ...units.utils import sanitize_scale
-from ...units.utils import quantity_asanyarray
-from ...units.quantity import Quantity
+from astropy.units.utils import sanitize_scale
+from astropy.units.utils import quantity_asanyarray
+from astropy.units.quantity import Quantity
 
 _float_finfo = finfo(float)
 

--- a/astropy/utils/compat/funcsigs.py
+++ b/astropy/utils/compat/funcsigs.py
@@ -3,7 +3,7 @@ from inspect import signature, Parameter, Signature, BoundArguments
 __all__ = ['BoundArguments', 'Parameter', 'Signature', 'signature']
 
 import warnings
-from ..exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 warnings.warn("astropy.utils.compat.funcsigs is now deprecated - "
               "use inspect instead", AstropyDeprecationWarning)

--- a/astropy/utils/compat/futures/__init__.py
+++ b/astropy/utils/compat/futures/__init__.py
@@ -1,7 +1,7 @@
 from concurrent.futures import *
 
 import warnings
-from ...exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 warnings.warn("astropy.utils.compat.futures is now deprecated - "
               "use concurrent.futures instead", AstropyDeprecationWarning)

--- a/astropy/utils/compat/numpy/core/multiarray.py
+++ b/astropy/utils/compat/numpy/core/multiarray.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 from numpy import matmul as np_matmul
 
-from ....exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['matmul', 'GE1P10']
 

--- a/astropy/utils/compat/numpy/lib/stride_tricks.py
+++ b/astropy/utils/compat/numpy/lib/stride_tricks.py
@@ -14,7 +14,7 @@ from numpy.lib.stride_tricks import (
     broadcast_arrays as np_broadcast_arrays,
     broadcast_to as np_broadcast_to)
 
-from ....exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 __all__ = ['broadcast_arrays', 'broadcast_to', 'GE1P10']
 __doctest_skip__ = ['*']

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -3,7 +3,7 @@
 This is a collection of monkey patches and workarounds for bugs in
 earlier versions of Numpy.
 """
-from ...utils import minversion
+from astropy.utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2']

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     _CAN_RESIZE_TERMINAL = False
 
-from .. import conf
+from astropy import conf
 
 from .misc import isiterable
 from .decorators import classproperty
@@ -461,7 +461,7 @@ def human_file_size(size):
     if hasattr(size, 'unit'):
         # Import units only if necessary because the import takes a
         # significant time [#4649]
-        from .. import units as u
+        from astropy import units as u
         size = u.Quantity(size, u.byte).value
 
     suffixes = ' kMGTPEZY'

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -23,9 +23,9 @@ import shelve
 from tempfile import NamedTemporaryFile, gettempdir
 from warnings import warn
 
-from .. import config as _config
-from ..utils.exceptions import AstropyWarning
-from ..utils.introspection import find_current_module, resolve_name
+from astropy import config as _config
+from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.introspection import find_current_module, resolve_name
 
 __all__ = [
     'Conf', 'conf', 'get_readable_fileobj', 'get_file_contents',
@@ -934,7 +934,7 @@ def check_free_space_in_dir(path, size):
     -------
     OSError : There is not enough room on the filesystem
     """
-    from ..utils.console import human_file_size
+    from astropy.utils.console import human_file_size
 
     space = get_free_space_in_dir(path)
     if space < size:
@@ -979,7 +979,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
         Whenever there's a problem getting the remote file.
     """
 
-    from ..utils.console import ProgressBarOrSpinner
+    from astropy.utils.console import ProgressBarOrSpinner
 
     if timeout is None:
         timeout = conf.remote_timeout
@@ -1283,7 +1283,7 @@ def _get_download_cache_locs():
     shelveloc : str
         The path to the shelve object that stores the cache info.
     """
-    from ..config.paths import get_cache_dir
+    from astropy.config.paths import get_cache_dir
 
     # datadir includes both the download files and the shelveloc.  This structure
     # is required since we cannot know a priori the actual file name corresponding

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -508,7 +508,7 @@ class BaseColumnInfo(DataInfo):
         """
         col = self._parent
         if self.parent_table is None:
-            from ..table.column import FORMATTER as formatter
+            from astropy.table.column import FORMATTER as formatter
         else:
             formatter = self.parent_table.formatter
 
@@ -568,7 +568,7 @@ class BaseColumnInfo(DataInfo):
         col_len : int
             Length of original object
         '''
-        from ..table.sorted_array import SortedArray
+        from astropy.table.sorted_array import SortedArray
         if not getattr(self, '_copy_indices', True):
             # Necessary because MaskedArray will perform a shallow copy
             col_slice.info.indices = []
@@ -622,7 +622,7 @@ class BaseColumnInfo(DataInfo):
         attrs : dict of merged attributes
 
         """
-        from ..table.np_utils import TableMergeError
+        from astropy.table.np_utils import TableMergeError
 
         def warn_str_func(key, left, right):
             out = ("In merged column '{}' the '{}' attribute does not match "
@@ -658,7 +658,7 @@ class MixinInfo(BaseColumnInfo):
         # table when setting the name attribute.  This mirrors the same
         # functionality in the BaseColumn class.
         if attr == 'name' and self.parent_table is not None:
-            from ..table.np_utils import fix_column_name
+            from astropy.table.np_utils import fix_column_name
             new_name = fix_column_name(value)  # Ensure col name is numpy compatible
             self.parent_table.columns._rename_column(self.name, new_name)
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -18,12 +18,12 @@ except ImportError:
 
 import numpy as np
 
-from ... import config as _config
-from ... import units as u
-from ...table import Table, QTable
-from ...utils.data import get_pkg_data_filename, clear_download_cache
-from ... import utils
-from ...utils.exceptions import AstropyWarning
+from astropy import config as _config
+from astropy import units as u
+from astropy.table import Table, QTable
+from astropy.utils.data import get_pkg_data_filename, clear_download_cache
+from astropy import utils
+from astropy.utils.exceptions import AstropyWarning
 
 __all__ = ['Conf', 'conf',
            'IERS', 'IERS_B', 'IERS_A', 'IERS_Auto',

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -7,11 +7,11 @@ import warnings
 import pytest
 import numpy as np
 
-from ....tests.helper import assert_quantity_allclose, catch_warnings
-from .. import iers
-from .... import units as u
-from ....table import QTable
-from ....time import Time, TimeDelta
+from astropy.tests.helper import assert_quantity_allclose, catch_warnings
+from astropy.utils.iers import iers
+from astropy import units as u
+from astropy.table import QTable
+from astropy.time import Time, TimeDelta
 
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
 

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -3,7 +3,7 @@
 This module contains helper functions and classes for handling metadata.
 """
 
-from ..utils import wraps
+from astropy.utils import wraps
 
 import warnings
 
@@ -12,8 +12,8 @@ from collections.abc import Mapping
 from copy import deepcopy
 
 import numpy as np
-from ..utils.exceptions import AstropyWarning
-from ..utils.misc import dtype_bytes_or_chars
+from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.misc import dtype_bytes_or_chars
 
 
 __all__ = ['MergeConflictError', 'MergeConflictWarning', 'MERGE_STRATEGIES',

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -205,7 +205,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
         obj = obj.__name__
 
     if version is None:
-        from .. import version
+        from astropy import version
 
         if version.release:
             version = 'v' + version.version
@@ -379,7 +379,7 @@ class JsonCustomEncoder(json.JSONEncoder):
     """
 
     def default(self, obj):
-        from .. import units as u
+        from astropy import units as u
         import numpy as np
         if isinstance(obj, u.Quantity):
             return dict(value=obj.value, unit=obj.unit.to_string())

--- a/astropy/utils/tests/test_codegen.py
+++ b/astropy/utils/tests/test_codegen.py
@@ -5,7 +5,7 @@ import traceback
 
 import pytest
 
-from ..codegen import make_function_with_signature
+from astropy.utils.codegen import make_function_with_signature
 
 
 def test_make_function_with_signature_lineno():

--- a/astropy/utils/tests/test_collections.py
+++ b/astropy/utils/tests/test_collections.py
@@ -2,9 +2,9 @@
 
 import pytest
 
-from ...tests.helper import raises
+from astropy.tests.helper import raises
 
-from .. import collections
+from astropy.utils import collections
 
 
 @raises(TypeError)

--- a/astropy/utils/tests/test_console.py
+++ b/astropy/utils/tests/test_console.py
@@ -9,8 +9,8 @@ import pytest
 
 
 from . import test_progress_bar_func
-from .. import console
-from ... import units as u
+from astropy.utils import console
+from astropy import units as u
 
 
 class FakeTTY(io.StringIO):

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -11,10 +11,10 @@ import urllib.error
 
 import pytest
 
-from ..data import (_get_download_cache_locs, CacheMissingWarning,
-                    get_pkg_data_filename, get_readable_fileobj, conf)
+from astropy.utils.data import (_get_download_cache_locs, CacheMissingWarning,
+                                get_pkg_data_filename, get_readable_fileobj, conf)
 
-from ...tests.helper import raises, catch_warnings
+from astropy.tests.helper import raises, catch_warnings
 
 TESTURL = 'http://www.astropy.org'
 
@@ -37,7 +37,7 @@ else:
 
 @pytest.mark.remote_data(source='astropy')
 def test_download_nocache():
-    from ..data import download_file
+    from astropy.utils.data import download_file
 
     fnout = download_file(TESTURL)
     assert os.path.isfile(fnout)
@@ -45,7 +45,7 @@ def test_download_nocache():
 
 @pytest.mark.remote_data(source='astropy')
 def test_download_parallel():
-    from ..data import download_files_in_parallel
+    from astropy.utils.data import download_files_in_parallel
 
     main_url = conf.dataurl
     mirror_url = conf.dataurl_mirror
@@ -61,7 +61,7 @@ def test_download_parallel():
 def test_download_mirror_cache():
     import pathlib
     import shelve
-    from ..data import _find_pkg_data_path, download_file, get_cached_urls
+    from astropy.utils.data import _find_pkg_data_path, download_file, get_cached_urls
 
     main_url = pathlib.Path(
         _find_pkg_data_path(os.path.join('data', 'dataurl'))).as_uri() + '/'
@@ -104,7 +104,7 @@ def test_download_mirror_cache():
 
 @pytest.mark.remote_data(source='astropy')
 def test_download_noprogress():
-    from ..data import download_file
+    from astropy.utils.data import download_file
 
     fnout = download_file(TESTURL, show_progress=False)
     assert os.path.isfile(fnout)
@@ -113,7 +113,7 @@ def test_download_noprogress():
 @pytest.mark.remote_data(source='astropy')
 def test_download_cache():
 
-    from ..data import download_file, clear_download_cache
+    from astropy.utils.data import download_file, clear_download_cache
 
     download_dir = _get_download_cache_locs()[0]
 
@@ -152,7 +152,7 @@ def test_url_nocache():
 @pytest.mark.remote_data(source='astropy')
 def test_find_by_hash():
 
-    from ..data import clear_download_cache
+    from astropy.utils.data import clear_download_cache
 
     with get_readable_fileobj(TESTURL, encoding="binary", cache=True) as page:
         hash = hashlib.md5(page.read())
@@ -180,7 +180,7 @@ def test_find_invalid():
 @pytest.mark.parametrize(('filename'), ['local.dat', 'local.dat.gz',
                                         'local.dat.bz2', 'local.dat.xz'])
 def test_local_data_obj(filename):
-    from ..data import get_pkg_data_fileobj
+    from astropy.utils.data import get_pkg_data_fileobj
 
     if (not HAS_BZ2 and 'bz2' in filename) or (not HAS_XZ and 'xz' in filename):
         with pytest.raises(ValueError) as e:
@@ -281,7 +281,7 @@ def test_local_data_nonlocalfail():
 
 
 def test_compute_hash(tmpdir):
-    from ..data import compute_hash
+    from astropy.utils.data import compute_hash
 
     rands = b'1234567890abcdefghijklmnopqrstuvwxyz'
 
@@ -298,7 +298,7 @@ def test_compute_hash(tmpdir):
 
 
 def test_get_pkg_data_contents():
-    from ..data import get_pkg_data_fileobj, get_pkg_data_contents
+    from astropy.utils.data import get_pkg_data_fileobj, get_pkg_data_contents
 
     with get_pkg_data_fileobj('data/local.dat') as f:
         contents1 = f.read()
@@ -315,8 +315,8 @@ def test_data_noastropy_fallback(monkeypatch):
     be located is correct
     """
 
-    from .. import data
-    from ...config import paths
+    from astropy.utils import data
+    from astropy.config import paths
 
     # needed for testing the *real* lock at the end
     lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
@@ -396,7 +396,7 @@ def test_data_noastropy_fallback(monkeypatch):
     pytest.param('unicode.txt.bz2', marks=pytest.mark.xfail(not HAS_BZ2, reason='no bz2 support')),
     pytest.param('unicode.txt.xz', marks=pytest.mark.xfail(not HAS_XZ, reason='no lzma support'))])
 def test_read_unicode(filename):
-    from ..data import get_pkg_data_contents
+    from astropy.utils.data import get_pkg_data_contents
 
     contents = get_pkg_data_contents(os.path.join('data', filename), encoding='utf-8')
     assert isinstance(contents, str)
@@ -447,7 +447,7 @@ def test_invalid_location_download():
     checks that download_file gives a URLError and not an AttributeError,
     as its code pathway involves some fiddling with the exception.
     """
-    from ..data import download_file
+    from astropy.utils.data import download_file
 
     with pytest.raises(urllib.error.URLError):
         download_file('http://www.astropy.org/nonexistentfile')
@@ -457,7 +457,7 @@ def test_invalid_location_download_noconnect():
     """
     checks that download_file gives an OSError if the socket is blocked
     """
-    from ..data import download_file
+    from astropy.utils.data import download_file
 
     # This should invoke socket's monkeypatched failure
     with pytest.raises(OSError):
@@ -466,7 +466,7 @@ def test_invalid_location_download_noconnect():
 
 @pytest.mark.remote_data(source='astropy')
 def test_is_url_in_cache():
-    from ..data import download_file, is_url_in_cache
+    from astropy.utils.data import download_file, is_url_in_cache
 
     assert not is_url_in_cache('http://astropy.org/nonexistentfile')
 

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -6,7 +6,7 @@
 import pytest
 import numpy as np
 
-from ..data_info import dtype_info_name
+from astropy.utils.data_info import dtype_info_name
 
 STRING_TYPE_NAMES = {(True, 'S'): 'bytes',
                      (True, 'U'): 'str'}

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -6,11 +6,11 @@ import pickle
 
 import pytest
 
-from ..decorators import (deprecated_attribute, deprecated, wraps,
+from astropy.utils.decorators import (deprecated_attribute, deprecated, wraps,
                           sharedmethod, classproperty,
                           format_doc, deprecated_renamed_argument)
-from ..exceptions import AstropyDeprecationWarning, AstropyUserWarning
-from ...tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.tests.helper import catch_warnings
 
 
 class NewDeprecationWarning(AstropyDeprecationWarning):

--- a/astropy/utils/tests/test_diff.py
+++ b/astropy/utils/tests/test_diff.py
@@ -7,8 +7,8 @@ import io
 import numpy as np
 import pytest
 
-from ..diff import diff_values, report_diff_values, where_not_allclose
-from ...table import Table
+from astropy.utils.diff import diff_values, report_diff_values, where_not_allclose
+from astropy.table import Table
 
 
 @pytest.mark.parametrize('a', [np.nan, np.inf, 1.11, 1, 'a'])

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -5,8 +5,8 @@ from collections import namedtuple
 
 import pytest
 
-from .. import introspection
-from ..introspection import (find_current_module, find_mod_objs,
+from astropy.utils import introspection
+from astropy.utils.introspection import (find_current_module, find_mod_objs,
                              isinstancemethod, minversion)
 
 

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -5,10 +5,10 @@ from collections import OrderedDict
 import pytest
 import numpy as np
 
-from ..metadata import MetaData, MergeConflictError, merge, enable_merge_strategies
-from ..metadata import common_dtype
-from ...utils import metadata
-from ...io import fits
+from astropy.utils.metadata import MetaData, MergeConflictError, merge, enable_merge_strategies
+from astropy.utils.metadata import common_dtype
+from astropy.utils import metadata
+from astropy.io import fits
 
 
 class OrderedDictSubclass(OrderedDict):

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -8,7 +8,7 @@ import locale
 import pytest
 import numpy as np
 
-from .. import data, misc
+from astropy.utils import data, misc
 
 
 def test_isiterable():
@@ -50,7 +50,7 @@ def test_skip_hidden():
 
 
 def test_JsonCustomEncoder():
-    from ... import units as u
+    from astropy import units as u
     assert json.dumps(np.arange(3), cls=misc.JsonCustomEncoder) == '[0, 1, 2]'
     assert json.dumps(1+2j, cls=misc.JsonCustomEncoder) == '[1.0, 2.0]'
     assert json.dumps(set([1, 2, 1]), cls=misc.JsonCustomEncoder) == '[1, 2]'

--- a/astropy/utils/tests/test_progress_bar_func.py
+++ b/astropy/utils/tests/test_progress_bar_func.py
@@ -2,7 +2,7 @@ import time
 
 import numpy as np
 
-from ..misc import NumpyRNGContext
+from astropy.utils.misc import NumpyRNGContext
 
 
 def func(i):

--- a/astropy/utils/tests/test_timer.py
+++ b/astropy/utils/tests/test_timer.py
@@ -16,9 +16,9 @@ import pytest
 import numpy as np
 
 # LOCAL
-from ..exceptions import AstropyUserWarning
-from ..timer import RunTimePredictor
-from ...modeling.fitting import ModelsError
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.timer import RunTimePredictor
+from astropy.modeling.fitting import ModelsError
 
 
 def func_to_time(x):

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -4,7 +4,7 @@ import io
 
 import pytest
 
-from ..xml import check, unescaper, writer
+from astropy.utils.xml import check, unescaper, writer
 
 
 def test_writer():

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -11,9 +11,9 @@ from functools import partial, wraps
 import numpy as np
 
 # LOCAL
-from .. import units as u
-from .. import log
-from .. import modeling
+from astropy import units as u
+from astropy import log
+from astropy import modeling
 from .exceptions import AstropyUserWarning
 
 __all__ = ['timefunc', 'RunTimePredictor']

--- a/astropy/utils/xml/iterparser.py
+++ b/astropy/utils/xml/iterparser.py
@@ -9,7 +9,7 @@ import io
 import sys
 
 # ASTROPY
-from .. import data
+from astropy.utils import data
 
 
 __all__ = ['get_xml_iterator', 'get_xml_encoding', 'xml_readlines']

--- a/astropy/utils/xml/tests/test_iterparse.py
+++ b/astropy/utils/xml/tests/test_iterparse.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 # LOCAL
-from ....utils.xml.iterparser import _fast_iterparse
+from astropy.utils.xml.iterparser import _fast_iterparse
 
 # SYSTEM
 import io

--- a/astropy/utils/xml/validate.py
+++ b/astropy/utils/xml/validate.py
@@ -48,7 +48,7 @@ def validate_schema(filename, schema_file):
         raise OSError(
             "xmllint not found, so can not validate schema")
     elif p.returncode < 0:
-        from ..misc import signal_number_to_name
+        from astropy.utils.misc import signal_number_to_name
         raise OSError(
             "xmllint was terminated by signal '{0}'".format(
                 signal_number_to_name(-p.returncode)))

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 from inspect import signature
-from ..stats.histogram import calculate_bin_edges
+from astropy.stats.histogram import calculate_bin_edges
 
 __all__ = ['hist']
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -9,7 +9,7 @@ various criteria.
 import abc
 import numpy as np
 
-from ..utils.misc import InheritDocstrings
+from astropy.utils.misc import InheritDocstrings
 from .transform import BaseTransform
 
 

--- a/astropy/visualization/mpl_style.py
+++ b/astropy/visualization/mpl_style.py
@@ -4,7 +4,7 @@
 # plotting style. It is no longer documented/recommended as of Astropy v3.0
 # but is kept here for backward-compatibility.
 
-from ..utils import minversion
+from astropy.utils import minversion
 
 # This returns False if matplotlib cannot be imported
 MATPLOTLIB_GE_1_5 = minversion('matplotlib', '1.5')

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -3,9 +3,9 @@
 import os
 from distutils.version import LooseVersion
 
-from ..mpl_normalize import simple_norm
-from ... import log
-from ...io.fits import getdata
+from astropy.visualization.mpl_normalize import simple_norm
+from astropy import log
+from astropy.io.fits import getdata
 
 
 def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',

--- a/astropy/visualization/scripts/tests/test_fits2bitmap.py
+++ b/astropy/visualization/scripts/tests/test_fits2bitmap.py
@@ -3,13 +3,13 @@
 import pytest
 import numpy as np
 
-from ....io import fits
+from astropy.io import fits
 
 try:
     import matplotlib  # pylint: disable=W0611
     import matplotlib.image as mpimg
     HAS_MATPLOTLIB = True
-    from ..fits2bitmap import fits2bitmap, main
+    from astropy.visualization.scripts.fits2bitmap import fits2bitmap, main
 except ImportError:
     HAS_MATPLOTLIB = False
 

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -8,7 +8,7 @@ another set of [0:1] values with a transformation
 
 import numpy as np
 
-from ..utils.misc import InheritDocstrings
+from astropy.utils.misc import InheritDocstrings
 from .transform import BaseTransform
 
 

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -18,8 +18,8 @@ except ImportError:
 import pytest
 import numpy as np
 
-from .. import hist
-from ...stats import histogram
+from astropy.visualization import hist
+from astropy.stats import histogram
 
 
 @pytest.mark.skipif('not HAS_PLT')

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -3,9 +3,9 @@
 import pytest
 import numpy as np
 
-from ...utils import NumpyRNGContext
+from astropy.utils import NumpyRNGContext
 
-from ..interval import (ManualInterval, MinMaxInterval, PercentileInterval,
+from astropy.visualization.interval import (ManualInterval, MinMaxInterval, PercentileInterval,
                         AsymmetricPercentileInterval, ZScaleInterval)
 
 

--- a/astropy/visualization/tests/test_lupton_rgb.py
+++ b/astropy/visualization/tests/test_lupton_rgb.py
@@ -13,8 +13,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_equal
 
-from ...convolution import convolve, Gaussian2DKernel
-from .. import lupton_rgb
+from astropy.convolution import convolve, Gaussian2DKernel
+from astropy.visualization import lupton_rgb
 
 try:
     import matplotlib  # noqa

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -5,9 +5,9 @@ import numpy as np
 from numpy import ma
 from numpy.testing import assert_allclose
 
-from ..mpl_normalize import ImageNormalize, simple_norm, imshow_norm
-from ..interval import ManualInterval
-from ..stretch import SqrtStretch
+from astropy.visualization.mpl_normalize import ImageNormalize, simple_norm, imshow_norm
+from astropy.visualization.interval import ManualInterval
+from astropy.visualization.stretch import SqrtStretch
 
 try:
     import matplotlib    # pylint: disable=W0611

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -3,7 +3,7 @@
 import pytest
 import numpy as np
 
-from ..stretch import (LinearStretch, SqrtStretch, PowerStretch,
+from astropy.visualization.stretch import (LinearStretch, SqrtStretch, PowerStretch,
                        PowerDistStretch, SquaredStretch, LogStretch,
                        AsinhStretch, SinhStretch, HistEqStretch,
                        ContrastBiasStretch)

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -13,8 +13,8 @@ except ImportError:
 else:
     HAS_PLT = True
 
-from ... import units as u
-from ..units import quantity_support
+from astropy import units as u
+from astropy.visualization.units import quantity_support
 
 
 @pytest.mark.skipif('not HAS_PLT')

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -32,7 +32,7 @@ def quantity_support(format='latex_inline'):
         provided, defaults to ``latex_inline``.
 
     """
-    from .. import units as u
+    from astropy import units as u
 
     from matplotlib import units
     from matplotlib import ticker

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -15,7 +15,7 @@ from .coordinate_helpers import CoordinateHelper
 from .coordinates_map import CoordinatesMap
 from .patches import *
 
-from ... import config as _config
+from astropy import config as _config
 
 
 class Conf(_config.ConfigNamespace):

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -15,8 +15,8 @@ from matplotlib.transforms import Affine2D, ScaledTranslation
 from matplotlib.patches import PathPatch
 from matplotlib import rcParams
 
-from ... import units as u
-from ...utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy import units as u
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 from .formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 from .ticks import Ticks

--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -5,7 +5,7 @@ import warnings
 
 import numpy as np
 
-from ... import units as u
+from astropy import units as u
 
 # Algorithm inspired by PGSBOX from WCSLIB by M. Calabretta
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -10,9 +10,9 @@ from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
 
-from ...coordinates import SkyCoord, BaseCoordinateFrame
-from ...wcs import WCS
-from ...wcs.utils import wcs_to_celestial_frame
+from astropy.coordinates import SkyCoord, BaseCoordinateFrame
+from astropy.wcs import WCS
+from astropy.wcs.utils import wcs_to_celestial_frame
 
 from .transforms import (WCSPixel2WorldTransform, WCSWorld2PixelTransform,
                          CoordinateTransform)

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -15,9 +15,9 @@ import numpy as np
 
 from matplotlib import rcParams
 
-from ... import units as u
-from ...units import UnitsError
-from ...coordinates import Angle
+from astropy import units as u
+from astropy.units import UnitsError
+from astropy.coordinates import Angle
 
 DMS_RE = re.compile('^dd(:mm(:ss(.(s)+)?)?)?$')
 HMS_RE = re.compile('^hh(:mm(:ss(.(s)+)?)?)?$')

--- a/astropy/visualization/wcsaxes/grid_paths.py
+++ b/astropy/visualization/wcsaxes/grid_paths.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from matplotlib.lines import Path
 
-from ...coordinates.angle_utilities import angular_separation
+from astropy.coordinates.angle_utilities import angular_separation
 
 # Tolerance for WCS round-tripping
 ROUND_TRIP_TOL = 1e-1

--- a/astropy/visualization/wcsaxes/patches.py
+++ b/astropy/visualization/wcsaxes/patches.py
@@ -4,9 +4,9 @@
 import numpy as np
 from matplotlib.patches import Polygon
 
-from ... import units as u
-from ...coordinates.representation import UnitSphericalRepresentation
-from ...coordinates.matrix_utilities import rotation_matrix, matrix_product
+from astropy import units as u
+from astropy.coordinates.representation import UnitSphericalRepresentation
+from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product
 
 
 __all__ = ['SphericalCircle']

--- a/astropy/visualization/wcsaxes/tests/datasets.py
+++ b/astropy/visualization/wcsaxes/tests/datasets.py
@@ -2,8 +2,8 @@
 """Downloads the FITS files that are used in image testing and for building documentation.
 """
 
-from ....utils.data import get_pkg_data_filename
-from ....io import fits
+from astropy.utils.data import get_pkg_data_filename
+from astropy.io import fits
 
 __all__ = ['fetch_msx_hdu',
            'fetch_rosat_hdu',

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -8,9 +8,9 @@ import matplotlib.pyplot as plt
 from astropy.wcs import WCS
 from astropy.io import fits
 
-from ..core import WCSAxes
-from .... import units as u
-from ....tests.image_tests import ignore_matplotlibrc
+from astropy.visualization.wcsaxes.core import WCSAxes
+from astropy import units as u
+from astropy.tests.image_tests import ignore_matplotlibrc
 
 ROOT = os.path.join(os.path.dirname(__file__))
 MSX_HEADER = fits.Header.fromtextfile(os.path.join(ROOT, 'data', 'msx_header'))

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from ..core import WCSAxes
+from astropy.visualization.wcsaxes.core import WCSAxes
 import matplotlib.pyplot as plt
 from matplotlib.backend_bases import KeyEvent
 
-from ....wcs import WCS
-from ....coordinates import FK5
-from ....time import Time
-from ....tests.image_tests import ignore_matplotlibrc
+from astropy.wcs import WCS
+from astropy.coordinates import FK5
+from astropy.time import Time
+from astropy.tests.image_tests import ignore_matplotlibrc
 
 from .test_images import BaseImageTests
 

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -6,10 +6,10 @@ from numpy.testing import assert_almost_equal
 
 from matplotlib import rc_context
 
-from .... import units as u
-from ....tests.helper import assert_quantity_allclose
-from ....units import UnitsError
-from ..formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import UnitsError
+from astropy.visualization.wcsaxes.formatter_locator import AngleFormatterLocator, ScalarFormatterLocator
 
 
 class TestAngleFormatterLocator:

--- a/astropy/visualization/wcsaxes/tests/test_frame.py
+++ b/astropy/visualization/wcsaxes/tests/test_frame.py
@@ -4,12 +4,12 @@ import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 
-from ....wcs import WCS
+from astropy.wcs import WCS
 
-from .. import WCSAxes
-from ..frame import BaseFrame
+from astropy.visualization.wcsaxes import WCSAxes
+from astropy.visualization.wcsaxes.frame import BaseFrame
 
-from ....tests.image_tests import IMAGE_REFERENCE_DIR
+from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from .test_images import BaseImageTests
 
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -8,16 +8,16 @@ import matplotlib.pyplot as plt
 from matplotlib.patches import Circle, Rectangle
 from matplotlib import rc_context
 
-from .... import units as u
-from ....io import fits
-from ....wcs import WCS
-from ....coordinates import SkyCoord
+from astropy import units as u
+from astropy.io import fits
+from astropy.wcs import WCS
+from astropy.coordinates import SkyCoord
 
-from ..patches import SphericalCircle
-from .. import WCSAxes
+from astropy.visualization.wcsaxes.patches import SphericalCircle
+from astropy.visualization.wcsaxes import WCSAxes
 from . import datasets
-from ....tests.image_tests import IMAGE_REFERENCE_DIR
-from ..frame import EllipticalFrame
+from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
+from astropy.visualization.wcsaxes.frame import EllipticalFrame
 
 
 class BaseImageTests:

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -7,16 +7,16 @@ import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .... import units as u
-from ....wcs import WCS
-from ....io import fits
-from ....coordinates import SkyCoord
-from ....tests.helper import catch_warnings
-from ....tests.image_tests import ignore_matplotlibrc
+from astropy import units as u
+from astropy.wcs import WCS
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
+from astropy.tests.helper import catch_warnings
+from astropy.tests.image_tests import ignore_matplotlibrc
 
-from ..core import WCSAxes
-from ..utils import get_coord_meta
-from ..transforms import CurvedTransform
+from astropy.visualization.wcsaxes.core import WCSAxes
+from astropy.visualization.wcsaxes.utils import get_coord_meta
+from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 

--- a/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
+++ b/astropy/visualization/wcsaxes/tests/test_transform_coord_meta.py
@@ -5,14 +5,14 @@ import pytest
 import numpy as np
 import matplotlib.pyplot as plt
 
-from .... import units as u
-from ....wcs import WCS
+from astropy import units as u
+from astropy.wcs import WCS
 
-from .. import WCSAxes
+from astropy.visualization.wcsaxes import WCSAxes
 from .test_images import BaseImageTests
-from ..transforms import CurvedTransform
+from astropy.visualization.wcsaxes.transforms import CurvedTransform
 
-from ....tests.image_tests import IMAGE_REFERENCE_DIR
+from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 
 # Create fake transforms that roughly mimic a polar projection
 

--- a/astropy/visualization/wcsaxes/tests/test_transforms.py
+++ b/astropy/visualization/wcsaxes/tests/test_transforms.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from matplotlib.transforms import Affine2D, IdentityTransform
 
-from ....wcs import WCS
+from astropy.wcs import WCS
 
-from ..transforms import WCSWorld2PixelTransform
+from astropy.visualization.wcsaxes.transforms import WCSWorld2PixelTransform
 
 WCS2D = WCS(naxis=2)
 WCS2D.wcs.ctype = ['x', 'y']

--- a/astropy/visualization/wcsaxes/tests/test_utils.py
+++ b/astropy/visualization/wcsaxes/tests/test_utils.py
@@ -3,11 +3,11 @@
 
 from numpy.testing import assert_almost_equal
 
-from .... import units as u
+from astropy import units as u
 
-from ..utils import (select_step_degree, select_step_hour, select_step_scalar,
+from astropy.visualization.wcsaxes.utils import (select_step_degree, select_step_hour, select_step_scalar,
                      coord_type_from_ctype)
-from ....tests.helper import (assert_quantity_allclose as
+from astropy.tests.helper import (assert_quantity_allclose as
                               assert_almost_equal_quantity)
 
 

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -13,10 +13,10 @@ import numpy as np
 from matplotlib.path import Path
 from matplotlib.transforms import Transform
 
-from ... import units as u
-from ...wcs import WCS
-from ...wcs.utils import wcs_to_celestial_frame
-from ...coordinates import (SkyCoord, frame_transform_graph,
+from astropy import units as u
+from astropy.wcs import WCS
+from astropy.wcs.utils import wcs_to_celestial_frame
+from astropy.coordinates import (SkyCoord, frame_transform_graph,
                             SphericalRepresentation,
                             UnitSphericalRepresentation,
                             BaseCoordinateFrame)

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -3,8 +3,8 @@
 
 import numpy as np
 
-from ... import units as u
-from ...coordinates import BaseCoordinateFrame
+from astropy import units as u
+from astropy.coordinates import BaseCoordinateFrame
 
 __all__ = ['select_step_degree', 'select_step_hour', 'select_step_scalar',
            'coord_type_from_ctype', 'transform_contour_set_inplace']

--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -7,10 +7,10 @@ import pickle
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from ...utils.data import get_pkg_data_contents, get_pkg_data_fileobj
-from ...utils.misc import NumpyRNGContext
-from ...io import fits
-from ... import wcs
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_fileobj
+from astropy.utils.misc import NumpyRNGContext
+from astropy.io import fits
+from astropy import wcs
 
 
 def test_basic():

--- a/astropy/wcs/tests/test_profiling.py
+++ b/astropy/wcs/tests/test_profiling.py
@@ -6,10 +6,10 @@ import os
 import pytest
 import numpy as np
 
-from ...utils.data import get_pkg_data_filenames, get_pkg_data_contents
-from ...utils.misc import NumpyRNGContext
+from astropy.utils.data import get_pkg_data_filenames, get_pkg_data_contents
+from astropy.utils.misc import NumpyRNGContext
 
-from ... import wcs
+from astropy import wcs
 
 # hdr_map_file_list = list(get_pkg_data_filenames("maps", pattern="*.hdr"))
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -6,12 +6,12 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 from numpy.testing import assert_allclose
 
-from ...utils.data import get_pkg_data_contents, get_pkg_data_filename
-from ...time import Time
-from ... import units as u
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
+from astropy.time import Time
+from astropy import units as u
 
-from ..wcs import WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE
-from ..utils import (proj_plane_pixel_scales, proj_plane_pixel_area,
+from astropy.wcs.wcs import WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE
+from astropy.wcs.utils import (proj_plane_pixel_scales, proj_plane_pixel_area,
                      is_proj_plane_distorted,
                      non_celestial_pixel_scales, wcs_to_celestial_frame,
                      celestial_frame_to_wcs, skycoord_to_pixel,
@@ -235,7 +235,7 @@ def test_celestial():
 def test_wcs_to_celestial_frame():
 
     # Import astropy.coordinates here to avoid circular imports
-    from ...coordinates.builtin_frames import ICRS, ITRS, FK5, FK4, Galactic
+    from astropy.coordinates.builtin_frames import ICRS, ITRS, FK5, FK4, Galactic
 
     mywcs = WCS(naxis=2)
     mywcs.wcs.set()
@@ -343,7 +343,7 @@ def test_wcs_to_celestial_frame_extend():
 def test_celestial_frame_to_wcs():
 
     # Import astropy.coordinates here to avoid circular imports
-    from ...coordinates import ICRS, ITRS, FK5, FK4, FK4NoETerms, Galactic, BaseCoordinateFrame
+    from astropy.coordinates import ICRS, ITRS, FK5, FK4, FK4NoETerms, Galactic, BaseCoordinateFrame
 
     class FakeFrame(BaseCoordinateFrame):
         pass
@@ -550,7 +550,7 @@ def test_noncelestial_scale(cdelt, pc, cd):
 def test_skycoord_to_pixel(mode):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ...coordinates import SkyCoord
+    from astropy.coordinates import SkyCoord
 
     header = get_pkg_data_contents('maps/1904-66_TAN.hdr', encoding='binary')
     wcs = WCS(header)
@@ -584,7 +584,7 @@ def test_skycoord_to_pixel_swapped():
     # WCS.
 
     # Import astropy.coordinates here to avoid circular imports
-    from ...coordinates import SkyCoord
+    from astropy.coordinates import SkyCoord
 
     header = get_pkg_data_contents('maps/1904-66_TAN.hdr', encoding='binary')
     wcs = WCS(header)
@@ -628,7 +628,7 @@ def test_is_proj_plane_distorted():
 def test_skycoord_to_pixel_distortions(mode):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ...coordinates import SkyCoord
+    from astropy.coordinates import SkyCoord
 
     header = get_pkg_data_filename('data/sip.fits')
     wcs = WCS(header)

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -11,15 +11,15 @@ from numpy.testing import (
     assert_allclose, assert_array_almost_equal, assert_array_almost_equal_nulp,
     assert_array_equal)
 
-from ...tests.helper import raises, catch_warnings
-from ... import wcs
-from .. import _wcs
-from ...utils.data import (
+from astropy.tests.helper import raises, catch_warnings
+from astropy import wcs
+from astropy.wcs import _wcs
+from astropy.utils.data import (
     get_pkg_data_filenames, get_pkg_data_contents, get_pkg_data_filename)
-from ...utils.misc import NumpyRNGContext
-from ...utils.exceptions import AstropyUserWarning
-from ...io import fits
-from ...coordinates import SkyCoord
+from astropy.utils.misc import NumpyRNGContext
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.io import fits
+from astropy.coordinates import SkyCoord
 
 
 class TestMaps:

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -10,12 +10,12 @@ import pytest
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np
 
-from ...tests.helper import raises, catch_warnings
-from ...io import fits
-from .. import wcs
-from .. import _wcs
-from ...utils.data import get_pkg_data_contents, get_pkg_data_fileobj, get_pkg_data_filename
-from ... import units as u
+from astropy.tests.helper import raises, catch_warnings
+from astropy.io import fits
+from astropy.wcs import wcs
+from astropy.wcs import _wcs
+from astropy.utils.data import get_pkg_data_contents, get_pkg_data_fileobj, get_pkg_data_filename
+from astropy import units as u
 
 
 ######################################################################
@@ -826,7 +826,7 @@ def test_detailed_err():
 
 
 def test_header_parse():
-    from ...io import fits
+    from astropy.io import fits
     with get_pkg_data_fileobj(
             'data/header_newlines.fits', encoding='binary') as test_file:
         hdulist = fits.open(test_file)

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from .. import units as u
+from astropy import units as u
 
 from .wcs import WCS, WCSSUB_LONGITUDE, WCSSUB_LATITUDE, WCSSUB_CELESTIAL
 
@@ -45,10 +45,10 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
 def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ..coordinates import FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
+    from astropy.coordinates import FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
 
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
-    from ..time import Time
+    from astropy.time import Time
 
     # Keep only the celestial part of the axes
     wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE])
@@ -103,7 +103,7 @@ def _wcs_to_celestial_frame_builtin(wcs):
 def _celestial_frame_to_wcs_builtin(frame, projection='TAN'):
 
     # Import astropy.coordinates here to avoid circular imports
-    from ..coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
+    from astropy.coordinates import BaseRADecFrame, FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
 
     # Create a 2-dimensional WCS
     wcs = WCS(naxis=2)
@@ -594,7 +594,7 @@ def pixel_to_skycoord(xp, yp, wcs, origin=0, mode='all', cls=None):
     """
 
     # Import astropy.coordinates here to avoid circular imports
-    from ..coordinates import SkyCoord, UnitSphericalRepresentation
+    from astropy.coordinates import SkyCoord, UnitSphericalRepresentation
 
     # we have to do this instead of actually setting the default to SkyCoord
     # because importing SkyCoord at the module-level leads to circular

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -43,8 +43,8 @@ import builtins
 import numpy as np
 
 # LOCAL
-from .. import log
-from ..io import fits
+from astropy import log
+from astropy.io import fits
 from . import _docutil as __
 try:
     from . import _wcs
@@ -54,8 +54,8 @@ except ImportError:
     else:
         _wcs = None
 
-from ..utils.compat import possible_filename
-from ..utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.compat import possible_filename
+from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning, AstropyDeprecationWarning
 
 
 # Mix-in class that provides the APE 14 API
@@ -3104,7 +3104,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         and this will generate a plot with the correct WCS coordinates on the
         axes.
         """
-        from ..visualization.wcsaxes import WCSAxes
+        from astropy.visualization.wcsaxes import WCSAxes
         return WCSAxes, {'wcs': self}
 
     def footprint_contains(self, coord, **kwargs):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -7,7 +7,7 @@ import warnings
 
 import numpy as np
 
-from ... import units as u
+from astropy import units as u
 
 from .low_level_api import BaseLowLevelWCS
 from .high_level_api import HighLevelWCSMixin
@@ -285,8 +285,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 self._components_and_classes_cache = None
 
         # Avoid circular imports by importing here
-        from ..utils import wcs_to_celestial_frame
-        from ...coordinates import SkyCoord
+        from astropy.wcs.utils import wcs_to_celestial_frame
+        from astropy.coordinates import SkyCoord
 
         components = [None] * self.naxis
         classes = {}

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -137,7 +137,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689
-                from ...coordinates import SkyCoord
+                from astropy.coordinates import SkyCoord
                 if isinstance(world_by_key[key], SkyCoord):
                     if 'frame' in kwargs:
                         objects[key] = world_by_key[key].transform_to(kwargs['frame'])
@@ -157,7 +157,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689
-                from ...coordinates import SkyCoord
+                from astropy.coordinates import SkyCoord
                 if isinstance(w, SkyCoord):
                     if 'frame' in kwargs:
                         objects[key] = w.transform_to(kwargs['frame'])

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -7,14 +7,14 @@ import warnings
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-from .... import units as u
-from ....tests.helper import assert_quantity_allclose
-from ....units import Quantity
-from ....coordinates import ICRS, FK5, Galactic, SkyCoord
-from ....io.fits import Header
-from ....utils.data import get_pkg_data_filename
-from ...wcs import WCS
-from ..fitswcs import custom_ctype_to_ucd_mapping
+from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.units import Quantity
+from astropy.coordinates import ICRS, FK5, Galactic, SkyCoord
+from astropy.io.fits import Header
+from astropy.utils.data import get_pkg_data_filename
+from astropy.wcs.wcs import WCS
+from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
 
 ###############################################################################
 # The following example is the simplest WCS with default values

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -1,11 +1,11 @@
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ....units import Quantity
-from ....coordinates import SkyCoord
+from astropy.units import Quantity
+from astropy.coordinates import SkyCoord
 
-from ..low_level_api import BaseLowLevelWCS
-from ..high_level_api import HighLevelWCSMixin
+from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
+from astropy.wcs.wcsapi.high_level_api import HighLevelWCSMixin
 
 
 class DoubleLowLevelWCS(BaseLowLevelWCS):

--- a/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
@@ -2,10 +2,10 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from ....coordinates import SkyCoord
+from astropy.coordinates import SkyCoord
 
-from ..low_level_api import BaseLowLevelWCS
-from ..high_level_wcs_wrapper import HighLevelWCSWrapper
+from astropy.wcs.wcsapi.low_level_api import BaseLowLevelWCS
+from astropy.wcs.wcsapi.high_level_wcs_wrapper import HighLevelWCSWrapper
 
 
 class CustomLowLevelWCS(BaseLowLevelWCS):

--- a/astropy/wcs/wcsapi/tests/test_low_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_low_level_api.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from ..low_level_api import validate_physical_types
+from astropy.wcs.wcsapi.low_level_api import validate_physical_types
 
 
 def test_validate_physical_types():

--- a/astropy/wcs/wcsapi/tests/test_utils.py
+++ b/astropy/wcs/wcsapi/tests/test_utils.py
@@ -1,9 +1,9 @@
 from pytest import raises
 
-from ....tests.helper import assert_quantity_allclose
-from .... import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy import units as u
 
-from ..utils import deserialize_class
+from astropy.wcs.wcsapi.utils import deserialize_class
 
 
 def test_construct():

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -143,10 +143,10 @@ Coding Style/Conventions
   maximum line length for different subpackages (typically either 80 or 100
   characters).  Please try to maintain the style when adding or modifying code.
 
-* One exception is to be made from the PEP8 style: while absolute imports
-  are generally recommended, we keep new-style relative imports
-  of the form ``from . import modname`` when referring to files within a same
-  sub-module, as this makes it clearer what code is from the current submodule
+* Following PEP8's recommendation, absolute imports are to be used in general.
+  The exception to this is relative imports of the form
+  ``from . import modname``, best when referring to files within the same
+  sub-module.  This makes it clearer what code is from the current submodule
   as opposed to from another.
 
   .. note:: There are multiple options for testing PEP8 compliance of code,

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -143,11 +143,11 @@ Coding Style/Conventions
   maximum line length for different subpackages (typically either 80 or 100
   characters).  Please try to maintain the style when adding or modifying code.
 
-* One exception is to be made from the PEP8 style: new style relative imports
-  of the form ``from . import modname`` are allowed and required for Astropy,
-  as opposed to absolute (as PEP8 suggests) or the simpler ``import modname``
-  syntax. This is primarily due to improved relative import support since PEP8
-  was developed, and to simplify the process of moving modules.
+* One exception is to be made from the PEP8 style: while absolute imports
+  are generally recommended, we keep new-style relative imports
+  of the form ``from . import modname`` when referring to files within a same
+  sub-module, as this makes it clearer what code is from the current submodule
+  as opposed to from another.
 
   .. note:: There are multiple options for testing PEP8 compliance of code,
             see :doc:`testguide` for more information.


### PR DESCRIPTION
Absolute imports are generally more readable than e.g. 'from ...utils import x' and are recommended by PEP8. However, this keep imports from the same level (e.g. from .utils import ...) as relative imports. See https://github.com/astropy/astropy/issues/6452 for a discussion of this.

Fixes https://github.com/astropy/astropy/issues/6452