### PR TITLE
Fixed a bug that caused newlines on Windows to be \r\r\n in ASCII tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -360,6 +360,9 @@ astropy.io.ascii
   method.  This can make writing ECSV significantly faster if the data do not
   actually have any masked values. [#8447]
 
+- Fixed a bug that caused newlines to be incorrect when writing out ASCII tables
+  on Windows (they were ``\r\r\n`` instead of ``\r\n``). [#8659]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -1020,7 +1020,10 @@ cdef class FastWriter:
         opened_file = False
 
         if not hasattr(output, 'write'): # output is a filename
-            output = open(output, 'w')
+            # NOTE: we need to specify newline='', otherwise the default
+            # behavior is for Python to translate \r\n (which we write because
+            # of os.linesep) into \r\r\n. Specifying newline='' disables any
+            output = open(output, 'w', newline='')
             opened_file = True # remember to close file afterwards
         writer = core.CsvWriter(output,
                                 delimiter=self.delimiter,

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -764,7 +764,7 @@ def test_write_newlines(fast_writer, tmpdir):
     t = table.Table([['a', 'b', 'c']], names=['col'])
     ascii.write(t, filename, fast_writer=fast_writer)
 
-    with open(filename, 'r') as f:
+    with open(filename, 'r', newline='') as f:
         content = f.read()
 
-    assert content.splitlines() == ['col', 'a', 'b', 'c']
+    assert content == os.linesep.join(['col', 'a', 'b', 'c']) + os.linesep

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -750,3 +750,21 @@ def test_roundtrip_masked(fmt_name_class):
     for col, col2 in zip(t.itercols(), t2.itercols()):
         assert col.dtype.kind == col2.dtype.kind
         assert np.all(col == col2)
+
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_write_newlines(fast_writer, tmpdir):
+
+    # Regression test for https://github.com/astropy/astropy/issues/5126
+    # On windows, when writing to a filename (not e.g. StringIO), newlines were
+    # \r\r\n instead of \r\n.
+
+    filename = tmpdir.join('test').strpath
+
+    t = table.Table([['a', 'b', 'c']], names=['col'])
+    ascii.write(t, filename, fast_writer=fast_writer)
+
+    with open(filename, 'r') as f:
+        content = f.read()
+
+    assert content.splitlines() == ['col', 'a', 'b', 'c']

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -798,7 +798,11 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
     # Write the lines to output
     outstr = os.linesep.join(lines)
     if not hasattr(output, 'write'):
-        output = open(output, 'w')
+        # NOTE: we need to specify newline='', otherwise the default
+        # behavior is for Python to translate \r\n (which we write because
+        # of os.linesep) into \r\r\n. Specifying newline='' disables any
+        # auto-translation.
+        output = open(output, 'w', newline='')
         output.write(outstr)
         output.write(os.linesep)
         output.close()


### PR DESCRIPTION
This is what happens when I decide to develop on Windows for fun!

On Windows:

```python
import os

with open('test', 'w') as f:
    f.write(os.linesep.join(['1','2','3']))

with open('test', 'rb') as f:
    print(repr(f.read()))
```

returns:

```
b'1\r\r\n2\r\r\n3'
```

Fun! This is because by default Python will 'helpfully' translate \n to \r\n on Windows, so if one already uses ``os.linesep`` (\r\n), \r\n gets translated to \r\r\n. Don't ask. This causes https://github.com/astropy/astropy/issues/5126.

There are two possible solutions to this - either we always only use \n internally for newlines, or we continue to use ``os.linesep`` but we need to then open files with ``newline=''`` which disables any auto-translation.

This PR implements the latter. Note that this will still produce the incorrect output if users open files themselves without specifying ``newline=`` in the ``open()`` call, but if we use the first approach above, we will produce the incorrect output if users pass in other kinds of file-like objects which don't auto-translate newlines (e.g. StringIO).

Fixes https://github.com/astropy/astropy/issues/5126
Fixes https://github.com/astropy/astropy/issues/5299

