### PR TITLE
MNT: Deprecate bundled six

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ astropy.cosmology
 astropy.extern
 ^^^^^^^^^^^^^^
 
+- Bundled ``six`` now emits ``AstropyDeprecationWarning``. It will be removed
+  in 4.0. [#8323]
+
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/extern/six.py
+++ b/astropy/extern/six.py
@@ -10,7 +10,8 @@ from distutils.version import StrictVersion
 
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
-warnings.warn('six bundled with Astropy will be removed in 4.0',
+warnings.warn('astropy.extern.six will be removed in 4.0, use the '
+              'six module directly if it is still needed',
               AstropyDeprecationWarning)
 
 _SIX_MIN_VERSION = StrictVersion('1.10.0')

--- a/astropy/extern/six.py
+++ b/astropy/extern/six.py
@@ -5,8 +5,13 @@ Handle loading six package from system or from the bundled copy
 """
 
 import imp
+import warnings
 from distutils.version import StrictVersion
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
+
+warnings.warn('six bundled with Astropy will be removed in 4.0',
+              AstropyDeprecationWarning)
 
 _SIX_MIN_VERSION = StrictVersion('1.10.0')
 


### PR DESCRIPTION
As agreed upon at https://github.com/astropy/astropy/pull/8315#issuecomment-450595066 . With this patch:

```python
>>> import astropy
>>> from astropy.extern import six
WARNING: AstropyDeprecationWarning: six bundled with Astropy will be removed in 4.0 [astropy.extern.six]
```
