### PR TITLE
Output IPAC tables with float and int columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- IPAC tables now output data types of ``float`` instead of ``double``, or
+  ``int`` instead of ``long``, based on the column ``dtype.itemsize``. [#8216]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -94,6 +97,9 @@ astropy.extern
 
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
+
+- IPAC tables now output data types of ``float`` instead of ``double``, or
+  ``int`` instead of ``long``, based on the column ``dtype.itemsize``. [#8216]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -259,9 +259,15 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             col_format = col.info.format
 
             if col_dtype.kind in ['i', 'u']:
-                dtypelist.append('long')
+                if col_dtype.itemsize <= 2:
+                    dtypelist.append('int')
+                else:
+                    dtypelist.append('long')
             elif col_dtype.kind == 'f':
-                dtypelist.append('double')
+                if col_dtype.itemsize <= 4:
+                    dtypelist.append('float')
+                else:
+                    dtypelist.append('double')
             else:
                 dtypelist.append('char')
 

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -402,6 +402,11 @@ class Ipac(basic.Basic):
                   N/A     29.09056      null         2.06               -999
          2345678901.0 3456789012.0 456789012 4567890123.0 567890123456789012
 
+    When writing a table with a column of integers, the data type is output
+    as ``int`` when the column ``dtype.itemsize`` is less than or equal to 2;
+    othewise the data type is ``long``. For a column of floating-point values,
+    the data type is ``float`` when ``dtype.itemsize`` is less than or equal
+    to 4; otherwise the data type is ``double``.
 
     Parameters
     ----------

--- a/astropy/io/ascii/tests/test_ipac_definitions.py
+++ b/astropy/io/ascii/tests/test_ipac_definitions.py
@@ -9,7 +9,7 @@ from ..ui import read
 from ..ipac import Ipac, IpacFormatError, IpacFormatErrorDBMS
 from ....tests.helper import catch_warnings
 from ... import ascii
-from ....table import Table
+from ....table import Table, Column
 from ..core import masked
 
 
@@ -146,5 +146,20 @@ def test_include_exclude_names():
 |    |
 |null|
     2
+"""
+    assert out.getvalue().strip().splitlines() == expected_out.splitlines()
+
+
+def test_short_dtypes():
+    table = Table([Column([1.0], dtype='f4'), Column([2], dtype='i2')],
+                  names=('float_col', 'int_col'))
+    out = StringIO()
+    ascii.write(table, out, Writer=Ipac)
+    expected_out = """\
+|float_col|int_col|
+|    float|    int|
+|         |       |
+|     null|   null|
+       1.0       2
 """
     assert out.getvalue().strip().splitlines() == expected_out.splitlines()


### PR DESCRIPTION
This PR originates from a request from my colleagues at IPAC. For the IPAC table format, `astropy.io.ascii` will write all floating-point columns with type `double`, and all integer columns with type `long`. Some legacy software at IPAC, such as the MOPEX software developed for Spitzer, requires `float` and `int` in the IPAC tables it uses. The dtype of columns can be checked to output `float` and `int` when appropriate.

* Check `dtype.itemsize` to decide when to output `float` or `int` for the type
* Add a test for output of `float` and `int`

TODO: 
- [x] Add a changelog entry