### PR TITLE
Remove remainder of astropy.tests.plugins.config plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -176,9 +176,10 @@ astropy.tests
 - Removed ``pytest_plugins`` as they are completely broken for ``pytest>=4``.
   [#7786]
 
-- Removed ``--astropy-config-dir`` and ``--astropy-cache-dir`` options from
+- Removed the ``astropy.tests.plugins.config`` plugin and removed the
+  ``--astropy-config-dir`` and ``--astropy-cache-dir`` options from
   testing. Please use caching functionality that is natively in ``pytest``.
-  [#7787]
+  [#7787, #8489]
 
 astropy.time
 ^^^^^^^^^^^^

--- a/astropy/tests/plugins/config.py
+++ b/astropy/tests/plugins/config.py
@@ -1,9 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This plugin provides customization of configuration used by pytest.
-"""
-from astropy.tests.helper import treat_deprecations_as_exceptions
-
-
-def pytest_configure(config):
-    treat_deprecations_as_exceptions()

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -223,11 +223,6 @@ class TestRunnerBase:
         else:
             plugins = []
 
-        # If we are running the astropy tests with the astropy plugins handle
-        # the config stuff, otherwise ignore it.
-        if 'astropy.tests.plugins.config' not in plugins:
-            return pytest.main(args=args, plugins=plugins)
-
         # override the config locations to not make a new directory nor use
         # existing cache or config
         astropy_config = tempfile.mkdtemp('astropy_config')
@@ -412,7 +407,7 @@ class TestRunner(TestRunnerBase):
 
         return []
 
-    @keyword(default_value=['astropy.tests.plugins.display', 'astropy.tests.plugins.config'])
+    @keyword(default_value=['astropy.tests.plugins.display'])
     def plugins(self, plugins, kwargs):
         """
         plugins : list, optional

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 pytest_plugins = [
-    'astropy.tests.plugins.config',
     'astropy.tests.plugins.display',
 ]


### PR DESCRIPTION
This is a follow-up to https://github.com/astropy/astropy/pull/7787 - it wasn't clear to me why we've retained the current simple function in ``config.py``? Was it for backward-compatibility?

In any case, we definitely should remove this plugin from ``conftest.py``.