### PR TITLE
Ensure Time._advanced_index returns a Tuple

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1377,10 +1377,10 @@ class Time(ShapedLikeNDArray):
 
         if keepdims and indices.ndim < self.ndim:
             indices = np.expand_dims(indices, axis)
-        return [(indices if i == axis else np.arange(s).reshape(
+        return tuple([(indices if i == axis else np.arange(s).reshape(
             (1,)*(i if keepdims or i < axis else i-1) + (s,) +
             (1,)*(ndim-i-(1 if keepdims or i > axis else 2))))
-                for i, s in enumerate(self.shape)]
+                for i, s in enumerate(self.shape)])
 
     def argmin(self, axis=None, out=None):
         """Return indices of the minimum values along the given axis.


### PR DESCRIPTION
With the previous list, it raises a FutureWarning on numpy.

Ignoring it for astropy 2, since numpy will not raise an exception for anything compatible with python2.

Probably should check all FutureWarnings rather than just solving one...