### PR TITLE
Remove unused import in astropy.uncertainty

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -8,7 +8,6 @@ Distribution class and associated machinery.
 import numpy as np
 
 from astropy import units as u
-from astropy import visualization
 from astropy import stats
 
 __all__ = ['Distribution']


### PR DESCRIPTION
This PR removes an unused import of `astropy.visualization` in `astropy.uncertainty`.

I noticed that `import astropy.uncertainty` pops up a GUI window on my Mac, because `astropy.visualization` is imported, which imports `matplotlib.pyplot`. Removing this unused import fixes this issue, and makes `import astropy.uncertainty` faster.

cc @eteq 