### PR TITLE
Preserve column order using ordered dicts with Table(rows=)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Initializing a table with ``Table(rows=...)``, if the first item is an ``OrderedDict``,
+  now preserves column order. [#8587]
+
 - Added new pprint_all() and pformat_all() methods to Table. These two new
   methods print the entire table by default. [#8577]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -765,31 +765,24 @@ class Table:
     def _init_from_list_of_dicts(self, data, names, dtype, n_cols, copy):
         if isinstance(data[0], OrderedDict):
             names_from_data = list(data[0].keys())
-
-            cols = {}
-            for name in names_from_data:
-                cols[name] = []
-                for i, row in enumerate(data):
-                    try:
-                        cols[name].append(row[name])
-                    except KeyError:
-                        raise ValueError('Row {0} has no value for column {1}'.format(i, name))
-            if all(name is None for name in names):
-                names = names_from_data
         else:
             names_from_data = set()
             for row in data:
                 names_from_data.update(row)
 
-            cols = {}
-            for name in names_from_data:
-                cols[name] = []
-                for i, row in enumerate(data):
-                    try:
-                        cols[name].append(row[name])
-                    except KeyError:
-                        raise ValueError('Row {0} has no value for column {1}'.format(i, name))
-            if all(name is None for name in names):
+        cols = {}
+        for name in names_from_data:
+            cols[name] = []
+            for i, row in enumerate(data):
+                try:
+                    cols[name].append(row[name])
+                except KeyError:
+                    raise ValueError('Row {0} has no value for column {1}'.format(i, name))
+
+        if all(name is None for name in names):
+            if isinstance(data[0], OrderedDict):
+                names = names_from_data
+            else:
                 names = sorted(names_from_data)
 
         self._init_from_dict(cols, names, dtype, n_cols, copy)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -763,20 +763,35 @@ class Table:
                 self._set_masked(True)
 
     def _init_from_list_of_dicts(self, data, names, dtype, n_cols, copy):
-        names_from_data = set()
-        for row in data:
-            names_from_data.update(row)
+        if isinstance(data[0], OrderedDict):
+            names_from_data = list(data[0].keys())
 
-        cols = {}
-        for name in names_from_data:
-            cols[name] = []
-            for i, row in enumerate(data):
-                try:
-                    cols[name].append(row[name])
-                except KeyError:
-                    raise ValueError('Row {0} has no value for column {1}'.format(i, name))
-        if all(name is None for name in names):
-            names = sorted(names_from_data)
+            cols = {}
+            for name in names_from_data:
+                cols[name] = []
+                for i, row in enumerate(data):
+                    try:
+                        cols[name].append(row[name])
+                    except KeyError:
+                        raise ValueError('Row {0} has no value for column {1}'.format(i, name))
+            if all(name is None for name in names):
+                names = names_from_data
+        else:
+            names_from_data = set()
+            for row in data:
+                names_from_data.update(row)
+
+            cols = {}
+            for name in names_from_data:
+                cols[name] = []
+                for i, row in enumerate(data):
+                    try:
+                        cols[name].append(row[name])
+                    except KeyError:
+                        raise ValueError('Row {0} has no value for column {1}'.format(i, name))
+            if all(name is None for name in names):
+                names = sorted(names_from_data)
+
         self._init_from_dict(cols, names, dtype, n_cols, copy)
         return
 

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -501,3 +501,24 @@ def test_init_and_ref_from_dict(table_type, copy):
     else:
         assert x1[0] == -200
         assert x2[1] == -100
+
+@pytest.mark.usefixtures('table_type')
+def test_init_from_row_OrderedDict(table_type):
+        row1 = OrderedDict()
+        row1['b'] = 1
+        row1['a'] = 0
+        row2 = OrderedDict()
+        row2['b'] = 11
+        row2['a'] = 10
+        rows12 = [row1,row2]
+        row3 = dict()
+        row3['b'] = 1
+        row3['a'] = 0
+        row4 = dict()
+        row4['b'] = 11
+        row4['a'] = 10
+        rows34 = [row3,row4]
+        t1 = table_type(rows=rows12)
+        t2 = table_type(rows=rows34)
+        assert t1.colnames == ['b', 'a']
+        assert t2.colnames == ['a', 'b']

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -502,13 +502,14 @@ def test_init_and_ref_from_dict(table_type, copy):
         assert x1[0] == -200
         assert x2[1] == -100
 
+
 @pytest.mark.usefixtures('table_type')
 def test_init_from_row_OrderedDict(table_type):
-        row1 = OrderedDict({'b': 1, 'a':0})
-        row2 = OrderedDict({'b': 11, 'a':10})
+        row1 = OrderedDict([('b', 1), ('a', 0)])
+        row2 = OrderedDict([('b', 11), ('a', 10)])
         rows12 = [row1, row2]
-        row3 = dict({'b': 1, 'a':0})
-        row4 = dict({'b': 11, 'a':10})
+        row3 = dict([('b', 1), ('a', 0)])
+        row4 = dict([('b', 11), ('a', 10)])
         rows34 = [row3, row4]
         t1 = table_type(rows=rows12)
         t2 = table_type(rows=rows34)

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -504,20 +504,12 @@ def test_init_and_ref_from_dict(table_type, copy):
 
 @pytest.mark.usefixtures('table_type')
 def test_init_from_row_OrderedDict(table_type):
-        row1 = OrderedDict()
-        row1['b'] = 1
-        row1['a'] = 0
-        row2 = OrderedDict()
-        row2['b'] = 11
-        row2['a'] = 10
-        rows12 = [row1,row2]
-        row3 = dict()
-        row3['b'] = 1
-        row3['a'] = 0
-        row4 = dict()
-        row4['b'] = 11
-        row4['a'] = 10
-        rows34 = [row3,row4]
+        row1 = OrderedDict({'b': 1, 'a':0})
+        row2 = OrderedDict({'b': 11, 'a':10})
+        rows12 = [row1, row2]
+        row3 = dict({'b': 1, 'a':0})
+        row4 = dict({'b': 11, 'a':10})
+        rows34 = [row3, row4]
         t1 = table_type(rows=rows12)
         t2 = table_type(rows=rows34)
         assert t1.colnames == ['b', 'a']

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -260,8 +260,8 @@ You can also preserve the column order by using ``OrderedDict``. If the first it
 ``OrderedDict`` then the order is preserved:
 
   >>> from collections import OrderedDict
-  >>> row1 = OrderedDict({'b': 1, 'a':0})
-  >>> row2 = OrderedDict({'b': 11, 'a':10})
+  >>> row1 = OrderedDict([('b', 1), ('a', 0)])
+  >>> row2 = OrderedDict([('b', 11), ('a', 10)])
   >>> rows = [row1, row2]
   >>> Table(rows=rows, dtype=('i4', 'i4'))
   <Table length=2>

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -262,7 +262,7 @@ You can also preserve the column order by using ``OrderedDict``. If the first it
   >>> from collections import OrderedDict
   >>> row1 = OrderedDict({'b': 1, 'a':0})
   >>> row2 = OrderedDict({'b': 11, 'a':10})
-  >>> rows = [row1,row2]
+  >>> rows = [row1, row2]
   >>> Table(rows=rows)  # doctest: +SKIP
   <Table length=2>
     b     a

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -263,10 +263,10 @@ You can also preserve the column order by using ``OrderedDict``. If the first it
   >>> row1 = OrderedDict({'b': 1, 'a':0})
   >>> row2 = OrderedDict({'b': 11, 'a':10})
   >>> rows = [row1, row2]
-  >>> Table(rows=rows)
+  >>> Table(rows=rows, dtype=('i4', 'i4'))
   <Table length=2>
     b     a
-  int64 int64
+  int32 int32
   ----- -----
       1     0
      11    10

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -259,6 +259,7 @@ Every row must have the same set of keys or a ValueError will be thrown::
 You can also preserve the column order by using ``OrderedDict``. If the first item is an 
 ``OrderedDict`` then the order is preserved:
 
+  >>> from collections import OrderedDict
   >>> row1 = OrderedDict({'b': 1, 'a':0})
   >>> row2 = OrderedDict({'b': 11, 'a':10})
   >>> rows = [row1,row2]

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -256,6 +256,20 @@ Every row must have the same set of keys or a ValueError will be thrown::
     ...
   ValueError: Row 0 has no value for column c
 
+You can also preserve the column order by using ``OrderedDict``. If the first item is an 
+``OrderedDict`` then the order is preserved:
+
+  >>> row1 = OrderedDict({'b': 1, 'a':0})
+  >>> row2 = OrderedDict({'b': 11, 'a':10})
+  >>> rows = [row1,row2]
+  >>> Table(rows=rows)  # doctest: +SKIP
+  <Table length=2>
+    b     a
+  int64 int64
+  ----- -----
+      1     0
+     11    10
+
 **Single row**
 
 You can also make a new table from a single row of an existing table::
@@ -572,7 +586,8 @@ for the ``data`` argument.
     key values in each dict define the column names and each row must
     have identical column names.  The ``names`` argument may be supplied
     to specify column ordering.  If it is not provided, the column order will
-    default to alphabetical.  The ``dtype`` list may be specified, and must
+    default to alphabetical. If the first item is an ``OrderedDict``, then the 
+    column order is preserved.  The ``dtype`` list may be specified, and must
     correspond to the order of output columns.  If any row's keys do no match
     the rest of the rows, a ValueError will be thrown.
 

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -256,14 +256,14 @@ Every row must have the same set of keys or a ValueError will be thrown::
     ...
   ValueError: Row 0 has no value for column c
 
-You can also preserve the column order by using ``OrderedDict``. If the first item is an 
+You can also preserve the column order by using ``OrderedDict``. If the first item is an
 ``OrderedDict`` then the order is preserved:
 
   >>> from collections import OrderedDict
   >>> row1 = OrderedDict({'b': 1, 'a':0})
   >>> row2 = OrderedDict({'b': 11, 'a':10})
   >>> rows = [row1, row2]
-  >>> Table(rows=rows)  # doctest: +SKIP
+  >>> Table(rows=rows)
   <Table length=2>
     b     a
   int64 int64
@@ -587,7 +587,7 @@ for the ``data`` argument.
     key values in each dict define the column names and each row must
     have identical column names.  The ``names`` argument may be supplied
     to specify column ordering.  If it is not provided, the column order will
-    default to alphabetical. If the first item is an ``OrderedDict``, then the 
+    default to alphabetical. If the first item is an ``OrderedDict``, then the
     column order is preserved.  The ``dtype`` list may be specified, and must
     correspond to the order of output columns.  If any row's keys do no match
     the rest of the rows, a ValueError will be thrown.


### PR DESCRIPTION
Now initializing a table with Table(rows=...), if the first item is an OrderedDict, column order is preserved. 

Closes #4667. 