### PR TITLE
MNT: Fix FutureWarning in io.registry

### DIFF
--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -137,7 +137,7 @@ def get_formats(data_class=None, readwrite=None):
     format_table = Table(data, names=('Data class', 'Format', 'Read', 'Write',
                                       'Auto-identify', 'Deprecated'))
 
-    if not np.any(format_table['Deprecated'] == 'Yes'):
+    if not np.any('Yes' in format_table['Deprecated']):
         format_table.remove_column('Deprecated')
 
     return format_table


### PR DESCRIPTION
I was trying to get rid of `FutureWarning` for just one test below from https://travis-ci.org/astropy/astropy/jobs/507881204 

```
___________________________ test_get_reader_invalid ____________________________
TypeError: ufunc 'equal' did not contain a loop with signature matching types dtype('<U32') dtype('<U32') dtype('bool')
The above exception was the direct cause of the following exception:
    def test_get_reader_invalid():
        with pytest.raises(io_registry.IORegistryError) as exc:
>           io_registry.get_reader('test', TestData)
astropy/io/tests/test_registry.py:51: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
astropy/io/registry.py:445: in get_reader
    format_table_str = _get_format_table_str(data_class, 'Read')
astropy/io/registry.py:418: in _get_format_table_str
    format_table = get_formats(data_class, readwrite=readwrite)
astropy/io/registry.py:140: in get_formats
    if not np.any(format_table['Deprecated'] == 'Yes'):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <Column name='Deprecated' dtype='float64' length=0>
, other = 'Yes'
    def _compare(self, other):
        op = oper  # copy enclosed ref to allow swap below
    
        # Special case to work around #6838.  Other combinations work OK,
        # see tests.test_column.test_unicode_sandwich_compare().  In this
        # case just swap self and other.
        #
        # This is related to an issue in numpy that was addressed in np 1.13.
        # However that fix does not make this problem go away, but maybe
        # future numpy versions will do so.  NUMPY_LT_1_13 to get the
        # attention of future maintainers to check (by deleting or versioning
        # the if block below).  See #6899 discussion.
        if (isinstance(self, MaskedColumn) and self.dtype.kind == 'U' and
                isinstance(other, MaskedColumn) and other.dtype.kind == 'S'):
            self, other = other, self
            op = swapped_oper
    
        if self.dtype.char == 'S':
            other = self._encode_str(other)
>       return getattr(self.data, op)(other)
E       FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
astropy/table/column.py:975: FutureWarning
```

I tackled the first one (see diff) but got stuck in the second one, as it is too much operator overload magic for me.

https://github.com/astropy/astropy/blob/cbfe2db93789d20b6abff4abc1c3e43ce8432b04/astropy/table/column.py#L975

@taldcroft , halp...

Related issue: #8516