### PR TITLE
Allow specifying column names in Table.as_array()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,6 +200,9 @@ astropy.table
   Table initialization so that input ``meta`` is copied only if ``copy=True``.
   [#8404]
 
+- Added a keyword key_values in ``Table.as_array()`` . If a value is passed then 
+  ``Table.as_array()`` will return a sliced array according to passed columns.
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,8 +200,8 @@ astropy.table
   Table initialization so that input ``meta`` is copied only if ``copy=True``.
   [#8404]
 
-- Added a keyword key_values in ``Table.as_array()`` . If a value is passed then 
-  ``Table.as_array()`` will return a sliced array according to passed columns.
+- Added a keyword ``names`` in ``Table.as_array()``.  If provided this specifies
+  a list of column names to include for the returned structured array. [#8532]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -267,14 +267,14 @@ class Table:
         dtype = []
 
         for key in key_values:
-           if key not in self.columns:
-              print('Warning! Key does not exist')
+            if key not in self.columns:
+                print('Warning! Key does not exist')
 
         if key_values != []:
-           cols = self[key_values].columns.values()
+            cols = self[key_values].columns.values()
 
         else:
-       	   cols = self.columns.values()
+            cols = self.columns.values()
 
         for col in cols:
             col_descr = descr(col)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -236,7 +236,7 @@ class Table:
     TableColumns = TableColumns
     TableFormatter = TableFormatter
 
-    def as_array(self, keep_byteorder=False, key_values=[]):
+    def as_array(self, keep_byteorder=False, names=None):
         """
         Return a new copy of the table in the form of a structured np.ndarray or
         np.ma.MaskedArray object (as appropriate).
@@ -248,10 +248,9 @@ class Table:
             order.  However, if this option is `True` this preserves the
             byte order of all columns (if any are non-native).
 
-        key_values : list, optional
-            By default the returned array contains all columns.
-            However, if this list contains some values of columns then
-            the returned array is sliced according to it.
+        names : list, optional:
+            List of column names to include for returned structured array.
+            Default is to include all table columns.
 
         Returns
         -------
@@ -266,12 +265,8 @@ class Table:
 
         dtype = []
 
-        for key in key_values:
-            if key not in self.columns:
-                print('Warning! Key does not exist')
-
-        if key_values != []:
-            cols = self[key_values].columns.values()
+        if names != None:
+            cols = self[names].columns.values()
 
         else:
             cols = self.columns.values()

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -236,7 +236,7 @@ class Table:
     TableColumns = TableColumns
     TableFormatter = TableFormatter
 
-    def as_array(self, keep_byteorder=False):
+    def as_array(self, keep_byteorder=False, key_values=[]):
         """
         Return a new copy of the table in the form of a structured np.ndarray or
         np.ma.MaskedArray object (as appropriate).
@@ -247,6 +247,11 @@ class Table:
             By default the returned array has all columns in native byte
             order.  However, if this option is `True` this preserves the
             byte order of all columns (if any are non-native).
+
+        key_values : list, optional
+            By default the returned array contains all columns.
+            However, if this list contains some values of columns then
+            the returned array is sliced according to it.
 
         Returns
         -------
@@ -261,7 +266,15 @@ class Table:
 
         dtype = []
 
-        cols = self.columns.values()
+        for key in key_values:
+           if key not in self.columns:
+              print('Warning! Key does not exist')
+
+        if key_values != []:
+           cols = self[key_values].columns.values()
+
+        else:
+       	   cols = self.columns.values()
 
         for col in cols:
             col_descr = descr(col)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -265,11 +265,10 @@ class Table:
 
         dtype = []
 
-        if names != None:
-            cols = self[names].columns.values()
+        cols = self.columns.values()
 
-        else:
-            cols = self.columns.values()
+        if names != None:
+            cols = [col for col in cols if col.info.name in names]
 
         for col in cols:
             col_descr = descr(col)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2208,7 +2208,7 @@ def test_key_values_in_as_array():
     a = np.array([(1, 2.), (4, 5.), (5, 8.2)],
                  dtype=[('a', '<i4'), ('b', '<f8')])
     # Values fo sliced column c is stored in a numpy array
-    b = np.array([(b'x',), (b'y',), (b'y',)], dtype=[('c', 'S1')])
+    b = np.array([(b'x',), (b'y',), (b'z',)], dtype=[('c', 'S1')])
     # Comparing initialised array with sliced array using Table.as_array()
-    assert np.array_equal(a, t1.as_array(key_values=['a', 'b']))
-    assert np.array_equal(b, t1.as_array(key_values=['c']))
+    assert np.array_equal(a, t1.as_array(names=['a', 'b']))
+    assert np.array_equal(b, t1.as_array(names=['c']))

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2193,3 +2193,22 @@ def test_create_table_from_final_row():
     row = t1[-1]
     t2 = table.Table(row)['col']
     assert t2[0] == 2
+
+
+def test_key_values_in_as_array():
+    # Test for cheking column slicing using key_values in Table.as_array()
+    data_rows = [(1, 2.0, 'x'),
+                 (4, 5.0, 'y'),
+                 (5, 8.2, 'z')]
+    # Creating a table with three columns
+    t1 = table.Table(rows=data_rows, names=('a', 'b', 'c'),
+                     meta={'name': 'first table'},
+                     dtype=('i4', 'f8', 'S1'))
+    # Values of sliced column a,b is stored in a numpy array
+    a = np.array([(1, 2.), (4, 5.), (5, 8.2)],
+                 dtype=[('a', '<i4'), ('b', '<f8')])
+    # Values fo sliced column c is stored in a numpy array
+    b = np.array([(b'x',), (b'y',), (b'y',)], dtype=[('c', 'S1')])
+    # Comparing initialised array with sliced array using Table.as_array()
+    assert np.array_equal(a, t1.as_array(key_values=['a', 'b']))
+    assert np.array_equal(b, t1.as_array(key_values=['c']))


### PR DESCRIPTION
#8529 @taldcroft Please have a look at this PR.

- Test for key_values is added.
- keyword added in Table.as_array() 