### PR TITLE
Bugfix for issue 8458

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -326,6 +326,9 @@ astropy.io.misc
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+- Fixed bug in ``ColDefs._init_from_array()`` that caused unsigned datatypes
+  with the opposite endianess as the host architecture to fail the
+  TestColumnFunctions.test_coldefs_init_from_array unit test. [#8460]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -326,9 +326,6 @@ astropy.io.misc
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
-- Fixed bug in ``ColDefs._init_from_array()`` that caused unsigned datatypes
-  with the opposite endianess as the host architecture to fail the
-  TestColumnFunctions.test_coldefs_init_from_array unit test. [#8460]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -1874,6 +1871,9 @@ astropy.io.ascii
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+- Fixed bug in ``ColDefs._init_from_array()`` that caused unsigned datatypes
+  with the opposite endianess as the host architecture to fail the
+  TestColumnFunctions.test_coldefs_init_from_array unit test. [#8460]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1423,12 +1423,13 @@ class ColDefs(NotifierMixin):
 
             # Check for unsigned ints.
             bzero = None
-            if 'I' in format and ftype.base == np.dtype('uint16'):
-                bzero = np.uint16(2**15)
-            elif 'J' in format and ftype.base == np.dtype('uint32'):
-                bzero = np.uint32(2**31)
-            elif 'K' in format and ftype.base == np.dtype('uint64'):
-                bzero = np.uint64(2**63)
+            if ftype.base.kind == 'u':
+                if 'I' in format:
+                    bzero = np.uint16(2**15)
+                elif 'J' in format:
+                    bzero = np.uint32(2**31)
+                elif 'K' in format:
+                    bzero = np.uint64(2**63)
 
             c = Column(name=cname, format=format,
                        array=array.view(np.ndarray)[cname], bzero=bzero,

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2930,7 +2930,7 @@ class TestColumnFunctions(FitsTestCase):
         """Test that ColDefs._init_from_array works with single element data-
         types as well as multi-element data-types
         """
-        nd_array = np.ndarray((1,), dtype=[('A', '<u4', (2,)), ('B', 'uint16')])
+        nd_array = np.ndarray((1,), dtype=[('A', '<u4', (2,)), ('B', '>u2')])
         col_defs = fits.column.ColDefs(nd_array)
         assert 2**31 == col_defs['A'].bzero
         assert 2**15 == col_defs['B'].bzero


### PR DESCRIPTION
Modified test TestColumnFunctions.test_coldefs_init_from_array for coverage of datatypes of little and big endianess

Fixed bug in ColDefs._init_from_array to cover all possible unsigned numpy datatypes