### PR TITLE
Add Lomb-Scargle model inspection methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Added model inspection methods (``model_parameters()``, ``design_matrix()``,
+  and ``offset()``) to ``astropy.stats.LombScargle`` class [#8397].
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/lombscargle/core.py
+++ b/astropy/stats/lombscargle/core.py
@@ -376,7 +376,7 @@ class LombScargle:
 
     def offset(self):
         """Return the offset of the model
-        
+
         The offset of the model is the (weighted) mean of the y values.
         Note that if self.center_data is False, the offset is 0 by definition.
 
@@ -409,7 +409,7 @@ class LombScargle:
         .. math::
 
             y(t; f, \vec{\theta}) = \theta_0 + \sum_{n=1}^{\tt nterms} [\theta_{2n-1}\sin(2\pi n f t) + \theta_{2n}\cos(2\pi n f t)]
- 
+
         where :math:`\vec{\theta}` is the array of parameters returned by this function.
 
         Parameters

--- a/astropy/stats/lombscargle/implementations/main.py
+++ b/astropy/stats/lombscargle/implementations/main.py
@@ -7,8 +7,6 @@ statement for the various implementations available in this submodule
 
 __all__ = ['lombscargle', 'available_methods']
 
-import warnings
-
 import numpy as np
 
 from .slow_impl import lombscargle_slow

--- a/astropy/stats/lombscargle/implementations/utils.py
+++ b/astropy/stats/lombscargle/implementations/utils.py
@@ -1,5 +1,3 @@
-
-import warnings
 from math import factorial
 import numpy as np
 

--- a/astropy/stats/lombscargle/tests/test_lombscargle.py
+++ b/astropy/stats/lombscargle/tests/test_lombscargle.py
@@ -418,7 +418,4 @@ def test_model_parameters(data, nterms, fit_mean, center_data,
 
     assert len(params) == int(fit_mean) + 2 * nterms
 
-    print(offset)
-    print(design)
-    print(params)
     assert_quantity_allclose(offset + design.dot(params), model)

--- a/astropy/stats/lombscargle/tests/test_lombscargle.py
+++ b/astropy/stats/lombscargle/tests/test_lombscargle.py
@@ -66,7 +66,7 @@ def test_autofrequency(data, minimum_frequency, maximum_frequency,
 @pytest.mark.parametrize('normalization', NORMALIZATIONS)
 def test_all_methods(data, method, center_data, fit_mean,
                      errors, with_units, normalization):
-    if method == 'scipy' and (fit_mean or with_errors):
+    if method == 'scipy' and (fit_mean or errors != 'none'):
         return
 
     t, y, dy = data

--- a/docs/stats/lombscargle.rst
+++ b/docs/stats/lombscargle.rst
@@ -243,7 +243,8 @@ This best-fit sinusoid can be computed using the :func:`~astropy.stats.LombScarg
 
 >>> best_frequency = frequency[np.argmax(power)]
 >>> t_fit = np.linspace(0, 1)
->>> y_fit = LombScargle(t, y, dy).model(t_fit, best_frequency)
+>>> ls = LombScargle(t, y, dy)
+>>> y_fit = ls.model(t_fit, best_frequency)
 
 We can then phase the data and plot the Lomb-Scargle model fit:
 
@@ -275,6 +276,30 @@ We can then phase the data and plot the Lomb-Scargle model fit:
     ax.set(xlabel='phase',
            ylabel='magnitude',
            title='phased data at frequency={0:.2f}'.format(best_frequency))
+
+The best-fit model parameters can be computed with the :func:`~astropy.stats.LombScargle.model_parameters`
+method of the :class:`~astropy.stats.LombScargle` object at a given frequency:
+
+>>> theta = ls.model_parameters(best_frequency)
+>>> theta.round(2)
+array([-0.02,  1.05,  0.07])
+
+These parameters :math:`\vec{\theta}` are fit using the following model:
+
+.. math::
+
+    y(t; f, \vec{\theta}) = \theta_0 + \sum_{n=1}^{\tt nterms} [\theta_{2n-1}\sin(2\pi n f t) + \theta_{2n}\cos(2\pi n f t)]
+
+The model can be constructed from these parameters by computing the associated
+:func:`~astropy.stats.LombScargle.offset`, which accounts for pre-centering of data
+(i.e. the ``center_data`` argument), and
+:func:`~astropy.stats.LombScargle.design_matrix`, which computes the sine and cosine
+terms for you:
+
+>>> offset = ls.offset()
+>>> design_matrix = ls.design_matrix(best_frequency, t_fit)
+>>> np.allclose(y_fit, offset + design_matrix.dot(theta))
+True
 
 Additional Arguments
 --------------------


### PR DESCRIPTION
The ``LombScargle`` methods currently lack easy access to the maximum likelihood model parameters. This PR adds model inspection methods to the ``LombScargle`` class, adds a comprehensive set of unit tests for these, and adds a section to the lomb-scargle documentation outlining how to understand these methods.

Edit: the motivation for this change was [this StackOverflow answer](https://stackoverflow.com/a/54523102/2937831), which made me realize that this functionality was missing.