### PR TITLE
FixedWidthNoHeader column splitting fixed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2582,6 +2582,8 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix ``FixedWidthNoHeader`` to pay attention to ``data_start`` keyword when finding first data line to split columns [#8485]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2582,7 +2582,8 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
-- Fix ``FixedWidthNoHeader`` to pay attention to ``data_start`` keyword when finding first data line to split columns [#8485]
+- Fix ``FixedWidthNoHeader`` to pay attention to ``data_start`` keyword when
+  finding first data line to split columns [#8485, #8511]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -103,7 +103,11 @@ class FixedWidthHeader(basic.BasicHeader):
         if start_line is None:
             if position_line is not None:
                 raise ValueError("Cannot set position_line without also setting header_start")
+
+            # data.data_lines attribute already set via self.data.get_data_lines(lines)
+            # in BaseReader.read().  This includes slicing for data_start / data_end.
             data_lines = self.data.data_lines
+
             if not data_lines:
                 raise InconsistentTableError(
                     'No data lines found so cannot autogenerate column names')

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -103,7 +103,7 @@ class FixedWidthHeader(basic.BasicHeader):
         if start_line is None:
             if position_line is not None:
                 raise ValueError("Cannot set position_line without also setting header_start")
-            data_lines = self.data.process_lines(lines)
+            data_lines = self.data.data_lines
             if not data_lines:
                 raise InconsistentTableError(
                     'No data lines found so cannot autogenerate column names')

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -3,6 +3,7 @@
 
 from io import StringIO
 
+import numpy as np
 import pytest
 
 from astropy.io import ascii
@@ -478,3 +479,21 @@ def test_write_twoline_no_bookend():
 | 1.2|  "hello"|   1|   a|
 | 2.4|'s worlds|   2|   2|
 """)
+
+
+def test_fixedwidthnoheader_splitting():
+    """Test fix in #8511 where data_start is being ignored"""
+    tbl = """\
+AAA y z
+1 2 3
+4 5 6
+7 8 9
+"""
+    names = ['a', 'b', 'c']
+    dat = ascii.read(tbl, data_start=1, data_end=3,
+                     delimiter=' ', names=names,
+                     format='fixed_width_no_header')
+    assert dat.colnames == names
+    assert np.all(dat['a'] == [1, 4])
+    assert np.all(dat['b'] == [2, 5])
+    assert np.all(dat['c'] == [3, 6])


### PR DESCRIPTION
Closes #8485

This is only a one-line change, which I tested with the script in the related issue, and I tested the table package afterwards too.  But it still should be reviewed by someone familiar with the table code.  It _seems_ like self.data below has a valid data_lines field by line 107, but I didn't read enough of the code to guarantee it. I haven't written an automated test or entered anything in the changelog.