### PR TITLE
Change reference to QTable within from_pandas

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2856,7 +2856,8 @@ class Table:
 
         Examples
         --------
-        Here we convert a :class:`pandas.DataFrame` instance to a `QTable`.
+        Here we convert a :class:`pandas.DataFrame` instance
+        to a `~astropy.table.QTable`.
 
           >>> import numpy as np
           >>> import pandas as pd


### PR DESCRIPTION
I needed to change this so the documentation build in astropy-timeseries would stop breaking. 

I don't think it needs any changelog entry. 