### PR TITLE
Linkcheck feature request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,9 @@ jobs:
             LC_CTYPE: C
             LC_ALL: C
             LANG: C
+      - run:
+          name: Link Check
+          command: venv/bin/python setup.py build_docs -b linkcheck
 
       - store_artifacts:
           path: docs/_build/html
@@ -113,7 +116,6 @@ jobs:
       - run:
           name: "Built documentation is available at:"
           command: DOCS_URL="${CIRCLE_BUILD_URL}/artifacts/${CIRCLE_NODE_INDEX}/${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/docs/_build/html/index.html"; echo $DOCS_URL
-
 
 workflows:
   version: 2

--- a/astropy/stats/info_theory.py
+++ b/astropy/stats/info_theory.py
@@ -391,11 +391,9 @@ def akaike_info_criterion_lsq(ssr, n_params, n_samples):
 
     References
     ----------
-    .. [1] Akaike Information Criteria
-       <http://avesbiodiv.mncn.csic.es/estadistica/ejemploaic.pdf>
-    .. [2] Hu, S. Akaike Information Criterion.
+    .. [1] Hu, S. Akaike Information Criterion.
        <http://www4.ncsu.edu/~shu3/Presentation/AIC.pdf>
-    .. [3] Origin Lab. Comparing Two Fitting Functions.
+    .. [2] Origin Lab. Comparing Two Fitting Functions.
        <http://www.originlab.com/doc/Origin-Help/PostFit-CompareFitFunc>
     """
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -131,7 +131,7 @@ class LatexInline(Latex):
     Attempts to follow the `IAU Style Manual
     <https://www.iau.org/static/publications/stylemanual1989.pdf>`_ and the
     `ApJ and AJ style guide
-    <http://journals.aas.org/authors/manuscript.html>`_.
+    <https://journals.aas.org/manuscript-preparation/>`_.
     """
     name = 'latex_inline'
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -191,9 +191,8 @@ class DataInfo:
     called ``info`` so that the DataInfo() object can be stored in the
     ``instance`` using the ``info`` key.  Because owner_cls.x is a descriptor,
     Python doesn't use __dict__['x'] normally, and the descriptor can safely
-    store stuff there.  Thanks to http://nbviewer.ipython.org/urls/
-    gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb for
-    this trick that works for non-hashable classes.
+    store stuff there.  Thanks to http://nbviewer.ipython.org/urls/gist.github.com/ChrisBeaumont/5758381/raw/descriptor_writeup.ipynb
+    for this trick that works for non-hashable classes.
 
     Parameters
     ----------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,7 +226,9 @@ except ImportError:
                  'gallery will not be built.  You will probably see '
                  'additional warnings about undefined references due '
                  'to this.')
-
+# -- Options for linkcheck output -------------------------------------------
+linkcheck_retry = 2
+linkcheck_timeout = 10
 linkcheck_anchors = False
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -226,10 +226,14 @@ except ImportError:
                  'gallery will not be built.  You will probably see '
                  'additional warnings about undefined references due '
                  'to this.')
+
+
 # -- Options for linkcheck output -------------------------------------------
-linkcheck_retry = 2
-linkcheck_timeout = 10
+linkcheck_retry = 5
+linkcheck_ignore = ['https://journals.aas.org/manuscript-preparation/']
+linkcheck_timeout = 180
 linkcheck_anchors = False
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/docs/development/docrules.rst
+++ b/docs/development/docrules.rst
@@ -556,9 +556,9 @@ Conclusion
 ==========
 
 `An example <https://github.com/numpy/numpy/blob/master/doc/example.py>`_ of the
-format shown here is available.  Refer to `How to Build API/Reference
-Documentation
-<https://github.com/numpy/numpy/blob/master/doc/HOWTO_BUILD_DOCS.rst.txt>`_
+format shown here is available.
+Refer to How to Build API/Reference
+Documentation :ref:`astropy-doc-building`
 on how to use Sphinx_ to build the manual.
 
 

--- a/docs/development/scripts.rst
+++ b/docs/development/scripts.rst
@@ -19,7 +19,7 @@ Command-line options can be parsed however desired, but the :mod:`argparse`
 module is recommended when possible, due to its simpler and more flexible
 interface relative to the older :mod:`optparse`.
 
-.. _"entry points": https://setuptools.readthedocs.iosetuptools.html#automatic-script-creation
+.. _"entry points": https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation
 
 Example
 =======

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -745,7 +745,7 @@ You can find the names of the available Docker images on the `Docker Hub
 Writing image tests
 -------------------
 
-The `README.rst <https://github.com/astropy/pytest-mpl/blob/master/README.rst>`__
+The `README.rst <https://github.com/matplotlib/pytest-mpl/blob/master/README.rst>`__
 for the plugin contains information on writing tests with this plugin. The only
 key addition compared to those instructions is that you should set
 ``baseline_dir``::

--- a/docs/development/workflow/virtual_pythons.rst
+++ b/docs/development/workflow/virtual_pythons.rst
@@ -190,6 +190,6 @@ which the ``ENV`` is located; both also provide commands to make that a bit easi
 
 .. _documentation for virtualenvwrapper: http://virtualenvwrapper.readthedocs.io/en/latest/install.html
 .. _virtualenvwrapper command documentation: http://virtualenvwrapper.readthedocs.io/en/latest/command_ref.html
-.. _documentation for the conda command: https://conda.io/docs/using/index.html
-.. _blog post announcing anaconda environments: https://www.anaconda.com/blog/developer-blog/conda-data-science/
+.. _documentation for the conda command: https://docs.conda.io/projects/conda/en/latest/commands.html
+.. _blog post announcing anaconda environments: https://www.anaconda.com/category/developer-blog/
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -407,6 +407,8 @@ install sphinx-astropy with conda, graphviz will automatically get installed,
 but if you use pip, you will need to install Graphviz separately as it isn't
 a Python package.
 
+.. _astropy-doc-building:
+
 Building
 ^^^^^^^^
 

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -30,7 +30,7 @@ Although PyFITS is written mostly in Python, it includes an optional module
 written in C that's required to read/write compressed image data.  However,
 the rest of PyFITS functions without this extension module.
 
-.. _PyFITS: http://www.stsci.edu/institute/software_hardware/pyfits
+.. _PyFITS: https://github.com/spacetelescope/pyfits
 .. _Python: https://www.python.org/
 .. _FITS: https://fits.gsfc.nasa.gov/
 .. _Numpy: http://www.numpy.org/

--- a/docs/io/fits/appendix/history.rst
+++ b/docs/io/fits/appendix/history.rst
@@ -954,8 +954,7 @@ API Changes
 New Features
 ------------
 
-- Added support for the proposed "FITS" extension HDU type.  See
-  http://listmgr.cv.nrao.edu/pipermail/fitsbits/2002-April/001094.html.  FITS
+- Added support for the proposed "FITS" extension HDU type. FITS
   HDUs contain an entire FITS file embedded in their data section.  ``FitsHDU``
   objects work like other HDU types in PyFITS.  Their ``.data`` attribute
   returns the raw data array.  However, they have a special ``.hdulist``
@@ -3239,4 +3238,4 @@ Things not yet supported but are part of future development:
 - Support for tables with TNULL values. This awaits an enhancement to numarray
   to support mask arrays (planned).  (At least a couple of months off).
 
-.. _PyFITS: http://www.stsci.edu/institute/software_hardware/pyfits
+.. _PyFITS: https://github.com/spacetelescope/pyfits

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -747,7 +747,7 @@ By default, ``serialize_method`` for Time columns is equal to
      In the FITS standard, the reference position for a time coordinate is a scalar
      expressed via keywords. However, vectorized reference position or location can
      be supported by the `Green Bank Keyword Convention
-     <https://fits.gsfc.nasa.gov/registry/greenbank.html/>`_ which is a Registered FITS
+     <https://fits.gsfc.nasa.gov/registry/greenbank.html>`_ which is a Registered FITS
      Convention. In Astropy Time, location can be an array which is broadcastable to the
      Time values.
 

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -283,7 +283,7 @@ NumPy structured array
 The structured array is the standard mechanism in `numpy` for storing
 heterogeneous table data.  Most scientific I/O packages that read table
 files (e.g.  `PyFITS
-<http://www.stsci.edu/institute/software_hardware/pyfits>`_, `vo.table
+<https://github.com/spacetelescope/pyfits>`_, `vo.table
 <http://stsdas.stsci.edu/astrolib/vo/html/intro_table.html>`_, `asciitable
 <http://cxc.harvard.edu/contrib/asciitable/>`_) will return the table in an
 object that is based on the structured array.  A structured array can be

--- a/docs/table/indexing.rst
+++ b/docs/table/indexing.rst
@@ -278,9 +278,7 @@ specified to use a particular indexing engine. The available engines are
 
 Note that FastRBT and FastBST depend on the bintrees dependency; without this
 dependency, both classes default to `~astropy.table.BST`. The SCEngine depends
-on the sortedcontainers dependency. For a comparison of
-engine performance, see `this IPython notebook
-<http://nbviewer.jupyter.org/github/grantjenks/astropy-notebooks/blob/master/table/indexing-profiling.ipynb>`_. Probably
+on the sortedcontainers dependency. Probably
 the most important takeaway is that `~astropy.table.SortedArray` (the default
 engine) is usually best, although `~astropy.table.SCEngine` may be more
 appropriate for an index created on an empty column since adding new values is quicker.

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -28,9 +28,9 @@ on masked arrays
    convention of ignoring masked (invalid) values.  This differs from
    the behavior of the floating point ``NaN``, for which the sum of an
    array including one or more ``NaN's`` will result in ``NaN``.
-   See `<http://www.numpy.org/NA-overview.html>`_ for a very
-   interesting discussion of different strategies for handling
-   missing data in the context of `numpy`.
+
+   See `<https://www.numpy.org/neps/>`_ for information on NumPy
+   Enhancement Proposals 24, 25, and 26.
 
 Table creation
 ===============

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -157,7 +157,7 @@ following formats:
     <https://www.iau.org/static/publications/stylemanual1989.pdf>`__
     recommendations for unit presentation, using negative powers instead of
     fractions, as required by some journals (e.g., `Apj and AJ
-    <http://journals.aas.org/authors/manuscript.html#_Toc2.2>`_.)
+    <https://journals.aas.org/manuscript-preparation/>`_.)
     Best suited for unit representation inline with text::
 
       >>> fluxunit.to_string('latex_inline')  # doctest: +SKIP

--- a/docs/visualization/wcsaxes/slicing_datacubes.rst
+++ b/docs/visualization/wcsaxes/slicing_datacubes.rst
@@ -14,7 +14,7 @@ Like the example introduced in :ref:`initialization`, we will read in the
 data using `astropy.io.fits
 <http://docs.astropy.org/en/stable/io/fits/index.html>`_ and parse the WCS
 information. The original FITS file can be downloaded from `here
-<http://astropy.github.io/wcsaxes-datasets/L1448_13CO.fits>`_.
+<https://astropy.stsci.edu/data/l1448/l1448_13co.fits>`_.
 
 .. plot::
    :context: reset

--- a/docs/whatsnew/0.2.rst
+++ b/docs/whatsnew/0.2.rst
@@ -4,6 +4,5 @@
 What's New in Astropy 0.2
 *************************
 
-See this page in the `Astropy v0.2 documentation`__.
+See this page in the ``Astropy v0.2 documentation``.
 
-__ http://docs.astropy.org/en/v0.2.5/whatsnew/0.2.html

--- a/docs/whatsnew/0.3.rst
+++ b/docs/whatsnew/0.3.rst
@@ -4,6 +4,5 @@
 What's New in Astropy 0.3?
 **************************
 
-See this page in the `Astropy v0.3 documentation`__.
+See this page in the ``Astropy v0.3 documentation``.
 
-__ http://docs.astropy.org/en/v0.3.2/whatsnew/0.3.html


### PR DESCRIPTION
I am submitting a pull request for Issue #8254 

Over the past week or so, I've looked into CircleCI and Sphinx. I had never touched them before, and I had a bit of trouble understanding how the Sphinx documents were actually generated. I see where the circleCI html-docs job creates the docker using the circleci/python:3.6 and I see how the build_docs command is run by calling setup.py, which then uses the setup.cfg file, but I get lost in how setup.py and setup.cfg interact.  I don't understand the error for why the html-docs job fails
![snap of circleci html-docs job failure](https://user-images.githubusercontent.com/28075025/51875662-d5df5b80-2333-11e9-96cc-ad95f3043fd3.PNG)
