### PR TITLE
Fix bug with raising to a negative power.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -300,6 +300,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Ensure correctness of units when raising to a negative power. [#8263]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2022,8 +2022,10 @@ class CompositeUnit(UnitBase):
                         "bases must be sequence of UnitBase instances")
             powers = [validate_power(p) for p in powers]
 
-        if not decompose and len(bases) == 1:
-            # Short-cut; with one unit there's nothing to expand and gather.
+        if not decompose and len(bases) == 1 and powers[0] >= 0:
+            # Short-cut; with one unit there's nothing to expand and gather,
+            # as that has happened already when creating the unit.  But do only
+            # positive powers, since for negative powers we need to re-sort.
             unit = bases[0]
             power = powers[0]
             if power == 1:
@@ -2038,6 +2040,7 @@ class CompositeUnit(UnitBase):
                 self._bases = unit.bases
                 self._powers = [operator.mul(*resolve_fractions(p, power))
                                 for p in unit.powers]
+
             self._scale = sanitize_scale(scale)
         else:
             # Regular case: use inputs as preliminary scale, bases, and powers,

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -807,3 +807,15 @@ def test_unit_summary_prefixes():
             assert prefixes == 'No'
         elif unit.name == 'vox':
             assert prefixes == 'Yes'
+
+
+def test_raise_to_negative_power():
+    """Test that order of bases is changed when raising to negative power.
+
+    Regression test for https://github.com/astropy/astropy/issues/8260
+    """
+    m2s2 = u.m ** 2 / u.s **2
+    spm = m2s2 ** (-1 / 2)
+    assert spm.bases == [u.s, u.m]
+    assert spm.powers == [1, -1]
+    assert spm == u.s / u.m


### PR DESCRIPTION
This is a regression introduced by gh-7649 and reported in gh-8260.
Before this fix:
```
v2 = 1*u.m**2/u.s**2
(v2 ** (-1/2)).to(u.s/u.m)
```
leads to a unit conversion error because the bases are in the
wrong order.

fixes #8260 

@bsipocz - this is a pretty bad bug, so may drive the 3.1.1 release...