### PR TITLE
[DOC] Transform a barycentric radial velocity to the Galactic Standard of R…

### DIFF
--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -92,7 +92,7 @@ def rv_to_gsr(c, v_sun=None):
     if v_sun is None:
         v_sun = coord.Galactocentric.galcen_v_sun.to_cartesian()
 
-    gal = icrs.transform_to(coord.Galactic)
+    gal = c.transform_to(coord.Galactic)
     cart_data = gal.data.to_cartesian()
     unit_vector = cart_data / cart_data.norm()
 


### PR DESCRIPTION
…est. The radial velocity associated with some sky coordinated is transformed to Galactic coordinates and a unit vector is generated for the data.

Minor DOC correction.

Closes #8550 