### PR TITLE
Updating astropy_helpers to 2.0.8

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -123,6 +123,7 @@ except:
 # End compatibility imports...
 
 
+# In case it didn't successfully import before the ez_setup checks
 import pkg_resources
 
 from setuptools import Distribution


### PR DESCRIPTION
~Don't yet merge, it's opened for testing and needs to be updated to point to the actual release when it's released.~

This is now points to the actual 2.0.8 release, so merge away when ci passes.