### PR TITLE
Fix replace_column for table sub-classes that have non-conventional initializers

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1922,7 +1922,9 @@ class Table:
         if self[name].info.indices:
             raise ValueError('cannot replace a table index column')
 
-        t = self.__class__([col], names=[name])
+        # We deliberately use ``Table`` here since it should be sufficient
+        # and it is just meant as a temporary container for the column
+        t = Table([col], names=[name])
         cols = OrderedDict(self.columns)
         cols[name] = t[name]
         self._init_from_cols(cols.values())

--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -53,6 +53,10 @@ class CommonTimeSeriesTests:
             ts.remove_columns(ts.colnames)
         assert 'TimeSeries object is invalid' in exc.value.args[0]
 
+    def test_set_unit(self):
+        # Regression test for https://github.com/astropy/astropy/issues/8642
+        self.series['a'].unit = u.m
+
 
 class TestTimeSeries(CommonTimeSeriesTests):
 


### PR DESCRIPTION
This is an attempt at a fix for #8642, but I need @taldcroft's input.

Basically ``replace_column`` doesn't work properly for ``TimeSeries`` because the ``TimeSeries`` initializer requires some kind of times to be passed to it. But in any case, it seems like we don't really need to use ``self.__class__`` in ``replace_column`` unless I'm missing something?

I don't fully understand why this is needed in the first place and why we can't simply modify the table column dictionary in-place, so @taldcroft if you could provide some background, that would be really useful, and I can try and add some comments in the code to explain.

If this is not an acceptable solution, I'll just overload ``replace_column`` in ``TimeSeries`` instead. 