### PR TITLE
Experimental CCDData file streaming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ astropy.modeling
 
 astropy.nddata
 ^^^^^^^^^^^^^^
+- CCDData: make possible data streaming using numpy.memmap [#8646]
 
 astropy.samp
 ^^^^^^^^^^^^
@@ -278,7 +279,6 @@ astropy.modeling
 
 astropy.nddata
 ^^^^^^^^^^^^^^
-- CCDData: make possible data streaming using numpy.memmap [#8646]
 
 astropy.samp
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,6 +278,7 @@ astropy.modeling
 
 astropy.nddata
 ^^^^^^^^^^^^^^
+- CCDData: make possible data streaming using numpy.memmap [#8646]
 
 astropy.samp
 ^^^^^^^^^^^^

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -500,6 +500,8 @@ class CCDData(NDDataArray):
             if len(os.listdir(dirname)) == 0:
                 shutil.rmtree(dirname)
 
+        super().__del__()
+
 
 # These need to be importable by the tests...
 _KEEP_THESE_KEYWORDS_IN_HEADER = [

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -210,7 +210,8 @@ class CCDData(NDDataArray):
     @data.setter
     def data(self, value):
         if self.streaming:
-            if self._data.shape != value.shape:
+            if self._data.shape != value.shape or \
+               self._data.dtype != value.dtype:
                 name = self._data.filename
                 self._delete_stream(self._data)
                 self._create_stream(name, value)

--- a/astropy/nddata/nddata.py
+++ b/astropy/nddata/nddata.py
@@ -222,7 +222,7 @@ class NDData(NDDataBase):
 
         # Store the attributes
         self._data = data
-        self.mask = mask
+        self._mask = mask
         self._wcs = wcs
         self.meta = meta  # TODO: Make this call the setter sometime
         self._unit = unit


### PR DESCRIPTION
This pull request implements an experimental feature to make possible stream data from disk in CCDData classes.

Why?
----
CCDData class in the basis of Astropy's `ccdproc` package. However, if you have to process hundreds of images, it's very easy to overflow the computer's memory.

With this changes, it's possible to store the data in a file, which is mutable and allow to change any part of the data without problem.

I had to implement this for a pipeline I'm developing and I think it's a good addition for the community.

How?
----
This commit simply make possible to use the `numpy.memmap` feature to stream only the `CCDData.data` value from a `numpy` array stored in the disk. Accessing and setting values work exactly as in any `numpy.ndarray`. Built-in Numpy functions (like `max`, `min`, etc.) also work in the same way.

This class also handle temporary files creation/deletion.

Performance
-----------
I noted just a small degradation of the performance using this streaming, of ~2% in reading operations. In writing operations, it's very depending on how much data is being written, but not too big performance issues are noted. Enabling the streaming (where all the data is copied to disk) requires some time (~2s for a 40000x4000 float64 array in my sshd disk) if the file is big.

How to use it?
--------------
It's possible to enable the streaming in the `CCDData` instance creation using `stream` and `cache_folder` arguments:
```
>>> c = CCDData(np.random.random((10000, 10000)), unit='adu', stream=True)
```
or
```
>>> c = CCDData(np.random.random((10000, 10000)), unit='adu', stream=True, cache_folder='/home/user/large_cache')
```

It's also possible to enable the streaming in a already created `CCDData`:
```
>>> ccddata.enable_stream(filename='mytest.npy', cache_folder='/home/user/another_cache')
>>> ccddata.disable_stream()
```
Deleting the class or exiting the python automatically delete the streaming files.

Final Considerations:
-----------------
Suggestions on how improve it are very welcome!

I also thought in create a different class, like `StreamedCCDData` to implement this, but, for integration reasons, just upgrade `CCDData` class may be a better way.