### PR TITLE
Rename RTD config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 build:
-    image: latest
+  image: latest
 
 python:
   version: 3.6


### PR DESCRIPTION
RTD now recommends naming the file ``.readthedocs.yml`` which is more consistent with our other CI files anyway, so renaming here. Skipping CI since this doesn't affect anything here.