### PR TITLE
Allow more options in Quantity LaTeX formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -247,6 +247,10 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Added a ``Quantity.to_string`` method to add flexibility to the string formatting
+  of quantities. It produces unadorned or LaTeX strings, and accepts two different
+  sets of delimiters in the latter case: ``inline`` and ``display``. [#8313]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1130,6 +1130,10 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         lstr
             A LaTeX string with the contents of this Quantity
         """
+        if unit is not None and unit != self.unit:
+            return self.to(unit).to_string(
+                unit=None, precision=precision, format=format, subfmt=subfmt)
+
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
         pops = np.get_printoptions()

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1134,8 +1134,21 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return self.to(unit).to_string(
                 unit=None, precision=precision, format=format, subfmt=subfmt)
 
-        if format is None:
+        formats = {
+            None: None,
+            "latex": {
+                None: ("$", "$"),
+                "inline": ("$", "$"),
+                "display": (r"$$", r"$$"),
+            },
+        }
+
+        if format not in formats:
+            raise ValueError("Unknown format '{0}'".format(format))
+        elif format is None:
             return '{0}{1:s}'.format(self.value, self._unitstr)
+
+        # else, for the moment we assume format="latex"
 
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
@@ -1184,7 +1197,11 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                       if self.unit is not None
                       else _UNIT_NOT_INITIALISED)
 
-        return r'${0} \; {1}$'.format(latex_value, latex_unit)
+        delimiter_left, delimiter_right = formats[format][subfmt]
+
+        return r'{left}{0} \; {1}{right}'.format(latex_value, latex_unit,
+                                                 left=delimiter_left,
+                                                 right=delimiter_right)
 
     # Display
     # TODO: we may want to add a hook for dimensionless quantities?

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1164,7 +1164,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             "latex": {
                 None: ("$", "$"),
                 "inline": ("$", "$"),
-                "display": (r"$\\displaystyle ", r"$"),
+                "display": (r"$\displaystyle ", r"$"),
             },
         }
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1102,6 +1102,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             raise TypeError('only integer dimensionless scalar quantities '
                             'can be converted to a Python index')
 
+    # TODO: we may want to add a hook for dimensionless quantities?
     @property
     def _unitstr(self):
         if self.unit is None:
@@ -1125,10 +1126,29 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         This is treated separately because the numpy default of 1000 is too big
         for most browsers to handle.
 
+        Parameters
+        ----------
+        unit : `~astropy.units.UnitBase`, optional
+            Specifies the unit.  If not provided,
+            the unit used to initialize the quantity will be used.
+
+        precision : , optional
+            The level of decimal precision. If `None`, or not provided,
+            it will be determined from NumPy print options.
+
+        format : str, optional
+            The format of the result. If not provided, an unadorned
+            string is returned. Supported values are:
+
+            - 'latex': Return a LaTeX-formatted string
+
+        subfmt : str, optional
+            Subformat of the result.
+
         Returns
         -------
         lstr
-            A LaTeX string with the contents of this Quantity
+            A string with the contents of this Quantity
         """
         if unit is not None and unit != self.unit:
             return self.to(unit).to_string(
@@ -1139,7 +1159,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             "latex": {
                 None: ("$", "$"),
                 "inline": ("$", "$"),
-                "display": (r"$$", r"$$"),
+                "display": (r"$\\displaystyle ", r"$"),
             },
         }
 
@@ -1154,7 +1174,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         # with array2string
         pops = np.get_printoptions()
 
-        format_spec = '.{}g'.format(pops['precision'])
+        format_spec = '.{}g'.format(
+            precision if precision is not None else pops['precision'])
 
         def float_formatter(value):
             return Latex.format_exponential_notation(value,
@@ -1203,8 +1224,6 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                                                  left=delimiter_left,
                                                  right=delimiter_right)
 
-    # Display
-    # TODO: we may want to add a hook for dimensionless quantities?
     def __str__(self):
         return self.to_string()
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1134,6 +1134,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return self.to(unit).to_string(
                 unit=None, precision=precision, format=format, subfmt=subfmt)
 
+        if format is None:
+            return '{0}{1:s}'.format(self.value, self._unitstr)
+
         # need to do try/finally because "threshold" cannot be overridden
         # with array2string
         pops = np.get_printoptions()
@@ -1186,7 +1189,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     # Display
     # TODO: we may want to add a hook for dimensionless quantities?
     def __str__(self):
-        return '{0}{1:s}'.format(self.value, self._unitstr)
+        return self.to_string()
 
     def __repr__(self):
         prefixstr = '<' + self.__class__.__name__ + ' '

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1132,7 +1132,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             Specifies the unit.  If not provided,
             the unit used to initialize the quantity will be used.
 
-        precision : , optional
+        precision : numeric, optional
             The level of decimal precision. If `None`, or not provided,
             it will be determined from NumPy print options.
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1143,7 +1143,12 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             - 'latex': Return a LaTeX-formatted string
 
         subfmt : str, optional
-            Subformat of the result.
+            Subformat of the result. For the moment,
+            only used for format="latex". Supported values are:
+
+            - 'inline': Use ``$ ... $`` as delimiters.
+
+            - 'display': Use ``$\\displaystyle ... $`` as delimiters.
 
         Returns
         -------

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1114,21 +1114,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
         return unitstr
 
-    # Display
-    # TODO: we may want to add a hook for dimensionless quantities?
-    def __str__(self):
-        return '{0}{1:s}'.format(self.value, self._unitstr)
-
-    def __repr__(self):
-        prefixstr = '<' + self.__class__.__name__ + ' '
-        sep = ',' if NUMPY_LT_1_14 else ', '
-        arrstr = np.array2string(self.view(np.ndarray), separator=sep,
-                                 prefix=prefixstr)
-        return '{0}{1}{2:s}>'.format(prefixstr, arrstr, self._unitstr)
-
-    def _repr_latex_(self):
+    def to_string(self, unit=None, precision=None, format=None, subfmt=None):
         """
-        Generate a latex representation of the quantity and its unit.
+        Generate a string representation of the quantity and its unit.
 
         The behavior of this function can be altered via the
         `numpy.set_printoptions` function and its various keywords.  The
@@ -1190,6 +1178,30 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                       else _UNIT_NOT_INITIALISED)
 
         return r'${0} \; {1}$'.format(latex_value, latex_unit)
+
+    # Display
+    # TODO: we may want to add a hook for dimensionless quantities?
+    def __str__(self):
+        return '{0}{1:s}'.format(self.value, self._unitstr)
+
+    def __repr__(self):
+        prefixstr = '<' + self.__class__.__name__ + ' '
+        sep = ',' if NUMPY_LT_1_14 else ', '
+        arrstr = np.array2string(self.view(np.ndarray), separator=sep,
+                                 prefix=prefixstr)
+        return '{0}{1}{2:s}>'.format(prefixstr, arrstr, self._unitstr)
+
+    def _repr_latex_(self):
+        """
+        Generate a latex representation of the quantity and its unit.
+
+        Returns
+        -------
+        lstr
+            A LaTeX string with the contents of this Quantity
+        """
+        # NOTE: This should change to display format in a future release
+        return self.to_string(format='latex', subfmt='inline')
 
     def __format__(self, format_spec):
         """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -895,6 +895,12 @@ class TestQuantityDisplay:
         assert str(bad_quantity).endswith(_UNIT_NOT_INITIALISED)
         assert repr(bad_quantity).endswith(_UNIT_NOT_INITIALISED + '>')
 
+    def test_to_string(self):
+        qscalar = u.Quantity(1.5e14, 'm/s')
+
+        res = 'Quantity as KMS: 150000000000.0 km / s'
+        assert "Quantity as KMS: {0}".format(qscalar.to_string(unit=u.km / u.s)) == res
+
     def test_repr_latex(self):
         from astropy.units.quantity import conf
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -898,6 +898,9 @@ class TestQuantityDisplay:
     def test_to_string(self):
         qscalar = u.Quantity(1.5e14, 'm/s')
 
+        # __str__ is the default `format`
+        assert str(qscalar) == qscalar.to_string()
+
         res = 'Quantity as KMS: 150000000000.0 km / s'
         assert "Quantity as KMS: {0}".format(qscalar.to_string(unit=u.km / u.s)) == res
 

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -910,7 +910,7 @@ class TestQuantityDisplay:
         res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex", subfmt="inline") == res
 
-        res = r'$$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$$'
+        res = r'$\displaystyle 1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex", subfmt="display") == res
 
     def test_repr_latex(self):

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -904,6 +904,15 @@ class TestQuantityDisplay:
         res = 'Quantity as KMS: 150000000000.0 km / s'
         assert "Quantity as KMS: {0}".format(qscalar.to_string(unit=u.km / u.s)) == res
 
+        res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
+        assert qscalar.to_string(format="latex") == res
+
+        res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
+        assert qscalar.to_string(format="latex", subfmt="inline") == res
+
+        res = r'$$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$$'
+        assert qscalar.to_string(format="latex", subfmt="display") == res
+
     def test_repr_latex(self):
         from astropy.units.quantity import conf
 


### PR DESCRIPTION
See https://github.com/astropy/astropy/pull/6502 for a first (failed) attempt. This is less aggressive, keeps backwards compatibility everywhere, and prepares the ground for changing the default in the future.