### PR TITLE
Improve table slice performance by managing col.info better

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,9 @@ astropy.table
   Table initialization so that input ``meta`` is copied only if ``copy=True``.
   [#8404]
 
+- Improved Table slicing performance with internal implementation changes
+  related to column attribute access and certain input validation. [#8493]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -824,24 +824,26 @@ class Table:
 
             newcols.append(newcol)
 
-        self._make_table_from_cols(table, newcols, check_cols=False,
-                                   names=self.columns.keys())
+        self._make_table_from_cols(table, newcols, verify=False, names=self.columns.keys())
         return table
 
     @staticmethod
-    def _make_table_from_cols(table, cols, check_cols=True, names=None):
+    def _make_table_from_cols(table, cols, verify=True, names=None):
         """
         Make ``table`` in-place so that it represents the given list of ``cols``.
         """
-        if check_cols:
-            colnames = set(col.info.name for col in cols)
-            if None in colnames:
-                raise TypeError('Cannot have None for column name')
-            if len(colnames) != len(cols):
-                raise ValueError('Duplicate column names')
-
         if names is None:
-            names = (col.info.name for col in cols)
+            names = [col.info.name for col in cols]
+
+        # Note: we do not test for len(names) == len(cols) if names is not None.  In that
+        # case the function is being called by from "trusted" source (e.g. right above here)
+        # that is assumed to provide valid inputs.  In that case verify=False.
+
+        if verify:
+            if None in names:
+                raise TypeError('Cannot have None for column name')
+            if len(set(names)) != len(names):
+                raise ValueError('Duplicate column names')
 
         columns = table.TableColumns((name, col) for name, col in zip(names, cols))
 


### PR DESCRIPTION
This improves table slicing performance by a factor of 2.  E.g. on my system slicing a table of 25 columns is 1580 usec with master vs. 740 usec with this branch.  For a "narrow" table the improvement is also around a factor of 2.  Still too slow, but at least less slow.

The key issue is recognizing that accessing any column `info` attribute (e.g. `col.info.name`) is really expensive, around 4 usec.  This needs to be addressed separately, perhaps following along #6720 and moving `Column` attributes to `info` (if that can be made to be fast).

This also skips some validation checks that are not needed in the case of slicing an existing (well-formed) table.

The changes are not really as big as they appear at first glance.   The only non-obvious change in logic is moving the two lines involving `col.info._copy_indices` inside the `if ...indices:` block.  There is no point in doing those two atrribute setting statements if the column does not have an index.  It only matters (as far as I can tell) if `col.info.slice_indices` gets called.