### PR TITLE
Change default timescale for epochs to 'tt'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -630,6 +630,10 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- The default time scale for epochs like 'J2000' or 'B1975' is now "tt",
+  which is the correct one for 'J2000' and avoids leap-second warnings
+  for epochs in the far future or past. [#8600]
+
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -341,6 +341,10 @@ astropy.coordinates
   ``GeocentricTrueEcliptic`` frames.
   The ecliptic frames are no longer considered experimental. [#8394]
 
+- The default time scale for epochs like 'J2000' or 'B1975' is now "tt",
+  which is the correct one for 'J2000' and avoids leap-second warnings
+  for epochs in the far future or past. [#8600]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -18,6 +18,8 @@ from astropy.utils.exceptions import AstropyWarning
 
 # We use tt as the time scale for this equinoxes, primarily because it is the
 # convention for J2000 (it is unclear if there is any "right answer" for B1950)
+# while #8600 makes this the default behavior, we show it here to ensure it's
+# clear which is used here
 EQUINOX_J2000 = Time('J2000', scale='tt')
 EQUINOX_B1950 = Time('B1950', scale='tt')
 

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -16,8 +16,8 @@ from astropy import units as u
 from .matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 
 
-jd1950 = Time('B1950', scale='tai').jd
-jd2000 = Time('J2000', scale='utc').jd
+jd1950 = Time('B1950').jd
+jd2000 = Time('J2000').jd
 _asecperrad = u.radian.to(u.arcsec)
 
 

--- a/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
+++ b/astropy/coordinates/tests/accuracy/test_altaz_icrs.py
@@ -164,7 +164,7 @@ def test_fk5_equinox_and_epoch_j2000_0_to_topocentric_observed():
                              lat=Angle('31.956389d'),
                              height=2093.093 * u.m)  # TODO: height correct?
 
-    obstime = Time('2010-01-01 12:00:00', scale='utc')
+    obstime = Time('2010-01-01 12:00:00')
     # relative_humidity = ?
     # obswl = ?
     altaz_frame = AltAz(obstime=obstime, location=location,

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -36,7 +36,7 @@ def test_fk4_no_e_fk4():
 
         # FK4 to FK4NoETerms
         c1 = FK4(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
-                 obstime=Time(r['obstime'], scale='utc'))
+                 obstime=Time(r['obstime']))
         c2 = c1.transform_to(FK4NoETerms)
 
         # Find difference
@@ -47,7 +47,7 @@ def test_fk4_no_e_fk4():
 
         # FK4NoETerms to FK4
         c1 = FK4NoETerms(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
-                         obstime=Time(r['obstime'], scale='utc'))
+                         obstime=Time(r['obstime']))
         c2 = c1.transform_to(FK4)
 
         # Find difference

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk5.py
@@ -33,9 +33,9 @@ def test_fk4_no_e_fk5():
 
         # FK4NoETerms to FK5
         c1 = FK4NoETerms(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
-                         obstime=Time(r['obstime'], scale='utc'),
-                         equinox=Time(r['equinox_fk4'], scale='utc'))
-        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'], scale='utc')))
+                         obstime=Time(r['obstime']),
+                         equinox=Time(r['equinox_fk4']))
+        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'])))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
@@ -46,9 +46,9 @@ def test_fk4_no_e_fk5():
 
         # FK5 to FK4NoETerms
         c1 = FK5(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
-                 equinox=Time(r['equinox_fk5'], scale='utc'))
-        fk4neframe = FK4NoETerms(obstime=Time(r['obstime'], scale='utc'),
-                                 equinox=Time(r['equinox_fk4'], scale='utc'))
+                 equinox=Time(r['equinox_fk5']))
+        fk4neframe = FK4NoETerms(obstime=Time(r['obstime']),
+                                 equinox=Time(r['equinox_fk4']))
         c2 = c1.transform_to(fk4neframe)
 
         # Find difference

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -33,7 +33,7 @@ def test_galactic_fk4():
 
         # Galactic to FK4
         c1 = Galactic(l=r['lon_in']*u.deg, b=r['lat_in']*u.deg)
-        c2 = c1.transform_to(FK4(equinox=Time(r['equinox_fk4'], scale='utc')))
+        c2 = c1.transform_to(FK4(equinox=Time(r['equinox_fk4'])))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
@@ -44,8 +44,8 @@ def test_galactic_fk4():
 
         # FK4 to Galactic
         c1 = FK4(ra=r['lon_in']*u.deg, dec=r['lat_in']*u.deg,
-                 obstime=Time(r['obstime'], scale='utc'),
-                 equinox=Time(r['equinox_fk4'], scale='utc'))
+                 obstime=Time(r['obstime']),
+                 equinox=Time(r['equinox_fk4']))
         c2 = c1.transform_to(Galactic)
 
         # Find difference

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -33,7 +33,7 @@ def test_icrs_fk5():
 
         # ICRS to FK5
         c1 = ICRS(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg)
-        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'], scale='utc')))
+        c2 = c1.transform_to(FK5(equinox=Time(r['equinox_fk5'])))
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
@@ -44,7 +44,7 @@ def test_icrs_fk5():
 
         # FK5 to ICRS
         c1 = FK5(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
-                 equinox=Time(r['equinox_fk5'], scale='utc'))
+                 equinox=Time(r['equinox_fk5']))
         c2 = c1.transform_to(ICRS)
 
         # Find difference

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -164,12 +164,12 @@ def test_frame_api():
     # as keyword parameters to the frame constructor.  Where sensible, defaults are
     # used. E.g., FK5 is almost always J2000 equinox
     fk5 = FK5(UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg))
-    J2000 = time.Time('J2000', scale='tt')
+    J2000 = time.Time('J2000')
     fk5_2000 = FK5(UnitSphericalRepresentation(lon=8*u.hour, lat=5*u.deg), equinox=J2000)
     assert fk5.equinox == fk5_2000.equinox
 
     # the information required to specify the frame is immutable
-    J2001 = time.Time('J2001', scale='tt')
+    J2001 = time.Time('J2001')
     with raises(AttributeError):
         fk5.equinox = J2001
 
@@ -245,7 +245,7 @@ def test_transform_api():
 
     # If no data (or `None`) is given, the class acts as a specifier of a frame, but
     # without any stored data.
-    J2001 = time.Time('J2001', scale='utc')
+    J2001 = time.Time('J2001')
     fk5_J2001_frame = FK5(equinox=J2001)
 
     # if they do not have data, the string instead is the frame specification
@@ -319,7 +319,7 @@ def test_transform_api():
 
 
 def test_highlevel_api():
-    J2001 = time.Time('J2001', scale='utc')
+    J2001 = time.Time('J2001')
 
     # <--------------------------"High-level" class-------------------------------->
     # The "high-level" class is intended to wrap the lower-level classes in such a

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -183,8 +183,8 @@ def test_array_precession():
     """
     Ensures that FK5 coordinates as arrays precess their equinoxes
     """
-    j2000 = Time('J2000', scale='utc')
-    j1975 = Time('J1975', scale='utc')
+    j2000 = Time('J2000')
+    j1975 = Time('J1975')
 
     fk5 = FK5([1, 1.1]*u.radian, [0.5, 0.6]*u.radian)
     assert fk5.equinox.jyear == j2000.jyear
@@ -215,7 +215,7 @@ def test_array_separation():
 def test_array_indexing():
     ra = np.linspace(0, 360, 10)
     dec = np.linspace(-90, 90, 10)
-    j1975 = Time(1975, format='jyear', scale='utc')
+    j1975 = Time(1975, format='jyear')
 
     c1 = FK5(ra*u.deg, dec*u.deg, equinox=j1975)
 

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -38,7 +38,7 @@ def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
     coo1 = fromsys(ra=fromcoo[0]*u.deg, dec=fromcoo[1]*u.deg, distance=m31_dist)
     coo2 = coo1.transform_to(tosys)
     if tosys is FK4:
-        coo2_prec = coo2.transform_to(FK4(equinox=Time('B1950', scale='utc')))
+        coo2_prec = coo2.transform_to(FK4(equinox=Time('B1950')))
         assert (coo2_prec.spherical.lon - tocoo[0]*u.deg) < convert_precision  # <1 arcsec
         assert (coo2_prec.spherical.lat - tocoo[1]*u.deg) < convert_precision
     else:
@@ -60,10 +60,10 @@ def test_precession():
     """
     Ensures that FK4 and FK5 coordinates precess their equinoxes
     """
-    j2000 = Time('J2000', scale='utc')
-    b1950 = Time('B1950', scale='utc')
-    j1975 = Time('J1975', scale='utc')
-    b1975 = Time('B1975', scale='utc')
+    j2000 = Time('J2000')
+    b1950 = Time('B1950')
+    j1975 = Time('J1975')
+    b1975 = Time('B1975')
 
     fk4 = FK4(ra=1*u.radian, dec=0.5*u.radian)
     assert fk4.equinox.byear == b1950.byear

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -108,7 +108,7 @@ def test_faux_fk5_galactic():
 
 
 def test_gcrs_diffs():
-    time = Time('J2017')
+    time = Time('2017-01-01')
     gf = GCRS(obstime=time)
     sung = get_sun(time)  # should have very little vhelio
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -357,7 +357,7 @@ def test_realizing():
     assert not i.has_data
     assert i2.has_data
 
-    f = FK5(equinox=Time('J2001', scale='utc'))
+    f = FK5(equinox=Time('J2001'))
     f2 = f.realize_frame(rep)
 
     assert not f.has_data
@@ -436,7 +436,7 @@ def test_transform():
 
     assert i2.data.__class__ != r.UnitSphericalRepresentation
 
-    f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001', scale='utc'))
+    f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
     f4 = f.transform_to(FK4)
     f4_2 = f.transform_to(FK4(equinox=f.equinox))
 
@@ -451,7 +451,7 @@ def test_transform():
     assert_allclose(i.ra, i2.ra)
     assert_allclose(i.dec, i2.dec)
 
-    f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001', scale='utc'))
+    f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
     f2 = f.transform_to(FK5)  # default equinox, so should be *different*
     assert f2.equinox == FK5().equinox
     with pytest.raises(AssertionError):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -804,7 +804,7 @@ def test_equivalent_frames():
 
     assert f1.is_equivalent_frame(f1)
     assert not i.is_equivalent_frame(f1)
-    assert not f0.is_equivalent_frame(f1)
+    assert f0.is_equivalent_frame(f1)
     assert f1.is_equivalent_frame(f2)
     assert not f1.is_equivalent_frame(f3)
     assert not f3.is_equivalent_frame(f4)

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -49,7 +49,7 @@ def test_icrs_cirs():
     assert_allclose(inod.dec, inod2.dec)
 
     # now check that a different time yields different answers
-    cframe2 = CIRS(obstime=Time('J2005', scale='utc'))
+    cframe2 = CIRS(obstime=Time('J2005'))
     cirsnod2 = inod.transform_to(cframe2)
     assert not allclose(cirsnod.ra, cirsnod2.ra, rtol=1e-8)
     assert not allclose(cirsnod.dec, cirsnod2.dec, rtol=1e-8)
@@ -77,7 +77,7 @@ def test_icrs_cirs():
 
 ra, dec, dist = randomly_sample_sphere(200)
 icrs_coords = [ICRS(ra=ra, dec=dec), ICRS(ra=ra, dec=dec, distance=dist*u.pc)]
-gcrs_frames = [GCRS(), GCRS(obstime=Time('J2005', scale='utc'))]
+gcrs_frames = [GCRS(), GCRS(obstime=Time('J2005'))]
 
 
 @pytest.mark.parametrize('icoo', icrs_coords)
@@ -248,7 +248,7 @@ def test_gcrs_altaz():
 
     # check array times sure N-d arrays work
     times = Time(np.linspace(2456293.25, 2456657.25, 51) * u.day,
-                 format='jd', scale='utc')
+                 format='jd')
 
     loc = EarthLocation(lon=10 * u.deg, lat=80. * u.deg)
     aaframe = AltAz(obstime=times, location=loc)
@@ -266,7 +266,7 @@ def test_gcrs_altaz():
 
 @pytest.mark.remote_data
 def test_precessed_geocentric():
-    assert PrecessedGeocentric().equinox.jd == Time('J2000', scale='utc').jd
+    assert PrecessedGeocentric().equinox.jd == Time('J2000').jd
 
     gcrs_coo = GCRS(180*u.deg, 2*u.deg, distance=10000*u.km)
     pgeo_coo = gcrs_coo.transform_to(PrecessedGeocentric)

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -601,7 +601,7 @@ def test_regression_6697():
     """
     pint_vels = CartesianRepresentation(*(348.63632871, -212.31704928, -0.60154936), unit=u.m/u.s)
     location = EarthLocation(*(5327448.9957829, -1718665.73869569,  3051566.90295403), unit=u.m)
-    t = Time(2458036.161966612, format='jd', scale='utc')
+    t = Time(2458036.161966612, format='jd')
     obsgeopos, obsgeovel = location.get_gcrs_posvel(t)
     delta = (obsgeovel-pint_vels).norm()
     assert delta < 1*u.cm/u.s

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -44,6 +44,10 @@ def test_regression_5085():
     At root was the transformation of Ecliptic coordinates with
     non-scalar times.
     """
+    # Note: for regression test, we need to be sure that we use UTC for the
+    # epoch, even though more properly that should be TT; but the "expected"
+    # values were calculated using that.
+    j2000 = Time('J2000', scale='utc')
     times = Time(["2015-08-28 03:30", "2015-09-05 10:30", "2015-09-15 18:35"])
     latitudes = Latitude([3.9807075, -5.00733806, 1.69539491]*u.deg)
     longitudes = Longitude([311.79678613, 72.86626741, 199.58698226]*u.deg)
@@ -56,8 +60,8 @@ def test_regression_5085():
     decs = Latitude([-18.25190443, -17.1556676, -15.71616522]*u.deg)
     distances = u.Quantity([1.78309901, 1.710874, 1.61326649]*u.au)
     expected_result = GCRS(ra=ras, dec=decs,
-                           distance=distances, obstime="J2000").cartesian.xyz
-    actual_result = coo.transform_to(GCRS(obstime="J2000")).cartesian.xyz
+                           distance=distances, obstime=j2000).cartesian.xyz
+    actual_result = coo.transform_to(GCRS(obstime=j2000)).cartesian.xyz
     assert_quantity_allclose(expected_result, actual_result)
 
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -32,7 +32,7 @@ RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
 C_ICRS = ICRS(RA, DEC)
 C_FK5 = C_ICRS.transform_to(FK5)
-J2001 = Time('J2001', scale='utc')
+J2001 = Time('J2001')
 
 
 def allclose(a, b, rtol=0.0, atol=None):

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -195,8 +195,8 @@ def test_obstime():
     Checks to make sure observation time is
     accounted for at least in FK4 <-> ICRS transformations
     """
-    b1950 = Time('B1950', scale='utc')
-    j1975 = Time('J1975', scale='utc')
+    b1950 = Time('B1950')
+    j1975 = Time('J1975')
 
     fk4_50 = FK4(ra=1*u.deg, dec=2*u.deg, obstime=b1950)
     fk4_75 = FK4(ra=1*u.deg, dec=2*u.deg, obstime=j1975)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -117,6 +117,8 @@ class TimeFormat(metaclass=TimeFormatMeta):
         If true then val1, val2 are jd1, jd2
     """
 
+    _default_scale = 'utc'  # As of astropy 0.4
+
     def __init__(self, val1, val2, scale, precision,
                  in_subfmt, out_subfmt, from_jd=False):
         self.scale = scale  # validation of scale done later with _check_scale
@@ -237,11 +239,8 @@ class TimeFormat(metaclass=TimeFormatMeta):
         scales.  Provide a different error message if `None` (no value) was
         supplied.
         """
-        if hasattr(self.__class__, 'epoch_scale') and scale is None:
-            scale = self.__class__.epoch_scale
-
         if scale is None:
-            scale = 'utc'  # Default scale as of astropy 0.4
+            scale = self._default_scale
 
         if scale not in TIME_SCALES:
             raise ScaleValueError("Scale value '{0}' not in "
@@ -460,6 +459,10 @@ class TimeFromEpoch(TimeFormat):
         return self.mask_if_needed(time_from_epoch)
 
     value = property(to_value)
+
+    @property
+    def _default_scale(self):
+        return self.epoch_scale
 
 
 class TimeUnix(TimeFromEpoch):
@@ -1105,6 +1108,7 @@ class TimeEpochDate(TimeFormat):
     """
     Base class for support floating point Besselian and Julian epoch dates
     """
+    _default_scale = 'tt'  # As of astropy 3.2, this is no longer 'utc'.
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # validate scale.
@@ -1147,6 +1151,7 @@ class TimeEpochDateString(TimeString):
     Base class to support string Besselian and Julian epoch dates
     such as 'B1950.0' or 'J2000.0' respectively.
     """
+    _default_scale = 'tt'  # As of astropy 3.2, this is no longer 'utc'.
 
     def set_jds(self, val1, val2):
         epoch_prefix = self.epoch_prefix

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -743,12 +743,14 @@ class TestSubFormat():
         t = Time(100.0, format='gps')
         assert t.scale == 'tai'
 
-        for date in ('J2000', '2000:001', '2000-01-01T00:00:00'):
+        for date in ('2000:001', '2000-01-01T00:00:00'):
             t = Time(date)
             assert t.scale == 'utc'
 
         t = Time(2000.1, format='byear')
-        assert t.scale == 'utc'
+        assert t.scale == 'tt'
+        t = Time('J2000')
+        assert t.scale == 'tt'
 
     def test_epoch_times(self):
         """Test time formats derived from EpochFromTime"""

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -423,7 +423,7 @@ def test_celestial_frame_to_wcs():
     mywcs = celestial_frame_to_wcs(frame, projection='CAR')
     assert tuple(mywcs.wcs.ctype) == ('TLON-CAR', 'TLAT-CAR')
     assert mywcs.wcs.radesys == 'ITRS'
-    assert mywcs.wcs.dateobs == Time('J2000', scale='tt').utc.isot
+    assert mywcs.wcs.dateobs == Time('J2000').fits
 
 
 def test_celestial_frame_to_wcs_extend():

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -423,7 +423,7 @@ def test_celestial_frame_to_wcs():
     mywcs = celestial_frame_to_wcs(frame, projection='CAR')
     assert tuple(mywcs.wcs.ctype) == ('TLON-CAR', 'TLAT-CAR')
     assert mywcs.wcs.radesys == 'ITRS'
-    assert mywcs.wcs.dateobs == Time('J2000').fits
+    assert mywcs.wcs.dateobs == Time('J2000').utc.fits
 
 
 def test_celestial_frame_to_wcs_extend():

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -54,12 +54,12 @@ their default values) are available as the class method
 You can access any of the attributes on a frame by using standard Python
 attribute access. Note that for cases like ``equinox``, which are time
 inputs, if you pass in any unambiguous time string, it will be converted
-into an `~astropy.time.Time` object with UTC scale (see
+into an `~astropy.time.Time` object (see
 :ref:`astropy-time-inferring-input`)::
 
     >>> f = FK5(equinox='J1975')
     >>> f.equinox
-    <Time object: scale='utc' format='jyear_str' value=J1975.000>
+    <Time object: scale='tt' format='jyear_str' value=J1975.000>
     >>> f = FK5(equinox='2011-05-15T12:13:14')
     >>> f.equinox
     <Time object: scale='utc' format='isot' value=2011-05-15T12:13:14.000>

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -322,7 +322,7 @@ the way you want. As an example::
   <MyFrame Coordinate (location=None, equinox=B1950.000, obstime=B1950.000): (R, D) in rad
       (0.17453293, 0.34906585)>
   >>> c.equinox
-  <Time object: scale='utc' format='byear_str' value=B1950.000>
+  <Time object: scale='tt' format='byear_str' value=B1950.000>
 
 If you also want to support velocity data in your coordinate frame, see the
 velocities documentation at

--- a/docs/coordinates/transforming.rst
+++ b/docs/coordinates/transforming.rst
@@ -75,8 +75,8 @@ You can also specify the equinox when you create a coordinate using a
 
     >>> from astropy.time import Time
     >>> fk5c = SkyCoord('02h31m49.09s', '+89d15m50.8s',
-    ...                 frame=FK5(equinox=Time('J1970', scale='utc')))
-    >>> fk5_2000 = FK5(equinox=Time(2000, format='jyear', scale='utc'))
+    ...                 frame=FK5(equinox=Time('J1970')))
+    >>> fk5_2000 = FK5(equinox=Time(2000, format='jyear'))
     >>> fk5c.transform_to(fk5_2000)  # doctest: +FLOAT_CMP
     <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg
         ( 48.023171,  89.38672485)>

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -508,7 +508,7 @@ when inputting time values from strings.  The default precision is 3.  Note
 that the limit of 9 digits is driven by the way that ERFA handles fractional
 seconds.  In practice this should should not be an issue.  ::
 
-  >>> t = Time('B1950.0', scale='utc', precision=3)
+  >>> t = Time('B1950.0', precision=3)
   >>> t.byear_str
   'B1950.000'
   >>> t.precision = 0
@@ -1118,9 +1118,9 @@ of time.  Usage is most easily illustrated by examples::
   <Time object: scale='tai' format='gps' value=315576000.0>
   >>> Time(10.*u.yr, 1.*u.s, format='gps')
   <Time object: scale='tai' format='gps' value=315576001.0>
-  >>> Time(2000.*u.yr, scale='utc', format='jyear')
-  <Time object: scale='utc' format='jyear' value=2000.0>
-  >>> Time(2000.*u.yr, scale='utc', format='byear')
+  >>> Time(2000.*u.yr, format='jyear')
+  <Time object: scale='tt' format='jyear' value=2000.0>
+  >>> Time(2000.*u.yr, format='byear')
   ...                                # but not for Besselian year, which implies
   ...                                # a different time scale
   ...

--- a/docs/whatsnew/3.2.rst
+++ b/docs/whatsnew/3.2.rst
@@ -88,6 +88,20 @@ Changes to Ecliptic Transformations
 Placeholder. gist is that True/Mean are now treated appropriately, but this
 might change code from older versions (no good way to do deprecation)
 
+.. _whatsnew-3.2-tt:
+
+Default time scale for "J2000"-style strings changed to TT
+==========================================================
+
+In past versions of astropy, times specified as "equinox-style strings" - e.g.,
+``Time('J2000')`` - defaulted to the UTC scale.  This includes default equinoxes
+for FK4/FK5 coordinates. To be more consistent with commonly-accepted usage of
+terms like "J2000", this strings now default to the TT time scale. This
+difference is on the order of 60 seconds, which for e.g. equinox precession is
+typically an extremely small differences (picoarcseconds).  However, if the
+previous behavior is needed, the easiest work-around is to change any use of
+e.g., ``'J2000'`` to ``Time('J2000', scale='utc')``.
+
 
 Full change log
 ===============


### PR DESCRIPTION
See discussion in #8594.

~Still to do: adjust coordinate tests to not set time scale for equinoxes to 'utc'~