### PR TITLE
Add note of side-effect API change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -601,6 +601,9 @@ astropy.coordinates
 - Negating a ``SphericalRepresentation`` object now changes the angular
   coordinates (by rotating 180º) instead of negating the distance. [#7988]
 
+- Creation of new frames now generally creates copies of frame attributes,
+  rather than inconsistently either copying or making references. [#8204]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
As discussed further in #8138 (although this is only *part* of that), some of the changes in coordinates in 3.1 have made frame attributes mostly copy when a new frame object is created, rather than being (often, but not always) by reference, as in previous versions.  That's a subtle API change (as the discussion in #8138 reveals), which we should document.  That's exactly what this PR does. 

(This is very trivial, but should of course be backported, @bsipocz, as it's about 3.1)