### PR TITLE
Expand exception message for magnitude->physical conversions

### DIFF
--- a/astropy/units/tests/test_logarithmic.py
+++ b/astropy/units/tests/test_logarithmic.py
@@ -235,6 +235,14 @@ class TestLogUnitConversion:
         lu = u.mag(u.Jy)
         assert lu.is_equivalent(pu_sample)
 
+    def test_magnitude_conversion_fails_message(self):
+        """Check that "dimensionless" magnitude units include a message in their
+        exception text suggesting a possible cause of the problem.
+        """
+        with pytest.raises(u.UnitConversionError) as excinfo:
+            (10*u.ABmag - 2*u.ABmag).to(u.nJy)
+        assert "Did you perhaps subtract magnitudes so the unit got lost?" in str(excinfo.value)
+
 
 class TestLogUnitArithmetic:
     def test_multiplication_division(self):


### PR DESCRIPTION
Now that I've written this, I'm somewhat skeptical of it: given the way tracebacks are printed and the length of `FunctionUnitBase.to()`, the original exception is a page or two up, so the "from-ness" of it could be easily lost on the user. I also wonder under what other cases this message would appear: I'm not sure what other cases to test.

Suggestions, or should I just drop this?

EDIT: Fix #8487 