### PR TITLE
Block repr in format when VOTable is converted to Table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1887,6 +1887,9 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Block floating-point columns from using repr format when converted to Table
+  [#8358]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -75,6 +75,9 @@ def test_read_through_table_interface(tmpdir):
 
     assert len(t) == 5
 
+    # Issue 8354
+    assert t['float'].format is None
+
     fn = os.path.join(str(tmpdir), "table_interface.xml")
     t.write(fn, table_id='FOO', format='votable')
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1530,7 +1530,8 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         if self.unit is not None:
             # TODO: Use units framework when it's available
             column.unit = self.unit
-        if isinstance(self.converter, converters.FloatingPoint):
+        if (isinstance(self.converter, converters.FloatingPoint) and
+                self.converter.output_format != '{!r:>}'):
             column.format = self.converter.output_format
 
     @classmethod


### PR DESCRIPTION
Addresses #8354 in which the null header line values have extra quotes around the null value, when the column format includes `repr` (as happens when using astroquery to query WISE catalogs).

EDIT: remove outdated description of changes