### PR TITLE
Fixing TimeSeries built-in format documentation rendering 

### DIFF
--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -277,6 +277,8 @@ class TimeSeries(BaseTimeSeries):
         out : `astropy.timeseries.sampled.TimeSeries`
             TimeSeries corresponding to file contents.
 
+        Notes
+        -----
         """
         try:
 


### PR DESCRIPTION
Opened a new PR for this given that #8626 should be backported to LTS.

Fixes #8628.