### PR TITLE
Make parallel tests insensitive to user configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Write configuration items to standard location to make sure they are ignored
+          name: Write configuration items to standard location to make sure they are ignored in parallel mode
           command: |
               mkdir -p $HOME/.astropy/config/
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Write configuration items to standard location to make sure they are ignored
+          command: |
+              mkdir -p $HOME/.astropy/config/
+              printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
+      - run:
           name: Install dependencies for Python 3.5
           command: /opt/python/cp35-cp35m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,6 +190,12 @@ before_install:
      # Check CC variable
     - echo $CC
 
+    # Write configuration items to standard location to make sure they are
+    # ignored (the tests will fail if not)
+    - mkdir -p $HOME/.astropy/config/
+    - printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
+
+
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -836,6 +836,9 @@ Other Changes and Additions
   time squared (division already correctly resulted in a dimensionless
   ``Quantity``). [#8356]
 
+- Made running the tests insensitive to local user configuration when running
+  the tests in parallel mode or directly with pytest. [#8727]
+
 Installation
 ^^^^^^^^^^^^
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -47,9 +47,9 @@ def pytest_configure(config):
         matplotlib.rcdefaults()
 
     # Make sure we use temporary directories for the config and cache
-    # so that the tests are insensitive to local configuration. We set this
-    # here and not in the test runner to make sure that it works even in e.g.
-    # parallel mode.
+    # so that the tests are insensitive to local configuration. Note that this
+    # is also set in the test runner, but we need to also set it here for
+    # things to work properly in parallel mode
 
     os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
     os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -51,6 +51,9 @@ def pytest_configure(config):
     # is also set in the test runner, but we need to also set it here for
     # things to work properly in parallel mode
 
+    builtins._xdg_config_home_orig = os.environ.get('XDG_CONFIG_HOME')
+    builtins._xdg_cache_home_orig = os.environ.get('XDG_CACHE_HOME')
+
     os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
     os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
 
@@ -65,8 +68,15 @@ def pytest_unconfigure(config):
         matplotlib.rcParams.update(matplotlibrc_cache)
         matplotlibrc_cache.clear()
 
-    os.environ.pop('XDG_CONFIG_HOME')
-    os.environ.pop('XDG_CACHE_HOME')
+    if builtins._xdg_config_home_orig is None:
+        os.environ.pop('XDG_CONFIG_HOME')
+    else:
+        os.environ['XDG_CONFIG_HOME'] = builtins._xdg_config_home_orig
+
+    if builtins._xdg_cache_home_orig is None:
+        os.environ.pop('XDG_CACHE_HOME')
+    else:
+        os.environ['XDG_CACHE_HOME'] = builtins._xdg_cache_home_orig
 
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -224,8 +224,13 @@ class TestRunnerBase:
         else:
             plugins = []
 
-        # override the config locations to not make a new directory nor use
-        # existing cache or config
+        # Override the config locations to not make a new directory nor use
+        # existing cache or config. Note that we need to do this here in
+        # addition to in conftest.py - for users running tests interactively
+        # in e.g. IPython, conftest.py would get read in too late, so we need
+        # to do it here - but at the same time the code here doesn't work when
+        # running tests in parallel mode because this uses subprocesses which
+        # don't know about the temporary config/cache.
         astropy_config = tempfile.mkdtemp('astropy_config')
         astropy_cache = tempfile.mkdtemp('astropy_cache')
 

--- a/conftest.py
+++ b/conftest.py
@@ -18,3 +18,8 @@ os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
 
 os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
 os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
+
+# Note that we don't need to change the environment variables back or remove
+# them after testing, because they are only changed for the duration of the
+# Python process, and this configuration only matters if running pytest
+# directly, not from e.g. an IPython session.

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,20 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+# This file is the main file used when running tests with pytest directly,
+# in particular if running e.g. ``pytest docs/``.
+
+import os
+import tempfile
+
 pytest_plugins = [
     'astropy.tests.plugins.display',
 ]
+
+# Make sure we use temporary directories for the config and cache
+# so that the tests are insensitive to local configuration.
+
+os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
+os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
+
+os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
+os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# This file needs to be included here to make sure commands such
+# as ``python setup.py test ... -t docs/...`` works, since this
+# will ignore the conftest.py file at the root of the repository
+# and the one in astropy/conftest.py
+
+import os
+import tempfile
+
+pytest_plugins = [
+    'astropy.tests.plugins.display',
+]
+
+# Make sure we use temporary directories for the config and cache
+# so that the tests are insensitive to local configuration.
+
+os.environ['XDG_CONFIG_HOME'] = tempfile.mkdtemp('astropy_config')
+os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
+
+os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
+os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -16,3 +16,8 @@ os.environ['XDG_CACHE_HOME'] = tempfile.mkdtemp('astropy_cache')
 
 os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
 os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
+
+# Note that we don't need to change the environment variables back or remove
+# them after testing, because they are only changed for the duration of the
+# Python process, and this configuration only matters if running pytest
+# directly, not from e.g. an IPython session.

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -8,10 +8,6 @@
 import os
 import tempfile
 
-pytest_plugins = [
-    'astropy.tests.plugins.display',
-]
-
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/astropy/astropy/issues/8691 - I discovered that when run in parallel mode, the user configuration is **not** ignored.

The first step here is to add a regression test by writing out to the config file before running the parallel tests on CircleCI. This failed, so I'm now pushing some fixes.

It turns out there are several places where we need to set the config/cache to be temporary directories, not just in the test runner:

* ``astropy/conftest.py`` - we need to set the path to the temporary config/cache directories here for cases when running the tests in parallel mode using e.g.

```
python setup.py test --parallel
```

This is because pytest starts up new subprocesses, which aren't aware of the temporary directories set in the test runner.

* ``conftest.py`` - the temporary paths need to be set here for when pytest is run directly on an astropy package, e.g.

```
pytest astropy/io/votable
```

* ``docs/conftest.py`` - we also need to set them here for when running the tests with ``python setup.py test -t docs/...`` since then the root-level ``conftest.py`` gets ignored (since the tests run from outside the source directory, and ``astropy/conftest.py`` gets ignored since we are only testing things in ``docs``

This will become simpler some day if we switch to only using ``pytest`` directly.

Fixes https://github.com/astropy/astropy/issues/8154
