### PR TITLE
Fix make.bat clean command for documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1833,6 +1833,8 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Fixed ``make clean`` for the documentation on Windows to ensure it
+  properly removes the ``api`` and ``generated`` directories. [#8346]
 
 
 2.0.11 (2018-12-31)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -37,6 +37,8 @@ if "%1" == "help" (
 if "%1" == "clean" (
 	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
 	del /q /s %BUILDDIR%\*
+	del /q /s api
+	del /q /s generated
 	goto end
 )
 


### PR DESCRIPTION
Currently doing ``make clean`` in the docs on Windows did not properly clear away the ``api`` and ``generated`` directories as on Linux/MacOS X.