### PR TITLE
Use defined minimum python version in install docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ templates_path.append('_templates')
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
 rst_epilog += """
+.. |minimum_python_version| replace:: {0.__minimum_python_version__}
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 
 .. Astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Requirements
 
 Astropy has the following strict requirements:
 
-- `Python <https://www.python.org/>`_ 3.5 or later
+- `Python <https://www.python.org/>`_ |minimum_python_version| or later
 
 - `Numpy`_ |minimum_numpy_version| or later
 


### PR DESCRIPTION
This mirrors what we already do for the `numpy` minimum version.

Not sure how to milestone this, but it's small enough that it *could* go in 3.1....