### PR TITLE
Better docs and infrastructure for unified read/write functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,11 @@ astropy.io.registry
 - Implement ``Table`` reader and writer methods to wrap ``pandas`` I/O methods
   for CSV, Fixed width format, HTML, and JSON. [#8381]
 
+- Add ``help()`` and ``list_formats()`` methods to unified I/O ``read`` and
+  ``write`` methods. For example ``Table.read.help()`` gives help on available
+  ``Table`` read formats and ``Table.read.help('fits')`` gives detailed
+  help on the arguments for reading FITS table file. [#8255]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -67,6 +67,7 @@ class Basic(core.BaseReader):
     """
     _format_name = 'basic'
     _description = 'Basic table with custom delimiters'
+    _io_registry_format_aliases = ['ascii']
 
     header_class = BasicHeader
     data_class = BasicData
@@ -273,7 +274,9 @@ class Csv(Basic):
       2,38.12321,-88.1321,2.2,17.0
     """
     _format_name = 'csv'
+    _io_registry_format_aliases = ['csv']
     _io_registry_can_write = True
+    _io_registry_suffix = '.csv'
     _description = 'Comma-separated-values'
 
     header_class = CsvHeader

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -14,6 +14,7 @@ import re
 
 from . import core
 
+
 class BasicHeader(core.BaseHeader):
     """
     Basic table Header Reader
@@ -39,21 +40,10 @@ class BasicData(core.BaseData):
 
 
 class Basic(core.BaseReader):
-    r"""
-    Read a character-delimited table with a single header line at the top
-    followed by data lines to the end of the table.  Lines beginning with # as
-    the first non-whitespace character are comments.  This reader is highly
-    configurable.
-    ::
+    r"""Character-delimited table with a single header line at the top.
 
-        rdr = ascii.get_reader(Reader=ascii.Basic)
-        rdr.header.splitter.delimiter = ' '
-        rdr.data.splitter.delimiter = ' '
-        rdr.header.start_line = 0
-        rdr.data.start_line = 1
-        rdr.data.end_line = None
-        rdr.header.comment = r'\s*#'
-        rdr.data.comment = r'\s*#'
+    Lines beginning with a comment character (default='#') as the first
+    non-whitespace character are comments.
 
     Example table::
 
@@ -93,14 +83,16 @@ class NoHeaderData(BasicData):
 
 
 class NoHeader(Basic):
-    """
-    Read a table with no header line.  Columns are autonamed using
-    header.auto_format which defaults to "col%d".  Otherwise this reader
-    the same as the :class:`Basic` class from which it is derived.  Example::
+    """Character-delimited table with no header line.
+
+    When reading, columns are autonamed using header.auto_format which defaults
+    to "col%d".  Otherwise this reader the same as the :class:`Basic` class
+    from which it is derived.  Example::
 
       # Table data
       1 2 "hello there"
       3 4 world
+
     """
     _format_name = 'no_header'
     _description = 'Basic table with no headers'
@@ -130,17 +122,20 @@ class CommentedHeaderHeader(BasicHeader):
 
 
 class CommentedHeader(Basic):
-    """
-    Read a file where the column names are given in a line that begins with
-    the header comment character. ``header_start`` can be used to specify the
+    """Character-delimited table with column names in a comment line.
+
+    When reading, ``header_start`` can be used to specify the
     line index of column names, and it can be a negative index (for example -1
     for the last commented line).  The default delimiter is the <space>
-    character.::
+    character.
+
+    Example::
 
       # col1 col2 col3
       # Comment line
       1 2 3
       4 5 6
+
     """
     _format_name = 'commented_header'
     _description = 'Column names in a commented line'
@@ -204,16 +199,17 @@ class TabData(BasicData):
 
 
 class Tab(Basic):
-    """
-    Read a tab-separated file.  Unlike the :class:`Basic` reader, whitespace is
-    not stripped from the beginning and end of either lines or individual column
-    values.
+    """Tab-separated table.
+
+    Unlike the :class:`Basic` reader, whitespace is not stripped from the
+    beginning and end of either lines or individual column values.
 
     Example::
 
       col1 <tab> col2 <tab> col3
       # Comment line
       1 <tab> 2 <tab> 5
+
     """
     _format_name = 'tab'
     _description = 'Basic table with tab-separated values'
@@ -248,20 +244,12 @@ class CsvData(BasicData):
 
 
 class Csv(Basic):
-    """
-    Read a CSV (comma-separated-values) file.
+    """CSV (comma-separated-values) table.
 
-    Example::
+    This file format may contain rows with fewer entries than the number of
+    columns, a situation that occurs in output from some spreadsheet editors.
+    The missing entries are marked as masked in the output table.
 
-      num,ra,dec,radius,mag
-      1,32.23222,10.1211,0.8,18.1
-      2,38.12321,-88.1321,2.2,17.0
-
-    Plain csv (comma separated value) files typically contain as many entries
-    as there are columns on each line. In contrast, common spreadsheet editors
-    stop writing if all remaining cells on a line are empty, which can lead to
-    lines where the rightmost entries are missing. This Reader can deal with
-    such files.
     Masked values (indicated by an empty '' field value when reading) are
     written out in the same way with an empty ('') field.  This is different
     from the typical default for `astropy.io.ascii` in which missing values are
@@ -272,6 +260,7 @@ class Csv(Basic):
       num,ra,dec,radius,mag
       1,32.23222,10.1211
       2,38.12321,-88.1321,2.2,17.0
+
     """
     _format_name = 'csv'
     _io_registry_format_aliases = ['csv']
@@ -374,15 +363,17 @@ class RdbData(TabData):
 
 
 class Rdb(Tab):
-    """
-    Read a tab-separated file with an extra line after the column definition
-    line.  The RDB format meets this definition.  Example::
+    """Tab-separated file with an extra line after the column definition line that
+    specifies either numeric (N) or string (S) data.
+
+    See: https://compbio.soe.ucsc.edu/rdb/
+
+    Example::
 
       col1 <tab> col2 <tab> col3
       N <tab> S <tab> N
       1 <tab> 2 <tab> 5
 
-    In this reader the second line is just ignored.
     """
     _format_name = 'rdb'
     _io_registry_format_aliases = ['rdb']

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -177,7 +177,10 @@ class CdsData(core.BaseData):
 
 
 class Cds(core.BaseReader):
-    """Read a CDS format table.  See http://vizier.u-strasbg.fr/doc/catstd.htx.
+    """CDS format table.
+
+    See: http://vizier.u-strasbg.fr/doc/catstd.htx
+
     Example::
 
       Table: Table name here

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -11,36 +11,20 @@ from astropy.table import Table
 __all__ = []
 
 
-# Generic
-# =======
-
-
-def read_asciitable(filename, **kwargs):
-    from .ui import read
-    return read(filename, **kwargs)
-
-
-io_registry.register_reader('ascii', Table, read_asciitable)
-
-
-def write_asciitable(table, filename, **kwargs):
-    from .ui import write
-    return write(table, filename, **kwargs)
-
-
-io_registry.register_writer('ascii', Table, write_asciitable)
-
-
 def io_read(format, filename, **kwargs):
     from .ui import read
-    format = re.sub(r'^ascii\.', '', format)
-    return read(filename, format=format, **kwargs)
+    if format != 'ascii':
+        format = re.sub(r'^ascii\.', '', format)
+        kwargs['format'] = format
+    return read(filename, **kwargs)
 
 
 def io_write(format, table, filename, **kwargs):
     from .ui import write
-    format = re.sub(r'^ascii\.', '', format)
-    return write(table, filename, format=format, **kwargs)
+    if format != 'ascii':
+        format = re.sub(r'^ascii\.', '', format)
+        kwargs['format'] = format
+    return write(table, filename, **kwargs)
 
 
 def io_identify(suffix, origin, filepath, fileobj, *args, **kwargs):
@@ -69,25 +53,3 @@ def _get_connectors_table():
         out[colname].format = '%-{0}s'.format(width)
 
     return out
-
-
-# Specific
-# ========
-
-def read_csv(filename, **kwargs):
-    from .ui import read
-    kwargs['format'] = 'csv'
-    return read(filename, **kwargs)
-
-
-def write_csv(table, filename, **kwargs):
-    from .ui import write
-    kwargs['format'] = 'csv'
-    return write(table, filename, **kwargs)
-
-
-csv_identify = functools.partial(io_identify, '.csv')
-
-io_registry.register_reader('csv', Table, read_csv)
-io_registry.register_writer('csv', Table, write_csv)
-io_registry.register_identifier('csv', Table, csv_identify)

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -30,6 +30,7 @@ from astropy.utils.exceptions import AstropyWarning
 from astropy.table import Table
 from astropy.utils.data import get_readable_fileobj
 from . import connect
+from .docs import READ_DOCSTRING, WRITE_DOCSTRING
 
 # Global dictionary mapping format arg to the corresponding Reader class
 FORMAT_CLASSES = {}
@@ -37,94 +38,6 @@ FORMAT_CLASSES = {}
 # Similar dictionary for fast readers
 FAST_CLASSES = {}
 
-
-READ_DOCSTRING = """
-    Read the input ``table`` and return the table.  Most of
-    the default behavior for various parameters is determined by the Reader
-    class.
-
-    See also:
-
-    - http://docs.astropy.org/en/stable/io/ascii/
-    - http://docs.astropy.org/en/stable/io/ascii/read.html
-
-    Parameters
-    ----------
-    table : str, file-like, list, pathlib.Path object
-        Input table as a file name, file-like object, list of strings,
-        single newline-separated string or pathlib.Path object .
-    guess : bool
-        Try to guess the table format. Defaults to None.
-    format : str, `~astropy.io.ascii.BaseReader`
-        Input table format
-    Inputter : `~astropy.io.ascii.BaseInputter`
-        Inputter class
-    Outputter : `~astropy.io.ascii.BaseOutputter`
-        Outputter class
-    delimiter : str
-        Column delimiter string
-    comment : str
-        Regular expression defining a comment line in table
-    quotechar : str
-        One-character string to quote fields containing special characters
-    header_start : int
-        Line index for the header line not counting comment or blank lines.
-        A line with only whitespace is considered blank.
-    data_start : int
-        Line index for the start of data not counting comment or blank lines.
-        A line with only whitespace is considered blank.
-    data_end : int
-        Line index for the end of data not counting comment or blank lines.
-        This value can be negative to count from the end.
-    converters : dict
-        Dictionary of converters
-    data_Splitter : `~astropy.io.ascii.BaseSplitter`
-        Splitter class to split data columns
-    header_Splitter : `~astropy.io.ascii.BaseSplitter`
-        Splitter class to split header columns
-    names : list
-        List of names corresponding to each data column
-    include_names : list
-        List of names to include in output.
-    exclude_names : list
-        List of names to exclude from output (applied after ``include_names``)
-    fill_values : dict
-        specification of fill values for bad or missing table values
-    fill_include_names : list
-        List of names to include in fill_values.
-    fill_exclude_names : list
-        List of names to exclude from fill_values (applied after ``fill_include_names``)
-    fast_reader : bool or dict
-        Whether to use the C engine, can also be a dict with options which
-        defaults to `False`; parameters for options dict:
-
-        use_fast_converter: bool
-            enable faster but slightly imprecise floating point conversion method
-        parallel: bool or int
-            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
-        exponent_style: str
-            One-character string defining the exponent or ``'Fortran'`` to auto-detect
-            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
-            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
-        chunk_size : int
-            If supplied with a value > 0 then read the table in chunks of
-            approximately ``chunk_size`` bytes. Default is reading table in one pass.
-        chunk_generator : bool
-            If True and ``chunk_size > 0`` then return an iterator that returns a
-            table for each chunk.  The default is to return a single stacked table
-            for all the chunks.
-
-    Reader : `~astropy.io.ascii.BaseReader`
-        Reader class (DEPRECATED)
-    encoding: str
-        Allow to specify encoding to read the file (default= ``None``).
-
-    Returns
-    -------
-    dat : `~astropy.table.Table` OR <generator>
-        Output table
-
-    """
 
 class CsvWriter:
     """
@@ -1112,15 +1025,18 @@ class MetaBaseReader(type):
 
         for io_format in io_formats:
             func = functools.partial(connect.io_read, io_format)
+            header = "ASCII reader '{}' details\n".format(io_format)
             func.__doc__ = (inspect.cleandoc(READ_DOCSTRING).strip() + '\n\n' +
-                            "ASCII reader '{}' details\n"
-                            "=======================".format(io_format)
-                            + '=' * len(io_format)) + '\n\n'
+                            header + re.sub('.', '=', header) + '\n')
             func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
             connect.io_registry.register_reader(io_format, Table, func)
 
             if dct.get('_io_registry_can_write', True):
                 func = functools.partial(connect.io_write, io_format)
+                header = "ASCII writer '{}' details\n".format(io_format)
+                func.__doc__ = (inspect.cleandoc(WRITE_DOCSTRING).strip() + '\n\n' +
+                                header + re.sub('.', '=', header) + '\n')
+                func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
                 connect.io_registry.register_writer(io_format, Table, func)
 
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -17,6 +17,7 @@ import operator
 import os
 import re
 import warnings
+import inspect
 
 from collections import OrderedDict
 from contextlib import suppress
@@ -36,6 +37,94 @@ FORMAT_CLASSES = {}
 # Similar dictionary for fast readers
 FAST_CLASSES = {}
 
+
+READ_DOCSTRING = """
+    Read the input ``table`` and return the table.  Most of
+    the default behavior for various parameters is determined by the Reader
+    class.
+
+    See also:
+
+    - http://docs.astropy.org/en/stable/io/ascii/
+    - http://docs.astropy.org/en/stable/io/ascii/read.html
+
+    Parameters
+    ----------
+    table : str, file-like, list, pathlib.Path object
+        Input table as a file name, file-like object, list of strings,
+        single newline-separated string or pathlib.Path object .
+    guess : bool
+        Try to guess the table format. Defaults to None.
+    format : str, `~astropy.io.ascii.BaseReader`
+        Input table format
+    Inputter : `~astropy.io.ascii.BaseInputter`
+        Inputter class
+    Outputter : `~astropy.io.ascii.BaseOutputter`
+        Outputter class
+    delimiter : str
+        Column delimiter string
+    comment : str
+        Regular expression defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    header_start : int
+        Line index for the header line not counting comment or blank lines.
+        A line with only whitespace is considered blank.
+    data_start : int
+        Line index for the start of data not counting comment or blank lines.
+        A line with only whitespace is considered blank.
+    data_end : int
+        Line index for the end of data not counting comment or blank lines.
+        This value can be negative to count from the end.
+    converters : dict
+        Dictionary of converters
+    data_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split data columns
+    header_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split header columns
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output.
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fill_values : dict
+        specification of fill values for bad or missing table values
+    fill_include_names : list
+        List of names to include in fill_values.
+    fill_exclude_names : list
+        List of names to exclude from fill_values (applied after ``fill_include_names``)
+    fast_reader : bool or dict
+        Whether to use the C engine, can also be a dict with options which
+        defaults to `False`; parameters for options dict:
+
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
+        exponent_style: str
+            One-character string defining the exponent or ``'Fortran'`` to auto-detect
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
+        chunk_size : int
+            If supplied with a value > 0 then read the table in chunks of
+            approximately ``chunk_size`` bytes. Default is reading table in one pass.
+        chunk_generator : bool
+            If True and ``chunk_size > 0`` then return an iterator that returns a
+            table for each chunk.  The default is to return a single stacked table
+            for all the chunks.
+
+    Reader : `~astropy.io.ascii.BaseReader`
+        Reader class (DEPRECATED)
+    encoding: str
+        Allow to specify encoding to read the file (default= ``None``).
+
+    Returns
+    -------
+    dat : `~astropy.table.Table` OR <generator>
+        Output table
+
+    """
 
 class CsvWriter:
     """
@@ -1023,6 +1112,11 @@ class MetaBaseReader(type):
 
         for io_format in io_formats:
             func = functools.partial(connect.io_read, io_format)
+            func.__doc__ = (inspect.cleandoc(READ_DOCSTRING).strip() + '\n\n' +
+                            "ASCII reader '{}' details\n"
+                            "=======================".format(io_format)
+                            + '=' * len(io_format)) + '\n\n'
+            func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
             connect.io_registry.register_reader(io_format, Table, func)
 
             if dct.get('_io_registry_can_write', True):

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -314,7 +314,8 @@ class DaophotInputter(core.ContinuationLinesInputter):
 
 class Daophot(core.BaseReader):
     """
-    Read a DAOphot file.
+    DAOphot format table.
+
     Example::
 
       #K MERGERAD   = INDEF                   scaleunit  %-23.7g

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -10,9 +10,9 @@ READ_DOCSTRING = """
 
     Parameters
     ----------
-    table : str, file-like, list, pathlib.Path object
+    table : str, file-like, list, `pathlib.Path` object
         Input table as a file name, file-like object, list of strings,
-        single newline-separated string or pathlib.Path object .
+        single newline-separated string or `pathlib.Path` object .
     guess : bool
         Try to guess the table format. Defaults to None.
     format : str, `~astropy.io.ascii.BaseReader`
@@ -74,9 +74,7 @@ READ_DOCSTRING = """
             table for each chunk.  The default is to return a single stacked table
             for all the chunks.
 
-    Reader : `~astropy.io.ascii.BaseReader`
-        Reader class (DEPRECATED)
-    encoding: str
+    encoding : str
         Allow to specify encoding to read the file (default= ``None``).
 
     Returns
@@ -129,7 +127,5 @@ WRITE_DOCSTRING = """
         exists, then an exception is raised.
         This parameter is ignored when the ``output`` arg is not a string
         (e.g., a file object).
-    Writer : ``Writer``
-        Writer class (DEPRECATED).
 
     """

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -1,0 +1,135 @@
+READ_DOCSTRING = """
+    Read the input ``table`` and return the table.  Most of
+    the default behavior for various parameters is determined by the Reader
+    class.
+
+    See also:
+
+    - http://docs.astropy.org/en/stable/io/ascii/
+    - http://docs.astropy.org/en/stable/io/ascii/read.html
+
+    Parameters
+    ----------
+    table : str, file-like, list, pathlib.Path object
+        Input table as a file name, file-like object, list of strings,
+        single newline-separated string or pathlib.Path object .
+    guess : bool
+        Try to guess the table format. Defaults to None.
+    format : str, `~astropy.io.ascii.BaseReader`
+        Input table format
+    Inputter : `~astropy.io.ascii.BaseInputter`
+        Inputter class
+    Outputter : `~astropy.io.ascii.BaseOutputter`
+        Outputter class
+    delimiter : str
+        Column delimiter string
+    comment : str
+        Regular expression defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    header_start : int
+        Line index for the header line not counting comment or blank lines.
+        A line with only whitespace is considered blank.
+    data_start : int
+        Line index for the start of data not counting comment or blank lines.
+        A line with only whitespace is considered blank.
+    data_end : int
+        Line index for the end of data not counting comment or blank lines.
+        This value can be negative to count from the end.
+    converters : dict
+        Dictionary of converters
+    data_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split data columns
+    header_Splitter : `~astropy.io.ascii.BaseSplitter`
+        Splitter class to split header columns
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output.
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fill_values : dict
+        specification of fill values for bad or missing table values
+    fill_include_names : list
+        List of names to include in fill_values.
+    fill_exclude_names : list
+        List of names to exclude from fill_values (applied after ``fill_include_names``)
+    fast_reader : bool or dict
+        Whether to use the C engine, can also be a dict with options which
+        defaults to `False`; parameters for options dict:
+
+        use_fast_converter: bool
+            enable faster but slightly imprecise floating point conversion method
+        parallel: bool or int
+            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
+        exponent_style: str
+            One-character string defining the exponent or ``'Fortran'`` to auto-detect
+            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
+            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
+        chunk_size : int
+            If supplied with a value > 0 then read the table in chunks of
+            approximately ``chunk_size`` bytes. Default is reading table in one pass.
+        chunk_generator : bool
+            If True and ``chunk_size > 0`` then return an iterator that returns a
+            table for each chunk.  The default is to return a single stacked table
+            for all the chunks.
+
+    Reader : `~astropy.io.ascii.BaseReader`
+        Reader class (DEPRECATED)
+    encoding: str
+        Allow to specify encoding to read the file (default= ``None``).
+
+    Returns
+    -------
+    dat : `~astropy.table.Table` OR <generator>
+        Output table
+
+    """
+
+WRITE_DOCSTRING = """
+    Write the input ``table`` to ``filename``.  Most of the default behavior
+    for various parameters is determined by the Writer class.
+
+    See also:
+
+    - http://docs.astropy.org/en/stable/io/ascii/
+    - http://docs.astropy.org/en/stable/io/ascii/write.html
+
+    Parameters
+    ----------
+    table : `~astropy.io.ascii.BaseReader`, array_like, str, file_like, list
+        Input table as a Reader object, Numpy struct array, file name,
+        file-like object, list of strings, or single newline-separated string.
+    output : str, file_like
+        Output [filename, file-like object]. Defaults to``sys.stdout``.
+    format : str
+        Output table format. Defaults to 'basic'.
+    delimiter : str
+        Column delimiter string
+    comment : str
+        String defining a comment line in table
+    quotechar : str
+        One-character string to quote fields containing special characters
+    formats : dict
+        Dictionary of format specifiers or formatting functions
+    strip_whitespace : bool
+        Strip surrounding whitespace from column values.
+    names : list
+        List of names corresponding to each data column
+    include_names : list
+        List of names to include in output.
+    exclude_names : list
+        List of names to exclude from output (applied after ``include_names``)
+    fast_writer : bool
+        Whether to use the fast Cython writer.
+    overwrite : bool
+        If ``overwrite=None`` (default) and the file exists, then a
+        warning will be issued. In a future release this will instead
+        generate an exception. If ``overwrite=False`` and the file
+        exists, then an exception is raised.
+        This parameter is ignored when the ``output`` arg is not a string
+        (e.g., a file object).
+    Writer : ``Writer``
+        Writer class (DEPRECATED).
+
+    """

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -233,11 +233,12 @@ class EcsvData(basic.BasicData):
 
 
 class Ecsv(basic.Basic):
-    """
-    Read a file which conforms to the ECSV (Enhanced Character Separated
-    Values) format.  This format allows for specification of key table
-    and column meta-data, in particular the data type and unit.  For details
-    see: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst.
+    """ECSV (Enhanced Character Separated Values) format table.
+
+    Th ECSV format allows for specification of key table and column meta-data, in
+    particular the data type and unit.
+
+    See: https://github.com/astropy/astropy-APEs/blob/master/APE6.rst
 
     Examples
     --------
@@ -252,6 +253,7 @@ class Ecsv(basic.Basic):
     ... 001 2
     ... 004 3
     ... '''
+
     >>> Table.read(ecsv_content, format='ascii.ecsv')
     <Table length=2>
       a     b
@@ -260,6 +262,7 @@ class Ecsv(basic.Basic):
     ----- -----
       001     2
       004     3
+
     """
     _format_name = 'ecsv'
     _description = 'Enhanced CSV'

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -262,9 +262,9 @@ class FixedWidthData(basic.BasicData):
 
 
 class FixedWidth(basic.Basic):
-    """
-    Read or write a fixed width table with a single header line that defines column
-    names and positions.  Examples::
+    """Fixed width table with single header line defining column names and positions.
+
+    Examples::
 
       # Bar delimiter in header and data
 
@@ -312,12 +312,13 @@ class FixedWidthNoHeaderData(FixedWidthData):
 
 
 class FixedWidthNoHeader(FixedWidth):
-    """
-    Read or write a fixed width table which has no header line.  Column
-    names are either input (``names`` keyword) or auto-generated.  Column
-    positions are determined either by input (``col_starts`` and ``col_stops``
-    keywords) or by splitting the first data line.  In the latter case a
-    ``delimiter`` is required to split the data line.
+    """Fixed width table which has no header line.
+
+    When reading, column names are either input (``names`` keyword) or
+    auto-generated.  Column positions are determined either by input
+    (``col_starts`` and ``col_stops`` keywords) or by splitting the first data
+    line.  In the latter case a ``delimiter`` is required to split the data
+    line.
 
     Examples::
 
@@ -368,10 +369,12 @@ class FixedWidthTwoLineData(FixedWidthData):
 
 
 class FixedWidthTwoLine(FixedWidth):
-    """
-    Read or write a fixed width table which has two header lines.  The first
-    header line defines the column names and the second implicitly defines the
-    column positions.  Examples::
+    """Fixed width table which has two header lines.
+
+    The first header line defines the column names and the second implicitly
+    defines the column positions.
+
+    Examples::
 
       # Typical case with column extent defined by ---- under column names.
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -256,7 +256,7 @@ class HTMLData(core.BaseData):
 
 
 class HTML(core.BaseReader):
-    """Read and write HTML tables.
+    """HTML format table.
 
     In order to customize input and output, a dict of parameters may
     be passed to this class holding specific customizations.

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -324,8 +324,11 @@ class IpacData(fixedwidth.FixedWidthData):
 
 
 class Ipac(basic.Basic):
-    r"""Read or write an IPAC format table.  See
-    http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html::
+    r"""IPAC format table.
+
+    See: http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html
+
+    Example::
 
       \\name=value
       \\ Comment

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -195,7 +195,7 @@ class LatexData(core.BaseData):
 
 
 class Latex(core.BaseReader):
-    r'''Write and read LaTeX tables.
+    r'''LaTeX format table.
 
     This class implements some LaTeX specific commands.  Its main
     purpose is to write out a table in a form that LaTeX can compile. It
@@ -425,7 +425,7 @@ class AASTexData(LatexData):
 
 
 class AASTex(Latex):
-    '''Write and read AASTeX tables.
+    '''AASTeX format table.
 
     This class implements some AASTeX specific commands.
     AASTeX is used for the AAS (American Astronomical Society)

--- a/astropy/io/ascii/rst.py
+++ b/astropy/io/ascii/rst.py
@@ -31,9 +31,9 @@ class SimpleRSTData(FixedWidthData):
 
 
 class RST(FixedWidth):
-    """
-    Read or write a `reStructuredText simple format table
-    <http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables>`_.
+    """reStructuredText simple format table.
+
+    See: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#simple-tables
 
     Example::
 
@@ -47,6 +47,7 @@ class RST(FixedWidth):
     Currently there is no support for reading tables which utilize continuation lines,
     or for ones which define column spans through the use of an additional
     line of dashes in the header.
+
     """
     _format_name = 'rst'
     _description = 'reStructuredText simple table'

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -103,10 +103,12 @@ class SExtractorData(core.BaseData):
 
 
 class SExtractor(core.BaseReader):
-    """Read a SExtractor file.
-       SExtractor is a package for faint-galaxy photometry.
-       Bertin & Arnouts 1996, A&A Supp. 317, 393.
-       http://www.astromatic.net/software/sextractor
+    """SExtractor format table.
+
+    SExtractor is a package for faint-galaxy photometry (Bertin & Arnouts
+    1996, A&A Supp. 317, 393.)
+
+    See: http://www.astromatic.net/software/sextractor
 
     Example::
 
@@ -121,10 +123,11 @@ class SExtractor(core.BaseReader):
       1 32.23222 10.1211 0.8 1.2 1.4 18.1 1000.0 0.00304 -3.498
       2 38.12321 -88.1321 2.2 2.4 3.1 17.0 1500.0 0.00908 1.401
 
-    Note the skipped numbers since flux_radius has 3 columns.  The three FLUX_RADIUS
-    columns will be named FLUX_RADIUS, FLUX_RADIUS_1, FLUX_RADIUS_2
-    Also note that a post-ID description (e.g. "Variance along x") is
-    optional and that units may be specified at the end of a line in brackets.
+    Note the skipped numbers since flux_radius has 3 columns.  The three
+    FLUX_RADIUS columns will be named FLUX_RADIUS, FLUX_RADIUS_1, FLUX_RADIUS_2
+    Also note that a post-ID description (e.g. "Variance along x") is optional
+    and that units may be specified at the end of a line in brackets.
+
     """
     _format_name = 'sextractor'
     _io_registry_can_write = False

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -807,6 +807,9 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
         output.write(os.linesep)
 
 
+write.__doc__ = core.WRITE_DOCSTRING
+
+
 def get_read_trace():
     """
     Return a traceback of the attempted read formats for the last call to

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -738,52 +738,7 @@ def get_writer(Writer=None, fast_writer=True, **kwargs):
 
 def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
           overwrite=None, **kwargs):
-    """Write the input ``table`` to ``filename``.  Most of the default behavior
-    for various parameters is determined by the Writer class.
-
-    See also:
-
-    - http://docs.astropy.org/en/stable/io/ascii/
-    - http://docs.astropy.org/en/stable/io/ascii/write.html
-
-    Parameters
-    ----------
-    table : `~astropy.io.ascii.BaseReader`, array_like, str, file_like, list
-        Input table as a Reader object, Numpy struct array, file name,
-        file-like object, list of strings, or single newline-separated string.
-    output : str, file_like
-        Output [filename, file-like object]. Defaults to``sys.stdout``.
-    format : str
-        Output table format. Defaults to 'basic'.
-    delimiter : str
-        Column delimiter string
-    comment : str
-        String defining a comment line in table
-    quotechar : str
-        One-character string to quote fields containing special characters
-    formats : dict
-        Dictionary of format specifiers or formatting functions
-    strip_whitespace : bool
-        Strip surrounding whitespace from column values.
-    names : list
-        List of names corresponding to each data column
-    include_names : list
-        List of names to include in output.
-    exclude_names : list
-        List of names to exclude from output (applied after ``include_names``)
-    fast_writer : bool
-        Whether to use the fast Cython writer.
-    overwrite : bool
-        If ``overwrite=None`` (default) and the file exists, then a
-        warning will be issued. In a future release this will instead
-        generate an exception. If ``overwrite=False`` and the file
-        exists, then an exception is raised.
-        This parameter is ignored when the ``output`` arg is not a string
-        (e.g., a file object).
-    Writer : ``Writer``
-        Writer class (DEPRECATED).
-
-    """
+    # Docstring inserted below
     if isinstance(output, str):
         if os.path.lexists(output):
             if overwrite is None:

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -202,93 +202,7 @@ def _get_fast_reader_dict(kwargs):
 
 
 def read(table, guess=None, **kwargs):
-    """
-    Read the input ``table`` and return the table.  Most of
-    the default behavior for various parameters is determined by the Reader
-    class.
-
-    See also:
-
-    - http://docs.astropy.org/en/stable/io/ascii/
-    - http://docs.astropy.org/en/stable/io/ascii/read.html
-
-    Parameters
-    ----------
-    table : str, file-like, list, pathlib.Path object
-        Input table as a file name, file-like object, list of strings,
-        single newline-separated string or pathlib.Path object .
-    guess : bool
-        Try to guess the table format. Defaults to None.
-    format : str, `~astropy.io.ascii.BaseReader`
-        Input table format
-    Inputter : `~astropy.io.ascii.BaseInputter`
-        Inputter class
-    Outputter : `~astropy.io.ascii.BaseOutputter`
-        Outputter class
-    delimiter : str
-        Column delimiter string
-    comment : str
-        Regular expression defining a comment line in table
-    quotechar : str
-        One-character string to quote fields containing special characters
-    header_start : int
-        Line index for the header line not counting comment or blank lines.
-        A line with only whitespace is considered blank.
-    data_start : int
-        Line index for the start of data not counting comment or blank lines.
-        A line with only whitespace is considered blank.
-    data_end : int
-        Line index for the end of data not counting comment or blank lines.
-        This value can be negative to count from the end.
-    converters : dict
-        Dictionary of converters
-    data_Splitter : `~astropy.io.ascii.BaseSplitter`
-        Splitter class to split data columns
-    header_Splitter : `~astropy.io.ascii.BaseSplitter`
-        Splitter class to split header columns
-    names : list
-        List of names corresponding to each data column
-    include_names : list
-        List of names to include in output.
-    exclude_names : list
-        List of names to exclude from output (applied after ``include_names``)
-    fill_values : dict
-        specification of fill values for bad or missing table values
-    fill_include_names : list
-        List of names to include in fill_values.
-    fill_exclude_names : list
-        List of names to exclude from fill_values (applied after ``fill_include_names``)
-    fast_reader : bool or dict
-        Whether to use the C engine, can also be a dict with options which
-        defaults to `False`; parameters for options dict:
-
-        use_fast_converter: bool
-            enable faster but slightly imprecise floating point conversion method
-        parallel: bool or int
-            multiprocessing conversion using ``cpu_count()`` or ``'number'`` processes
-        exponent_style: str
-            One-character string defining the exponent or ``'Fortran'`` to auto-detect
-            Fortran-style scientific notation like ``'3.14159D+00'`` (``'E'``, ``'D'``, ``'Q'``),
-            all case-insensitive; default ``'E'``, all other imply ``use_fast_converter``
-        chunk_size : int
-            If supplied with a value > 0 then read the table in chunks of
-            approximately ``chunk_size`` bytes. Default is reading table in one pass.
-        chunk_generator : bool
-            If True and ``chunk_size > 0`` then return an iterator that returns a
-            table for each chunk.  The default is to return a single stacked table
-            for all the chunks.
-
-    Reader : `~astropy.io.ascii.BaseReader`
-        Reader class (DEPRECATED)
-    encoding: str
-        Allow to specify encoding to read the file (default= ``None``).
-
-    Returns
-    -------
-    dat : `~astropy.table.Table` OR <generator>
-        Output table
-
-    """
+    # Docstring defined below
     del _read_trace[:]
 
     # Downstream readers might munge kwargs
@@ -413,6 +327,8 @@ def read(table, guess=None, **kwargs):
                                           '(no guessing)'})
 
     return dat
+
+read.__doc__ = core.READ_DOCSTRING
 
 
 def _guess(table, read_kwargs, format, fast_reader):

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -6,6 +6,7 @@ import pathlib
 import re
 import sys
 import inspect
+import os
 
 from collections import OrderedDict
 from operator import itemgetter
@@ -665,6 +666,7 @@ class UnifiedReadWrite:
             reader_doc = re.sub('.', '=', header)
             reader_doc += header
             reader_doc += re.sub('.', '=', header)
+            reader_doc += os.linesep
             reader_doc += inspect.cleandoc(getattr(cls, method_name).__doc__)
 
             if format:
@@ -675,6 +677,7 @@ class UnifiedReadWrite:
                 reader_doc += re.sub('.', '=', header)
                 reader_doc += header
                 reader_doc += re.sub('.', '=', header)
+                reader_doc += os.linesep
                 reader_doc += inspect.cleandoc(read_write_func.__doc__)
 
         if out is None:

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -660,25 +660,22 @@ class UnifiedReadWrite:
         except IORegistryError as err:
             reader_doc = 'ERROR: ' + str(err)
         else:
-            # General docs
-            header = ('{}.{} general documentation\n'
-                      .format(cls.__name__, method_name))
-            reader_doc = re.sub('.', '=', header)
-            reader_doc += header
-            reader_doc += re.sub('.', '=', header)
-            reader_doc += os.linesep
-            reader_doc += inspect.cleandoc(getattr(cls, method_name).__doc__)
-
             if format:
                 # Format-specific
                 header = ("{}.{}(format='{}') documentation\n"
                           .format(cls.__name__, method_name, format))
-                reader_doc += '\n\n'
-                reader_doc += re.sub('.', '=', header)
-                reader_doc += header
-                reader_doc += re.sub('.', '=', header)
-                reader_doc += os.linesep
-                reader_doc += inspect.cleandoc(read_write_func.__doc__)
+                doc = read_write_func.__doc__
+            else:
+                # General docs
+                header = ('{}.{} general documentation\n'
+                          .format(cls.__name__, method_name))
+                doc = getattr(cls, method_name).__doc__
+
+            reader_doc = re.sub('.', '=', header)
+            reader_doc += header
+            reader_doc += re.sub('.', '=', header)
+            reader_doc += os.linesep
+            reader_doc += inspect.cleandoc(doc)
 
         if out is None:
             import pydoc

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -617,7 +617,10 @@ class UnifiedReadWrite:
         import pydoc
         cls = self._cls
         method_name = self._method_name
-        reader = get_reader(format, cls)
+
+        # Get reader or writer function
+        get_func = get_reader if method_name == 'read' else get_writer
+        read_write_func = get_func(format, cls)
 
         # General docs
         header = ('{}.{} general documentation\n'
@@ -625,7 +628,7 @@ class UnifiedReadWrite:
         reader_doc = re.sub('.', '=', header)
         reader_doc += header
         reader_doc += re.sub('.', '=', header)
-        reader_doc += inspect.cleandoc(cls.read.__doc__)
+        reader_doc += inspect.cleandoc(getattr(cls, method_name).__doc__)
 
         # Format-specific
         header = ("{}.{}(format='{}') documentation\n"
@@ -634,6 +637,6 @@ class UnifiedReadWrite:
         reader_doc += re.sub('.', '=', header)
         reader_doc += header
         reader_doc += re.sub('.', '=', header)
-        reader_doc += inspect.cleandoc(reader.__doc__)
+        reader_doc += inspect.cleandoc(read_write_func.__doc__)
 
         pydoc.pager(reader_doc)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -686,6 +686,22 @@ class UnifiedReadWrite:
         else:
             out.write(reader_doc)
 
+    def list_formats(self, out=None):
+        """Print a list of available formats to console (or ``out`` filehandle)
+
+        out : None or file handle object
+            Output destination (default is stdout via a pager)
+        """
+        tbl = get_formats(self._cls, self._method_name.capitalize())
+        del tbl['Data class']
+
+        if out is None:
+            tbl.pprint(max_lines=-1, max_width=-1)
+        else:
+            out.write('\n'.join(tbl.pformat(max_lines=-1, max_width=-1)))
+
+        return out
+
 
 class UnifiedReadWriteMethod:
     """Descriptor class for creating read() and write() methods in unified I/O.

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -634,7 +634,7 @@ class UnifiedReadWrite:
         self._cls = cls
         self._method_name = method_name  # 'read' or 'write'
 
-    def help(self, format, out=None):
+    def help(self, format=None, out=None):
         """Output help documentation for the specified unified I/O ``format``.
 
         By default the help output is printed to the console via `pydoc.pager`.
@@ -654,7 +654,8 @@ class UnifiedReadWrite:
         # Get reader or writer function
         get_func = get_reader if method_name == 'read' else get_writer
         try:
-            read_write_func = get_func(format, cls)
+            if format:
+                read_write_func = get_func(format, cls)
         except IORegistryError as err:
             reader_doc = 'ERROR: ' + str(err)
         else:
@@ -666,14 +667,15 @@ class UnifiedReadWrite:
             reader_doc += re.sub('.', '=', header)
             reader_doc += inspect.cleandoc(getattr(cls, method_name).__doc__)
 
-            # Format-specific
-            header = ("{}.{}(format='{}') documentation\n"
-                      .format(cls.__name__, method_name, format))
-            reader_doc += '\n\n'
-            reader_doc += re.sub('.', '=', header)
-            reader_doc += header
-            reader_doc += re.sub('.', '=', header)
-            reader_doc += inspect.cleandoc(read_write_func.__doc__)
+            if format:
+                # Format-specific
+                header = ("{}.{}(format='{}') documentation\n"
+                          .format(cls.__name__, method_name, format))
+                reader_doc += '\n\n'
+                reader_doc += re.sub('.', '=', header)
+                reader_doc += header
+                reader_doc += re.sub('.', '=', header)
+                reader_doc += inspect.cleandoc(read_write_func.__doc__)
 
         if out is None:
             import pydoc

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -609,7 +609,8 @@ class UnifiedReadWrite:
     """
     Base class for unified read() or write() methods.
     """
-    def __init__(self, cls, method_name):
+    def __init__(self, instance, cls, method_name):
+        self._instance = instance
         self._cls = cls
         self._method_name = method_name  # 'read' or 'write'
 

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -637,7 +637,7 @@ class UnifiedReadWrite:
     def help(self, format=None, out=None):
         """Output help documentation for the specified unified I/O ``format``.
 
-        By default the help output is printed to the console via `pydoc.pager`.
+        By default the help output is printed to the console via ``pydoc.pager``.
         Instead one can supplied a file handle object as ``out`` and the output
         will be written to that handle.
 

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -12,13 +12,17 @@ from astropy.io import registry as io_registry
 from astropy.table import Table
 from astropy import units as u
 
-# Since we reset the readers/writers below, we need to also import any sub-package
-# that defines readers/writers first
+# Since we reset the readers/writers below, we need to also import any
+# sub-package that defines readers/writers first
 from astropy import timeseries  # noqa
 
-_READERS_ORIGINAL = copy(_readers)
-_WRITERS_ORIGINAL = copy(_writers)
-_IDENTIFIERS_ORIGINAL = copy(_identifiers)
+# Cache original _readers, _writers, _identifiers in setup_function
+# since tests modify them.  Important to do caching in setup_function
+# and not globally (as was the original implementation) because e.g.
+# CCDData reader/writers get registered *after* this module gets imported
+# during test collection but *before* tests (and the final teardown) get run.
+# This leaves the registry corrupted.
+ORIGINAL = {}
 
 try:
     import yaml  # pylint: disable=W0611
@@ -33,6 +37,10 @@ class TestData:
 
 
 def setup_function(function):
+    ORIGINAL['readers'] = copy(_readers)
+    ORIGINAL['writers'] = copy(_writers)
+    ORIGINAL['identifiers'] = copy(_identifiers)
+
     _readers.clear()
     _writers.clear()
     _identifiers.clear()
@@ -184,7 +192,7 @@ def test_write_noformat():
 
 def test_read_noformat_arbitrary():
     """Test that all identifier functions can accept arbitrary input"""
-    _identifiers.update(_IDENTIFIERS_ORIGINAL)
+    _identifiers.update(ORIGINAL['identifiers'])
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData.read(object())
     assert str(exc.value).startswith("Format could not be identified.")
@@ -192,7 +200,7 @@ def test_read_noformat_arbitrary():
 
 def test_read_noformat_arbitrary_file(tmpdir):
     """Tests that all identifier functions can accept arbitrary files"""
-    _readers.update(_READERS_ORIGINAL)
+    _readers.update(ORIGINAL['readers'])
     testfile = str(tmpdir.join('foo.example'))
     with open(testfile, 'w') as f:
         f.write("Hello world")
@@ -204,7 +212,7 @@ def test_read_noformat_arbitrary_file(tmpdir):
 
 def test_write_noformat_arbitrary():
     """Test that all identifier functions can accept arbitrary input"""
-    _identifiers.update(_IDENTIFIERS_ORIGINAL)
+    _identifiers.update(ORIGINAL['identifiers'])
     with pytest.raises(io_registry.IORegistryError) as exc:
         TestData().write(object())
     assert str(exc.value).startswith("Format could not be identified.")
@@ -212,7 +220,7 @@ def test_write_noformat_arbitrary():
 
 def test_write_noformat_arbitrary_file(tmpdir):
     """Tests that all identifier functions can accept arbitrary files"""
-    _writers.update(_WRITERS_ORIGINAL)
+    _writers.update(ORIGINAL['writers'])
     testfile = str(tmpdir.join('foo.example'))
 
     with pytest.raises(io_registry.IORegistryError) as exc:
@@ -384,9 +392,12 @@ def test_inherited_registration():
 
 
 def teardown_function(function):
-    _readers.update(_READERS_ORIGINAL)
-    _writers.update(_WRITERS_ORIGINAL)
-    _identifiers.update(_IDENTIFIERS_ORIGINAL)
+    _readers.clear()
+    _writers.clear()
+    _identifiers.clear()
+    _readers.update(ORIGINAL['readers'])
+    _writers.update(ORIGINAL['writers'])
+    _identifiers.update(ORIGINAL['identifiers'])
 
 
 class TestSubclass:

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -69,6 +69,34 @@ def test_table_write_help_fits():
     assert "Write a Table object to a FITS file" in doc
 
 
+def test_table_write_help_no_format():
+    """
+    Test dynamically created documentation help via the I/O registry for no
+    format provided.
+    """
+    out = StringIO()
+    Table.write.help(out=out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.write general documentation" in doc
+    assert "The available built-in formats" in doc
+
+
+def test_table_read_help_no_format():
+    """
+    Test dynamically created documentation help via the I/O registry for not
+    format provided.
+    """
+    out = StringIO()
+    Table.read.help(out=out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.read general documentation" in doc
+    assert "The available built-in formats" in doc
+
+
 def test_ccddata_write_help_fits():
     """
     Test dynamically created documentation help via the I/O registry for 'fits'.

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -3,6 +3,7 @@
 from io import StringIO
 
 from astropy.table import Table
+from astropy.nddata import CCDData
 
 
 def test_table_read_help_fits():
@@ -66,3 +67,34 @@ def test_table_write_help_fits():
     assert "The available built-in formats" in doc
     assert "Table.write(format='fits') documentation" in doc
     assert "Write a Table object to a FITS file" in doc
+
+
+def test_ccddata_write_help_fits():
+    """
+    Test dynamically created documentation help via the I/O registry for 'fits'.
+    """
+    out = StringIO()
+    CCDData.write.help('fits', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "CCDData.write general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "CCDData.write(format='fits') documentation" in doc
+    assert "Write this CCDData object out in the specified format" in doc
+
+
+def test_ccddata_read_help_fits():
+    """Test dynamically created documentation help via the I/O registry for
+    CCDData 'fits'.
+
+    """
+    out = StringIO()
+    CCDData.read.help('fits', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "CCDData.read general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "CCDData.read(format='fits') documentation" in doc
+    assert "Read and parse gridded N-dimensional data" in doc

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -54,6 +54,20 @@ def test_table_write_help_hdf5():
     assert "compression : bool or str or int" in doc
 
 
+def test_list_formats():
+    """
+    Test getting list of available formats
+    """
+    out = StringIO()
+    CCDData.write.list_formats(out)
+    output = out.getvalue()
+
+    assert output == """\
+Format Read Write Auto-identify
+------ ---- ----- -------------
+  fits  Yes   Yes           Yes"""
+
+
 def test_table_write_help_fits():
     """
     Test dynamically created documentation help via the I/O registry for 'fits'.

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -15,8 +15,8 @@ def test_table_read_help_fits():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "Table.read general documentation" in doc
-    assert "The available built-in formats" in doc
+    assert "Table.read general documentation" not in doc
+    assert "The available built-in formats" not in doc
     assert "Table.read(format='fits') documentation" in doc
     assert "hdu : int or str, optional" in doc
 
@@ -30,8 +30,8 @@ def test_table_read_help_ascii():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "Table.read general documentation" in doc
-    assert "The available built-in formats" in doc
+    assert "Table.read general documentation" not in doc
+    assert "The available built-in formats" not in doc
     assert "Table.read(format='ascii') documentation" in doc
     assert "delimiter : str" in doc
     assert "ASCII reader 'ascii' details" in doc
@@ -47,8 +47,8 @@ def test_table_write_help_hdf5():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "Table.write general documentation" in doc
-    assert "The available built-in formats" in doc
+    assert "Table.write general documentation" not in doc
+    assert "The available built-in formats" not in doc
     assert "Table.write(format='hdf5') documentation" in doc
     assert "Write a Table object to an HDF5 file" in doc
     assert "compression : bool or str or int" in doc
@@ -77,8 +77,8 @@ def test_table_write_help_fits():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "Table.write general documentation" in doc
-    assert "The available built-in formats" in doc
+    assert "Table.write general documentation" not in doc
+    assert "The available built-in formats" not in doc
     assert "Table.write(format='fits') documentation" in doc
     assert "Write a Table object to a FITS file" in doc
 
@@ -120,11 +120,9 @@ def test_ccddata_write_help_fits():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "CCDData.write general documentation" in doc
-    assert "The available built-in formats" in doc
     assert "CCDData.write(format='fits') documentation" in doc
-    assert "Write this CCDData object out in the specified format" in doc
-
+    assert "Write CCDData object to FITS file" in doc
+    assert "key_uncertainty_type : str, optional" in doc
 
 def test_ccddata_read_help_fits():
     """Test dynamically created documentation help via the I/O registry for
@@ -136,7 +134,6 @@ def test_ccddata_read_help_fits():
     doc = out.getvalue()
 
     # Check a smattering of expected content
-    assert "CCDData.read general documentation" in doc
-    assert "The available built-in formats" in doc
     assert "CCDData.read(format='fits') documentation" in doc
-    assert "Read and parse gridded N-dimensional data" in doc
+    assert "Generate a CCDData object from a FITS file" in doc
+    assert "hdu_uncertainty : str or None, optional" in doc

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -1,0 +1,68 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from io import StringIO
+
+from astropy.table import Table
+
+
+def test_table_read_help_fits():
+    """
+    Test dynamically created documentation help via the I/O registry for 'fits'.
+    """
+    out = StringIO()
+    Table.read.help('fits', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.read general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "Table.read(format='fits') documentation" in doc
+    assert "hdu : int or str, optional" in doc
+
+
+def test_table_read_help_ascii():
+    """
+    Test dynamically created documentation help via the I/O registry for 'ascii'.
+    """
+    out = StringIO()
+    Table.read.help('ascii', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.read general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "Table.read(format='ascii') documentation" in doc
+    assert "delimiter : str" in doc
+    assert "ASCII reader 'ascii' details" in doc
+    assert "Character-delimited table with a single header line" in doc
+
+
+def test_table_write_help_hdf5():
+    """
+    Test dynamically created documentation help via the I/O registry for 'hdf5'.
+    """
+    out = StringIO()
+    Table.write.help('hdf5', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.write general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "Table.write(format='hdf5') documentation" in doc
+    assert "Write a Table object to an HDF5 file" in doc
+    assert "compression : bool or str or int" in doc
+
+
+def test_table_write_help_fits():
+    """
+    Test dynamically created documentation help via the I/O registry for 'fits'.
+    """
+    out = StringIO()
+    Table.write.help('fits', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.write general documentation" in doc
+    assert "The available built-in formats" in doc
+    assert "Table.write(format='fits') documentation" in doc
+    assert "Write a Table object to a FITS file" in doc

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -646,13 +646,3 @@ with registry.delay_doc_updates(CCDData):
     registry.register_reader('fits', CCDData, fits_ccddata_reader)
     registry.register_writer('fits', CCDData, fits_ccddata_writer)
     registry.register_identifier('fits', CCDData, fits.connect.is_fits)
-
-try:
-    CCDData.read.__doc__ = fits_ccddata_reader.__doc__
-except AttributeError:
-    CCDData.read.__func__.__doc__ = fits_ccddata_reader.__doc__
-
-try:
-    CCDData.write.__doc__ = fits_ccddata_writer.__doc__
-except AttributeError:
-    CCDData.write.__func__.__doc__ = fits_ccddata_writer.__doc__

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -18,6 +18,11 @@ class NDDataRead(registry.UnifiedReadWrite):
       >>> from astropy.nddata import CCDData
       >>> dat = CCDData.read('image.fits')
 
+    Get help on the reader for a particular format (e.g. 'fits') using the
+    ``help()`` method::
+
+      >>> CCDData.read.help('fits')  # Get detailed help on FITS reader
+
     See also:
 
     - http://docs.astropy.org/en/stable/nddata
@@ -49,8 +54,7 @@ class NDDataRead(registry.UnifiedReadWrite):
 
 
 class NDDataWrite(registry.UnifiedReadWrite):
-    """
-    Write this CCDData object out in the specified format.
+    """Write this CCDData object out in the specified format.
 
     This function provides the NDData interface to the astropy unified I/O
     layer.  This allows easily writing a file in many supported data formats
@@ -59,6 +63,11 @@ class NDDataWrite(registry.UnifiedReadWrite):
       >>> from astropy.nddata import CCDData
       >>> dat = CCDData(np.zeros((12, 12)), unit='adu')  # 12x12 image of zeros
       >>> dat.write('zeros.fits')
+
+    Get help on the writer for a particular format (e.g. 'fits') using the
+    ``help()`` method::
+
+      >>> CCDData.write.help('fits')  # Get detailed help on FITS writer
 
     See also:
 
@@ -77,6 +86,7 @@ class NDDataWrite(registry.UnifiedReadWrite):
 
     Notes
     -----
+
     """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -22,6 +22,7 @@ class NDDataRead(registry.UnifiedReadWrite):
 
       >>> CCDData.read.help()  # Get help reading CCDData and list supported formats
       >>> CCDData.read.help('fits')  # Get detailed help on CCDData FITS reader
+      >>> CCDData.read.list_formats()  # Print list of available formats
 
     See also:
 
@@ -68,6 +69,7 @@ class NDDataWrite(registry.UnifiedReadWrite):
 
       >>> CCDData.write.help()  # Get help writing CCDData and list supported formats
       >>> CCDData.write.help('fits')  # Get detailed help on CCDData FITS writer
+      >>> CCDData.write.list_formats()  # Print list of available formats
 
     See also:
 

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -2,9 +2,87 @@
 # This module implements the I/O mixin to the NDData class.
 
 
-from astropy.io import registry as io_registry
+from astropy.io import registry
 
 __all__ = ['NDIOMixin']
+__doctest_skip__ = ['NDDataRead', 'NDDataWrite']
+
+class NDDataRead(registry.UnifiedReadWrite):
+    """Read and parse gridded N-dimensional data and return as an NDData-derived
+    object.
+
+    This function provides the NDDataBase interface to the astropy unified I/O
+    layer.  This allows easily reading a file in the supported data formats,
+    for example::
+
+      >>> from astropy.nddata import CCDData
+      >>> dat = CCDData.read('image.fits')
+
+    See also:
+
+    - http://docs.astropy.org/en/stable/nddata
+    - http://docs.astropy.org/en/stable/io/unified.html
+
+    Parameters
+    ----------
+    *args : tuple, optional
+        Positional arguments passed through to data reader. If supplied the
+        first argument is the input filename.
+    format : str, optional
+        File format specifier.
+    **kwargs : dict, optional
+        Keyword arguments passed through to data reader.
+
+    Returns
+    -------
+    out : `NDData` subclass
+        NDData-basd object corresponding to file contents
+
+    Notes
+    -----
+    """
+    def __init__(self, instance, cls):
+        super().__init__(instance, cls, 'read')
+
+    def __call__(self, *args, **kwargs):
+        return registry.read(self._cls, *args, **kwargs)
+
+
+class NDDataWrite(registry.UnifiedReadWrite):
+    """
+    Write this CCDData object out in the specified format.
+
+    This function provides the NDData interface to the astropy unified I/O
+    layer.  This allows easily writing a file in many supported data formats
+    using syntax such as::
+
+      >>> from astropy.nddata import CCDData
+      >>> dat = CCDData(np.zeros((12, 12)), unit='adu')  # 12x12 image of zeros
+      >>> dat.write('zeros.fits')
+
+    See also:
+
+    - http://docs.astropy.org/en/stable/nddata
+    - http://docs.astropy.org/en/stable/io/unified.html
+
+    Parameters
+    ----------
+    *args : tuple, optional
+        Positional arguments passed through to data writer. If supplied the
+        first argument is the output filename.
+    format : str, optional
+        File format specifier.
+    **kwargs : dict, optional
+        Keyword arguments passed through to data writer.
+
+    Notes
+    -----
+    """
+    def __init__(self, instance, cls):
+        super().__init__(instance, cls, 'write')
+
+    def __call__(self, *args, **kwargs):
+        registry.write(self._instance, *args, **kwargs)
 
 
 class NDIOMixin:
@@ -13,25 +91,5 @@ class NDIOMixin:
 
     This mixin adds two methods to its subclasses, ``read`` and ``write``.
     """
-
-    @classmethod
-    def read(cls, *args, **kwargs):
-        """
-        Read and parse gridded N-dimensional data and return as an
-        NDData-derived object.
-
-        This function provides the NDDataBase interface to the astropy unified
-        I/O layer.  This allows easily reading a file in the supported data
-        formats.
-        """
-        return io_registry.read(cls, *args, **kwargs)
-
-    def write(self, *args, **kwargs):
-        """
-        Write a gridded N-dimensional data object out in specified format.
-
-        This function provides the NDDataBase interface to the astropy unified
-        I/O layer.  This allows easily writing a file in the supported data
-        formats.
-        """
-        io_registry.write(self, *args, **kwargs)
+    read = registry.UnifiedReadWriteMethod(NDDataRead)
+    write = registry.UnifiedReadWriteMethod(NDDataWrite)

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -86,7 +86,6 @@ class NDDataWrite(registry.UnifiedReadWrite):
 
     Notes
     -----
-
     """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -18,10 +18,10 @@ class NDDataRead(registry.UnifiedReadWrite):
       >>> from astropy.nddata import CCDData
       >>> dat = CCDData.read('image.fits')
 
-    Get help on the reader for a particular format (e.g. 'fits') using the
-    ``help()`` method::
+    Get help on the available readers for ``CCDData`` using the``help()`` method::
 
-      >>> CCDData.read.help('fits')  # Get detailed help on FITS reader
+      >>> CCDData.read.help()  # Get help reading CCDData and list supported formats
+      >>> CCDData.read.help('fits')  # Get detailed help on CCDData FITS reader
 
     See also:
 
@@ -64,10 +64,10 @@ class NDDataWrite(registry.UnifiedReadWrite):
       >>> dat = CCDData(np.zeros((12, 12)), unit='adu')  # 12x12 image of zeros
       >>> dat.write('zeros.fits')
 
-    Get help on the writer for a particular format (e.g. 'fits') using the
-    ``help()`` method::
+    Get help on the available writers for ``CCDData`` using the``help()`` method::
 
-      >>> CCDData.write.help('fits')  # Get detailed help on FITS writer
+      >>> CCDData.write.help()  # Get help writing CCDData and list supported formats
+      >>> CCDData.write.help('fits')  # Get detailed help on CCDData FITS writer
 
     See also:
 

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -42,7 +42,6 @@ class TableRead(registry.UnifiedReadWrite):
 
     Notes
     -----
-
     """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'read')

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -18,10 +18,10 @@ class TableRead(registry.UnifiedReadWrite):
       >>> dat = Table.read('table.dat', format='ascii')
       >>> events = Table.read('events.fits', format='fits')
 
-    Get help on the reader for a particular format (e.g. 'fits') using the
-    ``help()`` method::
+    Get help on the available readers for ``Table`` using the``help()`` method::
 
-      >>> Table.read.help('fits')  # Get detailed help on FITS reader
+      >>> Table.read.help()  # Get help reading Table and list supported formats
+      >>> Table.read.help('fits')  # Get detailed help on Table FITS reader
 
     See also: http://docs.astropy.org/en/stable/io/unified.html
 
@@ -77,10 +77,10 @@ class TableWrite(registry.UnifiedReadWrite):
       >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
       >>> dat.write('table.dat', format='ascii')
 
-    Get help on the writer for a particular format (e.g. 'fits') using the
-    ``help()`` method::
+    Get help on the available writers for ``Table`` using the``help()`` method::
 
-      >>> Table.write.help('fits')  # Get detailed help on FITS writer
+      >>> Table.write.help()  # Get help writing Table and list supported formats
+      >>> Table.write.help('fits')  # Get detailed help on Table FITS writer
 
     The ``serialize_method`` argument is explained in the section on
     `Table serialization methods

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -8,8 +8,7 @@ __doctest_skip__ = ['TableRead', 'TableWrite']
 
 
 class TableRead(registry.UnifiedReadWrite):
-    """
-    Read and parse a data table and return as a Table.
+    """Read and parse a data table and return as a Table.
 
     This function provides the Table interface to the astropy unified I/O
     layer.  This allows easily reading a file in many supported data formats
@@ -18,6 +17,11 @@ class TableRead(registry.UnifiedReadWrite):
       >>> from astropy.table import Table
       >>> dat = Table.read('table.dat', format='ascii')
       >>> events = Table.read('events.fits', format='fits')
+
+    Get help on the reader for a particular format (e.g. 'fits') using the
+    ``help()`` method::
+
+      >>> Table.read.help('fits')  # Get detailed help on FITS reader
 
     See also: http://docs.astropy.org/en/stable/io/unified.html
 
@@ -38,6 +42,7 @@ class TableRead(registry.UnifiedReadWrite):
 
     Notes
     -----
+
     """
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'read')
@@ -71,6 +76,15 @@ class TableWrite(registry.UnifiedReadWrite):
       >>> from astropy.table import Table
       >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
       >>> dat.write('table.dat', format='ascii')
+
+    Get help on the writer for a particular format (e.g. 'fits') using the
+    ``help()`` method::
+
+      >>> Table.write.help('fits')  # Get detailed help on FITS writer
+
+    The ``serialize_method`` argument is explained in the section on
+    `Table serialization methods
+    <http://docs.astropy.org/en/latest/io/unified.html#table-serialization-methods>`_.
 
     See also: http://docs.astropy.org/en/stable/io/unified.html
 

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -97,13 +97,3 @@ class TableWrite(registry.UnifiedReadWrite):
         instance = self._instance
         with serialize_method_as(instance, serialize_method):
             registry.write(instance, *args, **kwargs)
-
-
-class TableReadMethod:
-    def __get__(self, instance, owner_cls):
-        return TableRead(instance, owner_cls)
-
-
-class TableWriteMethod:
-    def __get__(self, instance, owner_cls):
-        return TableWrite(instance, owner_cls)

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -23,11 +23,11 @@ class TableRead(registry.UnifiedReadWrite):
 
     Parameters
     ----------
-    format : str
-        File format specifier.
     *args : tuple, optional
         Positional arguments passed through to data reader. If supplied the
-        first argument is the input filename.
+        first argument is typically the input filename.
+    format : str
+        File format specifier.
     **kwargs : dict, optional
         Keyword arguments passed through to data reader.
 
@@ -76,13 +76,13 @@ class TableWrite(registry.UnifiedReadWrite):
 
     Parameters
     ----------
+    *args : tuple, optional
+        Positional arguments passed through to data writer. If supplied the
+        first argument is the output filename.
     format : str
         File format specifier.
     serialize_method : str, dict, optional
         Serialization method specifier for columns.
-    *args : tuple, optional
-        Positional arguments passed through to data writer. If supplied the
-        first argument is the output filename.
     **kwargs : dict, optional
         Keyword arguments passed through to data writer.
 

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -37,8 +37,8 @@ class TableRead(registry.UnifiedReadWrite):
     Notes
     -----
     """
-    def __init__(self, cls):
-        super().__init__(cls, 'read')
+    def __init__(self, instance, cls):
+        super().__init__(instance, cls, 'read')
 
     def __call__(self, *args, **kwargs):
         cls = self._cls
@@ -87,20 +87,21 @@ class TableWrite(registry.UnifiedReadWrite):
     Notes
     -----
     """
-    def __init__(self, cls):
-        super().__init__(cls, 'write')
+    def __init__(self, instance, cls):
+        super().__init__(instance, cls, 'write')
 
     def __call__(self, *args, **kwargs):
         serialize_method = kwargs.pop('serialize_method', None)
-        with serialize_method_as(self, serialize_method):
-            registry.write(self, *args, **kwargs)
+        instance = self._instance
+        with serialize_method_as(instance, serialize_method):
+            registry.write(instance, *args, **kwargs)
 
 
 class TableReadMethod:
     def __get__(self, instance, owner_cls):
-        return TableRead(owner_cls)
+        return TableRead(instance, owner_cls)
 
 
 class TableWriteMethod:
     def __get__(self, instance, owner_cls):
-        return TableWrite(owner_cls)
+        return TableWrite(instance, owner_cls)

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -1,0 +1,106 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from astropy.io import registry
+
+from .info import serialize_method_as
+
+
+class TableRead(registry.UnifiedReadWrite):
+    """
+    Read and parse a data table and return as a Table.
+
+    This function provides the Table interface to the astropy unified I/O
+    layer.  This allows easily reading a file in many supported data formats
+    using syntax such as::
+
+      >>> from astropy.table import Table
+      >>> dat = Table.read('table.dat', format='ascii')
+      >>> events = Table.read('events.fits', format='fits')
+
+    See also: http://docs.astropy.org/en/stable/io/unified.html
+
+    Parameters
+    ----------
+    format : str
+        File format specifier.
+    *args : tuple, optional
+        Positional arguments passed through to data reader. If supplied the
+        first argument is the input filename.
+    **kwargs : dict, optional
+        Keyword arguments passed through to data reader.
+
+    Returns
+    -------
+    out : `Table`
+        Table corresponding to file contents
+
+    Notes
+    -----
+    """
+    def __init__(self, cls):
+        super().__init__(cls, 'read')
+
+    def __call__(self, *args, **kwargs):
+        cls = self._cls
+        out = registry.read(cls, *args, **kwargs)
+
+        # For some readers (e.g., ascii.ecsv), the returned `out` class is not
+        # guaranteed to be the same as the desired output `cls`.  If so,
+        # try coercing to desired class without copying (io.registry.read
+        # would normally do a copy).  The normal case here is swapping
+        # Table <=> QTable.
+        if cls is not out.__class__:
+            try:
+                out = cls(out, copy=False)
+            except Exception:
+                raise TypeError('could not convert reader output to {0} '
+                                'class.'.format(cls.__name__))
+        return out
+
+
+class TableWrite(registry.UnifiedReadWrite):
+    """
+    Write this Table object out in the specified format.
+
+    This function provides the Table interface to the astropy unified I/O
+    layer.  This allows easily writing a file in many supported data formats
+    using syntax such as::
+
+      >>> from astropy.table import Table
+      >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
+      >>> dat.write('table.dat', format='ascii')
+
+    See also: http://docs.astropy.org/en/stable/io/unified.html
+
+    Parameters
+    ----------
+    format : str
+        File format specifier.
+    serialize_method : str, dict, optional
+        Serialization method specifier for columns.
+    *args : tuple, optional
+        Positional arguments passed through to data writer. If supplied the
+        first argument is the output filename.
+    **kwargs : dict, optional
+        Keyword arguments passed through to data writer.
+
+    Notes
+    -----
+    """
+    def __init__(self, cls):
+        super().__init__(cls, 'write')
+
+    def __call__(self, *args, **kwargs):
+        serialize_method = kwargs.pop('serialize_method', None)
+        with serialize_method_as(self, serialize_method):
+            registry.write(self, *args, **kwargs)
+
+
+class TableReadMethod:
+    def __get__(self, instance, owner_cls):
+        return TableRead(owner_cls)
+
+
+class TableWriteMethod:
+    def __get__(self, instance, owner_cls):
+        return TableWrite(owner_cls)

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -22,6 +22,7 @@ class TableRead(registry.UnifiedReadWrite):
 
       >>> Table.read.help()  # Get help reading Table and list supported formats
       >>> Table.read.help('fits')  # Get detailed help on Table FITS reader
+      >>> Table.read.list_formats()  # Print list of available formats
 
     See also: http://docs.astropy.org/en/stable/io/unified.html
 
@@ -80,6 +81,7 @@ class TableWrite(registry.UnifiedReadWrite):
 
       >>> Table.write.help()  # Get help writing Table and list supported formats
       >>> Table.write.help('fits')  # Get detailed help on Table FITS writer
+      >>> Table.write.list_formats()  # Print list of available formats
 
     The ``serialize_method`` argument is explained in the section on
     `Table serialization methods

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -4,6 +4,8 @@ from astropy.io import registry
 
 from .info import serialize_method_as
 
+__doctest_skip__ = ['TableRead', 'TableWrite']
+
 
 class TableRead(registry.UnifiedReadWrite):
     """

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -7,13 +7,11 @@ from collections import OrderedDict
 from collections.abc import Mapping
 import warnings
 from copy import deepcopy
-import inspect
 
 import numpy as np
 from numpy import ma
 
 from astropy import log
-from astropy.io import registry as io_registry
 from astropy.units import Quantity, QuantityInfo
 from astropy.utils import isiterable, ShapedLikeNDArray
 from astropy.utils.console import color_print
@@ -27,12 +25,13 @@ from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_copy)
 from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
-from .info import TableInfo, serialize_method_as
+from .info import TableInfo
 from .index import Index, _IndexModeContext, get_index
+from .connect import TableReadMethod, TableWriteMethod
 from . import conf
 
 
-__doctest_skip__ = ['Table.read', 'Table.write',
+__doctest_skip__ = ['Table.read', 'Table.write', 'Table._read',
                     'Table.convert_bytestring_to_unicode',
                     'Table.convert_unicode_to_bytestring',
                     ]
@@ -264,6 +263,20 @@ class TableColumns(OrderedDict):
         return cols
 
 
+class TableReadWrite:
+    def __get__(self, instance, owner_cls):
+        if instance is None:
+            # This is an unbound descriptor on the class
+            info = self
+            info._parent_cls = owner_cls
+        else:
+            info = instance.__dict__.get('info')
+            if info is None:
+                info = instance.__dict__['info'] = self.__class__(bound=True)
+            info._parent = instance
+        return info
+
+
 class Table:
     """A class to represent tables of heterogeneous data.
 
@@ -314,6 +327,10 @@ class Table:
     MaskedColumn = MaskedColumn
     TableColumns = TableColumns
     TableFormatter = TableFormatter
+
+    # Unified I/O read and write methods from .connect
+    read = TableReadMethod()
+    write = TableWriteMethod()
 
     def as_array(self, keep_byteorder=False, names=None):
         """
@@ -2604,104 +2621,6 @@ class Table:
             col[:] = col[::-1]
         for index in self.indices:
             index.reverse()
-
-    @classmethod
-    def read(cls, *args, **kwargs):
-        """
-        Read and parse a data table and return as a Table.
-
-        This function provides the Table interface to the astropy unified I/O
-        layer.  This allows easily reading a file in many supported data formats
-        using syntax such as::
-
-          >>> from astropy.table import Table
-          >>> dat = Table.read('table.dat', format='ascii')
-          >>> events = Table.read('events.fits', format='fits')
-
-        See also: http://docs.astropy.org/en/stable/io/unified.html
-
-        Parameters
-        ----------
-        format : str
-            File format specifier.
-        *args : tuple, optional
-            Positional arguments passed through to data reader. If supplied the
-            first argument is the input filename.
-        **kwargs : dict, optional
-            Keyword arguments passed through to data reader.
-
-        Returns
-        -------
-        out : `~astropy.table.Table`
-            Table corresponding to file contents
-
-        Notes
-        -----
-        """
-        # The hanging Notes section just above is a section placeholder for
-        # import-time processing that collects available formats into an
-        # RST table and inserts at the end of the docstring.  DO NOT REMOVE.
-
-        format = kwargs.pop('format', None)
-        if format and not args and not kwargs:
-            reader = io_registry.get_reader(format, cls)
-            reader_doc = ('Table.read() general documentation\n'
-                          '==================================\n')
-            reader_doc += inspect.cleandoc(cls.read.__doc__)
-            reader_doc = re.sub(r'Notes\n-----.*',
-                                'Table.read() format-specific documentation\n'
-                                '==========================================\n',
-                                reader_doc,
-                                flags=re.DOTALL)
-            reader_doc += inspect.cleandoc(reader.__doc__)
-            print(reader_doc)
-            return
-
-        out = io_registry.read(cls, *args, format=format, **kwargs)
-        # For some readers (e.g., ascii.ecsv), the returned `out` class is not
-        # guaranteed to be the same as the desired output `cls`.  If so,
-        # try coercing to desired class without copying (io.registry.read
-        # would normally do a copy).  The normal case here is swapping
-        # Table <=> QTable.
-        if cls is not out.__class__:
-            try:
-                out = cls(out, copy=False)
-            except Exception:
-                raise TypeError('could not convert reader output to {0} '
-                                'class.'.format(cls.__name__))
-        return out
-
-    def write(self, *args, **kwargs):
-        """Write this Table object out in the specified format.
-
-        This function provides the Table interface to the astropy unified I/O
-        layer.  This allows easily writing a file in many supported data formats
-        using syntax such as::
-
-          >>> from astropy.table import Table
-          >>> dat = Table([[1, 2], [3, 4]], names=('a', 'b'))
-          >>> dat.write('table.dat', format='ascii')
-
-        See also: http://docs.astropy.org/en/stable/io/unified.html
-
-        Parameters
-        ----------
-        format : str
-            File format specifier.
-        serialize_method : str, dict, optional
-            Serialization method specifier for columns.
-        *args : tuple, optional
-            Positional arguments passed through to data writer. If supplied the
-            first argument is the output filename.
-        **kwargs : dict, optional
-            Keyword arguments passed through to data writer.
-
-        Notes
-        -----
-        """
-        serialize_method = kwargs.pop('serialize_method', None)
-        with serialize_method_as(self, serialize_method):
-            io_registry.write(self, *args, **kwargs)
 
     def copy(self, copy_data=True):
         '''

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -18,6 +18,8 @@ from astropy.utils.console import color_print
 from astropy.utils.metadata import MetaData
 from astropy.utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
 from astropy.utils.decorators import format_doc
+from astropy.utils.exceptions import AstropyDeprecationWarning, NoValue
+from astropy.io.registry import UnifiedReadWriteMethod
 
 from . import groups
 from .pprint import TableFormatter
@@ -27,7 +29,7 @@ from .row import Row
 from .np_utils import fix_column_name, recarray_fromrecords
 from .info import TableInfo
 from .index import Index, _IndexModeContext, get_index
-from .connect import TableReadMethod, TableWriteMethod
+from .connect import TableRead, TableWrite
 from . import conf
 
 
@@ -329,8 +331,8 @@ class Table:
     TableFormatter = TableFormatter
 
     # Unified I/O read and write methods from .connect
-    read = TableReadMethod()
-    write = TableWriteMethod()
+    read = UnifiedReadWriteMethod(TableRead)
+    write = UnifiedReadWriteMethod(TableWrite)
 
     def as_array(self, keep_byteorder=False, names=None):
         """

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -8,6 +8,31 @@ For many common cases this will simplify the process of file I/O and reduce the 
 master the separate details of all the I/O packages within Astropy.  For
 details on the implementation see :ref:`io_registry`.
 
+Getting started with Image I/O
+==============================
+
+Reading and writing image data in the unified I/O interface is supported
+though the `~astropy.nddata.CCDData` class using FITS file format:
+
+.. doctest-skip::
+
+    # Read CCD image
+    >>> ccd = CCDData.read('image.fits')
+
+    # Write back CCD image
+    >>> ccd.write('new_image.fits')
+
+Note the unit is stored in the ``BUNIT`` keyword in the header on saving, and is
+read from the header if it is present.
+
+Detailed help on the available keyword arguments for reading and writing
+can be obtained via the ``help()`` method as follows:
+
+.. doctest-skip::
+
+    >>> CCDData.read.help('fits')  # Get help on the CCDData FITS reader
+    >>> CCDData.writer.help('fits')  # Get help on the CCDData FITS writer
+
 Getting started with Table I/O
 ==============================
 
@@ -59,10 +84,31 @@ fine control of the way to write out certain columns, for instance
 writing an ISO format Time column as a pair of JD1 / JD2 floating
 point values (for full resolution) or as a formatted ISO date string.
 
+Getting help on readers and writers
+-----------------------------------
 
-Any additional arguments specified will depend on the format.  For examples of this see the
-section `Built-in table readers/writers`_.  This section also provides the full list of
-choices for the ``format`` argument.
+Each file format is handled by a specific reader or writer, and each of those
+functions will have its own set of arguments.  For examples of
+this see the section `Built-in table readers/writers`_.  This section also
+provides the full list of choices for the ``format`` argument.
+
+To get help on the available arguments for each format, use the ``help()``
+method of the `~astropy.table.Table.read` or `~astropy.table.Table.write`
+methods.  Each of these calls prints a long help document which is divided
+into two sections, the generic read/write documentation (common to any
+call) and the format-specific documentation.  For ASCII tables the
+format-specific documentation includes the generic `astropy.io.ascii` package
+interface and then a description of the particular ASCII subformat.
+
+In the examples below we do not show the long output:
+
+.. doctest-skip::
+
+    >>> Table.read.help('fits')
+    >>> Table.read.help('ascii')
+    >>> Table.read.help('ascii.latex')
+    >>> Table.write.help('hdf5')
+    >>> Table.write.help('csv')
 
 Command-line utility
 --------------------

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -16,10 +16,12 @@ though the `~astropy.nddata.CCDData` class using FITS file format:
 
 .. doctest-skip::
 
-    # Read CCD image
+    >>> # Read CCD image
     >>> ccd = CCDData.read('image.fits')
 
-    # Write back CCD image
+.. doctest-skip::
+
+    >>> # Write back CCD image
     >>> ccd.write('new_image.fits')
 
 Note the unit is stored in the ``BUNIT`` keyword in the header on saving, and is

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -227,6 +227,12 @@ and can also be read in from a FITS file::
 Note the unit is stored in the ``BUNIT`` keyword in the header on saving, and is
 read from the header if it is present.
 
+Detailed help on the available keyword arguments for reading and writing
+can be obtained via the ``help()`` method as follows::
+
+    >>> CCDData.read.help('fits')  # Get help on the CCDData FITS reader
+    >>> CCDData.writer.help('fits')  # Get help on the CCDData FITS writer
+
 .. _image_utilities:
 
 Image utilities

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -228,7 +228,9 @@ Note the unit is stored in the ``BUNIT`` keyword in the header on saving, and is
 read from the header if it is present.
 
 Detailed help on the available keyword arguments for reading and writing
-can be obtained via the ``help()`` method as follows::
+can be obtained via the ``help()`` method as follows:
+
+.. doctest-skip::
 
     >>> CCDData.read.help('fits')  # Get help on the CCDData FITS reader
     >>> CCDData.writer.help('fits')  # Get help on the CCDData FITS writer


### PR DESCRIPTION
This PR is a decent-sized update to the unified I/O infrastructure, with the main driver being to make it possible to get format-specific documentation in a simple way.  This is done with (e.g.):
```
>>> Table.read.help('ascii.latex')
>>> Table.write.help('fits')
>>> CCDData.read.help('fits')
>>> Table.read.help()  # Generic reader help
>>> Table.read?  # Basically the same thing
```
This prints output to the console via a pager (`pydoc.pager`) and includes the generic read/write interface help and format-specific docs.

In order to make the `read.help` and `write.help` methods in a clean way I ended up with some new general-purpose infrastructure for defining read and write methods as class descriptors.  Along the way I cleaned up the `io.ascii` docs to make them more consistent within this framework.  

I also did cleanup of the Table registry by removing the custom-installed 'ascii' and 'csv' entry points in favor of generic mechanisms now in place.

NOTE for future readers: the comments up through https://github.com/astropy/astropy/pull/8255#issuecomment-446144448 are mostly overtaken by the new code.