### PR TITLE
Add CompositeStretch to visualization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,8 @@ astropy.utils
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
+- Added ``CompositeStretch``, which inherits from ``CompositeTransform`` and
+  also ``BaseStretch`` so that it can be used with ``ImageNormalize``. [#8564]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -90,13 +90,20 @@ class LinearStretch(BaseStretch):
     The stretch is given by:
 
     .. math::
-        y = ax + b
+        y = slope x + intercept
+
+    Parameters
+    ----------
+    slope : float, optional
+        The ``slope`` parameter used in the above formula.  Default is 1.
+    intercept : float, optional
+        The ``intercept`` parameter used in the above formula.  Default is 0.
     """
 
-    def __init__(self, a=1, b=0):
+    def __init__(self, slope=1, intercept=0):
         super().__init__()
-        self.slope = a
-        self.intercept = b
+        self.slope = slope
+        self.intercept = intercept
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -80,21 +80,29 @@ class BaseStretch(BaseTransform, metaclass=InheritDocstrings):
 
 class LinearStretch(BaseStretch):
     """
-    A linear stretch.
+    A linear stretch with a slope and offset.
 
     The stretch is given by:
 
     .. math::
-        y = x
+        y = ax + b
     """
 
+    def __init__(self, a=1, b=0):
+        super().__init__()
+        self.slope = a
+        self.intercept = b
+
     def __call__(self, values, clip=True, out=None):
-        return _prepare(values, clip=clip, out=out)
+        values = _prepare(values, clip=clip, out=out)
+        np.multiply(values, self.slope, out=values)
+        np.add(values, self.intercept, out=values)
+        return values
 
     @property
     def inverse(self):
         """A stretch object that performs the inverse operation."""
-        return LinearStretch()
+        return LinearStretch(1. / self.slope, - self.intercept / self.slope)
 
 
 class SqrtStretch(BaseStretch):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -551,14 +551,6 @@ class CompositeStretch(CompositeTransform, BaseStretch):
         The second stretch to apply.
     """
 
-    def __init__(self, stretch_1, stretch_2):
-        super().__init__(stretch_1, stretch_2)
-
     def __call__(self, values, clip=True, out=None):
         return self.transform_2(
             self.transform_1(values, clip=clip, out=out), clip=clip, out=out)
-
-    @property
-    def inverse(self):
-        return CompositeStretch(self.transform_2.inverse,
-                                self.transform_1.inverse)

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -100,8 +100,10 @@ class LinearStretch(BaseStretch):
 
     def __call__(self, values, clip=True, out=None):
         values = _prepare(values, clip=clip, out=out)
-        np.multiply(values, self.slope, out=values)
-        np.add(values, self.intercept, out=values)
+        if self.slope != 1:
+            np.multiply(values, self.slope, out=values)
+        if self.intercept != 0:
+            np.add(values, self.intercept, out=values)
         return values
 
     @property

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -13,6 +13,8 @@ DATA = np.array([0.00, 0.25, 0.50, 0.75, 1.00])
 
 RESULTS = {}
 RESULTS[LinearStretch()] = np.array([0.00, 0.25, 0.50, 0.75, 1.00])
+RESULTS[LinearStretch(intercept=0.5) + LinearStretch(slope=0.5)] = \
+    np.array([0.5, 0.625, 0.75, 0.875, 1.])
 RESULTS[SqrtStretch()] = np.array([0., 0.5, 0.70710678, 0.8660254, 1.])
 RESULTS[SquaredStretch()] = np.array([0., 0.0625, 0.25, 0.5625, 1.])
 RESULTS[PowerStretch(0.5)] = np.array([0., 0.5, 0.70710678, 0.8660254, 1.])

--- a/astropy/visualization/transform.py
+++ b/astropy/visualization/transform.py
@@ -38,5 +38,5 @@ class CompositeTransform(BaseTransform):
 
     @property
     def inverse(self):
-        return CompositeTransform(self.transform_2.inverse,
-                                  self.transform_1.inverse)
+        return self.__class__(self.transform_2.inverse,
+                              self.transform_1.inverse)

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -275,29 +275,19 @@ composite stretch can stretch residual images with negative values:
 
     import numpy as np
     import matplotlib.pyplot as plt
-    from astropy.visualization.stretch import AsinhStretch, \
-        LinearStretch, SinhStretch
+    from astropy.visualization.stretch import SinhStretch, LinearStretch
     from astropy.visualization import ImageNormalize
-    # For nicer colorbars to show the stretch
-    from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-    # Streches to transform normalized values [0,1] to [-1,1] and back
-    stretch_signed = LinearStretch(a=2, b=-1)
-    stretch_unsigned = LinearStretch(a=0.5, b=0.5)
-
-    # sinh and arcsinh stretches with default values
-    stretches = {
-        'sinh(a=1/3)': stretch_unsigned + SinhStretch(1/3) + stretch_signed,
-        'linear': LinearStretch(),
-        'asinh(a=0.2)': stretch_unsigned + AsinhStretch(0.2) + stretch_signed,
-    }
+    # Transforms normalized values [0,1] to [-1,1] before stretch and then back
+    stretch = LinearStretch(a=0.5, b=0.5) + SinhStretch() + \
+        LinearStretch(a=2, b=-1)
 
     # Image of random Gaussian noise
-    img = np.random.normal(size=(64, 64))
-    fig, axes = plt.subplots(1, len(stretches), figsize=(16, 16))
-    for (title, stretch), axis in zip(stretches.items(), axes):
-        norm = ImageNormalize(stretch=stretch)
-        imgax = axis.imshow(img, norm=norm, cmap='gray', vmin=-5, vmax=5)
-        axis.set_title(title)
-        cax = make_axes_locatable(axis).append_axes('right', size='5%', pad=0.1)
-        plt.colorbar(imgax, cax=cax, orientation='vertical')
+    image = np.random.normal(size=(64, 64))
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    # ImageNormalize normalizes values to [0,1] before applying the stretch
+    norm = ImageNormalize(stretch=stretch)
+    im = ax.imshow(image, origin='lower', norm=norm, cmap='gray',
+        vmin=-5, vmax=5)
+    fig.colorbar(im)

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -279,8 +279,8 @@ composite stretch can stretch residual images with negative values:
     from astropy.visualization import ImageNormalize
 
     # Transforms normalized values [0,1] to [-1,1] before stretch and then back
-    stretch = LinearStretch(a=0.5, b=0.5) + SinhStretch() + \
-        LinearStretch(a=2, b=-1)
+    stretch = LinearStretch(slope=0.5, intercept=0.5) + SinhStretch() + \
+        LinearStretch(slope=2, intercept=-1)
 
     # Image of random Gaussian noise
     image = np.random.normal(size=(64, 64))

--- a/docs/visualization/normalization.rst
+++ b/docs/visualization/normalization.rst
@@ -260,3 +260,44 @@ to be used in scripted programs; it's better to use
     ax = fig.add_subplot(1, 1, 1)
     im = ax.imshow(image, origin='lower', norm=norm)
     fig.colorbar(im)
+
+Combining stretches and Matplotlib normalization
+================================================
+
+Stretches can also be combined with other stretches, just like transformations.
+The resulting :class:`~astropy.visualization.stretch.CompositeStretch` can be 
+used to normalize Matplotlib images like any other stretch. For example, a
+composite stretch can stretch residual images with negative values:
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from astropy.visualization.stretch import AsinhStretch, \
+        LinearStretch, SinhStretch
+    from astropy.visualization import ImageNormalize
+    # For nicer colorbars to show the stretch
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+    # Streches to transform normalized values [0,1] to [-1,1] and back
+    stretch_signed = LinearStretch(a=2, b=-1)
+    stretch_unsigned = LinearStretch(a=0.5, b=0.5)
+
+    # sinh and arcsinh stretches with default values
+    stretches = {
+        'sinh(a=1/3)': stretch_unsigned + SinhStretch(1/3) + stretch_signed,
+        'linear': LinearStretch(),
+        'asinh(a=0.2)': stretch_unsigned + AsinhStretch(0.2) + stretch_signed,
+    }
+
+    # Image of random Gaussian noise
+    img = np.random.normal(size=(64, 64))
+    fig, axes = plt.subplots(1, len(stretches), figsize=(16, 16))
+    for (title, stretch), axis in zip(stretches.items(), axes):
+        norm = ImageNormalize(stretch=stretch)
+        imgax = axis.imshow(img, norm=norm, cmap='gray', vmin=-5, vmax=5)
+        axis.set_title(title)
+        cax = make_axes_locatable(axis).append_axes('right', size='5%', pad=0.1)
+        plt.colorbar(imgax, cax=cax, orientation='vertical')


### PR DESCRIPTION
This branch adds a CompositeStretch, which behaves much like CompositeTransform but also inherits from BaseStretch. It also adds a slope and intercept to LinearStretch, defaulting to one/zero so that the default behaviour of multiplying by unity is unchanged.

My main motivation is the example usage I added to the documentation, as I couldn't figure out how to do it any other way, but I don't see any reason why you shouldn't be able to combine power law and (arc)sinh transforms if you wanted to. I didn't add any tests as the existing *Stretch tests only seem to cover defaults for single stretches.

I see now that there used to be a CompositeStretch in imageutils/scaling/; I'm not sure what happened to that.