### PR TITLE
Add DLLs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 *.so
 *.pyd
+*.dll
 __pycache__
 
 # Ignore .c files by default to avoid including generated code. If you want to


### PR DESCRIPTION
On Cygwin extension modules have a .dll extension, as opposed to .pyd.