### PR TITLE
Make Table.as_array return empty arrays for empty tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2311,6 +2311,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Converting an empty table to an array using ``as_array`` method now returns
+  an empty array instead of ``None``. [#8647]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -425,7 +425,6 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
-
 - Initializing a table with ``Table(rows=...)``, if the first item is an ``OrderedDict``,
   now preserves column order. [#8587]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -425,6 +425,7 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+
 - Initializing a table with ``Table(rows=...)``, if the first item is an ``OrderedDict``,
   now preserves column order. [#8587]
 
@@ -596,6 +597,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Converting an empty table to an array using ``as_array`` method now returns
+  an empty array instead of ``None``. [#8647]
+
 - Changed the behavior when slicing a table (either in rows or with a list of column
   names) so now the sliced output gets a light (key-only) copy of ``meta`` instead of
   a deepcopy.  Changed the ``Table.meta`` class-level descriptor so that assigning
@@ -715,6 +719,9 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- Fixed a bug when initializing from an empty list: ``Table([])`` no longer
+  results in a crash. [#8647]
 
 - Fixed a bug when initializing from an existing ``Table``.  In this case the
   input ``meta`` argument was being ignored.  Now the input ``meta``, if
@@ -2310,9 +2317,6 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
-
-- Converting an empty table to an array using ``as_array`` method now returns
-  an empty array instead of ``None``. [#8647]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1176,9 +1176,8 @@ def test_table_with_no_newline():
     assert 'No header line found' in str(err.value)
 
     table = BytesIO()
-    with pytest.raises(ValueError) as err:
-        ascii.read(table, guess=False, fast_reader=True, format='fast_basic')
-    assert 'Inconsistent data column lengths' in str(err.value)
+    t = ascii.read(table, guess=False, fast_reader=True, format='fast_basic')
+    assert not t and t.as_array().size == 0
 
     # Put a single line of column names but with no newline
     for kwargs in [dict(),

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -355,8 +355,9 @@ class Table:
         table_array : np.ndarray (unmasked) or np.ma.MaskedArray (masked)
             Copy of table as a numpy structured array
         """
+        empty_init = ma.empty if self.masked else np.empty
         if len(self.columns) == 0:
-            return None
+            return empty_init(0, dtype=None)
 
         sys_byteorder = ('>', '<')[sys.byteorder == 'little']
         native_order = ('=', sys_byteorder)
@@ -378,7 +379,6 @@ class Table:
 
             dtype.append(col_descr)
 
-        empty_init = ma.empty if self.masked else np.empty
         data = empty_init(len(self), dtype=dtype)
         for col in cols:
             # When assigning from one array into a field of a structured array,
@@ -877,7 +877,7 @@ class Table:
         """Initialize table from a list of Column or mixin objects"""
 
         lengths = set(len(col) for col in cols)
-        if len(lengths) != 1:
+        if len(lengths) > 1:
             raise ValueError('Inconsistent data column lengths: {0}'
                              .format(lengths))
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -837,7 +837,11 @@ class TestRemove(SetupData):
         self._setup(table_types)
         self.t.remove_columns('a')
         assert self.t.columns.keys() == []
-        assert self.t.as_array() is None
+        assert self.t.as_array().size == 0
+        # Regression test for gh-8640
+        assert not self.t
+        assert isinstance(self.t == None, np.ndarray)
+        assert (self.t == None).size == 0
 
     def test_2(self, table_types):
         self._setup(table_types)
@@ -948,7 +952,11 @@ class TestRemove(SetupData):
         self._setup(table_types)
         del self.t['a']
         assert self.t.columns.keys() == []
-        assert self.t.as_array() is None
+        assert self.t.as_array().size == 0
+        # Regression test for gh-8640
+        assert not self.t
+        assert isinstance(self.t == None, np.ndarray)
+        assert (self.t == None).size == 0
 
     def test_delitem2(self, table_types):
         self._setup(table_types)
@@ -974,7 +982,11 @@ class TestKeep(SetupData):
         t = table_types.Table([self.a, self.b])
         t.keep_columns([])
         assert t.columns.keys() == []
-        assert t.as_array() is None
+        assert t.as_array().size == 0
+        # Regression test for gh-8640
+        assert not t
+        assert isinstance(t == None, np.ndarray)
+        assert (t == None).size == 0
 
     def test_2(self, table_types):
         self._setup(table_types)


### PR DESCRIPTION
This PR fixes issues described in https://github.com/astropy/astropy/issues/8640:

- `Table().as_array()` no longer returns `None` but rather an empty `numpy` array.

- `Table() == None` will no longer work.

CC: @mhvk @pllim 

edit: fixes https://github.com/astropy/astropy/issues/8579 and fixes https://github.com/astropy/astropy/issues/8640