### PR TITLE
Change time scale of J2000 to TT

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -225,6 +225,9 @@ astropy.coordinates
 - ``QuantityAttribute`` no longer has a default value for ``default``.  The
   previous value of None was misleading as it always was an error. [#8450]
 
+- The default J2000 has been changed to use be January 1, 2000 12:00 TT instead
+  of UTC.  This is more in line with convention. [#8594]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -19,12 +19,12 @@ from astropy.utils.exceptions import AstropyWarning
 # The UTC time scale is not properly defined prior to 1960, so Time('B1950',
 # scale='utc') will emit a warning. Instead, we use Time('B1950', scale='tai')
 # which is equivalent, but does not emit a warning.
-EQUINOX_J2000 = Time('J2000', scale='utc')
+EQUINOX_J2000 = Time('J2000', scale='tt')
 EQUINOX_B1950 = Time('B1950', scale='tai')
 
 # This is a time object that is the default "obstime" when such an attribute is
 # necessary.  Currently, we use J2000.
-DEFAULT_OBSTIME = Time('J2000', scale='utc')
+DEFAULT_OBSTIME = Time('J2000', scale='tt')
 
 PIOVER2 = np.pi / 2.
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -16,11 +16,10 @@ from astropy.utils import iers
 from astropy.utils.exceptions import AstropyWarning
 
 
-# The UTC time scale is not properly defined prior to 1960, so Time('B1950',
-# scale='utc') will emit a warning. Instead, we use Time('B1950', scale='tai')
-# which is equivalent, but does not emit a warning.
+# We use tt as the time scale for this equinoxes, primarily because it is the
+# convention for J2000 (it is unclear if there is any "right answer" for B1950)
 EQUINOX_J2000 = Time('J2000', scale='tt')
-EQUINOX_B1950 = Time('B1950', scale='tai')
+EQUINOX_B1950 = Time('B1950', scale='tt')
 
 # This is a time object that is the default "obstime" when such an attribute is
 # necessary.  Currently, we use J2000.

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -164,12 +164,12 @@ def test_frame_api():
     # as keyword parameters to the frame constructor.  Where sensible, defaults are
     # used. E.g., FK5 is almost always J2000 equinox
     fk5 = FK5(UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg))
-    J2000 = time.Time('J2000', scale='utc')
+    J2000 = time.Time('J2000', scale='tt')
     fk5_2000 = FK5(UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg), equinox=J2000)
     assert fk5.equinox == fk5_2000.equinox
 
     # the information required to specify the frame is immutable
-    J2001 = time.Time('J2001', scale='utc')
+    J2001 = time.Time('J2001', scale='tt')
     with raises(AttributeError):
         fk5.equinox = J2001
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -796,13 +796,15 @@ def test_equivalent_frames():
     with pytest.raises(TypeError):
         assert i2.is_equivalent_frame(SkyCoord(i2))
 
-    f1 = FK5()
+    f0 = FK5()  # this J2000 is TT
+    f1 = FK5(equinox='J2000')
     f2 = FK5(1*u.deg, 2*u.deg, equinox='J2000')
     f3 = FK5(equinox='J2010')
     f4 = FK4(equinox='J2010')
 
     assert f1.is_equivalent_frame(f1)
     assert not i.is_equivalent_frame(f1)
+    assert not f0.is_equivalent_frame(f1)
     assert f1.is_equivalent_frame(f2)
     assert not f1.is_equivalent_frame(f3)
     assert not f3.is_equivalent_frame(f4)

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -423,7 +423,7 @@ def test_celestial_frame_to_wcs():
     mywcs = celestial_frame_to_wcs(frame, projection='CAR')
     assert tuple(mywcs.wcs.ctype) == ('TLON-CAR', 'TLAT-CAR')
     assert mywcs.wcs.radesys == 'ITRS'
-    assert mywcs.wcs.dateobs == Time('J2000').utc.isot
+    assert mywcs.wcs.dateobs == Time('J2000', scale='tt').utc.isot
 
 
 def test_celestial_frame_to_wcs_extend():

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -49,7 +49,7 @@ their default values) are available as the class method
 ``get_frame_attr_names``::
 
     >>> FK5.get_frame_attr_names()
-    OrderedDict([('equinox', <Time object: scale='utc' format='jyear_str' value=J2000.000>)])
+    OrderedDict([('equinox', <Time object: scale='tt' format='jyear_str' value=J2000.000>)])
 
 You can access any of the attributes on a frame by using standard Python
 attribute access. Note that for cases like ``equinox``, which are time

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -439,7 +439,7 @@ additional attributes that are required to fully define the frame::
 
   >>> sc_fk4 = SkyCoord(1, 2, frame='fk4', unit='deg')
   >>> sc_fk4.get_frame_attr_names()
-  OrderedDict([('equinox', <Time object: scale='tai' format='byear_str' value=B1950.000>), ('obstime', None)])
+  OrderedDict([('equinox', <Time object: scale='tt' format='byear_str' value=B1950.000>), ('obstime', None)])
 
 The key values correspond to the defaults if no explicit value is provided by
 the user. This example shows that the `~astropy.coordinates.FK4` frame has two

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -61,7 +61,7 @@ frames use a default equinox if you do not specify one::
 
     >>> fk5c = SkyCoord('02h31m49.09s', '+89d15m50.8s', frame=FK5)
     >>> fk5c.equinox
-    <Time object: scale='utc' format='jyear_str' value=J2000.000>
+    <Time object: scale='tt' format='jyear_str' value=J2000.000>
     >>> fk5c  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=J2000.000): (ra, dec) in deg
         ( 37.95454167,  89.26411111)>


### PR DESCRIPTION
While reviewing #8394 I noticed that we have been using Jan 1, 2000 12:00 UTC as "J2000". It's not clear to me that this is the right thing to do.  Rather I think it's supposed to be Jan 1, 2000 12:00 TT.  This PR updates the default settings so that TT is used be default. 

While it would be nice to have a deprecation period, it's not really clear to me that there's any way to do that without massive disruption, so this seems a safer bet than waiting until 4.0...

Two questions, though:

1) I don't actually know how to determine the "true" J2000 definition.  The best I found to state it clearly is here: https://en.wikipedia.org/wiki/Epoch_(astronomy)#Julian_years_and_J2000 , but (citation needed), as "by international agreement" seems a bit sketchy to me!  There's also this on the IAU web site: https://www.iau.org/public/themes/place_in_cosmos/, but does anyone know an authoritative source?
2) Right now this creates an inconsistency between the default and if you use the string `equinox='J200'` because the latter is UTC.  This is a bit non-trivial to change because it's violating the basic rule that "whatever you give as the equinox attribute gets passed through to `Time`".  E.g. `Time('J2000')` yields the UTC, not the TT version (which is a defensible stance).  I think I'm OK with that because honestly if you're using the string the TT vs UTC difference is probably not that big a deal.  But we could add some logic to specifically set the scale to TT if the input value starts with 'J' if consistency is more important...

cc @adrn @mhvk @Juanlu001 @StuartLittlefair 