### PR TITLE
Update table.py  function _init_from_dict

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -746,10 +746,6 @@ class Table:
     def _init_from_dict(self, data, names, dtype, n_cols, copy):
         """Initialize table from a dictionary of columns"""
 
-        # TODO: is this restriction still needed with no ndarray?
-        if not copy:
-            raise ValueError('Cannot use copy=False with a dict data input')
-
         data_list = [data[name] for name in names]
         self._init_from_list(data_list, names, dtype, n_cols, copy)
 


### PR DESCRIPTION
Remove the restriction with no ndarray when initializing a Table from a copy=False dictionary.

(Novice to Github and will check how to add test code)