### PR TITLE
Make transform graph docs non-astropy specific

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -88,8 +88,8 @@ def make_transform_graph_docs(transform_graph):
                                             priorities=False)
 
     docstr = """
-    The diagram below shows all of the coordinate systems built into the
-    `~astropy.coordinates` package, their aliases (useful for converting
+    The diagram below shows all of the built in coordinate systems,
+    their aliases (useful for converting
     other coordinates to them using attribute-style access) and the
     pre-defined transformations between them.  The user is free to
     override any of these transformations by defining new transformations

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -89,12 +89,11 @@ def make_transform_graph_docs(transform_graph):
 
     docstr = """
     The diagram below shows all of the built in coordinate systems,
-    their aliases (useful for converting
-    other coordinates to them using attribute-style access) and the
-    pre-defined transformations between them.  The user is free to
-    override any of these transformations by defining new transformations
-    between these systems, but the pre-defined transformations should be
-    sufficient for typical usage.
+    their aliases (useful for converting other coordinates to them using
+    attribute-style access) and the pre-defined transformations between
+    them.  The user is free to override any of these transformations by
+    defining new transformations between these systems, but the
+    pre-defined transformations should be sufficient for typical usage.
 
     The color of an edge in the graph (i.e. the transformations between two
     frames) is set by the type of transformation; the legend box defines the


### PR DESCRIPTION
In https://github.com/astropy/astropy/pull/7135 it was made possible to make custom graph transformation docs; this PR changes the docs a little bit to make them non-astropy specific, so other projects can use the `make_doc` function without having a reference to `astropy.coordinates` specific frames.