### PR TITLE
Pin Matplotlib to <3.1 on CircleCI for docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install "numpydoc<0.9 matplotlib<3.1"
+            pip install "numpydoc<0.9" "matplotlib<3.1"
             pip install .[docs,all]
       - run:
           name: Build Docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,10 +95,12 @@ jobs:
             sudo apt install -y graphviz
       - run:
           name: Install Python dependencies
+          # NOTE: we pin matplotlib below due to a bug that affects plotting of
+          # quantities: https://github.com/matplotlib/matplotlib/issues/14274
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install "numpydoc<0.9"
+            pip install "numpydoc<0.9 matplotlib<3.1"
             pip install .[docs,all]
       - run:
           name: Build Docs


### PR DESCRIPTION
This is needed because Matplotlib 3.1.0 has a bug that causes plotting of quantities to be really slow (https://github.com/matplotlib/matplotlib/issues/14274). This should fix the HTML build.

I decided to not pin this on RTD for now (which would require actually changing this in ``setup.cfg``) as I think as long as we don't wipe the environment on RTD matplotlib won't get updated to 3.1