### PR TITLE
Implement ability to hide warnings in VO table parsing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,11 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Changed ``pedantic`` argument to ``verify`` and change it to have three
+  string-based options (``ignore``, ``warn``, and ``exception``) instead of just
+  being a boolean. In addition, changed default to ``ignore``, which means
+  that warnings will not be shown by default when loading VO tables. [#8715]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -24,12 +24,13 @@ class Conf(_config.ConfigNamespace):
     Configuration parameters for `astropy.io.votable`.
     """
 
-    pedantic = _config.ConfigItem(
+    verify = _config.ConfigItem(
         'ignore',
         "Can be 'exception' (treat fixable violations of the VOTable spec as "
         "exceptions), 'warn' (show warnings for VOTable spec violations), or "
         "'ignore' (silently fix VOTable spec violations)",
-        aliases=['astropy.io.votable.table.pedantic'])
+        aliases=['astropy.io.votable.table.pedantic',
+                 'astropy.io.votable.pedantic'])
 
 
 conf = Conf()

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -25,8 +25,10 @@ class Conf(_config.ConfigNamespace):
     """
 
     pedantic = _config.ConfigItem(
-        False,
-        'When True, treat fixable violations of the VOTable spec as exceptions.',
+        'warn',
+        "Can be 'exception' (treat fixable violations of the VOTable spec as "
+        "exceptions), 'warn' (show warnings for VOTable spec violations), or "
+        "'ignore' (silently fix VOTable spec violations)",
         aliases=['astropy.io.votable.table.pedantic'])
 
 

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -25,7 +25,7 @@ class Conf(_config.ConfigNamespace):
     """
 
     pedantic = _config.ConfigItem(
-        'warn',
+        'ignore',
         "Can be 'exception' (treat fixable violations of the VOTable spec as "
         "exceptions), 'warn' (show warnings for VOTable spec violations), or "
         "'ignore' (silently fix VOTable spec violations)",

--- a/astropy/io/votable/__init__.py
+++ b/astropy/io/votable/__init__.py
@@ -28,7 +28,7 @@ class Conf(_config.ConfigNamespace):
         'ignore',
         "Can be 'exception' (treat fixable violations of the VOTable spec as "
         "exceptions), 'warn' (show warnings for VOTable spec violations), or "
-        "'ignore' (silently fix VOTable spec violations)",
+        "'ignore' (silently ignore VOTable spec violations)",
         aliases=['astropy.io.votable.table.pedantic',
                  'astropy.io.votable.pedantic'])
 

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -75,7 +75,7 @@ def read_table_votable(input, table_id=None, use_names_over_ids=False, verify=No
         (``'ignore'``). Warnings may be controlled using the standard Python
         mechanisms.  See the `warnings` module in the Python standard library
         for more information. When not provided, uses the configuration setting
-        ``astropy.io.votable.verify``, which defaults to 'ignore'.
+        ``astropy.io.votable.verify``, which defaults to ``'ignore'``.
     """
     if not isinstance(input, (VOTableFile, VOTable)):
         input = parse(input, table_id=table_id, verify=verify)

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -44,7 +44,7 @@ def is_votable(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_votable(input, table_id=None, use_names_over_ids=False, pedantic=None):
+def read_table_votable(input, table_id=None, use_names_over_ids=False, verify=None):
     """
     Read a Table object from an VO table file
 
@@ -69,10 +69,16 @@ def read_table_votable(input, table_id=None, use_names_over_ids=False, pedantic=
         to be renamed by appending numbers to the end.  Otherwise
         (default), use the ID attributes as the column names.
 
-    
+    verify : {'ignore', 'warn', 'exception'}, optional
+        When ``'exception'``, raise an error when the file violates the spec,
+        otherwise either issue a warning (``'warn'``) or silently continue
+        (``'ignore'``). Warnings may be controlled using the standard Python
+        mechanisms.  See the `warnings` module in the Python standard library
+        for more information. When not provided, uses the configuration setting
+        ``astropy.io.votable.verify``, which defaults to 'ignore'.
     """
     if not isinstance(input, (VOTableFile, VOTable)):
-        input = parse(input, table_id=table_id, pedantic=pedantic)
+        input = parse(input, table_id=table_id, verify=verify)
 
     # Parse all table objects
     table_id_mapping = dict()

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -44,7 +44,7 @@ def is_votable(origin, filepath, fileobj, *args, **kwargs):
         return False
 
 
-def read_table_votable(input, table_id=None, use_names_over_ids=False):
+def read_table_votable(input, table_id=None, use_names_over_ids=False, pedantic=None):
     """
     Read a Table object from an VO table file
 
@@ -68,9 +68,11 @@ def read_table_votable(input, table_id=None, use_names_over_ids=False):
         are not guaranteed to be unique, this may cause some columns
         to be renamed by appending numbers to the end.  Otherwise
         (default), use the ID attributes as the column names.
+
+    
     """
     if not isinstance(input, (VOTableFile, VOTable)):
-        input = parse(input, table_id=table_id)
+        input = parse(input, table_id=table_id, pedantic=pedantic)
 
     # Parse all table objects
     table_id_mapping = dict()

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -319,7 +319,7 @@ class Char(Converter):
             self.binoutput = self._binoutput_fixed
             self._struct_format = ">{:d}s".format(self.arraysize)
 
-        if config.get('pedantic'):
+        if config.get('pedantic') == 'exception':
             self.parse = self._ascii_parse
         else:
             self.parse = self._str_parse
@@ -439,7 +439,7 @@ class Array(Converter):
         if config is None:
             config = {}
         Converter.__init__(self, field, config, pos)
-        if config.get('pedantic'):
+        if config.get('pedantic') == 'exception':
             self._splitter = self._splitter_pedantic
         else:
             self._splitter = self._splitter_lax
@@ -578,7 +578,7 @@ class NumericArray(Array):
         parts = self._splitter(value, config, pos)
         if len(parts) != self._items:
             warn_or_raise(E02, E02, (self._items, len(parts)), config, pos)
-        if config.get('pedantic'):
+        if config.get('pedantic') == 'error':
             return self.parse_parts(parts, config, pos)
         else:
             if len(parts) == self._items:
@@ -698,7 +698,7 @@ class FloatingPoint(Numeric):
             self._null_binoutput = self.binoutput(np.asarray(self.null), False)
             self.filter_array = self._filter_null
 
-        if config.get('pedantic'):
+        if config.get('pedantic') == 'exception':
             self.parse = self._parse_pedantic
         else:
             self.parse = self._parse_permissive

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -319,7 +319,7 @@ class Char(Converter):
             self.binoutput = self._binoutput_fixed
             self._struct_format = ">{:d}s".format(self.arraysize)
 
-        if config.get('verify') == 'exception':
+        if config.get('verify', 'ignore') == 'exception':
             self.parse = self._ascii_parse
         else:
             self.parse = self._str_parse
@@ -439,7 +439,7 @@ class Array(Converter):
         if config is None:
             config = {}
         Converter.__init__(self, field, config, pos)
-        if config.get('verify') == 'exception':
+        if config.get('verify', 'ignore') == 'exception':
             self._splitter = self._splitter_pedantic
         else:
             self._splitter = self._splitter_lax
@@ -578,7 +578,7 @@ class NumericArray(Array):
         parts = self._splitter(value, config, pos)
         if len(parts) != self._items:
             warn_or_raise(E02, E02, (self._items, len(parts)), config, pos)
-        if config.get('verify') == 'error':
+        if config.get('verify', 'ignore') == 'error':
             return self.parse_parts(parts, config, pos)
         else:
             if len(parts) == self._items:
@@ -698,7 +698,7 @@ class FloatingPoint(Numeric):
             self._null_binoutput = self.binoutput(np.asarray(self.null), False)
             self.filter_array = self._filter_null
 
-        if config.get('verify') == 'exception':
+        if config.get('verify', 'ignore') == 'exception':
             self.parse = self._parse_pedantic
         else:
             self.parse = self._parse_permissive

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -578,7 +578,7 @@ class NumericArray(Array):
         parts = self._splitter(value, config, pos)
         if len(parts) != self._items:
             warn_or_raise(E02, E02, (self._items, len(parts)), config, pos)
-        if config.get('verify', 'ignore') == 'error':
+        if config.get('verify', 'ignore') == 'exception':
             return self.parse_parts(parts, config, pos)
         else:
             if len(parts) == self._items:

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -319,7 +319,7 @@ class Char(Converter):
             self.binoutput = self._binoutput_fixed
             self._struct_format = ">{:d}s".format(self.arraysize)
 
-        if config.get('pedantic') == 'exception':
+        if config.get('verify') == 'exception':
             self.parse = self._ascii_parse
         else:
             self.parse = self._str_parse
@@ -439,7 +439,7 @@ class Array(Converter):
         if config is None:
             config = {}
         Converter.__init__(self, field, config, pos)
-        if config.get('pedantic') == 'exception':
+        if config.get('verify') == 'exception':
             self._splitter = self._splitter_pedantic
         else:
             self._splitter = self._splitter_lax
@@ -578,7 +578,7 @@ class NumericArray(Array):
         parts = self._splitter(value, config, pos)
         if len(parts) != self._items:
             warn_or_raise(E02, E02, (self._items, len(parts)), config, pos)
-        if config.get('pedantic') == 'error':
+        if config.get('verify') == 'error':
             return self.parse_parts(parts, config, pos)
         else:
             if len(parts) == self._items:
@@ -698,7 +698,7 @@ class FloatingPoint(Numeric):
             self._null_binoutput = self.binoutput(np.asarray(self.null), False)
             self.filter_array = self._filter_null
 
-        if config.get('pedantic') == 'exception':
+        if config.get('verify') == 'exception':
             self.parse = self._parse_pedantic
         else:
             self.parse = self._parse_permissive

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -122,7 +122,7 @@ def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     if config is None:
         config = {}
-    if config.get('verify') == 'warn':
+    if config.get('verify') != 'ignore':
         warning = warning_class(args, config, pos)
         _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -24,9 +24,9 @@ Exceptions
 
 .. note::
 
-    This is a list of many of the fatal exceptions emitted by astropy.io.votable
+    This is a list of many of the fatal exceptions emitted by ``astropy.io.votable``
     when the file does not conform to spec.  Other exceptions may be
-    raised due to unforeseen cases or bugs in astropy.io.votable itself.
+    raised due to unforeseen cases or bugs in ``astropy.io.votable`` itself.
 
 {exceptions}
 """
@@ -84,11 +84,12 @@ def warn_or_raise(warning_class, exception_class=None, args=(), config=None,
     # NOTE: the default here is deliberately warn rather than ignore, since
     # one would expect that calling warn_or_raise without config should not
     # silence the warnings.
-    if config.get('verify', 'warn') == 'exception':
+    config_value = config.get('verify', 'warn')
+    if config_value == 'exception':
         if exception_class is None:
             exception_class = warning_class
         vo_raise(exception_class, args, config, pos)
-    elif config.get('verify', 'warn') == 'warn':
+    elif config_value == 'warn':
         vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
@@ -660,8 +661,8 @@ class W23(IOWarning):
 class W24(VOWarning, FutureWarning):
     """
     The VO catalog database retrieved from the www is designed for a
-    newer version of astropy.io.votable.  This may cause problems or limited
-    features performing service queries.  Consider upgrading astropy.io.votable
+    newer version of ``astropy.io.votable``.  This may cause problems or limited
+    features performing service queries.  Consider upgrading ``astropy.io.votable``
     to the latest version.
     """
 
@@ -847,7 +848,7 @@ class W36(VOTableSpecWarning):
 class W37(UnimplementedWarning):
     """
     The 3 datatypes defined in the VOTable specification and supported by
-    astropy.io.votable are ``TABLEDATA``, ``BINARY`` and ``FITS``.
+    ``astropy.io.votable`` are ``TABLEDATA``, ``BINARY`` and ``FITS``.
 
     **References:** `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:data>`__,

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -24,9 +24,9 @@ Exceptions
 
 .. note::
 
-    This is a list of many of the fatal exceptions emitted by vo.table
+    This is a list of many of the fatal exceptions emitted by astropy.io.votable
     when the file does not conform to spec.  Other exceptions may be
-    raised due to unforeseen cases or bugs in vo.table itself.
+    raised due to unforeseen cases or bugs in astropy.io.votable itself.
 
 {exceptions}
 """
@@ -250,10 +250,10 @@ class W01(VOTableSpecWarning):
         encoded as multiple numbers separated by whitespace.
 
     Many VOTable files in the wild use commas as a separator instead,
-    and ``vo.table`` supports this convention when not in
+    and ``astropy.io.votable`` supports this convention when not in
     :ref:`pedantic-mode`.
 
-    ``vo.table`` always outputs files using only spaces, regardless of
+    ``astropy.io.votable`` always outputs files using only spaces, regardless of
     how they were input.
 
     **References**: `1.1
@@ -281,7 +281,7 @@ class W02(VOTableSpecWarning):
 
     However, this is in conflict with the XML standard, which says
     colons may not be used.  VOTable 1.1's own schema does not allow a
-    colon here.  Therefore, ``vo.table`` disallows the colon.
+    colon here.  Therefore, ``astropy.io.votable`` disallows the colon.
 
     VOTable 1.2 corrects this error in the specification.
 
@@ -324,7 +324,7 @@ class W03(VOTableChangeWarning):
         ``name`` attributes of ``FIELD``, ``PARAM`` and optional
         ``GROUP`` elements should be all different.
 
-    Since ``vo.table`` requires a unique identifier for each of its
+    Since ``astropy.io.votable`` requires a unique identifier for each of its
     columns, ``ID`` is used for the column name when present.
     However, when ``ID`` is not present, (since it is not required by
     the specification) ``name`` is used instead.  However, ``name``
@@ -416,7 +416,7 @@ class W07(VOTableSpecWarning):
 
 class W08(VOTableSpecWarning):
     """
-    To avoid local-dependent number parsing differences, ``vo.table``
+    To avoid local-dependent number parsing differences, ``astropy.io.votable``
     may require a string or unicode string where a numeric type may
     make more sense.
     """
@@ -431,7 +431,7 @@ class W09(VOTableSpecWarning):
     The VOTable specification uses the attribute name ``ID`` (with
     uppercase letters) to specify unique identifiers.  Some
     VOTable-producing tools use the more standard lowercase ``id``
-    instead.  ``vo.table`` accepts ``id`` and emits this warning if
+    instead. ``astropy.io.votable`` accepts ``id`` and emits this warning if
     ``verify`` is ``'warn'``.
 
     **References**: `1.1
@@ -450,7 +450,7 @@ class W10(VOTableSpecWarning):
     against the VOTable schema (with a tool such as `xmllint
     <http://xmlsoft.org/xmllint.html>`__.  If the file validates
     against the schema, and you still receive this warning, this may
-    indicate a bug in ``vo.table``.
+    indicate a bug in ``astropy.io.votable``.
 
     **References**: `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#ToC54>`__,
@@ -469,7 +469,7 @@ class W11(VOTableSpecWarning):
     <http://aladin.u-strasbg.fr/glu/>`__.  New files should
     specify a ``glu:`` protocol using the ``href`` attribute.
 
-    Since ``vo.table`` does not currently support GLU references, it
+    Since ``astropy.io.votable`` does not currently support GLU references, it
     likewise does not automatically convert the ``gref`` attribute to
     the new form.
 
@@ -489,7 +489,7 @@ class W12(VOTableChangeWarning):
     to derive a name from.  Strictly speaking, according to the
     VOTable schema, the ``name`` attribute is required.  However, if
     ``name`` is not present by ``ID`` is, and ``verify`` is not ``'exception'``,
-    ``vo.table`` will continue without a ``name`` defined.
+    ``astropy.io.votable`` will continue without a ``name`` defined.
 
     **References**: `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:name>`__,
@@ -538,7 +538,7 @@ class W15(VOTableSpecWarning):
     The ``name`` attribute is required on every ``FIELD`` element.
     However, many VOTable files in the wild omit it and provide only
     an ``ID`` instead.  In this case, when ``verify`` is not ``'exception'``
-    ``vo.table`` will copy the ``name`` attribute to a new ``ID``
+    ``astropy.io.votable`` will copy the ``name`` attribute to a new ``ID``
     attribute.
 
     **References**: `1.1
@@ -614,12 +614,12 @@ class W20(VOTableSpecWarning):
 
 class W21(UnimplementedWarning):
     """
-    Unknown issues may arise using ``vo.table`` with VOTable files
+    Unknown issues may arise using ``astropy.io.votable`` with VOTable files
     from a version other than 1.1, 1.2 or 1.3.
     """
 
     message_template = (
-        'vo.table is designed for VOTable version 1.1, 1.2 and 1.3, but ' +
+        'astropy.io.votable is designed for VOTable version 1.1, 1.2 and 1.3, but ' +
         'this file is {}')
     default_args = ('x',)
 
@@ -654,12 +654,12 @@ class W23(IOWarning):
 class W24(VOWarning, FutureWarning):
     """
     The VO catalog database retrieved from the www is designed for a
-    newer version of vo.table.  This may cause problems or limited
-    features performing service queries.  Consider upgrading vo.table
+    newer version of astropy.io.votable.  This may cause problems or limited
+    features performing service queries.  Consider upgrading astropy.io.votable
     to the latest version.
     """
 
-    message_template = "The VO catalog database is for a later version of vo.table"
+    message_template = "The VO catalog database is for a later version of astropy.io.votable"
 
 
 class W25(IOWarning):
@@ -841,7 +841,7 @@ class W36(VOTableSpecWarning):
 class W37(UnimplementedWarning):
     """
     The 3 datatypes defined in the VOTable specification and supported by
-    vo.table are ``TABLEDATA``, ``BINARY`` and ``FITS``.
+    astropy.io.votable are ``TABLEDATA``, ``BINARY`` and ``FITS``.
 
     **References:** `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:data>`__,

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -81,11 +81,11 @@ def warn_or_raise(warning_class, exception_class=None, args=(), config=None,
     """
     if config is None:
         config = {}
-    if config.get('pedantic'):
+    if config.get('pedantic') == 'exception':
         if exception_class is None:
             exception_class = warning_class
         vo_raise(exception_class, args, config, pos)
-    else:
+    elif config.get('pedantic') == 'warn':
         vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
@@ -122,8 +122,9 @@ def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     if config is None:
         config = {}
-    warning = warning_class(args, config, pos)
-    _suppressed_warning(warning, config, stacklevel=stacklevel+1)
+    if config.get('pedantic') == 'warn':
+        warning = warning_class(args, config, pos)
+        _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 
 
 def warn_unknown_attrs(element, attrs, config, pos, good_attr=[], stacklevel=1):

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -81,11 +81,14 @@ def warn_or_raise(warning_class, exception_class=None, args=(), config=None,
     """
     if config is None:
         config = {}
-    if config.get('verify') == 'exception':
+    # NOTE: the default here is deliberately warn rather than ignore, since
+    # one would expect that calling warn_or_raise without config should not
+    # silence the warnings.
+    if config.get('verify', 'warn') == 'exception':
         if exception_class is None:
             exception_class = warning_class
         vo_raise(exception_class, args, config, pos)
-    elif config.get('verify') == 'warn':
+    elif config.get('verify', 'warn') == 'warn':
         vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
@@ -122,7 +125,10 @@ def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     if config is None:
         config = {}
-    if config.get('verify', 'ignore') != 'ignore':
+    # NOTE: the default here is deliberately warn rather than ignore, since
+    # one would expect that calling warn_or_raise without config should not
+    # silence the warnings.
+    if config.get('verify', 'warn') != 'ignore':
         warning = warning_class(args, config, pos)
         _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -77,15 +77,15 @@ def _suppressed_warning(warning, config, stacklevel=2):
 def warn_or_raise(warning_class, exception_class=None, args=(), config=None,
                   pos=None, stacklevel=1):
     """
-    Warn or raise an exception, depending on the pedantic setting.
+    Warn or raise an exception, depending on the verify setting.
     """
     if config is None:
         config = {}
-    if config.get('pedantic') == 'exception':
+    if config.get('verify') == 'exception':
         if exception_class is None:
             exception_class = warning_class
         vo_raise(exception_class, args, config, pos)
-    elif config.get('pedantic') == 'warn':
+    elif config.get('verify') == 'warn':
         vo_warn(warning_class, args, config, pos, stacklevel=stacklevel+1)
 
 
@@ -122,7 +122,7 @@ def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     if config is None:
         config = {}
-    if config.get('pedantic') == 'warn':
+    if config.get('verify') == 'warn':
         warning = warning_class(args, config, pos)
         _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 
@@ -431,8 +431,8 @@ class W09(VOTableSpecWarning):
     The VOTable specification uses the attribute name ``ID`` (with
     uppercase letters) to specify unique identifiers.  Some
     VOTable-producing tools use the more standard lowercase ``id``
-    instead.  ``vo.table`` accepts ``id`` and emits this warning when
-    not in ``pedantic`` mode.
+    instead.  ``vo.table`` accepts ``id`` and emits this warning if
+    ``verify`` is not ``'exception'``.
 
     **References**: `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:name>`__,
@@ -488,7 +488,7 @@ class W12(VOTableChangeWarning):
     ``FIELD`` element must have either an ``ID`` or ``name`` attribute
     to derive a name from.  Strictly speaking, according to the
     VOTable schema, the ``name`` attribute is required.  However, if
-    ``name`` is not present by ``ID`` is, and *pedantic mode* is off,
+    ``name`` is not present by ``ID`` is, and ``verify`` is not ``'exception'``,
     ``vo.table`` will continue without a ``name`` defined.
 
     **References**: `1.1
@@ -537,7 +537,7 @@ class W15(VOTableSpecWarning):
     """
     The ``name`` attribute is required on every ``FIELD`` element.
     However, many VOTable files in the wild omit it and provide only
-    an ``ID`` instead.  In this case, when *pedantic mode* is off,
+    an ``ID`` instead.  In this case, when ``verify`` is not ``'exception'``
     ``vo.table`` will copy the ``name`` attribute to a new ``ID``
     attribute.
 
@@ -577,8 +577,8 @@ class W18(VOTableSpecWarning):
     The number of rows explicitly specified in the ``nrows`` attribute
     does not match the actual number of rows (``TR`` elements) present
     in the ``TABLE``.  This may indicate truncation of the file, or an
-    internal error in the tool that produced it.  If *pedantic mode*
-    is off, parsing will proceed, with the loss of some performance.
+    internal error in the tool that produced it.  If ``verify`` is not
+    ``'exception'``, parsing will proceed, with the loss of some performance.
 
     **References:** `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#ToC10>`__,
@@ -593,8 +593,8 @@ class W18(VOTableSpecWarning):
 class W19(VOTableSpecWarning):
     """
     The column fields as defined using ``FIELD`` elements do not match
-    those in the headers of the embedded FITS file.  If *pedantic
-    mode* is off, the embedded FITS file will take precedence.
+    those in the headers of the embedded FITS file.  If ``verify`` is not
+    ``'exception'``, the embedded FITS file will take precedence.
     """
 
     message_template = (
@@ -727,9 +727,9 @@ class W29(VOTableSpecWarning):
 
 class W30(VOTableSpecWarning):
     """
-    Some VOTable files write missing floating-point values in non-standard
-    ways, such as "null" and "-".  In non-pedantic mode, any non-standard
-    floating-point literals are treated as missing values.
+    Some VOTable files write missing floating-point values in non-standard ways,
+    such as "null" and "-".  If ``verify`` is not ``'exception'``, any
+    non-standard floating-point literals are treated as missing values.
 
     **References**: `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:datatypes>`__,

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -122,7 +122,7 @@ def vo_warn(warning_class, args=(), config=None, pos=None, stacklevel=1):
     """
     if config is None:
         config = {}
-    if config.get('verify') != 'ignore':
+    if config.get('verify', 'ignore') != 'ignore':
         warning = warning_class(args, config, pos)
         _suppressed_warning(warning, config, stacklevel=stacklevel+1)
 
@@ -432,7 +432,7 @@ class W09(VOTableSpecWarning):
     uppercase letters) to specify unique identifiers.  Some
     VOTable-producing tools use the more standard lowercase ``id``
     instead.  ``vo.table`` accepts ``id`` and emits this warning if
-    ``verify`` is not ``'exception'``.
+    ``verify`` is ``'warn'``.
 
     **References**: `1.1
     <http://www.ivoa.net/Documents/VOTable/20040811/REC-VOTable-1.1-20040811.html#sec:name>`__,

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -121,7 +121,14 @@ def parse(source, columns=None, invalid='exception', verify=None,
 
     if verify is None:
         if pedantic is None:
-            verify = conf.verify
+            # Note that we need to allow verify to be booleans as strings since
+            # the configuration framework doesn't make it easy/possible to have
+            # mixed types.
+            if conf.verify.lower() in ['false', 'true']:
+                verify = conf.verify.lower() == 'true'
+            else:
+                verify = conf.verify
+
         else:
             verify = 'exception' if pedantic else 'warn'
 

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -126,7 +126,7 @@ def parse(source, columns=None, invalid='exception', verify=None,
         # [io.votable] section.
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
-                                    "Config parameter \'pedantic\' in section \[io.votable\]",
+                                    r"Config parameter \'pedantic\' in section \[io.votable\]",
                                     AstropyDeprecationWarning)
             conf_verify_lowercase = conf.verify.lower()
 

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -27,9 +27,9 @@ VERIFY_OPTIONS = ['ignore', 'warn', 'exception']
 
 
 @deprecated_renamed_argument('pedantic', 'verify', pending=True, since='4.0')
-def parse(source, columns=None, invalid='exception', pedantic=None,
+def parse(source, columns=None, invalid='exception', verify=None,
           chunk_size=tree.DEFAULT_CHUNK_SIZE, table_number=None,
-          table_id=None, filename=None, unit_format=None, verify=None,
+          table_id=None, filename=None, unit_format=None,
           datatype_mapping=None, _debug_python_based_parser=False):
     """
     Parses a VOTABLE_ xml file (or file-like object), and returns a

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -124,11 +124,13 @@ def parse(source, columns=None, invalid='exception', verify=None,
         # mixed types.
         conf_verify_lowercase = conf.verify.lower()
         if conf_verify_lowercase in ['false', 'true']:
-            verify = 'exception' if conf_verify_lowercase == 'true' else 'warn'
+            verify = conf_verify_lowercase == 'true'
         else:
             verify = conf.verify
 
-    if verify not in VERIFY_OPTIONS:
+    if isinstance(verify, bool):
+        verify = 'exception' if verify else 'warn'
+    elif verify not in VERIFY_OPTIONS:
         raise ValueError('verify should be one of {0}'.format('/'.join(VERIFY_OPTIONS)))
 
     if datatype_mapping is None:

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -122,14 +122,13 @@ def parse(source, columns=None, invalid='exception', verify=None,
         # Note that we need to allow verify to be booleans as strings since
         # the configuration framework doesn't make it easy/possible to have
         # mixed types.
-        if conf.verify.lower() in ['false', 'true']:
-            verify = conf.verify.lower() == 'true'
+        conf_verify_lowercase = conf.verify.lower()
+        if conf_verify_lowercase in ['false', 'true']:
+            verify = 'exception' if conf_verify_lowercase == 'true' else 'warn'
         else:
             verify = conf.verify
 
-    if isinstance(verify, bool):
-        verify = 'exception' if verify else 'warn'
-    elif verify not in VERIFY_OPTIONS:
+    if verify not in VERIFY_OPTIONS:
         raise ValueError('verify should be one of {0}'.format('/'.join(VERIFY_OPTIONS)))
 
     if datatype_mapping is None:

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -52,11 +52,6 @@ def parse(source, columns=None, invalid='exception', verify=None,
 
             - 'mask': mask out invalid values
 
-    pedantic : bool, optional
-        This is now an alias for ``verify='warn'`` (if ``pedantic`` is `False`)
-        or ``verify='exception'`` (if ``pedantic`` is `True`). The ``pedantic``
-        option will be deprecated in future.
-
     verify : {'ignore', 'warn', 'exception'}, optional
         When ``'exception'``, raise an error when the file violates the spec,
         otherwise either issue a warning (``'warn'``) or silently continue

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -60,6 +60,10 @@ def parse(source, columns=None, invalid='exception', verify=None,
         for more information. When not provided, uses the configuration setting
         ``astropy.io.votable.verify``, which defaults to 'ignore'.
 
+        .. versionchanged:: 4.0
+           ``verify`` replaces the ``pedantic`` argument, which will be
+           deprecated in future.
+
     chunk_size : int, optional
         The number of rows to read before converting to an array.
         Higher numbers are likely to be faster, but will consume more

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -120,17 +120,13 @@ def parse(source, columns=None, invalid='exception', verify=None,
                          "``'exception'`` or ``'mask'``.")
 
     if verify is None:
-        if pedantic is None:
-            # Note that we need to allow verify to be booleans as strings since
-            # the configuration framework doesn't make it easy/possible to have
-            # mixed types.
-            if conf.verify.lower() in ['false', 'true']:
-                verify = conf.verify.lower() == 'true'
-            else:
-                verify = conf.verify
-
+        # Note that we need to allow verify to be booleans as strings since
+        # the configuration framework doesn't make it easy/possible to have
+        # mixed types.
+        if conf.verify.lower() in ['false', 'true']:
+            verify = conf.verify.lower() == 'true'
         else:
-            verify = 'exception' if pedantic else 'warn'
+            verify = conf.verify
 
     if isinstance(verify, bool):
         verify = 'exception' if verify else 'warn'

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -91,7 +91,7 @@ def test_float_mask():
 
 
 def test_float_mask_permissive():
-    config = {'pedantic': 'warn'}
+    config = {'verify': 'warn'}
     field = tree.Field(
         None, name='c', datatype='float',
         config=config)

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -91,7 +91,7 @@ def test_float_mask():
 
 
 def test_float_mask_permissive():
-    config = {'verify': 'warn'}
+    config = {'verify': 'ignore'}
     field = tree.Field(
         None, name='c', datatype='float',
         config=config)

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -26,7 +26,7 @@ def test_invalid_arraysize():
 
 
 def test_oversize_char():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     with catch_warnings(exceptions.W47) as w:
         field = tree.Field(
             None, name='c', datatype='char',
@@ -40,7 +40,7 @@ def test_oversize_char():
 
 
 def test_char_mask():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='char',
         config=config)
@@ -49,7 +49,7 @@ def test_char_mask():
 
 
 def test_oversize_unicode():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     with catch_warnings(exceptions.W46) as w:
         field = tree.Field(
             None, name='c2', datatype='unicodeChar',
@@ -61,7 +61,7 @@ def test_oversize_unicode():
 
 
 def test_unicode_mask():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='unicodeChar',
         config=config)
@@ -71,7 +71,7 @@ def test_unicode_mask():
 
 @raises(exceptions.E02)
 def test_wrong_number_of_elements():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='int', arraysize='2x3*',
         config=config)
@@ -81,7 +81,7 @@ def test_wrong_number_of_elements():
 
 @raises(ValueError)
 def test_float_mask():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='float',
         config=config)
@@ -91,7 +91,7 @@ def test_float_mask():
 
 
 def test_float_mask_permissive():
-    config = {'pedantic': False}
+    config = {'pedantic': 'warn'}
     field = tree.Field(
         None, name='c', datatype='float',
         config=config)
@@ -101,7 +101,7 @@ def test_float_mask_permissive():
 
 @raises(exceptions.E02)
 def test_complex_array_vararray():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='floatComplex', arraysize='2x3*',
         config=config)
@@ -110,7 +110,7 @@ def test_complex_array_vararray():
 
 
 def test_complex_array_vararray2():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='floatComplex', arraysize='2x3*',
         config=config)
@@ -120,7 +120,7 @@ def test_complex_array_vararray2():
 
 
 def test_complex_array_vararray3():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='doubleComplex', arraysize='2x3*',
         config=config)
@@ -131,7 +131,7 @@ def test_complex_array_vararray3():
 
 
 def test_complex_vararray():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='doubleComplex', arraysize='*',
         config=config)
@@ -143,7 +143,7 @@ def test_complex_vararray():
 
 @raises(exceptions.E03)
 def test_complex():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='doubleComplex',
         config=config)
@@ -153,7 +153,7 @@ def test_complex():
 
 @raises(exceptions.E04)
 def test_bit():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='bit',
         config=config)
@@ -162,7 +162,7 @@ def test_bit():
 
 
 def test_bit_mask():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     with catch_warnings(exceptions.W39) as w:
         field = tree.Field(
             None, name='c', datatype='bit',
@@ -174,7 +174,7 @@ def test_bit_mask():
 
 @raises(exceptions.E05)
 def test_boolean():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='boolean',
         config=config)
@@ -183,7 +183,7 @@ def test_boolean():
 
 
 def test_boolean_array():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='boolean', arraysize='*',
         config=config)
@@ -194,7 +194,7 @@ def test_boolean_array():
 
 @raises(exceptions.E06)
 def test_invalid_type():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(
         None, name='c', datatype='foobar',
         config=config)
@@ -202,7 +202,7 @@ def test_invalid_type():
 
 
 def test_precision():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
 
     field = tree.Field(
         None, name='c', datatype='float', precision="E4",
@@ -219,7 +219,7 @@ def test_precision():
 
 @raises(exceptions.W51)
 def test_integer_overflow():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
 
     field = tree.Field(
         None, name='c', datatype='int', config=config)
@@ -228,7 +228,7 @@ def test_integer_overflow():
 
 
 def test_float_default_precision():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
 
     field = tree.Field(
         None, name='c', datatype='float', arraysize="4",

--- a/astropy/io/votable/tests/exception_test.py
+++ b/astropy/io/votable/tests/exception_test.py
@@ -24,7 +24,7 @@ def test_reraise():
 
 
 def test_parse_vowarning():
-    config = {'pedantic': True,
+    config = {'verify': 'exception',
               'filename': 'foo.xml'}
     pos = (42, 64)
     with catch_warnings(exceptions.W47) as w:

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -20,9 +20,7 @@ from astropy.utils.exceptions import AstropyDeprecationWarning
 
 def test_table(tmpdir):
     # Read the VOTABLE
-    votable = parse(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore')
+    votable = parse(get_pkg_data_filename('data/regression.xml'))
     table = votable.get_first_table()
     astropy_table = table.to_table()
 
@@ -178,9 +176,7 @@ def test_write_with_format():
 
 
 def test_empty_table():
-    votable = parse(
-        get_pkg_data_filename('data/empty_table.xml'),
-        verify='ignore')
+    votable = parse(get_pkg_data_filename('data/empty_table.xml'))
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -232,11 +232,7 @@ def test_verify_options(tmpdir):
 
     # And make sure the old configuration item will keep working
 
-    from astropy.config.configuration import get_config_filename
-
     with set_temp_config(tmpdir.strpath):
-
-        print(get_config_filename())
 
         with open(tmpdir.join('astropy').join('astropy.cfg').strpath, 'w') as f:
             f.write('[io.votable]\npedantic = False')

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -6,11 +6,14 @@ import io
 import os
 
 import pathlib
+import pytest
 import numpy as np
 
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree
+from astropy.io.votable.exceptions import VOWarning
+from astropy.tests.helper import catch_warnings
 
 
 def test_table(tmpdir):
@@ -178,3 +181,21 @@ def test_empty_table():
         verify='warn')
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa
+
+
+def test_verify_options():
+
+    with catch_warnings(VOWarning) as w:
+        parse(get_pkg_data_filename('data/gemini.xml'))  # default (ignore)
+    assert len(w) == 0
+
+    with catch_warnings(VOWarning) as w:
+        parse(get_pkg_data_filename('data/gemini.xml'), verify='ignore')
+    assert len(w) == 0
+
+    with catch_warnings(VOWarning) as w:
+        parse(get_pkg_data_filename('data/gemini.xml'), verify='warn')
+    assert len(w) == 25
+
+    with pytest.raises(VOWarning):
+        parse(get_pkg_data_filename('data/gemini.xml'), verify='exception')

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -17,7 +17,7 @@ def test_table(tmpdir):
     # Read the VOTABLE
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False)
+        verify='warn')
     table = votable.get_first_table()
     astropy_table = table.to_table()
 
@@ -175,6 +175,6 @@ def test_write_with_format():
 def test_empty_table():
     votable = parse(
         get_pkg_data_filename('data/empty_table.xml'),
-        pedantic=False)
+        verify='warn')
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -199,3 +199,12 @@ def test_verify_options():
 
     with pytest.raises(VOWarning):
         parse(get_pkg_data_filename('data/gemini.xml'), verify='exception')
+
+    # Pending deprecated option
+
+    with catch_warnings(VOWarning) as w:
+        parse(get_pkg_data_filename('data/gemini.xml'), pedantic=False)
+    assert len(w) == 25
+
+    with pytest.raises(VOWarning):
+        parse(get_pkg_data_filename('data/gemini.xml'), pedantic=True)

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -22,7 +22,7 @@ def test_table(tmpdir):
     # Read the VOTABLE
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn')
+        verify='ignore')
     table = votable.get_first_table()
     astropy_table = table.to_table()
 
@@ -180,7 +180,7 @@ def test_write_with_format():
 def test_empty_table():
     votable = parse(
         get_pkg_data_filename('data/empty_table.xml'),
-        verify='warn')
+        verify='ignore')
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa
 
@@ -213,7 +213,7 @@ class TestVerifyOptions:
     # Make sure the pedantic option still works for now (pending deprecation)
 
     def test_pedantic_false(self):
-        with catch_warnings(VOWarning) as w:
+        with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), pedantic=False)
         assert len(w) == 25
         # Make sure we don't yet emit a deprecation warning
@@ -253,7 +253,7 @@ class TestVerifyOptions:
 
             reload_config('astropy.io.votable')
 
-            with catch_warnings(VOWarning) as w:
+            with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
             assert len(w) == 25
             # Make sure we don't yet emit a deprecation warning

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -7,14 +7,14 @@ from astropy.tests.helper import raises
 
 @raises(exceptions.W07)
 def test_check_astroyear_fail():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     field = tree.Field(None, name='astroyear')
     tree.check_astroyear('X2100', field, config)
 
 
 @raises(exceptions.W08)
 def test_string_fail():
-    config = {'pedantic': True}
+    config = {'verify': 'exception'}
     tree.check_string(42, 'foo', config)
 
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -48,18 +48,14 @@ def assert_validate_schema(filename, version):
 
 
 def test_parse_single_table():
-    table = parse_single_table(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore')
+    table = parse_single_table(get_pkg_data_filename('data/regression.xml'))
     assert isinstance(table, tree.Table)
     assert len(table.array) == 5
 
 
 def test_parse_single_table2():
-    table2 = parse_single_table(
-        get_pkg_data_filename('data/regression.xml'),
-        table_number=1,
-        verify='ignore')
+    table2 = parse_single_table(get_pkg_data_filename('data/regression.xml'),
+                                table_number=1)
     assert isinstance(table2, tree.Table)
     assert len(table2.array) == 1
     assert len(table2.array.dtype.names) == 28
@@ -67,17 +63,14 @@ def test_parse_single_table2():
 
 @raises(IndexError)
 def test_parse_single_table3():
-    parse_single_table(
-        get_pkg_data_filename('data/regression.xml'),
-        table_number=3, verify='ignore')
+    parse_single_table(get_pkg_data_filename('data/regression.xml'),
+                       table_number=3)
 
 
 def _test_regression(tmpdir, _python_based=False, binary_mode=1):
     # Read the VOTABLE
-    votable = parse(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore',
-        _debug_python_based_parser=_python_based)
+    votable = parse(get_pkg_data_filename('data/regression.xml'),
+                    _debug_python_based_parser=_python_based)
     table = votable.get_first_table()
 
     dtypes = [
@@ -139,8 +132,7 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
                            votable.version)
     # Also try passing a file handle
     with open(str(tmpdir.join("regression.binary.xml")), "rb") as fd:
-        votable2 = parse(fd, verify='ignore',
-                         _debug_python_based_parser=_python_based)
+        votable2 = parse(fd, _debug_python_based_parser=_python_based)
     votable2.get_first_table().format = 'tabledata'
     votable2.to_xml(str(tmpdir.join("regression.bin.tabledata.xml")),
                     _astropy_version="testing",
@@ -196,9 +188,7 @@ def test_regression_binary2(tmpdir):
 
 class TestFixups:
     def setup_class(self):
-        self.table = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore').get_first_table()
+        self.table = parse(get_pkg_data_filename('data/regression.xml')).get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
 
@@ -209,9 +199,7 @@ class TestFixups:
 
 class TestReferences:
     def setup_class(self):
-        self.votable = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore')
+        self.votable = parse(get_pkg_data_filename('data/regression.xml'))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -251,8 +239,7 @@ class TestReferences:
 def test_select_columns_by_index():
     columns = [0, 5, 13]
     table = parse(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore', columns=columns).get_first_table()
+        get_pkg_data_filename('data/regression.xml'), columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -265,8 +252,7 @@ def test_select_columns_by_index():
 def test_select_columns_by_name():
     columns = ['string_test', 'unsignedByte', 'bitarray']
     table = parse(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore', columns=columns).get_first_table()
+        get_pkg_data_filename('data/regression.xml'), columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -277,9 +263,7 @@ def test_select_columns_by_name():
 
 class TestParse:
     def setup_class(self):
-        self.votable = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore')
+        self.votable = parse(get_pkg_data_filename('data/regression.xml'))
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -609,14 +593,12 @@ class TestParse:
 
 class TestThroughTableData(TestParse):
     def setup_class(self):
-        votable = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore')
+        votable = parse(get_pkg_data_filename('data/regression.xml'))
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='ignore')
+        self.votable = parse(bio)
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -642,15 +624,13 @@ class TestThroughTableData(TestParse):
 
 class TestThroughBinary(TestParse):
     def setup_class(self):
-        votable = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore')
+        votable = parse(get_pkg_data_filename('data/regression.xml'))
         votable.get_first_table().format = 'binary'
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='ignore')
+        self.votable = parse(bio)
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -671,9 +651,7 @@ class TestThroughBinary(TestParse):
 
 class TestThroughBinary2(TestParse):
     def setup_class(self):
-        votable = parse(
-            get_pkg_data_filename('data/regression.xml'),
-            verify='ignore')
+        votable = parse(get_pkg_data_filename('data/regression.xml'))
         votable.version = '1.3'
         votable.get_first_table()._config['version_1_3_or_later'] = True
         votable.get_first_table().format = 'binary2'
@@ -681,7 +659,7 @@ class TestThroughBinary2(TestParse):
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='ignore')
+        self.votable = parse(bio)
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -729,14 +707,12 @@ def test_open_files():
     for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if filename.endswith('custom_datatype.xml'):
             continue
-        parse(filename, verify='ignore')
+        parse(filename)
 
 
 @raises(VOTableSpecError)
 def test_too_many_columns():
-    parse(
-        get_pkg_data_filename('data/too_many_columns.xml.gz'),
-        verify='ignore')
+    parse(get_pkg_data_filename('data/too_many_columns.xml.gz'))
 
 
 def test_build_from_scratch(tmpdir):
@@ -837,9 +813,7 @@ def test_validate_path_object():
 
 
 def test_gzip_filehandles(tmpdir):
-    votable = parse(
-        get_pkg_data_filename('data/regression.xml'),
-        verify='ignore')
+    votable = parse(get_pkg_data_filename('data/regression.xml'))
 
     with open(str(tmpdir.join("regression.compressed.xml")), 'wb') as fd:
         votable.to_xml(
@@ -848,9 +822,7 @@ def test_gzip_filehandles(tmpdir):
             _astropy_version="testing")
 
     with open(str(tmpdir.join("regression.compressed.xml")), 'rb') as fd:
-        votable = parse(
-            fd,
-            verify='ignore')
+        votable = parse(fd)
 
 
 def test_from_scratch_example():
@@ -908,17 +880,13 @@ def test_fileobj():
 def test_nonstandard_units():
     from astropy import units as u
 
-    votable = parse(
-        get_pkg_data_filename('data/nonstandard_units.xml'),
-        verify='ignore')
+    votable = parse(get_pkg_data_filename('data/nonstandard_units.xml'))
 
     assert isinstance(
         votable.get_first_table().fields[0].unit, u.UnrecognizedUnit)
 
-    votable = parse(
-        get_pkg_data_filename('data/nonstandard_units.xml'),
-        verify='ignore',
-        unit_format='generic')
+    votable = parse(get_pkg_data_filename('data/nonstandard_units.xml'),
+                    unit_format='generic')
 
     assert not isinstance(
         votable.get_first_table().fields[0].unit, u.UnrecognizedUnit)
@@ -1010,11 +978,8 @@ def test_instantiate_vowarning():
 
 
 def test_custom_datatype():
-    votable = parse(
-        get_pkg_data_filename('data/custom_datatype.xml'),
-        verify='ignore',
-        datatype_mapping={'bar': 'int'}
-    )
+    votable = parse(get_pkg_data_filename('data/custom_datatype.xml'),
+                    datatype_mapping={'bar': 'int'})
 
     table = votable.get_first_table()
     assert table.array.dtype['foo'] == np.int32

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -50,7 +50,7 @@ def assert_validate_schema(filename, version):
 def test_parse_single_table():
     table = parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn')
+        verify='ignore')
     assert isinstance(table, tree.Table)
     assert len(table.array) == 5
 
@@ -59,7 +59,7 @@ def test_parse_single_table2():
     table2 = parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
         table_number=1,
-        verify='warn')
+        verify='ignore')
     assert isinstance(table2, tree.Table)
     assert len(table2.array) == 1
     assert len(table2.array.dtype.names) == 28
@@ -69,14 +69,14 @@ def test_parse_single_table2():
 def test_parse_single_table3():
     parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
-        table_number=3, verify='warn')
+        table_number=3, verify='ignore')
 
 
 def _test_regression(tmpdir, _python_based=False, binary_mode=1):
     # Read the VOTABLE
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn',
+        verify='ignore',
         _debug_python_based_parser=_python_based)
     table = votable.get_first_table()
 
@@ -139,7 +139,7 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
                            votable.version)
     # Also try passing a file handle
     with open(str(tmpdir.join("regression.binary.xml")), "rb") as fd:
-        votable2 = parse(fd, verify='warn',
+        votable2 = parse(fd, verify='ignore',
                          _debug_python_based_parser=_python_based)
     votable2.get_first_table().format = 'tabledata'
     votable2.to_xml(str(tmpdir.join("regression.bin.tabledata.xml")),
@@ -198,7 +198,7 @@ class TestFixups:
     def setup_class(self):
         self.table = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn').get_first_table()
+            verify='ignore').get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
 
@@ -211,7 +211,7 @@ class TestReferences:
     def setup_class(self):
         self.votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn')
+            verify='ignore')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -252,7 +252,7 @@ def test_select_columns_by_index():
     columns = [0, 5, 13]
     table = parse(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn', columns=columns).get_first_table()
+        verify='ignore', columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -266,7 +266,7 @@ def test_select_columns_by_name():
     columns = ['string_test', 'unsignedByte', 'bitarray']
     table = parse(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn', columns=columns).get_first_table()
+        verify='ignore', columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -279,7 +279,7 @@ class TestParse:
     def setup_class(self):
         self.votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn')
+            verify='ignore')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -611,12 +611,12 @@ class TestThroughTableData(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn')
+            verify='ignore')
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='warn')
+        self.votable = parse(bio, verify='ignore')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -644,13 +644,13 @@ class TestThroughBinary(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn')
+            verify='ignore')
         votable.get_first_table().format = 'binary'
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='warn')
+        self.votable = parse(bio, verify='ignore')
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -673,7 +673,7 @@ class TestThroughBinary2(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            verify='warn')
+            verify='ignore')
         votable.version = '1.3'
         votable.get_first_table()._config['version_1_3_or_later'] = True
         votable.get_first_table().format = 'binary2'
@@ -681,7 +681,7 @@ class TestThroughBinary2(TestParse):
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, verify='warn')
+        self.votable = parse(bio, verify='ignore')
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -729,14 +729,14 @@ def test_open_files():
     for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if filename.endswith('custom_datatype.xml'):
             continue
-        parse(filename, verify='warn')
+        parse(filename, verify='ignore')
 
 
 @raises(VOTableSpecError)
 def test_too_many_columns():
     parse(
         get_pkg_data_filename('data/too_many_columns.xml.gz'),
-        verify='warn')
+        verify='ignore')
 
 
 def test_build_from_scratch(tmpdir):
@@ -839,7 +839,7 @@ def test_validate_path_object():
 def test_gzip_filehandles(tmpdir):
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        verify='warn')
+        verify='ignore')
 
     with open(str(tmpdir.join("regression.compressed.xml")), 'wb') as fd:
         votable.to_xml(
@@ -850,7 +850,7 @@ def test_gzip_filehandles(tmpdir):
     with open(str(tmpdir.join("regression.compressed.xml")), 'rb') as fd:
         votable = parse(
             fd,
-            verify='warn')
+            verify='ignore')
 
 
 def test_from_scratch_example():
@@ -910,14 +910,14 @@ def test_nonstandard_units():
 
     votable = parse(
         get_pkg_data_filename('data/nonstandard_units.xml'),
-        verify='warn')
+        verify='ignore')
 
     assert isinstance(
         votable.get_first_table().fields[0].unit, u.UnrecognizedUnit)
 
     votable = parse(
         get_pkg_data_filename('data/nonstandard_units.xml'),
-        verify='warn',
+        verify='ignore',
         unit_format='generic')
 
     assert not isinstance(
@@ -1012,7 +1012,7 @@ def test_instantiate_vowarning():
 def test_custom_datatype():
     votable = parse(
         get_pkg_data_filename('data/custom_datatype.xml'),
-        verify='warn',
+        verify='ignore',
         datatype_mapping={'bar': 'int'}
     )
 

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -50,7 +50,7 @@ def assert_validate_schema(filename, version):
 def test_parse_single_table():
     table = parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False)
+        verify='warn')
     assert isinstance(table, tree.Table)
     assert len(table.array) == 5
 
@@ -59,7 +59,7 @@ def test_parse_single_table2():
     table2 = parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
         table_number=1,
-        pedantic=False)
+        verify='warn')
     assert isinstance(table2, tree.Table)
     assert len(table2.array) == 1
     assert len(table2.array.dtype.names) == 28
@@ -69,14 +69,14 @@ def test_parse_single_table2():
 def test_parse_single_table3():
     parse_single_table(
         get_pkg_data_filename('data/regression.xml'),
-        table_number=3, pedantic=False)
+        table_number=3, verify='warn')
 
 
 def _test_regression(tmpdir, _python_based=False, binary_mode=1):
     # Read the VOTABLE
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False,
+        verify='warn',
         _debug_python_based_parser=_python_based)
     table = votable.get_first_table()
 
@@ -139,7 +139,7 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
                            votable.version)
     # Also try passing a file handle
     with open(str(tmpdir.join("regression.binary.xml")), "rb") as fd:
-        votable2 = parse(fd, pedantic=False,
+        votable2 = parse(fd, verify='warn',
                          _debug_python_based_parser=_python_based)
     votable2.get_first_table().format = 'tabledata'
     votable2.to_xml(str(tmpdir.join("regression.bin.tabledata.xml")),
@@ -198,7 +198,7 @@ class TestFixups:
     def setup_class(self):
         self.table = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False).get_first_table()
+            verify='warn').get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
 
@@ -211,7 +211,7 @@ class TestReferences:
     def setup_class(self):
         self.votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False)
+            verify='warn')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -252,7 +252,7 @@ def test_select_columns_by_index():
     columns = [0, 5, 13]
     table = parse(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False, columns=columns).get_first_table()
+        verify='warn', columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -266,7 +266,7 @@ def test_select_columns_by_name():
     columns = ['string_test', 'unsignedByte', 'bitarray']
     table = parse(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False, columns=columns).get_first_table()
+        verify='warn', columns=columns).get_first_table()
     array = table.array
     mask = table.array.mask
     assert array['string_test'][0] == b"String & test"
@@ -279,7 +279,7 @@ class TestParse:
     def setup_class(self):
         self.votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False)
+            verify='warn')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -611,12 +611,12 @@ class TestThroughTableData(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False)
+            verify='warn')
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, pedantic=False)
+        self.votable = parse(bio, verify='warn')
         self.table = self.votable.get_first_table()
         self.array = self.table.array
         self.mask = self.table.array.mask
@@ -644,13 +644,13 @@ class TestThroughBinary(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False)
+            verify='warn')
         votable.get_first_table().format = 'binary'
 
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, pedantic=False)
+        self.votable = parse(bio, verify='warn')
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -673,7 +673,7 @@ class TestThroughBinary2(TestParse):
     def setup_class(self):
         votable = parse(
             get_pkg_data_filename('data/regression.xml'),
-            pedantic=False)
+            verify='warn')
         votable.version = '1.3'
         votable.get_first_table()._config['version_1_3_or_later'] = True
         votable.get_first_table().format = 'binary2'
@@ -681,7 +681,7 @@ class TestThroughBinary2(TestParse):
         self.xmlout = bio = io.BytesIO()
         votable.to_xml(bio)
         bio.seek(0)
-        self.votable = parse(bio, pedantic=False)
+        self.votable = parse(bio, verify='warn')
 
         self.table = self.votable.get_first_table()
         self.array = self.table.array
@@ -729,14 +729,14 @@ def test_open_files():
     for filename in get_pkg_data_filenames('data', pattern='*.xml'):
         if filename.endswith('custom_datatype.xml'):
             continue
-        parse(filename, pedantic=False)
+        parse(filename, verify='warn')
 
 
 @raises(VOTableSpecError)
 def test_too_many_columns():
     parse(
         get_pkg_data_filename('data/too_many_columns.xml.gz'),
-        pedantic=False)
+        verify='warn')
 
 
 def test_build_from_scratch(tmpdir):
@@ -839,7 +839,7 @@ def test_validate_path_object():
 def test_gzip_filehandles(tmpdir):
     votable = parse(
         get_pkg_data_filename('data/regression.xml'),
-        pedantic=False)
+        verify='warn')
 
     with open(str(tmpdir.join("regression.compressed.xml")), 'wb') as fd:
         votable.to_xml(
@@ -850,7 +850,7 @@ def test_gzip_filehandles(tmpdir):
     with open(str(tmpdir.join("regression.compressed.xml")), 'rb') as fd:
         votable = parse(
             fd,
-            pedantic=False)
+            verify='warn')
 
 
 def test_from_scratch_example():
@@ -910,14 +910,14 @@ def test_nonstandard_units():
 
     votable = parse(
         get_pkg_data_filename('data/nonstandard_units.xml'),
-        pedantic=False)
+        verify='warn')
 
     assert isinstance(
         votable.get_first_table().fields[0].unit, u.UnrecognizedUnit)
 
     votable = parse(
         get_pkg_data_filename('data/nonstandard_units.xml'),
-        pedantic=False,
+        verify='warn',
         unit_format='generic')
 
     assert not isinstance(
@@ -1012,7 +1012,7 @@ def test_instantiate_vowarning():
 def test_custom_datatype():
     votable = parse(
         get_pkg_data_filename('data/custom_datatype.xml'),
-        pedantic=False,
+        verify='warn',
         datatype_mapping={'bar': 'int'}
     )
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1172,7 +1172,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         # actually contains character data.  We have to hack the field
         # to store character data, or we can't read it in.  A warning
         # will be raised when this happens.
-        if (config.get('verify') == 'warn' and name == 'cprojection' and
+        if (config.get('verify') != 'exception' and name == 'cprojection' and
             ID == 'cprojection' and ucd == 'VOX:WCS_CoordProjection' and
             datatype == 'double'):
             datatype = 'char'

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -268,9 +268,9 @@ def check_ucd(ucd, config=None, pos=None):
                 has_colon=config.get('version_1_2_or_later', False))
         except ValueError as e:
             # This weird construction is for Python 3 compatibility
-            if config.get('verify') == 'exception':
+            if config.get('verify', 'ignore') == 'exception':
                 vo_raise(W06, (ucd, str(e)), config, pos)
-            elif config.get('verify') == 'warn':
+            elif config.get('verify', 'ignore') == 'warn':
                 vo_warn(W06, (ucd, str(e)), config, pos)
                 return False
             else:
@@ -1172,7 +1172,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         # actually contains character data.  We have to hack the field
         # to store character data, or we can't read it in.  A warning
         # will be raised when this happens.
-        if (config.get('verify') != 'exception' and name == 'cprojection' and
+        if (config.get('verify', 'ignore') != 'exception' and name == 'cprojection' and
             ID == 'cprojection' and ucd == 'VOX:WCS_CoordProjection' and
             datatype == 'double'):
             datatype = 'char'

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -268,10 +268,12 @@ def check_ucd(ucd, config=None, pos=None):
                 has_colon=config.get('version_1_2_or_later', False))
         except ValueError as e:
             # This weird construction is for Python 3 compatibility
-            if config.get('pedantic'):
+            if config.get('pedantic') == 'exception':
                 vo_raise(W06, (ucd, str(e)), config, pos)
-            else:
+            elif config.get('pedantic') == 'warn':
                 vo_warn(W06, (ucd, str(e)), config, pos)
+                return False
+            else:
                 return False
     return True
 
@@ -1170,7 +1172,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         # actually contains character data.  We have to hack the field
         # to store character data, or we can't read it in.  A warning
         # will be raised when this happens.
-        if (not config.get('pedantic') and name == 'cprojection' and
+        if (config.get('pedantic') == 'warn' and name == 'cprojection' and
             ID == 'cprojection' and ucd == 'VOX:WCS_CoordProjection' and
             datatype == 'double'):
             datatype = 'char'

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -268,9 +268,9 @@ def check_ucd(ucd, config=None, pos=None):
                 has_colon=config.get('version_1_2_or_later', False))
         except ValueError as e:
             # This weird construction is for Python 3 compatibility
-            if config.get('pedantic') == 'exception':
+            if config.get('verify') == 'exception':
                 vo_raise(W06, (ucd, str(e)), config, pos)
-            elif config.get('pedantic') == 'warn':
+            elif config.get('verify') == 'warn':
                 vo_warn(W06, (ucd, str(e)), config, pos)
                 return False
             else:
@@ -1172,7 +1172,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         # actually contains character data.  We have to hack the field
         # to store character data, or we can't read it in.  A warning
         # will be raised when this happens.
-        if (config.get('pedantic') == 'warn' and name == 'cprojection' and
+        if (config.get('verify') == 'warn' and name == 'cprojection' and
             ID == 'cprojection' and ucd == 'VOX:WCS_CoordProjection' and
             datatype == 'double'):
             datatype = 'char'

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -163,7 +163,7 @@ class Result:
         with open(path, 'rb') as input:
             with warnings.catch_warnings(record=True) as warning_lines:
                 try:
-                    t = table.parse(input, pedantic=False, filename=path)
+                    t = table.parse(input, verify='warn', filename=path)
                 except (ValueError, TypeError, ExpatError) as e:
                     lines.append(str(e))
                     nexceptions += 1


### PR DESCRIPTION
This PR makes it possible to hide warnings when parsing VO tables, by replacing the boolean ``pedantic`` flag with a ``verify`` flag that can be ``ignore``, ``warn``, or ``exception`` (or should it be ``error``?)

In addition, as discussed in https://github.com/astropy/astropy/issues/8028, this makes ``ignore`` the default. I think in general we should move to a model where we don't give 25 warnings when reading in a table where these are fixed anyway and beyond the user's control (basically the [Robustness Principle](https://en.wikipedia.org/wiki/Robustness_principle) of being liberal in what you accept)

I've tagged various people I think might be interested. If we go ahead with this I think in another PR we should also change the default for FITS to not show fixable warnings on input.

EDIT: Fix #8028