### PR TITLE
Fixed a couple of small bugs in contour/contourf in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,6 +321,15 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+astropy.visualization.wcsaxes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fix a bug that caused an error when passing an array with all values the same
+  to contour or contourf. [#8321]
+
+- Fix a bug that caused contour and contourf to return None instead of the
+  contour set. [#8321]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -229,7 +229,7 @@ class WCSAxes(Axes):
             # a transData component at the end, but we can remove that since
             # we are already working in data space.
             transform = transform - self.transData
-            cset = transform_contour_set_inplace(cset, transform)
+            transform_contour_set_inplace(cset, transform)
 
         return cset
 
@@ -255,7 +255,7 @@ class WCSAxes(Axes):
             # a transData component at the end, but we can remove that since
             # we are already working in data space.
             transform = transform - self.transData
-            cset = transform_contour_set_inplace(cset, transform)
+            transform_contour_set_inplace(cset, transform)
 
         return cset
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -2,9 +2,11 @@
 
 import os
 import warnings
+from distutils.version import LooseVersion
 
 import pytest
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.contour import QuadContourSet
 
@@ -18,6 +20,8 @@ from astropy.tests.image_tests import ignore_matplotlibrc
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.visualization.wcsaxes.utils import get_coord_meta
 from astropy.visualization.wcsaxes.transforms import CurvedTransform
+
+MATPLOTLIB_LT_21 = LooseVersion(matplotlib.__version__) < LooseVersion("2.1")
 
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
@@ -297,6 +301,7 @@ def test_contour_return():
     assert isinstance(cset, QuadContourSet)
 
 
+@pytest.mark.skipif('MATPLOTLIB_LT_21')
 def test_contour_empty():
 
     # Regression test for a bug that caused contour to crash if no contours

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -6,6 +6,7 @@ import warnings
 import pytest
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.contour import QuadContourSet
 
 from astropy import units as u
 from astropy.wcs import WCS
@@ -278,3 +279,30 @@ def test_grid_contour_large_spacing(tmpdir):
 
     ax.coords[0].grid(grid_type='contours')
     plt.savefig(filename)
+
+
+def test_contour_return():
+
+    # Regression test for a bug that caused contour and contourf to return None
+    # instead of the contour object.
+
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+    fig.add_axes(ax)
+
+    cset = ax.contour(np.arange(16).reshape(4, 4), transform=ax.get_transform('world'))
+    assert isinstance(cset, QuadContourSet)
+
+    cset = ax.contourf(np.arange(16).reshape(4, 4), transform=ax.get_transform('world'))
+    assert isinstance(cset, QuadContourSet)
+
+
+def test_contour_empty():
+
+    # Regression test for a bug that caused contour to crash if no contours
+    # were present.
+
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
+    fig.add_axes(ax)
+    ax.contour(np.zeros((4, 4)), transform=ax.get_transform('world'))

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -164,6 +164,8 @@ def transform_contour_set_inplace(cset, transform):
 
     for collection in cset.collections:
         paths = collection.get_paths()
+        if len(paths) == 0:
+            continue
         all_paths.append(paths)
         # The last item in pos isn't needed for np.split and in fact causes
         # issues if we keep it because it will cause an extra empty array to be


### PR DESCRIPTION
This fixes an error that occurred when calling ``ax.contour`` with an array with all values the same, as well as the fact that contour and contourf did not correctly return the contour set.