### PR TITLE
Add functionality to deprecate argument rather than rename

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1790,6 +1790,17 @@ Other Changes and Additions
 2.0.12 (unreleased)
 ===================
 
+New Features
+------------
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- The ``deprecated_renamed_argument`` decorator now capable deprecating an
+  argument without renaming it. It also got a new ``alternative`` keyword
+  argument to suggest alternative functionality instead of the removed
+  one. [#8324]
+
 Bug Fixes
 ---------
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -277,7 +277,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                                 pending=False,
                                 warning_type=AstropyDeprecationWarning,
                                 alternative=''):
-    """Deprecate a _renamed_ function argument.
+    """Deprecate a _renamed_ or _removed_ function argument.
 
     The decorator assumes that the argument with the ``old_name`` was removed
     from the function signature and the ``new_name`` replaced it at the
@@ -291,8 +291,8 @@ def deprecated_renamed_argument(old_name, new_name, since,
         The old name of the argument.
 
     new_name : str or list/tuple thereof or `None`
-        The new name of the argument. ``old_name`` has been deprecated to
-        be removed if `None`.
+        The new name of the argument. Set this to `None` to remove the
+        argument ``old_name`` instead of renaming it.
 
     since : str or number or list/tuple thereof
         The release at which the old argument became deprecated.
@@ -324,6 +324,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
         An alternative function or class name that the user may use in
         place of the deprecated object if ``new_name`` is None. The deprecation
         warning will tell the user about this alternative if provided.
+
 
     Raises
     ------
@@ -402,6 +403,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
     In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which
     is applied to all renamed arguments) or must also be a `tuple` or `list`
     with values for each of the arguments.
+
     """
     cls_iter = (list, tuple)
     if isinstance(old_name, cls_iter):
@@ -510,12 +512,15 @@ def deprecated_renamed_argument(old_name, new_name, since,
                                 raise TypeError(
                                     'cannot specify both "{}" and "{}"'
                                     '.'.format(old_name[i], new_name[i]))
-                    elif new_name[i] is None:
-                        kwargs[old_name[i]] = value
                     else:
-                        # If the new argument isn't specified just pass the old
-                        # one with the name of the new argument to the function
-                        kwargs[new_name[i]] = value
+                        if new_name[i] is None:
+                            # Keep the old argument if it was deprecated to
+                            # be removed
+                            kwargs[old_name[i]] = value
+                        else:
+                            # Pass the value of the old argument with the
+                            # name of the new argument to the function
+                            kwargs[new_name[i]] = value
             return function(*args, **kwargs)
 
         return wrapper

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -275,7 +275,8 @@ def deprecated_attribute(name, since, message=None, alternative=None,
 def deprecated_renamed_argument(old_name, new_name, since,
                                 arg_in_kwargs=False, relax=False,
                                 pending=False,
-                                warning_type=AstropyDeprecationWarning):
+                                warning_type=AstropyDeprecationWarning,
+                                alternative=''):
     """Deprecate a _renamed_ function argument.
 
     The decorator assumes that the argument with the ``old_name`` was removed
@@ -289,8 +290,9 @@ def deprecated_renamed_argument(old_name, new_name, since,
     old_name : str or list/tuple thereof
         The old name of the argument.
 
-    new_name : str or list/tuple thereof
-        The new name of the argument.
+    new_name : str or list/tuple thereof or `None`
+        The new name of the argument. ``old_name`` has been deprecated to
+        be removed if `None`.
 
     since : str or number or list/tuple thereof
         The release at which the old argument became deprecated.
@@ -317,6 +319,11 @@ def deprecated_renamed_argument(old_name, new_name, since,
     warning_type : warning
         Warning to be issued.
         Default is `~astropy.utils.exceptions.AstropyDeprecationWarning`.
+
+    alternative : str, optional
+        An alternative function or class name that the user may use in
+        place of the deprecated object if ``new_name`` is None. The deprecation
+        warning will tell the user about this alternative if provided.
 
     Raises
     ------
@@ -427,8 +434,24 @@ def deprecated_renamed_argument(old_name, new_name, since,
 
         for i in range(n):
             # Determine the position of the argument.
-            if new_name[i] in arguments:
-                param = arguments[new_name[i]]
+            if arg_in_kwargs[i]:
+                position[i] = None
+            else:
+                if new_name[i] is None:
+                    param = arguments[old_name[i]]
+                elif new_name[i] in arguments:
+                    param = arguments[new_name[i]]
+                # In case the argument is not found in the list of arguments
+                # the only remaining possibility is that it should be caught
+                # by some kind of **kwargs argument.
+                # This case has to be explicitly specified, otherwise throw
+                # an exception!
+                else:
+                    raise TypeError('"{}" was not specified in the function '
+                                    'signature. If it was meant to be part of '
+                                    '"**kwargs" then set "arg_in_kwargs" to "True"'
+                                    '.'.format(new_name[i]))
+
                 # There are several possibilities now:
 
                 # 1.) Positional or keyword argument:
@@ -446,19 +469,6 @@ def deprecated_renamed_argument(old_name, new_name, since,
                     raise TypeError('cannot replace argument "{0}" of kind '
                                     '{1!r}.'.format(new_name[i], param.kind))
 
-            # In case the argument is not found in the list of arguments
-            # the only remaining possibility is that it should be caught
-            # by some kind of **kwargs argument.
-            # This case has to be explicitly specified, otherwise throw
-            # an exception!
-            elif arg_in_kwargs[i]:
-                position[i] = None
-            else:
-                raise TypeError('"{}" was not specified in the function '
-                                'signature. If it was meant to be part of '
-                                '"**kwargs" then set "arg_in_kwargs" to "True"'
-                                '.'.format(new_name[i]))
-
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             for i in range(n):
@@ -467,15 +477,19 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # parameter was renamed to newkeyword.
                 if old_name[i] in kwargs:
                     value = kwargs.pop(old_name[i])
-                    # Display the deprecation warning only when it's only
+                    # Display the deprecation warning only when it's not
                     # pending.
                     if not pending[i]:
-                        warnings.warn(
-                            '"{0}" was deprecated in version {1} '
-                            'and will be removed in a future version. '
-                            'Use argument "{2}" instead.'
-                            ''.format(old_name[i], since[i], new_name[i]),
-                            warning_type, stacklevel=2)
+                        message = ('"{0}" was deprecated in version {1} '
+                                   'and will be removed in a future version. '
+                                   .format(old_name[i], since[i]))
+                        if new_name[i] is not None:
+                            message += ('Use argument "{}" instead.'
+                                        .format(new_name[i]))
+                        elif alternative:
+                            message += ('\n        Use {} instead.'
+                                        .format(alternative))
+                        warnings.warn(message, warning_type, stacklevel=2)
 
                     # Check if the newkeyword was given as well.
                     newarg_in_args = (position[i] is not None and
@@ -496,6 +510,8 @@ def deprecated_renamed_argument(old_name, new_name, since,
                                 raise TypeError(
                                     'cannot specify both "{}" and "{}"'
                                     '.'.format(old_name[i], new_name[i]))
+                    elif new_name[i] is None:
+                        kwargs[old_name[i]] = value
                     else:
                         # If the new argument isn't specified just pass the old
                         # one with the name of the new argument to the function

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -437,10 +437,10 @@ def deprecated_renamed_argument(old_name, new_name, since,
         for i in range(n):
             # Determine the position of the argument.
             if arg_in_kwargs[i]:
-                position[i] = None
+                pass
             else:
                 if new_name[i] is None:
-                    param = arguments[old_name[i]]
+                    continue
                 elif new_name[i] in arguments:
                     param = arguments[new_name[i]]
                 # In case the argument is not found in the list of arguments
@@ -513,14 +513,11 @@ def deprecated_renamed_argument(old_name, new_name, since,
                                     'cannot specify both "{}" and "{}"'
                                     '.'.format(old_name[i], new_name[i]))
                     else:
-                        if new_name[i] is None:
-                            # Keep the old argument if it was deprecated to
-                            # be removed
-                            kwargs[old_name[i]] = value
-                        else:
-                            # Pass the value of the old argument with the
-                            # name of the new argument to the function
+                        # Pass the value of the old argument with the
+                        # name of the new argument to the function
+                        if new_name[i] is not None:
                             kwargs[new_name[i]] = value
+
             return function(*args, **kwargs)
 
         return wrapper

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -7,8 +7,8 @@ import pickle
 import pytest
 
 from astropy.utils.decorators import (deprecated_attribute, deprecated, wraps,
-                          sharedmethod, classproperty,
-                          format_doc, deprecated_renamed_argument)
+                                      sharedmethod, classproperty,
+                                      format_doc, deprecated_renamed_argument)
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 from astropy.tests.helper import catch_warnings
 
@@ -511,6 +511,23 @@ def test_deprecated_argument_not_allowed_use():
         @deprecated_renamed_argument('overwrite', 'kwargs', '1.3')
         def test3(**kwargs):
             return kwargs
+
+
+def test_deprecated_argument_remove():
+    @deprecated_renamed_argument('x', None, '2.0', alternative='astropy.y')
+    def test(dummy=11):
+        return dummy
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test(x=1) == 11
+        assert len(w) == 1
+        assert 'Use astropy.y instead' in str(w[0].message)
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test(x=1, dummy=10) == 10
+        assert len(w) == 1
+
+    assert test() == 11
 
 
 def test_sharedmethod_reuse_on_subclasses():


### PR DESCRIPTION
We currently have no way to deprecate an argument. I think it's preferable to reuse what we have, but I'm happy to add a new `deprecate_argument` decorator if people prefer that instead of this hack.

As for other utilities useful for downstream, I prefer to milestone it for LTS.