### PR TITLE
Fix the conversion of bytes values `Table.tolist`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -288,6 +288,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fix the conversion of bytes values to Python ``str`` with ``Table.tolist``.
+  [#8739]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -760,6 +760,12 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         return value
 
+    def tolist(self):
+        if self.dtype.kind == 'S':
+            return np.chararray.decode(self, encoding='utf-8').tolist()
+        else:
+            return super().tolist()
+
 
 class Column(BaseColumn):
     """Define a data column for use in a Table object.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2287,3 +2287,24 @@ def test_key_values_in_as_array():
     # Comparing initialised array with sliced array using Table.as_array()
     assert np.array_equal(a, t1.as_array(names=['a', 'b']))
     assert np.array_equal(b, t1.as_array(names=['c']))
+
+
+def test_tolist():
+    t = table.Table([[1, 2, 3], [1.1, 2.2, 3.3], [b'foo', b'bar', b'hello']],
+                    names=('a', 'b', 'c'))
+    assert t['a'].tolist() == [1, 2, 3]
+    assert_array_equal(t['b'].tolist(), [1.1, 2.2, 3.3])
+    assert t['c'].tolist() == ['foo', 'bar', 'hello']
+
+    assert isinstance(t['a'].tolist()[0], int)
+    assert isinstance(t['b'].tolist()[0], float)
+    assert isinstance(t['c'].tolist()[0], str)
+
+    t = table.Table([[[1, 2], [3, 4]],
+                     [[b'foo', b'bar'], [b'hello', b'world']]],
+                    names=('a', 'c'))
+
+    assert t['a'].tolist() == [[1, 2], [3, 4]]
+    assert t['c'].tolist() == [['foo', 'bar'], ['hello', 'world']]
+    assert isinstance(t['a'].tolist()[0][0], int)
+    assert isinstance(t['c'].tolist()[0][0], str)


### PR DESCRIPTION
Fix #8721, with the fix suggested by @taldcroft.

I put the changelog entry for 3.2.1 as it is not a blocker, but I would be happy to get this in 3.2 ;).