### PR TITLE
TST: Display skimage version and fix cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CRON_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
@@ -153,11 +154,13 @@ matrix:
         # We check numpy-dev also in a job that only runs from cron, so that
         # we can spot issues sooner. We do not use remote data here, since
         # that gives too many false positives due to URL timeouts.
+        # We also install all dependencies via pip here so we pick up the latest
+        # releases.
         - os: linux
           stage: Cron tests
           env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$ASDF_PIP_DEP
+               CONDA_DEPENDENCIES=''
+               PIP_DEPENDENCIES=$CRON_PIP_DEP
 
     allow_failures:
       - os: linux

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -54,3 +54,4 @@ def pytest_unconfigure(config):
 
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
+PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'


### PR DESCRIPTION
I don't understand why cron job is still plagued by `_validate_length` issue even after `scikit-image` 0.14.2 is already released on Jan 18, 2019. https://travis-ci.org/astropy/astropy/jobs/491580363 does not tell me which `scikit-image` version it is picking up. So displaying its version would be beneficial for debugging.

I don't think this needs to be backported? But if you think the extra info would be helpful for 2.x or 3.1.x CI, feel free to remilestone.