### PR TITLE
WIP: allow NDData as Table mixin column

### DIFF
--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -5,6 +5,7 @@
 import numpy as np
 
 from ..units import UnitsError, UnitConversionError, Unit
+from ..utils.data_info import ParentDtypeInfo
 from .. import log
 
 from .nddata import NDData
@@ -16,7 +17,7 @@ from .mixins.ndio import NDIOMixin
 
 from .flag_collection import FlagCollection
 
-__all__ = ['NDDataArray']
+__all__ = ['NDDataArray', 'NDDataColumn']
 
 
 class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
@@ -286,3 +287,21 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
                                 meta=self.meta, unit=unit)
 
         return result
+
+
+class NDDataColumn(NDDataArray):
+    info = ParentDtypeInfo()
+
+    def __len__(self):
+        return self.shape[0]
+
+    def __init__(self, data, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+        if 'info' in getattr(data, '__dict__', ()):
+            self.info = data.info
+
+    def __getitem__(self, item):
+        out = super().__getitem__(item)
+        if not isinstance(item, (int, np.integer)) and 'info' in self.__dict__:
+            out.info = self.info
+        return out

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -27,6 +27,7 @@ from ...table import table_helpers, Table, QTable
 from ... import time
 from ... import units as u
 from ... import coordinates
+from ... import nddata
 from .. import pprint
 
 
@@ -147,6 +148,10 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),
+              'nddata': nddata.NDDataColumn([[0, 1],
+                                             [2, 3],
+                                             [4, 5],
+                                             [6, 7]]),
               'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3]),
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                            dtype='<i4,|S1').view(table.NdarrayMixin),

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -30,6 +30,7 @@ from ... import units as u
 from ..column import BaseColumn
 from .. import table_helpers
 from .conftest import MIXIN_COLS
+from ... import nddata
 
 
 def test_attributes(mixin_cols):


### PR DESCRIPTION
This is a WIP and may not be suitable for merging because it requires a new subclass of NDData.

The issue is that propagating the `info` attribute requires overriding `__getitem__`, which will be slow (relative to the current C-code interface in numpy).  It is technically feasible to do the same trick using in `Column` to make a [Cython-based _`_getitem__`](https://github.com/astropy/astropy/blob/master/astropy/table/_column_mixins.pyx).

Fixes #8159 .