### PR TITLE
TST: Fix viz test failure due to MPL error refactoring

### DIFF
--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import io
 
 import pytest
@@ -59,11 +58,20 @@ def test_units_errbarr():
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_incompatible_units():
+    # NOTE: minversion check does not work properly for matplotlib dev.
+    try:
+        # https://github.com/matplotlib/matplotlib/pull/13005
+        from matplotlib.units import ConversionError
+    except ImportError:
+        err_type = u.UnitConversionError
+    else:
+        err_type = ConversionError
+
     plt.figure()
 
     with quantity_support():
         plt.plot([1, 2, 3] * u.m)
-        with pytest.raises(u.UnitConversionError):
+        with pytest.raises(err_type):
             plt.plot([105, 210, 315] * u.kg)
 
     plt.clf()


### PR DESCRIPTION
Fix #8347 , caused by matplotlib/matplotlib#13005 that is milestoned for Matplotlib 3.1.

This failure making reviewing new PR a pain, so I'd rather we fix it sooner than later. If this needs to be backported, please update the milestone.