### PR TITLE
Print filenames in report for fitsdiff --ignore-hdus

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,6 +278,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- ``fitsdiff --ignore-hdus`` now prints input filenames in the diff report
+  instead of ``<HDUList object at 0x1150f9778>``. [#8295]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -334,6 +334,17 @@ class FITSDiff(_BaseDiff):
         if len(self.a) != len(self.b):
             self.diff_hdu_count = (len(self.a), len(self.b))
 
+        # Record filenames for use later in _report
+        self.filenamea = self.a.filename()
+        if not self.filenamea:
+            self.filenamea = '<{} object at {:#x}>'.format(
+                self.a.__class__.__name__, id(self.a))
+
+        self.filenameb = self.b.filename()
+        if not self.filenameb:
+            self.filenameb = '<{} object at {:#x}>'.format(
+                self.b.__class__.__name__, id(self.b))
+
         if self.ignore_hdus:
             self.a = HDUList([h for h in self.a if h.name not in self.ignore_hdus])
             self.b = HDUList([h for h in self.b if h.name not in self.ignore_hdus])
@@ -361,20 +372,9 @@ class FITSDiff(_BaseDiff):
         wrapper = textwrap.TextWrapper(initial_indent='  ',
                                        subsequent_indent='  ')
 
-        # print out heading and parameter values
-        filenamea = self.a.filename()
-        if not filenamea:
-            filenamea = '<{} object at {:#x}>'.format(
-                self.a.__class__.__name__, id(self.a))
-
-        filenameb = self.b.filename()
-        if not filenameb:
-            filenameb = '<{} object at {:#x}>'.format(
-                self.b.__class__.__name__, id(self.b))
-
         self._fileobj.write('\n')
         self._writeln(' fitsdiff: {}'.format(__version__))
-        self._writeln(' a: {}\n b: {}'.format(filenamea, filenameb))
+        self._writeln(' a: {}\n b: {}'.format(self.filenamea, self.filenameb))
 
         if self.ignore_hdus:
             ignore_hdus = ' '.join(sorted(self.ignore_hdus))

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -290,3 +290,24 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
 
         numdiff = fitsdiff.main([tmp_a, tmp_b, "-u", "SCI"])
         assert numdiff == 0
+
+    def test_ignore_hdus_report(self, capsys):
+        a = np.arange(100).reshape(10, 10)
+        b = a.copy() + 1
+        ha = Header([('A', 1), ('B', 2), ('C', 3)])
+        phdu_a = PrimaryHDU(header=ha)
+        phdu_b = PrimaryHDU(header=ha)
+        ihdu_a = ImageHDU(data=a, name='SCI')
+        ihdu_b = ImageHDU(data=b, name='SCI')
+        hdulist_a = HDUList([phdu_a, ihdu_a])
+        hdulist_b = HDUList([phdu_b, ihdu_b])
+        tmp_a = self.temp('testa.fits')
+        tmp_b = self.temp('testb.fits')
+        hdulist_a.writeto(tmp_a)
+        hdulist_b.writeto(tmp_b)
+
+        numdiff = fitsdiff.main([tmp_a, tmp_b, "-u", "SCI"])
+        assert numdiff == 0
+        out, err = capsys.readouterr()
+        assert "testa.fits" in out
+        assert "testb.fits" in out


### PR DESCRIPTION
Currently if one uses `fitsdiff --ignore-hdus` on 2 FITS files, the diff report looks like:
```
 a: <HDUList object at 0x1150f9778>
 b: <HDUList object at 0x1150f9688>
```
But it should list the actual FITS files, even though it is ignoring HDUs.  It should look like
```
 a: file1.fits
 b: file2.fits
```
This was caused by redefining `self.a` and `self.a` as new `HDUList` objects that do not have an associated `self._file.name` in order to handle the ignoring of HDUs.

This PR fixes that bug.