### PR TITLE
Let pytest capture FutureWarning in fitswcs

### DIFF
--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -5,6 +5,7 @@
 import warnings
 
 import numpy as np
+import pytest
 from numpy.testing import assert_equal, assert_allclose
 
 from astropy import units as u
@@ -383,18 +384,20 @@ def test_time_cube():
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, False], [True, True, False], [False, False, True]])
 
-    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
-                                                  ('celestial', 0, 'spherical.lon.degree'),
-                                                  ('utc', 0, 'value')]
+    with pytest.warns(FutureWarning):
+        assert wcs.world_axis_object_components == [
+            ('celestial', 1, 'spherical.lat.degree'),
+            ('celestial', 0, 'spherical.lon.degree'),
+            ('utc', 0, 'value')]
 
-    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
-    assert wcs.world_axis_object_classes['celestial'][1] == ()
-    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], ICRS)
-    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+        assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+        assert wcs.world_axis_object_classes['celestial'][1] == ()
+        assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], ICRS)
+        assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
 
-    assert wcs.world_axis_object_classes['utc'][0] is Quantity
-    assert wcs.world_axis_object_classes['utc'][1] == ()
-    assert wcs.world_axis_object_classes['utc'][2] == {'unit': 's'}
+        assert wcs.world_axis_object_classes['utc'][0] is Quantity
+        assert wcs.world_axis_object_classes['utc'][1] == ()
+        assert wcs.world_axis_object_classes['utc'][2] == {'unit': 's'}
 
     assert_allclose(wcs.pixel_to_world_values(-449.2, 2955.6, 0),
                     (14.8289418840003, 2.01824372640628, 2375.341))


### PR DESCRIPTION
This should be non-controversial? This lets `pytest` captures an internally raised `FutureWarning` in the test:

```
        if 'time' in self.world_axis_physical_types:
            warnings.warn('In future, times will be represented by the Time class '
>                         'instead of Quantity', FutureWarning)
E           FutureWarning: In future, times will be represented by the Time class instead of Quantity
astropy/wcs/wcsapi/fitswcs.py:315: FutureWarning
```

xref #8506 #8516