### PR TITLE
Upgrade pytest pin due pytest-xdist dependency conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
-               PYTEST_VERSION=3.7
+               PYTEST_VERSION=4.4
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
                INSTALL_WITH_PIP=True
                EXTRAS_INSTALL="test,all"


### PR DESCRIPTION
Attempt to fix #8555 .

p.s. @drdavella introduced the pinning in #7890

Note: I tried removing the pin first but that didn't work because it picked up another pin (3.10) farther up the matrix.