### PR TITLE
[WIP] Using Tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,12 +96,10 @@ jobs:
       - run:
           name: Install Python dependencies
           command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -q .[docs,all]
+            sudo python3 -m pip install tox tox-venv
       - run:
           name: Build Docs
-          command: venv/bin/python setup.py build_docs -w
+          command: tox -e docs
           environment:
             LC_CTYPE: C
             LC_ALL: C

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,6 +160,6 @@ script:
 
 after_success:
     - if [[ $TOXARGS == *--coverage* ]]; then
-        pip install codecov
+        pip install codecov;
         codecov --gcov-glob "*cextern*";
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6
                TOXENV=py36-setup-all
-               TOXOPTS='--force-dep \'pytest==3.7\''
+               TOXOPTS='--force-dep pytest==3.7'
                TOXARGS='--remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
         # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5
-               PYTEST_VERSION='==3.7'
+               PYTEST_VERSION='==3.6'
                NUMPY_VERSION='==1.13.3'
                TOXENV=py35-pytest
                TOXOPTS='--develop'
@@ -77,7 +77,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6
                TOXENV=py36-setup-all
-               PYTEST_VERSION='==3.7'
+               PYTEST_VERSION='==3.6'
                TOXARGS='--remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,8 @@ matrix:
         # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5
-               PYTEST_VERSION='==3.6'
-               NUMPY_VERSION='==1.13.3'
+               PYTEST_VERS='==3.6'
+               NUMPY_VERS='==1.13.3'
                TOXENV=py35-pytest
                TOXOPTS='--develop'
                TOXARGS='--open-files --doctest-rst'
@@ -77,7 +77,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6
                TOXENV=py36-setup-all
-               PYTEST_VERSION='==3.6'
+               PYTEST_VERS='==3.6'
                TOXARGS='--remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ compiler: gcc
 # https://docs.travis-ci.com/user/caching#Clearing-Caches
 cache:
   - ccache
+  - pip
 
 os:
     - linux
@@ -23,45 +24,13 @@ sudo: false
 addons:
     apt:
         packages:
-            - graphviz
             - language-pack-de
 
 env:
     global:
         # Set defaults to avoid repeating in most cases
-        - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
-        - PYTEST_VERSION=3.10
-        - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
-        - CRON_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
-        - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
-        - SETUP_CMD='test'
-        - INSTALL_WITH_PIP=False
-        - EXTRAS_INSTALL=""
-
-        # PEP8 errors/warnings:
-        # E101 - mix of tabs and spaces
-        # W191 - use of tabs
-        # W291 - trailing whitespace
-        # W292 - no newline at end of file
-        # W293 - trailing whitespace
-        # W391 - blank line at end of file
-        # E111 - 4 spaces per indentation level
-        # E112 - 4 spaces per indentation level
-        # E113 - 4 spaces per indentation level
-        # E502 - the backslash is redundant between brackets
-        # E722 - do not use bare except
-        # E901 - SyntaxError or IndentationError
-        # E902 - IOError
-        # E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
-        # # F821: undefined name  # Note: Removed for now because of heavy use of units.si
-        # F822: undefined name in __all__
-        # F823: local variable name referenced before assignment
-        - FLAKE8_OPT="--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902,E999,F822,F823"
 
 stages:
    # Do the style check and a single test job, don't proceed if it fails
@@ -81,11 +50,12 @@ matrix:
         # all supported numpy versions.
         - os: osx
           stage: Cron tests
-          env: SETUP_CMD='test --remote-data=astropy'
-               CONDA_DEPENDENCIES="$CONDA_ALL_DEPENDENCIES clang"
-               PIP_DEPENDENCIES="jplephem $ASDF_PIP_DEP"
-               CCOMPILER=clang
-               EVENT_TYPE='cron'
+          env: PYTHON_VERSION=3.6
+               TOXENV=py36-setup-all
+               TOXARGS='--remote-data=astropy'
+               # EVENT_TYPE='cron'
+               # CONDA_DEPENDENCIES="$CONDA_ALL_DEPENDENCIES clang"
+               # CCOMPILER=clang
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -93,63 +63,64 @@ matrix:
         # time.
         # Run this test using native pytest
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13
-               INSTALL_CMD='python setup.py build_ext --inplace'
-               PIP_DEPENDENCIES='pytest-astropy'
-               TEST_CMD='pytest --open-files --doctest-rst'
-               PYTEST_VERSION=3.7
-          script:
-            - $INSTALL_CMD
-            - $TEST_CMD
+          env: PYTHON_VERSION=3.5
+               TOXENV=py35
+               TOXOPTS='--develop --force-dep \'pytest==3.7\' --force-dep \'numpy==1.13.3\''
+               TOXARGS='--open-files --doctest-rst'
 
         # Now try with all optional dependencies. We also include the --readonly
         # flag to make sure no files are being written to the temporary install
         # location during testing. We also use this build to make sure that the
         # dependencies get correctly installed with pip.
         - os: linux
-          env: SETUP_CMD='test --remote-data=astropy --readonly'
+          env: PYTHON_VERSION=3.6
+               TOXENV=py36-setup-all
+               TOXOPTS='--force-dep \'pytest==3.7\''
+               TOXARGS='--remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
-               PYTEST_VERSION=3.7
-               PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
-               INSTALL_WITH_PIP=True
-               EXTRAS_INSTALL="test,all"
 
         - os: linux
           stage: Initial tests
-          env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$ASDF_PIP_DEP
-               SETUP_CMD='test -a "--durations=50"'
+          # language: python
+          # python: 3.7
+          # dist: xenial
+          # sudo: true
+          env: PYTHON_VERSION=3.7
+               TOXENV=py37-all
+               TOXARGS='--durations=50'
           compiler: clang
 
         # Full tests with coverage checks.
         - os: linux
-          env: SETUP_CMD='test --coverage --remote-data=astropy --readonly'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="codecov objgraph jplephem bintrees sortedcontainers $ASDF_PIP_DEP"
+          env: PYTHON_VERSION=3.6
+               TOXENV=py36-setup-all
+               TOXARGS='--coverage --remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='--coverage -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=2.0
                EVENT_TYPE='push pull_request cron'
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux
-          env: NUMPY_VERSION=prerelease
+          env: PYTHON_VERSION=3.6
+               TOXENV=py36
+               TOXOPTS='--pre'
                EVENT_TYPE='push pull_request cron'
 
         # Do a PEP8/pyflakes test with flake8
         - os: linux
           stage: Initial tests
-          env: MAIN_CMD="flake8 astropy --count $FLAKE8_OPT" SETUP_CMD=''
+          # language: python
+          # python: 3.6
+          env: TOXENV=flake8
 
         # Try developer version of Numpy with optional dependencies and also
         # run all remote tests. Since both cases will be potentially
         # unstable, we combine them into a single unstable build that we can
         # mark as an allowed failure below.
         - os: linux
-          env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$ASDF_PIP_DEP
-               MATPLOTLIB_VERSION=dev
+          env: PYTHON_VERSION=3.7
+               TOXENV=dev
+               TOXARGS='--remote-data=astropy'
 
         # We check numpy-dev also in a job that only runs from cron, so that
         # we can spot issues sooner. We do not use remote data here, since
@@ -158,16 +129,15 @@ matrix:
         # releases.
         - os: linux
           stage: Cron tests
-          env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
-               CONDA_DEPENDENCIES=''
-               PIP_DEPENDENCIES=$CRON_PIP_DEP
+          env: PYTHON_VERSION=3.6
+               TOXENV=dev
+               EVENT_TYPE='cron'
 
     allow_failures:
       - os: linux
-        env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
-             CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-             PIP_DEPENDENCIES=$ASDF_PIP_DEP
-             MATPLOTLIB_VERSION=dev
+        env: PYTHON_VERSION=3.7
+             TOXENV=dev
+             TOXARGS='--remote-data=astropy'
 
 before_install:
 
@@ -183,18 +153,12 @@ before_install:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    - if [[ $INSTALL_WITH_PIP == True ]]; then
-        if [ -z $EXTRAS_INSTALL ]; then
-          pip install -e .;
-        else
-          pip install -e .[$EXTRAS_INSTALL];
-        fi
-      fi
+    - pip install tox tox-venv tox-conda
 
 script:
-    - $MAIN_CMD $SETUP_CMD
+    - tox -vv $TOXOPTS -- $TOXARGS
 
 after_success:
-    - if [[ $SETUP_CMD == *--coverage* ]]; then
+    - if [[ $TOXARGS == *--coverage* ]]; then
         codecov --gcov-glob "*cextern*";
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
         # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5
-               TOXENV=py35
+               TOXENV=py35-pytest
                TOXOPTS='--develop --force-dep \'pytest==3.7\' --force-dep \'numpy==1.13.3\''
                TOXARGS='--open-files --doctest-rst'
 
@@ -86,7 +86,7 @@ matrix:
           # dist: xenial
           # sudo: true
           env: PYTHON_VERSION=3.7
-               TOXENV=py37-all
+               TOXENV=py37-pytest-all
                TOXARGS='--durations=50'
           compiler: clang
 
@@ -102,7 +102,7 @@ matrix:
         # Try pre-release version of Numpy without optional dependencies
         - os: linux
           env: PYTHON_VERSION=3.6
-               TOXENV=py36
+               TOXENV=py36-pytest
                TOXOPTS='--pre'
                EVENT_TYPE='push pull_request cron'
 
@@ -160,5 +160,6 @@ script:
 
 after_success:
     - if [[ $TOXARGS == *--coverage* ]]; then
+        pip install codecov
         codecov --gcov-glob "*cextern*";
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
         # Set defaults to avoid repeating in most cases
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
+        - USE_CONDA=True
 
 stages:
    # Do the style check and a single test job, don't proceed if it fails
@@ -92,6 +93,17 @@ matrix:
                TOXARGS='--durations=50'
           compiler: clang
 
+        - os: linux
+          stage: Initial tests
+          language: python
+          python: 3.7
+          dist: xenial
+          sudo: true
+          env: USE_CONDA=False
+               TOXENV=py37-pytest-all
+               TOXARGS='--durations=50'
+          compiler: clang
+
         # Full tests with coverage checks.
         - os: linux
           env: PYTHON_VERSION=3.6
@@ -111,9 +123,10 @@ matrix:
         # Do a PEP8/pyflakes test with flake8
         - os: linux
           stage: Initial tests
-          # language: python
-          # python: 3.6
-          env: TOXENV=flake8
+          language: python
+          python: 3.6
+          env: USE_CONDA=False
+               TOXENV=flake8
 
         # Try developer version of Numpy with optional dependencies and also
         # run all remote tests. Since both cases will be potentially
@@ -153,9 +166,13 @@ before_install:
     - echo $CC
 
 install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
-    - pip install tox tox-venv tox-conda
+    - if [[ $USE_CONDA == True ]]; then
+        git clone git://github.com/astropy/ci-helpers.git;
+        source ci-helpers/travis/setup_conda.sh;
+        pip install tox tox-conda tox-venv;
+      else
+        pip install tox tox-venv;
+      fi
 
 script:
     - tox -vv $TOXOPTS -- $TOXARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,9 +54,7 @@ matrix:
           env: PYTHON_VERSION=3.6
                TOXENV=py36-setup-all
                TOXARGS='--remote-data=astropy'
-               # EVENT_TYPE='cron'
-               # CONDA_DEPENDENCIES="$CONDA_ALL_DEPENDENCIES clang"
-               # CCOMPILER=clang
+               # FIXME: uncomment this! EVENT_TYPE='cron'
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -84,10 +82,6 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          # language: python
-          # python: 3.7
-          # dist: xenial
-          # sudo: true
           env: PYTHON_VERSION=3.7
                TOXENV=py37-pytest-all
                TOXARGS='--durations=50'

--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,7 @@ matrix:
         # mark as an allowed failure below.
         - os: linux
           env: PYTHON_VERSION=3.7
-               TOXENV=dev
+               TOXENV=py37-pytest-dev
                TOXARGS='--remote-data=astropy'
 
         # We check numpy-dev also in a job that only runs from cron, so that
@@ -145,13 +145,13 @@ matrix:
         - os: linux
           stage: Cron tests
           env: PYTHON_VERSION=3.6
-               TOXENV=dev
+               TOXENV=py37-pytest-dev
                EVENT_TYPE='cron'
 
     allow_failures:
       - os: linux
         env: PYTHON_VERSION=3.7
-             TOXENV=dev
+             TOXENV=py37-pytest-dev
              TOXARGS='--remote-data=astropy'
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,10 @@ matrix:
         # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.5
+               PYTEST_VERSION='==3.7'
+               NUMPY_VERSION='==1.13.3'
                TOXENV=py35-pytest
-               TOXOPTS='--develop --force-dep \'pytest==3.7\' --force-dep \'numpy==1.13.3\''
+               TOXOPTS='--develop'
                TOXARGS='--open-files --doctest-rst'
 
         # Now try with all optional dependencies. We also include the --readonly
@@ -75,7 +77,7 @@ matrix:
         - os: linux
           env: PYTHON_VERSION=3.6
                TOXENV=py36-setup-all
-               TOXOPTS='--force-dep pytest==3.7'
+               PYTEST_VERSION='==3.7'
                TOXARGS='--remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,10 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 jinja2 pyyaml matplotlib scikit-image pytz"
-        PIP_DEPENDENCIES: "objgraph"
 
     matrix:
-        - PYTHON_VERSION: "3.7"
-          NUMPY_VERSION: "stable"
+        - TOXENV: "py37-setup-all"
+          PYTHON_VERSION: "3.7"
 
 matrix:
     fast_finish: true
@@ -35,4 +33,5 @@ install:
 build: false
 
 test_script:
-    - "%CMD_IN_ENV% python setup.py test --readonly"
+    - "%CMD_IN_ENV% pip install tox tox-venv"
+    - "%CMD_IN_ENV% tox -vv -- --readonly"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ asdf_extensions =
 
 [options.extras_require]
 test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
 docs = sphinx-astropy
 
 [build_sphinx]

--- a/tox.ini
+++ b/tox.ini
@@ -13,37 +13,33 @@ description =
     setup-!all: run tests with python setup.py
     pytest-all: run tests with pytest and all dependencies
     pytest-!all: run tests with pytest
+    dev: run tests with numpy and matplotlib dev versions
+# declaring numpy and pytest is needed for --force-dep
 deps =
-    pytest-cov
-    !all: pytest-astropy
-    !all: pytest-xdist
-    all: -rpip-requirements-dev
+    pytest
+    !dev: numpy
+    dev: git+https://github.com/numpy/numpy.git#egg=numpy
+    dev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+extras =
+    test
+    all: all
 conda_deps=
     Cython
     jinja2
     numpy
+    all: scipy
 commands =
     python --version
     which python
     pip freeze -l
-    pytest: pytest {posargs}
+    dev,pytest: pytest {posargs}
     setup: python setup.py test {posargs}
-
-[testenv:dev]
-description = run tests with numpy and matplotlib dev versions
-deps =
-    -rpip-requirements-dev
-commands =
-    pip install git+https://github.com/numpy/numpy.git#egg=numpy
-    pip install git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
-    python --version
-    which python
-    pip freeze -l
-    pytest {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs
-deps = -rpip-requirements-doc
+extras =
+    docs
+    all
 commands = sphinx-build {posargs:-W} docs docs/_build/html
 
 [testenv:flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}{,-setup}{,-all},docs,dev,pre,flake8
+envlist = py{35,36,37}-{pytest,setup}{,-all},docs,dev,flake8
 skipsdist = True
 requires = tox-venv
            setuptools >= 30.0.0
@@ -10,7 +10,7 @@ whitelist_externals = which
 passenv = HOME LC_ALL LC_CTYPE
 description =
     setup: run tests with python setup.py
-    !setup: run tests with pytest
+    pytest: run tests with pytest
 deps =
     pytest-cov
     !all: pytest-astropy
@@ -20,12 +20,11 @@ conda_deps=
     Cython
     jinja2
     numpy
-    scipy
 commands =
     python --version
     which python
     pip freeze -l
-    !setup: pytest {posargs}
+    pytest: pytest {posargs}
     setup: python setup.py test {posargs}
 
 [testenv:dev]
@@ -35,12 +34,10 @@ deps =
 commands =
     pip install git+https://github.com/numpy/numpy.git#egg=numpy
     pip install git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
-    {[testenv]commands}
-
-[testenv:pre]
-description = run tests with pre-release versions of any dependencies
-pip_pre = True
-deps = -rpip-requirements-dev
+    python --version
+    which python
+    pip freeze -l
+    pytest {posargs}
 
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ description =
     dev: run tests with numpy and matplotlib dev versions
 # declaring numpy and pytest is needed for --force-dep
 deps =
-    pytest
-    !dev: numpy
+    pytest{env:PYTEST_VERSION:}
+    !dev: numpy{env:NUMPY_VERSION:}
     dev: git+https://github.com/numpy/numpy.git#egg=numpy
     dev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
 extras =
@@ -26,7 +26,7 @@ extras =
 conda_deps=
     Cython
     jinja2
-    numpy
+    numpy{env:NUMPY_VERSION:}
     all: scipy
 commands =
     python --version

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,8 @@ description =
     dev: run tests with numpy and matplotlib dev versions
 # declaring numpy and pytest is needed for --force-dep
 deps =
-    pytest{env:PYTEST_VERSION:}
-    !dev: numpy{env:NUMPY_VERSION:}
+    pytest{env:PYTEST_VERS:}
+    !dev: numpy{env:NUMPY_VERS:}
     dev: git+https://github.com/numpy/numpy.git#egg=numpy
     dev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
 extras =
@@ -26,7 +26,7 @@ extras =
 conda_deps=
     Cython
     jinja2
-    numpy{env:NUMPY_VERSION:}
+    numpy{env:NUMPY_VERS:}
     all: scipy
 commands =
     python --version

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,12 @@ requires = tox-venv
 [testenv]
 usedevelop = True
 whitelist_externals = which
-passenv = HOME LC_ALL LC_CTYPE
+passenv = HOME LC_ALL LC_CTYPE CC CFLAGS
 description =
-    setup: run tests with python setup.py
-    pytest: run tests with pytest
+    setup-all: run tests with python setup.py and all dependencies
+    setup-!all: run tests with python setup.py
+    pytest-all: run tests with pytest and all dependencies
+    pytest-!all: run tests with pytest
 deps =
     pytest-cov
     !all: pytest-astropy
@@ -28,7 +30,7 @@ commands =
     setup: python setup.py test {posargs}
 
 [testenv:dev]
-description = run with numpy and matplotlib dev versions
+description = run tests with numpy and matplotlib dev versions
 deps =
     -rpip-requirements-dev
 commands =
@@ -64,5 +66,6 @@ commands = sphinx-build {posargs:-W} docs docs/_build/html
 # F822: undefined name in __all__
 # F823: local variable name referenced before assignment
 skip_install = true
+description = invoke flake8 to check pep8 errors
 deps = flake8
 commands = flake8 astropy --count {env:FLAKE8_OPT:--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902,E999,F822,F823}

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,71 @@
+[tox]
+envlist = py{35,36,37}{,-setup}{,-all},docs,dev,pre,flake8
+skipsdist = True
+requires = tox-venv
+           setuptools >= 30.0.0
+
+[testenv]
+usedevelop = True
+whitelist_externals = which
+passenv = HOME LC_ALL LC_CTYPE
+description =
+    setup: run tests with python setup.py
+    !setup: run tests with pytest
+deps =
+    pytest-cov
+    !all: pytest-astropy
+    !all: pytest-xdist
+    all: -rpip-requirements-dev
+conda_deps=
+    Cython
+    jinja2
+    numpy
+    scipy
+commands =
+    python --version
+    which python
+    pip freeze -l
+    !setup: pytest {posargs}
+    setup: python setup.py test {posargs}
+
+[testenv:dev]
+description = run with numpy and matplotlib dev versions
+deps =
+    -rpip-requirements-dev
+commands =
+    pip install git+https://github.com/numpy/numpy.git#egg=numpy
+    pip install git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+    {[testenv]commands}
+
+[testenv:pre]
+description = run tests with pre-release versions of any dependencies
+pip_pre = True
+deps = -rpip-requirements-dev
+
+[testenv:docs]
+description = invoke sphinx-build to build the HTML docs
+deps = -rpip-requirements-doc
+commands = sphinx-build {posargs:-W} docs docs/_build/html
+
+[testenv:flake8]
+# PEP8 errors/warnings:
+# E101 - mix of tabs and spaces
+# W191 - use of tabs
+# W291 - trailing whitespace
+# W292 - no newline at end of file
+# W293 - trailing whitespace
+# W391 - blank line at end of file
+# E111 - 4 spaces per indentation level
+# E112 - 4 spaces per indentation level
+# E113 - 4 spaces per indentation level
+# E502 - the backslash is redundant between brackets
+# E722 - do not use bare except
+# E901 - SyntaxError or IndentationError
+# E902 - IOError
+# E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
+# F821: undefined name  # Note: Removed for now because of heavy use of units.si
+# F822: undefined name in __all__
+# F823: local variable name referenced before assignment
+skip_install = true
+deps = flake8
+commands = flake8 astropy --count {env:FLAKE8_OPT:--select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E502,E722,E901,E902,E999,F822,F823}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py{35,36,37}-{pytest,setup}{,-all,-dev},docs,flake8
 skipsdist = True
 requires = tox-venv
-           setuptools >= 30.0.0
+           setuptools >= 30.3.0
 
 [testenv]
 usedevelop = True
@@ -13,7 +13,6 @@ description =
     setup: run tests with python setup.py,
     all: and all dependencies,
     dev: and numpy and matplotlib dev versions,
-# declaring numpy and pytest is needed for --force-dep
 deps =
     pytest{env:PYTEST_VERS:}
     !dev: numpy{env:NUMPY_VERS:}

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ deps =
 extras =
     test
     all: all
+# when using a conda env, install some common packages with conda (numpy, scipy)
 conda_deps=
     Cython
     jinja2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}-{pytest,setup}{,-all},docs,dev,flake8
+envlist = py{35,36,37}-{pytest,setup}{,-all,-dev},docs,flake8
 skipsdist = True
 requires = tox-venv
            setuptools >= 30.0.0
@@ -9,11 +9,10 @@ usedevelop = True
 whitelist_externals = which
 passenv = HOME LC_ALL LC_CTYPE CC CFLAGS
 description =
-    setup-all: run tests with python setup.py and all dependencies
-    setup-!all: run tests with python setup.py
-    pytest-all: run tests with pytest and all dependencies
-    pytest-!all: run tests with pytest
-    dev: run tests with numpy and matplotlib dev versions
+    pytest: run tests with pytest,
+    setup: run tests with python setup.py,
+    all: and all dependencies,
+    dev: and numpy and matplotlib dev versions,
 # declaring numpy and pytest is needed for --force-dep
 deps =
     pytest{env:PYTEST_VERS:}
@@ -32,7 +31,7 @@ commands =
     python --version
     which python
     pip freeze -l
-    dev,pytest: pytest {posargs}
+    pytest: pytest {posargs}
     setup: python setup.py test {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
This adds a tox config, with envs both for pytest and setup.py, and use it on Travis and CircleCI (docs). 
If run in a python with conda and tox-conda, then a conda env is used.
So this still relies on ci-helpers to install miniconda, but then the other features like pinning versions are not used. Discussion needed here. We could imagine running a script inside the conda env to do what is done currently by ci-helpers, but I'm not sure about what exactly is needed here (it would probably be great to simplify this!).

```
❯ tox -lv
using tox.ini: /home/simon/dev/astropy/tox.ini
using tox-3.5.3 from /home/simon/.pyenv/versions/3.7.0/lib/python3.7/site-packages/tox/__init__.py
default environments:
py35-pytest     -> run tests with pytest
py35-pytest-all -> run tests with pytest
py35-setup      -> run tests with python setup.py
py35-setup-all  -> run tests with python setup.py
py36-pytest     -> run tests with pytest
py36-pytest-all -> run tests with pytest
py36-setup      -> run tests with python setup.py
py36-setup-all  -> run tests with python setup.py
py37-pytest     -> run tests with pytest
py37-pytest-all -> run tests with pytest
py37-setup      -> run tests with python setup.py
py37-setup-all  -> run tests with python setup.py
docs            -> invoke sphinx-build to build the HTML docs
dev             -> run with numpy and matplotlib dev versions
flake8          -> [no description]
```

TODO:
- [x] Appveyor
- [ ] need more flexibility with tox-conda to use conda only on a given env ? currently everything is run with conda on Travis
- [ ] testing the installed version. Currently `usedevelop` is always used, I will come back to this later.
- [ ] doctests (how is this done currently?)

See also:  #8202