### PR TITLE
Make sure the QuantityAttribute default doesn't default to None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- ``QuantityAttribute`` no longer has a default value for ``default``.  The
+  previous value of None was misleading as it always was an error. [#8450] 
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -277,7 +277,7 @@ class QuantityAttribute(Attribute):
         If given, specifies the shape the attribute must be
     """
 
-    def __init__(self, default=None, secondary_attribute='', unit=None, shape=None):
+    def __init__(self, default, secondary_attribute='', unit=None, shape=None):
         self.unit = unit
         self.shape = shape
         default = self.convert_input(default)[0]

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -641,4 +641,4 @@ def test_regression_8276():
             MyFrame()
         finally:
             baseframe.frame_transform_graph = old_transform_graph
-    assert 'QuantityAttributes cannot be None' in str(excinfo.value)
+    assert "missing 1 required positional argument: 'default'" in str(excinfo.value)


### PR DESCRIPTION
This is detailed further in #8300 (especially https://github.com/astropy/astropy/pull/8300#discussion_r259564405).  To summarize, this is removing the ``default=None`` in the `QuantityAttribute` initializer, because `None` is actually an invalid choice for `QuantityAttribute`.  So it was a but confusing/misleading to have that default in the first place.  This PR is here separate from #8300 so that we'll have a period where there's an error message for anyone who sort of relied on the "old" behavior, but I'm milestoning this for 3.2 so we get it in reasonably soon (as @mhvk and @adrn wanted).

It's debatable if this is really an API change (that's where I put it in the changelog) since the default of `None` never really worked anyway (even before #8300), but that was the best thing I could come up with because it's not really a bug nor a new feature, either.