### PR TITLE
Add TextIOWrapper fileobj to list of fds to close in get_readable_fileobj

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -295,6 +295,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
 
         fileobj = io.BufferedReader(fileobj)
         fileobj = io.TextIOWrapper(fileobj, encoding=encoding)
+        close_fds.append(fileobj)
 
         # Ensure that file is at the start - io.FileIO will for
         # example not always be at the start:


### PR DESCRIPTION
This one-line change addresses what I found in https://github.com/astropy/astropy/issues/8673#issuecomment-490268591.  But to be totally honest I have no idea if this is messing anything else up.  Tossing this up as a PR to see if it passes all tests (locally passed Table and all astropy/io tests).

@timj - could you confirm this removes the ResourceWarning for you?

Fixes #8673.