### PR TITLE
Updated donor link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,4 +86,4 @@ reach out to PyPI.
     :alt: Powered by NumFOCUS
 
 .. |Donate| image:: https://img.shields.io/badge/Donate-to%20Astropy-brightgreen.svg
-    :target: https://www.flipcause.com/widget/give_now/MjI1NA==
+    :target: https://numfocus.salsalabs.org/donate-to-astropy/index.html


### PR DESCRIPTION
NumFOCUS has changed from using flipcause to Salsa. The link has been updated here.

https://numfocus.salsalabs.org/donate-to-astropy/index.html

Lisa Martin
NumFOCUS.org