### PR TITLE
Minor test fix for Cygwin: There were too many slashes in the file: URL

### DIFF
--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -650,7 +650,7 @@ class TestFileFunctions(FitsTestCase):
 
     def test_open_from_url(self):
         import urllib.request
-        file_url = "file:///" + self.data('test0.fits')
+        file_url = "file://" + self.data('test0.fits')
         with urllib.request.urlopen(file_url) as urlobj:
             with fits.open(urlobj) as fits_handle:
                 pass

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -650,7 +650,7 @@ class TestFileFunctions(FitsTestCase):
 
     def test_open_from_url(self):
         import urllib.request
-        file_url = "file://" + self.data('test0.fits')
+        file_url = 'file:///' +  self.data('test0.fits').lstrip('/')
         with urllib.request.urlopen(file_url) as urlobj:
             with fits.open(urlobj) as fits_handle:
                 pass


### PR DESCRIPTION
On most *nix this results in a file path starting with // where the extra superfluous
slash is ignored.  However, on Cygwin a path starting with // refers to a network
path.