### PR TITLE
To add comments to clarify WCS examples - Part 2

### DIFF
--- a/docs/wcs/examples/programmatic.py
+++ b/docs/wcs/examples/programmatic.py
@@ -20,7 +20,10 @@ w.wcs.ctype = ["RA---AIR", "DEC--AIR"]
 w.wcs.set_pv([(2, 1, 45.0)])
 
 # Some pixel coordinates of interest.
-pixcrd = numpy.array([[0, 0], [24, 38], [45, 98]], numpy.float_)
+# Note the pixel coordinates are in pairs of [X, Y].
+# FITS WCS usually uses [1, 1] as the origin, as it hails from the Fortran tradition, unlike in Python/Numpy
+# where the origin is [0, 0]. 
+pixcrd = numpy.array([[1, 1], [24, 38], [45, 98]], numpy.float_)
 
 # Convert pixel coordinates to world coordinates
 world = w.wcs_pix2world(pixcrd, 1)

--- a/docs/wcs/examples/programmatic.py
+++ b/docs/wcs/examples/programmatic.py
@@ -23,7 +23,7 @@ w.wcs.set_pv([(2, 1, 45.0)])
 # Note the pixel coordinates are in pairs of [X, Y].
 # FITS WCS usually uses [1, 1] as the origin, as it hails from the Fortran tradition, unlike in Python/Numpy
 # where the origin is [0, 0]. 
-pixcrd = numpy.array([[1, 1], [24, 38], [45, 98]], dtype=float_)
+pixcrd = numpy.array([[1, 1], [24, 38], [45, 98]], dtype=float)
 
 # Convert pixel coordinates to world coordinates
 world = w.wcs_pix2world(pixcrd, 1)

--- a/docs/wcs/examples/programmatic.py
+++ b/docs/wcs/examples/programmatic.py
@@ -23,7 +23,7 @@ w.wcs.set_pv([(2, 1, 45.0)])
 # Note the pixel coordinates are in pairs of [X, Y].
 # FITS WCS usually uses [1, 1] as the origin, as it hails from the Fortran tradition, unlike in Python/Numpy
 # where the origin is [0, 0]. 
-pixcrd = numpy.array([[1, 1], [24, 38], [45, 98]], numpy.float_)
+pixcrd = numpy.array([[1, 1], [24, 38], [45, 98]], dtype=float_)
 
 # Convert pixel coordinates to world coordinates
 world = w.wcs_pix2world(pixcrd, 1)


### PR DESCRIPTION
To follow up on Issue #3840, to adhere to the Fortran tradition instead and to clear some confusion with manipulating a FITS file arising from the definition of the `origin`.  Also added a comment regarding the implicit ordering of the pixel coordinate pair as [X, Y] instead of [Y, X].