### PR TITLE
Use numpy 1.16 fixed gufunc dimensions in erfa.

### DIFF
--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -30,10 +30,11 @@ module (compiled as ``ufunc``), derived from the ``ufunc.c`` file.
 
 import warnings
 
-from ..utils.exceptions import AstropyUserWarning
-from ..utils.misc import check_broadcast
-
 import numpy
+
+from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.misc import check_broadcast
+
 from . import ufunc
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_pv,
                     dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
@@ -117,6 +118,11 @@ def check_errwarn(statcodes, func_name):
 
 # <------------------------structured dtype conversion------------------------>
 
+{%- if NUMPY_LT_1_16 %}
+# Note: the following are only necessary for NUMPY_LT_1_16.  Once we support
+# only numpy >=1.16, they can be removed, and the template code below should be
+# adapted.  Note that for >=1.16, these are not used, since the template parts
+# that use it are never inserted (since `d3_fix_arg` is always empty).
 class D3Fix(numpy.ndarray):
     """NDarray subclass that can transfer itself into a Quantity.
 
@@ -186,6 +192,7 @@ def arrayify_inputs_and_create_d3_fix(inputs, core_dims, out_core_shape, out_dty
     broadcast_shape = check_broadcast(*shapes)
     d3_fix = numpy.empty(broadcast_shape + out_core_shape, out_dtype).view(D3Fix)
     return arrays, d3_fix
+{%- endif %}
 
 
 dt_bytes1 = numpy.dtype('S1')

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -16,6 +16,11 @@ import re
 import os.path
 from collections import OrderedDict
 
+# Note: once we support only numpy >=1.16, all things related to "d3_fix"
+# can be removed, here and in the templates (core.py.templ
+from astropy.utils.compat import NUMPY_LT_1_16
+
+
 DEFAULT_ERFA_LOC = os.path.join(os.path.split(__file__)[0],
                                 '../../cextern/erfa')
 DEFAULT_TEMPLATE_LOC = os.path.split(__file__)[0]
@@ -222,9 +227,9 @@ class Variable:
         if self.ctype == 'eraLDBODY':
             return '(n)'
         elif self.ctype == 'double' and self.shape == (3,):
-            return '(d3)'
+            return '(d3)' if NUMPY_LT_1_16 else '(3)'
         elif self.ctype == 'double' and self.shape == (3, 3):
-            return '(d3, d3)'
+            return '(d3, d3)' if NUMPY_LT_1_16 else '(3, 3)'
         else:
             return '()'
 
@@ -683,8 +688,9 @@ def main(srcdir=DEFAULT_ERFA_LOC, outfn='core.py', ufuncfn='ufunc.c',
     #             funcs.append(ExtraFunction(match.group(1), ls, erfaextrahfn))
 
     print_("Rendering template")
-    erfa_c = erfa_c_in.render(funcs=funcs)
-    erfa_py = erfa_py_in.render(funcs=funcs, constants=constants)
+    erfa_c = erfa_c_in.render(funcs=funcs, NUMPY_LT_1_16=NUMPY_LT_1_16)
+    erfa_py = erfa_py_in.render(funcs=funcs, constants=constants,
+                                NUMPY_LT_1_16=NUMPY_LT_1_16)
 
     if outfn is not None:
         print_("Saving to", outfn, 'and', ufuncfn)

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -1,8 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from astropy._erfa import core as erfa
+
+from astropy._erfa import core as erfa, ufunc as erfa_ufunc
 from astropy.tests.helper import catch_warnings
+from astropy.utils.compat import NUMPY_LT_1_16
+
+
+def test_output_dim_3_signature():
+    if NUMPY_LT_1_16:
+        assert erfa_ufunc.c2i00a.signature == "(),()->(d3, d3)"
+    else:
+        assert erfa_ufunc.c2i00a.signature == "(),()->(3, 3)"
 
 
 def test_erfa_wrapper():

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -581,11 +581,15 @@ fail:
     return -1;
 }
 
+{%- if NUMPY_LT_1_16 %}
 /*
- * The following is a bit of a hack, which can be removed once ufuncs support
- * fixed dimensions (see numpy gh-5015 and gh-11132)
+ * The following is only necessary for NUMPY_LT_1_16.  Once we support
+ * only numpy >=1.16, it can be removed here and in the template part.
  *
- * Rather than just go for our type resolver, we check here whether the
+ * For numpy <1.16, this works around the fact that gufuncs could not
+ * have fixed dimensions.
+ *
+ * Rather than just go for our type resolver, we check here whether
  * any double input with core dimensions has dimension equal to 3.  Here,
  * we already know that all core dimensions are equal, so we have to check
  * only one.
@@ -624,6 +628,7 @@ static int ErfaUFuncD3CheckTypeResolver(PyUFuncObject *ufunc,
     return ErfaUFuncTypeResolver(ufunc, casting, operands, type_tup,
                                  out_dtypes);
 }
+{%- endif %}
 
 /*
  * UFUNC MODULE DEFINITIONS AND INITIALIZATION


### PR DESCRIPTION
The new feature of allowing frozen dimensions in the `gufunc` signature was in fact introduced in part because of this, so we should obviously use it.  Should make coordinate transformations a bit faster still.

Milestone for 3.2, since it doesn't fix any bug.

EDIT: relevant tests here are the prerelease one and numpy-dev.