### PR TITLE
TST: Fix doctest failures due to upstream changes

### DIFF
--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -328,11 +328,15 @@ the mask, metadata, etc are discarded:
 
 .. doctest-requires:: skimage
 
+    >>> from astropy.utils import minversion
+    >>> from astropy.utils.compat import NUMPY_LT_1_16
     >>> from astropy.nddata import block_reduce, block_replicate
-    >>> smaller = block_reduce(ccd, 4)
-    >>> smaller
-    array(...)
-    >>> plt.imshow(smaller, origin='lower')  # doctest: +SKIP
+    >>> SKIMAGE_LT_1_14_2 = not minversion('skimage', '0.14.2')
+    >>> # Version check is necessary here due to upstream incompatibility.
+    >>> if not SKIMAGE_LT_1_14_2 or (SKIMAGE_LT_1_14_2 and NUMPY_LT_1_16):
+    ...     smaller = block_reduce(ccd, 4)
+    ...     print(smaller)  # doctest: +SKIP
+    ...     plt.imshow(smaller, origin='lower')  # doctest: +SKIP
 
 .. plot::
 

--- a/docs/nddata/index.rst
+++ b/docs/nddata/index.rst
@@ -340,27 +340,31 @@ the mask, metadata, etc are discarded:
 
 .. plot::
 
-    import numpy as np
-    import matplotlib.pyplot as plt
-    from astropy.modeling.models import Gaussian2D
-    from astropy.nddata import block_reduce, block_replicate
-    from astropy.nddata import CCDData, Cutout2D
-    y, x = np.mgrid[0:500, 0:600]
-    data = (Gaussian2D(1, 150, 100, 20, 10, theta=0.5)(x, y) +
-            Gaussian2D(0.5, 400, 300, 8, 12, theta=1.2)(x,y) +
-            Gaussian2D(0.75, 250, 400, 5, 7, theta=0.23)(x,y) +
-            Gaussian2D(0.9, 525, 150, 3, 3)(x,y) +
-            Gaussian2D(0.6, 200, 225, 3, 3)(x,y))
-    np.random.seed(123456)
-    data += 0.01 * np.random.randn(500, 600)
-    cosmic_ray_value = 0.997
-    data[100, 300:310] = cosmic_ray_value
-    mask = (data == cosmic_ray_value)
-    ccd = CCDData(data, mask=mask,
-                  meta={'object': 'fake galaxy', 'filter': 'R'},
-                  unit='adu')
-    smaller = block_reduce(ccd.data, 4)
-    plt.imshow(smaller, origin='lower')
+    from astropy.utils import minversion
+    from astropy.utils.compat import NUMPY_LT_1_16
+    SKIMAGE_LT_1_14_2 = not minversion('skimage', '0.14.2')
+    if not SKIMAGE_LT_1_14_2 or (SKIMAGE_LT_1_14_2 and NUMPY_LT_1_16):
+        import numpy as np
+        import matplotlib.pyplot as plt
+        from astropy.modeling.models import Gaussian2D
+        from astropy.nddata import block_reduce, block_replicate
+        from astropy.nddata import CCDData, Cutout2D
+        y, x = np.mgrid[0:500, 0:600]
+        data = (Gaussian2D(1, 150, 100, 20, 10, theta=0.5)(x, y) +
+                Gaussian2D(0.5, 400, 300, 8, 12, theta=1.2)(x,y) +
+                Gaussian2D(0.75, 250, 400, 5, 7, theta=0.23)(x,y) +
+                Gaussian2D(0.9, 525, 150, 3, 3)(x,y) +
+                Gaussian2D(0.6, 200, 225, 3, 3)(x,y))
+        np.random.seed(123456)
+        data += 0.01 * np.random.randn(500, 600)
+        cosmic_ray_value = 0.997
+        data[100, 300:310] = cosmic_ray_value
+        mask = (data == cosmic_ray_value)
+        ccd = CCDData(data, mask=mask,
+                      meta={'object': 'fake galaxy', 'filter': 'R'},
+                      unit='adu')
+        smaller = block_reduce(ccd.data, 4)
+        plt.imshow(smaller, origin='lower')
 
 By default, both `~astropy.nddata.block_reduce` and
 `~astropy.nddata.block_replicate` conserve flux.

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -171,10 +171,10 @@ Plotting a quantity with an incompatible unit will raise an exception:
 
 .. doctest-requires:: matplotlib
 
-    >>> plt.plot([1, 2, 3] * u.kg)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> plt.plot([1, 2, 3] * u.kg)  # doctest: +SKIP
     Traceback (most recent call last):
     ...
-    UnitConversionError: 'kg' (mass) and 'm' (length) are not convertible
+    ... 'kg' (mass) and 'm' (length) are not convertible
     >>> plt.clf()
 
 To make sure unit support is turned off afterward, you can use


### PR DESCRIPTION
Close #8145

Also address the doctest portion of #8347 and #8352 that only fails in cron job.

https://travis-ci.org/astropy/astropy/jobs/480329696
```
_______________________ [doctest] docs/nddata/index.rst ________________________
323 
324 The functions `~astropy.nddata.block_reduce` and
325 `~astropy.nddata.block_replicate` resize images. The example below reduces the
326 size of the image by a factor of 4. Note that the result is a `numpy.ndarray`;
327 the mask, metadata, etc are discarded:
328 
329 .. doctest-requires:: skimage
330 
331     >>> from astropy.nddata import block_reduce, block_replicate
332     >>> smaller = block_reduce(ccd, 4)
UNEXPECTED EXCEPTION: ImportError("cannot import name '_validate_lengths'",)
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/test/lib/python3.6/doctest.py", line 1330, in __run
    compileflags, 1), test.globs)
  File "<doctest index.rst[61]>", line 1, in <module>
  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/utils/decorators.py", line 842, in block_reduce
    func = make_function_with_signature(func, name=name, **wrapped_args)
  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/nddata/decorators.py", line 245, in wrapper
    result = func(data, *args, **kwargs)
  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/nddata/utils.py", line 370, in block_reduce
    from skimage.measure import block_reduce
  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/skimage/__init__.py", line 176, in <module>
    from .util.lookfor import lookfor
  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/skimage/util/__init__.py", line 8, in <module>
    from .arraycrop import crop
  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/skimage/util/arraycrop.py", line 8, in <module>
    from numpy.lib.arraypad import _validate_lengths
ImportError: cannot import name '_validate_lengths'
/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/docs/nddata/index.rst:332: UnexpectedException
------------------------------ Captured log call -------------------------------
ndslicing.py               122 INFO     wcs cannot be sliced.
ndslicing.py               122 INFO     wcs cannot be sliced.
ccddata.py                 234 INFO     array provided for uncertainty; assuming it is a StdDevUncertainty.
______________________ [doctest] docs/units/quantity.rst _______________________
165     from matplotlib import pyplot as plt
166     plt.figure(figsize=(5,3))
167     plt.plot([1, 2, 3] * u.m)
168     plt.plot([1, 2, 3] * u.cm)
169 
170 Plotting a quantity with an incompatible unit will raise an exception:
171 
172 .. doctest-requires:: matplotlib
173 
174     >>> plt.plot([1, 2, 3] * u.kg)  # doctest: +IGNORE_EXCEPTION_DETAIL
Differences (unified diff with -expected +actual):
    @@ -1,3 +1,52 @@
     Traceback (most recent call last):
    -...
    -UnitConversionError: 'kg' (mass) and 'm' (length) are not convertible
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/quantity.py", line 712, in to_value
    +    scale = self.unit._to(unit)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/core.py", line 953, in _to
    +    "'{0!r}' is not a scaled version of '{1!r}'".format(self, other))
    +astropy.units.core.UnitConversionError: 'Unit("kg")' is not a scaled version of 'Unit("m")'
    +<BLANKLINE>
    +During handling of the above exception, another exception occurred:
    +<BLANKLINE>
    +Traceback (most recent call last):
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/axis.py", line 1446, in convert_units
    +    ret = self.converter.convert(x, self.units, self)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/visualization/units.py", line 82, in convert
    +    return val.to_value(unit)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/quantity.py", line 715, in to_value
    +    value = self._to_value(unit, equivalencies)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/quantity.py", line 646, in _to_value
    +    equivalencies=equivalencies)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/core.py", line 989, in to
    +    return self._get_converter(other, equivalencies=equivalencies)(value)
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/core.py", line 920, in _get_converter
    +    raise exc
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/core.py", line 906, in _get_converter
    +    self, other, self._normalize_equivalencies(equivalencies))
    +  File "/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/astropy/units/core.py", line 890, in _apply_equivalencies
    +    unit_str, other_str))
    +astropy.units.core.UnitConversionError: 'kg' (mass) and 'm' (length) are not convertible
    +<BLANKLINE>
    +The above exception was the direct cause of the following exception:
    +<BLANKLINE>
    +Traceback (most recent call last):
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/doctest.py", line 1330, in __run
    +    compileflags, 1), test.globs)
    +  File "<doctest quantity.rst[29]>", line 1, in <module>
    +    plt.plot([1, 2, 3] * u.kg)  # doctest: +IGNORE_EXCEPTION_DETAIL
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/pyplot.py", line 2780, in plot
    +    is not None else {}), **kwargs)
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/axes/_axes.py", line 1563, in plot
    +    self.add_line(line)
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 1876, in add_line
    +    self._update_line_limits(line)
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/axes/_base.py", line 1898, in _update_line_limits
    +    path = line.get_path()
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/lines.py", line 1025, in get_path
    +    self.recache()
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/lines.py", line 672, in recache
    +    yconv = self.convert_yunits(self._yorig)
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/artist.py", line 192, in convert_yunits
    +    return ax.yaxis.convert_units(y)
    +  File "/home/travis/miniconda/envs/test/lib/python3.6/site-packages/matplotlib/axis.py", line 1449, in convert_units
    +    f'units: {x!r}') from e
    +matplotlib.units.ConversionError: Failed to convert value(s) to axis units: <Quantity [1., 2., 3.] kg>
/tmp/astropy-test-k4hj1404/lib/python3.6/site-packages/docs/units/quantity.rst:174: DocTestFailure
```