### PR TITLE
Fix HDU detection in convenience methods (via _makehdu)

### DIFF
--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1034,7 +1034,7 @@ def _getext(filename, mode, *args, ext=None, extname=None, extver=None,
 def _makehdu(data, header):
     if header is None:
         header = Header()
-    hdu = _BaseHDU(data, header)
+    hdu = _BaseHDU._from_data(data, header)
     if hdu.__class__ in (_BaseHDU, _ValidHDU):
         # The HDU type was unrecognized, possibly due to a
         # nonexistent/incomplete header

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -362,6 +362,15 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
                         checksum=checksum)
 
     @classmethod
+    def _from_data(cls, data, header, **kwargs):
+        """
+        Instantiate the HDU object after guessing the HDU class from the
+        FITS Header.
+        """
+        klass = _hdu_class_from_header(cls, header)
+        return klass(data=data, header=header, **kwargs)
+
+    @classmethod
     def _readfrom_internal(cls, data, header=None, checksum=False,
                            ignore_missing_end=False, **kwargs):
         """

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -56,8 +56,19 @@ class InvalidHDUException(Exception):
 
 def _hdu_class_from_header(cls, header):
     """
-    Used primarily by _BaseHDU.__new__ to find an appropriate HDU class to use
-    based on values in the header.  See the _BaseHDU.__new__ docstring.
+    Iterates through the subclasses of _BaseHDU and uses that class's
+    match_header() method to determine which subclass to instantiate.
+
+    It's important to be aware that the class hierarchy is traversed in a
+    depth-last order.  Each match_header() should identify an HDU type as
+    uniquely as possible.  Abstract types may choose to simply return False
+    or raise NotImplementedError to be skipped.
+
+    If any unexpected exceptions are raised while evaluating
+    match_header(), the type is taken to be _CorruptedHDU.
+
+    Used primarily by _BaseHDU._readfrom_internal and _BaseHDU._from_data to
+    find an appropriate HDU class to use based on values in the header.
     """
 
     klass = cls  # By default, if no subclasses are defined

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -187,3 +187,17 @@ class TestConvenience(FitsTestCase):
         append_file = tmpdir.join('append.fits')
         with append_file.open(mode) as handle:
             fits.append(filename=handle, data=np.ones((4, 4)))
+
+    def test_append_with_header(self):
+        """
+        Test fits.append with a fits Header, which triggers detection of the
+        HDU class. Regression test for
+        https://github.com/astropy/astropy/issues/8660
+        """
+        testfile = self.temp('test_append_1.fits')
+        with fits.open(self.data('test0.fits')) as hdus:
+            for hdu in hdus:
+                fits.append(testfile, hdu.data, hdu.header, checksum=True)
+
+        with fits.open(testfile, checksum=True) as hdus:
+            assert len(hdus) == 5


### PR DESCRIPTION
Fix #8660: In 6800eec (EDIT: xref #8502) I removed `_BaseHDU.__new__` because when reading from a FITS file this HDU detection was done twice. Instead of reverting this commit I'm adding a new classmethod which can be used to explicitly call the class detection, which allows to avoid the duplicated detection when reading from a file. 

@MSeifert04 - do you see any drawback with this approach ?