### PR TITLE
When reading URL map, open read-only

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -19,6 +19,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import shelve
+import dbm
 
 from tempfile import NamedTemporaryFile, gettempdir
 from warnings import warn
@@ -1021,7 +1022,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                                                              conf.dataurl_mirror)
                                 if url_mirror in url2hash:
                                     return url2hash[url_mirror]
-            except:
+            except dbm.error:
                 # shelve->dbm with flag='r' fails if the urlmap file does not exist.
                 pass
 
@@ -1130,7 +1131,7 @@ def is_url_in_cache(url_key):
         with shelve.open(urlmapfn, flag='r') as url2hash:
             if url_key in url2hash:
                 return True
-    except:
+    except dbm.error:
         # shelve->dbm with flag='r' fails if the urlmap file does not exist.
         return False
     return False
@@ -1382,6 +1383,6 @@ def get_cached_urls():
     try:
         with shelve.open(urlmapfn, flag='r') as url2hash:
             return list(url2hash.keys())
-    except:
+    except dbm.error:
         # shelve->dbm with flag='r' fails if the urlmap file does not exist.
         return []

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1009,7 +1009,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
     try:
         if cache:
             # We don't need to acquire the lock here, since we are only reading
-            with shelve.open(urlmapfn) as url2hash:
+            with shelve.open(urlmapfn, flag='r') as url2hash:
                 if url_key in url2hash:
                     return url2hash[url_key]
                 # If there is a cached copy from mirror, use it.
@@ -1122,7 +1122,7 @@ def is_url_in_cache(url_key):
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
         return False
 
-    with shelve.open(urlmapfn) as url2hash:
+    with shelve.open(urlmapfn, flag='r') as url2hash:
         if url_key in url2hash:
             return True
     return False
@@ -1371,5 +1371,5 @@ def get_cached_urls():
         warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
         return False
 
-    with shelve.open(urlmapfn) as url2hash:
+    with shelve.open(urlmapfn, flag='r') as url2hash:
         return list(url2hash.keys())


### PR DESCRIPTION
Without this, is it impossible to retrieve a cached downloaded file from a read-only filesystem, because shelve wants to open the file read-write by default.

There is still one place where there is a possible read-only path, but I didn't see an easy way to work around that.
