### PR TITLE
Fix consistency of APE 14 WCS API when dealing with single scalars/arrays/objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -646,6 +646,14 @@ astropy.units
 
 - Unit equivalencies can now be introspected. [#8252]
 
+astropy.wcs
+^^^^^^^^^^^
+
+- The ``world_to_pixel``, ``world_to_array_index*``, ``pixel_to_world*`` and
+  ``array_index_to_world*`` methods now all consistently return scalars, arrays,
+  or objects not wrapped in a one-element tuple/list when only one scalar,
+  array, or object (as was previously already the case for ``WCS.pixel_to_world``
+  and ``WCS.array_index_to_world``). [#8663]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -236,18 +236,21 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         return matrix
 
     def pixel_to_world_values(self, *pixel_arrays):
-        return self.all_pix2world(*pixel_arrays, 0)
+        world = self.all_pix2world(*pixel_arrays, 0)
+        return world[0] if self.world_n_dim == 1 else world
 
     def array_index_to_world_values(self, *indices):
-        return self.all_pix2world(*indices[::-1], 0)
+        world = self.all_pix2world(*indices[::-1], 0)
+        return world[0] if self.world_n_dim == 1 else world
 
     def world_to_pixel_values(self, *world_arrays):
-        return self.all_world2pix(*world_arrays, 0)
+        pixel = self.all_world2pix(*world_arrays, 0)
+        return pixel[0] if self.pixel_n_dim == 1 else pixel
 
     def world_to_array_index_values(self, *world_arrays):
         pixel_arrays = self.all_world2pix(*world_arrays, 0)[::-1]
         array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int) for pixel in pixel_arrays)
-        return array_indices
+        return array_indices[0] if self.pixel_n_dim == 1 else array_indices
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -43,8 +43,11 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         Convert pixel coordinates to world coordinates (represented by high-level
         objects).
 
-        See `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values` for pixel indexing and
-        ordering conventions.
+        If a single high-level object is used to represent the world
+        coordinates, it is returned as-is (not in a tuple/list), otherwise a
+        tuple of high-level objects is returned. See
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values` for pixel
+        indexing and ordering conventions.
         """
 
     @abc.abstractmethod
@@ -53,8 +56,11 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         Convert array indices to world coordinates (represented by Astropy
         objects).
 
-        See `~astropy.wcs.wcsapi.BaseLowLevelWCS.array_index_to_world_values` for pixel indexing and
-        ordering conventions.
+        If a single high-level object is used to represent the world
+        coordinates, it is returned as-is (not in a tuple/list), otherwise a
+        tuple of high-level objects is returned. See
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.array_index_to_world_values` for
+        pixel indexing and ordering conventions.
         """
 
     @abc.abstractmethod
@@ -63,8 +69,11 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         Convert world coordinates (represented by Astropy objects) to pixel
         coordinates.
 
-        See `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_to_pixel_values` for pixel indexing and
-        ordering conventions.
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned. See
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_to_pixel_values` for pixel
+        indexing and ordering conventions.
         """
 
     @abc.abstractmethod
@@ -73,9 +82,12 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         Convert world coordinates (represented by Astropy objects) to array
         indices.
 
-        See `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_to_array_index_values` for pixel indexing
-        and ordering conventions. The indices should be returned as rounded
-        integers.
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned. See
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_to_array_index_values` for
+        pixel indexing and ordering conventions. The indices should be returned
+        as rounded integers.
         """
 
 
@@ -181,6 +193,9 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         # Compute the world coordinate values
         world = self.low_level_wcs.pixel_to_world_values(*pixel_arrays)
 
+        if self.world_n_dim == 1:
+            world = (world,)
+
         # Cache the classes and components since this may be expensive
         components = self.low_level_wcs.world_axis_object_components
         classes = self.low_level_wcs.world_axis_object_classes
@@ -218,4 +233,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         return self.pixel_to_world(*index_arrays[::-1])
 
     def world_to_array_index(self, *world_objects):
-        return tuple(np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int).tolist())
+        if self.pixel_n_dim == 1:
+            return np.round(self.world_to_pixel(*world_objects)).astype(int)
+        else:
+            return tuple(np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int).tolist())

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -68,6 +68,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         The coordinates should be specified in the ``(x, y)`` order, where for
         an image, ``x`` is the horizontal coordinate and ``y`` is the vertical
         coordinate.
+
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned.
         """
 
     @abc.abstractmethod
@@ -79,6 +83,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         the indices should be given in ``(i, j)`` order, where for an image
         ``i`` is the row and ``j`` is the column (i.e. the opposite order to
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values`).
+
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned.
         """
 
     @abc.abstractmethod
@@ -94,6 +102,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         coordinate, NaN can be returned.  The coordinates should be returned in
         the ``(x, y)`` order, where for an image, ``x`` is the horizontal
         coordinate and ``y`` is the vertical coordinate.
+
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned.
         """
 
     @abc.abstractmethod
@@ -106,6 +118,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         ``i`` is the row and ``j`` is the column (i.e. the opposite order to
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_to_world_values`). The indices should be
         returned as rounded integers.
+
+        If `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` is ``1``, this
+        method returns a single scalar or array, otherwise a tuple of scalars or
+        arrays is returned.
         """
 
     @property

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -50,21 +50,34 @@ def test_empty():
     assert_allclose(wcs.pixel_to_world_values(29), 29)
     assert_allclose(wcs.array_index_to_world_values(29), 29)
 
+    assert np.ndim(wcs.pixel_to_world_values(29)) == 0
+    assert np.ndim(wcs.array_index_to_world_values(29)) == 0
+
     assert_allclose(wcs.world_to_pixel_values(29), 29)
     assert_equal(wcs.world_to_array_index_values(29), (29,))
+
+    assert np.ndim(wcs.world_to_pixel_values(29)) == 0
+    assert np.ndim(wcs.world_to_array_index_values(29)) == 0
 
     # High-level API
 
     coord = wcs.pixel_to_world(29)
     assert_quantity_allclose(coord, 29 * u.one)
+    assert np.ndim(coord) == 0
+
+    coord = wcs.array_index_to_world(29)
+    assert_quantity_allclose(coord, 29 * u.one)
+    assert np.ndim(coord) == 0
 
     coord = 15 * u.one
 
     x = wcs.world_to_pixel(coord)
     assert_allclose(x, 15.)
+    assert np.ndim(x) == 0
 
     i = wcs.world_to_array_index(coord)
-    assert_equal(i, (15,))
+    assert_equal(i, 15)
+    assert np.ndim(i) == 0
 
 
 ###############################################################################


### PR DESCRIPTION
APE 14 was not specific about what should be returned by coordinate transformation methods when a single scalar, array, or high-level object is returned. Before this PR, the behavior was in fact inconsistent:

```python
In [1]: from astropy.wcs import WCS                                                                                                                    

In [2]: from astropy import units as u                                                                                                                 

In [3]: wcs = WCS(naxis=1)                                                                                                                             

In [4]: wcs.pixel_to_world(3)                                                                                                                          
Out[4]: <Quantity 4.>

In [5]: wcs.world_to_pixel(4 * u.one)                                                                                                                 
Out[5]: [array(3.)]
```

This PR clarifies the docstrings of the APE 14 base classes (since they are the 'reference') to specify that if a single world coordinate is returned, then we don't wrap it in a one-element tuple/list. Note that ``pixel_to_world`` and ``array_index_to_world`` therefore had the correct behavior already, and it is other ones that are changed. Also note that for the high-level API, this can also happen if ``world_n_dim`` is greater than one but we return one high-level object, e.g. SkyCoord.

This is an API change but I believe it counts as a bug fix, as it was a shortcoming of the APE that it was not specific about this, and the current behavior was not self-consistent. I don't think we need to update the APE since we now say in it:

*We note that while we have made efforts to ensure that the API described here is as close as possible to the final implemented API, the authoritative version of the API will be given by the base classes that live in the core astropy package.*

With this PR, I believe the API will be more user-friendly. It does mean that we can't as easily do ``world_to_pixel(*pixel_to_world)`` but I believe user-friendliness is the top priority.

Fixes https://github.com/astropy/astropy/issues/8559

I'm marking this as v3.2 since I believe it's important we get this fix in ASAP.