### PR TITLE
Work on fixing documentation bug for convenience function fits.append()

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -601,10 +601,13 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
         faster.
 
     kwargs
-        Any additional keyword arguments to be passed to
-        `astropy.io.fits.open`.
-    """
+        Additional arguments are passed to:
+        - `~astropy.io.fits.writeto` if the file does not exist or is empty. In this case
+        ``output_verify`` is the only possible argument.
+        - `~astropy.io.fits.open` if ``verify`` is True or if ``filename`` is a file object.
+        - Otherwise no additional arguments can be used.
 
+    """
     name, closed, noexist_or_empty = _stat_filename_or_fileobj(filename)
 
     if noexist_or_empty:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -602,9 +602,11 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
 
     kwargs
         Additional arguments are passed to:
-        - `~astropy.io.fits.writeto` if the file does not exist or is empty. In this case
-        ``output_verify`` is the only possible argument.
-        - `~astropy.io.fits.open` if ``verify`` is True or if ``filename`` is a file object.
+
+        - `~astropy.io.fits.writeto` if the file does not exist or is empty.
+          In this case ``output_verify`` is the only possible argument.
+        - `~astropy.io.fits.open` if ``verify`` is True or if ``filename``
+          is a file object.
         - Otherwise no additional arguments can be used.
 
     """
@@ -624,7 +626,7 @@ def append(filename, data, header=None, checksum=False, verify=True, **kwargs):
             hdu = ImageHDU(data, header)
 
         if verify or not closed:
-            f = fitsopen(filename, mode='append')
+            f = fitsopen(filename, mode='append', **kwargs)
             try:
                 f.append(hdu)
 

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -157,6 +157,29 @@ class TestConvenience(FitsTestCase):
         fits.tabledump(self.temp('tb.fits'), datafile=self.temp('test_tb.txt'))
         assert os.path.isfile(self.temp('test_tb.txt'))
 
+    def test_append(self):
+        """
+        Test that ``fits.append()`` works in the case where the file does not exist
+        or is empty in case 1, and in case 2 in which ``verify`` is True or if
+        ``filename`` is a file object, as well as in case 3 where ``verify`` is set to
+        False
+        """
+        # Test case 1
+        fits.append('test_append_1.fits', data=np.ones((16,32)))
+        with fits.open('test_append_1.fits', checksum=True, verify=True) as hdu1:
+            assert isinstance(hdu1[0], fits.PrimaryHDU)
+            assert np.all(hdu1[0].data == np.ones((16,32)))
+
+        # Test case 2
+        filename = self.temp('test_append_2.fits')
+        with open(filename, mode='wb') as fp:
+            fits.append(fp, data=np.arange(10), verify=True)
+
+        # Test case 3
+        filename2 = self.temp('test_append_3.fits')
+        with open(filename2, mode='wb') as fp:
+            fits.append(fp, data=np.arange(10), verify=False)
+
     @pytest.mark.parametrize('mode', ['wb', 'wb+', 'ab', 'ab+'])
     def test_append_filehandle(self, tmpdir, mode):
 


### PR DESCRIPTION
Fixes #7882. Aims to clarify some confusion inherent in the existing documentation regarding the convenience function fits.append(). To follow on on the suggestions in https://github.com/astropy/astropy/issues/7882#issuecomment-467213239. 

To recap those comments:
> 1. If the file does not exist, writeto is used, and kwargs are passed here. The only option that can be used here is output_verify. We can keep it like this and document this properly.
> 2. If the file exists, and filename is a string, fits.open is used. Here we need to pass kwargs.
> 3. If the file exists, and filename is a file object, there is no additional argument to pass. We could maybe check that kwargs is empty and raise a warning if it is not empty ?

But first some tests are needed to check code. 