### PR TITLE
Fixed has_celestial and wcs_to_celestial_frame when celestial axes were correlated with other axes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1856,8 +1856,9 @@ astropy.vo
 astropy.wcs
 ^^^^^^^^^^^
 
-- Fix bug that caused ``WCS.has_celestial`` and other functionality depending on
-  it to fail in the presence of correlated celestial and other axes. [#8420]
+- Fix bug that caused ``WCS.has_celestial``, ``wcs_to_celestial_frame``, and
+  other functionality depending on it to fail in the presence of correlated
+  celestial and other axes. [#8420]
 
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1856,6 +1856,9 @@ astropy.vo
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fix bug that caused ``WCS.has_celestial`` and other functionality depending on
+  it to fail in the presence of correlated celestial and other axes. [#8420]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -524,6 +524,16 @@ def test_has_celestial(ctype, cel):
     assert mywcs.has_celestial == cel
 
 
+def test_has_celestial_correlated():
+    # Regression test for astropy/astropy#8416 - has_celestial failed when
+    # celestial axes were correlated with other axes.
+    mywcs = WCS(naxis=3)
+    mywcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+    mywcs.wcs.cd = np.ones((3, 3))
+    mywcs.wcs.set()
+    assert mywcs.has_celestial
+
+
 @pytest.mark.parametrize(('cdelt', 'pc', 'cd'),
                          ((np.array([0.1, 0.2]), np.eye(2), np.eye(2)),
                           (np.array([1, 1]), np.diag([0.1, 0.2]), np.eye(2)),

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -316,6 +316,22 @@ def test_wcs_to_celestial_frame():
     assert isinstance(frame, Galactic)
 
 
+def test_wcs_to_celestial_frame_correlated():
+
+    # Regression test for a bug that caused wcs_to_celestial_frame to fail when
+    # the celestial axes were correlated with other axes.
+
+    # Import astropy.coordinates here to avoid circular imports
+    from astropy.coordinates.builtin_frames import ICRS
+
+    mywcs = WCS(naxis=3)
+    mywcs.wcs.ctype = 'RA---TAN', 'DEC--TAN', 'FREQ'
+    mywcs.wcs.cd = np.ones((3, 3))
+    mywcs.wcs.set()
+    frame = wcs_to_celestial_frame(mywcs)
+    assert isinstance(frame, ICRS)
+
+
 def test_wcs_to_celestial_frame_extend():
 
     mywcs = WCS(naxis=2)

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -50,9 +50,6 @@ def _wcs_to_celestial_frame_builtin(wcs):
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
     from astropy.time import Time
 
-    # Keep only the celestial part of the axes
-    wcs = wcs.sub([WCSSUB_LONGITUDE, WCSSUB_LATITUDE])
-
     if wcs.wcs.lng == -1 or wcs.wcs.lat == -1:
         return None
 
@@ -63,8 +60,8 @@ def _wcs_to_celestial_frame_builtin(wcs):
     else:
         equinox = wcs.wcs.equinox
 
-    xcoord = wcs.wcs.ctype[0][:4]
-    ycoord = wcs.wcs.ctype[1][:4]
+    xcoord = wcs.wcs.ctype[wcs.wcs.lng][:4]
+    ycoord = wcs.wcs.ctype[wcs.wcs.lat][:4]
 
     # Apply logic from FITS standard to determine the default radesys
     if radesys == '' and xcoord == 'RA--' and ycoord == 'DEC-':

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3052,10 +3052,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
     @property
     def has_celestial(self):
-        try:
-            return self.celestial.naxis == 2
-        except InconsistentAxisTypesError:
-            return False
+        return self.wcs.lng >= 0 and self.wcs.lat >= 0
 
     @property
     def has_distortion(self):

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -3052,7 +3052,10 @@ reduce these to 2 dimensions using the naxis kwarg.
 
     @property
     def has_celestial(self):
-        return self.wcs.lng >= 0 and self.wcs.lat >= 0
+        try:
+            return self.wcs.lng >= 0 and self.wcs.lat >= 0
+        except InconsistentAxisTypesError:
+            return False
 
     @property
     def has_distortion(self):

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -288,8 +288,27 @@ def test_spectral_cube_nonaligned():
 
     wcs = WCS_SPECTRAL_CUBE_NONALIGNED
 
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
     assert_equal(wcs.axis_correlation_matrix, [[True, True, True], [False, True, True], [True, True, True]])
 
+    # NOTE: we check world_axis_object_components and world_axis_object_classes
+    # again here because in the past this failed when non-aligned axes were
+    # present, so this serves as a regression test.
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                  ('freq', 0, 'value'),
+                                                  ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
 
 ###############################################################################
 # The following example is from Rots et al (2015), Table 5. It represents a


### PR DESCRIPTION
This also affected the high-level WCS API.

Fixes https://github.com/astropy/astropy/issues/8416