### PR TITLE
Printing the version of astropy_helpers of the package being tested

### DIFF
--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -98,10 +98,12 @@ def pytest_report_header(config):
     try:
         astropy_helpers_version = TESTED_VERSIONS['astropy_helpers']
     except KeyError:
-        from ...version import astropy_helpers_version
-    except ImportError:
-        pass
-    else:
+        try:
+            from ...version import astropy_helpers_version
+        except ImportError:
+            astropy_helpers_version = None
+
+    if astropy_helpers_version:
         s += "astropy_helpers: {0}\n".format(astropy_helpers_version)
 
     special_opts = ["remote_data", "pep8"]

--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -40,7 +40,7 @@ def pytest_report_header(config):
     # TESTED_VERSIONS can contain the affiliated package version, too
     if len(TESTED_VERSIONS) > 1:
         for pkg, version in TESTED_VERSIONS.items():
-            if pkg != 'Astropy':
+            if pkg not in ['Astropy', 'astropy_helpers']:
                 s = "\nRunning tests with {0} version {1}.\n".format(
                     pkg, version)
     else:
@@ -96,6 +96,8 @@ def pytest_report_header(config):
 
     # Helpers version
     try:
+        astropy_helpers_version = TESTED_VERSIONS['astropy_helpers']
+    except KeyError:
         from ...version import astropy_helpers_version
     except ImportError:
         pass


### PR DESCRIPTION
rather than Astropy's

This is a follow-up on https://github.com/astropy/astropy/pull/7392, so LTS milestoned.

Fixes: #https://github.com/astropy/astropy/issues/8147