### PR TITLE
Updating bundled pytest-openfiles to v0.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
 
         # Try MacOS X.
         - os: osx
-          env: SETUP_CMD='test --remote-data=astropy'
+          env: PYTHON_VERSION=3.7 SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
 
@@ -93,7 +93,7 @@ matrix:
           env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.11
                SETUP_CMD='test --open-files'
         - os: linux
-          env: PYTHON_VERSION=3.7 NUMPY_VERSION=1.14
+          env: NUMPY_VERSION=1.14
                SETUP_CMD='test --open-files'
         - os: linux
           env: NUMPY_VERSION=1.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,12 +111,7 @@ matrix:
                MATPLOTLIB_VERSION=1.5
                EVENT_TYPE='push pull_request cron'
 
-        # Pinning conda version temporarily to 4.3.21, as some anaconda
-        # packges build with 4.3.27 are faulty and we see this job failing,
-        # while locally there are no issues when the same version of
-        # packages are installed from pip.  Also make sure that series v2.0.x
-        # is compatible with pytest-astropy
-        # TODO: remove the pinning once the issue is solved upstream.
+        # Making sure that series v2.0.x is compatible with pytest-astropy
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
@@ -125,7 +120,6 @@ matrix:
                CFLAGS='-ftest-coverage -fprofile-arcs -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0 NUMPY_VERSION=1.13
                EVENT_TYPE='push pull_request cron'
-               CONDA_VERSION=4.3.21
 
         # Try pre-release version of Numpy without optional dependencies
         - os: linux

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,8 @@ Other Changes and Additions
 - Fixed ``make clean`` for the documentation on Windows to ensure it
   properly removes the ``api`` and ``generated`` directories. [#8346]
 
+- Updating bundled ``pytest-openfiles`` to v0.3.2. [#8434]
+
 
 
 2.0.11 (2018-12-31)

--- a/astropy/extern/plugins/pytest_openfiles/plugin.py
+++ b/astropy/extern/plugins/pytest_openfiles/plugin.py
@@ -6,6 +6,10 @@ closed.
 import imp
 import os
 
+from distutils.version import StrictVersion
+
+import pytest
+
 try:
     import importlib.machinery as importlib_machinery
 except ImportError:
@@ -56,9 +60,16 @@ def _get_open_file_list():
 
 
 def pytest_runtest_setup(item):
+
+    # Retain backwards compatibility with earlier versions of pytest
+    if StrictVersion(pytest.__version__) < StrictVersion("3.6"):
+        ignore = item.get_marker('openfiles_ignore')
+    else:
+        ignore = item.get_closest_marker('openfiles_ignore')
+
     # Store a list of the currently opened files so we can compare
     # against them when the test is done.
-    if item.config.getvalue('open_files') and not item.get_marker('openfiles_ignore'):
+    if item.config.getvalue('open_files') and not ignore:
         item.open_files = _get_open_file_list()
 
 


### PR DESCRIPTION
There are some openfile related failures on the LTS branch, hopefully this update will solve them.