### PR TITLE
Add examples for using dimensionless units

### DIFF
--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -82,6 +82,13 @@ Units that "cancel out" become a special unit called the
 
     >>> u.m / u.m
     Unit(dimensionless)
+    
+To create a simple :ref:`dimensionless quantity <doc_dimensionless_unit>`, 
+multiply a value by the unscaled dimensionless unit::
+
+    >>> q = 1.0 * u.dimensionless_unscaled
+    >>> q.unit
+    Unit(dimensionless)
 
 `astropy.units` is able to match compound units against the units it already
 knows about::

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -162,7 +162,24 @@ For example::
    Unit(dimensionless with a scale of 1000.0)
    >>> (u.km / u.m).decompose() == u.dimensionless_unscaled
    False
+   
+As an example of why you might want to create a scaled dimensionless
+quantity, say you will be doing many calculations with some big
+unitless number, ``big_unitless_num = 20000000  # 20 million``,
+but you want all of your answers to be in multiples of a million. This
+can be done by simply dividing ``big_unitless_num`` by ``1e6``, but this
+requires you to remember that this scaling factor has been applied,
+which may be difficult to do after many calculations. Instead, create
+a scaled dimensionless quantity by multiplying a value by ``Unit(scale)``
+to keep track of the scaling factor, e.g.::
 
+   >>> scale = 1e6
+   >>> big_unitless_num = 20 * u.Unit(scale)  # 20 million
+
+   >>> some_measurement = 5.0 * u.cm
+   >>> some_measurement * big_unitless_num  # doctest: +FLOAT_CMP
+   <Quantity 100. 1e+06 cm>
+     
 To determine if a unit is dimensionless (but regardless of the scale),
 use the `~astropy.units.core.UnitBase.physical_type` property::
 


### PR DESCRIPTION
As a user, I had some confusion when trying to use and create dimensionless quantities, and according to issue #5850 I'm not the only one. To help others like me, I've added an example of creating a dimensionless quantity and a link to the more detailed dimensionless quantities section to the top-level "Getting Started" astropy.units documentation. 

In the more detailed section on dimensionless quantities, I've also added an example of creating a _scaled_ dimensionless quantity and why you might want to do so (see the second half of [this comment](https://github.com/astropy/astropy/issues/5850#issuecomment-283091582)).

Let me know if my changes can be improved in any way!

EDIT: Fix #5850 

cc @bmorris3 and @eteq 