### PR TITLE
Table no longer access variable length VO table as bytes string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -374,6 +374,8 @@ astropy.table
 
 - Removed the non-public method ``astropy.table.np_utils.recarray_fromrecords``.
   [#9165]
+- Accessing variable length columns from VO table no longer returns bytes
+  string type. [#????]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -374,8 +374,11 @@ astropy.table
 
 - Removed the non-public method ``astropy.table.np_utils.recarray_fromrecords``.
   [#9165]
-- Accessing variable length columns from VO table no longer returns bytes
-  string type. [#????]
+
+- Table item access behavior of a ``Column`` with ``bytes`` data type has
+  changed in a way that it looks like ``str`` when accessed. This change is
+  necessary so that a variable length column in a VO table no longer returns
+  ``bytes`` string type. [#8745]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -270,3 +270,8 @@ def test_gemini_v1_2():
     '''
     table = parse_single_table(get_pkg_data_filename('data/gemini.xml'))
     assert table is not None
+
+    tt = table.to_table()
+    assert tt['access_url'][0] == (
+        'http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEMINI/'
+        'S20120515S0064?runid=bx9b1o8cvk1qesrt')

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -31,7 +31,7 @@ def test_table(tmpdir):
     t = votable2.get_first_table()
 
     field_types = [
-        ('string_test', {'datatype': 'char', 'arraysize': '*'}),
+        ('string_test', {'datatype': 'unicodeChar', 'arraysize': '*'}),
         ('string_test_2', {'datatype': 'char', 'arraysize': '10'}),
         ('unicode_test', {'datatype': 'unicodeChar', 'arraysize': '*'}),
         ('fixed_unicode_test', {'datatype': 'unicodeChar', 'arraysize': '10'}),
@@ -63,7 +63,7 @@ def test_table(tmpdir):
     for field, type in zip(t.fields, field_types):
         name, d = type
         assert field.ID == name
-        assert field.datatype == d['datatype']
+        assert field.datatype == d['datatype'], '{} expected {} but get {}'.format(name, d['datatype'], field.datatype)  # noqa
         if 'arraysize' in d:
             assert field.arraysize == d['arraysize']
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -63,7 +63,7 @@ def test_table(tmpdir):
     for field, type in zip(t.fields, field_types):
         name, d = type
         assert field.ID == name
-        assert field.datatype == d['datatype'], '{} expected {} but get {}'.format(name, d['datatype'], field.datatype)  # noqa
+        assert field.datatype == d['datatype'], f'{name} expected {d["datatype"]} but get {field.datatype}'  # noqa
         if 'arraysize' in d:
             assert field.arraysize == d['arraysize']
 

--- a/astropy/table/_column_mixins.pyx
+++ b/astropy/table/_column_mixins.pyx
@@ -57,7 +57,8 @@ cdef inline object base_getitem(object self, object item, item_getter getitem):
     value = getitem(self, item)
 
     try:
-        if value.dtype.char == 'S' and not value.shape:
+        if (isinstance(value, bytes) or
+                (value.dtype.char == 'S' and not value.shape)):
             value = value.decode('utf-8', errors='replace')
     except AttributeError:
         pass

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import operator
 
 import pytest
@@ -676,6 +675,25 @@ def test_col_unicode_sandwich_create_from_str(Column):
     assert isinstance(c[0], str)
     assert isinstance(c[:0], table.Column)
     assert np.all(c[:2] == np.array([uba, 'def']))
+
+
+@pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))
+def test_col_unicode_sandwich_bytes_obj(Column):
+    """
+    Create a Column of dtype object with bytestring in it and make sure
+    it keeps the bytestring and not convert to str with accessed.
+
+    See https://github.com/astropy/astropy/pull/8745
+    """
+    c = Column([None, b'def'])
+    assert c.dtype.char == 'O'
+    assert not c[0]
+    assert c[1] == 'def'  # Was b'def' before PR 8745
+    assert isinstance(c[1], str)  # Was bytes before PR 8745
+    assert not isinstance(c[1], bytes)  # Was str before PR 8745
+    assert isinstance(c[:0], table.Column)
+    assert np.all(c[:2] == np.array([None, b'def']))
+    assert not np.all(c[:2] == np.array([None, 'def']))
 
 
 @pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))


### PR DESCRIPTION
Fix #8716 . This does change a subtle behavior, so it should only go into a major release.

I suspect it would affect packages downstream, e.g., `astroquery.vo_conesearch` or whoever is parsing VO table using `Table.read()` and then decoding bytes to UTF-8 themselves.

Fun fact: Incidentally, I have just tagged all four Toms for review!

TODO:
- [ ] Discuss whether this is the correct approach and the possible side effects (breaking behavior, memory usage, performance).
- [x] Add PR number to change log.