### PR TITLE
Solution for Input meta ignored when creating a Table from a Table

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -480,9 +480,9 @@ class Table:
             # If user-input meta is not None and data.meta also contains data
             if meta is not None and data.meta:
                 if copy:
-                    meta = {**data.meta, **meta}
+                    meta.update(data.meta)
                 else:
-                    meta = {**data.meta.copy(), **meta}
+                    meta.update(data.meta.copy())
 
             # Handle indices on input table. Copy primary key and don't copy indices
             # if the input Table is in non-copy mode.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -312,6 +312,10 @@ class Table:
         Copy the input data. If the input is a Table the ``meta`` is always
         copied regardless of the ``copy`` parameter.
         Default is True.
+    merge_meta: bool, optional
+        Merge ``data.meta`` with ``meta``. When input is Table and contains
+        Metadata as well as ``meta`` is also passed to merge them.
+        Default is False
     rows : numpy ndarray, list of lists, optional
         Row-oriented data for table instead of ``data`` argument.
     copy_indices : bool, optional
@@ -389,8 +393,8 @@ class Table:
         return data
 
     def __init__(self, data=None, masked=None, names=None, dtype=None,
-                 meta=None, copy=True, rows=None, copy_indices=True,
-                 **kwargs):
+                 meta=None, copy=True, merge_meta=False, rows=None,
+                 copy_indices=True, **kwargs):
 
         # Set up a placeholder empty table
         self._set_masked(masked)
@@ -478,7 +482,7 @@ class Table:
                 # is used.
                 meta = data.meta if copy else data.meta.copy()
             # If user-input meta is not None and data.meta also contains data
-            if meta is not None and data.meta:
+            if meta is not None and data.meta and merge_meta:
                 if copy:
                     meta.update(data.meta)
                 else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -477,6 +477,12 @@ class Table:
                 # gets a key copy here if copy=False because later a direct object ref
                 # is used.
                 meta = data.meta if copy else data.meta.copy()
+            # If user-input meta is not None and data.meta also contains data
+            if meta is not None and data.meta:
+                if copy:
+                    meta = {**data.meta, **meta}
+                else:
+                    meta = {**data.meta.copy(), **meta}
 
             # Handle indices on input table. Copy primary key and don't copy indices
             # if the input Table is in non-copy mode.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2284,6 +2284,6 @@ def test_metadata_created_using_table():
     t2 = table.Table(t1, meta={'b': 2})
     # When copy is False
     t3 = table.Table(t1, meta={'b': 2}, copy=False)
-    meta1 = {'a': 1, 'b': 2}
+    meta1 = {'b': 2, 'a': 1}
     assert t2.meta == meta1
     assert t3.meta == meta1

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2281,9 +2281,9 @@ def test_metadata_created_using_table():
     '''Test for metadata when a Table is passed as data contains meta and
     meta is also not none'''
     t1 = table.Table([(2, 3), (8, 7)], names=('a', 'b'), meta={'a': 1})
-    t2 = table.Table(t1, meta={'b': 2})
+    t2 = table.Table(t1, meta={'b': 2}, merge_meta=True)
     # When copy is False
-    t3 = table.Table(t1, meta={'b': 2}, copy=False)
+    t3 = table.Table(t1, meta={'b': 2}, copy=False, merge_meta=True)
     meta1 = {'b': 2, 'a': 1}
     assert t2.meta == meta1
     assert t3.meta == meta1

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2275,3 +2275,15 @@ def test_key_values_in_as_array():
     # Comparing initialised array with sliced array using Table.as_array()
     assert np.array_equal(a, t1.as_array(names=['a', 'b']))
     assert np.array_equal(b, t1.as_array(names=['c']))
+
+
+def test_metadata_created_using_table():
+    '''Test for metadata when a Table is passed as data contains meta and
+    meta is also not none'''
+    t1 = table.Table([(2, 3), (8, 7)], names=('a', 'b'), meta={'a': 1})
+    t2 = table.Table(t1, meta={'b': 2})
+    # When copy is False
+    t3 = table.Table(t1, meta={'b': 2}, copy=False)
+    meta1 = {'a': 1, 'b': 2}
+    assert t2.meta == meta1
+    assert t3.meta == meta1


### PR DESCRIPTION
Fix: #8405
This PR will solve the issue by creating meta using both table meta as well as meta value passed as an argument.