### PR TITLE
Fix default quantize method in CompImageHDU docstring

### DIFF
--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -439,7 +439,7 @@ class CompImageHDU(BinTableHDU):
 
         quantize_method : int, optional
             Floating point quantization dithering method; can be either
-            ``NO_DITHER`` (-1), ``SUBTRACTIVE_DITHER_1`` (1; default), or
+            ``NO_DITHER`` (-1; default), ``SUBTRACTIVE_DITHER_1`` (1), or
             ``SUBTRACTIVE_DITHER_2`` (2); see note below
 
         dither_seed : int, optional


### PR DESCRIPTION
Ref #8392. The default quantize_method was wrong.