### PR TITLE
Bugfix: Passing the final row of a table into Table should return a new table containing that row

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1845,6 +1845,9 @@ astropy.table
   ``dex``). Previously setting this was possible, but getting raised
   an error. [#8425]
 
+- Passing the final row of a table into ``Table`` now returns a new table
+  containing that row. [#8422]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1845,8 +1845,9 @@ astropy.table
   ``dex``). Previously setting this was possible, but getting raised
   an error. [#8425]
 
-- Passing the final row of a table into ``Table`` now returns a new table
-  containing that row. [#8422]
+- Fixes a bug where initializing a new ``Table`` from the final row of an
+  existing ``Table`` failed.  This happened when that row was generated using
+  the item index ``[-1]``. [#8422]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -37,6 +37,9 @@ class Row:
             raise IndexError('index {0} out of range for table with length {1}'
                              .format(index, len(table)))
 
+        # Ensure that the row index is positive [#8422]
+        self._index = self._index % n
+
     def __getitem__(self, item):
         if self._table._is_list_or_tuple_of_str(item):
             cols = [self._table[name] for name in item]

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2105,3 +2105,12 @@ def test_qtable_read_for_ipac_table_with_char_columns():
     t1.write(out, format="ascii.ipac")
     t2 = table.QTable.read(out.getvalue(), format="ascii.ipac", guess=False)
     assert t2["B"].unit is None
+
+
+def test_create_table_from_final_row():
+    """Regression test for issue #8422: passing the last row of a table into
+    Table should return a new table containing that row."""
+    t1 = table.Table([(1, 2)], names=['col'])
+    row = t1[-1]
+    t2 = table.Table(row)['col']
+    assert t2[0] == 2


### PR DESCRIPTION
The indexing on [line 338 of astropy/table/table.py](https://github.com/astropy/astropy/blob/26bc6acf1e39633b6883feec0dcbae373eead9e9/astropy/table/table.py#L338) fails for the last index when `data._index == -1`.

**Example**:
```python
t = Table([(1, 2)], names=['col'])
row = t[-1]
Table(row)
```
**Expected output**:
```
<Table length=1>
 col 
int64
-----
    2
```
**Actual output**:
```
<Table length=0>
 col 
int64
-----
```
This should have returned a `Table` of length 1 containing the input row. This PR changes indexing when `data._index == -1` and creates the `Table` with the correct input.