### PR TITLE
WIP: Azure pipelines configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,126 @@
+resources:
+  repositories:
+  - repository: OpenAstronomy
+    type: github
+    endpoint: astropy
+    name: OpenAstronomy/azure-pipelines-templates
+    ref: master
+
+jobs:
+
+- template: run-tox-env.yml@OpenAstronomy
+  parameters:
+
+    coverage: codecov
+
+    envs:
+
+    - linux: codestyle
+
+    # Linux job with minimal dependencies
+    - linux: py37-test
+
+    # Try MacOS X, with clang installed from conda
+    - macos: py37-test-alldeps-conda-clang
+      posargs: --remote-data=astropy
+
+    # Try all python versions and Numpy versions. Since we can assume that
+    # the Numpy developers have taken care of testing Numpy with different
+    # versions of Python, we can vary Python and Numpy versions at the same
+    # time.
+
+    # For the Numpy 1.16 build we use oldestdeps not numpy116 since we can check
+    # the oldest version of all dependencies where this is known. We also check
+    # that tests do not open and leave open any files. This has a performance
+    # impact on running the tests, hence why it is not enabled by default.
+    - linux: py36-test-oldestdeps
+      posargs: --open-files
+
+    # Now try with all optional dependencies.
+    - linux: py37-test-alldeps-clang
+      posargs: --durations=50
+
+    # Full tests with coverage checks.
+    - linux: py37-test-alldeps-numpy117-clocale-cov
+      posargs: --remote-data=astropy
+
+    # Try on Windows
+    - windows: py37-test-alldeps
+
+    # Do a PEP8/pyflakes test with flake8
+    - linux: codestyle
+
+    # Try developer version of Numpy with optional dependencies and also
+    # run all remote tests.
+    # TODO: determine how to do cron jobs
+    - linux: py37-test-devdeps
+      posargs: --remote-data=any
+
+    # We check numpy-dev also in a job that only runs from cron, so that
+    # we can spot issues sooner. We do not use remote data here, since
+    # that gives too many false positives due to URL timeouts.
+    # We also install all dependencies via pip here so we pick up the latest
+    # releases.
+    # TODO: determine how to do cron jobs
+    - linux: py37-test-devdeps
+
+    # Run documentation build
+    - linux: build_docs
+      # libraries:
+      #   apt:
+      #     - graphviz
+
+    # Run documentation link check in a cron job.
+    # TODO: determine how to do cron jobs
+    - linux: linkcheck
+      # libraries:
+      #   apt:
+      #     - graphviz
+
+    # Test against Python dev in cron job.
+    # TODO: determine how to run with Python dev
+
+    # Also regularly try the big-endian s390 architecture, in the
+    # process checking that installing dependencies with apt works.
+    # TODO: determine how to run with s390x architecture
+
+    # And with an arm64 processor, again with apt for convenience.
+    # TODO: determine how to run with arm64 architecture
+
+    # Regularly make sure that astropy can be used in application bundles
+    - linux: pyinstaller
+
+    # 32-bit Linux builds
+    - linux32: py36-test
+      posargs: n=4 --durations=50
+    - linux32: py37-test
+      posargs: n=4 --durations=50
+    - linux32: py38-test
+      posargs: n=4 --durations=50
+
+# Visualization tests with pixel-by-pixel image comparisons
+
+- job: VisualizationMatplotlib
+  displayName: Visualization tests
+  strategy:
+    matrix:
+      mpl212:
+        version: 2.1.2
+        image: astropy/image-tests-py35-mpl212:1.10
+      mpl222:
+        version: 2.2.2
+        image: astropy/image-tests-py35-mpl222:1.10
+      mpl300:
+        version: 3.0.2
+        image: astropy/image-tests-py35-mpl302:1.10
+      mpl310:
+        version: 3.1.1
+        image: astropy/image-tests-py35-mpl301:1.10
+  pool:
+    vmImage: Ubuntu 16.04
+  container: $[ variables['image'] ]
+  steps:
+  - script: pip install -e .[test] pytest-mpl
+    displayName: Installing dependencies
+  - script: pytest -P visualization --remote-data=astropy --open-files --mpl --mpl-results-path=$PWD/results -W ignore:np.asscalar
+    displayName: Running tests

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,9 @@ setenv =
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = --mpl
     !image: MPLFLAGS =
+    clang: CCOMPILER = clang
+    clocale: LC_CTYPE = C.ascii
+    clocale: LC_ALL = C
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -77,6 +80,10 @@ deps =
     devdeps: :NIGHTLY:numpy
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
+
+# The following dependencies will also be included if tox-conda is installed
+conda_deps =
+    clang: clang
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =


### PR DESCRIPTION
With rumors that Travis CI might be shutting down (or at least something major happening to it), I just thought I'd play around with Azure Pipelines to see what's possible there. I haven't activated Azure Pipelines for this repo yet because it require write-access to the repo code (not sure why and curious if anyone knows how to avoid it) but you can see it in action for my fork here:

https://dev.azure.com/thomasrobitaille/astropy-test/_build/results?buildId=154

**Pros:** We can basically run the equivalent of the Travis, CircleCI and AppVeyor jobs in one CI service (we can even run the CircleCI container jobs). It's very fast and allows 10 concurrent builds. It has conda support built-in if we really want, and configuration is simple enough that we don't need ci-helpers.

**Cons:** Setting up Azure Pipelines for a repo is a bit more annoying because it seems to insist on having write access to the repo (the code) and also wants to open a PR for the initial config file. Anyone know how to avoid this? Also, artifact support isn't as good as CircleCI because the files uploaded as artifacts aren't served, they auto-download, so one can't have an in-browser preview of the docs with Giles for instance. It can be solved with a Heroku app if we want, or we could simply keep CircleCI for the doc build. Another downside is that I can't find the option for cron jobs.

At the moment, the configuration isn't complete, this is just an example. Things that still need to be done:

* [ ] Discuss this first on astropy-dev to see if we actually want to do this
* [ ] Check that we replicate what we were doing on Travis currently, including the numpy dev build etc.
* [ ] Fix the builds that are failing/hanging
* [ ] Remove other CI services we no longer need.

If anyone is interested in helping with all this, let me know! 🙏 

EDIT: Close #9556 and other Travis related issues.