### PR TITLE
Remove duplicate call to update_header

### DIFF
--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -152,7 +152,6 @@ class _ImageBaseHDU(_ValidHDU):
             # appropriate BITPIX for the data, and always sets _bzero=0 and
             # _bscale=1.
             self.data = data
-            self.update_header()
 
             # Check again for BITPIX/BSCALE/BZERO in case they changed when the
             # data was assigned. This can happen, for example, if the input

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -148,9 +148,9 @@ class _ImageBaseHDU(_ValidHDU):
                 self._data_needs_rescale = True
             return
         else:
-            # Setting data will set set _bitpix, _bzero, and _bscale to the
-            # appropriate BITPIX for the data, and always sets _bzero=0 and
-            # _bscale=1.
+            # Setting data will update the header and set _bitpix, _bzero,
+            # and _bscale to the appropriate BITPIX for the data, and always
+            # sets _bzero=0 and _bscale=1.
             self.data = data
 
             # Check again for BITPIX/BSCALE/BZERO in case they changed when the


### PR DESCRIPTION
See https://github.com/astropy/astropy/pull/5053/files#r66576117

I stumbled upon this while looking at #5559, `update_header` is called twice (it is called in the `.data` setter).