### PR TITLE
Revert removal of mean, std, and var methods on Quantity.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,7 +88,9 @@ astropy.units
 - ``Quantity`` overrides of ``ndarray`` methods such as ``sum``, ``min``,
   ``max``, which are implemented via reductions, have been removed since they
   are dealt with in ``Quantity.__array_ufunc__``. This should not affect
-  subclasses, but they may consider doing similarly. [#8316]
+  subclasses, but they may consider doing similarly. [#8316]  Note that this
+  does not include methods that use more complicated python code such as
+  ``mean``, ``std`` and ``var``. [#8370]
 
 astropy.utils
 ^^^^^^^^^^^^^
@@ -318,7 +320,7 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
-- Fixed slowness for certain compound models consisting of large numbers 
+- Fixed slowness for certain compound models consisting of large numbers
   of multi-input models [#8338, #8349]
 
 astropy.nddata

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -185,6 +185,30 @@ def test_angle_ops():
         np.sin(a6, out=a6)
 
 
+def test_angle_methods():
+    # Most methods tested as part of the Quantity tests.
+    # A few tests here which caused problems before: #8368
+    a = Angle([0., 2.], 'deg')
+    a_mean = a.mean()
+    assert type(a_mean) is Angle
+    assert a_mean == 1. * u.degree
+    a_std = a.std()
+    assert type(a_std) is Angle
+    assert a_std == 1. * u.degree
+    a_var = a.var()
+    assert type(a_var) is u.Quantity
+    assert a_var == 1. * u.degree ** 2
+    a_ptp = a.ptp()
+    assert type(a_ptp) is Angle
+    assert a_ptp == 2. * u.degree
+    a_max = a.max()
+    assert type(a_max) is Angle
+    assert a_max == 2. * u.degree
+    a_min = a.min()
+    assert type(a_min) is Angle
+    assert a_min == 0. * u.degree
+
+
 def test_angle_convert():
     """
     Test unit conversion of Angle objects

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -646,9 +646,6 @@ class FunctionQuantity(Quantity):
 
     # Override functions that are supported but do not use _wrap_function
     # in Quantity.
-    def mean(self, axis=None, dtype=None, out=None):
-        return self._wrap_function(np.mean, axis, dtype, out=out)
-
     def max(self, axis=None, out=None, keepdims=False):
         return self._wrap_function(np.max, axis, out=out, keepdims=keepdims)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1502,6 +1502,16 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         return self._wrap_function(np.trace, offset, axis1, axis2, dtype,
                                    out=out)
 
+    def var(self, axis=None, dtype=None, out=None, ddof=0):
+        return self._wrap_function(np.var, axis, dtype,
+                                   out=out, ddof=ddof, unit=self.unit**2)
+
+    def std(self, axis=None, dtype=None, out=None, ddof=0):
+        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof)
+
+    def mean(self, axis=None, dtype=None, out=None):
+        return self._wrap_function(np.mean, axis, dtype, out=out)
+
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)
 


### PR DESCRIPTION
It turned out that var and std in particular did not work on Angle;
mean is reverted mostly because it is also fairly involved python
code, not just a reduction.

fixes #8368