### PR TITLE
Speed up time calculations a tiny bit using faster test.

### DIFF
--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -11,12 +11,11 @@ import numpy as np
 from astropy import units as u
 
 
-def day_frac(val1, val2, factor=1., divisor=1.):
+def day_frac(val1, val2, factor=None, divisor=None):
     """
     Return the sum of ``val1`` and ``val2`` as two float64s, an integer part
-    and the fractional remainder.  If ``factor`` is not 1.0 then multiply the
-    sum by ``factor``.  If ``divisor`` is not 1.0 then divide the sum by
-    ``divisor``.
+    and the fractional remainder.  If ``factor`` is given, then multiply the
+    sum by it.  If ``divisor`` is given, then divide the sum by it.
 
     The arithmetic is all done with exact floating point operations so no
     precision is lost to rounding error.  This routine assumes the sum is less
@@ -32,12 +31,12 @@ def day_frac(val1, val2, factor=1., divisor=1.):
     # and the second is the error of the float64 sum.
     sum12, err12 = two_sum(val1, val2)
 
-    if np.any(factor != 1.):
+    if factor is not None:
         sum12, carry = two_product(sum12, factor)
         carry += err12 * factor
         sum12, err12 = two_sum(sum12, carry)
 
-    if np.any(divisor != 1.):
+    if divisor is not None:
         q1 = sum12 / divisor
         p1, p2 = two_product(q1, divisor)
         d1, d2 = two_sum(sum12, -p1)


### PR DESCRIPTION
I was alerted to this by getting annoying deprecationwarnings arising from `np.any(factor != 1)` with `factor` a quantity. Really, the test should just short-cut only when one passes in exactly unity, and execute otherwise; inside `time`, the most frequent call is without a factor or divisor, so good to skip those as fast as possible.

EDIT: this relies on
```
In [16]: 1 is 1
Out[16]: True
```
This works for int, not float.