### PR TITLE
Fix ASDF schema test location in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true
 addopts = -p no:warnings
-asdf_schema_root = astropy/io/misc/asdf/schemas
+asdf_schema_root = astropy/io/misc/asdf/data/schemas
 xfail_strict = true
 qt_no_exception_capture = 1
 


### PR DESCRIPTION
The schema locations were changed in #8413, but the location referenced by the ASDF schema tester was not.