### PR TITLE
Remove a few uses of six

### DIFF
--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -1,8 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-import six
-
 from asdf.types import CustomType, ExtensionTypeMeta
 
 
@@ -30,8 +28,7 @@ class AstropyTypeMeta(ExtensionTypeMeta):
         return cls
 
 
-@six.add_metaclass(AstropyTypeMeta)
-class AstropyType(CustomType):
+class AstropyType(CustomType, metaclass=AstropyTypeMeta):
     """
     This class represents types that have schemas and tags that are defined by
     Astropy.
@@ -43,8 +40,7 @@ class AstropyType(CustomType):
     standard = 'astropy'
 
 
-@six.add_metaclass(AstropyTypeMeta)
-class AstropyAsdfType(CustomType):
+class AstropyAsdfType(CustomType, metaclass=AstropyTypeMeta):
     """
     This class represents types that have schemas that are defined in the ASDF
     standard, but have tags that are implemented within astropy.

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -232,7 +232,7 @@ def treat_deprecations_as_exceptions():
     # on. See https://github.com/astropy/astropy/pull/5513.
     for module in list(sys.modules.values()):
         # We don't want to deal with six.MovedModules, only "real"
-        # modules.
+        # modules. FIXME: we no more use six, this should be useless ?
         if (isinstance(module, types.ModuleType) and
                 hasattr(module, '__warningregistry__')):
             del module.__warningregistry__

--- a/docs/io/registry.rst
+++ b/docs/io/registry.rst
@@ -71,10 +71,9 @@ files with filenames ending in ``.mtf`` as being in the ``my-table-format``
 format::
 
     import os
-    from astropy.extern import six
 
     def identify_mtf(origin, *args, **kwargs):
-        return (isinstance(args[0], six.string_types) and
+        return (isinstance(args[0], str) and
                 os.path.splitext(args[0].lower())[1] == '.mtf')
 
 .. note:: Identifier functions should be prepared for arbitrary input - in

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -961,7 +961,7 @@ fields.  This might look something like::
       Row = ParamsRow
 
       def __getitem__(self, item):
-          if isinstance(item, six.string_types):
+          if isinstance(item, str):
               if item in self.colnames:
                   return self.columns[item]
               else:


### PR DESCRIPTION
While looking at the debian package dependencies, there is six that should no more be required, so I did grep for it and found a use of it in `io.misc.asdf`, and in some documentation examples. I guess this should go in 3.1.x ?