### PR TITLE
To allow passing of constraints as tuples in setting model parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,7 @@ astropy.modeling
 
 - Significant reorganization of the documentation. [#9078]
 - Add Tabular1D.inverse [#9083]
+- Modeling now allows passing of constraints as ``tuples`` in the setting of model parameters. [#8442]
 
 astropy.nddata
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
Fixes #3028. 

To allow tuples as a convenience for setting contraints on model parameters in astropy. Since the required parameters already follows some predefined order, this change will be a logical extension to that. Am following up on PR astropy/astropy#4574. Will probably need some guidance in debugging. 