### PR TITLE
Minor: CASA should be --user installed

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -340,7 +340,7 @@ Now, quit CASA and re-open it, then type the following to install Astropy::
 
     CASA <2>: import subprocess, sys
 
-    CASA <3>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'astropy'])
+    CASA <3>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'astropy'])
 
 Then close CASA again and open it, and you should be able to import Astropy::
 


### PR DESCRIPTION
In the docs, the CASA installation instructions leave out `--user`, which should be specified when installing into CASA to avoid possible conflicts with the default packages.