### PR TITLE
Avoid ResourceWarning with io.fits tests

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1044,5 +1044,6 @@ class TestHDUListFunctions(FitsTestCase):
         hdulist = fits.HDUList([hdu])
 
         with open(self.temp('test.fits'), 'wb') as fout:
-            p = subprocess.Popen(["cat"], stdin=subprocess.PIPE, stdout=fout)
-            hdulist.writeto(p.stdin)
+            with subprocess.Popen(["cat"], stdin=subprocess.PIPE,
+                                  stdout=fout) as p:
+                hdulist.writeto(p.stdin)


### PR DESCRIPTION
The warning that was printed at the end of pytest run:

    sys:1: ResourceWarning: unclosed file <_io.BufferedWriter name=6>

comes from `test_write_hdulist_to_stream` and is because of the use of a subprocess with a pipe that was not closed. See https://mail.python.org/pipermail/python-dev/2016-August/145830.html

Ref #7913 (can be closed ?)
Probably doesn't need to be backported ? Using Popen as a context manager seems to be possible since Python 3.2