### PR TITLE
Fix with_H0/little-h equivalency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,7 +313,7 @@ astropy.units
 
 - Ensure correctness of units when raising to a negative power. [#8263]
 
-- Fix ``with_H0`` equivalency to how the appropriate direction of
+- Fix ``with_H0`` equivalency to use the correct direction of
   conversion. [#8292]
 
 astropy.utils

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,6 +313,9 @@ astropy.units
 
 - Ensure correctness of units when raising to a negative power. [#8263]
 
+- Fix ``with_H0`` equivalency to how the appropriate direction of
+  conversion. [#8292]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -728,6 +728,6 @@ def with_H0(H0=None):
         from astropy import cosmology
         H0 = cosmology.default_cosmology.get().H0
 
-    h100_val_unit = Unit(100/(H0.to((si.km/si.s)/astrophys.Mpc).value) * astrophys.littleh)
+    h100_val_unit = Unit(100/(H0.to_value((si.km/si.s)/astrophys.Mpc)) * astrophys.littleh)
 
     return [(h100_val_unit, None)]

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -728,6 +728,6 @@ def with_H0(H0=None):
         from astropy import cosmology
         H0 = cosmology.default_cosmology.get().H0
 
-    h100_val_unit = Unit(H0.to((si.km/si.s)/astrophys.Mpc).value/100 * astrophys.littleh)
+    h100_val_unit = Unit(100/(H0.to((si.km/si.s)/astrophys.Mpc).value) * astrophys.littleh)
 
     return [(h100_val_unit, None)]

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -751,22 +751,21 @@ def test_plate_scale():
 
 def test_littleh():
     H0_70 = 70*u.km/u.s/u.Mpc
-    h100dist = 100 * u.Mpc/u.littleh
+    h70dist = 70 * u.Mpc/u.littleh
 
-    assert_quantity_allclose(h100dist.to(u.Mpc, u.with_H0(H0_70)), 70*u.Mpc)
+    assert_quantity_allclose(h70dist.to(u.Mpc, u.with_H0(H0_70)), 100*u.Mpc)
 
     # make sure using the default cosmology works
-    H0_default_cosmo = cosmology.default_cosmology.get().H0
-    assert_quantity_allclose(h100dist.to(u.Mpc, u.with_H0()),
-                             H0_default_cosmo.value*u.Mpc)
+    cosmodist = cosmology.default_cosmology.get().H0.value * u.Mpc/u.littleh
+    assert_quantity_allclose(cosmodist.to(u.Mpc, u.with_H0()), 100*u.Mpc)
 
     # Now try a luminosity scaling
-    h1lum = 1 * u.Lsun * u.littleh**-2
-    assert_quantity_allclose(h1lum.to(u.Lsun, u.with_H0(H0_70)), .49*u.Lsun)
+    h1lum = .49 * u.Lsun * u.littleh**-2
+    assert_quantity_allclose(h1lum.to(u.Lsun, u.with_H0(H0_70)), 1*u.Lsun)
 
     # And the trickiest one: magnitudes.  Using H0=10 here for the round numbers
     H0_10 = 10*u.km/u.s/u.Mpc
     # assume the "true" magnitude M = 12.
     # Then M - 5*log_10(h)  = M + 5 = 17
-    withlittlehmag = 17 * (u.mag + u.MagUnit(u.littleh**2))
+    withlittlehmag = 17 * (u.mag - u.MagUnit(u.littleh**2))
     assert_quantity_allclose(withlittlehmag.to(u.mag, u.with_H0(H0_10)), 12*u.mag)

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -385,12 +385,12 @@ convert to/from physical to "little h" units.  Two example conversions:
 
     >>> import astropy.units as u
     >>> H0_70 = 70 * u.km/u.s / u.Mpc
-    >>> distance = 100 * (u.Mpc/u.littleh)
+    >>> distance = 70 * (u.Mpc/u.littleh)
     >>> distance.to(u.Mpc, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
-    <Quantity 70.0 Mpc>
-    >>> luminosity = 1 * u.Lsun * u.littleh**-2
+    <Quantity 100.0 Mpc>
+    >>> luminosity = 0.49 * u.Lsun * u.littleh**-2
     >>> luminosity.to(u.Lsun, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
-    <Quantity 0.49 solLum>
+    <Quantity 1.0 solLum>
 
 Note the unit name ``littleh`` - while this unit is usually expressed in the
 literature as just ``h``, here it is ``littleh`` to not cause confusion with
@@ -401,14 +401,14 @@ the ``H0`` from the current default cosmology:
 
     >>> distance = 100 * (u.Mpc/u.littleh)
     >>> distance.to(u.Mpc, u.with_H0())  # doctest: +FLOAT_CMP
-    <Quantity 67.74 Mpc>
+    <Quantity 147.62326543 Mpc>
 
-This equivalency also allows the common magnitude formulation of little h
+This equivalency also allows a common magnitude formulation of little h
 scaling:
 
-    >>> mag_quantity = 12 * (u.mag + u.MagUnit(u.littleh**2))
+    >>> mag_quantity = 12 * (u.mag - u.MagUnit(u.littleh**2))
     >>> mag_quantity  # doctest: +FLOAT_CMP
-    <Magnitude 12. mag(littleh2)>
+    <Magnitude 12. mag(1 / littleh2)>
     >>> mag_quantity.to(u.mag, u.with_H0(H0_70))  # doctest: +FLOAT_CMP
     <Quantity 11.2254902 mag>
 

--- a/docs/whatsnew/3.1.rst
+++ b/docs/whatsnew/3.1.rst
@@ -315,11 +315,11 @@ and cosmologists.  To see it in action::
 
   >>> import astropy.units as u
   >>> from astropy.cosmology import WMAP9
-  >>> distance = 100 * (u.Mpc/u.littleh)
+  >>> distance = 70 * (u.Mpc/u.littleh)
   >>> distance  # doctest: +FLOAT_CMP
-  <Quantity 100. Mpc / littleh>
+  <Quantity 70. Mpc / littleh>
   >>> distance.to(u.Mpc, u.with_H0(WMAP9.H0))  # doctest: +FLOAT_CMP
-  <Quantity 69.32 Mpc>
+  <Quantity 100.98095788 Mpc>
 
 See :ref:`H0-equivalency` for more details.
 


### PR DESCRIPTION
This should fix #8271. 

A double-check by @dr-guangtou and/or @aphearin would be greatly appreciated, given that I already messed this up once! (especially the magnitudes, although admittedly that's a bit more ambiguous because it really depends on how it's expressed in a paper to be sure which is the "right way")