### PR TITLE
Cosmology: integral divergence for high z in lookback_time

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1088,7 +1088,13 @@ class FLRW(Cosmology, metaclass=ABCMeta):
           Lookback time in Gyr to each input redshift.
         """
         from scipy.integrate import quad
-        f = lambda red: quad(self._lookback_time_integrand_scalar, 0, red)[0]
+        # f = lambda red: quad(self._lookback_time_integrand_scalar, 0, red)[0]
+        def f(red):
+            val = quad(self._lookback_time_integrand_scalar, 0, red)[0]
+            if val * self._hubble_time < 1e-6 * u.Gyr and red > 1:
+                x, w = np.polynomial.legendre.leggauss(2000)
+                return np.inner(np.vectorize(self._lookback_time_integrand_scalar)(x * red / 2 + red / 2), w) * red / 2
+            return val
         return self._hubble_time * vectorize_if_needed(f, z)
 
     def lookback_distance(self, z):

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1088,13 +1088,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
           Lookback time in Gyr to each input redshift.
         """
         from scipy.integrate import quad
-        # f = lambda red: quad(self._lookback_time_integrand_scalar, 0, red)[0]
-        def f(red):
-            val = quad(self._lookback_time_integrand_scalar, 0, red)[0]
-            if val * self._hubble_time < 1e-6 * u.Gyr and red > 1:
-                x, w = np.polynomial.legendre.leggauss(2000)
-                return np.inner(np.vectorize(self._lookback_time_integrand_scalar)(x * red / 2 + red / 2), w) * red / 2
-            return val
+        f = lambda red: quad(self._lookback_time_integrand_scalar, 0, np.min([red, 1e4]))[0] + quad(self._lookback_time_integrand_scalar, np.min([red, 1e4]), red)[0]
         return self._hubble_time * vectorize_if_needed(f, z)
 
     def lookback_distance(self, z):


### PR DESCRIPTION
Astropy version: 3.0.4
Python version 3.6
Machine: Microsoft Azure notebooks

How to reproduce:

> import astropy.cosmology as cosmo
> cosmo.LambdaCDM(H0=H_0, Om0=0.3, Ob0=0, Ode0=0.7).ookback_time(1e6)
![image](https://user-images.githubusercontent.com/17602594/49779615-9cde1f80-fcd0-11e8-998a-84081a4e7163.png)

Expected output:
13.5Gyr
Got:
−8.88×10−9Gyr

Possible solution that is included in patch:
To avoid high decrease in speed performance, add case check for definitely wrong answer (such as integral return less than 1e-10 for z > 1) to perform integration using Gauss-Legendre quadrature. With 2
2000 weight achieves correct answer up to z < 2e6. This will not add overheat in case if machine didn't face the issue in a first place but will improve for the cases if it is.

As far as I found out, this issue does not exist on all machines, locally on 64 bits Ubuntu 18.04 scipy quad works perfectly for much higher values for z but this is not true for Microsoft Azure notebooks.

Hope this time I followed guidlines correctly. I don't know how to properly include tests but
> python setup.py test -P cosmology

returns 46 passes in 0.88 seconds

