### PR TITLE
Fix bug for ascii write of mixin column with format specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -698,6 +698,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fixed a bug where an exception was raised when writing a table which includes
+  mixin columns (e.g. a Quantity column) and the output format was specified
+  using the ``formats`` keyword. [#8681]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -835,7 +835,7 @@ class BaseData:
         """
         for col in self.cols:
             if col.info.name in self.formats:
-                col.info.format = self.formats[col.name]
+                col.info.format = self.formats[col.info.name]
 
 
 def convert_numpy(numpy_type):

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -15,7 +15,7 @@ from astropy import table
 from astropy.table.table_helpers import simple_table
 from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
-from astropy import units
+from astropy import units as u
 
 from .common import setup_function, teardown_function
 
@@ -582,8 +582,8 @@ b & 2
     ascii.write(t, out, format='aastex', latexdict=latexdict)
     assert out.getvalue() == expected
     # use unit attribute instead
-    t['NUV exp.time'].unit = units.s
-    t['date'].unit = units.yr
+    t['NUV exp.time'].unit = u.s
+    t['date'].unit = u.yr
     out = StringIO()
     ascii.write(t, out, format='aastex', latexdict=ascii.latexdicts['AA'])
     assert out.getvalue() == expected.replace(
@@ -768,3 +768,16 @@ def test_write_newlines(fast_writer, tmpdir):
         content = f.read()
 
     assert content == os.linesep.join(['col', 'a', 'b', 'c']) + os.linesep
+
+@pytest.mark.parametrize("fast_writer", [True, False])
+def test_write_formatted_mixin(fast_writer):
+    """
+    Test fix for #8680 where writing a QTable with a quantity mixin generates
+    an exception if a format is specified.
+    """
+    out = StringIO()
+    t = table.QTable([[1, 2], [1, 2] * u.m], names=['a', 'b'])
+    ascii.write(t, out, fast_writer=fast_writer, formats={'a': '%02d', 'b': '%.2f'})
+    assert out.getvalue().splitlines() == ['a b',
+                                           '01 1.00',
+                                           '02 2.00']


### PR DESCRIPTION
The code for doing formatting of columns in `ascii.write` was using `col.name` instead of the mixin-safe `col.info.name` version.  This fixes the issue in both the pure Python and fast C writer versions.

Fixes #8680 
