### PR TITLE
Improve FITS header performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,12 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
--  Optimize ``Header`` parsing. [#8428]
+- Optimize parsing of cards within the ``Header`` class. [#8428]
+
+- Optimize the parsing of headers to get the structural keywords that are
+  needed to find extensions. Thanks to this, getting a random HDU from a file
+  with many extensions is much faster than before, in particular when the
+  extension headers contain many keywords. [#8502]
 
 -  Change behavior of FITS undefined value in ``Header`` such that ``None``
    is used in Python to represent FITS undefined when using dict interface.

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -41,8 +41,8 @@ def parse_header(fileobj):
                 keyword = card_image[:8].strip()
                 cards[keyword.upper()] = card_image
             else:
-                sep_idx = card_image[:8].find(VALUE_INDICATOR)
-                if 0 < sep_idx < 8:
+                sep_idx = card_image.find(VALUE_INDICATOR, 0, 8)
+                if sep_idx > 0:
                     keyword = card_image[:sep_idx]
                     cards[keyword.upper()] = card_image
                 elif card_image == END_CARD:

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -34,20 +34,20 @@ def parse_header(fileobj):
             card_image = block_str[idx:end_idx]
             idx = end_idx
 
-            keyword = card_image[:8].strip()
-            sep_idx = card_image.find(VALUE_INDICATOR)
-
             # We are interested only in standard keyword, so we skip
-            # other cards, e.G. CONTINUE, HIERARCH, COMMENT.
-            if sep_idx == 8:
+            # other cards, e.g. CONTINUE, HIERARCH, COMMENT.
+            if card_image[8:10] == VALUE_INDICATOR:
                 # ok, found standard keyword
+                keyword = card_image[:8].strip()
                 cards[keyword.upper()] = card_image
-            elif 0 < sep_idx < 8:
-                keyword = card_image[:sep_idx]
-                cards[keyword.upper()] = card_image
-            elif card_image == END_CARD:
-                found_end = 1
-                break
+            else:
+                sep_idx = card_image[:8].find(VALUE_INDICATOR)
+                if 0 < sep_idx < 8:
+                    keyword = card_image[:sep_idx]
+                    cards[keyword.upper()] = card_image
+                elif card_image == END_CARD:
+                    found_end = 1
+                    break
 
     # we keep the full header string as it may be needed later to
     # create a Header object

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -1,0 +1,56 @@
+cdef Py_ssize_t BLOCK_SIZE = 2880  # the FITS block size
+cdef Py_ssize_t CARD_LENGTH = 80
+cdef bytes VALUE_INDICATOR = b'= '  # The standard FITS value indicator
+cdef bytes END_CARD = b'END' + b' ' * 77
+
+
+def parse_header(fileobj):
+    """The main method allowing to parse quickly a FITS header."""
+
+    cards = {}
+    read_blocks = []
+    cdef int found_end = 0
+    cdef bytes header_str, block, card_image, keyword
+    cdef str keyword_upper
+    cdef Py_ssize_t idx, end_idx, sep_idx
+
+    while True:
+        # iterate on blocks
+        block = fileobj.read(BLOCK_SIZE)
+        if not block or len(block) < BLOCK_SIZE:
+            # header looks incorrect, raising exception to fall back to
+            # the full Header parsing
+            raise Exception
+
+        read_blocks.append(block)
+        idx = 0
+        while idx < BLOCK_SIZE:
+            # iterate on cards
+            end_idx = idx + CARD_LENGTH
+            card_image = block[idx:end_idx]
+            idx = end_idx
+
+            keyword = card_image[:8].strip()
+            sep_idx = card_image.find(VALUE_INDICATOR)
+
+            # We are interested only in standard keyword, so we skip
+            # other cards, e.G. CONTINUE, HIERARCH, COMMENT.
+            if sep_idx == 8:
+                # ok, found standard keyword
+                keyword_upper = keyword.decode('ascii').upper()
+                cards[keyword_upper] = card_image
+            elif 0 < sep_idx < 8:
+                keyword = card_image[:sep_idx]
+                keyword_upper = keyword.decode('ascii').upper()
+                cards[keyword_upper] = card_image
+            elif card_image == END_CARD:
+                found_end = 1
+                break
+
+        if found_end == 1:
+            break
+
+    # we keep the full header string as it may be needed later to
+    # create a Header object
+    header_str = b''.join(read_blocks)
+    return header_str, cards

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -10,13 +10,13 @@ def parse_header(fileobj):
     """The main method allowing to parse quickly a FITS header."""
 
     cards = OrderedDict()
-    read_blocks = []
+    cdef read_blocks = []
     cdef int found_end = 0
     cdef bytes block
     cdef str header_str, block_str, card_image, keyword
     cdef Py_ssize_t idx, end_idx, sep_idx
 
-    while True:
+    while found_end == 0:
         # iterate on blocks
         block = fileobj.read(BLOCK_SIZE)
         if not block or len(block) < BLOCK_SIZE:
@@ -47,9 +47,6 @@ def parse_header(fileobj):
             elif card_image == END_CARD:
                 found_end = 1
                 break
-
-        if found_end == 1:
-            break
 
     # we keep the full header string as it may be needed later to
     # create a Header object

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -8,7 +8,17 @@ cdef str END_CARD = 'END' + ' ' * 77
 
 
 def parse_header(fileobj):
-    """The main method allowing to parse quickly a FITS header."""
+    """Fast (and incomplete) parser for FITS headers.
+
+    This parser only reads the standard 8 character keywords, and ignores the
+    CONTINUE, COMMENT, HISTORY and HIERARCH cards. The goal is to find quickly
+    the structural keywords needed to build the HDU objects.
+
+    The implementation is straightforward: first iterate on the 2880-bytes
+    blocks, then iterate on the 80-bytes cards, find the value separator, and
+    store the parsed (keyword, card image) in a dictionary.
+
+    """
 
     cards = OrderedDict()
     cdef list read_blocks = []

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 cdef Py_ssize_t BLOCK_SIZE = 2880  # the FITS block size
 cdef Py_ssize_t CARD_LENGTH = 80
 cdef str VALUE_INDICATOR = '= '  # The standard FITS value indicator
@@ -7,7 +9,7 @@ cdef str END_CARD = 'END' + ' ' * 77
 def parse_header(fileobj):
     """The main method allowing to parse quickly a FITS header."""
 
-    cards = {}
+    cards = OrderedDict()
     read_blocks = []
     cdef int found_end = 0
     cdef bytes block

--- a/astropy/io/fits/_utils.pyx
+++ b/astropy/io/fits/_utils.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=3
 from collections import OrderedDict
 
 cdef Py_ssize_t BLOCK_SIZE = 2880  # the FITS block size
@@ -10,7 +11,7 @@ def parse_header(fileobj):
     """The main method allowing to parse quickly a FITS header."""
 
     cards = OrderedDict()
-    cdef read_blocks = []
+    cdef list read_blocks = []
     cdef int found_end = 0
     cdef bytes block
     cdef str header_str, block_str, card_image, keyword

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -379,6 +379,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
                 try:
                     header_str, header = _BasicHeader.fromfile(data)
                 except Exception:
+                    # if the fast header parsing failed, fallback to the normal
+                    # one
                     data.seek(header_offset)
                     header = Header.fromfile(data,
                                              endcard=not ignore_missing_end)

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -67,7 +67,6 @@ def _hdu_class_from_header(cls, header):
                 if not (c.__module__.startswith('astropy.io.fits.') or
                         c in cls._hdu_registry):
                     continue
-                # print('try', c)
                 if c.match_header(header):
                     klass = c
                     break

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
+
+
 import datetime
 import os
 import sys
@@ -13,9 +15,9 @@ from astropy.io.fits import conf
 from astropy.io.fits.file import _File
 from astropy.io.fits.header import (Header, _BasicHeader, _pad_length,
                                     _DelayedHeader)
-from astropy.io.fits.util import (
-    _is_int, _is_pseudo_unsigned, _unsigned_zero, itersubclasses, decode_ascii,
-    _get_array_mmap, first, _free_space_check, _extract_number)
+from astropy.io.fits.util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
+                    itersubclasses, decode_ascii, _get_array_mmap, first,
+                    _free_space_check, _extract_number)
 from astropy.io.fits.verify import _Verify, _ErrList
 
 from astropy.utils import lazyproperty

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -176,7 +176,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
 
     @property
     def header(self):
-        if self._header is None and self._header_str is not None:
+        if self._header_str is not None:
             self._header = Header.fromstring(self._header_str)
             self._header_str = None
         return self._header
@@ -466,7 +466,6 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             hdu._verify_checksum_datasum()
 
         if isinstance(hdu._header, BasicHeader):
-            hdu._header = None
             hdu._header_str = header_str
 
         return hdu

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from astropy.io.fits import conf
 from astropy.io.fits.file import _File
-from astropy.io.fits.header import Header, BasicHeader, _pad_length
+from astropy.io.fits.header import Header, _BasicHeader, _pad_length
 from astropy.io.fits.util import (
     _is_int, _is_pseudo_unsigned, _unsigned_zero, itersubclasses, decode_ascii,
     _get_array_mmap, first, _free_space_check, _extract_number)
@@ -394,7 +394,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             if header is None:
                 header_offset = data.tell()
                 try:
-                    header_str, header = BasicHeader.fromfile(data)
+                    header_str, header = _BasicHeader.fromfile(data)
                 except Exception:
                     data.seek(header_offset)
                     header = Header.fromfile(data,
@@ -465,7 +465,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
         if checksum and checksum != 'remove' and isinstance(hdu, _ValidHDU):
             hdu._verify_checksum_datasum()
 
-        if isinstance(hdu._header, BasicHeader):
+        if isinstance(hdu._header, _BasicHeader):
             hdu._header_str = header_str
 
         return hdu

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -135,23 +135,6 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
 
     _header = _DelayedHeader()
 
-    def __new__(cls, data=None, header=None, *args, **kwargs):
-        """
-        Iterates through the subclasses of _BaseHDU and uses that class's
-        match_header() method to determine which subclass to instantiate.
-
-        It's important to be aware that the class hierarchy is traversed in a
-        depth-last order.  Each match_header() should identify an HDU type as
-        uniquely as possible.  Abstract types may choose to simply return False
-        or raise NotImplementedError to be skipped.
-
-        If any unexpected exceptions are raised while evaluating
-        match_header(), the type is taken to be _CorruptedHDU.
-        """
-
-        klass = _hdu_class_from_header(cls, header)
-        return super().__new__(klass)
-
     def __init__(self, data=None, header=None, *args, **kwargs):
         if header is None:
             header = Header()

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1471,10 +1471,6 @@ class CompImageHDU(BinTableHDU):
         if hasattr(self, '_image_header'):
             return self._image_header
 
-        if self._header_str is not None:
-            self._header = Header.fromstring(self._header_str)
-            self._header_str = None
-
         # Start with a copy of the table header.
         image_header = self._header.copy()
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1471,7 +1471,7 @@ class CompImageHDU(BinTableHDU):
         if hasattr(self, '_image_header'):
             return self._image_header
 
-        if self._header is None and self._header_str is not None:
+        if self._header_str is not None:
             self._header = Header.fromstring(self._header_str)
             self._header_str = None
 

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1471,6 +1471,10 @@ class CompImageHDU(BinTableHDU):
         if hasattr(self, '_image_header'):
             return self._image_header
 
+        if self._header is None and self._header_str is not None:
+            self._header = Header.fromstring(self._header_str)
+            self._header_str = None
+
         # Start with a copy of the table header.
         image_header = self._header.copy()
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from .base import DELAYED, _ValidHDU, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
-from astropy.io.fits.header import Header, BasicHeader
+from astropy.io.fits.header import Header, _BasicHeader
 from astropy.io.fits.util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from astropy.io.fits.verify import VerifyWarning
 
@@ -43,7 +43,7 @@ class _ImageBaseHDU(_ValidHDU):
         super().__init__(data=data, header=header)
 
         if header is not None:
-            if not isinstance(header, (Header, BasicHeader)):
+            if not isinstance(header, (Header, _BasicHeader)):
                 # TODO: Instead maybe try initializing a new Header object from
                 # whatever is passed in as the header--there are various types
                 # of objects that could work for this...

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from .base import DELAYED, _ValidHDU, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
-from astropy.io.fits.header import Header, _BasicHeader
+from astropy.io.fits.header import Header
 from astropy.io.fits.util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from astropy.io.fits.verify import VerifyWarning
 
@@ -42,24 +42,12 @@ class _ImageBaseHDU(_ValidHDU):
 
         super().__init__(data=data, header=header)
 
-        if header is not None:
-            if not isinstance(header, (Header, _BasicHeader)):
-                # TODO: Instead maybe try initializing a new Header object from
-                # whatever is passed in as the header--there are various types
-                # of objects that could work for this...
-                raise ValueError('header must be a Header object')
-
         if data is DELAYED:
             # Presumably if data is DELAYED then this HDU is coming from an
             # open file, and was not created in memory
             if header is None:
                 # this should never happen
                 raise ValueError('No header to setup HDU.')
-
-            # if the file is read the first time, no need to copy, and keep it
-            # unchanged
-            else:
-                self._header = header
         else:
             # TODO: Some of this card manipulation should go into the
             # PrimaryHDU and GroupsHDU subclasses
@@ -213,9 +201,6 @@ class _ImageBaseHDU(_ValidHDU):
 
     @property
     def header(self):
-        if self._header_str is not None:
-            self._header = Header.fromstring(self._header_str)
-            self._header_str = None
         return self._header
 
     @header.setter

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -213,7 +213,7 @@ class _ImageBaseHDU(_ValidHDU):
 
     @property
     def header(self):
-        if self._header is None and self._header_str is not None:
+        if self._header_str is not None:
             self._header = Header.fromstring(self._header_str)
             self._header_str = None
         return self._header

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 
 from .base import DELAYED, _ValidHDU, ExtensionHDU, BITPIX2DTYPE, DTYPE2BITPIX
-from astropy.io.fits.header import Header
+from astropy.io.fits.header import Header, BasicHeader
 from astropy.io.fits.util import _is_pseudo_unsigned, _unsigned_zero, _is_int
 from astropy.io.fits.verify import VerifyWarning
 
@@ -43,7 +43,7 @@ class _ImageBaseHDU(_ValidHDU):
         super().__init__(data=data, header=header)
 
         if header is not None:
-            if not isinstance(header, Header):
+            if not isinstance(header, (Header, BasicHeader)):
                 # TODO: Instead maybe try initializing a new Header object from
                 # whatever is passed in as the header--there are various types
                 # of objects that could work for this...
@@ -213,6 +213,9 @@ class _ImageBaseHDU(_ValidHDU):
 
     @property
     def header(self):
+        if self._header is None and self._header_str is not None:
+            self._header = Header.fromstring(self._header_str)
+            self._header_str = None
         return self._header
 
     @header.setter

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -24,7 +24,7 @@ from astropy.io.fits.column import (
     _parse_tformat, _scalar_to_format, _convert_format, _cmp_recformats
 )
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
-from astropy.io.fits.header import Header, _BasicHeader, _pad_length
+from astropy.io.fits.header import Header, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num
 
 from astropy.utils import lazyproperty
@@ -276,10 +276,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                  character_as_bytes=False):
 
         super().__init__(data=data, header=header, name=name, ver=ver)
-
-        if header is not None and \
-                not isinstance(header, (_BasicHeader, Header)):
-            raise ValueError('header must be a Header object.')
 
         self._uint = uint
         self._character_as_bytes = character_as_bytes

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -18,11 +18,11 @@ from .base import DELAYED, _ValidHDU, ExtensionHDU
 # This module may have many dependencies on astropy.io.fits.column, but
 # astropy.io.fits.column has fewer dependencies overall, so it's easier to
 # keep table/column-related utilities in astropy.io.fits.column
-from astropy.io.fits.column import (
-    FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE, ATTRIBUTE_TO_KEYWORD,
-    TDEF_RE, Column, ColDefs, _AsciiColDefs, _FormatP, _FormatQ, _makep,
-    _parse_tformat, _scalar_to_format, _convert_format, _cmp_recformats
-)
+from astropy.io.fits.column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
+                      ATTRIBUTE_TO_KEYWORD, TDEF_RE, Column, ColDefs,
+                      _AsciiColDefs, _FormatP, _FormatQ, _makep,
+                      _parse_tformat, _scalar_to_format, _convert_format,
+                      _cmp_recformats)
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from astropy.io.fits.header import Header, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -18,13 +18,13 @@ from .base import DELAYED, _ValidHDU, ExtensionHDU
 # This module may have many dependencies on astropy.io.fits.column, but
 # astropy.io.fits.column has fewer dependencies overall, so it's easier to
 # keep table/column-related utilities in astropy.io.fits.column
-from astropy.io.fits.column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
-                      ATTRIBUTE_TO_KEYWORD, TDEF_RE, Column, ColDefs,
-                      _AsciiColDefs, _FormatP, _FormatQ, _makep,
-                      _parse_tformat, _scalar_to_format, _convert_format,
-                      _cmp_recformats)
+from astropy.io.fits.column import (
+    FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE, ATTRIBUTE_TO_KEYWORD,
+    TDEF_RE, Column, ColDefs, _AsciiColDefs, _FormatP, _FormatQ, _makep,
+    _parse_tformat, _scalar_to_format, _convert_format, _cmp_recformats
+)
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
-from astropy.io.fits.header import Header, _pad_length
+from astropy.io.fits.header import Header, BasicHeader, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num
 
 from astropy.utils import lazyproperty
@@ -277,7 +277,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
 
         super().__init__(data=data, header=header, name=name, ver=ver)
 
-        if header is not None and not isinstance(header, Header):
+        if header is not None and \
+                not isinstance(header, (BasicHeader, Header)):
             raise ValueError('header must be a Header object.')
 
         self._uint = uint

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -24,7 +24,7 @@ from astropy.io.fits.column import (
     _parse_tformat, _scalar_to_format, _convert_format, _cmp_recformats
 )
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
-from astropy.io.fits.header import Header, BasicHeader, _pad_length
+from astropy.io.fits.header import Header, _BasicHeader, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num
 
 from astropy.utils import lazyproperty
@@ -278,7 +278,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         super().__init__(data=data, header=header, name=name, ver=ver)
 
         if header is not None and \
-                not isinstance(header, (BasicHeader, Header)):
+                not isinstance(header, (_BasicHeader, Header)):
             raise ValueError('header must be a Header object.')
 
         self._uint = uint

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1903,13 +1903,16 @@ collections.abc.MutableMapping.register(Header)
 
 
 class _DelayedHeader:
+    """
+    Descriptor used to create the Header object from the header string that
+    is stored when parsing a file.
+    """
 
     def __get__(self, obj, owner=None):
         try:
             return obj.__dict__['_header']
         except KeyError:
             if obj._header_str is not None:
-                # print('>> LOAD HEADER')
                 hdr = Header.fromstring(obj._header_str)
                 obj._header_str = None
             else:
@@ -1920,17 +1923,17 @@ class _DelayedHeader:
             return hdr
 
     def __set__(self, obj, val):
-        # print('>> SET:', val)
         obj.__dict__['_header'] = val
 
     def __delete__(self, obj):
-        # print('>> DELETE')
         del obj.__dict__['_header']
 
 
 class _BasicHeaderCards:
     """
     This class allows to access cards with the _BasicHeader.cards attribute.
+    Cards cannot be modified as the _BasicHeader object will be deleted
+    once the HDU object is created.
     """
 
     def __init__(self, header):
@@ -1981,8 +1984,7 @@ class _BasicHeader(collections.abc.Mapping):
             return self._cards[key].value
         except KeyError:
             # parse the Card and store it
-            card = Card.fromstring(self._raw_cards[key])
-            self._cards[key] = card
+            self._cards[key] = card = Card.fromstring(self._raw_cards[key])
             return card.value
 
     def __len__(self):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1914,8 +1914,7 @@ class _DelayedHeader:
             return obj.__dict__['_header']
         except KeyError:
             if obj._header_str is not None:
-                header = decode_ascii(obj._header_str)
-                hdr = Header.fromstring(header)
+                hdr = Header.fromstring(obj._header_str)
                 obj._header_str = None
             else:
                 raise AttributeError("'{}' object has no attribute '_header'"
@@ -1948,7 +1947,7 @@ class _BasicHeaderCards:
         try:
             return self.header._cards[key]
         except KeyError:
-            cardstr = self.header._raw_cards[key].decode('ascii')
+            cardstr = self.header._raw_cards[key]
             card = Card.fromstring(cardstr)
             self.header._cards[key] = card
             return card
@@ -1987,7 +1986,7 @@ class _BasicHeader(collections.abc.Mapping):
             return self._cards[key].value
         except KeyError:
             # parse the Card and store it
-            cardstr = self._raw_cards[key].decode('ascii')
+            cardstr = self._raw_cards[key]
             self._cards[key] = card = Card.fromstring(cardstr)
             return card.value
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1928,6 +1928,30 @@ collections.abc.MutableSequence.register(Header)
 collections.abc.MutableMapping.register(Header)
 
 
+class _DelayedHeader:
+
+    def __get__(self, obj, owner=None):
+        try:
+            return obj.__dict__['_header']
+        except KeyError:
+            if obj._header_str is not None:
+                # print('>> LOAD HEADER')
+                hdr = Header.fromstring(obj._header_str)
+                obj._header_str = None
+            else:
+                hdr = None
+            obj.__dict__['_header'] = hdr
+            return hdr
+
+    def __set__(self, obj, val):
+        # print('>> SET:', val)
+        obj.__dict__['_header'] = val
+
+    def __delete__(self, obj):
+        # print('>> DELETE')
+        del obj.__dict__['_header']
+
+
 class _BasicHeaderCards:
     """
     This class allows to access cards with the _BasicHeader.cards attribute.

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1971,6 +1971,8 @@ class _BasicHeader(collections.abc.Mapping):
         # keyword indices
         self.cards = _BasicHeaderCards(self)
 
+        self._modified = False
+
     def __getitem__(self, key):
         if isinstance(key, int):
             key = self._keys[key]
@@ -1988,6 +1990,9 @@ class _BasicHeader(collections.abc.Mapping):
 
     def __iter__(self):
         return iter(self._raw_cards)
+
+    def index(self, keyword):
+        return self._keys.index(keyword)
 
     @classmethod
     def fromfile(cls, fileobj):

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -1939,7 +1939,9 @@ class _DelayedHeader:
                 hdr = Header.fromstring(obj._header_str)
                 obj._header_str = None
             else:
-                hdr = None
+                raise AttributeError("'{}' object has no attribute '_header'"
+                                     .format(obj.__class__.__name__))
+
             obj.__dict__['_header'] = hdr
             return hdr
 


### PR DESCRIPTION
This PR is to optimize the initial parsing of FITS headers, as described in #5593 (which could probably be closed then). As discussed in #5593, a long-standing problem with `io.fits` is that to access a given HDU all the previous HDU headers must be parsed. And before the lazy loading feature, all HDU headers were parsed. So this is a crucial issue for FITS files with many HDUs, and often a barrier to use them.

The main issue is that the headers must be parsed to find the structural keywords (BITPIX, NAXIS*) that are needed to know the position of the following extension. After having tried to optimize the header parsing itself (#8428), which is always good, I came to the same conclusion as @embray (https://github.com/astropy/astropy/issues/5593#issuecomment-422493941): we need a fast header parser. Which this PR implements.  

The `_BasicHeader` class is added with a "fast" parser written in Cython. It is not as fast as I would like, only twice faster as the pure Python. I think that it is possible to do better but will keep this for the future, it is already much faster that `Header`. This new class is used only during the construction of the HDU classes, where we need only a subset of standard keywords, so COMMENT, HIERARCH, and special keywords are not parsed. The cards are parsed only if needed, and cached. Typically only a few cards will be parsed, during the HDU class detection step. Then the header string is stored, and used to construct the usual `Header` object if the HDU is accessed.

One remains that remains is to know if we need to parse to full header (currently implemented), or just the first block, which would bring another interesting speedup for headers with many cards (see https://github.com/astropy/astropy/issues/5593#issuecomment-290389892 and following comments). We could maybe imagine having a keyword to trigger the full header parsing ?

To give some numbers, and testing on different files:

`astropy/io/fits/tests/data/stddata.fits`, with 2 tables and just a few
keywords, to check if there is a penalty. The PR is still faster.

```
❯ python -m perf timeit --fast -s "from astropy.io import fits" "fits.getheader('astropy/io/fits/tests/data/stddata.fits', ext=1)"
```
*Before*: Mean +- std dev: 1.28 ms +- 0.03 ms
*After*: Mean +- std dev: 1.17 ms +- 0.02 ms

```
❯ python -m perf timeit --fast -s "from astropy.io import fits" "fits.getheader('astropy/io/fits/tests/data/stddata.fits', ext=2)"
```
*Before*: Mean +- std dev: 2.88 ms +- 0.10 ms
*After*: Mean +- std dev: 2.30 ms +- 0.08 ms

Then on a quite extreme case, a file with 335 extensions, where each header
has ~1700 cards (with HIERARCH):

```
❯ python -m perf timeit --fast -s "from astropy.io import fits" "fits.getheader('scipost_white.fits', ext=10)"
```
*Before*: Mean +- std dev: 173 ms +- 6 ms
*After*: Mean +- std dev: 26.8 ms +- 1.2 ms

```
❯ python -m perf timeit --fast -s "from astropy.io import fits" "fits.getheader('scipost_white.fits', ext=60)"
```
*Before*: Mean +- std dev: 1.01 sec +- 0.01 sec
*After*: Mean +- std dev: 101 ms +- 3 ms

```
❯ python -m perf timeit --fast -s "from astropy.io import fits" "fits.getheader('scipost_white.fits', ext=300)"
```
*Before*: Mean +- std dev: 5.26 sec +- 0.16 sec
*After*: Mean +- std dev: 450 ms +- 10 ms

![fits_perf_scipost](https://user-images.githubusercontent.com/311639/54467659-e4b88b00-4786-11e9-804b-78271f1eebe3.png)

And finally with a Euclid test file, with 650 extensions but a small number of keywords (15 to 20). It seems that they have more critical cases, and use `fitsio` instead of Astropy because of that.

![fits_perf_euclid](https://user-images.githubusercontent.com/311639/54467665-ee41f300-4786-11e9-8e41-41d040c43bf2.png)

ping @embray - if you have some time to have a look, it would be great to have your comments!