### PR TITLE
WIP: Fix representation as dict of SkyCoord with velocities

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -72,6 +72,9 @@ class SkyCoordInfo(MixinInfo):
         if 'distance' in attrs and np.all(obj.distance == 1.0):
             attrs.remove('distance')
 
+        if 's' in obj.frame.data.differentials:
+            attrs.extend(obj.get_representation_component_names('s'))
+
         self._represent_as_dict_attrs = attrs
 
         out = super()._represent_as_dict()

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -27,6 +27,7 @@ from astropy.utils.compat import NUMPY_LT_1_14
 from astropy.units import allclose as quantity_allclose
 from astropy.io import fits
 from astropy.wcs import WCS
+from astropy.table.tests.test_operations import skycoord_equal
 
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
@@ -1555,3 +1556,23 @@ def test_none_differential_type():
 
     fr = MockHeliographicStonyhurst(lon=1*u.deg, lat=2*u.deg, radius=10*u.au)
     SkyCoord(0*u.deg, fr.lat, fr.radius, frame=fr) # this was the failure
+
+
+def test_represent_as_dict_proper_motion():
+
+    c = SkyCoord(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=2*u.mas/u.yr,
+                 pm_dec=1*u.mas/u.yr)
+
+    newc = SkyCoord.info._construct_from_dict(c.info._represent_as_dict())
+
+    assert skycoord_equal(c, newc)
+
+
+def test_represent_as_dict_radial_velocity():
+
+    c = SkyCoord(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=2*u.mas/u.yr,
+                 pm_dec=1*u.mas/u.yr)
+
+    newc = SkyCoord.info._construct_from_dict(c.info._represent_as_dict())
+
+    assert skycoord_equal(c, newc)

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
@@ -99,7 +99,6 @@ def test_skycoord_proper_motion(tmpdir):
     assert_roundtrip_tree(tree, tmpdir)
 
 
-@pytest.mark.skip(reason='Apparent loss of precision during serialization')
 def test_skycoord_extra_attribute(tmpdir):
 
     sc = SkyCoord(10*u.deg, 20*u.deg, equinox="2011-01-01T00:00", frame="fk4")

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
@@ -84,7 +84,6 @@ def test_skycoord_vector_frames(tmpdir):
     assert_roundtrip_tree(tree, tmpdir)
 
 
-@pytest.mark.xfail(reason='Velocities are not properly serialized yet')
 def test_skycoord_radial_velocity(tmpdir):
 
     c = SkyCoord(ra=1*u.deg, dec=2*u.deg, radial_velocity=10*u.km/u.s)
@@ -92,7 +91,6 @@ def test_skycoord_radial_velocity(tmpdir):
     assert_roundtrip_tree(tree, tmpdir)
 
 
-@pytest.mark.xfail(reason='Velocities are not properly serialized yet')
 def test_skycoord_proper_motion(tmpdir):
 
     c = SkyCoord(ra=1*u.deg, dec=2*u.deg, pm_ra_cosdec=2*u.mas/u.yr,


### PR DESCRIPTION
This addresses an issue that was revealed by #8284. It appears that `SkyCoord` objects with velocities are not round-trippable using the current machinery.

This PR adds unit tests and attempts a fairly naive solution, but I think I need some additional input from @mhvk and/or @taldcroft (or anyone else) for a path forward.