### PR TITLE
Revert deprecation of make_function_with_signature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,10 +183,6 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- Deprecate ``make_function_with_signature`` in anticipation of removing it
-  in a future release and use ``functools.wraps`` instead of providing a
-  custom implementation. [#7554]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 - Added ``CompositeStretch``, which inherits from ``CompositeTransform`` and

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -11,7 +11,6 @@ import re
 import textwrap
 
 from .introspection import find_current_module
-from .decorators import deprecated
 
 
 __all__ = ['make_function_with_signature']
@@ -25,7 +24,6 @@ the ASCII range and not beginning with '_' are allowed, currently.
 """
 
 
-@deprecated("3.1", "This function is no longer needed, directly use `inspect.Signature`.")
 def make_function_with_signature(func, args=(), kwargs={}, varargs=None,
                                  varkwargs=None, name=None):
     """


### PR DESCRIPTION
The `make_function_with_signature` function was deprecated in https://github.com/astropy/astropy/pull/7554 (https://github.com/astropy/astropy/pull/7554/commits/11bca39a614385a1e7baee1458d767790d7d7a4e).  However, it is still used in `modeling/core.py` to dynamically add keyword arguments to the `__call__` method of some models.

As a result, cryptic `AstropyDeprecationWarnings` are currently being issued whenever modeling is imported:
```python
>>> from astropy.modeling import models
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
```

```python
>>> from astropy.modeling.models import Gaussian2D
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
WARNING: AstropyDeprecationWarning: This function is no longer needed, directly use `inspect.Signature`. [astropy.modeling.core]
```

Further, it's causing CI tests to fail in `photutils` (this is how I discovered the issue) because `astropy` deprecations are treated as exceptions by default in `astropy.tests.helper.enable_deprecations_as_exceptions`.


My initial PR attempt (https://github.com/larrybradley/astropy/commit/293b7a18b1c45e736130b4358aa6c93d010ffbaa) to replace those remaining `make_function_with_signature` calls with `inspect.Signature` failed.   I don't see an easy way to replicate the `make_function_with_signature` usage in modeling with `inspect.Signature` (if it's possible at all).  For example, `make_function_with_signature` takes a `varkwargs` argument (e.g. `**kwargs`; see example use in `modeling/core.py` here: https://github.com/astropy/astropy/blob/master/astropy/modeling/core.py#L419) that is not allowed as a `inspect.Parameter` name.  Also, modeling uses a `update_wrapper` method to make it look like the dynamically-created `__call__` method was defined in the class (by defining `__module__`, `__doc__`, etc. on the new function).  That machinery depends on `make_function_with_signature` returning an actual *function*.

This PR simply reverts the deprecation of `make_function_with_signature` since it's still being used in `astropy.modeling` (we shouldn't be issuing deprecation warnings from our own code).  I think it's the most sensible thing to do for the v3.2 release, unless someone can quickly figure out how to refactor modeling to remove the remaining `make_function_with_signature` calls.
