### PR TITLE
Include highly visible message about acknowledgement in core docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,12 @@ the community to develop a robust ecosystem of `Affiliated Packages
 <http://www.astropy.org/affiliated/index.html>`_ covering a broad range of
 needs for astronomical research, data processing, and data analysis.
 
+.. Important:: If you use Astropy for work presented in a publication or talk
+   please help the project via proper `citation or acknowledgement
+   <http://www.astropy.org/acknowledging.html>`_.  This also applies to use of
+   software or `affliated packages <http://www.astropy.org/affiliated/>`_ that
+   depend on the astropy core package.
+
 .. _getting-started:
 
 ***************


### PR DESCRIPTION
I recently saw a paper that acknowledged astropy, but only as text in the acknowledgements instead of a citation.  It turns out from the astropy core docs it was surprisingly difficult for me to discover that one *should* acknowledge astropy and then how to do so.  (Of course googling works just fine).

Instead I propose we bring this front-and-center on the main landing page for astropy core docs.

![image](https://user-images.githubusercontent.com/348089/50055531-619f7e80-011e-11e9-904c-8d87599aee9a.png)
