### PR TITLE
MNT: Deprecate composition of model classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Composition of model classes is deprecated and will be removed in 4.0.
+  Composition of model instances remain unaffected. [#8234, #8408]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Fix #8234

I am trying to do this in the laziest way I can think of; hopefully no significant performance hit. Suggestions welcome.