### PR TITLE
DOC: Add impostor syndrome disclaimer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ the errors and assumptions that seasoned contributors have glossed over.
 Note: This disclaimer was originally written by
 `Adrienne Lowe <https://github.com/adriennefriend>`_ for a
 `PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
-{{ cookiecutter.package_name }} based on its use in the README file for the
+Astropy based on its use in the README file for the
 `MetPy project <https://github.com/Unidata/MetPy>`_.
 
 Most contributions to Astropy are done via pull requests from GitHub users'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,34 @@ Contributing Code
 -----------------
 
 So you are interested in contributing code to the Astropy Project? Excellent!
+We love contributions! Astropy is open source, built on open source,
+and we'd love to have you hang out in our community.
+
+**Imposter syndrome disclaimer**: We want your help. No, really.
+
+There may be a little voice inside your head that is telling you that you're not
+ready to be an open source contributor; that your skills aren't nearly good
+enough to contribute. What could you possibly offer a project like this one?
+
+We assure you - the little voice in your head is wrong. If you can write code at
+all, you can contribute code to open source. Contributing to open source
+projects is a fantastic way to advance one's coding skills. Writing perfect code
+isn't the measure of a good developer (that would disqualify all of us!); it's
+trying to create something, making mistakes, and learning from those
+mistakes. That's how we all improve, and we are happy to help others learn.
+
+Being an open source contributor doesn't just mean writing code, either. You can
+help out by writing documentation, tests, or even giving feedback about the
+project (and yes - that includes giving feedback about the contribution
+process). Some of these contributions may be the most valuable to the project as
+a whole, because you're coming to the project with fresh eyes, so you can see
+the errors and assumptions that seasoned contributors have glossed over.
+
+Note: This disclaimer was originally written by
+`Adrienne Lowe <https://github.com/adriennefriend>`_ for a
+`PyCon talk <https://www.youtube.com/watch?v=6Uj746j9Heo>`_, and was adapted by
+{{ cookiecutter.package_name }} based on its use in the README file for the
+`MetPy project <https://github.com/Unidata/MetPy>`_.
 
 Most contributions to Astropy are done via pull requests from GitHub users'
 forks of the [astropy repository](https://github.com/astropy/astropy). If you
@@ -135,7 +163,7 @@ package.
     * References to the original algorithms?
     * Any exceptions which are raised?
     * An example of running the code?
-  * Is there any information needed to be added to the docs to describe the   
+  * Is there any information needed to be added to the docs to describe the
     function?
   * Does the documentation build without errors or warnings?
 


### PR DESCRIPTION
Similar to astropy/package-template#350 . I didn't realize we never ported it from template to core!