### PR TITLE
Fix elliptic analytical solution for comoving distance.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ astropy.cosmology
 
 - Fix elliptic analytical solution for comoving distance. Only
   relevant for non-flat cosmologies without radiation and ``Om0`` >
-  ``Ode0``.
+  ``Ode0``. [#8391]
 
 astropy.extern
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,10 @@ astropy.coordinates
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
+- Fix elliptic analytical solution for comoving distance. Only
+  relevant for non-flat cosmologies without radiation and ``Om0`` >
+  ``Ode0``.
+
 astropy.extern
 ^^^^^^^^^^^^^^
 

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1789,12 +1789,12 @@ class LambdaCDM(FLRW):
 
             phi_z1 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z1)
             phi_z2 = phi_z(self._Om0, self._Ok0, kappa, y1, A, z2)
-        # Get lower-right 0<b<2 solution in Om, Ol plane.
+        # Get lower-right 0<b<2 solution in Om0, Ode0 plane.
         # Fot the upper-left 0<b<2 solution the Big Bang didn't happen.
-        elif (0 < b) and (b < 2) and self._Om0 > self.Ol0:
-            def phi_z(Om0, Ok0, kappa, y1, A, z):
+        elif (0 < b) and (b < 2) and self._Om0 > self._Ode0:
+            def phi_z(Om0, Ok0, y1, y2, z):
                 return np.arcsin(np.sqrt((y1 - y2) /
-                                         (1 + z) * Om0 / abs(Ok0) + y1))
+                                         ((1. + z) * Om0 / abs(Ok0) + y1)))
 
             yb = cos(acos(1 - b) / 3)
             yc = sqrt(3) * sin(acos(1 - b) / 3)

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1794,7 +1794,7 @@ class LambdaCDM(FLRW):
         elif (0 < b) and (b < 2) and self._Om0 > self._Ode0:
             def phi_z(Om0, Ok0, y1, y2, z):
                 return np.arcsin(np.sqrt((y1 - y2) /
-                                         ((1. + z) * Om0 / abs(Ok0) + y1)))
+                                         ((1 + z) * Om0 / abs(Ok0) + y1)))
 
             yb = cos(acos(1 - b) / 3)
             yc = sqrt(3) * sin(acos(1 - b) / 3)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1624,6 +1624,7 @@ def test_z_at_value_roundtrip():
         assert allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
                         rtol=2e-8)
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_elliptic_comoving_distance_z1z2():
     """Regression test for #8388."""
     cosmo = core.LambdaCDM(70., 2.3, 0.05, Tcmb0=0)

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1630,3 +1630,5 @@ def test_elliptic_comoving_distance_z1z2():
     z = 0.2
     assert allclose(cosmo.comoving_distance(z),
                     cosmo._integral_comoving_distance_z1z2(0., z))
+    assert allclose(cosmo._elliptic_comoving_distance_z1z2(0., z),
+                    cosmo._integral_comoving_distance_z1z2(0., z))

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1623,3 +1623,10 @@ def test_z_at_value_roundtrip():
         fval = func(z)
         assert allclose(z, funcs.z_at_value(func, fval, zmax=1.5),
                         rtol=2e-8)
+
+def test_elliptic_comoving_distance_z1z2():
+    """Regression test for #8388."""
+    cosmo = core.LambdaCDM(70., 2.3, 0.05, Tcmb0=0)
+    z = 0.2
+    assert allclose(cosmo.comoving_distance(z),
+                    cosmo._integral_comoving_distance_z1z2(0., z))


### PR DESCRIPTION
Fix elliptic analytical solution for comoving distance, see also #8388 .

```python
from astropy.cosmology import LambdaCDM
H0, Om0, Ode0 = 70., 2.3, 0.05
cosmo = LambdaCDM(H0, Om0, Ode0, Tcmb0=0)
cosmo.comoving_distance(0.2)
```

Before:

```shell
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/astropy/cosmology/core.py", line 1208, in comoving_distance
    return self._comoving_distance_z1z2(0, z)
  File "/usr/lib/python3/dist-packages/astropy/cosmology/core.py", line 1794, in _elliptic_comoving_distance_z1z2
    elif (0 < b) and (b < 2) and self._Om0 > self.Ol0:
AttributeError: 'LambdaCDM' object has no attribute 'Ol0'
```

After:
```shell
<Quantity 711.40661805 Mpc>
```

Details of the changes:

* astropy/cosmology/core.py (LambdaCDM._elliptic_comoving_distance_z1z2):
  The analytic branch ``0<b<2`` had two issues:
  - ``self.Ol0`` (not defined) -> ``self._Ode0``.
  - Wrong signature and missing parenthesis at the denominator of the
    internal function phi_z().

* astropy/cosmology/tests/test_cosmology.py
  (test_elliptic_comoving_distance_z1z2): Add regression test.

* CHANGES.rst: Add change log.

This bug is only relevant for non-flat cosmologies without radiation and ``Om0`` > ``Ode0``.