### PR TITLE
Fix Quantity.take for a single element.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2078,6 +2078,9 @@ astropy.units
 
 - Fix parsing of numerical powers in FITS-compatible units. [#8251]
 
+- Fix ``take`` when one gets only a single element from a ``Quantity``,
+  ensuring it returns a ``Quantity`` rather than a scalar. [#8617]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1422,7 +1422,15 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         y[:] = value
 
     # Item selection and manipulation
-    # take, repeat, sort, compress, diagonal OK
+    # repeat, sort, compress, diagonal OK
+    def take(self, indices, axis=None, out=None, mode='raise'):
+        out = super().take(indices, axis=axis, out=out, mode=mode)
+        # For single elements, ndarray.take returns scalars; these
+        # need a new view as a Quantity.
+        if type(out) is not type(self):
+            out = self._new_view(out)
+        return out
+
     def put(self, indices, values, mode='raise'):
         self.view(np.ndarray).put(indices, self._to_own_unit(values), mode)
 

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -408,7 +408,9 @@ class TestArrayConversion:
         with pytest.raises(TypeError):
             q1[1] = 1.5 * u.m / u.km
 
+    def test_take_put(self):
         q1 = np.array([1, 2, 3]) * u.m / u.km
+        assert q1.take(1) == 2 * u.m / u.km
         assert all(q1.take((0, 2)) == np.array([1, 3]) * u.m / u.km)
         q1.put((1, 2), (3, 4))
         assert np.all(q1.take((1, 2)) == np.array([3000, 4000]) * q1.unit)


### PR DESCRIPTION
Previously, this returned a numerical scalar, now a scalar Quantity.

Found while trying to check the coverage of all numpy functions, in preparation of ``__array_function__``.