### PR TITLE
Bump required ASDF version in docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -62,7 +62,7 @@ Astropy also depends on other packages for optional features:
 - `mpmath <http://mpmath.org/>`_: Used for the 'kraft-burrows-nousek'
   interval in `~astropy.stats.poisson_conf_interval`.
 
-- `asdf <https://github.com/spacetelescope/asdf>`_ 2.0 or later: Enables the
+- `asdf <https://github.com/spacetelescope/asdf>`_ 2.3 or later: Enables the
   serialization of various Astropy classes into a portable, hierarchical,
   human-readable representation.
 


### PR DESCRIPTION
This really should have gone into 3.1 due to #8183, but alas.