### PR TITLE
[Temp fix] Pin PyYAML<5.1 until we fix the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
-        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml<5.1 scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ asdf_extensions =
 
 [options.extras_require]
 test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+all = scipy; h5py; beautifulsoup4; bleach; PyYAML<5.1; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
 docs = sphinx-astropy
 
 [build_sphinx]


### PR DESCRIPTION
Stop gap for #8498 so CI is green until we have a chance to update the tests themselves.

Since this is supposed to be temporary, I didn't assign any milestones, but feel free to add a milestone if you want.