### PR TITLE
Optimize fits.Header parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+-  Optimize ``Header`` parsing. [#8428]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -606,8 +606,7 @@ class Card(_Verify):
             return False
 
         if len(args) == 1:
-            # FIXME: result is not used here!
-            self._check_if_rvkc_image(*args)
+            return self._check_if_rvkc_image(*args)
         elif len(args) == 2:
             keyword, value = args
             if not isinstance(keyword, str):

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -24,7 +24,7 @@ BLANK_CARD = ' ' * CARD_LENGTH
 KEYWORD_LENGTH = 8  # The max length for FITS-standard keywords
 
 VALUE_INDICATOR = '= '  # The standard FITS value indicator
-VALUE_INDICATOR_LEN = 2
+VALUE_INDICATOR_LEN = len(VALUE_INDICATOR)
 HIERARCH_VALUE_INDICATOR = '='  # HIERARCH cards may use a shortened indicator
 
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -93,7 +93,9 @@ class Header:
 
             .. versionadded:: 1.3
         """
-        self.clear()
+        self._cards = []
+        self._keyword_indices = collections.defaultdict(list)
+        self._rvkc_indices = collections.defaultdict(list)
 
         if isinstance(cards, Header):
             if copy:
@@ -951,13 +953,14 @@ class Header:
         instance has the same behavior.
         """
 
-        return self.__iter__()
+        for card in self._cards:
+            yield card.keyword
 
     def values(self):
         """Like :meth:`dict.values`."""
 
-        for _, v in self.items():
-            yield v
+        for card in self._cards:
+            yield card.value
 
     def pop(self, *args):
         """
@@ -1254,7 +1257,7 @@ class Header:
             temp._strip()
 
         if len(self):
-            first = self.cards[0].keyword
+            first = self._cards[0].keyword
         else:
             first = None
 
@@ -1517,10 +1520,10 @@ class Header:
                                  'renamed to each other.')
         elif not force and newkeyword in self:
             raise ValueError('Intended keyword {} already exists in header.'
-                            .format(newkeyword))
+                             .format(newkeyword))
 
         idx = self.index(oldkeyword)
-        card = self.cards[idx]
+        card = self._cards[idx]
         del self[idx]
         self.insert(idx, (newkeyword, card.value, card.comment))
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -387,7 +387,7 @@ class Header:
         if image:
             cards.append(Card.fromstring(''.join(image)))
 
-        return cls(cards)
+        return cls._fromcards(cards)
 
     @classmethod
     def fromfile(cls, fileobj, sep='', endcard=True, padding=True):
@@ -448,6 +448,19 @@ class Header:
         finally:
             if close_file:
                 fileobj.close()
+
+    @classmethod
+    def _fromcards(cls, cards):
+        header = cls()
+        for idx, card in enumerate(cards):
+            header._cards.append(card)
+            keyword = Card.normalize_keyword(card.keyword)
+            header._keyword_indices[keyword].append(idx)
+            if card.field_specifier is not None:
+                header._rvkc_indices[card.rawkeyword].append(idx)
+
+        header._modified = False
+        return header
 
     @classmethod
     def _from_blocks(cls, block_iter, is_binary, sep, endcard, padding):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -93,9 +93,7 @@ class Header:
 
             .. versionadded:: 1.3
         """
-        self._cards = []
-        self._keyword_indices = collections.defaultdict(list)
-        self._rvkc_indices = collections.defaultdict(list)
+        self.clear()
 
         if isinstance(cards, Header):
             if copy:


### PR DESCRIPTION
Related to #5593, this implements one of the idea mentioned there: adding a `fromcards` class method to speed up the creation of a Header instance from a list of cards. 
The other main change is some reorganization of keyword parsing (`_parse_keyword`), improving the most common case.
And probably a small bugfix with the return value from `_check_if_rvkc_image` which was not used. This was probably harmless, I guess the check was done again later.

The gain is significant (~12-13%) for files with many HDUs, below just computing the number of HDUs for a file with >300 extensions (the second command is using 100 extensions, the third only 10). 

Before:
```
~/lib/astropy/fits-header
❯ python -m timeit -n 1 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')))"
336
336
336
336
336
1 loop, best of 5: 6.16 sec per loop

~/lib/astropy/fits-header 34s
❯ python -m timeit -n 1 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')[:100]))"
100
100
100
100
100
1 loop, best of 5: 1.85 sec per loop

~/lib/astropy/fits-header
❯ python -m timeit -n 5 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')[:10]))"
10
...
10
5 loops, best of 5: 167 msec per loop
```
After:
```
~/lib/astropy/fits-header
❯ python -m timeit -n 1 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')))"
336
336
336
336
336
1 loop, best of 5: 5.38 sec per loop

~/lib/astropy/fits-header 28s
❯ python -m timeit -n 1 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')[:100]))"
100
100
100
100
100
1 loop, best of 5: 1.64 sec per loop

~/lib/astropy/fits-header
❯ python -m timeit -n 5 -r 5 -s "from astropy.io import fits" "print(len(fits.open('./scipost_white.fits')[:10]))"
10
...
10
5 loops, best of 5: 152 msec per loop
```
I'm also working on other ideas from  #5593, but this will take more time, so let's go with this for now!