### PR TITLE
Allow representations with same name, fixes #8509

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -557,6 +557,12 @@ astropy.coordinates
 - The ``QuantityAttribute`` class now supports a None default value if a unit
   is specified. [#9345]
 
+- When ``Representation`` classes with the same name are defined, this no
+  longer leads to a ``ValueError``, but instead to a warning and the removal
+  of both from the name registry (i.e., one either has to use the class itself
+  to set, e.g., ``representation_type``, or refer to the class by its fully
+  qualified name). [#8561]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -12,6 +12,7 @@ from astropy import units as u
 from astropy.tests.helper import (assert_quantity_allclose as
                                   assert_allclose_quantity)
 from astropy.utils import isiterable
+from astropy.utils.exceptions import DuplicateRepresentationWarning
 from astropy.coordinates.angles import Longitude, Latitude, Angle
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
@@ -1074,12 +1075,20 @@ def test_minimal_subclass():
     with pytest.raises(TypeError):
         LogDRepresentation(0.*u.deg, 1.*u.deg, 1.*u.dex(u.kpc), foo='bar')
 
+    # if we define it a second time, even the qualnames are the same,
+    # so we raise
     with pytest.raises(ValueError):
-        # check we cannot redefine an existing class.
         class LogDRepresentation(BaseRepresentation):
             attr_classes = OrderedDict([('lon', Longitude),
                                         ('lat', Latitude),
                                         ('logr', u.Dex)])
+
+
+def test_duplicate_warning():
+    with pytest.warns(DuplicateRepresentationWarning):
+        class UnitSphericalRepresentation(BaseRepresentation):
+            attr_classes = OrderedDict([('lon', Longitude),
+                                        ('lat', Latitude)])
 
 
 def test_combine_xyz():

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1085,10 +1085,18 @@ def test_minimal_subclass():
 
 
 def test_duplicate_warning():
+    from astropy.coordinates.representation import DUPLICATE_REPRESENTATIONS
+    from astropy.coordinates.representation import REPRESENTATION_CLASSES
+
     with pytest.warns(DuplicateRepresentationWarning):
         class UnitSphericalRepresentation(BaseRepresentation):
             attr_classes = OrderedDict([('lon', Longitude),
                                         ('lat', Latitude)])
+
+    assert 'unitspherical' in DUPLICATE_REPRESENTATIONS
+    assert 'unitspherical' not in REPRESENTATION_CLASSES
+    assert 'astropy.coordinates.representation.UnitSphericalRepresentation' in REPRESENTATION_CLASSES
+    assert __name__ + '.test_duplicate_warning.<locals>.UnitSphericalRepresentation' in REPRESENTATION_CLASSES
 
 
 def test_combine_xyz():

--- a/astropy/utils/exceptions.py
+++ b/astropy/utils/exceptions.py
@@ -45,6 +45,12 @@ class AstropyBackwardsIncompatibleChangeWarning(AstropyWarning):
     """
 
 
+class DuplicateRepresentationWarning(AstropyWarning):
+    """
+    A warning class indicating a represenation name was already registered
+    """
+
+
 class ErfaError(ValueError):
     """
     A class for errors triggered by ERFA functions (status codes < 0)


### PR DESCRIPTION
Fallback to `__qualname__` to avoid naming conflicts
in case there are multiple representations with
the same name.

fix #8509