### PR TITLE
Update MaskedColumn 'data_mask' serialization for performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,10 @@ astropy.io.ascii
 - IPAC tables now output data types of ``float`` instead of ``double``, or
   ``int`` instead of ``long``, based on the column ``dtype.itemsize``. [#8216]
 
+- Update handling of MaskedColumn columns when using the 'data_mask' serialization
+  method.  This can make writing ECSV significantly faster if the data do not
+  actually have any masked values. [#8447]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -480,6 +480,10 @@ def test_round_trip_masked_table_serialize_mask(tmpdir):
     t = simple_table(masked=True)  # int, float, and str cols with one masked element
     t['c'][0] = ''  # This would come back as masked for default "" NULL marker
 
+    # MaskedColumn with no masked elements. See table the MaskedColumnInfo class
+    # _represent_as_dict() method for info about we test a column with no masked elements.
+    t['d'] = [1, 2, 3]
+
     t.write(filename, serialize_method='data_mask')
 
     t2 = Table.read(filename)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -669,13 +669,17 @@ def test_round_trip_masked_table_serialize_mask(tmpdir, method):
 
     t = simple_table(masked=True)  # int, float, and str cols with one masked element
 
+    # MaskedColumn but no masked elements.  See table the MaskedColumnInfo class
+    # _represent_as_dict() method for info about we test a column with no masked elements.
+    t['d'] = [1, 2, 3]
+
     if method == 'set_cols':
         for col in t.itercols():
             col.info.serialize_method['fits'] = 'data_mask'
         t.write(filename)
     elif method == 'names':
         t.write(filename, serialize_method={'a': 'data_mask', 'b': 'data_mask',
-                                            'c': 'data_mask'})
+                                            'c': 'data_mask', 'd': 'data_mask'})
     elif method == 'class':
         t.write(filename, serialize_method='data_mask')
 


### PR DESCRIPTION
As discussed in #8443, the repr() for MaskedArray values is very slow, of order 10 times slower than the repr() of ndarray values.  This has a significant impact on overall speed of writing ECSV files for tables containing MaskColumns.

This fix works around that by not allowing the MaskedArray repr() to be called and instead serializing the `<masked_col>.data.data` values which are ndarray.  

The impact is that the column is not stored as an "ordinary" column but as one of the `serialized_columns`.  So the ECSV header will now look like:

```
# %ECSV 0.9
# ---
# datatype:
# - {name: col0, datatype: float64}
# meta: !!omap
# - __serialized_columns__:
#     col0:
#       __class__: astropy.table.column.MaskedColumn
#       data: !astropy.table.SerializedColumn {name: col0}
# schema: astropy-2.0
```
instead of the current:
```
# %ECSV 0.9
# ---
# datatype:
# - {name: col0, datatype: float64}
# schema: astropy-2.0
```

This impacts FITS as well in terms of the meta data that will be stored in the header.  There should be no change to the column names for the case of a column with no masked elements.

Fixes #8443 

