### PR TITLE
Added instructions for uploading releases to Zenodo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,6 +267,8 @@ Other Changes and Additions
 
 - Update bundled expat to 2.2.6. [#8343]
 
+- Added instructions for uploading releases to Zenodo. [#8395]
+
 Installation
 ^^^^^^^^^^^^
 

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -283,6 +283,22 @@ packages that use the full bugfix/maintenance branch approach.)
    in the ``ci-helpers`` repository once the ``conda`` packages became
    available.
 
+#. Upload the release to Zenodo. This has to be done manually since the
+   Zenodo/GitHub integration relies on making releases on GitHub, which we
+   don't do. So for the Astropy core package, log in to
+   Zenodo using the Astropy team credentials, then go to the `existing
+   record <https://zenodo.org/record/1461593>`_. Click on **New version** - note
+   that it's important to do this rather than upload the release as a completely
+   new record. You should now see a pre-filled deposit form with the details from
+   the previous release. Start off by removing the existing file under the
+   **Files** section, then click on **Choose Files** and select the ``tar.gz``
+   release file for the core package release you are uploading, and click
+   **Start upload**. Before you publish this, there are a few fields to update
+   in the form: the **Publication date** should be set to the date the tar
+   file was uploaded to PyPI, the **Title** should be updated to include the
+   new version number, and the **Version** should be updated to include the
+   version number (with no ``v`` prefix). Once you are happy with the changes,
+   click **Save**, then **Publish**.
 
 .. _release-procedure-beta-rc:
 


### PR DESCRIPTION
This should now be done as part of the release process.

@bsipocz, if you fancy trying it out for 3.1 and 3.1.1 let me know and I can give you the credentials.

@adrn - you might also like to review this since you worked on https://github.com/astropy/astropy.github.com/pull/297