### PR TITLE
Copy editing: top-level documentation pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,22 @@ Reporting Issues
 
 When opening an issue to report a problem, please try to provide a minimal code
 example that reproduces the issue along with details of the operating
-system and the Python, Numpy, and Astropy versions you are using.
+system and the Python, NumPy, and `astropy` versions you are using.
 
 Contributing Code
 -----------------
 
-So you're interested in contributing code to Astropy? Excellent!
+So you are interested in contributing code to the Astropy Project? Excellent!
 
 Most contributions to Astropy are done via pull requests from GitHub users'
-forks of the [astropy repository](https://github.com/astropy/astropy). If you're
-new to this style of development, you'll want to read over our
+forks of the [astropy repository](https://github.com/astropy/astropy). If you
+are new to this style of development, you will want to read over our
 [development workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html).
 
 You may also/instead be interested in contributing to an
 [astropy affiliated package](http://www.astropy.org/affiliated/).
 Affiliated packages are astronomy-related software packages that are not a part
-of the Astropy core package, but build on it for more specialized applications
+of the `astropy` core package, but build on it for more specialized applications
 and follow the Astropy guidelines for reuse, interoperability, and interfacing.
 Each affiliated package has its own developers/maintainers and its own specific
 guidelines for contributions, so be sure to read their docs.
@@ -30,37 +30,36 @@ Once you open a pull request (which should be opened against the ``master``
 branch, not against any of the other branches), please make sure to
 include the following:
 
-- **Code**: the code you're adding, which should follow
+- **Code**: the code you are adding, which should follow
   our [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html) as much as possible.
 
 - **Tests**: these are usually tests to ensure code that previously
-  failed now works (regression tests) or tests that cover as much as possible
-  of the new functionality to make sure it doesn't break in future, and also
-  returns consistent results on all platforms (since we run these tests on many
-  platforms/configurations). For more information about how to write tests, see
-  our [testing guidelines](http://docs.astropy.org/en/latest/development/testguide.html).
+  failed now works (regression tests), or tests that cover as much as possible
+  of the new functionality to make sure it does not break in the future and
+  also returns consistent results on all platforms (since we run these tests on
+  many platforms/configurations). For more information about how to write
+  tests, see our [testing guidelines](http://docs.astropy.org/en/latest/development/testguide.html).
 
-- **Documentation**: if you're adding new functionality, be sure to include a
+- **Documentation**: if you are adding new functionality, be sure to include a
   description in the main documentation (in ``docs/``). Again, we have some
-  detailed [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html)
-  to help you out.
+  detailed [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html) to help you out.
 
-- **Performance improvements**: if you're making changes that impact Astropy
+- **Performance improvements**: if you are making changes that impact `astropy`
   performance, consider adding a performance benchmark in the
   [astropy-benchmarks](https://github.com/astropy/astropy-benchmarks)
   repository. You can find out more about how to do this
   [in the README for that repository](https://github.com/astropy/astropy-benchmarks#contributing-a-benchmark).
 
-- **Changelog entry**: whether you're fixing a bug or adding new
+- **Changelog entry**: whether you are fixing a bug or adding new
   functionality, you should add an entry to the ``CHANGES.rst`` file that
-  includes the PR number. If you're opening a pull request you may not know
-  this yet, but you can add it once the pull request is open. If you're not
-  sure where to put the changelog entry, wait until a maintainer
+  includes the PR number. If you are opening a pull request you may not know
+  the PR number yet, but you can add it once the pull request is open. If you
+  are not sure where to put the changelog entry, wait until a maintainer
   has reviewed your PR and assigned it to a milestone.
 
-  You don't need to include a changelog entry for fixes to bugs introduced in
+  You do not need to include a changelog entry for fixes to bugs introduced in
   the developer version and therefore are not present in the stable releases. In
-  general you don't need to include a changelog entry for minor documentation
+  general you do not need to include a changelog entry for minor documentation
   or test updates. Only user-visible changes (new features/API changes, fixed
   issues) need to be mentioned. If in doubt, ask the core maintainer reviewing
   your changes.
@@ -97,8 +96,8 @@ Checklist for Contributed Code
 ------------------------------
 
 A pull request for a new feature will be reviewed to see if it meets the
-following requirements. For any pull request, an Astropy maintainer can help to
-make sure that the pull request meets the requirements for inclusion in the
+following requirements. For any pull request, an `astropy` maintainer can help
+to make sure that the pull request meets the requirements for inclusion in the
 package.
 
 **Scientific Quality** (when applicable)
@@ -108,15 +107,14 @@ package.
   * Has the code been tested against previously existing implementations?
 
 **Code Quality**
-  * Are the [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html)
-    followed?
+  * Are the [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html) followed?
   * Is the code compatible with Python >=3.5?
-  * Are there dependencies other than the Astropy core, the Python Standard
+  * Are there dependencies other than the `astropy` core, the Python Standard
     Library, and NumPy 1.10.0 or later?
     * Is the package importable even if the C-extensions are not built?
     * Are additional dependencies handled appropriately?
     * Do functions that require additional dependencies raise an `ImportError`
-        if they are not present?
+      if they are not present?
 
 **Testing**
   * Are the [testing guidelines](http://docs.astropy.org/en/latest/development/testguide.html) followed?
@@ -124,27 +122,28 @@ package.
   * Are there tests for any exceptions raised?
   * Are there tests for the expected performance?
   * Are the sources for the tests documented?
-  * Have tests that require an [optional dependency marked](http://docs.astropy.org/en/latest/development/testguide.html#tests-requiring-optional-dependencies) as such?
+  * Have tests that require an [optional dependency](http://docs.astropy.org/en/latest/development/testguide.html#tests-requiring-optional-dependencies)
+    been marked as such?
   * Does ``python setup.py test`` run without failures?
 
 **Documentation**
   * Are the [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html) followed?
-  * Is there a [docstring](http://docs.astropy.org/en/latest/development/docrules.html)
-    in the function describing:
+  * Is there a [docstring](http://docs.astropy.org/en/latest/development/docrules.html) in the function describing:
     * What the code does?
     * The format of the inputs of the function?
     * The format of the outputs of the function?
     * References to the original algorithms?
     * Any exceptions which are raised?
     * An example of running the code?
-  * Is there any information needed to be added to the docs to describe the function?
+  * Is there any information needed to be added to the docs to describe the   
+    function?
   * Does the documentation build without errors or warnings?
 
 **License**
-  * Is the Astropy license included at the top of the file?
+  * Is the `astropy` license included at the top of the file?
   * Are there any conflicts with this code and existing codes?
 
 **Astropy requirements**
   * Do all the Travis CI, AppVeyor, and CircleCI tests pass?
   * If applicable, has an entry been added into the changelog?
-  * Can you checkout the pull request and repeat the examples and tests?
+  * Can you check out the pull request and repeat the examples and tests?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ Contributing to Astropy
 Reporting Issues
 ----------------
 
-When opening an issue to report a problem, please try and provide a minimal code
-example that reproduces the issue, and also include details of the operating
-system, and the Python, Numpy, and Astropy versions you are using.
+When opening an issue to report a problem, please try to provide a minimal code
+example that reproduces the issue along with details of the operating
+system and the Python, Numpy, and Astropy versions you are using.
 
-Contributing code
+Contributing Code
 -----------------
 
 So you're interested in contributing code to Astropy? Excellent!
@@ -21,56 +21,56 @@ new to this style of development, you'll want to read over our
 You may also/instead be interested in contributing to an
 [astropy affiliated package](http://www.astropy.org/affiliated/).
 Affiliated packages are astronomy-related software packages that are not a part
-of the astropy core package, but build on it for more specialized applications
-and follow the astropy guidelines for reuse, interoperability, and interfacing.
+of the Astropy core package, but build on it for more specialized applications
+and follow the Astropy guidelines for reuse, interoperability, and interfacing.
 Each affiliated package has its own developers/maintainers and its own specific
 guidelines for contributions, so be sure to read their docs.
 
 Once you open a pull request (which should be opened against the ``master``
-branch, not against any of the other branches), please make sure that you
+branch, not against any of the other branches), please make sure to
 include the following:
 
-- **Code**: the code you are adding, which should follow as much as possible
-  our [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html).
+- **Code**: the code you're adding, which should follow
+  our [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html) as much as possible.
 
-- **Tests**: these are usually tests to ensure that code that previously
+- **Tests**: these are usually tests to ensure code that previously
   failed now works (regression tests) or tests that cover as much as possible
   of the new functionality to make sure it doesn't break in future, and also
   returns consistent results on all platforms (since we run these tests on many
   platforms/configurations). For more information about how to write tests, see
   our [testing guidelines](http://docs.astropy.org/en/latest/development/testguide.html).
 
-- **Documentation**: if you are adding new functionality, be sure to include a
+- **Documentation**: if you're adding new functionality, be sure to include a
   description in the main documentation (in ``docs/``). Again, we have some
   detailed [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html)
   to help you out.
 
-- **Performance improvements**: if you are making changes that impact Astropy
+- **Performance improvements**: if you're making changes that impact Astropy
   performance, consider adding a performance benchmark in the
   [astropy-benchmarks](https://github.com/astropy/astropy-benchmarks)
   repository. You can find out more about how to do this
   [in the README for that repository](https://github.com/astropy/astropy-benchmarks#contributing-a-benchmark).
 
-- **Changelog entry**: whether you are fixing a bug or adding new
+- **Changelog entry**: whether you're fixing a bug or adding new
   functionality, you should add an entry to the ``CHANGES.rst`` file that
-  includes the PR number (if you are opening a pull request you may not know
-  this yet, but you can add it once the pull request is open). If you're not
-  sure where to put the changelog entry, wait at least until a maintainer
+  includes the PR number. If you're opening a pull request you may not know
+  this yet, but you can add it once the pull request is open. If you're not
+  sure where to put the changelog entry, wait until a maintainer
   has reviewed your PR and assigned it to a milestone.
 
-  You do not need to include a changelog entry for fixes to bugs introduced in
+  You don't need to include a changelog entry for fixes to bugs introduced in
   the developer version and therefore are not present in the stable releases. In
-  general you do not need to include a changelog entry for minor documentation
-  or test updates.  Only user-visible changes (new features/API changes, fixed
-  issues) need to be mentioned.  If in doubt ask the core maintainer reviewing
+  general you don't need to include a changelog entry for minor documentation
+  or test updates. Only user-visible changes (new features/API changes, fixed
+  issues) need to be mentioned. If in doubt, ask the core maintainer reviewing
   your changes.
 
 Other Tips
 ----------
 
-- To prevent the automated tests from running you can add ``[ci skip]`` to your
+- To prevent the automated tests from running, you can add ``[ci skip]`` to your
   commit message. This is useful if your PR is a work in progress and you are
-  not yet ready for the tests to run.  For example:
+  not yet ready for the tests to run. For example:
 
       $ git commit -m "WIP widget [ci skip]"
 
@@ -82,12 +82,12 @@ Other Tips
 - To skip only the AppVeyor (Windows) CI builds you can use ``[skip appveyor]``,
   and to skip testing on Travis CI use ``[skip travis]``.
 
-- If your commit makes substantial changes to the documentation, but no code
-  changes, the you can use ``[docs only]``, that will skip all but the
+- If your commit makes substantial changes to the documentation but no code
+  changes, then you can use ``[docs only]``, which will skip all but the
   documentation building jobs on Travis.
 
 - When contributing trivial documentation fixes (i.e. fixes to typos, spelling,
-  grammar) that do not contain any special markup and are not associated with
+  grammar) that don't contain any special markup and are not associated with
   code changes, please include the string ``[docs only]`` in your commit
   message.
 
@@ -97,7 +97,7 @@ Checklist for Contributed Code
 ------------------------------
 
 A pull request for a new feature will be reviewed to see if it meets the
-following requirements.  For any pull request, an astropy maintainer can help to
+following requirements. For any pull request, an Astropy maintainer can help to
 make sure that the pull request meets the requirements for inclusion in the
 package.
 
@@ -115,7 +115,7 @@ package.
     Library, and NumPy 1.10.0 or later?
     * Is the package importable even if the C-extensions are not built?
     * Are additional dependencies handled appropriately?
-    * Do functions that require additional dependencies  raise an `ImportError`
+    * Do functions that require additional dependencies raise an `ImportError`
         if they are not present?
 
 **Testing**
@@ -125,7 +125,7 @@ package.
   * Are there tests for the expected performance?
   * Are the sources for the tests documented?
   * Have tests that require an [optional dependency marked](http://docs.astropy.org/en/latest/development/testguide.html#tests-requiring-optional-dependencies) as such?
-  * Does python setup.py test run without failures?
+  * Does ``python setup.py test`` run without failures?
 
 **Documentation**
   * Are the [documentation guidelines](http://docs.astropy.org/en/latest/development/docguide.html) followed?
@@ -141,7 +141,7 @@ package.
   * Does the documentation build without errors or warnings?
 
 **License**
-  * Is the astropy license included at the top of the file?
+  * Is the Astropy license included at the top of the file?
   * Are there any conflicts with this code and existing codes?
 
 **Astropy requirements**

--- a/README.rst
+++ b/README.rst
@@ -20,24 +20,25 @@ or  `docs/install.rst <docs/install.rst>`_ in this source distribution.
 Contributing Code, Documentation, or Feedback
 ---------------------------------------------
 
-The Astropy Project is made both by and for its users, so we welcome and encourage
-contributions of many kinds. Our goal is to keep this a positive, inclusive,
-successful, and growing community, by abiding with the
+The Astropy Project is made both by and for its users, so we welcome and
+encourage contributions of many kinds. Our goal is to keep this a positive,
+inclusive, successful, and growing community by abiding with the
 `Astropy Community Code of Conduct <http://www.astropy.org/about.html#codeofconduct>`_.
 
 More detailed information on contributing to the project or submitting feedback
-can be found on the `contributions <http://www.astropy.org/contribute.html>`_ page.
-A `summary of contribution guidelines <CONTRIBUTING.md>`_ can also be used as a quick
-reference when you're ready to start writing or validating code for submission.
+can be found on the `contributions <http://www.astropy.org/contribute.html>`_
+page. A `summary of contribution guidelines <CONTRIBUTING.md>`_ can also be
+used as a quick reference when you are ready to start writing or validating
+code for submission.
 
-Supporting the project
+Supporting the Project
 ----------------------
 
 |NumFOCUS| |Donate|
 
 The Astropy Project is sponsored by NumFOCUS, a 501(c)(3) nonprofit in the
 United States. You can donate to the project by using the link above, and this
-donation will support our mission to promote sustainable high-level code base
+donation will support our mission to promote sustainable, high-level code base
 for the astronomy community, open code development, educational materials, and
 reproducible scientific research.
 
@@ -47,10 +48,10 @@ License
 Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
-Notes for package managers
+Notes for Package Managers
 --------------------------
 
-For system packagers: Please install Astropy with the command::
+For system packagers: Please install `astropy` with the command::
 
     $ python setup.py --offline install
 

--- a/docs/importing_astropy.rst
+++ b/docs/importing_astropy.rst
@@ -1,16 +1,16 @@
-*********************************
-Importing astropy and subpackages
-*********************************
+**********************************
+Importing Astropy and sub-packages
+**********************************
 
-In order to encourage consistency amongst users in importing and using Astropy
+In order to encourage consistency among users in importing and using Astropy
 functionality, we have put together the following guidelines.
 
 Since most of the functionality in Astropy resides in sub-packages, importing
-astropy as::
+Astropy as::
 
     >>> import astropy
 
-is not very useful. Instead, it is best to import the desired sub-package
+is not very useful. Instead, it's best to import the desired sub-package
 with the syntax::
 
     >>> from astropy import subpackage  # doctest: +SKIP
@@ -22,7 +22,7 @@ For example, to access the FITS-related functionality, you can import
     >>> hdulist = fits.open('data.fits')  # doctest: +SKIP
 
 In specific cases, we have recommended shortcuts in the documentation for
-specific sub-packages, for example::
+specific sub-packages. For example::
 
     >>> from astropy import units as u
     >>> from astropy import coordinates as coord
@@ -38,26 +38,27 @@ imported::
     >>> from astropy.table import Table
     >>> from astropy.wcs import WCS
 
-Note that for clarity, and to avoid any issues, we recommend to **never**
-import any Astropy functionality using ``*``, for example::
+Note that for clarity, and to avoid any issues, we recommend **never**
+importing any Astropy functionality using ``*``, for example::
 
     >>> from astropy.io.fits import *  # NOT recommended
 
-Some components of Astropy started off as standalone packages (e.g. PyFITS, PyWCS),
-so in cases where Astropy needs to be used as a drop-in replacement, the following
-syntax is also acceptable::
+Some components of Astropy started off as standalone packages (e.g. PyFITS,
+PyWCS), so in cases where Astropy needs to be used as a drop-in replacement,
+the following syntax is also acceptable::
 
     >>> from astropy.io import fits as pyfits
 
-********************************
-Getting started with subpackages
-********************************
+*********************************
+Getting started with sub-packages
+*********************************
 
-Because different subpackages have very different functionality, each subpackage has its own
-getting started guide. These can be found by browsing the sections listed in the :ref:`user-docs`.
+Because different sub-packages have very different functionalities, each
+sub-package has its own getting started guide. These can be found by browsing
+the sections listed in the :ref:`user-docs`.
 
-You can also look at docstrings for a
-particular package or object, or access their documentation using the
+You can also look at docstrings for a particular package or object, or access
+their documentation using the
 `~astropy.utils.misc.find_api_page` function. For example, ::
 
     >>> from astropy import find_api_page

--- a/docs/importing_astropy.rst
+++ b/docs/importing_astropy.rst
@@ -1,6 +1,6 @@
-**********************************
-Importing `astropy` and sub-packages
-**********************************
+************************************
+Importing `astropy` and Sub-packages
+************************************
 
 In order to encourage consistency among users in importing and using Astropy
 functionality, we have put together the following guidelines.

--- a/docs/importing_astropy.rst
+++ b/docs/importing_astropy.rst
@@ -1,12 +1,12 @@
 **********************************
-Importing Astropy and sub-packages
+Importing `astropy` and sub-packages
 **********************************
 
 In order to encourage consistency among users in importing and using Astropy
 functionality, we have put together the following guidelines.
 
 Since most of the functionality in Astropy resides in sub-packages, importing
-Astropy as::
+`astropy` as::
 
     >>> import astropy
 
@@ -50,7 +50,7 @@ the following syntax is also acceptable::
     >>> from astropy.io import fits as pyfits
 
 *********************************
-Getting started with sub-packages
+Getting Started with Sub-packages
 *********************************
 
 Because different sub-packages have very different functionalities, each
@@ -58,8 +58,8 @@ sub-package has its own getting started guide. These can be found by browsing
 the sections listed in the :ref:`user-docs`.
 
 You can also look at docstrings for a particular package or object, or access
-their documentation using the
-`~astropy.utils.misc.find_api_page` function. For example, ::
+their documentation using the `~astropy.utils.misc.find_api_page` function. For
+example, ::
 
     >>> from astropy import find_api_page
     >>> from astropy.units import Quantity

--- a/docs/importing_astropy.rst
+++ b/docs/importing_astropy.rst
@@ -1,12 +1,12 @@
-************************************
-Importing `astropy` and Sub-packages
-************************************
+**************************************
+Importing ``astropy`` and Sub-packages
+**************************************
 
 In order to encourage consistency among users in importing and using Astropy
 functionality, we have put together the following guidelines.
 
 Since most of the functionality in Astropy resides in sub-packages, importing
-`astropy` as::
+``astropy`` as::
 
     >>> import astropy
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -183,7 +183,7 @@ Prerequisites
 -------------
 
 You will need a compiler suite and the development headers for Python and
-NumPy in order to build `astropy`.
+NumPy in order to build ``astropy``.
 
 If you are building the latest developer version rather than using a stable
 release, you will also need `Cython <http://cython.org/>`_ (v0.21 or later) and
@@ -195,7 +195,7 @@ Prerequisites for Linux
 -----------------------
 
 On Linux, using the package manager for your distribution will usually be the
-easiest route to making sure you have the prerequisites to build `astropy`. In
+easiest route to making sure you have the prerequisites to build ``astropy``. In
 order to build from source, you will need the Python development package for
 your Linux distribution.
 
@@ -240,9 +240,9 @@ using this command::
 
    git clone --recursive git://github.com/astropy/astropy.git
 
-If you wish to participate in the development of `astropy`, see
+If you wish to participate in the development of ``astropy``, see
 :ref:`developer-docs`. This document covers only the basics necessary to
-installing `astropy`.
+installing ``astropy``.
 
 Building and Installing
 -----------------------
@@ -339,13 +339,13 @@ installed. Start up CASA as normal, and then type::
 
     CASA <3>: easy_install.main(['--user', 'pip'])
 
-Now, quit CASA and re-open it, then type the following to install `astropy`::
+Now, quit CASA and re-open it, then type the following to install ``astropy``::
 
     CASA <2>: import subprocess, sys
 
     CASA <3>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'astropy'])
 
-Then close CASA again and open it, and you should be able to import `astropy`::
+Then close CASA again and open it, and you should be able to import ``astropy``::
 
     CASA <2>: import astropy
 
@@ -437,7 +437,7 @@ Alternatively, you can do::
     make html
 
 And the documentation will be generated in the same location, but using the
-*installed* version of `astropy`.
+*installed* version of ``astropy``.
 
 Reporting Issues/Requesting Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -476,7 +476,7 @@ More information on what the ``pytest-astropy`` package provides can be found
 in :ref:`testing-dependencies`.
 
 The most convenient way to test that your Astropy built correctly
-(without installing `astropy`) is to run this from the root of the source tree::
+(without installing ``astropy``) is to run this from the root of the source tree::
 
     python setup.py test
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,8 +98,8 @@ However, note that these packages require installation only if those particular
 features are needed. `astropy` will import even if these dependencies are not
 installed.
 
-Installing `astropy`
-====================
+Installing ``astropy``
+======================
 
 Using pip
 ---------
@@ -327,7 +327,7 @@ The C libraries currently bundled with `astropy` include:
 
 
 Installing `astropy` into CASA
--------------------------------
+---------------------------------
 
 If you want to be able to use `astropy` inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
@@ -464,8 +464,8 @@ can also open issues in the repositories for some of the dependencies:
 
 .. _sourcebuildtest:
 
-Testing a Source Code Build of Astropy
---------------------------------------
+Testing a Source Code Build of ``astropy``
+------------------------------------------
 
 Before running tests, it is necessary to make sure that Astropy's test
 dependencies are installed. This can be done with the following command::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Installation
 Requirements
 ============
 
-`astropy` has the following strict requirements:
+``astropy`` has the following strict requirements:
 
 - `Python <https://www.python.org/>`_ |minimum_python_version| or later
 
@@ -15,7 +15,7 @@ Requirements
 
 - `pytest`_ 3.1 or later
 
-`astropy` also depends on other packages for optional features:
+``astropy`` also depends on other packages for optional features:
 
 - `scipy`_: To power a variety of features in several modules.
 
@@ -95,7 +95,7 @@ And the following packages can optionally be used when testing:
   coordinates.
 
 However, note that these packages require installation only if those particular
-features are needed.``astropy``will import even if these dependencies are not
+features are needed. ``astropy`` will import even if these dependencies are not
 installed.
 
 Installing ``astropy``
@@ -109,7 +109,7 @@ Using pip
     Users of the Anaconda Python distribution should follow the instructions
     for :ref:`anaconda_install`.
 
-To install``astropy``with `pip <https://pip.pypa.io>`__, run::
+To install ``astropy`` with `pip <https://pip.pypa.io>`__, run::
 
     pip install astropy
 
@@ -118,7 +118,7 @@ can also do::
 
     pip install astropy --no-deps
 
-On the other hand, if you want to install``astropy``along with all of the
+On the other hand, if you want to install ``astropy`` along with all of the
 available optional dependencies, you can do::
 
     pip install astropy[all]
@@ -133,10 +133,10 @@ into your home directory. You can read more about how to do this in the `pip
 documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
 Alternatively, if you intend to do development on other software that uses
-`astropy`, such as an affiliated package, consider installing``astropy``into a
+``astropy``, such as an affiliated package, consider installing ``astropy`` into a
 :ref:`virtualenv<using-virtualenv>`.
 
-Do **not** install``astropy``or other third-party packages using ``sudo``
+Do **not** install ``astropy`` or other third-party packages using ``sudo``
 unless you are fully aware of the risks.
 
 .. _anaconda_install:
@@ -144,26 +144,26 @@ unless you are fully aware of the risks.
 Using Conda
 -----------
 
-`astropy` is installed by default with the `Anaconda Distribution
+``astropy`` is installed by default with the `Anaconda Distribution
 <https://www.anaconda.com/download/>`_. To update to the latest version run::
 
     conda update astropy
 
-There may be a delay of a day or two between when a new version of `astropy`
+There may be a delay of a day or two between when a new version of ``astropy``
 is released and when a package is available for Anaconda. You can check
 for the list of available versions with ``conda search astropy``.
 
 .. warning::
 
     Attempting to use `pip <https://pip.pypa.io>`__ to upgrade your installation
-    of``astropy``may result in a corrupted installation.
+    of ``astropy`` may result in a corrupted installation.
 
 .. _testing_installed_astropy:
 
-Testing an Installed `astropy`
-------------------------------
+Testing an Installed ``astropy``
+--------------------------------
 
-The easiest way to test if your installed version of``astropy``is running
+The easiest way to test if your installed version of ``astropy`` is running
 correctly is to use the :ref:`astropy.test()` function::
 
     import astropy
@@ -172,7 +172,7 @@ correctly is to use the :ref:`astropy.test()` function::
 The tests should run and print out any failures, which you can report at
 the `Astropy issue tracker <https://github.com/astropy/astropy/issues>`_.
 
-This way of running the tests may not work if you do it in the``astropy``source
+This way of running the tests may not work if you do it in the ``astropy`` source
 distribution. See :ref:`sourcebuildtest` for how to run the tests from the
 source code directory, or :ref:`running-tests` for more details.
 
@@ -229,13 +229,13 @@ Obtaining the Source Packages
 Source Packages
 ^^^^^^^^^^^^^^^
 
-The latest stable source package for``astropy``can be `downloaded here
+The latest stable source package for ``astropy`` can be `downloaded here
 <https://pypi.python.org/pypi/astropy>`_.
 
 Development Repository
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The latest development version of``astropy``can be cloned from GitHub
+The latest development version of ``astropy`` can be cloned from GitHub
 using this command::
 
    git clone --recursive git://github.com/astropy/astropy.git
@@ -247,15 +247,15 @@ installing `astropy`.
 Building and Installing
 -----------------------
 
-`astropy` uses the Python built-in `distutils framework
+``astropy`` uses the Python built-in `distutils framework
 <http://docs.python.org/install/index.html>`_ for building and
 installing, and requires the `setuptools`_ package.
 
-If NumPy is not already installed in your Python environment, the `astropy`
+If NumPy is not already installed in your Python environment, the ``astropy``
 setup process will try to download and install it before continuing to install
-`astropy`.
+``astropy``.
 
-To build and install``astropy``(from the root of the source tree)::
+To build and install ``astropy`` (from the root of the source tree)::
 
     pip install .
 
@@ -265,14 +265,14 @@ use::
 
     pip install -e .
 
-which installs``astropy``in develop/editable mode, which means that changes in
+which installs ``astropy`` in develop/editable mode, which means that changes in
 the code are immediately reflected in the installed version.
 
 Troubleshooting
 ---------------
 
 If you get an error mentioning that you do not have the correct permissions to
-install``astropy``into the default ``site-packages`` directory, you can try
+install ``astropy`` into the default ``site-packages`` directory, you can try
 installing with::
 
     pip install . --user
@@ -283,13 +283,13 @@ which will install into a default directory in your home directory.
 External C Libraries
 ^^^^^^^^^^^^^^^^^^^^
 
-The``astropy``source ships with the C source code of a number of
+The ``astropy`` source ships with the C source code of a number of
 libraries. By default, these internal copies are used to build
-`astropy`. However, if you wish to use the system-wide installation of
+``astropy``. However, if you wish to use the system-wide installation of
 one of those libraries, you can pass one or more of the
 ``--use-system-X`` flags to the ``setup.py build`` command.
 
-For example, to build``astropy``using the system `libexpat
+For example, to build ``astropy`` using the system `libexpat
 <http://www.libexpat.org/>`_, use::
 
     python setup.py build --use-system-expat
@@ -298,7 +298,7 @@ To build using all of the system libraries, use::
 
     python setup.py build --use-system-libraries
 
-To see which system libraries``astropy``knows how to build against, use::
+To see which system libraries ``astropy`` knows how to build against, use::
 
     python setup.py build --help
 
@@ -311,7 +311,7 @@ the system `libexpat <http://www.libexpat.org/>`_, add the following to the
     use_system_expat=1
 
 
-The C libraries currently bundled with``astropy``include:
+The C libraries currently bundled with ``astropy`` include:
 
 - `wcslib <http://www.atnf.csiro.au/people/mcalabre/WCS/>`_ see
   ``cextern/wcslib/README`` for the bundled version.
@@ -326,10 +326,10 @@ The C libraries currently bundled with``astropy``include:
   bundled version.
 
 
-Installing``astropy``into CASA
----------------------------------
+Installing ``astropy`` into CASA
+--------------------------------
 
-If you want to be able to use``astropy``inside `CASA
+If you want to be able to use ``astropy`` inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
 
 First, we need to make sure `pip <https://pip.pypa.io>`__ is
@@ -349,13 +349,13 @@ Then close CASA again and open it, and you should be able to import `astropy`::
 
     CASA <2>: import astropy
 
-Any``astropy``affiliated package can be installed the same way (e.g. the
+Any ``astropy`` affiliated package can be installed the same way (e.g. the
 `spectral-cube <http://spectral-cube.readthedocs.io/en/latest/>`_ or other
 packages that may be useful for radio astronomy).
 
 .. note:: The above instructions have not been tested on all systems.
    We know of a few examples that do work, but that is not a guarantee
-   that this will work on all systems. If you install``astropy``and begin to
+   that this will work on all systems. If you install ``astropy`` and begin to
    encounter issues with CASA, please look at the `known CASA issues
    <https://github.com/astropy/astropy/issues?q=+label%3ACASA-Installation+>`_
    and if you do not encounter your issue there, please post a new one.
@@ -375,7 +375,7 @@ Building Documentation
 Dependencies
 ^^^^^^^^^^^^
 
-Building the documentation requires the``astropy``source code and some
+Building the documentation requires the ``astropy`` source code and some
 additional packages, including those in :ref:`astropy-main-req`. The easiest
 way to install the extra dependencies for documentation is to install
 the `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ package,
@@ -394,7 +394,7 @@ dependencies, including:
 * `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
   the documentation
 * `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
-  the default 'bootstrap' theme used by``astropy``and a number of affiliated
+  the default 'bootstrap' theme used by ``astropy`` and a number of affiliated
   packages
 * `sphinx-automodapi <http://sphinx-automodapi.readthedocs.io>`_ - an extension
   that makes it easy to automatically generate API documentation
@@ -416,7 +416,7 @@ Building
 ^^^^^^^^
 
 There are two ways to build the Astropy documentation. The first way is to
-execute the command (from the``astropy``source directory)::
+execute the command (from the ``astropy`` source directory)::
 
     python setup.py build_docs
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -67,8 +67,8 @@ Astropy also depends on other packages for optional features:
   human-readable representation.
 
 - `bottleneck <https://pypi.org/project/Bottleneck/>`_: Improves the performance
-  of sigma-clipping and other functionality that may required computing statistics
-  on arrays with NaN values.
+  of sigma-clipping and other functionality that may require computing
+  statistics on arrays with NaN values.
 
 And the following packages can optionally be used when testing:
 
@@ -83,7 +83,7 @@ And the following packages can optionally be used when testing:
 
 - `objgraph <https://mg.pov.lt/objgraph/>`_: Used only in tests to test for reference leaks.
 
-- `IPython <https://ipython.org/>`__: Used for testing notebook interface of
+- `IPython <https://ipython.org/>`__: Used for testing the notebook interface of
   `~astropy.table.Table`.
 
 - `coverage <https://coverage.readthedocs.io/>`_: Used for code coverage
@@ -92,8 +92,9 @@ And the following packages can optionally be used when testing:
 - `skyfield <https://rhodesmill.org/skyfield/>`_: Used for testing Solar System
   coordinates.
 
-However, note that these only need to be installed if those particular features
-are needed. Astropy will import even if these dependencies are not installed.
+However, note that these packages require installation only if those particular
+features are needed. Astropy will import even if these dependencies are not
+installed.
 
 Installing Astropy
 ==================
@@ -106,7 +107,7 @@ Using pip
     Users of the Anaconda python distribution should follow the instructions
     for :ref:`anaconda_install`.
 
-To install Astropy with `pip <https://pip.pypa.io>`__, simply run::
+To install Astropy with `pip <https://pip.pypa.io>`__, run::
 
     pip install astropy
 
@@ -115,8 +116,8 @@ can also do::
 
     pip install astropy --no-deps
 
-On the other hand, if you want to install Astropy along with all the available
-optional depdendencies, you can do::
+On the other hand, if you want to install Astropy along with all of the
+available optional dependencies, you can do::
 
     pip install astropy[all]
 
@@ -124,9 +125,9 @@ Note that you will need a C compiler (e.g. ``gcc`` or ``clang``) to be installed
 (see `Building from source`_ below) for the installation to succeed.
 
 If you get a ``PermissionError`` this means that you do not have the required
-administrative access to install new packages to your Python installation.  In
+administrative access to install new packages to your Python installation. In
 this case you may consider using the ``--user`` option to install the package
-into your home directory.  You can read more about how to do this in the `pip
+into your home directory. You can read more about how to do this in the `pip
 documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
 Alternatively, if you intend to do development on other software that uses
@@ -160,7 +161,7 @@ for the list of available versions with ``conda search astropy``.
 Testing an installed Astropy
 ----------------------------
 
-The easiest way to test your installed version of astropy is running
+The easiest way to test if your installed version of Astropy is running
 correctly is to use the :ref:`astropy.test()` function::
 
     import astropy
@@ -169,8 +170,8 @@ correctly is to use the :ref:`astropy.test()` function::
 The tests should run and print out any failures, which you can report at
 the `Astropy issue tracker <https://github.com/astropy/astropy/issues>`_.
 
-This way of running the tests may not work if you do it in the astropy source
-distribution.  See :ref:`sourcebuildtest` for how to run the tests from the
+This way of running the tests may not work if you do it in the Astropy source
+distribution. See :ref:`sourcebuildtest` for how to run the tests from the
 source code directory, or :ref:`running-tests` for more details.
 
 Building from source
@@ -179,21 +180,21 @@ Building from source
 Prerequisites
 -------------
 
-You will need a compiler suite and the development headers for Python and
+You'll need a compiler suite and the development headers for Python and
 Numpy in order to build Astropy.
 
-If you are building the latest developer version rather than using a stable
+If you're building the latest developer version rather than using a stable
 release, you will also need `Cython <http://cython.org/>`_ (v0.21 or later) and
-`jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed (the
+`jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed. The
 released packages have the necessary C files packaged with them, and hence do
-not require Cython).
+not require Cython.
 
 Prerequisites for Linux
 -----------------------
 
 On Linux, using the package manager for your distribution will usually be the
-easiest route to making sure you have the pre-requisites to build Astropy. In
-order to build from source, you'll need the python development package for your
+easiest route to making sure you have the prerequisites to build Astropy. In
+order to build from source, you'll need the Python development package for your
 Linux distribution.
 
 For Debian/Ubuntu::
@@ -232,37 +233,37 @@ The latest stable source package for Astropy can be `downloaded here
 Development repository
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The latest development version of Astropy can be cloned from github
+The latest development version of Astropy can be cloned from GitHub
 using this command::
 
    git clone --recursive git://github.com/astropy/astropy.git
 
 If you wish to participate in the development of Astropy, see
-:ref:`developer-docs`.  This document covers only the basics necessary to
-install Astropy.
+:ref:`developer-docs`. This document covers only the basics necessary to
+installing Astropy.
 
-Building and Installing
+Building and installing
 -----------------------
 
 Astropy uses the Python built-in `distutils framework
 <http://docs.python.org/install/index.html>`_ for building and
-installing and requires the `setuptools`_ package.
+installing, and requires the `setuptools`_ package.
 
-If Numpy is not already installed in your Python environment, the astropy setup
+If Numpy is not already installed in your Python environment, the Astropy setup
 process will try to download and install it before continuing to install
-astropy.
+Astropy.
 
 To build and install Astropy (from the root of the source tree)::
 
     pip install .
 
-If you install in this way, if you make changes to the code, you will need to
+If you install in this way and you make changes to the code, you'll need to
 re-run the install command for changes to be reflected. Alternatively, you can
 use::
 
     pip install -e .
 
-Which installs astropy in develop/editable mode, which means that changes in
+Which installs Astropy in develop/editable mode, which means that changes in
 the code are immediately reflected in the installed version.
 
 Troubleshooting
@@ -281,8 +282,8 @@ External C libraries
 ^^^^^^^^^^^^^^^^^^^^
 
 The Astropy source ships with the C source code of a number of
-libraries.  By default, these internal copies are used to build
-Astropy.  However, if you wish to use the system-wide installation of
+libraries. By default, these internal copies are used to build
+Astropy. However, if you wish to use the system-wide installation of
 one of those libraries, you can pass one or more of the
 ``--use-system-X`` flags to the ``setup.py build`` command.
 
@@ -299,8 +300,8 @@ To see which system libraries Astropy knows how to build against, use::
 
     python setup.py build --help
 
-As with all distutils commandline options, they may also be provided in a
-``setup.cfg`` in the same directory as ``setup.py``.  For example, to use
+As with all distutils command line options, they may also be provided in a
+``setup.cfg`` in the same directory as ``setup.py``. For example, to use
 the system `libexpat <http://www.libexpat.org/>`_, add the following to the
 ``setup.cfg`` file::
 
@@ -330,7 +331,7 @@ If you want to be able to use Astropy inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
 
 First, we need to make sure `pip <https://pip.pypa.io>`__ is
-installed. Start up CASA as normal, and type::
+installed. Start up CASA as normal, and then type::
 
     CASA <2>: from setuptools.command import easy_install
 
@@ -346,16 +347,16 @@ Then close CASA again and open it, and you should be able to import Astropy::
 
     CASA <2>: import astropy
 
-Any astropy affiliated package can be installed the same way (e.g. the
+Any Astropy affiliated package can be installed the same way (e.g. the
 `spectral-cube <http://spectral-cube.readthedocs.io/en/latest/>`_ or other
 packages that may be useful for radio astronomy).
 
 .. note:: The above instructions have not been tested on all systems.
    We know of a few examples that do work, but that is not a guarantee
-   that this will work on all systems.  If you install astropy and begin to
+   that this will work on all systems. If you install Astropy and begin to
    encounter issues with CASA, please look at the `known CASA issues
    <https://github.com/astropy/astropy/issues?q=+label%3ACASA-Installation+>`_
-   and, if you don't encounter your issue there, post a new one.
+   and if you don't encounter your issue there, please post a new one.
 
 .. _builddocs:
 
@@ -364,9 +365,9 @@ Building documentation
 
 .. note::
 
-    Building the documentation is in general not necessary unless you
-    are writing new documentation or do not have internet access, because
-    the latest (and archive) versions of astropy's documentation should
+    Building the documentation is in general not necessary unless you're
+    writing new documentation or do not have internet access, because
+    the latest (and archive) versions of Astropy's documentation should
     be available at `docs.astropy.org <http://docs.astropy.org>`_ .
 
 Dependencies
@@ -389,22 +390,22 @@ ecosystem, this package also serves as a way to automatically get the main
 dependencies, including:
 
 * `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
-  the documentation.
+  the documentation
 * `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
   the default 'bootstrap' theme use by Astropy and a number of affiliated
-  packages.
+  packages
 * `sphinx-automodapi <http://sphinx-automodapi.readthedocs.io>`_ - an extension
-  that makes it easy to automatically generate API documentation.
+  that makes it easy to automatically generate API documentation
 * `sphinx-gallery <https://sphinx-gallery.readthedocs.io/en/latest/>`_ - an
   extension to generate example galleries
 * `numpydoc <https://numpydoc.readthedocs.io>`_ - an extension to parse
   docstrings in NumpyDoc format
 * `pillow <https://pillow.readthedocs.io>`_ - used in one of the examples
 
-In addition, if you want inheritance graphs to be generated, you will need to
+In addition, if you want inheritance graphs to be generated, you'll need to
 make sure that `Graphviz <http://www.graphviz.org>`_ is installed. If you
-install sphinx-astropy with conda, graphviz will automatically get installed,
-but if you use pip, you will need to install Graphviz separately as it isn't
+install sphinx-astropy with conda, Graphviz will automatically get installed,
+but if you use pip, you'll need to install Graphviz separately as it isn't
 a Python package.
 
 .. _astropy-doc-building:
@@ -412,15 +413,15 @@ a Python package.
 Building
 ^^^^^^^^
 
-There are two ways to build the Astropy documentation. The most straightforward
-way is to execute the command (from the astropy source directory)::
+There are two ways to build the Astropy documentation. The first way is to
+execute the command (from the Astropy source directory)::
 
     python setup.py build_docs
 
 The documentation will be built in the ``docs/_build/html`` directory, and can
 be read by pointing a web browser to ``docs/_build/html/index.html``.
 
-The LaTeX documentation can be generated by using the command::
+In the second way, LaTeX documentation can be generated by using the command::
 
     python setup.py build_docs -b latex
 
@@ -440,10 +441,10 @@ Reporting issues/requesting features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As mentioned above, building the documentation depends on a number of sphinx
-extensions and other packages. Since it isn't necessarily straightforward to
-know which package is causing issues or would need to have a new feature
-implemented, you can simply open an issue in the `core astropy package issue
-tracker <https://github.com/astropy/astropy/issues>`_. However, if you wish you
+extensions and other packages. Since it isn't always possible to know which
+package is causing issues or would need to have a new feature implemented, you
+can open an issue in the `core Astropy package issue
+tracker <https://github.com/astropy/astropy/issues>`_. However, if you wish, you
 can also open issues in the repositories for some of the dependencies:
 
 * For requests/issues related to the appearance of the docs (e.g. related to
@@ -464,7 +465,7 @@ can also open issues in the repositories for some of the dependencies:
 Testing a source code build of Astropy
 --------------------------------------
 
-Before running tests, it is necessary to make sure that Astropy's test
+Before running tests, it's necessary to make sure that Astropy's test
 dependencies are installed. This can be done with the following command::
 
     pip install pytest-astropy
@@ -472,12 +473,12 @@ dependencies are installed. This can be done with the following command::
 More information on what the ``pytest-astropy`` package provides can be found
 in :ref:`testing-dependencies`.
 
-The easiest way to test that your Astropy built correctly (without
-installing astropy) is to run this from the root of the source tree::
+The most convenient way to test that your Astropy package built correctly
+(without installing Astropy) is to run this from the root of the source tree::
 
     python setup.py test
 
-There are also alternative methods of :ref:`running-tests`. Note that you will
+There are also alternative methods of :ref:`running-tests`. Note that you'll
 need `pytest <http://pytest.org>`_ to be installed for this to work.
 
 .. include:: development/workflow/known_projects.inc

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,7 +7,7 @@ Installation
 Requirements
 ============
 
-Astropy has the following strict requirements:
+`astropy` has the following strict requirements:
 
 - `Python <https://www.python.org/>`_ |minimum_python_version| or later
 
@@ -15,7 +15,7 @@ Astropy has the following strict requirements:
 
 - `pytest`_ 3.1 or later
 
-Astropy also depends on other packages for optional features:
+`astropy` also depends on other packages for optional features:
 
 - `scipy`_: To power a variety of features in several modules.
 
@@ -46,7 +46,8 @@ Astropy also depends on other packages for optional features:
   ``SCEngine`` indexing engine with ``Table``, although this may still be
   slower in some cases than the default indexing engine.
 
-- `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between timezones.
+- `pytz <http://pythonhosted.org/pytz/>`_: To specify and convert between
+  timezones.
 
 - `jplephem <https://pypi.org/project/jplephem/>`_: To retrieve JPL
   ephemeris of Solar System objects.
@@ -54,7 +55,8 @@ Astropy also depends on other packages for optional features:
 - `matplotlib <http://matplotlib.org/>`_ 2.0 or later: To provide plotting
   functionality that `astropy.visualization` enhances.
 
-- `scikit-image <http://scikit-image.org/>`_: To downsample a data array in `astropy.nddata.utils`.
+- `scikit-image <http://scikit-image.org/>`_: To downsample a data array in
+  `astropy.nddata.utils`.
 
 - `setuptools <https://setuptools.readthedocs.io>`_: Used for discovery of
   entry points which are used to insert fitters into `astropy.modeling.fitting`.
@@ -93,10 +95,10 @@ And the following packages can optionally be used when testing:
   coordinates.
 
 However, note that these packages require installation only if those particular
-features are needed. Astropy will import even if these dependencies are not
+features are needed. `astropy` will import even if these dependencies are not
 installed.
 
-Installing Astropy
+Installing `astropy`
 ==================
 
 Using pip
@@ -104,10 +106,10 @@ Using pip
 
 .. warning::
 
-    Users of the Anaconda python distribution should follow the instructions
+    Users of the Anaconda Python distribution should follow the instructions
     for :ref:`anaconda_install`.
 
-To install Astropy with `pip <https://pip.pypa.io>`__, run::
+To install `astropy` with `pip <https://pip.pypa.io>`__, run::
 
     pip install astropy
 
@@ -116,7 +118,7 @@ can also do::
 
     pip install astropy --no-deps
 
-On the other hand, if you want to install Astropy along with all of the
+On the other hand, if you want to install `astropy` along with all of the
 available optional dependencies, you can do::
 
     pip install astropy[all]
@@ -131,37 +133,37 @@ into your home directory. You can read more about how to do this in the `pip
 documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
 Alternatively, if you intend to do development on other software that uses
-Astropy, such as an affiliated package, consider installing Astropy into a
+`astropy`, such as an affiliated package, consider installing `astropy` into a
 :ref:`virtualenv<using-virtualenv>`.
 
-Do **not** install Astropy or other third-party packages using ``sudo``
+Do **not** install `astropy` or other third-party packages using ``sudo``
 unless you are fully aware of the risks.
 
 .. _anaconda_install:
 
-Using conda
+Using Conda
 -----------
 
-Astropy is installed by default with the `Anaconda Distribution
+`astropy` is installed by default with the `Anaconda Distribution
 <https://www.anaconda.com/download/>`_. To update to the latest version run::
 
     conda update astropy
 
-There may be a delay of a day or two between when a new version of Astropy
+There may be a delay of a day or two between when a new version of `astropy`
 is released and when a package is available for Anaconda. You can check
 for the list of available versions with ``conda search astropy``.
 
 .. warning::
 
     Attempting to use `pip <https://pip.pypa.io>`__ to upgrade your installation
-    of Astropy may result in a corrupted installation.
+    of `astropy` may result in a corrupted installation.
 
 .. _testing_installed_astropy:
 
-Testing an installed Astropy
+Testing an Installed `astropy`
 ----------------------------
 
-The easiest way to test if your installed version of Astropy is running
+The easiest way to test if your installed version of `astropy` is running
 correctly is to use the :ref:`astropy.test()` function::
 
     import astropy
@@ -170,20 +172,20 @@ correctly is to use the :ref:`astropy.test()` function::
 The tests should run and print out any failures, which you can report at
 the `Astropy issue tracker <https://github.com/astropy/astropy/issues>`_.
 
-This way of running the tests may not work if you do it in the Astropy source
+This way of running the tests may not work if you do it in the `astropy` source
 distribution. See :ref:`sourcebuildtest` for how to run the tests from the
 source code directory, or :ref:`running-tests` for more details.
 
-Building from source
+Building from Source
 ====================
 
 Prerequisites
 -------------
 
-You'll need a compiler suite and the development headers for Python and
-Numpy in order to build Astropy.
+You will need a compiler suite and the development headers for Python and
+NumPy in order to build `astropy`.
 
-If you're building the latest developer version rather than using a stable
+If you are building the latest developer version rather than using a stable
 release, you will also need `Cython <http://cython.org/>`_ (v0.21 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed. The
 released packages have the necessary C files packaged with them, and hence do
@@ -193,9 +195,9 @@ Prerequisites for Linux
 -----------------------
 
 On Linux, using the package manager for your distribution will usually be the
-easiest route to making sure you have the prerequisites to build Astropy. In
-order to build from source, you'll need the Python development package for your
-Linux distribution.
+easiest route to making sure you have the prerequisites to build `astropy`. In
+order to build from source, you will need the Python development package for
+your Linux distribution.
 
 For Debian/Ubuntu::
 
@@ -217,60 +219,60 @@ Follow the onscreen instructions to install the command line tools required.
 Note that you do **not** need to install the full XCode distribution (assuming
 you are using MacOS X 10.9 or later).
 
-The `instructions for building Numpy from source
+The `instructions for building NumPy from source
 <https://docs.scipy.org/doc/numpy/user/building.html>`_ are a good
 resource for setting up your environment to build Python packages.
 
-Obtaining the source packages
+Obtaining the Source Packages
 -----------------------------
 
-Source packages
+Source Packages
 ^^^^^^^^^^^^^^^
 
-The latest stable source package for Astropy can be `downloaded here
+The latest stable source package for `astropy` can be `downloaded here
 <https://pypi.python.org/pypi/astropy>`_.
 
-Development repository
+Development Repository
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The latest development version of Astropy can be cloned from GitHub
+The latest development version of `astropy` can be cloned from GitHub
 using this command::
 
    git clone --recursive git://github.com/astropy/astropy.git
 
-If you wish to participate in the development of Astropy, see
+If you wish to participate in the development of `astropy`, see
 :ref:`developer-docs`. This document covers only the basics necessary to
-installing Astropy.
+installing `astropy`.
 
-Building and installing
+Building and Installing
 -----------------------
 
-Astropy uses the Python built-in `distutils framework
+`astropy` uses the Python built-in `distutils framework
 <http://docs.python.org/install/index.html>`_ for building and
 installing, and requires the `setuptools`_ package.
 
-If Numpy is not already installed in your Python environment, the Astropy setup
-process will try to download and install it before continuing to install
-Astropy.
+If NumPy is not already installed in your Python environment, the `astropy`
+setup process will try to download and install it before continuing to install
+`astropy`.
 
-To build and install Astropy (from the root of the source tree)::
+To build and install `astropy` (from the root of the source tree)::
 
     pip install .
 
-If you install in this way and you make changes to the code, you'll need to
+If you install in this way and you make changes to the code, you will need to
 re-run the install command for changes to be reflected. Alternatively, you can
 use::
 
     pip install -e .
 
-Which installs Astropy in develop/editable mode, which means that changes in
+which installs `astropy` in develop/editable mode, which means that changes in
 the code are immediately reflected in the installed version.
 
 Troubleshooting
 ---------------
 
 If you get an error mentioning that you do not have the correct permissions to
-install Astropy into the default ``site-packages`` directory, you can try
+install `astropy` into the default ``site-packages`` directory, you can try
 installing with::
 
     pip install . --user
@@ -278,16 +280,16 @@ installing with::
 which will install into a default directory in your home directory.
 
 
-External C libraries
+External C Libraries
 ^^^^^^^^^^^^^^^^^^^^
 
-The Astropy source ships with the C source code of a number of
+The `astropy` source ships with the C source code of a number of
 libraries. By default, these internal copies are used to build
-Astropy. However, if you wish to use the system-wide installation of
+`astropy`. However, if you wish to use the system-wide installation of
 one of those libraries, you can pass one or more of the
 ``--use-system-X`` flags to the ``setup.py build`` command.
 
-For example, to build Astropy using the system `libexpat
+For example, to build `astropy` using the system `libexpat
 <http://www.libexpat.org/>`_, use::
 
     python setup.py build --use-system-expat
@@ -296,7 +298,7 @@ To build using all of the system libraries, use::
 
     python setup.py build --use-system-libraries
 
-To see which system libraries Astropy knows how to build against, use::
+To see which system libraries `astropy` knows how to build against, use::
 
     python setup.py build --help
 
@@ -309,7 +311,7 @@ the system `libexpat <http://www.libexpat.org/>`_, add the following to the
     use_system_expat=1
 
 
-The C libraries currently bundled with Astropy include:
+The C libraries currently bundled with `astropy` include:
 
 - `wcslib <http://www.atnf.csiro.au/people/mcalabre/WCS/>`_ see
   ``cextern/wcslib/README`` for the bundled version.
@@ -324,10 +326,10 @@ The C libraries currently bundled with Astropy include:
   bundled version.
 
 
-Installing Astropy into CASA
+Installing `astropy` into CASA
 ----------------------------
 
-If you want to be able to use Astropy inside `CASA
+If you want to be able to use `astropy` inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
 
 First, we need to make sure `pip <https://pip.pypa.io>`__ is
@@ -337,35 +339,35 @@ installed. Start up CASA as normal, and then type::
 
     CASA <3>: easy_install.main(['--user', 'pip'])
 
-Now, quit CASA and re-open it, then type the following to install Astropy::
+Now, quit CASA and re-open it, then type the following to install `astropy`::
 
     CASA <2>: import subprocess, sys
 
     CASA <3>: subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', 'astropy'])
 
-Then close CASA again and open it, and you should be able to import Astropy::
+Then close CASA again and open it, and you should be able to import `astropy`::
 
     CASA <2>: import astropy
 
-Any Astropy affiliated package can be installed the same way (e.g. the
+Any `astropy` affiliated package can be installed the same way (e.g. the
 `spectral-cube <http://spectral-cube.readthedocs.io/en/latest/>`_ or other
 packages that may be useful for radio astronomy).
 
 .. note:: The above instructions have not been tested on all systems.
    We know of a few examples that do work, but that is not a guarantee
-   that this will work on all systems. If you install Astropy and begin to
+   that this will work on all systems. If you install `astropy` and begin to
    encounter issues with CASA, please look at the `known CASA issues
    <https://github.com/astropy/astropy/issues?q=+label%3ACASA-Installation+>`_
-   and if you don't encounter your issue there, please post a new one.
+   and if you do not encounter your issue there, please post a new one.
 
 .. _builddocs:
 
-Building documentation
+Building Documentation
 ----------------------
 
 .. note::
 
-    Building the documentation is in general not necessary unless you're
+    Building the documentation is in general not necessary unless you are
     writing new documentation or do not have internet access, because
     the latest (and archive) versions of Astropy's documentation should
     be available at `docs.astropy.org <http://docs.astropy.org>`_ .
@@ -373,15 +375,15 @@ Building documentation
 Dependencies
 ^^^^^^^^^^^^
 
-Building the documentation requires the Astropy source code and some additional
-packages, including those in :ref:`astropy-main-req`. The easiest way to
-install the extra dependencies for documentation is to install
+Building the documentation requires the `astropy` source code and some
+additional packages, including those in :ref:`astropy-main-req`. The easiest
+way to install the extra dependencies for documentation is to install
 the `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ package,
 either with pip::
 
     pip install sphinx-astropy
 
-or with conda::
+or with Conda::
 
     conda install -c astropy sphinx-astropy
 
@@ -392,20 +394,20 @@ dependencies, including:
 * `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
   the documentation
 * `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
-  the default 'bootstrap' theme use by Astropy and a number of affiliated
+  the default 'bootstrap' theme used by `astropy` and a number of affiliated
   packages
 * `sphinx-automodapi <http://sphinx-automodapi.readthedocs.io>`_ - an extension
   that makes it easy to automatically generate API documentation
 * `sphinx-gallery <https://sphinx-gallery.readthedocs.io/en/latest/>`_ - an
   extension to generate example galleries
 * `numpydoc <https://numpydoc.readthedocs.io>`_ - an extension to parse
-  docstrings in NumpyDoc format
+  docstrings in NumPyDoc format
 * `pillow <https://pillow.readthedocs.io>`_ - used in one of the examples
 
-In addition, if you want inheritance graphs to be generated, you'll need to
+In addition, if you want inheritance graphs to be generated, you will need to
 make sure that `Graphviz <http://www.graphviz.org>`_ is installed. If you
-install sphinx-astropy with conda, Graphviz will automatically get installed,
-but if you use pip, you'll need to install Graphviz separately as it isn't
+install sphinx-astropy with Conda, Graphviz will automatically get installed,
+but if you use pip, you will need to install Graphviz separately as it is not
 a Python package.
 
 .. _astropy-doc-building:
@@ -414,7 +416,7 @@ Building
 ^^^^^^^^
 
 There are two ways to build the Astropy documentation. The first way is to
-execute the command (from the Astropy source directory)::
+execute the command (from the `astropy` source directory)::
 
     python setup.py build_docs
 
@@ -435,15 +437,15 @@ Alternatively, you can do::
     make html
 
 And the documentation will be generated in the same location, but using the
-*installed* version of Astropy.
+*installed* version of `astropy`.
 
-Reporting issues/requesting features
+Reporting Issues/Requesting Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As mentioned above, building the documentation depends on a number of sphinx
-extensions and other packages. Since it isn't always possible to know which
+extensions and other packages. Since it is not always possible to know which
 package is causing issues or would need to have a new feature implemented, you
-can open an issue in the `core Astropy package issue
+can open an issue in the `core astropy package issue
 tracker <https://github.com/astropy/astropy/issues>`_. However, if you wish, you
 can also open issues in the repositories for some of the dependencies:
 
@@ -462,10 +464,10 @@ can also open issues in the repositories for some of the dependencies:
 
 .. _sourcebuildtest:
 
-Testing a source code build of Astropy
+Testing a Source Code Build of Astropy
 --------------------------------------
 
-Before running tests, it's necessary to make sure that Astropy's test
+Before running tests, it is necessary to make sure that Astropy's test
 dependencies are installed. This can be done with the following command::
 
     pip install pytest-astropy
@@ -473,12 +475,12 @@ dependencies are installed. This can be done with the following command::
 More information on what the ``pytest-astropy`` package provides can be found
 in :ref:`testing-dependencies`.
 
-The most convenient way to test that your Astropy package built correctly
-(without installing Astropy) is to run this from the root of the source tree::
+The most convenient way to test that your Astropy built correctly
+(without installing `astropy`) is to run this from the root of the source tree::
 
     python setup.py test
 
-There are also alternative methods of :ref:`running-tests`. Note that you'll
+There are also alternative methods of :ref:`running-tests`. Note that you will
 need `pytest <http://pytest.org>`_ to be installed for this to work.
 
 .. include:: development/workflow/known_projects.inc

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -99,7 +99,7 @@ features are needed. `astropy` will import even if these dependencies are not
 installed.
 
 Installing `astropy`
-==================
+====================
 
 Using pip
 ---------
@@ -161,7 +161,7 @@ for the list of available versions with ``conda search astropy``.
 .. _testing_installed_astropy:
 
 Testing an Installed `astropy`
-----------------------------
+------------------------------
 
 The easiest way to test if your installed version of `astropy` is running
 correctly is to use the :ref:`astropy.test()` function::
@@ -327,7 +327,7 @@ The C libraries currently bundled with `astropy` include:
 
 
 Installing `astropy` into CASA
-----------------------------
+-------------------------------
 
 If you want to be able to use `astropy` inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -95,7 +95,7 @@ And the following packages can optionally be used when testing:
   coordinates.
 
 However, note that these packages require installation only if those particular
-features are needed. `astropy` will import even if these dependencies are not
+features are needed.``astropy``will import even if these dependencies are not
 installed.
 
 Installing ``astropy``
@@ -109,7 +109,7 @@ Using pip
     Users of the Anaconda Python distribution should follow the instructions
     for :ref:`anaconda_install`.
 
-To install `astropy` with `pip <https://pip.pypa.io>`__, run::
+To install``astropy``with `pip <https://pip.pypa.io>`__, run::
 
     pip install astropy
 
@@ -118,7 +118,7 @@ can also do::
 
     pip install astropy --no-deps
 
-On the other hand, if you want to install `astropy` along with all of the
+On the other hand, if you want to install``astropy``along with all of the
 available optional dependencies, you can do::
 
     pip install astropy[all]
@@ -133,10 +133,10 @@ into your home directory. You can read more about how to do this in the `pip
 documentation <https://pip.pypa.io/en/stable/user_guide/#user-installs>`_.
 
 Alternatively, if you intend to do development on other software that uses
-`astropy`, such as an affiliated package, consider installing `astropy` into a
+`astropy`, such as an affiliated package, consider installing``astropy``into a
 :ref:`virtualenv<using-virtualenv>`.
 
-Do **not** install `astropy` or other third-party packages using ``sudo``
+Do **not** install``astropy``or other third-party packages using ``sudo``
 unless you are fully aware of the risks.
 
 .. _anaconda_install:
@@ -156,14 +156,14 @@ for the list of available versions with ``conda search astropy``.
 .. warning::
 
     Attempting to use `pip <https://pip.pypa.io>`__ to upgrade your installation
-    of `astropy` may result in a corrupted installation.
+    of``astropy``may result in a corrupted installation.
 
 .. _testing_installed_astropy:
 
 Testing an Installed `astropy`
 ------------------------------
 
-The easiest way to test if your installed version of `astropy` is running
+The easiest way to test if your installed version of``astropy``is running
 correctly is to use the :ref:`astropy.test()` function::
 
     import astropy
@@ -172,7 +172,7 @@ correctly is to use the :ref:`astropy.test()` function::
 The tests should run and print out any failures, which you can report at
 the `Astropy issue tracker <https://github.com/astropy/astropy/issues>`_.
 
-This way of running the tests may not work if you do it in the `astropy` source
+This way of running the tests may not work if you do it in the``astropy``source
 distribution. See :ref:`sourcebuildtest` for how to run the tests from the
 source code directory, or :ref:`running-tests` for more details.
 
@@ -229,13 +229,13 @@ Obtaining the Source Packages
 Source Packages
 ^^^^^^^^^^^^^^^
 
-The latest stable source package for `astropy` can be `downloaded here
+The latest stable source package for``astropy``can be `downloaded here
 <https://pypi.python.org/pypi/astropy>`_.
 
 Development Repository
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The latest development version of `astropy` can be cloned from GitHub
+The latest development version of``astropy``can be cloned from GitHub
 using this command::
 
    git clone --recursive git://github.com/astropy/astropy.git
@@ -255,7 +255,7 @@ If NumPy is not already installed in your Python environment, the `astropy`
 setup process will try to download and install it before continuing to install
 `astropy`.
 
-To build and install `astropy` (from the root of the source tree)::
+To build and install``astropy``(from the root of the source tree)::
 
     pip install .
 
@@ -265,14 +265,14 @@ use::
 
     pip install -e .
 
-which installs `astropy` in develop/editable mode, which means that changes in
+which installs``astropy``in develop/editable mode, which means that changes in
 the code are immediately reflected in the installed version.
 
 Troubleshooting
 ---------------
 
 If you get an error mentioning that you do not have the correct permissions to
-install `astropy` into the default ``site-packages`` directory, you can try
+install``astropy``into the default ``site-packages`` directory, you can try
 installing with::
 
     pip install . --user
@@ -283,13 +283,13 @@ which will install into a default directory in your home directory.
 External C Libraries
 ^^^^^^^^^^^^^^^^^^^^
 
-The `astropy` source ships with the C source code of a number of
+The``astropy``source ships with the C source code of a number of
 libraries. By default, these internal copies are used to build
 `astropy`. However, if you wish to use the system-wide installation of
 one of those libraries, you can pass one or more of the
 ``--use-system-X`` flags to the ``setup.py build`` command.
 
-For example, to build `astropy` using the system `libexpat
+For example, to build``astropy``using the system `libexpat
 <http://www.libexpat.org/>`_, use::
 
     python setup.py build --use-system-expat
@@ -298,7 +298,7 @@ To build using all of the system libraries, use::
 
     python setup.py build --use-system-libraries
 
-To see which system libraries `astropy` knows how to build against, use::
+To see which system libraries``astropy``knows how to build against, use::
 
     python setup.py build --help
 
@@ -311,7 +311,7 @@ the system `libexpat <http://www.libexpat.org/>`_, add the following to the
     use_system_expat=1
 
 
-The C libraries currently bundled with `astropy` include:
+The C libraries currently bundled with``astropy``include:
 
 - `wcslib <http://www.atnf.csiro.au/people/mcalabre/WCS/>`_ see
   ``cextern/wcslib/README`` for the bundled version.
@@ -326,10 +326,10 @@ The C libraries currently bundled with `astropy` include:
   bundled version.
 
 
-Installing `astropy` into CASA
+Installing``astropy``into CASA
 ---------------------------------
 
-If you want to be able to use `astropy` inside `CASA
+If you want to be able to use``astropy``inside `CASA
 <https://casa.nrao.edu/>`_, the easiest way is to do so from inside CASA.
 
 First, we need to make sure `pip <https://pip.pypa.io>`__ is
@@ -349,13 +349,13 @@ Then close CASA again and open it, and you should be able to import `astropy`::
 
     CASA <2>: import astropy
 
-Any `astropy` affiliated package can be installed the same way (e.g. the
+Any``astropy``affiliated package can be installed the same way (e.g. the
 `spectral-cube <http://spectral-cube.readthedocs.io/en/latest/>`_ or other
 packages that may be useful for radio astronomy).
 
 .. note:: The above instructions have not been tested on all systems.
    We know of a few examples that do work, but that is not a guarantee
-   that this will work on all systems. If you install `astropy` and begin to
+   that this will work on all systems. If you install``astropy``and begin to
    encounter issues with CASA, please look at the `known CASA issues
    <https://github.com/astropy/astropy/issues?q=+label%3ACASA-Installation+>`_
    and if you do not encounter your issue there, please post a new one.
@@ -375,7 +375,7 @@ Building Documentation
 Dependencies
 ^^^^^^^^^^^^
 
-Building the documentation requires the `astropy` source code and some
+Building the documentation requires the``astropy``source code and some
 additional packages, including those in :ref:`astropy-main-req`. The easiest
 way to install the extra dependencies for documentation is to install
 the `sphinx-astropy <https://github.com/astropy/sphinx-astropy>`_ package,
@@ -394,7 +394,7 @@ dependencies, including:
 * `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
   the documentation
 * `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
-  the default 'bootstrap' theme used by `astropy` and a number of affiliated
+  the default 'bootstrap' theme used by``astropy``and a number of affiliated
   packages
 * `sphinx-automodapi <http://sphinx-automodapi.readthedocs.io>`_ - an extension
   that makes it easy to automatically generate API documentation
@@ -416,7 +416,7 @@ Building
 ^^^^^^^^
 
 There are two ways to build the Astropy documentation. The first way is to
-execute the command (from the `astropy` source directory)::
+execute the command (from the``astropy``source directory)::
 
     python setup.py build_docs
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -6,7 +6,7 @@ Known Issues
    :local:
    :depth: 2
 
-While most bugs and issues are managed using the `Astropy issue
+While most bugs and issues are managed using the `astropy issue
 tracker <https://github.com/astropy/astropy/issues>`_, this document
 lists issues that are too difficult to fix, may require some
 intervention from the user to work around, or are caused by bugs in other
@@ -15,22 +15,22 @@ projects or packages.
 Issues listed on this page are grouped into two categories: The first is known
 issues and shortcomings in actual algorithms and interfaces that currently do
 not have fixes or workarounds, and that users should be aware of when writing
-code that uses Astropy. Some of those issues are still platform-specific,
+code that uses `astropy`. Some of those issues are still platform-specific,
 while others are very general. The second category is of common issues that come
-up when configuring, building, or installing Astropy. This also includes
+up when configuring, building, or installing `astropy`. This also includes
 cases where the test suite can report false negatives depending on the context/
 platform on which it was run.
 
-Known deficiencies
+Known Deficiencies
 ==================
 
 .. _quantity_issues:
 
-Quantities lose their units with some operations
+Quantities Lose Their Units with Some Operations
 ------------------------------------------------
 
-Quantities are subclassed from Numpy's `~numpy.ndarray` and in some Numpy
-operations (and in SciPy operations using Numpy internally) the subclass is
+Quantities are subclassed from NumPy's `~numpy.ndarray` and in some NumPy
+operations (and in SciPy operations using NumPy internally) the subclass is
 ignored, which means that either a plain array is returned, or a
 `~astropy.units.quantity.Quantity` without units.
 E.g.::
@@ -118,10 +118,10 @@ Both will throw an exception if units do not cancel, e.g.::
 
 See: https://github.com/astropy/astropy/issues/7582
 
-Quantities lose their units when broadcasted
+Quantities Lose Their Units When Broadcasted
 --------------------------------------------
 
-When broadcasting Quantities, it's necessary to pass ``subok=True`` to
+When broadcasting Quantities, it is necessary to pass ``subok=True`` to
 `~numpy.broadcast_to`, or else a bare `~numpy.ndarray` will be returned::
 
    >>> q = u.Quantity(np.arange(10.), u.m)
@@ -145,11 +145,11 @@ This is analogous to the case of passing a Quantity to `~numpy.array`::
 
 See: https://github.com/astropy/astropy/issues/7832
 
-Quantities float comparison with np.isclose fails
+Quantities Float Comparison with np.isclose Fails
 -------------------------------------------------
 
-Comparing Quantities floats using the Numpy function `~numpy.isclose` fails on
-Numpy 1.9 as the comparison between ``a`` and ``b`` is made using the formula
+Comparing Quantities floats using the NumPy function `~numpy.isclose` fails on
+NumPy 1.9 as the comparison between ``a`` and ``b`` is made using the formula
 
 .. math::
 
@@ -169,15 +169,15 @@ One solution is::
     >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s, atol=1e-8 * u.mm / u.s) # doctest: +SKIP
     False
 
-Quantities in np.linspace failure on Numpy 1.10
+Quantities in np.linspace Failure on NumPy 1.10
 -----------------------------------------------
 
-`~numpy.linspace` does not work correctly with quantities when using Numpy
-1.10.0 to 1.10.5 due to a bug in Numpy. The solution is to upgrade to Numpy
+`~numpy.linspace` does not work correctly with quantities when using NumPy
+1.10.0 to 1.10.5 due to a bug in NumPy. The solution is to upgrade to NumPy
 1.10.6 or later, in which the bug was fixed.
 
 
-mmap support for ``astropy.io.fits`` on GNU Hurd
+mmap Support for ``astropy.io.fits`` on GNU Hurd
 ------------------------------------------------
 
 On Hurd and possibly other platforms, ``flush()`` on memory-mapped files are not
@@ -188,16 +188,16 @@ result in a warning (and mmap will be disabled on the file automatically).
 See: https://github.com/astropy/astropy/issues/968
 
 
-Bug with Unicode endianness in ``io.fits`` for big endian processors
+Bug with Unicode Endianness in ``io.fits`` for Big Endian Processors
 --------------------------------------------------------------------
 
 On big endian processors (e.g. SPARC, PowerPC, MIPS), string columns in FITS
 files may not be correctly read when using the ``Table.read`` interface. This
-will be fixed in a subsequent bug fix release of Astropy (see `bug report here
+will be fixed in a subsequent bug fix release of `astropy` (see `bug report here
 <https://github.com/astropy/astropy/issues/3415>`_).
 
 
-Color printing on Windows
+Color Printing on Windows
 -------------------------
 
 Colored printing of log messages and other colored text does work in Windows,
@@ -205,21 +205,21 @@ but only when running in the IPython console. Colors are not currently
 supported in the basic Python command-line interpreter on Windows.
 
 
-Build/installation/test issues
+Build/Installation/Test Issues
 ==============================
 
-Anaconda users should upgrade with ``conda``, not ``pip``
+Anaconda Users Should Upgrade with ``conda``, Not ``pip``
 ---------------------------------------------------------
 
-Upgrading Astropy in the Anaconda Python distribution using ``pip`` can result
+Upgrading `astropy` in the Anaconda Python distribution using ``pip`` can result
 in a corrupted install with a mix of files from the old version and the new
 version. Anaconda users should update with ``conda update astropy``. There
-may be a brief delay between the release of Astropy on PyPI and its release
+may be a brief delay between the release of `astropy` on PyPI and its release
 via the ``conda`` package manager; users can check the availability of new
 versions with ``conda search astropy``.
 
 
-Locale errors in MacOS X and Linux
+Locale Errors in MacOS X and Linux
 ----------------------------------
 
 On MacOS X, you may see the following error when running ``setup.py``::
@@ -267,10 +267,10 @@ If so, you can go ahead and try running ``setup.py`` again (in the new
 terminal).
 
 
-Creating a Time object fails with ValueError after upgrading Astropy
+Creating a Time Object Fails with ValueError After Upgrading `astropy`
 --------------------------------------------------------------------
 
-In some cases, when users have upgraded Astropy from an older version to v1.0
+In some cases, when users have upgraded `astropy` from an older version to v1.0
 or greater, they have run into the following crash when trying to create an
 `~astropy.time.Time` object::
 
@@ -283,13 +283,13 @@ or greater, they have run into the following crash when trying to create an
     u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
 
 This problem can occur when there is a version mismatch between the compiled
-ERFA library (included as part of Astropy in most distributions), and
-the version of the Astropy Python source.
+ERFA library (included as part of `astropy` in most distributions), and
+the version of the `astropy` Python source.
 
 This can be from a number of causes. The most likely is that when installing the
-new Astropy version, your previous Astropy version was not fully uninstalled
+new `astropy` version, your previous `astropy` version was not fully uninstalled
 first, resulting in a mishmash of versions. Your best bet is to fully remove
-Astropy from its installation path and reinstall from scratch using your
+`astropy` from its installation path and reinstall from scratch using your
 preferred installation method. Removing the old version may be achieved by
 removing the entire ``astropy/`` directory from within the
 ``site-packages`` directory it is installed in. However, if in doubt, ask
@@ -303,7 +303,7 @@ Make sure before running this that there are no untracked files in the
 repository you intend to save. Then rebuild/reinstall from the clean repo.
 
 
-Failing logging tests when running the tests in IPython
+Failing Logging Tests When Running the Tests in IPython
 -------------------------------------------------------
 
 When running the Astropy tests using ``astropy.test()`` in an IPython
@@ -315,7 +315,7 @@ not due to a problem with the test itself or the feature being tested.
 See: https://github.com/astropy/astropy/issues/717
 
 
-Some docstrings can not be displayed in IPython < 0.13.2
+Some Docstrings Can Not Be Displayed in IPython < 0.13.2
 --------------------------------------------------------
 
 Displaying long docstrings that contain Unicode characters may fail on
@@ -343,25 +343,25 @@ acceptable.
 
 The IPython issue: https://github.com/ipython/ipython/pull/2738
 
-Compatibility issues with pytest 3.7 and later
+Compatibility Issues with pytest 3.7 and later
 ----------------------------------------------
 
 Due to a bug in `pytest <http://www.pytest.org>`_ related to test collection,
-the tests for the core Astropy package for version 2.0.x (LTS), and for packages
-using the core package's test infrastructure and being tested against 2.0.x
-(LTS), will not be executed correctly with pytest 3.7, 3.8, or 3.9. The symptom
-of this bug is that no tests or only tests in RST files are collected. In
-addition, Astropy 2.0.x (LTS) is not compatible with pytest 4.0 and above,
+the tests for the core `astropy` package for version 2.0.x (LTS), and for
+packages using the core package's test infrastructure and being tested against
+2.0.x (LTS), will not be executed correctly with pytest 3.7, 3.8, or 3.9. The
+symptom of this bug is that no tests or only tests in RST files are collected.
+In addition, `astropy` 2.0.x (LTS) is not compatible with pytest 4.0 and above,
 as in this case deprecation errors from pytest can cause tests to fail.
-Therefore, when testing against Astropy v2.0.x (LTS), pytest 3.6 or earlier
+Therefore, when testing against `astropy` v2.0.x (LTS), pytest 3.6 or earlier
 versions should be used. These issues do not occur in version 3.0.x and above of
 the core package.
 
 There is an unrelated issue that also affects more recent versions of
-Astropy when testing with pytest 4.0 and later, which can
-cause issues when collecting tests - in this case, the symptom is that the
-test collection hangs and/or appears to run the tests recursively. If you're
-maintaining a package that was created using the Astropy
+`astropy` when testing with pytest 4.0 and later, which can
+cause issues when collecting tests — in this case, the symptom is that the
+test collection hangs and/or appears to run the tests recursively. If you are
+maintaining a package that was created using the `astropy`
 `package template <http://github.com/astropy/package-template>`_, then
 this can be fixed by updating to the latest version of the ``_astropy_init.py``
 file. The root cause of this issue is that pytest now tries to pick up the

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -6,18 +6,18 @@ Known Issues
    :local:
    :depth: 2
 
-While most bugs and issues are managed using the `astropy issue
+While most bugs and issues are managed using the `Astropy issue
 tracker <https://github.com/astropy/astropy/issues>`_, this document
 lists issues that are too difficult to fix, may require some
-intervention from the user to workaround, or are due to bugs in other
+intervention from the user to work around, or are caused by bugs in other
 projects or packages.
 
-Issues listed on this page are grouped into two categories:  The first is known
+Issues listed on this page are grouped into two categories: The first is known
 issues and shortcomings in actual algorithms and interfaces that currently do
 not have fixes or workarounds, and that users should be aware of when writing
-code that uses Astropy.  Some of those issues are still platform-specific,
-while others are very general.  The second category is common issues that come
-up when configuring, building, or installing Astropy.  This also includes
+code that uses Astropy. Some of those issues are still platform-specific,
+while others are very general. The second category is of common issues that come
+up when configuring, building, or installing Astropy. This also includes
 cases where the test suite can report false negatives depending on the context/
 platform on which it was run.
 
@@ -29,9 +29,10 @@ Known deficiencies
 Quantities lose their units with some operations
 ------------------------------------------------
 
-Quantities are subclassed from numpy's `~numpy.ndarray` and in some numpy operations
-(and in scipy operations using numpy internally) the subclass is ignored, which
-means that either a plain array is returned, or a `~astropy.units.quantity.Quantity` without units.
+Quantities are subclassed from Numpy's `~numpy.ndarray` and in some Numpy
+operations (and in SciPy operations using Numpy internally) the subclass is
+ignored, which means that either a plain array is returned, or a
+`~astropy.units.quantity.Quantity` without units.
 E.g.::
 
     >>> import astropy.units as u
@@ -53,7 +54,7 @@ E.g.::
     >>> np.array([ratio]) # doctest: +FLOAT_CMP
     array([1.])
 
-Work-arounds are available for some cases.  For the above::
+Workarounds are available for some cases. For the above::
 
     >>> q.dot(q) # doctest: +FLOAT_CMP
     <Quantity 285. m2>
@@ -65,7 +66,7 @@ Work-arounds are available for some cases.  For the above::
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 0., 1., 2., 3., 4., 5.,
                6., 7., 8., 9.] m>
 
-An incomplete list of specific functions which are known to exhibit this behavior follows.
+An incomplete list of specific functions which are known to exhibit this behavior follows:
 
 * `numpy.dot`
 * `numpy.hstack`, `numpy.vstack`, ``numpy.c_``, ``numpy.r_``, `numpy.append`
@@ -78,7 +79,7 @@ An incomplete list of specific functions which are known to exhibit this behavio
 See: https://github.com/astropy/astropy/issues/1274
 
 
-Care has to be taken when setting array slices using Quantities::
+Care must be taken when setting array slices using Quantities::
 
     >>> a = np.ones(4)
     >>> a[2:3] = 2*u.kg
@@ -120,7 +121,7 @@ See: https://github.com/astropy/astropy/issues/7582
 Quantities lose their units when broadcasted
 --------------------------------------------
 
-When broadcasting Quantities, it is necessary to pass ``subok=True`` to
+When broadcasting Quantities, it's necessary to pass ``subok=True`` to
 `~numpy.broadcast_to`, or else a bare `~numpy.ndarray` will be returned::
 
    >>> q = u.Quantity(np.arange(10.), u.m)
@@ -147,8 +148,8 @@ See: https://github.com/astropy/astropy/issues/7832
 Quantities float comparison with np.isclose fails
 -------------------------------------------------
 
-Comparing Quantities floats using the numpy function `~numpy.isclose` fails on
-numpy 1.9 as the comparison between ``a`` and ``b`` is made using the formula
+Comparing Quantities floats using the Numpy function `~numpy.isclose` fails on
+Numpy 1.9 as the comparison between ``a`` and ``b`` is made using the formula
 
 .. math::
 
@@ -163,44 +164,44 @@ This will result in the following traceback when using this with Quantities::
     ...
     UnitConversionError: Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)
 
-An easy solution is::
+One solution is::
 
     >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s, atol=1e-8 * u.mm / u.s) # doctest: +SKIP
     False
 
-Quantities in np.linspace failure on numpy 1.10
+Quantities in np.linspace failure on Numpy 1.10
 -----------------------------------------------
 
-`~numpy.linspace` does not work correctly with quantities when using numpy
-1.10.0 to 1.10.5 due to a bug in numpy. The solution is to upgrade to numpy
+`~numpy.linspace` does not work correctly with quantities when using Numpy
+1.10.0 to 1.10.5 due to a bug in Numpy. The solution is to upgrade to Numpy
 1.10.6 or later, in which the bug was fixed.
 
 
 mmap support for ``astropy.io.fits`` on GNU Hurd
 ------------------------------------------------
 
-On Hurd and possibly other platforms ``flush()`` on memory-mapped files is not
+On Hurd and possibly other platforms, ``flush()`` on memory-mapped files are not
 implemented, so writing changes to a mmap'd FITS file may not be reliable and is
-thus disabled.  Attempting to open a FITS file in writeable mode with mmap will
+thus disabled. Attempting to open a FITS file in writeable mode with mmap will
 result in a warning (and mmap will be disabled on the file automatically).
 
 See: https://github.com/astropy/astropy/issues/968
 
 
-Bug with unicode endianness in ``io.fits`` for big-endian processors
+Bug with Unicode endianness in ``io.fits`` for big endian processors
 --------------------------------------------------------------------
 
-On big-endian processors (e.g. SPARC, PowerPC, MIPS), string columns in FITS
+On big endian processors (e.g. SPARC, PowerPC, MIPS), string columns in FITS
 files may not be correctly read when using the ``Table.read`` interface. This
 will be fixed in a subsequent bug fix release of Astropy (see `bug report here
-<https://github.com/astropy/astropy/issues/3415>`_)
+<https://github.com/astropy/astropy/issues/3415>`_).
 
 
 Color printing on Windows
 -------------------------
 
-Colored printing of log messages and other colored text does work in Windows
-but only when running in the IPython console.  Colors are not currently
+Colored printing of log messages and other colored text does work in Windows,
+but only when running in the IPython console. Colors are not currently
 supported in the basic Python command-line interpreter on Windows.
 
 
@@ -210,7 +211,7 @@ Build/installation/test issues
 Anaconda users should upgrade with ``conda``, not ``pip``
 ---------------------------------------------------------
 
-Upgrading Astropy in the anaconda python distribution using ``pip`` can result
+Upgrading Astropy in the Anaconda Python distribution using ``pip`` can result
 in a corrupted install with a mix of files from the old version and the new
 version. Anaconda users should update with ``conda update astropy``. There
 may be a brief delay between the release of Astropy on PyPI and its release
@@ -269,8 +270,8 @@ terminal).
 Creating a Time object fails with ValueError after upgrading Astropy
 --------------------------------------------------------------------
 
-In some cases, have users have upgraded Astropy from an older version to v1.0
-or greater they have run into the following crash when trying to create a
+In some cases, when users have upgraded Astropy from an older version to v1.0
+or greater, they have run into the following crash when trying to create an
 `~astropy.time.Time` object::
 
     >>> from astropy.time import Time
@@ -282,32 +283,32 @@ or greater they have run into the following crash when trying to create a
     u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
 
 This problem can occur when there is a version mismatch between the compiled
-ERFA library (this is included as part of Astropy in most distributions), and
+ERFA library (included as part of Astropy in most distributions), and
 the version of the Astropy Python source.
 
-This can have a number of causes.  The most likely is that when installing the
+This can be from a number of causes. The most likely is that when installing the
 new Astropy version, your previous Astropy version was not fully uninstalled
-first, resulting in a mishmash of versions.  Your best bet is to fully remove
-Astropy from its installation path, and reinstall from scratch using your
-preferred installation method.  How to remove the old version may be a simple
-matter if removing the entire ``astropy/`` directory from within the
-``site-packages`` directory it is installed in.  However, if in doubt, ask
+first, resulting in a mishmash of versions. Your best bet is to fully remove
+Astropy from its installation path and reinstall from scratch using your
+preferred installation method. Removing the old version may be achieved by
+removing the entire ``astropy/`` directory from within the
+``site-packages`` directory it is installed in. However, if in doubt, ask
 how best to uninstall packages from your preferred Python distribution.
 
-Another possible cause of this, in particular for people developing on Astropy
-and installing from a source checkout, is simply that your Astropy build
-directory is unclean.  To fix this, run ``git clean -dfx``.  This removes
+Another possible cause of this error, in particular for people developing on
+Astropy and installing from a source checkout, is that your Astropy build
+directory is unclean. To fix this, run ``git clean -dfx``. This removes
 *all* build artifacts from the repository that aren't normally tracked by git.
 Make sure before running this that there are no untracked files in the
-repository you intend to save.  Then rebuild/reinstall from the clean repo.
+repository you intend to save. Then rebuild/reinstall from the clean repo.
 
 
 Failing logging tests when running the tests in IPython
 -------------------------------------------------------
 
 When running the Astropy tests using ``astropy.test()`` in an IPython
-interpreter some of the tests in the ``astropy/tests/test_logger.py`` *might*
-fail, depending on the version of IPython or other factors.
+interpreter, some of the tests in the ``astropy/tests/test_logger.py`` *might*
+fail depending on the version of IPython or other factors.
 This is due to mutually incompatible behaviors in IPython and py.test, and is
 not due to a problem with the test itself or the feature being tested.
 
@@ -336,7 +337,7 @@ by adding the following to your ``sitecustomize.py`` file::
 Note that in general, `this is not recommended
 <https://ziade.org/2008/01/08/syssetdefaultencoding-is-evil/>`_,
 because it can hide other Unicode encoding bugs in your application.
-However, in general if your application does not deal with text
+However, if your application does not deal with text
 processing and you just want docstrings to work, this may be
 acceptable.
 
@@ -346,21 +347,21 @@ Compatibility issues with pytest 3.7 and later
 ----------------------------------------------
 
 Due to a bug in `pytest <http://www.pytest.org>`_ related to test collection,
-the tests for the core astropy package for version 2.0.x (LTS), and for packages
+the tests for the core Astropy package for version 2.0.x (LTS), and for packages
 using the core package's test infrastructure and being tested against 2.0.x
-(LTS) will not be executed correctly with pytest 3.7, 3.8, or 3.9. The symptom
+(LTS), will not be executed correctly with pytest 3.7, 3.8, or 3.9. The symptom
 of this bug is that no tests or only tests in RST files are collected. In
-addition, astropy 2.0.x (LTS) is not compatible with pytest 4.0 and above
+addition, Astropy 2.0.x (LTS) is not compatible with pytest 4.0 and above,
 as in this case deprecation errors from pytest can cause tests to fail.
-Therefore, when testing against astropy v2.0.x (LTS), pytest 3.6 or earlier
+Therefore, when testing against Astropy v2.0.x (LTS), pytest 3.6 or earlier
 versions should be used. These issues do not occur in version 3.0.x and above of
 the core package.
 
-There is also an unrelated issue that also affects more recent versions of
-astropy when testing with pytest 4.0 and later, which can
+There is an unrelated issue that also affects more recent versions of
+Astropy when testing with pytest 4.0 and later, which can
 cause issues when collecting tests - in this case, the symptom is that the
-test collection hangs and/or appears to run the tests recursively. If you are
-maintaining a package that was created using the astropy
+test collection hangs and/or appears to run the tests recursively. If you're
+maintaining a package that was created using the Astropy
 `package template <http://github.com/astropy/package-template>`_, then
 this can be fixed by updating to the latest version of the ``_astropy_init.py``
 file. The root cause of this issue is that pytest now tries to pick up the

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -15,9 +15,9 @@ projects or packages.
 Issues listed on this page are grouped into two categories: The first is known
 issues and shortcomings in actual algorithms and interfaces that currently do
 not have fixes or workarounds, and that users should be aware of when writing
-code that uses `astropy`. Some of those issues are still platform-specific,
+code that uses ``astropy``. Some of those issues are still platform-specific,
 while others are very general. The second category is of common issues that come
-up when configuring, building, or installing `astropy`. This also includes
+up when configuring, building, or installing ``astropy``. This also includes
 cases where the test suite can report false negatives depending on the context/
 platform on which it was run.
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -193,7 +193,7 @@ Bug with Unicode Endianness in ``io.fits`` for Big Endian Processors
 
 On big endian processors (e.g. SPARC, PowerPC, MIPS), string columns in FITS
 files may not be correctly read when using the ``Table.read`` interface. This
-will be fixed in a subsequent bug fix release of `astropy` (see `bug report here
+will be fixed in a subsequent bug fix release of``astropy``(see `bug report here
 <https://github.com/astropy/astropy/issues/3415>`_).
 
 
@@ -211,10 +211,10 @@ Build/Installation/Test Issues
 Anaconda Users Should Upgrade with ``conda``, Not ``pip``
 ---------------------------------------------------------
 
-Upgrading `astropy` in the Anaconda Python distribution using ``pip`` can result
+Upgrading``astropy``in the Anaconda Python distribution using ``pip`` can result
 in a corrupted install with a mix of files from the old version and the new
 version. Anaconda users should update with ``conda update astropy``. There
-may be a brief delay between the release of `astropy` on PyPI and its release
+may be a brief delay between the release of``astropy``on PyPI and its release
 via the ``conda`` package manager; users can check the availability of new
 versions with ``conda search astropy``.
 
@@ -270,7 +270,7 @@ terminal).
 Creating a Time Object Fails with ValueError After Upgrading ``astropy``
 ------------------------------------------------------------------------
 
-In some cases, when users have upgraded `astropy` from an older version to v1.0
+In some cases, when users have upgraded``astropy``from an older version to v1.0
 or greater, they have run into the following crash when trying to create an
 `~astropy.time.Time` object::
 
@@ -283,11 +283,11 @@ or greater, they have run into the following crash when trying to create an
     u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
 
 This problem can occur when there is a version mismatch between the compiled
-ERFA library (included as part of `astropy` in most distributions), and
-the version of the `astropy` Python source.
+ERFA library (included as part of``astropy``in most distributions), and
+the version of the``astropy``Python source.
 
 This can be from a number of causes. The most likely is that when installing the
-new `astropy` version, your previous `astropy` version was not fully uninstalled
+new``astropy``version, your previous``astropy``version was not fully uninstalled
 first, resulting in a mishmash of versions. Your best bet is to fully remove
 `astropy` from its installation path and reinstall from scratch using your
 preferred installation method. Removing the old version may be achieved by
@@ -347,13 +347,13 @@ Compatibility Issues with pytest 3.7 and later
 ----------------------------------------------
 
 Due to a bug in `pytest <http://www.pytest.org>`_ related to test collection,
-the tests for the core `astropy` package for version 2.0.x (LTS), and for
+the tests for the core``astropy``package for version 2.0.x (LTS), and for
 packages using the core package's test infrastructure and being tested against
 2.0.x (LTS), will not be executed correctly with pytest 3.7, 3.8, or 3.9. The
 symptom of this bug is that no tests or only tests in RST files are collected.
-In addition, `astropy` 2.0.x (LTS) is not compatible with pytest 4.0 and above,
+In addition,``astropy``2.0.x (LTS) is not compatible with pytest 4.0 and above,
 as in this case deprecation errors from pytest can cause tests to fail.
-Therefore, when testing against `astropy` v2.0.x (LTS), pytest 3.6 or earlier
+Therefore, when testing against``astropy``v2.0.x (LTS), pytest 3.6 or earlier
 versions should be used. These issues do not occur in version 3.0.x and above of
 the core package.
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -267,8 +267,8 @@ If so, you can go ahead and try running ``setup.py`` again (in the new
 terminal).
 
 
-Creating a Time Object Fails with ValueError After Upgrading `astropy`
-----------------------------------------------------------------------
+Creating a Time Object Fails with ValueError After Upgrading ``astropy``
+------------------------------------------------------------------------
 
 In some cases, when users have upgraded `astropy` from an older version to v1.0
 or greater, they have run into the following crash when trying to create an

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -193,7 +193,7 @@ Bug with Unicode Endianness in ``io.fits`` for Big Endian Processors
 
 On big endian processors (e.g. SPARC, PowerPC, MIPS), string columns in FITS
 files may not be correctly read when using the ``Table.read`` interface. This
-will be fixed in a subsequent bug fix release of``astropy``(see `bug report here
+will be fixed in a subsequent bug fix release of ``astropy`` (see `bug report here
 <https://github.com/astropy/astropy/issues/3415>`_).
 
 
@@ -211,10 +211,10 @@ Build/Installation/Test Issues
 Anaconda Users Should Upgrade with ``conda``, Not ``pip``
 ---------------------------------------------------------
 
-Upgrading``astropy``in the Anaconda Python distribution using ``pip`` can result
+Upgrading ``astropy`` in the Anaconda Python distribution using ``pip`` can result
 in a corrupted install with a mix of files from the old version and the new
 version. Anaconda users should update with ``conda update astropy``. There
-may be a brief delay between the release of``astropy``on PyPI and its release
+may be a brief delay between the release of ``astropy`` on PyPI and its release
 via the ``conda`` package manager; users can check the availability of new
 versions with ``conda search astropy``.
 
@@ -270,7 +270,7 @@ terminal).
 Creating a Time Object Fails with ValueError After Upgrading ``astropy``
 ------------------------------------------------------------------------
 
-In some cases, when users have upgraded``astropy``from an older version to v1.0
+In some cases, when users have upgraded ``astropy`` from an older version to v1.0
 or greater, they have run into the following crash when trying to create an
 `~astropy.time.Time` object::
 
@@ -283,13 +283,13 @@ or greater, they have run into the following crash when trying to create an
     u'jyear_str', u'iso', u'isot', u'yday', u'byear_str']
 
 This problem can occur when there is a version mismatch between the compiled
-ERFA library (included as part of``astropy``in most distributions), and
-the version of the``astropy``Python source.
+ERFA library (included as part of ``astropy`` in most distributions), and
+the version of the ``astropy`` Python source.
 
 This can be from a number of causes. The most likely is that when installing the
-new``astropy``version, your previous``astropy``version was not fully uninstalled
+new ``astropy`` version, your previous ``astropy`` version was not fully uninstalled
 first, resulting in a mishmash of versions. Your best bet is to fully remove
-`astropy` from its installation path and reinstall from scratch using your
+``astropy`` from its installation path and reinstall from scratch using your
 preferred installation method. Removing the old version may be achieved by
 removing the entire ``astropy/`` directory from within the
 ``site-packages`` directory it is installed in. However, if in doubt, ask
@@ -347,21 +347,21 @@ Compatibility Issues with pytest 3.7 and later
 ----------------------------------------------
 
 Due to a bug in `pytest <http://www.pytest.org>`_ related to test collection,
-the tests for the core``astropy``package for version 2.0.x (LTS), and for
+the tests for the core ``astropy`` package for version 2.0.x (LTS), and for
 packages using the core package's test infrastructure and being tested against
 2.0.x (LTS), will not be executed correctly with pytest 3.7, 3.8, or 3.9. The
 symptom of this bug is that no tests or only tests in RST files are collected.
-In addition,``astropy``2.0.x (LTS) is not compatible with pytest 4.0 and above,
+In addition, ``astropy`` 2.0.x (LTS) is not compatible with pytest 4.0 and above,
 as in this case deprecation errors from pytest can cause tests to fail.
-Therefore, when testing against``astropy``v2.0.x (LTS), pytest 3.6 or earlier
+Therefore, when testing against ``astropy`` v2.0.x (LTS), pytest 3.6 or earlier
 versions should be used. These issues do not occur in version 3.0.x and above of
 the core package.
 
 There is an unrelated issue that also affects more recent versions of
-`astropy` when testing with pytest 4.0 and later, which can
+``astropy`` when testing with pytest 4.0 and later, which can
 cause issues when collecting tests — in this case, the symptom is that the
 test collection hangs and/or appears to run the tests recursively. If you are
-maintaining a package that was created using the `astropy`
+maintaining a package that was created using the Astropy
 `package template <http://github.com/astropy/package-template>`_, then
 this can be fixed by updating to the latest version of the ``_astropy_init.py``
 file. The root cause of this issue is that pytest now tries to pick up the

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -268,7 +268,7 @@ terminal).
 
 
 Creating a Time Object Fails with ValueError After Upgrading `astropy`
---------------------------------------------------------------------
+----------------------------------------------------------------------
 
 In some cases, when users have upgraded `astropy` from an older version to v1.0
 or greater, they have run into the following crash when trying to create an


### PR DESCRIPTION
This is the first in what will be a series of pull requests in which I'll go through the full documentation to proofread and copy edit.

We decided to do one pull request per sub-package, so I'll begin on the coordinates package next.

Aside from typos and grammar, I tried to remove any extraneous or hostile language, as well as bring more consistency to formatting such as capitalization in headers or package names.

cc @kelle @adrn 