### PR TITLE
Add photometric API doc link

### DIFF
--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -212,6 +212,8 @@ Reference/API
 
 .. automodapi:: astropy.units.function
 
+.. automodapi:: astropy.units.photometric
+
 .. automodapi:: astropy.units.deprecated
 
 .. automodapi:: astropy.units.required_by_vounit


### PR DESCRIPTION
Expose API doc for #7891 . That PR was milestoned for 3.1, but I am milestoning to 3.1.1 as not wanting to delay the 3.1 release.

Thanks to @parejkoj for bringing this up.

p.s. I don't want to attempt a local doc build on Windows, so I'll wait for the CI to build it for me.