### PR TITLE
Fix votable warning on COOSYS

### DIFF
--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1639,7 +1639,9 @@ class CooSys(SimpleElement):
         self._config = config
         self._pos = pos
 
-        if config.get('version_1_2_or_later'):
+        # COOSYS was deprecated in 1.2 but then re-instated in 1.3
+        if (config.get('version_1_2_or_later') and
+                not config.get('version_1_3_or_later')):
             warn_or_raise(W27, W27, (), config, pos)
 
         SimpleElement.__init__(self)


### PR DESCRIPTION
Tom D, does this address the misleading COOSYS warning?

Given that this only affects one of the many warnings `votable` generates that no one reads anyway, I don't think we need a change log, though technically it is a bug.