### PR TITLE
Expose ERFA exceptions through utils.exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1877,6 +1877,10 @@ Other Changes and Additions
 - Fixed ``make clean`` for the documentation on Windows to ensure it
   properly removes the ``api`` and ``generated`` directories. [#8346]
 
+- Making ``ErfaWarning`` and ``ErfaError`` available via
+  ``astropy.utils.exceptions``. [#8441]
+
+
 
 2.0.11 (2018-12-31)
 ===================

--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -32,7 +32,7 @@ import warnings
 
 import numpy
 
-from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.exceptions import ErfaError, ErfaWarning
 from astropy.utils.misc import check_broadcast
 
 from . import ufunc
@@ -48,17 +48,6 @@ __all__ = ['ErfaError', 'ErfaWarning',
 
 
 # <---------------------------------Error-handling---------------------------->
-
-class ErfaError(ValueError):
-    """
-    A class for errors triggered by ERFA functions (status codes < 0)
-    """
-
-
-class ErfaWarning(AstropyUserWarning):
-    """
-    A class for warnings triggered by ERFA functions (status codes > 0)
-    """
 
 
 STATUS_CODES = {}  # populated below before each function that returns an int

--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -32,6 +32,8 @@ import warnings
 
 import numpy
 
+# we import these exceptions from astropy locations instead of defining them
+# in this file because otherwise there are circular dependencies
 from astropy.utils.exceptions import ErfaError, ErfaWarning
 from astropy.utils.misc import check_broadcast
 

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -48,12 +48,22 @@ class AstropyBackwardsIncompatibleChangeWarning(AstropyWarning):
 class ErfaError(ValueError):
     """
     A class for errors triggered by ERFA functions (status codes < 0)
+
+    Note: this class should *not* be referenced by fully-qualified name, because
+    it may move to ERFA in a future version.  In a future such move it will
+    still be imported here as an alias, but the true namespace of the class may
+    change.
     """
 
 
 class ErfaWarning(AstropyUserWarning):
     """
     A class for warnings triggered by ERFA functions (status codes > 0)
+
+    Note: this class should *not* be referenced by fully-qualified name, because
+    it may move to ERFA in a future version.  In a future such move it will
+    still be imported here as an alias, but the true namespace of the class may
+    change.
     """
 
 

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module contains errors/exceptions and warnings of general use for
-astropy. Exceptions that are specific to a given subpackage should *not*
-be here, but rather in the particular subpackage.
+astropy. Exceptions that are specific to a given subpackage should *not* be
+here, but rather in the particular subpackage. Exception is the _erfa module
+as we rather have the users import those exceptions from here.
 """
 
 
@@ -42,6 +43,19 @@ class AstropyBackwardsIncompatibleChangeWarning(AstropyWarning):
     The suggested procedure is to issue this warning for the version in
     which the change occurs, and remove it for all following versions.
     """
+
+
+class ErfaError(ValueError):
+    """
+    A class for errors triggered by ERFA functions (status codes < 0)
+    """
+
+
+class ErfaWarning(AstropyUserWarning):
+    """
+    A class for warnings triggered by ERFA functions (status codes > 0)
+    """
+
 
 class _NoValue:
     """Special keyword value.


### PR DESCRIPTION
Couldn't do it the other way around (to import into utils.exceptions from _erfa) as it would have been a circular import then.

cc @eteq and @pllim 

Also I wasn't sure whether to add an API change changelog or it's OK under "Others".