### PR TITLE
Remove unused imports in io.fits

### DIFF
--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -14,11 +14,10 @@ from astropy.time import Time
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data_info import MixinInfo, serialize_context_as
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
-from .column import KEYWORD_NAMES, ASCII_DEFAULT_WIDTHS, _fortran_to_python_format
+from .column import KEYWORD_NAMES, _fortran_to_python_format
 from .convenience import table_to_hdu
 from .hdu.hdulist import fitsopen as fits_open
 from .util import first
-from .verify import VerifyError, VerifyWarning
 
 
 # FITS file signature as per RFC 4047
@@ -299,7 +298,7 @@ def _encode_mixins(tbl):
     # description or meta) will be silently dropped, consistent with astropy <=
     # 2.0 behavior.
     try:
-        import yaml
+        import yaml  # noqa
     except ImportError:
         for col in tbl.itercols():
             if (has_info_class(col, MixinInfo) and

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -42,7 +42,6 @@ Example uses of fitscheck:
 
 import logging
 import optparse
-import os
 import sys
 import textwrap
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -13,15 +13,14 @@ import numpy as np
 from numpy.testing import assert_equal
 
 from astropy.io import fits
-from astropy.utils.exceptions import AstropyPendingDeprecationWarning
-from astropy.tests.helper import raises, catch_warnings, ignore_warnings
+from astropy.tests.helper import catch_warnings, ignore_warnings
 from astropy.io.fits.hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from .test_table import comparerecords
 
 from . import FitsTestCase
 
 try:
-    import scipy  # pylint: disable=W0611
+    import scipy  # noqa
 except ImportError:
     HAS_SCIPY = False
 else:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -19,7 +19,7 @@ except ImportError:
 from astropy.io import fits
 from astropy.tests.helper import catch_warnings, ignore_warnings
 from astropy.utils.compat import NUMPY_LT_1_14_1, NUMPY_LT_1_14_2
-from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy.io.fits.column import Delayed, NUMPY2FITS
 from astropy.io.fits.util import decode_ascii


### PR DESCRIPTION
Related to the unused imports discussion in #8470 

A few remarks:
- there are already some imports marked with `# pylint: disable=W0611`, I don't know we can combine this with `noqa`. I guess the easiest is to replace with `noqa`, unless some pylint users object ?
- having to add the `noqa` mark everywhere in `__init__.py` files is annoying, but the only alternative is to exclude completely these files, not a good idea.
- these kind of changes will probably make backports more difficult.