### PR TITLE
Add pandas backend support for Table read/write

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ env:
         - PYTEST_VERSION=3.10
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
-        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
+        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,9 @@ astropy.io.registry
 
 - Implement ``Table`` reader and writer for ``ASDF``. [#8261]
 
+- Implement ``Table`` reader and writer methods to wrap ``pandas`` I/O methods
+  for CSV, Fixed width format, HTML, and JSON. [#8381]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
         PYTHON_ARCH: "64" # needs to be set for CMD_IN_ENV to succeed. If a mix
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
-        CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 jinja2 pyyaml matplotlib scikit-image pytz"
+        CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 html5lib jinja2 pyyaml matplotlib scikit-image pytz"
         PIP_DEPENDENCIES: "objgraph"
 
     matrix:

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -1,0 +1,75 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# This file connects the readers/writers to the astropy.table.Table class
+
+import functools
+
+from astropy.table import Table
+import astropy.io.registry as io_registry
+
+__all__ = ['PANDAS_FMTS']
+
+# By default pandas ``to_<fmt>`` methods want to write the index row, which
+# for ``Table.to_pandas()`` is going to be just the integer row number.
+# Normally astropy users don't expect that in their output table.
+# But JSON is different for some reason.
+PANDAS_FMTS = {'csv': {'read': {},
+                       'write': {'index': False}},
+               'fwf': {'read': {}},  # No writer
+               'html': {'read': {},
+                        'write': {'index': False}},
+               'json': {'read': {'orient': 'columns'},
+                        'write': {'orient': 'columns', 'index': True}}}
+PANDAS_PREFIX = 'pandas.'
+
+
+def _pandas_read(fmt, filespec, **kwargs):
+    """Provide io Table connector to read table using pandas.
+
+    """
+    try:
+        import pandas
+    except ImportError:
+        raise ImportError('pandas must be installed to use pandas table reader')
+
+    pandas_fmt = fmt[len(PANDAS_PREFIX):]  # chop the 'pandas.' in front
+    read_func = getattr(pandas, 'read_' + pandas_fmt)
+
+    # Get defaults and then override with user-supplied values
+    read_kwargs = PANDAS_FMTS[pandas_fmt]['read'].copy()
+    read_kwargs.update(kwargs)
+
+    df = read_func(filespec, **read_kwargs)
+
+    # Special case for HTML
+    if pandas_fmt == 'html':
+        df = df[0]
+
+    return Table.from_pandas(df)
+
+
+def _pandas_write(fmt, tbl, filespec, **kwargs):
+    """Provide io Table connector to write table using pandas.
+
+    """
+    pandas_fmt = fmt[len(PANDAS_PREFIX):]  # chop the 'pandas.' in front
+
+    # Get defaults and then override with user-supplied values
+    write_kwargs = PANDAS_FMTS[pandas_fmt]['write'].copy()
+    write_kwargs.update(kwargs)
+
+    df = tbl.to_pandas()
+    write_method = getattr(df, 'to_' + pandas_fmt)
+
+    return write_method(filespec, **write_kwargs)
+
+
+for pandas_fmt, defaults in PANDAS_FMTS.items():
+    fmt = PANDAS_PREFIX + pandas_fmt  # Full format specifier
+
+    if 'read' in defaults:
+        func = functools.partial(_pandas_read, fmt)
+        io_registry.register_reader(fmt, Table, func)
+
+    if 'write' in defaults:
+        func = functools.partial(_pandas_write, fmt)
+        io_registry.register_writer(fmt, Table, func)

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -15,7 +15,7 @@ __all__ = ['PANDAS_FMTS']
 PANDAS_FMTS = {'csv': {'read': {},
                        'write': {'index': False}},
                'fwf': {'read': {}},  # No writer
-               'html': {'read': {},
+               'html': {'read': {'flavor': 'bs4'},
                         'write': {'index': False}},
                'json': {'read': {'orient': 'columns'},
                         'write': {'orient': 'columns', 'index': True}}}

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -21,14 +21,18 @@ PANDAS_FMTS = {'csv': {'read': {},
 
 PANDAS_PREFIX = 'pandas.'
 
-# Copy the following from pandas.io.html
+# Imports for reading HTML
 _IMPORTS = False
 _HAS_BS4 = False
 _HAS_LXML = False
 _HAS_HTML5LIB = False
 
 
-def _importers():
+def import_html_libs():
+    """Try importing dependencies for reading HTML.
+
+    This is copied from pandas.io.html
+    """
     # import things we need
     # but make this done on a first use basis
 
@@ -79,7 +83,7 @@ def _pandas_read(fmt, filespec, **kwargs):
     # not specifically selected a flavor.  If things go wrong the pandas exception
     # with instruction to install a library will come up.
     if pandas_fmt == 'html' and 'flavor' not in kwargs:
-        _importers()
+        import_html_libs()
         if (not _HAS_LXML and _HAS_HTML5LIB and _HAS_BS4):
             read_kwargs['flavor'] = 'bs4'
 

--- a/astropy/io/misc/pandas/connect.py
+++ b/astropy/io/misc/pandas/connect.py
@@ -62,6 +62,7 @@ def import_html_libs():
 
     _IMPORTS = True
 
+
 def _pandas_read(fmt, filespec, **kwargs):
     """Provide io Table connector to read table using pandas.
 

--- a/astropy/io/misc/tests/test_pandas.py
+++ b/astropy/io/misc/tests/test_pandas.py
@@ -42,7 +42,7 @@ def test_read_fixed_width_format():
     """
     tbl = """\
     a   b   c
-    1  2.0  a 
+    1  2.0  a
     2  3.0  b"""
     buf = StringIO()
     buf.write(tbl)

--- a/astropy/io/misc/tests/test_pandas.py
+++ b/astropy/io/misc/tests/test_pandas.py
@@ -9,11 +9,17 @@ from astropy.io import ascii
 from astropy.table import Table, QTable
 from astropy import units as u
 from astropy.coordinates import SkyCoord
-from astropy.io.misc.pandas.connect import PANDAS_FMTS
+from astropy.io.misc.pandas import connect
 
+# Check dependencies
 pandas = pytest.importorskip("pandas")
 
-WRITE_FMTS = [fmt for fmt in PANDAS_FMTS if 'write' in PANDAS_FMTS[fmt]]
+connect.import_html_libs()
+HAS_HTML_DEPS = connect._HAS_LXML or (connect._HAS_BS4 and connect._HAS_HTML5LIB)
+
+
+WRITE_FMTS = [fmt for fmt in connect.PANDAS_FMTS
+              if 'write' in connect.PANDAS_FMTS[fmt]]
 
 
 @pytest.mark.parametrize('fmt', WRITE_FMTS)
@@ -24,6 +30,10 @@ def test_read_write_format(fmt):
     :param fmt: format name, e.g. csv, html, json
     :return:
     """
+    # Skip the reading tests
+    if fmt == 'html' and not HAS_HTML_DEPS:
+        pytest.skip('Missing lxml or bs4 + html5lib for HTML read/write test')
+
     pandas_fmt = 'pandas.' + fmt
     t = Table([[1, 2, 3], [1.0, 2.5, 5.0], ['a', 'b', 'c']])
     buf = StringIO()

--- a/astropy/io/misc/tests/test_pandas.py
+++ b/astropy/io/misc/tests/test_pandas.py
@@ -1,0 +1,80 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from io import StringIO
+
+import pytest
+import numpy as np
+
+from astropy.io import ascii
+from astropy.table import Table, QTable
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.io.misc.pandas.connect import PANDAS_FMTS
+
+pandas = pytest.importorskip("pandas")
+
+WRITE_FMTS = [fmt for fmt in PANDAS_FMTS if 'write' in PANDAS_FMTS[fmt]]
+
+
+@pytest.mark.parametrize('fmt', WRITE_FMTS)
+def test_read_write_format(fmt):
+    """
+    Test round-trip through pandas write/read for supported formats.
+
+    :param fmt: format name, e.g. csv, html, json
+    :return:
+    """
+    pandas_fmt = 'pandas.' + fmt
+    t = Table([[1, 2, 3], [1.0, 2.5, 5.0], ['a', 'b', 'c']])
+    buf = StringIO()
+    t.write(buf, format=pandas_fmt)
+
+    buf.seek(0)
+    t2 = Table.read(buf, format=pandas_fmt)
+
+    assert t.colnames == t2.colnames
+    assert np.all(t == t2)
+
+
+def test_read_fixed_width_format():
+    """Test reading with pandas read_fwf()
+
+    """
+    tbl = """\
+    a   b   c
+    1  2.0  a 
+    2  3.0  b"""
+    buf = StringIO()
+    buf.write(tbl)
+
+    t = Table.read(tbl, format='ascii', guess=False)
+
+    buf.seek(0)
+    t2 = Table.read(buf, format='pandas.fwf')
+
+    assert t.colnames == t2.colnames
+    assert np.all(t == t2)
+
+
+def test_write_with_mixins():
+    """Writing a table with mixins just drops them via to_pandas()
+
+    This also tests passing a kwarg to pandas read and write.
+    """
+    sc = SkyCoord([1, 2], [3, 4], unit='deg')
+    q = [5, 6] * u.m
+    qt = QTable([[1, 2], q, sc], names=['i', 'q', 'sc'])
+
+    buf = StringIO()
+    qt.write(buf, format='pandas.csv', sep=' ')
+    exp = ['i q sc.ra sc.dec',
+           '1 5.0 1.0 3.0',
+           '2 6.0 2.0 4.0']
+    assert buf.getvalue().splitlines() == exp
+
+    # Read it back
+    buf.seek(0)
+    qt2 = Table.read(buf, format='pandas.csv', sep=' ')
+    exp_t = ascii.read(exp)
+    assert qt2.colnames == exp_t.colnames
+    assert np.all(qt2 == exp_t)

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -60,3 +60,4 @@ with registry.delay_doc_updates(Table):
     from astropy.io.misc import connect
     from astropy.io.votable import connect
     from astropy.io.misc.asdf import connect
+    from astropy.io.misc.pandas import connect

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,6 +25,10 @@ Astropy also depends on other packages for optional features:
 - `BeautifulSoup <https://www.crummy.com/software/BeautifulSoup/>`_: To read
   :class:`~astropy.table.table.Table` objects from HTML files.
 
+- `html5lib <https://html5lib.readthedocs.io/en/stable/>`_: To read
+  :class:`~astropy.table.table.Table` objects from HTML files using the
+  `pandas <http://pandas.pydata.org/>`_ reader.
+
 - `bleach <https://bleach.readthedocs.io/>`_: Used to sanitize text when
   disabling HTML escaping in the :class:`~astropy.table.Table` HTML writer.
 
@@ -35,8 +39,10 @@ Astropy also depends on other packages for optional features:
 - `xmllint <http://www.xmlsoft.org/>`_: To validate VOTABLE XML files.
   This is a command line tool installed outside of Python.
 
-- `pandas <http://pandas.pydata.org/>`_: To read/write
+- `pandas <http://pandas.pydata.org/>`_: To convert
   :class:`~astropy.table.Table` objects from/to pandas DataFrame objects.
+  Version 0.14 or higher is required to use the :ref:`table_io_pandas`
+  I/O functions to read/write :class:`~astropy.table.Table` objects.
 
 - `bintrees <https://pypi.python.org/pypi/bintrees>`_ for faster ``FastRBT`` and
   ``FastBST`` indexing engines with ``Table``, although these will still be

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -89,7 +89,8 @@ Built-in table readers/writers
 
 The :class:`~astropy.table.Table` class has built-in support for various input
 and output formats including :ref:`table_io_ascii`,
--:ref:`table_io_fits`, :ref:`table_io_hdf5`, and :ref:`table_io_votable`.
+-:ref:`table_io_fits`, :ref:`table_io_hdf5`, :ref:`table_io_pandas`,
+and :ref:`table_io_votable`.
 
 A full list of the supported formats and corresponding classes
 is shown in the table below.
@@ -122,6 +123,10 @@ ascii.fixed_width_no_header    Yes          :class:`~astropy.io.ascii.FixedWidth
                   ascii.tab    Yes          :class:`~astropy.io.ascii.Tab`: Basic table with tab-separated values
                        fits    Yes    auto  :mod:`~astropy.io.fits`: Flexible Image Transport System file
                        hdf5    Yes    auto  HDF5_: Hierarchical Data Format binary file
+                 pandas.csv    Yes          Wrapper around ``pandas.read_csv()`` and ``pandas.to_csv()``
+                 pandas.fwf     No          Wrapper around ``pandas.read_fwf()`` (fixed width format)
+                pandas.html    Yes          Wrapper around ``pandas.read_html()`` and ``pandas.to_html()``
+                pandas.json    Yes          Wrapper around ``pandas.read_json()`` and ``pandas.to_json()``
                     votable    Yes    auto  :mod:`~astropy.io.votable`: Table format used by Virtual Observatory (VO) initiative
 ===========================  =====  ======  ============================================================================================
 
@@ -850,6 +855,42 @@ specify the deprecated ``compatibility_mode`` keyword::
 
 .. warning:: The ``compatibility_mode`` keyword will be removed in a future
    version of astropy so your code should be changed.
+
+.. _table_io_pandas:
+
+Pandas
+------
+
+.. _pandas: https://pandas.pydata.org/pandas-docs/stable/index.html
+
+Astropy `~astropy.table.Table` supports the ability to read or write tables
+using some of the `I/O methods <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html>`_
+available within pandas_.  This interface thus provides
+convenient wrappers to the following functions / methods:
+
+.. csv-table::
+    :header: "Format name", "Data Description", "Reader", "Writer"
+    :widths: 25, 25, 25, 25
+    :delim: ;
+
+    ``pandas.csv``;`CSV <https://en.wikipedia.org/wiki/Comma-separated_values>`__;`read_csv() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-read-csv-table>`_;`to_csv() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-store-in-csv>`_
+    ``pandas.json``;`JSON <https://www.json.org/>`__;`read_json() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-json-reader>`_;`to_json() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-json-writer>`_
+    ``pandas.html``;`HTML <https://en.wikipedia.org/wiki/HTML>`__;`read_html() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-read-html>`_;`to_html() <https://pandas.pydata.org/pandas-docs/stable/user_guide/io.html#io-html>`_
+    ``pandas.fwf``;Fixed Width;`read_fwf() <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_fwf.html#pandas.read_fwf>`_;
+
+**Notes**:
+
+- There is no fixed width writer in pandas_.
+- Reading HTML requires `BeautifulSoup4 <https://pypi.org/project/beautifulsoup4/>`_ and
+  `html5lib <https://pypi.org/project/html5lib/>`_ to be installed.
+
+When reading or writing a table, any keyword arguments apart from the ``format`` and file
+name are passed through to pandas, for instance:
+
+.. doctest-skip::
+
+  >>> t.write('data.csv', format='pandas.csv', sep=' ', header=False)
+  >>> t2 = Table.read('data.csv', format='pandas.csv', sep=' ', names=['a', 'b', 'c'])
 
 .. _table_io_jsviewer:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ asdf_extensions =
 
 [options.extras_require]
 test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+all = scipy; h5py; beautifulsoup4; html5lib; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
 docs = sphinx-astropy
 
 [build_sphinx]


### PR DESCRIPTION
This makes it easy to use pandas `read_*` functions or `DataFrame.to_*` methods to read/write tables via pandas I/O.  E.g. see #8379.  This is a relatively bare-bones start but it does the basics of round-tripping a simple table.  There are other more obscure pandas formats like `feather` or `parquet` that could be supported, but these all require additional packages so my initial plan is to just cover the common formats.

To do:
- [x] Changelog
- [x] Docs
- [x] HTML reader has a bs4 or lxml dependency, need to capture this in testing.

With #8255 the underlying pandas function/method docstrings should also show up.  @astrofrog - any chance of reviewing that?

Example:
```
In [2]: t = simple_table()

In [3]: t.write('junk.csv', format='pandas.csv')

In [4]: Table.read('junk.csv', format='pandas.csv')
Out[4]: 
<Table length=3>
  a      b     c  
int64 float64 str1
----- ------- ----
    1     1.0    c
    2     2.0    d
    3     3.0    e
```
