### PR TITLE
Allow Header.fromstring to work on str and bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -401,6 +401,9 @@ astropy.io.fits
    Previously setting a header card value to ``None`` resulted in an
    empty string field rather than a FITS undefined value. [#8572]
 
+- Allow ``Header.fromstring`` and ``Card.fromstring`` to accept ``bytes``.
+  [#8707]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -554,6 +554,13 @@ class Card(_Verify):
         """
 
         card = cls()
+        if isinstance(image, bytes):
+            # FITS supports only ASCII, but decode as latin1 and just take all
+            # bytes for now; if it results in mojibake due to e.g. UTF-8
+            # encoded data in a FITS header that's OK because it shouldn't be
+            # there in the first place
+            image = image.decode('latin1')
+
         card._image = _pad(image)
         card._verified = False
         return card

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -390,6 +390,11 @@ class Header:
         require_full_cardlength = set(sep).issubset(VALID_HEADER_CHARS)
 
         if isinstance(data, bytes):
+            # FITS supports only ASCII, but decode as latin1 and just take all
+            # bytes for now; if it results in mojibake due to e.g. UTF-8
+            # encoded data in a FITS header that's OK because it shouldn't be
+            # there in the first place--accepting it here still gives us the
+            # opportunity to display warnings later during validation
             CONTINUE = b'CONTINUE'
             END = b'END'
             end_card = END_CARD.encode('ascii')

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -34,7 +34,8 @@ VALID_HEADER_CHARS = set(map(chr, range(0x20, 0x7F)))
 END_CARD = 'END' + ' ' * 77
 
 
-__doctest_skip__ = ['Header', 'Header.*']
+__doctest_skip__ = ['Header', 'Header.comments', 'Header.fromtextfile',
+                    'Header.totextfile', 'Header.set', 'Header.update']
 
 
 class Header:
@@ -359,7 +360,7 @@ class Header:
         to have the exact binary structure as it would appear in a FITS file,
         with the full 80 byte card length.  Rather, each "card" can end in a
         newline and does not have to be padded out to a full card length as
-        long as it "looks like" a FITS header::
+        long as it "looks like" a FITS header:
 
         >>> hdr = Header.fromstring(\"\"\"\\
         ... SIMPLE  =                    T / conforms to FITS standard

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -399,12 +399,12 @@ class Header:
             END = b'END'
             end_card = END_CARD.encode('ascii')
             sep = sep.encode('latin1')
-            join = lambda i: b''.join(i)
+            empty = b''
         else:
             CONTINUE = 'CONTINUE'
             END = 'END'
             end_card = END_CARD
-            join = lambda i: ''.join(i)
+            empty = ''
 
         # Split the header into individual cards
         idx = 0
@@ -426,7 +426,7 @@ class Header:
                 if next_image[:8] == CONTINUE:
                     image.append(next_image)
                     continue
-                cards.append(Card.fromstring(join(image)))
+                cards.append(Card.fromstring(empty.join(image)))
 
             if require_full_cardlength:
                 if next_image == end_card:
@@ -441,7 +441,7 @@ class Header:
 
         # Add the last image that was found before the end, if any
         if image:
-            cards.append(Card.fromstring(join(image)))
+            cards.append(Card.fromstring(empty.join(image)))
 
         return cls._fromcards(cards)
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2338,6 +2338,21 @@ class TestHeaderFunctions(FitsTestCase):
             else:
                 c.verify('exception')
 
+    def test_header_fromstring_bytes(self):
+        """
+        Test reading a Header from a `bytes` string.
+
+        See https://github.com/astropy/astropy/issues/8706
+        """
+
+        with open(self.data('test0.fits'), 'rb') as fobj:
+            pri_hdr_from_bytes = fits.Header.fromstring(fobj.read())
+
+        pri_hdr = fits.getheader(self.data('test0.fits'))
+        assert pri_hdr['NAXIS'] == pri_hdr_from_bytes['NAXIS']
+        assert pri_hdr == pri_hdr_from_bytes
+        assert pri_hdr.tostring() == pri_hdr_from_bytes.tostring()
+
 
 class TestRecordValuedKeywordCards(FitsTestCase):
     """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -85,6 +85,15 @@ class TestHeaderFunctions(FitsTestCase):
         c = fits.Card()
         assert '' == c.keyword
 
+    def test_card_from_bytes(self):
+        """
+        Test loading a Card from a `bytes` object (assuming latin-1 encoding).
+        """
+
+        c = fits.Card.fromstring(b"ABC     = 'abc'")
+        assert c.keyword == 'ABC'
+        assert c.value == 'abc'
+
     def test_string_value_card(self):
         """Test Card constructor with string value"""
 


### PR DESCRIPTION
Here is a possible fix for #8706.  It should work well-enough as a quick fix.

As I noted in the commit message, longer-term it would make vastly more sense to rework all the header parsing code to work intrinsically on raw binary bytes (which was more-or-less already the case on Python 2, but now is *not* the case on Python 3).

All the user-level interfaces should take `str` but all the parsing code should work on binary and only try to decode things to strings before they're shown to the user (including in error/warning messages).

EDIT: Fix #8706 