### PR TITLE
Remove FutureWarning in modeling test

### DIFF
--- a/astropy/modeling/tests/test_fitters.py
+++ b/astropy/modeling/tests/test_fitters.py
@@ -56,7 +56,7 @@ class TestPolynomial2D:
 
     def test_poly2D_fitting(self):
         v = self.model.fit_deriv(x=self.x, y=self.y)
-        p = linalg.lstsq(v, self.z.flatten())[0]
+        p = linalg.lstsq(v, self.z.flatten(), rcond=-1)[0]
         new_model = self.fitter(self.model, self.x, self.y, self.z)
         assert_allclose(new_model.parameters, p)
 


### PR DESCRIPTION
This should be non-controversial? This removes `FutureWarning` by explicitly setting `rcond` to a "backward compatible" mode.

```
E           FutureWarning: `rcond` parameter will change to the default of machine
precision times ``max(M, N)`` where M and N are the input matrix dimensions.
E           To use the future default and silence this warning we advise to pass
`rcond=None`, to keep using the old, explicitly pass `rcond=-1`.
```

xref #8506 #8516