### PR TITLE
Support ASDF serialization of tables with mixin columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ astropy.io.misc
 - Implement serialization of ``SkyCoord`` in ASDF. [#8284]
 
 - No warnings when reading HDF5 files with only one table and no ``path=`` argument [#8483]
+- Support serialization of Astropy tables with mixin columns in ASDF. [#8337]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/time/timedelta-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/time/timedelta-1.0.0.yaml
@@ -9,11 +9,15 @@ description: |
 type: object
 properties:
     jd1:
-      type: number
+      anyOf:
+        - type: number
+        - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       description: |
         Value representing first 64 bits of precision
     jd2:
-      type: number
+      anyOf:
+        - type: number
+        - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
       description: |
         Value representing second 64 bits of precision
     format:

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/fits/fits-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/fits/fits-1.0.0.yaml
@@ -1,0 +1,89 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/fits/fits-1.0.0"
+title: >
+  A FITS file inside of an ASDF file.
+description: |
+  This schema is useful for distributing ASDF files that can
+  automatically be converted to FITS files by specifying the exact
+  content of the resulting FITS file.
+
+  Not all kinds of data in FITS are directly representable in ASDF.
+  For example, applying an offset and scale to the data using the
+  `BZERO` and `BSCALE` keywords.  In these cases, it will not be
+  possible to store the data in the native format from FITS and also
+  be accessible in its proper form in the ASDF file.
+
+  Only image and binary table extensions are supported.
+
+examples:
+  -
+    - A simple FITS file with a primary header and two extensions
+    - |
+        !<tag:astropy.org:astropy/fits/fits-1.0.0>
+            - header:
+              - [SIMPLE, true, conforms to FITS standard]
+              - [BITPIX, 8, array data type]
+              - [NAXIS, 0, number of array dimensions]
+              - [EXTEND, true]
+              - []
+              - ['', Top Level MIRI Metadata]
+              - []
+              - [DATE, '2013-08-30T10:49:55.070373', The date this file was created (UTC)]
+              - [FILENAME, MiriDarkReferenceModel_test.fits, The name of the file]
+              - [TELESCOP, JWST, The telescope used to acquire the data]
+              - []
+              - ['', Information about the observation]
+              - []
+              - [DATE-OBS, '2013-08-30T10:49:55.000000', The date the observation was made (UTC)]
+            - data: !core/ndarray-1.0.0
+                datatype: float32
+                shape: [2, 3, 3, 4]
+                source: 0
+                byteorder: big
+              header:
+              - [XTENSION, IMAGE, Image extension]
+              - [BITPIX, -32, array data type]
+              - [NAXIS, 4, number of array dimensions]
+              - [NAXIS1, 4]
+              - [NAXIS2, 3]
+              - [NAXIS3, 3]
+              - [NAXIS4, 2]
+              - [PCOUNT, 0, number of parameters]
+              - [GCOUNT, 1, number of groups]
+              - [EXTNAME, SCI, extension name]
+              - [BUNIT, DN, Units of the data array]
+            - data: !core/ndarray-1.0.0
+                datatype: float32
+                shape: [2, 3, 3, 4]
+                source: 1
+                byteorder: big
+              header:
+              - [XTENSION, IMAGE, Image extension]
+              - [BITPIX, -32, array data type]
+              - [NAXIS, 4, number of array dimensions]
+              - [NAXIS1, 4]
+              - [NAXIS2, 3]
+              - [NAXIS3, 3]
+              - [NAXIS4, 2]
+              - [PCOUNT, 0, number of parameters]
+              - [GCOUNT, 1, number of groups]
+              - [EXTNAME, ERR, extension name]
+              - [BUNIT, DN, Units of the error array]
+
+allOf:
+  - tag: "tag:astropy.org:astropy/fits/fits-1.0.0"
+  - type: array
+    items:
+      type: object
+      properties:
+        data:
+          description: "The data part of the HDU."
+          anyOf:
+            - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
+            - $ref: "../table/table-1.0.0"
+            # Retain backwards compatibility with table defined by ASDF Standard
+            - $ref: "tag:stsci.edu:asdf/core/table-1.0.0"
+            - type: "null"
+          default: null

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -1,0 +1,125 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/table/table-1.0.0"
+tag: "tag:astropy.org:astropy/table/table-1.0.0"
+
+title: >
+  A table.
+
+description: |
+  A table is represented as a list of columns, where each entry is a
+  [column](ref:http://stsci.edu/schemas/asdf/core/column-1.0.0)
+  object, containing the data and some additional information.
+
+  The data itself may be stored inline as text, or in binary in either
+  row- or column-major order by use of the `strides` property on the
+  individual column arrays.
+
+  Each column in the table must have the same first (slowest moving)
+  dimension.
+
+examples:
+  -
+    - A table stored in column-major order, with each column in a separate block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.0.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 1
+              datatype: float64
+              byteorder: little
+              shape: [3]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 2
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+  -
+    - A table stored in row-major order, all stored in the same block
+    - |
+        !<tag:astropy.org:astropy/table/table-1.0.0>
+          columns:
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              strides: [13]
+            description: RA
+            meta: {foo: bar}
+            name: a
+            unit: !unit/unit-1.0.0 deg
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: float64
+              byteorder: little
+              shape: [3]
+              offset: 4
+              strides: [13]
+            description: DEC
+            name: b
+          - !core/column-1.0.0
+            data: !core/ndarray-1.0.0
+              source: 0
+              datatype: [ascii, 1]
+              byteorder: big
+              shape: [3]
+              offset: 12
+              strides: [13]
+            description: The target name
+            name: c
+          colnames: [a, b, c]
+
+type: object
+properties:
+  columns:
+    description: |
+      A list of columns in the table.
+    type: array
+    items:
+      anyOf:
+        - $ref: "tag:stsci.edu:asdf/core/column-1.0.0"
+        - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+
+  colnames:
+    description: |
+      A list containing the names of the columns in the table (in order).
+    type: array
+    items:
+      - type: string
+
+  qtable:
+    description: |
+      A flag indicating whether or not the serialized type was a QTable
+    type: boolean
+    default: False
+
+  meta:
+    description: |
+      Additional free-form metadata about the table.
+    type: object
+    default: {}
+
+additionalProperties: false
+required: [columns, colnames]

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -102,6 +102,7 @@ properties:
         - $ref: "tag:stsci.edu:asdf/core/column-1.0.0"
         - $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
         - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
+        - $ref: "../coordinates/skycoord-1.0.0"
 
   colnames:
     description: |

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -100,6 +100,7 @@ properties:
     items:
       anyOf:
         - $ref: "tag:stsci.edu:asdf/core/column-1.0.0"
+        - $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
         - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
 
   colnames:

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -103,6 +103,7 @@ properties:
         - $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
         - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
         - $ref: "../coordinates/skycoord-1.0.0"
+        - $ref: "../coordinates/earthlocation-1.0.0"
         - $ref: "../time/timedelta-1.0.0"
 
   colnames:

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -103,6 +103,7 @@ properties:
         - $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
         - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
         - $ref: "../coordinates/skycoord-1.0.0"
+        - $ref: "../time/timedelta-1.0.0"
 
   colnames:
     description: |

--- a/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
+++ b/astropy/io/misc/asdf/schemas/astropy.org/astropy/table/table-1.0.0.yaml
@@ -100,6 +100,7 @@ properties:
     items:
       anyOf:
         - $ref: "tag:stsci.edu:asdf/core/column-1.0.0"
+        - $ref: "tag:stsci.edu:asdf/core/ndarray-1.0.0"
         - $ref: "tag:stsci.edu:asdf/time/time-1.1.0"
         - $ref: "tag:stsci.edu:asdf/unit/quantity-1.1.0"
         - $ref: "../coordinates/skycoord-1.0.0"

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_skycoord.py
@@ -111,3 +111,11 @@ def test_skycoord_extra_attribute(tmpdir):
         assert hasattr(asdffile['coord'], 'equinox')
 
     assert_roundtrip_tree(tree, tmpdir, asdf_check_func=check_asdf)
+
+
+def test_skycoord_2d_obstime(tmpdir):
+
+    sc = SkyCoord([1, 2], [3, 4], [5, 6], unit='deg,deg,m', frame='fk4',
+                    obstime=['J1990.5', 'J1991.5']),
+    tree = dict(coord=sc)
+    assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -8,10 +8,10 @@ from asdf import yamlutil
 
 from astropy import table
 from astropy.io import fits
-from astropy.io.misc.asdf.types import AstropyAsdfType
+from astropy.io.misc.asdf.types import AstropyType
 
 
-class FitsType(AstropyAsdfType):
+class FitsType(AstropyType):
     name = 'fits/fits'
     types = ['astropy.io.fits.HDUList']
     requires = ['astropy']

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -8,10 +8,10 @@ from asdf import yamlutil
 
 from astropy import table
 from astropy.io import fits
-from astropy.io.misc.asdf.types import AstropyType
+from astropy.io.misc.asdf.types import AstropyType, AstropyAsdfType
 
 
-class FitsType(AstropyType):
+class FitsType:
     name = 'fits/fits'
     types = ['astropy.io.fits.HDUList']
     requires = ['astropy']
@@ -82,3 +82,23 @@ class FitsType(AstropyType):
             assert_array_equal(hdua.data, hdub.data)
             for carda, cardb in zip(hdua.header.cards, hdub.header.cards):
                 assert tuple(carda) == tuple(cardb)
+
+
+class AstropyFitsType(FitsType, AstropyType):
+    """
+    This class implements ASDF serialization/deserialization that corresponds
+    to the FITS schema defined by Astropy. It will be used by default when
+    writing new HDUs to ASDF files.
+    """
+
+
+class AsdfFitsType(FitsType, AstropyAsdfType):
+    """
+    This class implements ASDF serialization/deserialization that corresponds
+    to the FITS schema defined by the ASDF Standard. It will not be used by
+    default, except when reading files that use the ASDF Standard definition
+    rather than the one defined in Astropy. It will primarily be used for
+    backwards compatibility for reading older files. In the unlikely case that
+    another ASDF implementation uses the FITS schema from the ASDF Standard,
+    this tag could also be used to read a file it generated.
+    """

--- a/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
@@ -33,6 +33,6 @@ def test_fits_table(tmpdir):
     tree = {'fits': h}
 
     def check_yaml(content):
-        assert b'!core/table' in content
+        assert b'!<tag:astropy.org:astropy/table/table-1.0.0>' in content
 
     helpers.assert_roundtrip_tree(tree, tmpdir, raw_yaml_check_func=check_yaml)

--- a/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
@@ -12,6 +12,8 @@ from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
 
+from ...tests.helpers import run_schema_example_test
+
 
 def test_complex_structure(tmpdir):
     with fits.open(os.path.join(
@@ -36,3 +38,18 @@ def test_fits_table(tmpdir):
         assert b'!<tag:astropy.org:astropy/table/table-1.0.0>' in content
 
     helpers.assert_roundtrip_tree(tree, tmpdir, raw_yaml_check_func=check_yaml)
+
+
+def test_backwards_compat():
+    """
+    Make sure that we can continue to read FITS HDUs that use the schema from
+    the ASDF Standard.
+
+    This test uses the examples in the fits schema from the ASDF Standard,
+    since these make no reference to Astropy's own fits definition.
+    """
+
+    def check(asdffile):
+        assert isinstance(asdffile['example'], fits.HDUList)
+
+    run_schema_example_test('stsci.edu', 'asdf', 'fits/fits', '1.0.0', check)

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -68,7 +68,14 @@ class TableType:
     @classmethod
     def assert_equal(cls, old, new):
         assert old.meta == new.meta
-        NDArrayType.assert_equal(np.array(old), np.array(new))
+        try:
+            NDArrayType.assert_equal(np.array(old), np.array(new))
+        except (AttributeError, TypeError, ValueError):
+            for col0, col1 in zip(old, new):
+                try:
+                    NDArrayType.assert_equal(np.array(col0), np.array(col1))
+                except (AttributeError, TypeError, ValueError):
+                    assert col0 == col1
 
 
 class AstropyTableType(TableType, AstropyType):

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -10,13 +10,31 @@ from astropy import table
 from astropy.io.misc.asdf.types import AstropyType, AstropyAsdfType
 
 
-class TableType(AstropyType):
-    name = 'table/table'
-    types = ['astropy.table.Table']
-    requires = ['astropy']
+class TableType:
+    """
+    This class defines to_tree and from_tree methods that are used by both the
+    AstropyTableType and the AsdfTableType defined below. The behavior is
+    differentiated by the ``_compat`` class attribute. When ``_compat==True``,
+    the behavior will conform to the table schema defined by the ASDF Standard.
+    Otherwise, the behavior will conform to the custom table schema defined by
+    Astropy.
+    """
+    _compat = False
 
     @classmethod
     def from_tree(cls, node, ctx):
+
+        # This is getting meta, guys
+        meta = node.get('meta', {})
+
+        # This enables us to support files that use the table definition from
+        # the ASDF Standard, rather than the custom one that Astropy defines.
+        if cls._compat:
+            columns = [
+                yamlutil.tagged_tree_to_custom_tree(col, ctx)
+                for col in node['columns']
+            ]
+            return table.Table(columns, meta=meta)
 
         if node.get('qtable', False):
             t = table.QTable(meta=node.get('meta', {}))
@@ -36,11 +54,12 @@ class TableType(AstropyType):
             column = yamlutil.custom_tree_to_tagged_tree(thiscol, ctx)
             columns.append(column)
 
-        node = dict(
-            columns=columns,
-            colnames=data.colnames,
-            qtable = isinstance(data, table.QTable)
-        )
+        node = dict(columns=columns)
+        # Files that use the table definition from the ASDF Standard (instead
+        # of the one defined by Astropy) will not contain these fields
+        if not cls._compat:
+            node['colnames'] = data.colnames
+            node['qtable'] = isinstance(data, table.QTable)
         if data.meta:
             node['meta'] = data.meta
 
@@ -50,6 +69,32 @@ class TableType(AstropyType):
     def assert_equal(cls, old, new):
         assert old.meta == new.meta
         NDArrayType.assert_equal(np.array(old), np.array(new))
+
+
+class AstropyTableType(TableType, AstropyType):
+    """
+    This tag class reads and writes tables that conform to the custom schema
+    that is defined by Astropy (in contrast to the one that is defined by the
+    ASDF Standard). The primary reason for differentiating is to enable the
+    support of Astropy mixin columns, which are not supported by the ASDF
+    Standard.
+    """
+    name = 'table/table'
+    types = ['astropy.table.Table']
+    requires = ['astropy']
+
+
+class AsdfTableType(TableType, AstropyAsdfType):
+    """
+    This tag class allows Astropy to read (and write) ASDF files that use the
+    table definition that is provided by the ASDF Standard (instead of the
+    custom one defined by Astropy). This is important to maintain for
+    cross-compatibility.
+    """
+    name = 'core/table'
+    types = ['astropy.table.Table']
+    requires = ['astropy']
+    _compat = True
 
 
 class ColumnType(AstropyAsdfType):

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -102,23 +102,25 @@ def test_table_inline(tmpdir):
 
 def test_mismatched_columns():
     yaml = """
-table: !core/table
+table: !<tag:astropy.org:astropy/table/table-1.0.0>
   columns:
-  - !core/column
-    data: !core/ndarray
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
       data: [0, 1, 2]
     name: a
-  - !core/column
-    data: !core/ndarray
+  - !core/column-1.0.0
+    data: !core/ndarray-1.0.0
       data: [0, 1, 2, 3]
     name: b
+  colnames: [a, b]
     """
 
     buff = helpers.yaml_to_asdf(yaml)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as err:
         with asdf.open(buff) as ff:
             pass
+    assert 'Inconsistent data column lengths' in str(err)
 
 
 def test_masked_table(tmpdir):

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -1,9 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-import os
-import urllib.parse
-
-import yaml
 
 import pytest
 import numpy as np
@@ -14,10 +10,9 @@ from astropy import __minimum_asdf_version__
 
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 
-from asdf import treeutil
 from asdf.tests import helpers
-from asdf.types import format_tag
-from asdf.resolver import default_resolver
+
+from ...tests.helpers import run_schema_example_test
 
 
 def test_table(tmpdir):
@@ -163,7 +158,7 @@ def test_quantity_mixin(tmpdir):
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
 
 
-def test_backwards_compat(tmpdir):
+def test_backwards_compat():
     """
     Make sure that we can continue to read tables that use the schema from
     the ASDF Standard.
@@ -172,27 +167,7 @@ def test_backwards_compat(tmpdir):
     since these make no reference to Astropy's own table definition.
     """
 
-    tag = format_tag('stsci.edu', 'asdf', '1.0.0', 'core/table')
-    schema_path = urllib.parse.urlparse(default_resolver(tag)).path
+    def check(asdffile):
+        assert isinstance(asdffile['example'], table.Table)
 
-    with open(schema_path, 'rb') as ff:
-        schema = yaml.load(ff)
-
-    examples = []
-    for node in treeutil.iter_tree(schema):
-        if (isinstance(node, dict) and
-            'examples' in node and
-            isinstance(node['examples'], list)):
-            for desc, example in node['examples']:
-                examples.append(example)
-
-    for example in examples:
-        buff = helpers.yaml_to_asdf('example: ' + example.strip())
-        ff = asdf.AsdfFile(uri=schema_path)
-        # Add some dummy blocks so that the ndarray examples work
-        for i in range(3):
-            b = asdf.block.Block(np.zeros((1024*1024*8), dtype=np.uint8))
-            b._used = True
-            ff.blocks.add(b)
-        ff._open_impl(ff, buff, mode='r')
-        assert isinstance(ff['example'], table.Table)
+    run_schema_example_test('stsci.edu', 'asdf', 'core/table', '1.0.0', check)

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -7,10 +7,10 @@ import numpy as np
 import astropy.units as u
 from astropy import table
 from astropy.time import Time, TimeDelta
-from astropy.coordinates import SkyCoord
-from astropy import __minimum_asdf_version__
+from astropy.coordinates import SkyCoord, EarthLocation
 from astropy.table.tests.test_operations import skycoord_equal
 
+from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
 from asdf.tags.core.ndarray import NDArrayType
@@ -204,6 +204,19 @@ def test_skycoord_mixin(tmpdir):
 
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check,
                                   tree_match_func=tree_match)
+
+
+def test_earthlocation_mixin(tmpdir):
+
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['b'] = ['x', 'y']
+    t['c'] = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+
+    def check(ff):
+        assert isinstance(ff['table']['c'], EarthLocation)
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
 
 
 def test_backwards_compat():

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import astropy.units as u
 from astropy import table
-from astropy.time import Time
+from astropy.time import Time, TimeDelta
 from astropy.coordinates import SkyCoord
 from astropy import __minimum_asdf_version__
 from astropy.table.tests.test_operations import skycoord_equal
@@ -170,6 +170,19 @@ def test_time_mixin(tmpdir):
 
     def check(ff):
         assert isinstance(ff['table']['c'], Time)
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
+
+
+def test_timedelta_mixin(tmpdir):
+
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['b'] = ['x', 'y']
+    t['c'] = TimeDelta([1, 2] * u.day)
+
+    def check(ff):
+        assert isinstance(ff['table']['c'], TimeDelta)
 
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
 

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -3,6 +3,7 @@
 import pytest
 import numpy as np
 
+import astropy.units as u
 from astropy import table
 from astropy import __minimum_asdf_version__
 
@@ -134,5 +135,18 @@ def test_masked_table(tmpdir):
 
     def check(ff):
         assert len(ff.blocks) == 4
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
+
+
+def test_quantity_mixin(tmpdir):
+
+    t = table.QTable()
+    t['a'] = [1, 2, 3]
+    t['b'] = ['x', 'y', 'z']
+    t['c'] = [2.0, 5.0, 8.2] * u.m
+
+    def check(ff):
+        assert isinstance(ff['table']['c'], u.Quantity)
 
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -7,9 +7,11 @@ import numpy as np
 import astropy.units as u
 from astropy import table
 from astropy import __minimum_asdf_version__
+from astropy.table.tests.test_operations import skycoord_equal
 
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
+from asdf.tags.core.ndarray import NDArrayType
 
 from astropy.time import Time
 
@@ -170,6 +172,25 @@ def test_time_mixin(tmpdir):
         assert isinstance(ff['table']['c'], Time)
 
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
+
+
+def test_skycoord_mixin(tmpdir):
+
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['b'] = ['x', 'y']
+    t['c'] = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4', obstime='J1990.5')
+
+    def check(ff):
+        assert isinstance(ff['table']['c'], SkyCoord)
+
+    def tree_match(old, new):
+        NDArrayType.assert_equal(new['a'], old['a'])
+        NDArrayType.assert_equal(new['b'], old['b'])
+        assert skycoord_equal(new['c'], old['c'])
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check,
+                                  tree_match_func=tree_match)
 
 
 def test_backwards_compat():

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -9,8 +9,9 @@ from astropy import table
 from astropy import __minimum_asdf_version__
 
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
-
 from asdf.tests import helpers
+
+from astropy.time import Time
 
 from ...tests.helpers import run_schema_example_test
 
@@ -154,6 +155,19 @@ def test_quantity_mixin(tmpdir):
 
     def check(ff):
         assert isinstance(ff['table']['c'], u.Quantity)
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
+
+
+def test_time_mixin(tmpdir):
+
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['b'] = ['x', 'y']
+    t['c'] = Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+
+    def check(ff):
+        assert isinstance(ff['table']['c'], Time)
 
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
 

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -6,14 +6,14 @@ import numpy as np
 
 import astropy.units as u
 from astropy import table
+from astropy.time import Time
+from astropy.coordinates import SkyCoord
 from astropy import __minimum_asdf_version__
 from astropy.table.tests.test_operations import skycoord_equal
 
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
 from asdf.tags.core.ndarray import NDArrayType
-
-from astropy.time import Time
 
 from ...tests.helpers import run_schema_example_test
 

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -219,6 +219,16 @@ def test_earthlocation_mixin(tmpdir):
     helpers.assert_roundtrip_tree({'table': t}, tmpdir, asdf_check_func=check)
 
 
+def test_ndarray_mixin(tmpdir):
+
+    t = table.Table()
+    t['a'] = [1, 2]
+    t['b'] = ['x', 'y']
+    t['c'] = table.NdarrayMixin([5, 6])
+
+    helpers.assert_roundtrip_tree({'table': t}, tmpdir)
+
+
 def test_backwards_compat():
     """
     Make sure that we can continue to read tables that use the schema from

--- a/astropy/io/misc/asdf/tags/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/tests/__init__.py
@@ -1,0 +1,2 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-

--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -1,0 +1,42 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+import os
+import urllib.parse
+
+import yaml
+
+import numpy as np
+
+
+def run_schema_example_test(organization, standard, name, version, check_func=None):
+
+    import asdf
+    from asdf.tests import helpers
+    from asdf.types import format_tag
+    from asdf.resolver import default_resolver
+
+    tag = format_tag(organization, standard, version, name)
+    schema_path = urllib.parse.urlparse(default_resolver(tag)).path
+
+    with open(schema_path, 'rb') as ff:
+        schema = yaml.load(ff)
+
+    examples = []
+    for node in asdf.treeutil.iter_tree(schema):
+        if (isinstance(node, dict) and
+            'examples' in node and
+            isinstance(node['examples'], list)):
+            for desc, example in node['examples']:
+                examples.append(example)
+
+    for example in examples:
+        buff = helpers.yaml_to_asdf('example: ' + example.strip())
+        ff = asdf.AsdfFile(uri=schema_path)
+        # Add some dummy blocks so that the ndarray examples work
+        for i in range(3):
+            b = asdf.block.Block(np.zeros((1024*1024*8), dtype=np.uint8))
+            b._used = True
+            ff.blocks.add(b)
+        ff._open_impl(ff, buff, mode='r')
+        if check_func:
+            check_func(ff)

--- a/astropy/io/misc/asdf/tags/time/tests/test_time.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_time.py
@@ -79,6 +79,15 @@ def test_isot(tmpdir):
     assert isinstance(tree['time'], str)
 
 
+def test_isot_array(tmpdir):
+
+    tree = {
+        'time': time.Time(['2001-01-02T12:34:56', '2001-02-03T00:01:02'])
+    }
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
 def test_time_tag():
     schema = asdf_schema.load_schema(
         'http://stsci.edu/schemas/asdf/time/time-1.1.0',

--- a/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/tests/test_timedelta.py
@@ -6,6 +6,7 @@ import pytest
 asdf = pytest.importorskip('asdf')
 from asdf.tests.helpers import assert_roundtrip_tree
 
+from astropy import units as u
 from astropy.time import Time, TimeDelta
 
 
@@ -21,7 +22,13 @@ def test_timedelta(fmt, tmpdir):
 
 
 @pytest.mark.parametrize('scale', list(TimeDelta.SCALES) + [None])
-def test_timedetal_scales(scale, tmpdir):
+def test_timedelta_scales(scale, tmpdir):
 
     tree = dict(timedelta=TimeDelta(0.125, scale=scale))
+    assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_timedelta_vector(tmpdir):
+
+    tree = dict(timedelta=TimeDelta([1, 2] * u.day))
     assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -41,22 +41,22 @@ class TimeType(AstropyAsdfType):
 
     @classmethod
     def to_tree(cls, node, ctx):
-        format = node.format
+        fmt = node.format
 
-        if format == 'byear':
+        if fmt == 'byear':
             node = time.Time(node, format='byear_str')
 
-        elif format == 'jyear':
+        elif fmt == 'jyear':
             node = time.Time(node, format='jyear_str')
 
-        elif format in ('fits', 'datetime', 'plot_date'):
+        elif fmt in ('fits', 'datetime', 'plot_date'):
             node = time.Time(node, format='isot')
 
-        format = node.format
+        fmt = node.format
 
-        format = _astropy_format_to_asdf_format.get(format, format)
+        fmt = _astropy_format_to_asdf_format.get(fmt, fmt)
 
-        guessable_format = format in _guessable_formats
+        guessable_format = fmt in _guessable_formats
 
         if node.scale == 'utc' and guessable_format and node.isscalar:
             return node.value
@@ -64,7 +64,7 @@ class TimeType(AstropyAsdfType):
         d = {'value': yamlutil.custom_tree_to_tagged_tree(node.value, ctx)}
 
         if not guessable_format:
-            d['format'] = format
+            d['format'] = fmt
 
         if node.scale != 'utc':
             d['scale'] = node.scale
@@ -93,13 +93,13 @@ class TimeType(AstropyAsdfType):
     def from_tree(cls, node, ctx):
         if isinstance(node, (str, list, np.ndarray)):
             t = time.Time(node)
-            format = _astropy_format_to_asdf_format.get(t.format, t.format)
-            if format not in _guessable_formats:
+            fmt = _astropy_format_to_asdf_format.get(t.format, t.format)
+            if fmt not in _guessable_formats:
                 raise ValueError("Invalid time '{0}'".format(node))
             return t
 
         value = node['value']
-        format = node.get('format')
+        fmt = node.get('format')
         scale = node.get('scale')
         location = node.get('location')
         if location is not None:
@@ -112,7 +112,7 @@ class TimeType(AstropyAsdfType):
             location = EarthLocation.from_geocentric(
                 location['x'], location['y'], location['z'])
 
-        return time.Time(value, format=format, scale=scale, location=location)
+        return time.Time(value, format=fmt, scale=scale, location=location)
 
     @classmethod
     def assert_equal(cls, old, new):

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -58,12 +58,8 @@ class TimeType(AstropyAsdfType):
 
         guessable_format = format in _guessable_formats
 
-        if node.scale == 'utc' and guessable_format:
-            if node.isscalar:
-                return node.value
-            else:
-                return yamlutil.custom_tree_to_tagged_tree(
-                    node.value, ctx)
+        if node.scale == 'utc' and guessable_format and node.isscalar:
+            return node.value
 
         d = {'value': yamlutil.custom_tree_to_tagged_tree(node.value, ctx)}
 

--- a/astropy/io/misc/asdf/tags/time/timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/timedelta.py
@@ -5,6 +5,8 @@
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
 from astropy.time import TimeDelta
+from astropy.time.tests.test_delta import (allclose_jd, allclose_jd2,
+                                           allclose_sec)
 
 from ...types import AstropyType
 
@@ -26,3 +28,10 @@ class TimeDeltaType(AstropyType):
     @classmethod
     def from_tree(cls, node, ctx):
         return TimeDelta.info._construct_from_dict(node)
+
+
+    @classmethod
+    def assert_equal(cls, old, new):
+        assert allclose_jd(old.jd, new.jd)
+        assert allclose_jd2(old.jd2, new.jd2)
+        assert allclose_sec(old.sec, new.sec)


### PR DESCRIPTION
While #8261 implemented a table reader/writer for ASDF, this PR allows tables with all valid column mixins to be serialized.