### PR TITLE
TST: Move linkcheck to cron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,6 @@ jobs:
             LC_CTYPE: C
             LC_ALL: C
             LANG: C
-      - run:
-          name: Link Check
-          command: venv/bin/python setup.py build_docs -b linkcheck
 
       - store_artifacts:
           path: docs/_build/html

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
         - PYTEST_VERSION=3.10
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
         - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
@@ -83,7 +83,7 @@ matrix:
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
                CONDA_DEPENDENCIES="$CONDA_ALL_DEPENDENCIES clang"
-               PIP_DEPENDENCIES="jplephem $ASDF_PIP_DEP"
+               PIP_DEPENDENCIES="scikit-image jplephem $ASDF_PIP_DEP"
                CCOMPILER=clang
                EVENT_TYPE='cron'
 
@@ -117,7 +117,7 @@ matrix:
         - os: linux
           stage: Initial tests
           env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$ASDF_PIP_DEP
+               PIP_DEPENDENCIES="scikit-image $ASDF_PIP_DEP"
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
 
@@ -125,7 +125,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --coverage --remote-data=astropy --readonly'
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES="codecov objgraph jplephem bintrees sortedcontainers $ASDF_PIP_DEP"
+               PIP_DEPENDENCIES="scikit-image codecov objgraph jplephem bintrees sortedcontainers $ASDF_PIP_DEP"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='--coverage -fno-inline-functions -O0'
                MATPLOTLIB_VERSION=2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,16 @@ matrix:
                CONDA_DEPENDENCIES=''
                PIP_DEPENDENCIES=$DEV_PIP_DEP
 
+        # Run documentation link check in a cron job.
+        # Was originally in CircleCI doc build but links are too flaky, so
+        # we moved it here instead.
+        - os: linux
+          stage: Cron tests
+          env: SETUP_CMD='build_docs -b linkcheck'
+               PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
+               INSTALL_WITH_PIP=True
+               EXTRAS_INSTALL="docs,all"
+
     allow_failures:
       - os: linux
         env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'

--- a/astropy/io/misc/asdf/__init__.py
+++ b/astropy/io/misc/asdf/__init__.py
@@ -60,8 +60,8 @@ Advanced Usage
 
 The fundamental ASDF data structure is the tree, which is simply a nested
 combination of basic data structures (see `this
-<https://asdf.readthedocs.io/asdf/features#data-model>`_ for a more detailed
-description). At the top level, the tree is a `dict`.
+<https://asdf.readthedocs.io/en/latest/asdf/features.html#data-model>`_
+for a more detailed description). At the top level, the tree is a `dict`.
 
 The consequence of this is that a `~astropy.table.Table` object (or any object,
 for that matter) can be stored at any arbitrary location within an ASDF tree.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -230,7 +230,8 @@ except ImportError:
 
 # -- Options for linkcheck output -------------------------------------------
 linkcheck_retry = 5
-linkcheck_ignore = ['https://journals.aas.org/manuscript-preparation/']
+linkcheck_ignore = ['https://journals.aas.org/manuscript-preparation/',
+                    r'https://github\.com/astropy/astropy/(?:issues|pull)/\d+']
 linkcheck_timeout = 180
 linkcheck_anchors = False
 

--- a/docs/io/fits/appendix/header_transition.rst
+++ b/docs/io/fits/appendix/header_transition.rst
@@ -406,10 +406,8 @@ Other Gotchas
   return just ``'Value'``.
 
   There is, however, one convention used by the IRAF ccdmosaic task for
-  representing its `TNX World Coordinate System
-  <http://iraf.noao.edu/projects/ccdmosaic/tnx.html>`_ and `ZPX World
-  Coordinate System <http://iraf.noao.edu/projects/ccdmosaic/zpx.html>`_
-  non-standard WCS' that uses a series of keywords in the form ``WATj_nnn``
+  representing its TNX World Coordinate System and ZPX World Coordinate System
+  non-standard WCS that uses a series of keywords in the form ``WATj_nnn``
   which store a text description of coefficients for a non-linear distortion
   projection.  It uses its own microformat for listing the coefficients as a
   string, but the string is long, and thus broken up into several of these

--- a/docs/io/fits/appendix/history.rst
+++ b/docs/io/fits/appendix/history.rst
@@ -2823,7 +2823,7 @@ The following bugs were fixed:
   windows platform using a drive letter in the file specification caused a
   misleading IOError exception to be raised.
 
-.. _[2]: http://stsdas.stsci.edu/stsci_python_sphinxdocs_2.13/tools/stpyfits.html
+.. _[2]: https://stscitools.readthedocs.io/en/latest/stpyfits.html
 
 
 1.1 (2007-06-15)

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -282,9 +282,7 @@ NumPy structured array
 ----------------------
 The structured array is the standard mechanism in `numpy` for storing
 heterogeneous table data.  Most scientific I/O packages that read table
-files (e.g.  `PyFITS
-<https://github.com/spacetelescope/pyfits>`_, `vo.table
-<http://stsdas.stsci.edu/astrolib/vo/html/intro_table.html>`_, `asciitable
+files (e.g., `astropy.io.fits`, `astropy.io.votable`, and `asciitable
 <http://cxc.harvard.edu/contrib/asciitable/>`_) will return the table in an
 object that is based on the structured array.  A structured array can be
 created using::

--- a/docs/whatsnew/1.2.rst
+++ b/docs/whatsnew/1.2.rst
@@ -154,7 +154,7 @@ The **Jackknife resampling method** is available via the
 generates n deterministic samples of size n-1 from a measured sample of size n.
 Those samples can then be used for various statistics estimation such as
 variance and bias using the :func:`~astropy.stats.jackknife_stats` function.
-  
+
 **Circular statistics** (circular mean, variance, etc) are now provided by the
 :func:`~astropy.stats.circmean`, :func:`~astropy.stats.circvar`, ,
 :func:`~astropy.stats.circmoment`, and :func:`~astropy.stats.circcorrcoef`
@@ -220,7 +220,7 @@ The `zscale <http://iraf.net/forum/viewtopic.php?showtopic=134139>`_ algorithm
 from IRAF is now included in Astropy's :ref:`visualization
 <astropy-visualization>` sub-package, and available as
 a `~astropy.visualization.ZScaleInterval` interval class. The implementation is
-based on `Numdisplay’s <http://stsdas.stsci.edu/numdisplay/>`_ one, slightly
+based on `Numdisplay’s <https://github.com/spacetelescope/stsci.numdisplay>`_ one, slightly
 modified to expose more arguments and work with data with any number of
 dimensions.
 


### PR DESCRIPTION
Move #8386 from CircleCI (run per PR) to Travis cron ~~(I recommend weekly but up to you)~~. Also fixed some links that are broken.

TODO:

- [x] Make sure the new check in Travis runs once in this PR to see if it works.
- [x] Turns out cron jobs runs everything for the branch, no way to pick and choose. So this will have to be nightly like everything else. Need to adjust comment in the config.
- [x] Remove hack to run for every PR. This should be set to cron only before merge.