### PR TITLE
Move a large chunk of the setup.py configuration to setup.cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
 
   image-tests-mpl202:
     docker:
-      - image: astropy/image-tests-py35-mpl202:1.3
+      - image: astropy/image-tests-py35-mpl202:1.4
     steps:
       - checkout
       - run:
@@ -43,7 +43,7 @@ jobs:
 
   image-tests-mpl212:
     docker:
-      - image: astropy/image-tests-py35-mpl212:1.3
+      - image: astropy/image-tests-py35-mpl212:1.4
     steps:
       - checkout
       - run:
@@ -52,7 +52,7 @@ jobs:
 
   image-tests-mpl222:
     docker:
-      - image: astropy/image-tests-py35-mpl222:1.3
+      - image: astropy/image-tests-py35-mpl222:1.4
     steps:
       - checkout
       - run:
@@ -61,7 +61,7 @@ jobs:
 
   image-tests-mpl300:
     docker:
-      - image: astropy/image-tests-py35-mpl300:1.3
+      - image: astropy/image-tests-py35-mpl300:1.4
     steps:
       - checkout
       - run:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -244,6 +244,9 @@ Other Changes and Additions
 Installation
 ^^^^^^^^^^^^
 
+- We now require setuptools 30.3.0 or later to install the core astropy
+  package. [#8240]
+
 - We now define groups of dependencies that can be installed with pip, e.g.
   ``pip install astropy[all]`` (to install all optional dependencies). [#8198]
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -68,7 +68,7 @@ packages that use the full bugfix/maintenance branch approach.)
 #. Make sure that the continuous integration services (e.g., Travis) are passing
    for the `astropy core repository`_ branch you're going to release.  You may
    also want to locally run the tests (with remote data on to ensure all the
-   tests actually run), and make sure the description in ``setup.py`` is ReST
+   tests actually run), and make sure the description in ``setup.cfg`` is ReST
    compliant::
 
       $ python setup.py test --remote-data=any
@@ -98,12 +98,12 @@ packages that use the full bugfix/maintenance branch approach.)
       $ git add CHANGES.rst
       $ git commit -m "Finalizing changelog for v<version>"
 
-#. Edit the ``setup.py`` file by removing the ``".dev"`` at the end of the
-   ``VERSION`` string, then add and commit that change as the final step prior
+#. Edit the ``setup.cfg`` file by removing the ``".dev"`` at the end of the
+   ``version`` string, then add and commit that change as the final step prior
    to release::
 
-      <use your favorite editor on setup.py>
-      $ git add setup.py
+      <use your favorite editor on setup.cfg>
+      $ git add setup.cfg
       $ git commit -m "Preparing release v<version>"
 
 #. Tag the commit with ``v<version>``, being certain to sign the tag with the
@@ -200,13 +200,13 @@ packages that use the full bugfix/maintenance branch approach.)
       $ gpg --detach-sign -a dist/astropy-<version>.tar.gz
       $ twine upload dist/astropy-<version>*
 
-#. Go back to release branch (e.g., ``1.2.x``) and edit the ``VERSION`` in
-   ``setup.py`` to be the next version number, but with
+#. Go back to release branch (e.g., ``1.2.x``) and edit the ``version`` in
+   ``setup.cfg`` to be the next version number, but with
    a ``.dev`` suffix at the end (e.g., ``1.2.3.dev``).  Then add and commit::
 
       $ git checkout v1.2.x
-      <use your favorite editor on setup.py>
-      $ git add setup.py
+      <use your favorite editor on setup.cfg>
+      $ git add setup.cfg
       $ git commit -m "Back to development: v<next_version>.dev"
 
 #. Also update the ``CHANGES.rst`` file with a new section for the next version.
@@ -333,12 +333,12 @@ The procedure for this is straightforward:
 
       $ git branch v<version>.x
 
-#. Update the ``VERSION`` in ``setup.py`` to reflect the new major version. For
+#. Update the ``version`` in ``setup.cfg`` to reflect the new major version. For
    example, if you are about to issue a feature freeze for version ``1.2``, you
    will want to set the new version to ``'1.3.dev'``. Then add and commit that::
 
-      <use your favorite editor on setup.py>
-      $ git add setup.py
+      <use your favorite editor on setup.cfg>
+      $ git add setup.cfg
       $ git commit -m "Next major version: <next_version>"
 
 #. Update the ``CHANGES.rst`` file with a new section at the very top for the

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,50 @@
+[metadata]
+name = astropy
+version = 3.2.dev
+provides = astropy
+author = The Astropy Developers
+author_email = astropy.team@gmail.com
+license = BSD 3-Clause License
+url = http://astropy.org
+description = Community-developed python astronomy tools
+keywords = astronomy, astrophysics, cosmology, space, science,units, table, wcs, samp, coordinate, fits, modeling, models, fitting, ascii],
+classifiers =
+    Intended Audience :: Science/Research
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: C
+    Programming Language :: Cython
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Scientific/Engineering :: Physics
+minimum_python_version = 3.5
+
+[options]
+requires = numpy
+zip_safe = False
+test_require = pytest-astropy
+
+[options.entry_points]
+console_scripts =
+    fits2bitmap = astropy.visualization.scripts.fits2bitmap:main
+    fitscheck = astropy.io.fits.scripts.fitscheck:main
+    fitsdiff = astropy.io.fits.scripts.fitsdiff:main
+    fitsheader = astropy.io.fits.scripts.fitsheader:main
+    fitsinfo = astropy.io.fits.scripts.fitsinfo:main
+    samp_hub = astropy.samp.hub_script:hub_script
+    showtable = astropy.table.scripts.showtable:main
+    volint = astropy.io.votable.volint:main
+    wcslint = astropy.wcs.wcslint:main
+asdf_extensions =
+    astropy = astropy.io.misc.asdf.extension:AstropyExtension
+    astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension
+
+[options.extras_require]
+test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
+all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+docs = sphinx-astropy
+
 [build_sphinx]
 source-dir = docs
 build-dir = docs/_build
@@ -36,9 +83,6 @@ exclude = extern,*parsetab.py,*lextab.py
 [pycodestyle]
 exclude = extern,*parsetab.py,*lextab.py
 
-[metadata]
-license_file = LICENSE.rst
-
 [isort]
 line_length = 99
 sections = FUTURE,STDLIB,THIRDPARTY,NUMPY,FIRSTPARTY,LOCALFOLDER
@@ -49,8 +93,3 @@ multi_line_output = 0
 balanced_wrapping = True
 include_trailing_comma = false
 length_sort = True
-
-[options.extras_require]
-test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
-docs = sphinx-astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,10 @@ provides = astropy
 author = The Astropy Developers
 author_email = astropy.team@gmail.com
 license = BSD 3-Clause License
+license_file = LICENSE.rst
 url = http://astropy.org
 description = Community-developed python astronomy tools
-keywords = astronomy, astrophysics, cosmology, space, science,units, table, wcs, samp, coordinate, fits, modeling, models, fitting, ascii],
+keywords = astronomy, astrophysics, cosmology, space, science,units, table, wcs, samp, coordinate, fits, modeling, models, fitting, ascii
 classifiers =
     Intended Audience :: Science/Research
     License :: OSI Approved :: BSD License

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,12 +18,12 @@ classifiers =
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
-minimum_python_version = 3.5
 
 [options]
 requires = numpy
 zip_safe = False
 test_require = pytest-astropy
+python_requires = >=3.5
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 [options]
 requires = numpy
 zip_safe = False
-test_require = pytest-astropy
+tests_require = pytest-astropy
 python_requires = >=3.5
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,15 @@
 
 import sys
 
+from setuptools.config import read_configuration
+conf = read_configuration('setup.cfg')
+
 # This is the same check as astropy/__init__.py but this one has to
 # happen before importing ah_bootstrap
-__minimum_python_version__ = '3.5'
-if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
+minimum_python_version = conf['minimum_python_version']
+if sys.version_info < tuple((int(val) for val in minimum_python_version.split('.'))):
     sys.stderr.write("ERROR: Astropy requires Python {} or later\n".format(
-        __minimum_python_version__))
+        minimum_python_version))
     sys.exit(1)
 
 import os
@@ -25,10 +28,8 @@ from astropy_helpers.version_helpers import generate_version_py
 
 import astropy
 
-NAME = 'astropy'
-
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
-VERSION = '3.2.dev'
+VERSION = conf['metadata']['version']
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION
@@ -53,34 +54,19 @@ package_info = get_package_info()
 # Add the project-global data
 package_info['package_data'].setdefault('astropy', []).append('data/*')
 
-# Add any necessary entry points
-entry_points = {}
-# Command-line scripts
-entry_points['console_scripts'] = [
-    'fits2bitmap = astropy.visualization.scripts.fits2bitmap:main',
-    'fitscheck = astropy.io.fits.scripts.fitscheck:main',
-    'fitsdiff = astropy.io.fits.scripts.fitsdiff:main',
-    'fitsheader = astropy.io.fits.scripts.fitsheader:main',
-    'fitsinfo = astropy.io.fits.scripts.fitsinfo:main',
-    'samp_hub = astropy.samp.hub_script:hub_script',
-    'showtable = astropy.table.scripts.showtable:main',
-    'volint = astropy.io.votable.volint:main',
-    'wcslint = astropy.wcs.wcslint:main',
-]
-# Register ASDF extensions
-entry_points['asdf_extensions'] = [
-    'astropy = astropy.io.misc.asdf.extension:AstropyExtension',
-    'astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension',
-]
-
 min_numpy_version = 'numpy>=' + astropy.__minimum_numpy_version__
 
-setup_requires = [min_numpy_version]
+if is_distutils_display_option():
+    # Avoid installing setup_requires dependencies if the user just
+    # queries for information
+    setup_requires = []
+else:
+    setup_requires = [min_numpy_version]
 
-# Make sure to have the packages needed for building astropy, but do not require them
-# when installing from an sdist as the c files are included there.
-if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
-    setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
+    # Make sure we have the packages needed for building astropy, but do not require them
+    # when installing from an sdist as the c files are included there.
+    if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
+        setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
 
 install_requires = [min_numpy_version]
 
@@ -89,37 +75,10 @@ install_requires = [min_numpy_version]
 if is_distutils_display_option():
     setup_requires = []
 
-
-setup(name=NAME,
-      version=VERSION,
-      description='Community-developed python astronomy tools',
-      requires=['numpy'],
+setup(version=VERSION,
       setup_requires=setup_requires,
       install_requires=install_requires,
-      provides=[NAME],
-      author='The Astropy Developers',
-      author_email='astropy.team@gmail.com',
-      license='BSD',
-      url='http://astropy.org',
       long_description=astropy.__doc__,
-      keywords=['astronomy', 'astrophysics', 'cosmology', 'space', 'science',
-                'units', 'table', 'wcs', 'samp', 'coordinate', 'fits',
-                'modeling', 'models', 'fitting', 'ascii'],
-      classifiers=[
-          'Intended Audience :: Science/Research',
-          'License :: OSI Approved :: BSD License',
-          'Operating System :: OS Independent',
-          'Programming Language :: C',
-          'Programming Language :: Cython',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: Implementation :: CPython',
-          'Topic :: Scientific/Engineering :: Astronomy',
-          'Topic :: Scientific/Engineering :: Physics'
-      ],
       cmdclass=cmdclassd,
-      zip_safe=False,
-      entry_points=entry_points,
-      python_requires='>=' + __minimum_python_version__,
-      tests_require=['pytest-astropy'],
       **package_info
 )

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,9 @@ from setuptools.config import read_configuration
 conf = read_configuration('setup.cfg')
 
 # This is the same check as astropy/__init__.py but this one has to
-# happen before importing ah_bootstrap
-minimum_python_version = conf['options']['python_requires'].replace('>', '').replace('<', '').replace('=', '')
+# happen before importing ah_bootstrap. We strip the > or >= from
+# python_requires to find the actual minimum version.
+minimum_python_version = conf['options']['python_requires'].replace('>', '').replace('=', '')
 if sys.version_info < tuple((int(val) for val in minimum_python_version.split('.'))):
     sys.stderr.write("ERROR: Astropy requires Python {} or later\n".format(
         minimum_python_version))

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,16 @@
 
 import sys
 
+from distutils.version import LooseVersion
+
+# We require setuptools 30.3.0 or later for the configuration in setup.cfg to
+# work properly.
+import setuptools
+if LooseVersion(setuptools.__version__) < LooseVersion('30.3.0'):
+    sys.stderr.write("ERROR: Astropy requires setuptools 30.3.0 or later "
+                     "(found {0})".format(setuptools.__version__))
+    sys.exit(1)
+
 from setuptools.config import read_configuration
 conf = read_configuration('setup.cfg')
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ conf = read_configuration('setup.cfg')
 
 # This is the same check as astropy/__init__.py but this one has to
 # happen before importing ah_bootstrap
-minimum_python_version = conf['minimum_python_version']
+minimum_python_version = conf['options']['python_requires'].replace('>', '').replace('<', '').replace('=', '')
 if sys.version_info < tuple((int(val) for val in minimum_python_version.split('.'))):
     sys.stderr.write("ERROR: Astropy requires Python {} or later\n".format(
         minimum_python_version))
@@ -27,6 +27,8 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 import astropy
+
+NAME = conf['metadata']['name']
 
 # VERSION should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 VERSION = conf['metadata']['version']

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,6 @@ else:
 
 install_requires = [min_numpy_version]
 
-# Avoid installing setup_requires dependencies if the user just
-# queries for information
-if is_distutils_display_option():
-    setup_requires = []
-
 setup(version=VERSION,
       setup_requires=setup_requires,
       install_requires=install_requires,


### PR DESCRIPTION
As of setuptools 30 (released December 2016), setuptools can use options and metadata directly from ``setup.cfg``:

https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files

Note that Python 3.6 was released the same month, so in effect any Python 3.6 and 3.7 users should definitely have recent enough versions of setuptools, and most Python 3.5 users will likely also have a recent version, so I think this is probably relatively safe. By the time of the 3.2 release, setuptools 30 will be almost 2.5 years old.

*(this is part of a series of PRs to simplify setup.py)*