### PR TITLE
Adding WCS Slicing to APE 14 Low Level WCSes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -168,6 +168,12 @@ astropy.wcs
 
 - The ``OBSGEO`` attribute as expanded to 6 members - ``XYZLBH``. [#8592]
 
+- Added a new class ``SlicedLowLevelWCS`` in ``astropy.wcs.wcsapi`` that can be
+  used to slice any WCS that conforms to the ``BaseLowLevelWCS`` API. [#8546]
+
+- Updated implementation of ``WCS.__getitem__`` and ``WCS.slice`` to now return
+  a ``SlicedLowLevelWCS`` rather than raising an error when reducing the
+  dimensionality of the WCS. [#8546]
 
 API Changes
 -----------

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -11,12 +11,15 @@ from astropy.time import Time
 from astropy import units as u
 
 from astropy.wcs.wcs import WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE
-from astropy.wcs.utils import (proj_plane_pixel_scales, proj_plane_pixel_area,
-                     is_proj_plane_distorted,
-                     non_celestial_pixel_scales, wcs_to_celestial_frame,
-                     celestial_frame_to_wcs, skycoord_to_pixel,
-                     pixel_to_skycoord, custom_wcs_to_frame_mappings,
-                     custom_frame_to_wcs_mappings, add_stokes_axis_to_wcs)
+from astropy.wcs.wcsapi.fitswcs import SlicedFITSWCS
+from astropy.wcs.utils import (proj_plane_pixel_scales,
+                               is_proj_plane_distorted,
+                               non_celestial_pixel_scales,
+                               wcs_to_celestial_frame,
+                               celestial_frame_to_wcs, skycoord_to_pixel,
+                               pixel_to_skycoord, custom_wcs_to_frame_mappings,
+                               custom_frame_to_wcs_mappings,
+                               add_stokes_axis_to_wcs)
 
 
 def test_wcs_dropping():
@@ -197,20 +200,15 @@ def test_slice_fitsorder():
     assert np.all(slice_wcs.wcs.cdelt == np.array([0.2, 0.1]))
 
 
-def test_invalid_slice():
+def test_slice_wcs():
     mywcs = WCS(naxis=2)
 
-    with pytest.raises(ValueError) as exc:
-        mywcs[0]
-    assert exc.value.args[0] == ("Cannot downsample a WCS with indexing.  Use "
-                                 "wcs.sub or wcs.dropaxis if you want to remove "
-                                 "axes.")
+    sub = mywcs[0]
+    assert isinstance(sub, SlicedFITSWCS)
 
     with pytest.raises(ValueError) as exc:
         mywcs[0, ::2]
-    assert exc.value.args[0] == ("Cannot downsample a WCS with indexing.  Use "
-                                 "wcs.sub or wcs.dropaxis if you want to remove "
-                                 "axes.")
+    assert exc.value.args[0] == "Slicing WCS with a step is not supported."
 
 
 def test_axis_names():

--- a/astropy/wcs/wcsapi/__init__.py
+++ b/astropy/wcs/wcsapi/__init__.py
@@ -1,3 +1,4 @@
 from .low_level_api import *
 from .high_level_api import *
 from .high_level_wcs_wrapper import *
+from .sliced_low_level_wcs import *

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -11,8 +11,9 @@ from astropy import units as u
 
 from .low_level_api import BaseLowLevelWCS
 from .high_level_api import HighLevelWCSMixin
+from .sliced_low_level_wcs import SlicedLowLevelWCS
 
-__all__ = ['custom_ctype_to_ucd_mapping', 'FITSWCSAPIMixin']
+__all__ = ['custom_ctype_to_ucd_mapping', 'SlicedFITSWCS', 'FITSWCSAPIMixin']
 
 # Mapping from CTYPE axis name to UCD1
 
@@ -105,6 +106,10 @@ class custom_ctype_to_ucd_mapping:
 
     def __exit__(self, type, value, tb):
         CTYPE_TO_UCD1_CUSTOM.remove(self.mapping)
+
+
+class SlicedFITSWCS(SlicedLowLevelWCS, HighLevelWCSMixin):
+    pass
 
 
 class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -279,7 +279,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         s += (('{0:' + str(pixel_dim_width) + 's}').format('Pixel Dim') + '  ' +
               ('{0:' + str(pixel_siz_width) + 's}').format('Data size') + '  ' +
-              'Units\n')
+              'Bounds\n')
 
         for ipix in range(self.pixel_n_dim):
             s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
@@ -331,7 +331,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
                            for ipix in range(self.pixel_n_dim)]) +
                   '\n')
 
-        return s
+        # Make sure we get rid of the extra whitespace at the end of some lines
+        return '\n'.join([l.rstrip() for l in s.splitlines()])
 
     __repr__ = __str__
 

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -262,6 +262,79 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         return False
 
+    def __str__(self):
+
+        # Overall header
+
+        s = '{0} Transformation\n\n'.format(self.__class__.__name__)
+        s += ('This transformation has {0} pixel and {1} world dimensions\n\n'
+              .format(self.pixel_n_dim, self.world_n_dim))
+        s += 'Array shape (Numpy order): {0}\n\n'.format(self.array_shape)
+
+        # Pixel dimensions table
+
+        # Find largest between header size and value length
+        pixel_dim_width = max(9, len(str(self.pixel_n_dim)))
+        pixel_siz_width = max(9, len(str(max(self.array_shape))))
+
+        s += (('{0:' + str(pixel_dim_width) + 's}').format('Pixel Dim') + '  ' +
+              ('{0:' + str(pixel_siz_width) + 's}').format('Data size') + '  ' +
+              'Units\n')
+
+        for ipix in range(self.pixel_n_dim):
+            s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
+                  ('{0:' + str(pixel_siz_width) + 'd}').format(self.pixel_shape[ipix]) + '  ' +
+                  '{0:s}'.format(str(None if self.pixel_bounds is None else self.pixel_bounds[ipix]) + '\n'))
+
+        s += '\n'
+
+        # World dimensions table
+
+        # Find largest between header size and value length
+        world_dim_width = max(9, len(str(self.world_n_dim)))
+        world_typ_width = max(13, max(len(x) for x in self.world_axis_physical_types))
+
+        s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') + '  ' +
+              ('{0:' + str(world_typ_width) + 's}').format('Physical Type') + '  ' +
+               'Units\n')
+
+        for iwrl in range(self.world_n_dim):
+            s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
+                  ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +
+                  '{0:s}'.format(self.world_axis_units[iwrl] + '\n'))
+
+        s += '\n'
+
+        # Axis correlation matrix
+
+        pixel_dim_width = max(3, len(str(self.world_n_dim)))
+
+        s += 'Correlation between pixel and world axes:\n\n'
+
+        s += (' ' * world_dim_width + '  ' +
+              ('{0:^' + str(self.pixel_n_dim * 5 - 2) + 's}').format('Pixel Dim') +
+              '\n')
+
+        s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') +
+              ''.join(['  ' + ('{0:' + str(pixel_dim_width) + 'd}').format(ipix)
+                       for ipix in range(self.pixel_n_dim)]) +
+              '\n')
+
+        matrix = self.axis_correlation_matrix
+        matrix_str = np.empty(matrix.shape, dtype='U3')
+        matrix_str[matrix] = 'yes'
+        matrix_str[~matrix] = 'no'
+
+        for iwrl in range(self.world_n_dim):
+            s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) +
+                  ''.join(['  ' + ('{0:>' + str(pixel_dim_width) + 's}').format(matrix_str[iwrl, ipix])
+                           for ipix in range(self.pixel_n_dim)]) +
+                  '\n')
+
+        return s
+
+    __repr__ = __str__
+
 
 UCDS_FILE = os.path.join(os.path.dirname(__file__), 'data', 'ucds.txt')
 with open(UCDS_FILE) as f:

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -76,10 +76,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
         pixel_arrays_new = []
         ipix_curr = -1
         for ipix in range(self._wcs.pixel_n_dim):
-            if self._slices_pixel[ipix] is slice(None):
-                ipix_curr += 1
-                pixel_arrays_new.append(pixel_arrays[ipix_curr])
-            elif isinstance(self._slices_pixel[ipix], int):
+            if isinstance(self._slices_pixel[ipix], int):
                 pixel_arrays_new.append(self._slices_pixel[ipix])
             else:
                 ipix_curr += 1
@@ -106,14 +103,9 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
         pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays_new)
 
-        print('here1', pixel_arrays)
-
         for ipixel in range(self._wcs.pixel_n_dim):
             if isinstance(self._slices_pixel[ipixel], slice) and self._slices_pixel[ipixel].start is not None:
                 pixel_arrays[ipixel] -= self._slices_pixel[ipixel].start
-
-        print('here2', pixel_arrays)
-        print('here3', self._pixel_keep)
 
         return [pixel_arrays[ip] for ip in self._pixel_keep]
 
@@ -141,13 +133,23 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def pixel_bounds(self):
-        # FIXME: incorect when slices are present
-        return [self._wcs.pixel_bounds[::-1][idx] for idx in self._pixel_keep][::-1]
+
+        if self._wcs.pixel_bounds is None:
+            return None
+
+        bounds = []
+        for idx in self._pixel_keep:
+            if self._slices_pixel[idx].start is None:
+                bounds.append(self._wcs.pixel_bounds[idx])
+            else:
+                imin, imax = self._wcs.pixel_bounds[idx]
+                start = self._slices_pixel[idx].start
+                bounds.append([imin - start, imax - start])
+
+        return bounds
    
     @property
     def axis_correlation_matrix(self):
         return self._wcs.axis_correlation_matrix[self._world_keep][:,self._pixel_keep]
-
-
 
 

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -1,0 +1,148 @@
+import numbers
+import numpy as np
+from astropy.wcs.wcsapi import BaseLowLevelWCS
+
+
+def sanitize_slices(slices, ndim):
+    """
+    Given a set of input 
+    """
+
+    if not isinstance(slices, (tuple, list)):  # We just have a single int
+        slices = (slices,)
+
+    slices = list(slices)
+
+    if Ellipsis in slices:
+        if slices.count(Ellipsis) > 1:
+            raise IndexError("an index can only have a single ellipsis ('...')")
+
+        # Replace the Ellipsis with the correct number of slice(None)s
+        e_ind = slices.index(Ellipsis)
+        slices.remove(Ellipsis)
+        n_e = ndim - len(slices)
+        for i in range(n_e):
+            ind = e_ind + i
+            slices.insert(ind, slice(None))
+
+    for i in range(ndim):
+        if i < len(slices):
+            slc = slices[i]
+            if isinstance(slc, slice):
+                if slc.step and slc.step != 1:
+                    raise ValueError("Slicing WCS with a step is not supported.")
+            elif not isinstance(slc, numbers.Integral):
+                raise ValueError("Only integer or range slices are accepted.")
+        else:
+            slices.append(slice(None)) 
+
+    return slices
+
+
+class SlicedLowLevelWCS(BaseLowLevelWCS):
+
+    def __init__(self, wcs, slices):
+ 
+        self._wcs = wcs
+        self._slices = sanitize_slices(slices, self._wcs.pixel_n_dim)
+
+        # figure out which pixel dimensions have been kept, then use axis correlation
+        # matrix to figure out which world dims are kept
+        self._pixel_keep = np.nonzero([not isinstance(self._slices[ip], numbers.Integral)
+                                       for ip in range(self._wcs.pixel_n_dim)])[0]
+
+        # axis_correlation_matrix[world, pixel]
+        self._world_keep = np.nonzero(
+            self._wcs.axis_correlation_matrix[:, self._pixel_keep].any(axis=1))[0]
+
+    @property
+    def pixel_n_dim(self):
+        return len(self._pixel_keep)
+
+    @property
+    def world_n_dim(self):
+        return len(self._world_keep)
+
+    @property
+    def world_axis_physical_types(self):
+        return [self._wcs.world_axis_physical_types[i] for i in self._world_keep]
+      
+    @property
+    def world_axis_units(self):
+        return [self._wcs.world_axis_units[i] for i in self._world_keep]
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        pixel_arrays_new = []
+        ipix_curr = -1
+        for ipix in range(self._wcs.pixel_n_dim):
+            if self._slices[ipix] is slice(None):
+                ipix_curr += 1
+                pixel_arrays_new.append(pixel_arrays[ipix_curr])
+            elif isinstance(self._slices[ipix], int):
+                pixel_arrays_new.append(self._slices[ipix])
+            else:
+                ipix_curr += 1
+                if self._slices[ipix].start is not None:
+                    pixel_arrays_new.append(pixel_arrays[ipix_curr] + self._slices[ipix].start)
+                else:
+                    pixel_arrays_new.append(pixel_arrays[ipix_curr])
+
+        world_arrays = self._wcs.pixel_to_world_values(*pixel_arrays_new)
+        return [world_arrays[iw] for iw in self._world_keep]
+
+    def array_index_to_world_values(self, *index_arrays):
+        return self.pixel_to_world_values(*index_arrays[::-1])
+ 
+    def world_to_pixel_values(self, *world_arrays):
+        world_arrays_new = []
+        iworld_curr = -1
+        for iworld in range(self._wcs.world_n_dim):
+            if iworld in self._world_keep:
+                iworld_curr += 1
+                world_arrays_new.append(world_arrays[iworld_curr])
+            else:
+                world_arrays_new.append(1.)
+
+        pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays_new)
+
+        for ipixel in range(self._wcs.pixel_n_dim):
+            if isinstance(self._slices[ipixel], slice) and self._slices[ipixel].start is not None:
+                pixel_arrays[ipixel] -= self._slices[ipixel].start
+
+        return [pixel_arrays[ip] for ip in self._pixel_keep]
+
+    def world_to_array_index_values(self, *world_arrays):
+        pixel_arrays = self.world_to_pixel_values(*world_arrays, 0)[::-1]
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int) for pixel in pixel_arrays)
+        return array_indices
+
+    @property
+    def world_axis_object_components(self):
+        return [self._wcs.world_axis_object_components[idx] for idx in self._world_keep]
+
+    @property
+    def world_axis_object_classes(self):
+        keys_keep = [item[0] for item in self.world_axis_object_components]
+        return dict([item for item in self._wcs.world_axis_object_classes.items() if item[0] in keys_keep])
+
+    @property
+    def array_shape(self):
+        return np.broadcast_to(0, self._wcs.array_shape)[self._slices].shape
+        # return tuple([self._wcs.array_shape[idx] for idx in self._pixel_keep])
+
+    @property
+    def pixel_shape(self):
+        return self.array_shape[::-1]
+
+    @property
+    def pixel_bounds(self):
+        # FIXME: incorect when slices are present
+        return [self._wcs.pixel_bounds[::-1][idx] for idx in self._pixel_keep][::-1]
+   
+    @property
+    def axis_correlation_matrix(self):
+        return self._wcs.axis_correlation_matrix[self._world_keep][:,self._pixel_keep]
+
+
+
+

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -2,10 +2,12 @@ import numbers
 import numpy as np
 from astropy.wcs.wcsapi import BaseLowLevelWCS
 
+__all__ = ['sanitize_slices', 'SlicedLowLevelWCS']
+
 
 def sanitize_slices(slices, ndim):
     """
-    Given a set of input 
+    Given a set of input
     """
 
     if not isinstance(slices, (tuple, list)):  # We just have a single int
@@ -34,7 +36,7 @@ def sanitize_slices(slices, ndim):
             elif not isinstance(slc, numbers.Integral):
                 raise ValueError("Only integer or range slices are accepted.")
         else:
-            slices.append(slice(None)) 
+            slices.append(slice(None))
 
     return slices
 
@@ -42,7 +44,7 @@ def sanitize_slices(slices, ndim):
 class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     def __init__(self, wcs, slices):
- 
+
         self._wcs = wcs
         self._slices_array = sanitize_slices(slices, self._wcs.pixel_n_dim)
         self._slices_pixel = self._slices_array[::-1]
@@ -67,7 +69,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     @property
     def world_axis_physical_types(self):
         return [self._wcs.world_axis_physical_types[i] for i in self._world_keep]
-      
+
     @property
     def world_axis_units(self):
         return [self._wcs.world_axis_units[i] for i in self._world_keep]
@@ -90,7 +92,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     def array_index_to_world_values(self, *index_arrays):
         return self.pixel_to_world_values(*index_arrays[::-1])
- 
+
     def world_to_pixel_values(self, *world_arrays):
         world_arrays_new = []
         iworld_curr = -1
@@ -147,9 +149,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
                 bounds.append([imin - start, imax - start])
 
         return bounds
-   
+
     @property
     def axis_correlation_matrix(self):
         return self._wcs.axis_correlation_matrix[self._world_keep][:,self._pixel_keep]
-
-

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -146,7 +146,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
             else:
                 imin, imax = self._wcs.pixel_bounds[idx]
                 start = self._slices_pixel[idx].start
-                bounds.append([imin - start, imax - start])
+                bounds.append((imin - start, imax - start))
 
         return bounds
 

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -1,0 +1,149 @@
+import pytest
+
+import numpy as np
+
+from numpy.testing import assert_equal, assert_allclose
+from astropy.wcs import WCS
+from astropy.io.fits import Header
+from astropy.coordinates import SkyCoord, Galactic
+from astropy.units import Quantity
+from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS, sanitize_slices
+import astropy.units as u
+
+# To test the slicing we start off from standard FITS WCS
+# objects since those implement the low-level API. We create
+# a WCS for a spectral cube with axes in non-standard order
+# and with correlated celestial axes and an uncorrelated
+# spectral axis.
+
+HEADER_SPECTRAL_CUBE = """
+NAXIS   = 3
+NAXIS1  = 10
+NAXIS2  = 20
+NAXIS3  = 30
+CTYPE1  = GLAT-CAR
+CTYPE2  = FREQ
+CTYPE3  = GLON-CAR
+CRVAL1  = 10
+CRVAL2  = 20
+CRVAL3  = 25
+CRPIX1  = 30
+CRPIX2  = 40
+CRPIX3  = 45
+CDELT1  = -0.1
+CDELT2  =  0.5
+CDELT3  =  0.1
+CUNIT1  = deg
+CUNIT2  = Hz
+CUNIT3  = deg
+"""
+
+WCS_SPECTRAL_CUBE = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
+
+
+@pytest.mark.parametrize("item, ndim, expected", (
+    ([Ellipsis, 10], 4, [slice(None)] * 3 + [10]),
+    ([10, slice(20, 30)], 5, [10, slice(20, 30)] + [slice(None)] * 3),
+    ([10, Ellipsis, 8], 10, [10] + [slice(None)] * 8 + [8])
+))
+def test_sanitize_slice(item, ndim, expected):
+    new_item = sanitize_slices(item, ndim)
+    # FIXME: do we still need the first two since the third assert
+    # should cover it all?
+    assert len(new_item) == ndim
+    assert all(isinstance(i, (slice, int)) for i in new_item)
+    assert new_item == expected
+
+
+def test_ellipsis():
+
+    wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, Ellipsis)
+
+    assert wcs.pixel_n_dim == 3
+    assert wcs.world_n_dim == 3
+    assert wcs.array_shape == (30, 20, 10)
+    assert wcs.pixel_shape == (10, 20, 30)
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                  ('freq', 0, 'value'),
+                                                  ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
+
+    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
+
+
+def test_spectral_slice():
+
+    wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [slice(None), 10])
+
+    assert wcs.pixel_n_dim == 2
+    assert wcs.world_n_dim == 2
+    assert wcs.array_shape == (30, 10)
+    assert wcs.pixel_shape == (10, 30)
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, True], [True, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert_allclose(wcs.pixel_to_world_values(29, 44), (10, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 29), (10, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(10, 25), (29., 44.))
+    assert_equal(wcs.world_to_array_index_values(10, 25), (44, 29))
+
+
+def test_spectral_range():
+    
+    wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [slice(None), slice(4, 10)])
+
+    assert wcs.pixel_n_dim == 3
+    assert wcs.world_n_dim == 3
+    assert wcs.array_shape == (30, 6, 10)
+    assert wcs.pixel_shape == (10, 6, 30)
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                  ('freq', 0, 'value'),
+                                                  ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
+
+    assert_allclose(wcs.pixel_to_world_values(29, 35, 44), (10, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 35, 29), (10, 20, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 35., 44.))
+    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 35, 29))

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -39,6 +39,7 @@ CUNIT3  = deg
 """
 
 WCS_SPECTRAL_CUBE = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
+WCS_SPECTRAL_CUBE.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 
 
 @pytest.mark.parametrize("item, ndim, expected", (
@@ -87,6 +88,8 @@ def test_ellipsis():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
+    assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
+
 
 def test_spectral_slice():
 
@@ -114,6 +117,8 @@ def test_spectral_slice():
 
     assert_allclose(wcs.world_to_pixel_values(10, 25), (29., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 25), (44, 29))
+
+    assert_equal(wcs.pixel_bounds, [(-1, 11), (5, 15)])
 
 
 def test_spectral_range():
@@ -148,6 +153,8 @@ def test_spectral_range():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 35., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 35, 29))
 
+    assert_equal(wcs.pixel_bounds, [(-1, 11), (-6, 14), (5, 15)])
+
 
 def test_celestial_slice():
 
@@ -180,6 +187,8 @@ def test_celestial_slice():
 
     assert_allclose(wcs.world_to_pixel_values(12.4, 20, 25), (39., 44.))
     assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))
+
+    assert_equal(wcs.pixel_bounds, [(-2, 18), (5, 15)])
 
 
 def test_celestial_range():
@@ -214,11 +223,16 @@ def test_celestial_range():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (24., 39., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 24))
 
+    assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
+
+
 # Now try with a 90 degree rotation
 
 WCS_SPECTRAL_CUBE_ROT = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
 WCS_SPECTRAL_CUBE_ROT.wcs.pc = [[0, 0, 1], [0, 1, 0], [1, 0, 0]]
 WCS_SPECTRAL_CUBE_ROT.wcs.crval[0] = 0
+WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+
 
 def test_celestial_range_rot():
     
@@ -251,3 +265,5 @@ def test_celestial_range_rot():
 
     assert_allclose(wcs.world_to_pixel_values(1, 15, 24), (14., 29., 34.))
     assert_equal(wcs.world_to_array_index_values(1, 15, 24), (34, 29, 14))
+
+    assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -147,3 +147,69 @@ def test_spectral_range():
 
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 35., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 35, 29))
+
+
+def test_celestial_slice():
+
+    wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [Ellipsis, 5])
+
+    assert wcs.pixel_n_dim == 2
+    assert wcs.world_n_dim == 3
+    assert wcs.array_shape == (30, 20)
+    assert wcs.pixel_shape == (20, 30)
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[False, True], [True, False], [False, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                ('freq', 0, 'value'),
+                                                ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
+
+    assert_allclose(wcs.pixel_to_world_values(39, 44), (12.4, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 39), (12.4, 20, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(12.4, 20, 25), (39., 44.))
+    assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))
+
+
+def test_celestial_range():
+
+    wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [Ellipsis, slice(5, 10)])
+
+    assert wcs.pixel_n_dim == 3
+    assert wcs.world_n_dim == 3
+    assert wcs.array_shape == (30, 20, 5)
+    assert wcs.pixel_shape == (5, 20, 30)
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                ('freq', 0, 'value'),
+                                                ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
+
+    assert_allclose(wcs.pixel_to_world_values(24, 39, 44), (10, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 24), (10, 20, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (24., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 24))

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -122,7 +122,7 @@ def test_spectral_slice():
 
 
 def test_spectral_range():
-    
+
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [slice(None), slice(4, 10)])
 
     assert wcs.pixel_n_dim == 3
@@ -235,7 +235,7 @@ WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 
 
 def test_celestial_range_rot():
-    
+
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE_ROT, [Ellipsis, slice(5, 10)])
 
     assert wcs.pixel_n_dim == 3

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -56,6 +56,33 @@ def test_sanitize_slice(item, ndim, expected):
     assert new_item == expected
 
 
+EXPECTED_ELLIPSIS_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 3 pixel and 3 world dimensions
+
+Array shape (Numpy order): (30, 20, 10)
+
+Pixel Dim  Data size  Bounds
+        0         10  (-1, 11)
+        1         20  (-2, 18)
+        2         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+             Pixel Dim
+World Dim    0    1    2
+        0  yes   no  yes
+        1   no  yes   no
+        2  yes   no  yes
+"""
+
+
 def test_ellipsis():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, Ellipsis)
@@ -90,6 +117,31 @@ def test_ellipsis():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
 
+    assert str(wcs) == repr(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
+
+
+EXPECTED_SPECTRAL_SLICE_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 2 pixel and 2 world dimensions
+
+Array shape (Numpy order): (30, 10)
+
+Pixel Dim  Data size  Bounds
+        0         10  (-1, 11)
+        1         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+           Pixel Dim
+World Dim    0    1
+        0  yes  yes
+        1  yes  yes
+"""
 
 def test_spectral_slice():
 
@@ -119,6 +171,35 @@ def test_spectral_slice():
     assert_equal(wcs.world_to_array_index_values(10, 25), (44, 29))
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (5, 15)])
+
+    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
+
+
+EXPECTED_SPECTRAL_RANGE_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 3 pixel and 3 world dimensions
+
+Array shape (Numpy order): (30, 6, 10)
+
+Pixel Dim  Data size  Bounds
+        0         10  (-1, 11)
+        1          6  (-6, 14)
+        2         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+             Pixel Dim
+World Dim    0    1    2
+        0  yes   no  yes
+        1   no  yes   no
+        2  yes   no  yes
+"""
 
 
 def test_spectral_range():
@@ -155,6 +236,34 @@ def test_spectral_range():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-6, 14), (5, 15)])
 
+    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
+
+
+EXPECTED_CELESTIAL_SLICE_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 2 pixel and 3 world dimensions
+
+Array shape (Numpy order): (30, 20)
+
+Pixel Dim  Data size  Bounds
+        0         20  (-2, 18)
+        1         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+           Pixel Dim
+World Dim    0    1
+        0   no  yes
+        1  yes   no
+        2   no  yes
+"""
+
 
 def test_celestial_slice():
 
@@ -189,6 +298,35 @@ def test_celestial_slice():
     assert_equal(wcs.world_to_array_index_values(12.4, 20, 25), (44, 39))
 
     assert_equal(wcs.pixel_bounds, [(-2, 18), (5, 15)])
+
+    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
+
+
+EXPECTED_CELESTIAL_RANGE_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 3 pixel and 3 world dimensions
+
+Array shape (Numpy order): (30, 20, 5)
+
+Pixel Dim  Data size  Bounds
+        0          5  (-6, 6)
+        1         20  (-2, 18)
+        2         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+             Pixel Dim
+World Dim    0    1    2
+        0  yes   no  yes
+        1   no  yes   no
+        2  yes   no  yes
+"""
 
 
 def test_celestial_range():
@@ -225,6 +363,8 @@ def test_celestial_range():
 
     assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
 
+    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
+
 
 # Now try with a 90 degree rotation
 
@@ -233,6 +373,31 @@ WCS_SPECTRAL_CUBE_ROT.wcs.pc = [[0, 0, 1], [0, 1, 0], [1, 0, 0]]
 WCS_SPECTRAL_CUBE_ROT.wcs.crval[0] = 0
 WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 
+EXPECTED_CELESTIAL_RANGE_ROT_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 3 pixel and 3 world dimensions
+
+Array shape (Numpy order): (30, 20, 5)
+
+Pixel Dim  Data size  Bounds
+        0          5  (-6, 6)
+        1         20  (-2, 18)
+        2         30  (5, 15)
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+             Pixel Dim
+World Dim    0    1    2
+        0  yes   no  yes
+        1   no  yes   no
+        2  yes   no  yes
+"""
 
 def test_celestial_range_rot():
 
@@ -267,3 +432,5 @@ def test_celestial_range_rot():
     assert_equal(wcs.world_to_array_index_values(1, 15, 24), (34, 29, 14))
 
     assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
+
+    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip()

--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -316,7 +316,7 @@ a spectral cube to extract a 1D dataset corresponding to a row in the
 image plane of a spectral slice, the final WCS will have one pixel dimension
 and two world dimensions (since both RA/Dec vary over the extracted 1D slice)::
 
-    >>> wcs[10, 40, :]
+    >>> wcs[10, 40, :]  # doctest: +REMOTE_DATA
     SlicedFITSWCS Transformation
     <BLANKLINE>
     This transformation has 1 pixel and 2 world dimensions


### PR DESCRIPTION
The aim of this pull request is to add a new class ``SlicedLowLevelWCS`` that takes a WCS object implementing the ``BaseLowLevelWCS`` API along with a slice (using whatever would slice a Numpy array) and presents a new WCS object also conforming to the ``BaseLowLevelWCS`` API. 

Currently, slicing in the (FITS) WCS doesn't work if the slicing results in a dimension getting dropped - for example taking a celestial image:

```
In [1]: from astropy.wcs import WCS                                                                                                                    

In [2]: wcs = WCS('MSX_E.fits')                                                                                                                        

In [3]: wcs[0,:]                                                                                                                                       
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-7786fa2dcf4a> in <module>
----> 1 wcs[0,:]

~/Dropbox/Code/Astropy/astropy/astropy/wcs/wcs.py in __getitem__(self, item)
   3009         # We COULD allow wcs[1] to link to wcs.sub([2])
   3010         # (wcs[i] -> wcs.sub([i+1])
-> 3011         return self.slice(item)
   3012 
   3013     def __iter__(self):

~/Dropbox/Code/Astropy/astropy/astropy/wcs/wcs.py in slice(self, view, numpy_order)
   2943 
   2944         if not all(isinstance(x, slice) for x in view):
-> 2945             raise ValueError("Cannot downsample a WCS with indexing.  Use "
   2946                              "wcs.sub or wcs.dropaxis if you want to remove "
   2947                              "axes.")

ValueError: Cannot downsample a WCS with indexing.  Use wcs.sub or wcs.dropaxis if you want to remove axes.
```

Futhermore, ``sub`` doesn't work if we try and remove one of the celestial axes:

```
In [4]: wcs.sub(1)                                                                                                                                    
---------------------------------------------------------------------------
InconsistentAxisTypesError                Traceback (most recent call last)
<ipython-input-11-6a8448877371> in <module>
----> 1 wcs.sub(1)

~/Dropbox/Code/Astropy/astropy/astropy/wcs/wcs.py in sub(self, axes)
    564     def sub(self, axes=None):
    565         copy = self.deepcopy()
--> 566         copy.wcs = self.wcs.sub(axes)
    567         copy.naxis = copy.wcs.naxis
    568         return copy

InconsistentAxisTypesError: ERROR 4 in wcs_types() at line 2522 of file cextern/wcslib/C/wcs.c:
Unmatched celestial axes.
```

With the class in this PR, we can now slice a WCS in this way:

```
In [5]: from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS                                                                          

In [6]: wcs2 = SlicedLowLevelWCS(wcs, [0, slice(None)])                                                                                                
```

This WCS has one pixel and two world coordinates:

```
In [7]: wcs2.pixel_n_dim                                                                                                                               
Out[7]: 1

In [8]: wcs2.world_n_dim                                                                                                                               
Out[8]: 2
```

Essentially this works by never actually calling sub but instead just keeping an internal reference to the original WCS and doing bookkeeping on-the-fly to make it look like a sliced WCS.

With this, we can then update ``WCS.slice`` to now return a ``SlicedFITSWCS`` object when slicing in a way that drops dimensions, although in the case where no dimensions are dropped, we keep the old behavior for backward-compatibility:


```
In [1]: from astropy.wcs import WCS                                                                                                                    

In [2]: wcs = WCS('MSX_E.fits')                                                                                                                        

In [3]: wcs[0,:]                                                                                                                                       
Out[3]: <astropy.wcs.wcsapi.fitswcs.SlicedFITSWCS at 0x109f00dd8>

In [4]: wcs[0:3,:]                                                                                                                                     
Out[4]: 
WCS Keywords

Number of WCS axes: 2
CTYPE : 'GLON-CAR'  'GLAT-CAR'  
CRVAL : 0.0  0.0  
CRPIX : 299.628  299.394  
NAXIS : 599  3
```

This was written with @astrofrog 

---

## To Do

- [x] Add support for FITS WCS.
- [x] Improve `repr`s for base APE14 classes and sliced class.
- [ ] <s>Test with gWCS.</s> *will be done after merging*
- [x] Documentation.