### PR TITLE
Remove test of erfa ufunc signature.

### DIFF
--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -2,16 +2,8 @@
 
 import numpy as np
 
-from astropy._erfa import core as erfa, ufunc as erfa_ufunc
+from astropy._erfa import core as erfa
 from astropy.tests.helper import catch_warnings
-from astropy.utils.compat import NUMPY_LT_1_16
-
-
-def test_output_dim_3_signature():
-    if NUMPY_LT_1_16:
-        assert erfa_ufunc.c2i00a.signature == "(),()->(d3, d3)"
-    else:
-        assert erfa_ufunc.c2i00a.signature == "(),()->(3, 3)"
 
 
 def test_erfa_wrapper():


### PR DESCRIPTION
The problem was that this tests what numpy the functions are compiled with, which can be a lower version than the one we're running on.

fixes #8672