### PR TITLE
Implement atleast_nd method on ShapedLikeNDArray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,9 @@ astropy.coordinates
   ``GeocentricTrueEcliptic`` frames.
   The ecliptic frames are no longer considered experimental. [#8394]
 
+- Frame objects (including ``SkyCoord``) now have an `atleast_nd` method that
+  allows similar behavior as ``numpy.atleast_1d``, etc. [#8607]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -129,6 +132,9 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
+
+- ``Time`` objects now have an `atleast_nd` method that allows similar behavior
+  as ``numpy.atleast_1d``, etc. [#8607]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
@@ -258,6 +264,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- All subclasses of ``ShapedLikeNDArray`` now have an `atleast_nd` method that
+  allows similar behavior as ``numpy.atleast_1d``, etc. [#8607]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -354,9 +363,9 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
-- Added a ``PyUnitListProxy_richcmp`` method in ``UnitListProxy`` class to enable 
-  ``WCS.wcs.cunit`` equality testing. It helps to check whether the two instances of 
-  ``WCS.wcs.cunit`` are equal or not by comparing the data members of 
+- Added a ``PyUnitListProxy_richcmp`` method in ``UnitListProxy`` class to enable
+  ``WCS.wcs.cunit`` equality testing. It helps to check whether the two instances of
+  ``WCS.wcs.cunit`` are equal or not by comparing the data members of
   ``UnitListProxy`` class [#8480]
 
 Other Changes and Additions

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1555,3 +1555,36 @@ def test_none_differential_type():
 
     fr = MockHeliographicStonyhurst(lon=1*u.deg, lat=2*u.deg, radius=10*u.au)
     SkyCoord(0*u.deg, fr.lat, fr.radius, frame=fr) # this was the failure
+
+
+def test_reshape():
+    """
+    Test that SkyCoord objects can be reshaped sensibly
+
+    Implictly tests ShapedLikeNDArray and the lower-level frames
+    """
+    ra = np.random.randn(3, 8)*u.deg
+    dec = np.random.randn(3, 8)*u.deg
+    sc2d = SkyCoord(ra, dec, frame='icrs')
+
+    reshaped1 = sc2d.reshape(8*3)
+    reshaped3 = sc2d.reshape(3, 4, 2)
+
+    assert reshaped1.shape == (24,)
+    assert reshaped3.shape == (3, 4, 2)
+
+    assert quantity_allclose(reshaped1.cartesian.xyz.ravel(), sc2d.cartesian.xyz.ravel())
+    assert quantity_allclose(reshaped3.cartesian.xyz.ravel(), sc2d.cartesian.xyz.ravel())
+
+
+def test_ndmin():
+    """
+    Test that SkyCoord objects can be set to a minimum dimension sensibly
+
+    Implictly tests ShapedLikeNDArray and the lower-level frames
+    """
+    sc_scalar = SkyCoord(1*u.deg, 2*u.deg)
+    sc1d = sc_scalar.atleast_nd(1)
+
+    assert sc1d.shape == (1,)
+    assert quantity_allclose(sc_scalar.cartesian.xyz, sc1d.cartesian.xyz[:, 0])

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -432,3 +432,12 @@ def test_regression():
     t_ut1_ravel = t_ut1.ravel()
     assert type(t_ut1_ravel.delta_ut1_utc) is np.ndarray
     assert t_ut1_copy.delta_ut1_utc == t_ut1.delta_ut1_utc
+
+
+def test_atleast_nd():
+    # An implicit test of the ShapedLikeNDArray atleast_nd machinery
+    t_scalar = Time('J2000')
+    t1d = t_scalar.atleast_nd(1)
+
+    assert t1d.shape == (1,)
+    assert t1d.jd[0] == t_scalar.jd

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -978,6 +978,35 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
         """
         return self._apply('reshape', *args, **kwargs)
 
+    def atleast_nd(self, ndmin, *args, **kwargs):
+        """Returns an instance containing the same data with shape at
+        least as large as the requested dimensionality. The behavior is
+        analogous to the :func:`numpy.atleast_1d`, :func:`numpy.atleast_2d`,
+        and :func:`numpy.atleast_3d` functions.
+
+        Note that the same caveats regarding copying apply to this method as to
+        :meth:`reshape`.
+
+        Parameters
+        ----------
+        ndmin : int
+            The minimum dimensionality/shape length of the returned array.
+        Additional parameters are as for :meth:`reshape` (other than the leading
+        shape positional argument).
+
+        Returns
+        -------
+        ret
+            An object of the same type as this one but possibly reshaped based
+            on the requested dimensionality.
+        """
+        dimstoadd = ndmin - len(self.shape)
+        # if dimstoadd is 0 or negative - i.e., already big enough - the
+        # resulting shape is the same as the starting shape so the reshape
+        # is a no-op
+        newshape = [1]*dimstoadd + list(self.shape)
+        return self.reshape(newshape, *args, **kwargs)
+
     def ravel(self, *args, **kwargs):
         """Return an instance with the array collapsed into one dimension.
 


### PR DESCRIPTION
This implementing the method @larrybradley asked for on `SkyCoord` in #8593 on `ShapedLikeNDArray`.  That means `Time` gets it too for "free".  So this closes #8593.

Turns out the implementation here was pretty trivial so maybe we can squeeze in a review ASAP? 

cc @mhvk @larrybradley 