### PR TITLE
Add equality for representations (to fix #8138)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -582,6 +582,8 @@ astropy.coordinates
 - Added a ``directional_offset_by`` method to ``SkyCoord`` that computes a new
   coordinate given a coordinate, position angle, and angular separation [#5727]
 
+- Representations now have equality comparison. [#8205]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 - The default cosmology has been changed from ``WMAP9`` to ``Planck15``. [#8123]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Representations now have equality comparison. [#8205]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -581,8 +583,6 @@ astropy.coordinates
 
 - Added a ``directional_offset_by`` method to ``SkyCoord`` that computes a new
   coordinate given a coordinate, position angle, and angular separation [#5727]
-
-- Representations now have equality comparison. [#8205]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -173,7 +173,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
     def __eq__(self, other):
         if not isinstance(other, BaseRepresentationOrDifferential):
-            return False
+            return NotImplemented
 
         if isinstance(other, self.__class__):
             for comp in self.components:

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -176,10 +176,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             return NotImplemented
 
         if isinstance(other, self.__class__):
-            for comp in self.components:
-                if np.any(getattr(self, comp) != getattr(other, comp)):
-                    return False
-            return True
+            return np.all([getattr(self, comp) != getattr(other, comp)
+                           for comp in self.components], axis=0)
         else:
             return self.to_cartesian() == other.to_cartesian()
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -177,7 +177,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         if isinstance(other, self.__class__):
             for comp in self.components:
-                if getattr(self, comp) != getattr(other, comp):
+                if np.any(getattr(self, comp) != getattr(other, comp)):
                     return False
             return True
         else:

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1524,3 +1524,53 @@ def test_distance_warning(recwarn):
     # second check is because the "originating" ValueError says the above,
     # while the representation one includes the below
     assert 'you must explicitly pass' in str(excinfo.value)
+
+
+def test_basic_equality():
+    r1 = CartesianRepresentation(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc)
+    r2 = CartesianRepresentation(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc)
+
+    assert r1 == r2
+
+    r3 = CartesianRepresentation(x=1*u.kpc, y=2*u.kpc, z=3.1*u.kpc)
+
+    assert r1 != r3
+    assert r2 != r3
+
+
+def test_non_matching_reprtype_equality():
+    cr = CartesianRepresentation(1*u.kpc, 0*u.kpc, 0*u.kpc)
+    sr = SphericalRepresentation(0*u.rad, 0*u.rad, 1*u.kpc)
+    assert cr == sr
+
+    sr2 = SphericalRepresentation(0.001*u.rad, 0*u.rad, 1*u.kpc)
+
+    assert sr != sr2
+    assert cr != sr2
+
+
+def test_differential_equality():
+    diff = CartesianDifferential(d_x=1*u.km/u.s,
+                                 d_y=2*u.km/u.s,
+                                 d_z=3*u.km/u.s)
+
+    crd = CartesianRepresentation(x=1*u.kpc, y=0*u.kpc, z=0*u.kpc,
+                                  differentials=diff)
+    srd = crd.represent_as(SphericalRepresentation, SphericalDifferential)
+    # we don't try to auto=convert differentials
+    assert crd != srd
+
+    #but they should do the right thing if matched
+    srd_to_crd = srd.represent_as(CartesianRepresentation, CartesianDifferential)
+    assert crd == srd_to_crd
+
+    crnod = CartesianRepresentation(x=1*u.kpc, y=0*u.kpc, z=0*u.kpc)
+    assert crnod != crd
+
+    diff2 = CartesianDifferential(d_x=1*u.km/u.s,
+                                  d_y=2*u.km/u.s,
+                                  d_z=4*u.km/u.s)
+    crd2 = CartesianRepresentation(x=1*u.kpc, y=0*u.kpc, z=0*u.kpc,
+                                   differentials=diff2)
+
+    assert crd != crd2

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1574,3 +1574,16 @@ def test_differential_equality():
                                    differentials=diff2)
 
     assert crd != crd2
+
+
+def test_equality_array():
+    r1 = CartesianRepresentation(x=1*u.kpc, y=2*u.kpc, z=3*u.kpc)
+    dr = CartesianRepresentation(x=[1, 0]*u.kpc,
+                                 y=[1, 0]*u.kpc,
+                                 z=[1, 0]*u.kpc)
+    r2 = CartesianRepresentation(x=[2, 1]*u.kpc,
+                                 y=[3, 2]*u.kpc,
+                                 z=[4, 3]*u.kpc)
+
+    assert r1 + dr == r2
+    assert r1 + dr != r2 + dr

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -179,6 +179,8 @@ To see how the operations work, consider the following examples::
   >>> car_array.mean(axis=0)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
       [(2. ,  2.,  0. ), (2.5,  1.,  6. ), (1.5, -2., -4.5)]>
+  >>> car_array == car_array + CartesianRepresentation([0, 0, 0]*u.m)
+  True
 
   >>> unit_x = UnitSphericalRepresentation(0.*u.deg, 0.*u.deg)
   >>> unit_y = UnitSphericalRepresentation(90.*u.deg, 0.*u.deg)
@@ -470,6 +472,12 @@ and use this ``Differential``-free object for any arithmetic operation::
   <CartesianRepresentation (x, y, z) in AU
       [( 0.,  60., 120.), (15.,  75., 135.), (30.,  90., 150.),
        (45., 105., 165.)]>
+
+.. note::
+
+  Currently representations with differentials only are considered equal if they
+  are the same type of representation (in addition to having all the same)
+  values in the differentials.
 
 .. _astropy-coordinates-create-repr:
 


### PR DESCRIPTION
This fixes #8138 by adding an equality comparison for representation objects.  Some implementation notes:
* It does the reasonable thing of converting to cartesian if the two objects aren't the same
* It yields False (not TypeError) if the right-hand-side is not a representation
* It does *not* try to do fancy differential-converting - it will only return True if the classes of the representation match and the differentials are all equal.

Note that this is high priority as it is currently a blocker for release of 3.1 because it fixes #8138 (somewhat counter-intuitively by creating a new feature

cc @adrn @bsipocz @astrofrog (the latter mostly because it probably needs a 👍 since we're post feature-freeze... although debatable since it's both a new feature *and* a bug fix?)