### PR TITLE
Have QuantityAttribute yield a useful error when default is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,8 +214,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- Catch the error case case of a ``QuantityAttribute`` defaulting to None at
-  attribute creation, and give a more useful error message [#8300]
+- Convert the default of ``QuantityAttribute``, thereby catching the error case
+  case of it being set to None at attribute creation, and giving a more useful
+  error message in the process. [#8300]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,6 +214,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Catch the error case case of a ``QuantityAttribute`` defaulting to None at
+  attribute creation, and give a more useful error message [#8300]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,10 +214,6 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
-- Convert the default of ``QuantityAttribute``, thereby catching the error case
-  case of it being set to None at attribute creation, and giving a more useful
-  error message in the process. [#8300]
-
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -312,6 +308,10 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- Convert the default of ``QuantityAttribute``, thereby catching the error case
+  case of it being set to None at attribute creation, and giving a more useful
+  error message in the process. [#8300]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -278,6 +278,9 @@ class QuantityAttribute(Attribute):
     """
 
     def __init__(self, default=None, secondary_attribute='', unit=None, shape=None):
+        if default is None:
+            raise TypeError('QuantityAttributes need to have defaults, because '
+                            'None is not a Quantity')
         super().__init__(default, secondary_attribute)
         self.unit = unit
         self.shape = shape

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -278,12 +278,10 @@ class QuantityAttribute(Attribute):
     """
 
     def __init__(self, default=None, secondary_attribute='', unit=None, shape=None):
-        if default is None:
-            raise TypeError('QuantityAttributes need to have defaults, because '
-                            'None is not a Quantity')
-        super().__init__(default, secondary_attribute)
         self.unit = unit
         self.shape = shape
+        default = self.convert_input(default)[0]
+        super().__init__(default, secondary_attribute)
 
     def convert_input(self, value):
         """
@@ -306,6 +304,10 @@ class QuantityAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
+        if value is None:
+            raise TypeError('QuantityAttributes cannot be None, because None '
+                            'is not a Quantity')
+
         if np.all(value == 0) and self.unit is not None:
             return u.Quantity(np.zeros(self.shape), self.unit), True
         else:

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -613,6 +613,7 @@ def test_regression_8138():
     sc2 = sc.transform_to(newframe)
     assert newframe.is_equivalent_frame(sc2.frame)
 
+
 def test_regression_8276():
     from astropy.coordinates import baseframe
 
@@ -624,8 +625,13 @@ def test_regression_8276():
     try:
         baseframe.frame_transform_graph = copy.copy(baseframe.frame_transform_graph)
 
+        # as reported in 8276, this fails right here because registering the
+        # transform tries to create a frame attribute
         @baseframe.frame_transform_graph.transform(FunctionTransform, MyFrame, AltAz)
         def trans(my_frame_coord, altaz_frame):
             pass
+
+        # should also be able to *create* the Frame at this point
+        MyFrame()
     finally:
         baseframe.frame_transform_graph = old_transform_graph

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -617,21 +617,23 @@ def test_regression_8138():
 def test_regression_8276():
     from astropy.coordinates import baseframe
 
-    class MyFrame(BaseCoordinateFrame):
-        a = QuantityAttribute(unit=u.m)
+    with pytest.raises(TypeError) as excinfo:
+        class MyFrame(BaseCoordinateFrame):
+            a = QuantityAttribute(unit=u.m)
 
-    # we save the transform graph so that it doesn't acidentally mess with other tests
-    old_transform_graph = baseframe.frame_transform_graph
-    try:
-        baseframe.frame_transform_graph = copy.copy(baseframe.frame_transform_graph)
+        # we save the transform graph so that it doesn't acidentally mess with other tests
+        old_transform_graph = baseframe.frame_transform_graph
+        try:
+            baseframe.frame_transform_graph = copy.copy(baseframe.frame_transform_graph)
 
-        # as reported in 8276, this fails right here because registering the
-        # transform tries to create a frame attribute
-        @baseframe.frame_transform_graph.transform(FunctionTransform, MyFrame, AltAz)
-        def trans(my_frame_coord, altaz_frame):
-            pass
+            # as reported in 8276, this fails right here because registering the
+            # transform tries to create a frame attribute
+            @baseframe.frame_transform_graph.transform(FunctionTransform, MyFrame, AltAz)
+            def trans(my_frame_coord, altaz_frame):
+                pass
 
-        # should also be able to *create* the Frame at this point
-        MyFrame()
-    finally:
-        baseframe.frame_transform_graph = old_transform_graph
+            # should also be able to *create* the Frame at this point
+            MyFrame()
+        finally:
+            baseframe.frame_transform_graph = old_transform_graph
+    assert 'QuantityAttributes need to have defaults' in str(excinfo.value)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -641,4 +641,4 @@ def test_regression_8276():
             MyFrame()
         finally:
             baseframe.frame_transform_graph = old_transform_graph
-    assert 'QuantityAttributes need to have defaults' in str(excinfo.value)
+    assert 'QuantityAttributes cannot be None' in str(excinfo.value)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -620,6 +620,11 @@ def test_regression_8276():
     with pytest.raises(TypeError) as excinfo:
         class MyFrame(BaseCoordinateFrame):
             a = QuantityAttribute(unit=u.m)
+            # note that the remainder of this with clause does not get executed
+            # because an exception is raised here. A future PR is planned to
+            # allow the default to be left off, after which the rest of this
+            # test will get executed, so it is being left in place.  See
+            # https://github.com/astropy/astropy/pull/8300 for more info
 
         # we save the transform graph so that it doesn't acidentally mess with other tests
         old_transform_graph = baseframe.frame_transform_graph

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -706,8 +706,8 @@ class CoordinateTransform(metaclass=ABCMeta):
                 hasattr(tosys, 'get_frame_attr_names')):
             # the if statement is there so that non-frame things might be usable
             # if it makes sense
-            for from_nm in fromsys.get_frame_attr_names():
-                if from_nm in tosys.get_frame_attr_names():
+            for from_nm in fromsys.frame_attributes.keys():
+                if from_nm in tosys.frame_attributes.keys():
                     overlap.append(from_nm)
 
     def register(self, graph):


### PR DESCRIPTION
This was prompted by #8276, but is not a full fix for it, as there may be a "new feature" PR needed (see https://github.com/astropy/astropy/issues/8276#issuecomment-448640543 for a bit more context).

This does two things: it makes it so that creating a transform doesn't actually instantiate any frame attributes (after looking more closely at the code I think this wasn't really needed anywhere and was just an oversight @MaxNoe), and also makes it so that a useful error is thrown *at creation time* of a `QuantityAttribute` instead of when the frame is created.  That also explains the slightly odd test: I first wrote a test to get the actual error @MaxNoe reported, then fixed things so that it gives a *different* *(but more meaningful) error.

If we do go the route discussed in #8276, the PR implementing that should just remove the `raises` clause in the regression test.

Milestoning 3.1.1, *but* it is not urgent so it should not delay a 3.1.1 release if otherwise it is ready.