### PR TITLE
Fix import of assert_quantity_allclose in ASDF tags...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -321,6 +321,9 @@ astropy.io.ascii
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Fixed bug in ASDF tag that inadvertently introduced dependency on ``pytest``.
+  [#8456]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -6,9 +6,9 @@ import glob
 from asdf import tagged
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
+import astropy.units as u
 import astropy.coordinates
 from astropy.coordinates.baseframe import frame_transform_graph
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
 
@@ -99,8 +99,8 @@ class BaseCoordType:
     def assert_equal(cls, old, new):
         assert isinstance(new, type(old))
         if new.has_data:
-            assert_quantity_allclose(new.data.lon, old.data.lon)
-            assert_quantity_allclose(new.data.lat, old.data.lat)
+            assert u.allclose(new.data.lon, old.data.lon)
+            assert u.allclose(new.data.lat, old.data.lat)
 
 
 class CoordType(BaseCoordType, AstropyType):
@@ -160,5 +160,5 @@ class ICRSType10(AstropyType):
     def assert_equal(cls, old, new):
         assert isinstance(old, ICRS)
         assert isinstance(new, ICRS)
-        assert_quantity_allclose(new.ra, old.ra)
-        assert_quantity_allclose(new.dec, old.dec)
+        assert u.allclose(new.ra, old.ra)
+        assert u.allclose(new.dec, old.dec)

--- a/astropy/io/misc/asdf/tags/coordinates/representation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/representation.py
@@ -1,8 +1,8 @@
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
+import astropy.units as u
 import astropy.coordinates.representation
 from astropy.coordinates.representation import BaseRepresentationOrDifferential
-from astropy.tests.helper import assert_quantity_allclose
 
 from astropy.io.misc.asdf.types import AstropyType
 
@@ -43,4 +43,4 @@ class RepresentationType(AstropyType):
         for comp in new.components:
             nc = getattr(new, comp)
             oc = getattr(old, comp)
-            assert_quantity_allclose(nc, oc)
+            assert u.allclose(nc, oc)

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -9,7 +9,6 @@ from asdf import yamlutil
 from astropy import modeling
 from astropy import units as u
 from .basic import TransformType
-from astropy.tests.helper import assert_quantity_allclose
 
 __all__ = ['TabularType']
 
@@ -61,10 +60,10 @@ class TabularType(TransformType):
     @classmethod
     def assert_equal(cls, a, b):
         if isinstance(a.lookup_table, u.Quantity):
-            assert_quantity_allclose(a.lookup_table, b.lookup_table)
-            assert_quantity_allclose(a.points, b.points)
+            assert u.allclose(a.lookup_table, b.lookup_table)
+            assert u.allclose(a.points, b.points)
             for i in range(len(a.bounding_box)):
-                assert_quantity_allclose(a.bounding_box[i], b.bounding_box[i])
+                assert u.allclose(a.bounding_box[i], b.bounding_box[i])
         else:
             assert_array_equal(a.lookup_table, b.lookup_table)
             assert_array_equal(a.points, b.points)


### PR DESCRIPTION
This function is only necessary for testing-related methods, but it was being imported at the top level of a few ASDF-related modules, which introduced pytest as a runtime dependency.