### PR TITLE
Make table meta do shallow copy by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,14 @@ astropy.table
   corresponding pandas date or time delta types.  The ``DataFrame``
   index is now handled in the conversion methods. [#8247]
 
+- Improved Table performance by reducing unnecessary calls to copy and deepcopy,
+  especially as related to the table and column ``meta`` attributes.  Changed the
+  behavior when slicing a table (either in rows or with a list of column names)
+  so now the sliced output gets a light (key-only) copy of ``meta`` instead of a
+  deepcopy.  Changed the ``Table.meta`` class-level descriptor so that assigning
+  directly to ``meta``, e.g. ``tbl.meta = new_meta`` no longer does a deepcopy
+  and instead just directly assigns the ``new_meta`` object reference. [#8404]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -169,6 +177,12 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Changed the behavior when slicing a table (either in rows or with a list of column
+  names) so now the sliced output gets a light (key-only) copy of ``meta`` instead of
+  a deepcopy.  Changed the ``Table.meta`` class-level descriptor so that assigning
+  directly to ``meta``, e.g. ``tbl.meta = new_meta`` no longer does a deepcopy
+  and instead just directly assigns the ``new_meta`` object reference. [#8404]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,7 +88,9 @@ astropy.table
   so now the sliced output gets a light (key-only) copy of ``meta`` instead of a
   deepcopy.  Changed the ``Table.meta`` class-level descriptor so that assigning
   directly to ``meta``, e.g. ``tbl.meta = new_meta`` no longer does a deepcopy
-  and instead just directly assigns the ``new_meta`` object reference. [#8404]
+  and instead just directly assigns the ``new_meta`` object reference.  Changed
+  Table initialization so that input ``meta`` is copied only if ``copy=True``.
+  [#8404]
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -182,7 +184,9 @@ astropy.table
   names) so now the sliced output gets a light (key-only) copy of ``meta`` instead of
   a deepcopy.  Changed the ``Table.meta`` class-level descriptor so that assigning
   directly to ``meta``, e.g. ``tbl.meta = new_meta`` no longer does a deepcopy
-  and instead just directly assigns the ``new_meta`` object reference. [#8404]
+  and instead just directly assigns the ``new_meta`` object reference. Changed
+  Table initialization so that input ``meta`` is copied only if ``copy=True``.
+  [#8404]
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -267,6 +271,10 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fixed a bug when initializing from an existing ``Table``.  In this case the
+  input ``meta`` argument was being ignored.  Now the input ``meta``, if
+  supplied, will be used as the ``meta`` for the new ``Table``. [#8404]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -457,7 +457,7 @@ class Table:
         return self.as_array().mask
 
     def filled(self, fill_value=None):
-        """Return self, with masked values filled.
+        """Return copy of self, with masked values filled.
 
         If input ``fill_value`` supplied then that value is used for all
         masked entries in the table.  Otherwise the individual

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1894,14 +1894,15 @@ class Test__Astropy_Table__():
         st = self.SimpleTable()
         dtypes = [np.int32, np.float32, np.float16]
         names = ['a', 'b', 'c']
-        t = table.Table(st, dtype=dtypes, names=names, meta=OrderedDict([('c', 3)]))
+        meta = OrderedDict([('c', 3)])
+        t = table.Table(st, dtype=dtypes, names=names, meta=meta)
         assert t.colnames == names
         assert all(col.dtype.type is dtype
                    for col, dtype in zip(t.columns.values(), dtypes))
 
-        # The supplied meta is ignored.  This is consistent with current
-        # behavior when initializing from an existing astropy Table.
-        assert t.meta == st.meta
+        # The supplied meta is overrides the existing meta.  Changed in astropy 3.2.
+        assert t.meta != st.meta
+        assert t.meta == meta
 
     def test_kwargs_exception(self):
         """If extra kwargs provided but without initializing with a table-like

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1967,6 +1967,17 @@ def test_table_meta_copy_with_meta_arg():
     assert t2.meta is not meta2
     assert t2.meta != t.meta  # Change behavior in #8404
 
+    # Table init with copy=True and empty dict meta gets that empty dict
+    t2 = table.Table(t, copy=True, meta={})
+    assert t2.meta == {}
+
+    # Table init with copy=True and kwarg meta=None gets the original table dict.
+    # This is a somewhat ambiguous case because it could be interpreted as the
+    # user wanting NO meta set on the output.  This could be implemented by inspecting
+    # call args.
+    t2 = table.Table(t, copy=True, meta=None)
+    assert t2.meta == t.meta
+
     # Test initializing empty table with meta with copy=False
     t = table.Table(meta=meta, copy=False)
     assert t.meta is meta


### PR DESCRIPTION
This stemmed from real-world problems using a Table that has significant content stored in `meta`.  Currently any time the table is sliced or copied (even with copy=False) then the `meta` is deep-copied.

This PR makes the default be to do shallow copying for slices and when copying with `copy=False`.  The original design was to be conservative here, but I think that slicing and copying (copy=False) are well-understood to result in linkage between the original and secondary object.

Locally this passed all existing table tests (though indicating a fail in current test coverage).

To do:
- [x] Get feedback on whether anyone has concerns
- [x] Tests
- [x] Quick performance evaluation for the case of a "heavy" meta object.

**Performance benefit**

Even without heavy meta, this improves slicing performance noticeably:
- Factor of 2 faster for slicing a column.
- 20 to 25% faster for slicing a table (depending on number of columns).

For tables with very large meta, the improvement can be arbitrary.  A common case is a FITS file from an observatory that has a lot of keywords.

cc: @mhvk 
