### PR TITLE
Removing verbose flag for circleCI runs 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,19 @@ jobs:
           command: /opt/python/cp35-cp35m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.5
-          command: PYTHONHASHSEED=42 /opt/python/cp35-cp35m/bin/python setup.py test --parallel=4 -V -a "--durations=50"
+          command: PYTHONHASHSEED=42 /opt/python/cp35-cp35m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.6
           command: /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.6
-          command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -V -a "--durations=50"
+          command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.7
           command: /opt/python/cp37-cp37m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.7
-          command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -V -a "--durations=50"
+          command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
 
   image-tests-mpl202:
     docker:


### PR DESCRIPTION
to avoid the need to download the full log each time