### PR TITLE
fix variable names in example snippet (docs)

### DIFF
--- a/docs/coordinates/matchsep.rst
+++ b/docs/coordinates/matchsep.rst
@@ -236,9 +236,9 @@ considered a match) by creating a boolean mask with ``d2d`` or ``d3d``. For exam
 
     >>> max_sep = 1.0 * u.arcsec # doctest: +SKIP
     >>> idx, d2d, d3d = c.match_to_catalog_3d(catalog) # doctest: +SKIP
-    >>> sep_constraint = idx < max_sep # doctest: +SKIP
+    >>> sep_constraint = d2d < max_sep # doctest: +SKIP
     >>> c_matches = c[sep_constraint] # doctest: +SKIP
-    >>> catalog_matches = c[idx[sep_constraint]] # doctest: +SKIP
+    >>> catalog_matches = catalog[idx[sep_constraint]] # doctest: +SKIP
 
 Now, ``c_matches`` and ``catalog_matches`` are the matched sources in ``c``
 and ``catalog``, respectively, which are separated by less than 1 arcsecond.


### PR DESCRIPTION
I found a couple of typos in a code snippet in the documentation. Since it was a pretty simple fix, I figured I'd open a pull request right away, without opening an issue. I hope this is ok. :)