### PR TITLE
Map FITS undefined value to None in astropy.io.fits.header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,12 @@ astropy.io.fits
 
 -  Optimize ``Header`` parsing. [#8428]
 
+-  Change behavior of FITS undefined value in ``Header`` such that ``None``
+   is used in Python to represent FITS undefined when using dict interface.
+   ``Undefined`` can also be assigned and is translated to ``None``.
+   Previously setting a header card value to ``None`` resulted in an
+   empty string field rather than a FITS undefined value. [#8572]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -286,7 +286,10 @@ class Card(_Verify):
             self._value = self._parse_value()
             value = self._value
         else:
-            self._value = value = ''
+            if self._keyword == '':
+                self._value = value = ''
+            else:
+                self._value = value = UNDEFINED
 
         if conf.strip_header_whitespace and isinstance(value, str):
             value = value.rstrip()
@@ -301,10 +304,10 @@ class Card(_Verify):
                 'delete this card from the header or replace it.')
 
         if value is None:
-            value = ''
+            value = UNDEFINED
         oldvalue = self._value
         if oldvalue is None:
-            oldvalue = ''
+            oldvalue = UNDEFINED
 
         if not isinstance(value,
                           (str, int, float, complex, bool, Undefined,

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -6,7 +6,7 @@ import itertools
 import re
 import warnings
 
-from .card import Card, _pad, KEYWORD_LENGTH
+from .card import Card, _pad, KEYWORD_LENGTH, UNDEFINED
 from .file import _File
 from .util import encode_ascii, decode_ascii, fileobj_closed, fileobj_is_binary
 
@@ -147,7 +147,11 @@ class Header:
             # This is RVKC; if only the top-level keyword was specified return
             # the raw value, not the parsed out float value
             return card.rawvalue
-        return card.value
+
+        value = card.value
+        if value == UNDEFINED:
+            return None
+        return value
 
     def __setitem__(self, key, value):
         if self._set_slice(key, value, self):
@@ -162,11 +166,11 @@ class Header:
             if len(value) == 1:
                 value, comment = value[0], None
                 if value is None:
-                    value = ''
+                    value = UNDEFINED
             elif len(value) == 2:
                 value, comment = value
                 if value is None:
-                    value = ''
+                    value = UNDEFINED
                 if comment is None:
                     comment = ''
         else:
@@ -177,6 +181,8 @@ class Header:
             card = self._cards[key]
         elif isinstance(key, tuple):
             card = self._cards[self._cardindex(key)]
+        if value is None:
+            value = UNDEFINED
         if card:
             card.value = value
             if comment is not None:

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -820,10 +820,16 @@ class TestHeaderFunctions(FitsTestCase):
         # And now assign an undefined value to the header through setitem
         header['UNDEF3'] = fits.card.UNDEFINED
 
+        # Tuple assignment
+        header.append(("UNDEF5", None, "Undefined value"), end=True)
+        header.append("UNDEF6")
+
         assert header['DEFINED'] == 42
         assert header['UNDEF'] is None
         assert header['UNDEF2'] is None
         assert header['UNDEF3'] is None
+        assert header['UNDEF5'] is None
+        assert header['UNDEF6'] is None
 
         # Assign an undefined value to a new card
         header['UNDEF4'] = None
@@ -831,11 +837,9 @@ class TestHeaderFunctions(FitsTestCase):
         # Overwrite an existing value with None
         header["DEFINED"] = None
 
-        # Check that stringification of these new headers look like FITS
-        # undefined values
-        hstr = str(header)
-        for k in ("UNDEF", "UNDEF2", "UNDEF3", "UNDEF4", "DEFINED"):
-            assert "{:8s}=        ".format(k) in hstr
+        # All headers now should be undefined
+        for c in header.cards:
+            assert c.value == fits.card.UNDEFINED
 
     def test_set_comment_only(self):
         header = fits.Header([('A', 'B', 'C')])
@@ -965,10 +969,10 @@ class TestHeaderFunctions(FitsTestCase):
     def test_header_fromkeys(self):
         header = fits.Header.fromkeys(['A', 'B'])
         assert 'A' in header
-        assert header['A'] == ''
+        assert header['A'] is None
         assert header.comments['A'] == ''
         assert 'B' in header
-        assert header['B'] == ''
+        assert header['B'] is None
         assert header.comments['B'] == ''
 
     def test_header_fromkeys_with_value(self):
@@ -1300,7 +1304,7 @@ class TestHeaderFunctions(FitsTestCase):
         header.append('E')
         assert len(header) == 3
         assert list(header)[-1] == 'E'
-        assert header[-1] == ''
+        assert header[-1] is None
         assert header.comments['E'] == ''
 
         # Try appending a blank--normally this can be accomplished with just

--- a/docs/io/fits/usage/headers.rst
+++ b/docs/io/fits/usage/headers.rst
@@ -207,6 +207,26 @@ commentary card by using the :meth:`Header.insert` method.
     Ironically, there is no comment in a commentary card, only a string
     value.
 
+Undefined values
+----------------
+
+FITS headers can have undefined values and these are represented in Python
+with the special value `None`.  `None` can be used when assigning values
+to a `~astropy.io.fits.Header` or `~astropy.io.fits.Card`.
+
+    >>> hdr = fits.Header()
+    >>> hdr['UNDEF'] = None
+    >>> hdr['UNDEF'] is None
+    True
+    >>> repr(hdr)
+    'UNDEF   =                                                                       '
+    >>> hdr.append('UNDEF2')
+    >>> hdr['UNDEF2'] is None
+    True
+    >>> hdr.append(('UNDEF3', None, 'Undefined value'))
+    >>> str(hdr.cards[-1])
+    'UNDEF3  =  / Undefined value                                                    '
+
 
 Card Images
 ===========


### PR DESCRIPTION
Assigning None results in FITS undefined. On retrieval an undefined
FITS value becomes Python None.

See motivating discussion in #8544 

(I'll do a change log item in a moment, but I wanted to get the code in a PR first).