### PR TITLE
Fix specification of dependencies for RTD build

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -4,7 +4,7 @@ build:
 python:
   version: 3.6
   pip_install: true
-  extra_requirements: ['docs']
+  extra_requirements: ['docs', 'all']
 
 # Don't build any extra formats
 formats: []


### PR DESCRIPTION
We need to make sure the optional dependencies are included. This should only affect 3.2.