### PR TITLE
Add support for the new clip ufunc in numpy >=1.17

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -311,6 +311,10 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Add support for the ``clip`` ufunc, which in numpy 1.17 is used to implement
+  ``np.clip``.  As part of that, remove the ``Quantity.clip`` method under
+  numpy 1.17. [#8747]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -683,3 +683,7 @@ class FunctionQuantity(Quantity):
 
     def cumsum(self, axis=None, dtype=None, out=None):
         return self._wrap_function(np.cumsum, axis, dtype, out=out)
+
+    def clip(self, a_min, a_max, out=None):
+        return self._wrap_function(np.clip, self._to_own_unit(a_min),
+                                   self._to_own_unit(a_max), out=out)

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -496,11 +496,10 @@ class TestQuantityOperations:
 
     def test_non_number_type(self):
         q1 = u.Quantity(11.412, unit=u.meter)
-        type_err_msg = ("Unsupported operand type(s) for ufunc add: "
-                        "'Quantity' and 'dict'")
         with pytest.raises(TypeError) as exc:
             q1 + {'a': 1}
-        assert exc.value.args[0] == type_err_msg
+        assert exc.value.args[0].startswith(
+            "Unsupported operand type(s) for ufunc add:")
 
         with pytest.raises(TypeError):
             q1 + u.meter

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -868,6 +868,92 @@ class TestInplaceUfuncs:
             a4 += u.Quantity(10, u.mm, dtype=np.int64)
 
 
+@pytest.mark.skipif(not hasattr(np.core.umath, 'clip'),
+                    reason='no clip ufunc available')
+class TestClip:
+    """Test the clip ufunc.
+
+    In numpy, this is hidden behind a function that does not backwards
+    compatibility checks.  We explicitly test the ufunc here.
+    """
+    def setup(self):
+        self.clip = np.core.umath.clip
+
+    def test_clip_simple(self):
+        q = np.arange(-1., 10.) * u.m
+        q_min = 125 * u.cm
+        q_max = 0.0055 * u.km
+        result = self.clip(q, q_min, q_max)
+        assert result.unit == q.unit
+        expected = self.clip(q.value, q_min.to_value(q.unit),
+                             q_max.to_value(q.unit)) * q.unit
+        assert np.all(result == expected)
+
+    def test_clip_unitless_parts(self):
+        q = np.arange(-1., 10.) * u.m
+        qlim = 0.0055 * u.km
+        # one-sided
+        result1 = self.clip(q, -np.inf, qlim)
+        expected1 = self.clip(q.value, -np.inf, qlim.to_value(q.unit)) * q.unit
+        assert np.all(result1 == expected1)
+        result2 = self.clip(q, qlim, np.inf)
+        expected2 = self.clip(q.value, qlim.to_value(q.unit), np.inf) * q.unit
+        assert np.all(result2 == expected2)
+        # Zero
+        result3 = self.clip(q, np.zeros(q.shape), qlim)
+        expected3 = self.clip(q.value, 0, qlim.to_value(q.unit)) * q.unit
+        assert np.all(result3 == expected3)
+        # Two unitless parts, array-shaped.
+        result4 = self.clip(q, np.zeros(q.shape), np.full(q.shape, np.inf))
+        expected4 = self.clip(q.value, 0, np.inf) * q.unit
+        assert np.all(result4 == expected4)
+
+    def test_clip_dimensionless(self):
+        q = np.arange(-1., 10.) * u.dimensionless_unscaled
+        result = self.clip(q, 200 * u.percent, 5.)
+        expected = self.clip(q, 2., 5.)
+        assert result.unit == u.dimensionless_unscaled
+        assert np.all(result == expected)
+
+    def test_clip_ndarray(self):
+        a = np.arange(-1., 10.)
+        result = self.clip(a, 200 * u.percent, 5. * u.dimensionless_unscaled)
+        assert isinstance(result, u.Quantity)
+        expected = self.clip(a, 2., 5.) * u.dimensionless_unscaled
+        assert np.all(result == expected)
+
+    def test_clip_quantity_inplace(self):
+        q = np.arange(-1., 10.) * u.m
+        q_min = 125 * u.cm
+        q_max = 0.0055 * u.km
+        expected = self.clip(q.value, q_min.to_value(q.unit),
+                             q_max.to_value(q.unit)) * q.unit
+        result = self.clip(q, q_min, q_max, out=q)
+        assert result is q
+        assert np.all(result == expected)
+
+    def test_clip_ndarray_dimensionless_output(self):
+        a = np.arange(-1., 10.)
+        q = np.zeros_like(a) * u.m
+        expected = self.clip(a, 2., 5.) * u.dimensionless_unscaled
+        result = self.clip(a, 200 * u.percent, 5. * u.dimensionless_unscaled,
+                           out=q)
+        assert result is q
+        assert result.unit == u.dimensionless_unscaled
+        assert np.all(result == expected)
+
+    def test_clip_errors(self):
+        q = np.arange(-1., 10.) * u.m
+        with pytest.raises(u.UnitsError):
+            self.clip(q, 0, 1*u.s)
+        with pytest.raises(u.UnitsError):
+            self.clip(q.value, 0, 1*u.s)
+        with pytest.raises(u.UnitsError):
+            self.clip(q, -1, 0.)
+        with pytest.raises(u.UnitsError):
+            self.clip(q, 0., 1.)
+
+
 class TestUfuncAt:
     """Test that 'at' method for ufuncs (calculates in-place at given indices)
 

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,7 +7,7 @@ from astropy.utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
-           'NUMPY_LT_1_16']
+           'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -16,3 +16,4 @@ NUMPY_LT_1_14 = not minversion('numpy', '1.14')
 NUMPY_LT_1_14_1 = not minversion('numpy', '1.14.1')
 NUMPY_LT_1_14_2 = not minversion('numpy', '1.14.2')
 NUMPY_LT_1_16 = not minversion('numpy', '1.16')
+NUMPY_LT_1_17 = not minversion('numpy', '1.17')


### PR DESCRIPTION
fixes #8712 

Since this is the first three-argument ufunc, it caused a bit more trouble than hoped...

In principle, could go into 3.2 still if wanted. Since numpy 1.17 doesn't officially support python 2 any more, we don't need to backport to 2.0.