### PR TITLE
Set YAML default_flow_style=None for consistent output with PyYAML version 5.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
-        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml<5.1 scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
+        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1908,6 +1908,9 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Explicitly set PyYAML default flow style to None to ensure consistent
+  astropy YAML output for PyYAML version 5.1 and later. [#8500]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -538,7 +538,8 @@ def test_fail_meta_serialize(tmpdir):
 
     with pytest.raises(Exception) as err:
         t1.write(test_file, path='the_table', serialize_meta=True)
-    assert "cannot represent an object: <class 'str'>" in str(err)
+    assert "cannot represent an object" in str(err)
+    assert "<class 'str'>" in str(err)
 
 
 @pytest.mark.skipif('not HAS_H5PY')

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -352,4 +352,5 @@ def dump(data, stream=None, **kwargs):
 
     """
     kwargs['Dumper'] = AstropyDumper
+    kwargs.setdefault('default_flow_style', None)
     return yaml.dump(data, stream=stream, **kwargs)

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -287,7 +287,8 @@ def get_yaml_from_header(header):
     header['datatype'] = [_get_col_attributes(col) for col in header['cols']]
     del header['cols']
 
-    lines = yaml.dump(header, Dumper=TableDumper, width=130).splitlines()
+    lines = yaml.dump(header, default_flow_style=None,
+                      Dumper=TableDumper, width=130).splitlines()
     return lines
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ asdf_extensions =
 
 [options.extras_require]
 test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; bleach; PyYAML<5.1; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+all = scipy; h5py; beautifulsoup4; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
 docs = sphinx-astropy
 
 [build_sphinx]


### PR DESCRIPTION
See #8499 and enclosed.  This should allow reverting #8499.

I tested locally with PyYAML 5.1 installed:
- Reproduced test failures from #8498 using master
- Saw no related test failures with this PR (two unrelated IERS fails).

I haven't specifically checked but it seems like this could be backported to 2.0.

EDIT: Fix #8498 