### PR TITLE
patch to prevent change points index from going negative

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -476,6 +476,8 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed a bug where ``bayesian_blocks`` returned a single edge. [#8560]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -37,7 +37,6 @@ References
 .. [1] http://adsabs.harvard.edu/abs/2012arXiv1207.5578S
 .. [2] http://astroml.org/ https://github.com//astroML/astroML/
 """
-
 import warnings
 
 import numpy as np
@@ -385,12 +384,14 @@ class FitnessFunc:
         change_points = np.zeros(N, dtype=int)
         i_cp = N
         ind = N
-        while True:
+        while i_cp > 0:
             i_cp -= 1
             change_points[i_cp] = ind
             if ind == 0:
                 break
             ind = last[ind - 1]
+        if i_cp == 0:
+            change_points[i_cp] = 0
         change_points = change_points[i_cp:]
 
         return edges[change_points]

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -162,3 +162,13 @@ def test_fitness_function_results():
     edges = bayesian_blocks(t, x_obs, sigma, fitness='measures',
                             gamma=gamma_sel)
     assert_allclose(edges, expected)
+
+
+def test_zero_change_points(rseed=0):
+    ''' Ensure that edges contains both endpoints when there are no change points '''
+    np.random.seed(rseed)
+    # Using the failed edge case from https://github.com/astropy/astropy/issues/8558
+    values = np.array([1, 1, 1, 1, 1, 1, 1, 1, 2])
+    bins = bayesian_blocks(values)
+    assert values.min() == bins[0]
+    assert values.max() == bins[-1]


### PR DESCRIPTION
This patch may solve https://github.com/astropy/astropy/issues/8558

I've tested it on a few basic examples and don't see a problem, but I have to admit I don't understand the algorithm. The basic strategy of my patch was to observe that the `i_cp` index could (and did) go negative, which I don't think was intended. My patch simply forced this not to happen, but does not address the underlying reason for why it happened in the first place.

EDIT: Fix #8558 