### PR TITLE
Delay bleach import to save time

### DIFF
--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -21,7 +21,12 @@ import numpy as np
 
 from .common import setup_function, teardown_function
 from astropy.io import ascii
-from astropy.utils.xml.writer import HAS_BLEACH
+
+try:
+    import bleach  # noqa
+    HAS_BLEACH = True
+except ImportError:
+    HAS_BLEACH = False
 
 # Check to see if the BeautifulSoup dependency is present.
 try:

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -5,7 +5,12 @@ import pytest
 
 from astropy.table.table import Table
 from astropy import extern
-from astropy.utils.xml.writer import HAS_BLEACH
+
+try:
+    import bleach  # noqa
+    HAS_BLEACH = True
+except ImportError:
+    HAS_BLEACH = False
 
 try:
     import IPython  # pylint: disable=W0611

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -6,6 +6,12 @@ import pytest
 
 from astropy.utils.xml import check, unescaper, writer
 
+try:
+    import bleach  # noqa
+    HAS_BLEACH = True
+except ImportError:
+    HAS_BLEACH = False
+
 
 def test_writer():
     fh = io.StringIO()
@@ -74,7 +80,7 @@ def test_escape_xml():
     assert s == b'This &amp; That'
 
 
-@pytest.mark.skipif('writer.HAS_BLEACH')
+@pytest.mark.skipif('HAS_BLEACH')
 def test_escape_xml_without_bleach():
     fh = io.StringIO()
     w = writer.XMLWriter(fh)
@@ -85,7 +91,7 @@ def test_escape_xml_without_bleach():
     assert 'bleach package is required when HTML escaping is disabled' in str(err)
 
 
-@pytest.mark.skipif('not writer.HAS_BLEACH')
+@pytest.mark.skipif('not HAS_BLEACH')
 def test_escape_xml_with_bleach():
     fh = io.StringIO()
     w = writer.XMLWriter(fh)

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -182,6 +182,8 @@ class XMLWriter:
         current_xml_escape_cdata = self.xml_escape_cdata
 
         if method == 'bleach_clean':
+            # NOTE: bleach is imported locally to avoid importing it when
+            # it is not nocessary
             try:
                 import bleach
             except ImportError:

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -9,12 +9,6 @@ import contextlib
 import textwrap
 
 try:
-    import bleach
-    HAS_BLEACH = True
-except ImportError:
-    HAS_BLEACH = False
-
-try:
     from . import _iterparser
 except ImportError:
     def xml_escape_cdata(s):
@@ -188,13 +182,15 @@ class XMLWriter:
         current_xml_escape_cdata = self.xml_escape_cdata
 
         if method == 'bleach_clean':
-            if HAS_BLEACH:
-                if clean_kwargs is None:
-                    clean_kwargs = {}
-                self.xml_escape_cdata = lambda x: bleach.clean(x, **clean_kwargs)
-            else:
+            try:
+                import bleach
+            except ImportError:
                 raise ValueError('bleach package is required when HTML escaping is disabled.\n'
                                  'Use "pip install bleach".')
+
+            if clean_kwargs is None:
+                clean_kwargs = {}
+            self.xml_escape_cdata = lambda x: bleach.clean(x, **clean_kwargs)
         elif method == "none":
             self.xml_escape_cdata = lambda x: x
         elif method != 'escape_xml':


### PR DESCRIPTION
While optimizing import time for my package, I noticed that a bleach import is really slowing down `astropy.table` import, though it is only needed here for the xml writer:

![image](https://user-images.githubusercontent.com/311639/50244833-38f2df80-03d1-11e9-906b-8c1f309947bf.png)

After moving this to a local import:

![image](https://user-images.githubusercontent.com/311639/50244862-4314de00-03d1-11e9-9eb7-e68502b7f6c3.png)
