### PR TITLE
FOLLOW UP: Preserve column order using ordered dicts with Table(rows=)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -426,7 +426,7 @@ astropy.table
 ^^^^^^^^^^^^^
 
 - Initializing a table with ``Table(rows=...)``, if the first item is an ``OrderedDict``,
-  now preserves column order. [#8587]
+  now uses the column order of the first row. [#8587]
 
 - Added new pprint_all() and pformat_all() methods to Table. These two new
   methods print the entire table by default. [#8577]

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -763,12 +763,18 @@ class Table:
                 self._set_masked(True)
 
     def _init_from_list_of_dicts(self, data, names, dtype, n_cols, copy):
-        if isinstance(data[0], OrderedDict):
+        names_from_data = set()
+        for row in data:
+            names_from_data.update(row)
+
+        if (isinstance(data[0], OrderedDict) and
+                set(data[0].keys()) == names_from_data):
             names_from_data = list(data[0].keys())
         else:
-            names_from_data = set()
-            for row in data:
-                names_from_data.update(row)
+            names_from_data = sorted(names_from_data)
+
+        # Note: if set(data[0].keys()) != names_from_data, this will give an
+        # exception later, so NO need to catch here.
 
         cols = {}
         for name in names_from_data:
@@ -780,10 +786,7 @@ class Table:
                     raise ValueError('Row {0} has no value for column {1}'.format(i, name))
 
         if all(name is None for name in names):
-            if isinstance(data[0], OrderedDict):
-                names = names_from_data
-            else:
-                names = sorted(names_from_data)
+            names = names_from_data
 
         self._init_from_dict(cols, names, dtype, n_cols, copy)
         return

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -505,13 +505,16 @@ def test_init_and_ref_from_dict(table_type, copy):
 
 @pytest.mark.usefixtures('table_type')
 def test_init_from_row_OrderedDict(table_type):
-        row1 = OrderedDict([('b', 1), ('a', 0)])
-        row2 = OrderedDict([('b', 11), ('a', 10)])
-        rows12 = [row1, row2]
-        row3 = dict([('b', 1), ('a', 0)])
-        row4 = dict([('b', 11), ('a', 10)])
-        rows34 = [row3, row4]
-        t1 = table_type(rows=rows12)
-        t2 = table_type(rows=rows34)
-        assert t1.colnames == ['b', 'a']
-        assert t2.colnames == ['a', 'b']
+    row1 = OrderedDict([('b', 1), ('a', 0)])
+    row2 = {'a': 10, 'b': 20}
+    rows12 = [row1, row2]
+    row3 = dict([('b', 1), ('a', 0)])
+    row4 = dict([('b', 11), ('a', 10)])
+    rows34 = [row3, row4]
+    t1 = table_type(rows=rows12)
+    t2 = table_type(rows=rows34)
+    assert t1.colnames == ['b', 'a']
+    assert t2.colnames == ['a', 'b']
+
+    with pytest.raises(ValueError):
+        table_type(rows=[OrderedDict([('b', 1)]), {'a': 10, 'b': 20}])


### PR DESCRIPTION
Follow up of #8587 based on post-merge review from @taldcroft .

Maintainer's note: If this is re-milestoned beyond 3.2, it needs its own change log, but ideally this should go into 3.2.