### PR TITLE
removed the copy restriction when initializing a Table from a dict with copy=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Removed restriction of initializing a Table from a dict with copy=False. [#8541]
+
 - Improved speed of table row access by a factor of about 2-3.  Improved speed
   of Table len() by a factor of around 3-10 (depending on the number of columns).
   [#8494]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -746,10 +746,6 @@ class Table:
     def _init_from_dict(self, data, names, dtype, n_cols, copy):
         """Initialize table from a dictionary of columns"""
 
-        # TODO: is this restriction still needed with no ndarray?
-        if not copy:
-            raise ValueError('Cannot use copy=False with a dict data input')
-
         data_list = [data[name] for name in names]
         self._init_from_list(data_list, names, dtype, n_cols, copy)
 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -478,3 +478,28 @@ def test_init_and_ref_from_multidim_ndarray(table_type):
         else:
             assert nd[str('a')][0] == -200
             assert nd[str('b')][1][1] == -100
+
+@pytest.mark.usefixtures('table_type')
+def test_init_and_ref_from_dict(table_type):
+    """
+    Test that initializing from a dict works for both copy=False and True and that
+    the referencing is as expected.
+    """
+    for copy in (False, True):
+        x1 = np.arange(10.)
+        x2 = np.zeros(10)
+        x3 = np.random.randint(10, size=10)
+        col_dict = dict([('x1', x1), ('x2', x2), ('x3', x3)])
+        t = table_type(col_dict, copy=copy)
+        assert t.colnames == ['x1', 'x2', 'x3']
+        assert t['x1'].shape == (10,)
+        assert t['x2'].shape == (10,)
+        assert t['x3'].shape == (10,)
+        t['x1'][0] = -200
+        t['x2'][1] = -100
+        if copy:
+            assert x1[0] == 0.
+            assert x2[1] == 0.
+        else:
+            assert x1[0] == -200
+            assert x2[1] == -100

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -480,26 +480,24 @@ def test_init_and_ref_from_multidim_ndarray(table_type):
             assert nd[str('b')][1][1] == -100
 
 @pytest.mark.usefixtures('table_type')
-def test_init_and_ref_from_dict(table_type):
+@pytest.mark.parametrize('copy', [False, True])
+def test_init_and_ref_from_dict(table_type, copy):
     """
     Test that initializing from a dict works for both copy=False and True and that
     the referencing is as expected.
     """
-    for copy in (False, True):
-        x1 = np.arange(10.)
-        x2 = np.zeros(10)
-        x3 = np.random.randint(10, size=10)
-        col_dict = dict([('x1', x1), ('x2', x2), ('x3', x3)])
-        t = table_type(col_dict, copy=copy)
-        assert t.colnames == ['x1', 'x2', 'x3']
-        assert t['x1'].shape == (10,)
-        assert t['x2'].shape == (10,)
-        assert t['x3'].shape == (10,)
-        t['x1'][0] = -200
-        t['x2'][1] = -100
-        if copy:
-            assert x1[0] == 0.
-            assert x2[1] == 0.
-        else:
-            assert x1[0] == -200
-            assert x2[1] == -100
+    x1 = np.arange(10.)
+    x2 = np.zeros(10)
+    col_dict = dict([('x1', x1), ('x2', x2)])
+    t = table_type(col_dict, copy=copy)
+    assert t.colnames == ['x1', 'x2']
+    assert t['x1'].shape == (10,)
+    assert t['x2'].shape == (10,)
+    t['x1'][0] = -200
+    t['x2'][1] = -100
+    if copy:
+        assert x1[0] == 0.
+        assert x2[1] == 0.
+    else:
+        assert x1[0] == -200
+        assert x2[1] == -100

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -490,7 +490,7 @@ def test_init_and_ref_from_dict(table_type, copy):
     x2 = np.zeros(10)
     col_dict = dict([('x1', x1), ('x2', x2)])
     t = table_type(col_dict, copy=copy)
-    assert t.colnames == ['x1', 'x2']
+    assert set(t.colnames) == set(['x1', 'x2'])
     assert t['x1'].shape == (10,)
     assert t['x2'].shape == (10,)
     t['x1'][0] = -200

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -629,7 +629,7 @@ copy
 
 By default the input ``data`` are copied into a new internal ``np.ndarray``
 object in the Table object.  In the case where ``data`` is either an
-``np.ndarray`` object or an existing ``Table``, it is possible to use a
+``np.ndarray`` object, a ``dict``, or an existing ``Table``, it is possible to use a
 reference to the existing data by setting ``copy=False``.  This has the
 advantage of reducing memory use and being faster.  However one should take
 care because any modifications to the new Table data will also be seen in the
@@ -645,7 +645,7 @@ Copy versus Reference
 Normally when a new |Table| object is created, the input data are *copied* into
 a new internal array object.  This ensures that if the new table elements are
 modified then the original data will not be affected.  However, when creating a
-table from a numpy ndarray object (structured or homogeneous), it is possible to
+table from a numpy ndarray object (structured or homogeneous) or a dict, it is possible to
 disable copying so that instead a memory reference to the original data is
 used.  This has the advantage of being faster and using less memory.  However,
 caution must be exercised because the new table data and original data will be


### PR DESCRIPTION
removes the copy restriction when initializing a Table from a dict with copy=False from issue #8538 

I've simply removed the check on copy. I think there should be some updates to the documentation as well, but wanted to check before I went ahead and worked on that. I'm assuming I'll need to update the docs/table/construct_table.rst files, in the "Initialization Details" and "Copy versus Reference" sections?