### PR TITLE
BLD: allow pre-releases to pass the python version check

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -116,9 +116,10 @@ if SETUP_CFG.has_option('options', 'python_requires'):
 
     # We want the Python version as a string, which we can get from the platform module
     import platform
-    python_version = platform.python_version()
-
-    if not req.specifier.contains(python_version):
+    # strip off trailing '+' incase this is a dev install of python
+    python_version = platform.python_version().strip('+')
+    # allow pre-releases to count as 'new enough'
+    if not req.specifier.contains(python_version, True):
         if parent_package is None:
             message = "ERROR: Python {} is required by this package\n".format(req.specifier)
         else:


### PR DESCRIPTION
The 

```
(bleeding) ✔  ~/source/other_source/astropy [master {origin/master}|✔ ]
jupiter@14:55  ➤  python --version
Python 3.8.0a3+
```

```
(bleeding) ✔  ~/source/other_source/astropy [master {origin/master}|✔ ]
jupiter@22:20  ➤  pip install .
Processing /home/tcaswell/source/other_source/astropy
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: ERROR: Python >=3.5 is required by astropy
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-req-build-i1do9ltm/

```

This goes back to behavior from `pkg_resource`:

```
(bleeding) ✔  ~/source/other_source/astropy [master {origin/master}|✔ ]
jupiter@22:22  ➤  ipython -i  setup.py -- -v egg_info 
Python 3.8.0a3+ (heads/master:29500737d4, May  5 2019, 12:15:32) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.3.0.dev -- An enhanced Interactive Python. Type '?' for help.
ERROR: Python >=3.5 is required by astropy
---------------------------------------------------------------------------
SystemExit                                Traceback (most recent call last)
~/source/other_source/astropy/setup.py in <module>
     10 import builtins
     11 
---> 12 import ah_bootstrap  # noqa
     13 
     14 from astropy_helpers.distutils_helpers import is_distutils_display_option

~/source/other_source/astropy/ah_bootstrap.py in <module>
    125             message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
    126         sys.stderr.write(message)
--> 127         sys.exit(1)
    128 
    129 if sys.version_info < __minimum_python_version__:

SystemExit: 1

In [1]: %debug                                                                                                                                                                                                                                                                                       
> /home/tcaswell/source/other_source/astropy/ah_bootstrap.py(127)<module>()
    125             message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
    126         sys.stderr.write(message)
--> 127         sys.exit(1)
    128 
    129 if sys.version_info < __minimum_python_version__:

ipdb> l                                                                                                                                                                                                                                                                                              
    122         if parent_package is None:
    123             message = "ERROR: Python {} is required by this package\n".format(req.specifier)
    124         else:
    125             message = "ERROR: Python {} is required by {}\n".format(req.specifier, parent_package)
    126         sys.stderr.write(message)
--> 127         sys.exit(1)
    128 
    129 if sys.version_info < __minimum_python_version__:
    130 
    131     if parent_package is None:
    132         message = "ERROR: Python {} or later is required by astropy-helpers\n".format(

ipdb> req.specifier                                                                                                                                                                                                                                                                                  
<SpecifierSet('>=3.5')>
ipdb> p python_version                                                                                                                                                                                                                                                                               
'3.8.0a3+'
ipdb> p req.specifier.contains(python_version)                                                                                                                                                                                                                                                       
False
ipdb> p req.specifier.contains('3.8.0')                                                                                                                                                                                                                                                              
True
ipdb> p req.specifier.contains('3.8.0a1')                                                                                                                                                                                                                                                            
False
ipdb>       
```

The two fixes are to allow pre-releases and to strip off the trailing '+' on un-tagged builds of python.

Not sure if this should go here or against the `astropy_helpers` repo.