### PR TITLE
Fix ASDF tag test helper to load schemas correctly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
                           # of 32 bit and 64 bit builds are needed, move this
                           # to the matrix section.
         CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 html5lib jinja2 pyyaml matplotlib scikit-image pytz"
-        PIP_DEPENDENCIES: "objgraph"
+        PIP_DEPENDENCIES: "objgraph asdf"
 
     matrix:
         - PYTHON_VERSION: "3.7"

--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import urllib.parse
+import urllib.request
 
 import yaml
 
@@ -13,15 +14,15 @@ def run_schema_example_test(organization, standard, name, version, check_func=No
     import asdf
     from asdf.tests import helpers
     from asdf.types import format_tag
-    from asdf.resolver import default_resolver
+    from asdf.resolver import default_tag_to_url_mapping
+    from asdf.schema import load_schema
 
     tag = format_tag(organization, standard, version, name)
-    schema_path = urllib.parse.urlparse(default_resolver(tag)).path
-
-    with open(schema_path, 'rb') as ff:
-        schema = yaml.load(ff)
+    uri = asdf.resolver.default_tag_to_url_mapping(tag)
+    r = asdf.AsdfFile().resolver
 
     examples = []
+    schema = load_schema(uri, resolver=r)
     for node in asdf.treeutil.iter_tree(schema):
         if (isinstance(node, dict) and
             'examples' in node and
@@ -31,7 +32,7 @@ def run_schema_example_test(organization, standard, name, version, check_func=No
 
     for example in examples:
         buff = helpers.yaml_to_asdf('example: ' + example.strip())
-        ff = asdf.AsdfFile(uri=schema_path)
+        ff = asdf.AsdfFile(uri=uri)
         # Add some dummy blocks so that the ndarray examples work
         for i in range(3):
             b = asdf.block.Block(np.zeros((1024*1024*8), dtype=np.uint8))

--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -1,11 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-import os
-import urllib.parse
-import urllib.request
-
-import yaml
-
 import numpy as np
 
 
@@ -14,7 +8,6 @@ def run_schema_example_test(organization, standard, name, version, check_func=No
     import asdf
     from asdf.tests import helpers
     from asdf.types import format_tag
-    from asdf.resolver import default_tag_to_url_mapping
     from asdf.schema import load_schema
 
     tag = format_tag(organization, standard, version, name)


### PR DESCRIPTION
Instead of trying to convert the ASDF tag to a schema file path in the test, just use the resolver in `asdf` via `entry_points`, as designed.

Fixes #8683