### PR TITLE
Remove edit on github option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,26 +186,6 @@ man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
 
-# -- Options for the edit_on_github extension ----------------------------------------
-
-extensions += ['sphinx_astropy.ext.edit_on_github']
-
-# Don't import the module as "version" or it will override the
-# "version" configuration parameter
-from astropy import version as versionmod
-edit_on_github_project = "astropy/astropy"
-if versionmod.release:
-    edit_on_github_branch = "v{0}.{1}.x".format(
-        versionmod.major, versionmod.minor)
-else:
-    edit_on_github_branch = "master"
-edit_on_github_source_root = ""
-edit_on_github_doc_root = "docs"
-
-edit_on_github_skip_regex = '_.*|api/.*'
-
-github_issues_url = 'https://github.com/astropy/astropy/issues/'
-
 # Enable nitpicky mode - which ensures that all references in the docs
 # resolve.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,6 +185,8 @@ latex_logo = '_static/astropy_logo.pdf'
 man_pages = [('index', project.lower(), project + u' Documentation',
               [author], 1)]
 
+# Setting this URL is requited by sphinx-astropy
+github_issues_url = 'https://github.com/astropy/astropy/issues/'
 
 # Enable nitpicky mode - which ensures that all references in the docs
 # resolve.


### PR DESCRIPTION
This plugin causes issues all the time for users opening PRs starting from a wrong branch. The latest one is: https://github.com/astropy/astropy/pull/8257

A drastic but effective way to fix it is to remove the plugin. The other option would be to redirect all edits to start from master, but then they may start to fix something running into in an older version that has already been fixed in master.

cc @pllim @eteq @astrofrog 