### PR TITLE
Automatically generate ASDF schema documentation using sphinx-asdf

### DIFF
--- a/astropy/io/misc/asdf/__init__.py
+++ b/astropy/io/misc/asdf/__init__.py
@@ -128,11 +128,59 @@ classes provided here are specific implementations of particular schemas. Some
 of the tags in Astropy (e.g., those related to transforms) implement schemas
 that are defined by the ASDF Standard. In other cases, both the tags and
 schemas are defined within Astropy (e.g., those related to many of the
-coordinate frames).
+coordinate frames). Documentation of the individual schemas defined by Astropy
+can be found below in the :ref:`asdf_schemas` section.
 
 Not all Astropy types are currently serializable by ASDF. Attempting to write
 unsupported types to an ASDF file will lead to a ``RepresenterError``. In order
 to support new types, new tags and schemas must be created. See `Writing ASDF
 Extensions <https://asdf.readthedocs.io/en/latest/asdf/extensions.html>`_ for
 additional details.
+
+
+.. _asdf_schemas:
+
+Schemas
+=======
+
+Documentation for each of the individual ASDF schemas defined by Astropy can
+be found at the links below.
+
+Documentation for the schemas defined in the ASDF Standard can be found `here
+<https://asdf-standard.readthedocs.io/en/latest/schemas/index.html>`__.
+
+Coordinates
+-----------
+
+The following schemas are associated with Astropy types from the
+:ref:`astropy-coordinates` submodule:
+
+.. asdf-autoschemas::
+
+    coordinates/angle-1.0.0
+    coordinates/latitude-1.0.0
+    coordinates/longitude-1.0.0
+    coordinates/representation-1.0.0
+    coordinates/skycoord-1.0.0
+    coordinates/earthlocation-1.0.0
+
+Time
+----
+
+The following schemas are associated with Astropy types from the
+:ref:`astropy-time` submodule:
+
+.. asdf-autoschemas::
+
+    time/timedelta-1.0.0
+
+Units
+-----
+
+The following schemas are associated with Astropy types from the
+:ref:`astropy-units` submodule:
+
+.. asdf-autoschemas::
+
+    units/equivalency-1.0.0
 """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,3 +239,14 @@ linkcheck_anchors = False
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
 html_extra_path = ['robots.txt']
+
+# -- Options for ASDF schema documentation ----------------------------------
+extensions += ['sphinx_asdf']
+# Top-level directory containing ASDF schemas (relative to current directory)
+asdf_schema_path = '../astropy/io/misc/asdf/data/schemas'
+# This is the prefix common to all schema IDs in this repository
+asdf_schema_standard_prefix = 'astropy.org/astropy'
+asdf_schema_reference_mappings = [
+    ('tag:stsci.edu:asdf',
+     'http://asdf-standard.readthedocs.io/en/latest/generated/stsci.edu/asdf/'),
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,9 @@ asdf_extensions =
 [options.extras_require]
 test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
 all = scipy; h5py; beautifulsoup4; html5lib; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
-docs = sphinx-astropy
+docs =
+    sphinx-astropy
+    sphinx-asdf
 
 [build_sphinx]
 source-dir = docs


### PR DESCRIPTION
This PR adds ASDF schema documentation that is automatically generated using the [sphinx-asdf](https://github.com/spacetelescope/sphinx-asdf) plugin (which is now a dependency for doc builds).