### PR TITLE
Fix APE14 slicing when array_shape is None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -773,6 +773,8 @@ astropy.wcs
   ``WCS.wcs.cunit`` are equal or not by comparing the data members of
   ``UnitListProxy`` class [#8480]
 
+- Fixed ``SlicedLowLevelWCS`` when ``array_shape`` is ``None``. [#8649]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -273,9 +273,12 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         # Pixel dimensions table
 
+        array_shape = self.array_shape or (0,)
+        pixel_shape = self.pixel_shape or (None,) * self.pixel_n_dim
+
         # Find largest between header size and value length
         pixel_dim_width = max(9, len(str(self.pixel_n_dim)))
-        pixel_siz_width = max(9, len(str(max(self.array_shape))))
+        pixel_siz_width = max(9, len(str(max(array_shape))))
 
         s += (('{0:' + str(pixel_dim_width) + 's}').format('Pixel Dim') + '  ' +
               ('{0:' + str(pixel_siz_width) + 's}').format('Data size') + '  ' +
@@ -283,7 +286,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         for ipix in range(self.pixel_n_dim):
             s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
-                  ('{0:' + str(pixel_siz_width) + 'd}').format(self.pixel_shape[ipix]) + '  ' +
+                  ('{0:' + str(pixel_siz_width) + 's}').format(
+                      str(None if pixel_shape[ipix] is None else pixel_shape[ipix])) + '  ' +
                   '{0:s}'.format(str(None if self.pixel_bounds is None else self.pixel_bounds[ipix]) + '\n'))
 
         s += '\n'

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -286,8 +286,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         for ipix in range(self.pixel_n_dim):
             s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
-                  ('{0:' + str(pixel_siz_width) + 's}').format(
-                      str(None if pixel_shape[ipix] is None else pixel_shape[ipix])) + '  ' +
+                  (" "*5 + str(None) if pixel_shape[ipix] is None else
+                   ('{0:' + str(pixel_siz_width) + 'd}').format(pixel_shape[ipix])) + '  ' +
                   '{0:s}'.format(str(None if self.pixel_bounds is None else self.pixel_bounds[ipix]) + '\n'))
 
         s += '\n'

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -103,7 +103,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
             else:
                 world_arrays_new.append(1.)
 
-        pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays_new)
+        pixel_arrays = list(self._wcs.world_to_pixel_values(*world_arrays_new))
 
         for ipixel in range(self._wcs.pixel_n_dim):
             if isinstance(self._slices_pixel[ipixel], slice) and self._slices_pixel[ipixel].start is not None:

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -127,11 +127,13 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def array_shape(self):
-        return np.broadcast_to(0, self._wcs.array_shape)[tuple(self._slices_array)].shape
+        if self._wcs.array_shape:
+            return np.broadcast_to(0, self._wcs.array_shape)[tuple(self._slices_array)].shape
 
     @property
     def pixel_shape(self):
-        return self.array_shape[::-1]
+        if self.array_shape:
+            return self.array_shape[::-1]
 
     @property
     def pixel_bounds(self):

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -434,3 +434,86 @@ def test_celestial_range_rot():
     assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
 
     assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip()
+
+
+HEADER_NO_SHAPE_CUBE = """
+NAXIS   = 3
+CTYPE1  = GLAT-CAR
+CTYPE2  = FREQ
+CTYPE3  = GLON-CAR
+CRVAL1  = 10
+CRVAL2  = 20
+CRVAL3  = 25
+CRPIX1  = 30
+CRPIX2  = 40
+CRPIX3  = 45
+CDELT1  = -0.1
+CDELT2  =  0.5
+CDELT3  =  0.1
+CUNIT1  = deg
+CUNIT2  = Hz
+CUNIT3  = deg
+"""
+
+WCS_NO_SHAPE_CUBE = WCS(Header.fromstring(HEADER_NO_SHAPE_CUBE, sep='\n'))
+
+EXPECTED_NO_SHAPE_REPR = """
+SlicedLowLevelWCS Transformation
+
+This transformation has 3 pixel and 3 world dimensions
+
+Array shape (Numpy order): None
+
+Pixel Dim  Data size  Bounds
+        0  None       None
+        1  None       None
+        2  None       None
+
+World Dim  Physical Type     Units
+        0  pos.galactic.lat  deg
+        1  em.freq           Hz
+        2  pos.galactic.lon  deg
+
+Correlation between pixel and world axes:
+
+             Pixel Dim
+World Dim    0    1    2
+        0  yes   no  yes
+        1   no  yes   no
+        2  yes   no  yes
+"""
+
+
+def test_no_array_shape():
+
+    wcs = SlicedLowLevelWCS(WCS_NO_SHAPE_CUBE, Ellipsis)
+
+    assert wcs.pixel_n_dim == 3
+    assert wcs.world_n_dim == 3
+    assert wcs.array_shape is None
+    assert wcs.pixel_shape is None
+    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
+    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
+
+    assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
+                                                  ('freq', 0, 'value'),
+                                                  ('celestial', 0, 'spherical.lon.degree')]
+
+    assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
+    assert wcs.world_axis_object_classes['celestial'][1] == ()
+    assert isinstance(wcs.world_axis_object_classes['celestial'][2]['frame'], Galactic)
+    assert wcs.world_axis_object_classes['celestial'][2]['unit'] is u.deg
+
+    assert wcs.world_axis_object_classes['freq'][0] is Quantity
+    assert wcs.world_axis_object_classes['freq'][1] == ()
+    assert wcs.world_axis_object_classes['freq'][2] == {'unit': 'Hz'}
+
+    assert_allclose(wcs.pixel_to_world_values(29, 39, 44), (10, 20, 25))
+    assert_allclose(wcs.array_index_to_world_values(44, 39, 29), (10, 20, 25))
+
+    assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
+    assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
+
+    assert str(wcs) == repr(wcs) == EXPECTED_NO_SHAPE_REPR.strip()

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -496,8 +496,8 @@ def test_no_array_shape():
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
     assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
-                                                  ('freq', 0, 'value'),
-                                                  ('celestial', 0, 'spherical.lon.degree')]
+                                                ('freq', 0, 'value'),
+                                                ('celestial', 0, 'spherical.lon.degree')]
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -1,7 +1,5 @@
 import pytest
 
-import numpy as np
-
 from numpy.testing import assert_equal, assert_allclose
 from astropy.wcs import WCS
 from astropy.io.fits import Header
@@ -465,9 +463,9 @@ This transformation has 3 pixel and 3 world dimensions
 Array shape (Numpy order): None
 
 Pixel Dim  Data size  Bounds
-        0  None       None
-        1  None       None
-        2  None       None
+        0       None  None
+        1       None  None
+        2       None  None
 
 World Dim  Physical Type     Units
         0  pos.galactic.lat  deg


### PR DESCRIPTION
This came up when testing #8546 with gWCS. It should be in 3.2