### PR TITLE
Changing remaining private represent_mixins_as_columns method to public

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2889,7 +2889,7 @@ class Table:
                     tbl[col.info.name] = new_col
 
             # Convert the table to one with no mixins, only Column objects.
-            encode_tbl = serialize._represent_mixins_as_columns(tbl)
+            encode_tbl = serialize.represent_mixins_as_columns(tbl)
             return encode_tbl
 
         tbl = _encode_mixins(self)


### PR DESCRIPTION
This has been added in the past 6 month after the CI last run in #7729.

Uncontroversial change, so anyone please approve and merge to fix CI on master. 