### PR TITLE
Units interaction with unyt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - PYTEST_VERSION=3.10
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck unyt'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1844,8 +1844,17 @@ class _UnitMetaClass(InheritDocstrings):
         elif s is None:
             raise TypeError("None is not a valid Unit")
 
-        else:
-            raise TypeError("{0} can not be converted to a Unit".format(s))
+        elif 'unit' in s.__class__.__name__.lower():
+            try:
+                # Some unity thing. Try conversion via string.
+                string = str(s)
+                # But already ensure we don't do dimensionless
+                string = string.replace('dimensionless', '')
+                return Unit(string, parse_strict=parse_strict)
+            except Exception:
+                pass
+
+        raise TypeError("{0} can not be converted to a Unit".format(s))
 
 
 class Unit(NamedUnit, metaclass=_UnitMetaClass):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -343,6 +343,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             # If the value has a `unit` attribute and if not None
             # (for Columns with uninitialized unit), treat it like a quantity.
             value_unit = getattr(value, 'unit', None)
+            # Also check "units", to capture quantities from the unyt package
+            if value_unit is None:
+                value_unit = getattr(value, 'units', None)
             if value_unit is None:
                 # Default to dimensionless for no (initialized) unit attribute.
                 if unit is None:

--- a/astropy/units/tests/test_unyt_interaction.py
+++ b/astropy/units/tests/test_unyt_interaction.py
@@ -2,6 +2,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import pytest
 
+import numpy as np
+
 from ... import units as u
 
 unyt = pytest.importorskip("unyt")
@@ -23,3 +25,24 @@ class TestUnit:
         u_m_per_s = u.Unit(u_unyt)
         assert isinstance(u_m_per_s, u.UnitBase)
         assert u_m_per_s == u.m / u.s
+
+
+class TestQuantity:
+    @pytest.mark.parametrize('unit', (unyt.m, unyt.dimensionless,
+                                      unyt.m/unyt.s))
+    @pytest.mark.parametrize('value', (1., np.arange(10.)))
+    def test_simple(self, value, unit):
+        q_unyt = value * unyt.m
+        q = u.Quantity(q_unyt)
+        assert type(q) is u.Quantity
+        assert q.unit is u.m
+        assert np.all(q.value == value)
+
+    def test_conversion(self):
+        q_unyt = 1. * u.m
+        q = u.Quantity(q_unyt, u.cm)
+        assert q.unit == u.cm
+        assert q.value == 100.
+        q = u.Quantity(q_unyt, unyt.cm)
+        assert q.unit == u.cm
+        assert q.value == 100.

--- a/astropy/units/tests/test_unyt_interaction.py
+++ b/astropy/units/tests/test_unyt_interaction.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
+from ... import units as u
+
+unyt = pytest.importorskip("unyt")
+
+
+class TestUnit:
+    def test_simple(self):
+        assert str(unyt.m == 'm')
+        u_m = u.Unit(unyt.m)
+        assert u_m is u.m
+
+    def test_dimensionless(self):
+        u_dimensionless = u.Unit(unyt.dimensionless)
+        assert isinstance(u_dimensionless, u.UnitBase)
+        assert u_dimensionless == u.dimensionless_unscaled
+
+    def test_more_complicated(self):
+        u_unyt = unyt.m / unyt.s
+        u_m_per_s = u.Unit(u_unyt)
+        assert isinstance(u_m_per_s, u.UnitBase)
+        assert u_m_per_s == u.m / u.s


### PR DESCRIPTION
As a proof of concept following #8210, a quick attempt at accepting `unyt` units and quantities in our `Unit` and `Quantity` constructors. With this:
```
import astropy.units as u
import unyt
q = 1.*unyt.m/unyt.s
u.Unit(q.units)
# Unit("m / s")
u.Quantity(q)
# <Quantity 1. m / s>
```
But note that this is far from good enough:
```
q * (10.*u.minute)
# OOPS: unyt_quantity(10., 'm/s')
```
The reason is that we look for a `unit` attribute for our multiplication, and `unyt` looks for `units`. Obviously, it is possible to look for both but that it is not that easy to do so without slowing other things down (such as multiplication with a plain array).