### PR TITLE
Fix a bug in `io.fits` with fortran-ordered arrays in python3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1725,6 +1725,8 @@ astropy.io.ascii
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Fix a bug in ``io.fits`` with writting Fortran-ordered arrays to file objects [#8282]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -168,6 +168,53 @@ class TestImageFunctions(FitsTestCase):
         finally:
             fits.conf.lazy_load_hdus = True
 
+    def test_fortran_array(self):
+        # Test that files are being correctly written+read for "C" and "F" order arrays
+        a = np.arange(21).reshape(3,7)
+        b = np.asfortranarray(a)
+
+        afits = self.temp('a_str.fits')
+        bfits = self.temp('b_str.fits')
+        # writting to str specified files
+        fits.PrimaryHDU(data=a).writeto(afits)
+        fits.PrimaryHDU(data=b).writeto(bfits)
+        np.testing.assert_array_equal(fits.getdata(afits), a)
+        np.testing.assert_array_equal(fits.getdata(bfits), a)
+
+        # writting to fileobjs
+        aafits = self.temp('a_fileobj.fits')
+        bbfits = self.temp('b_fileobj.fits')
+        with open(aafits, mode='wb') as fd:
+            fits.PrimaryHDU(data=a).writeto(fd)
+        with open(bbfits, mode='wb') as fd:
+            fits.PrimaryHDU(data=b).writeto(fd)
+        np.testing.assert_array_equal(fits.getdata(aafits), a)
+        np.testing.assert_array_equal(fits.getdata(bbfits), a)
+
+    def test_fortran_array_non_contiguous(self):
+        # Test that files are being correctly written+read for 'C' and 'F' order arrays
+        a = np.arange(105).reshape(3,5,7)
+        b = np.asfortranarray(a)
+
+        # writting to str specified files
+        afits = self.temp('a_str_slice.fits')
+        bfits = self.temp('b_str_slice.fits')
+        fits.PrimaryHDU(data=a[::2, ::2]).writeto(afits)
+        fits.PrimaryHDU(data=b[::2, ::2]).writeto(bfits)
+        np.testing.assert_array_equal(fits.getdata(afits), a[::2, ::2])
+        np.testing.assert_array_equal(fits.getdata(bfits), a[::2, ::2])
+
+        # writting to fileobjs
+        aafits = self.temp('a_fileobj_slice.fits')
+        bbfits = self.temp('b_fileobj_slice.fits')
+        with open(aafits, mode='wb') as fd:
+            fits.PrimaryHDU(data=a[::2, ::2]).writeto(fd)
+        with open(bbfits, mode='wb') as fd:
+            fits.PrimaryHDU(data=b[::2, ::2]).writeto(fd)
+        np.testing.assert_array_equal(fits.getdata(aafits), a[::2, ::2])
+        np.testing.assert_array_equal(fits.getdata(bbfits), a[::2, ::2])
+
+
     def test_primary_with_extname(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/151
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -671,7 +671,7 @@ def _array_to_file_like(arr, fileobj):
 
     if hasattr(np, 'nditer'):
         # nditer version for non-contiguous arrays
-        for item in np.nditer(arr):
+        for item in np.nditer(arr, order='C'):
             fileobj.write(item.tostring())
     else:
         # Slower version for Numpy versions without nditer;


### PR DESCRIPTION
I'm using python 3.6.5 with numpy 1.15.4

I wrote a code relying on astropy.io.fits to write and read .fits files. My code worked nicely under astropy 3.0.0 up to 3.0.4, but broke after I updated to 3.0.5 (also in 3.1.0). I was able to locate the change that caused the break in this commit

https://github.com/astropy/astropy/commit/e0236766aa295e46eaff27746a5c549107888492

I'm just putting in the dirty fix here, which is a simple reversing of the change made to `astropy/io/fits/util.py`, and I will provide a simple example later today. In the mean time I don't know what the change I reversed was for and I'd like to see if this part of the code is covered by your test pipeline.