### PR TITLE
TST: Get rid of time test warnings

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1522,7 +1522,8 @@ def test_strptime_leapsecond():
 
 def test_strptime_3_digit_year():
     time_obj1 = Time('0995-12-31T00:00:00', format='isot', scale='tai')
-    time_obj2 = Time.strptime('0995-Dec-31 00:00:00', '%Y-%b-%d %H:%M:%S')
+    time_obj2 = Time.strptime('0995-Dec-31 00:00:00', '%Y-%b-%d %H:%M:%S',
+                              scale='tai')
 
     assert time_obj1 == time_obj2
 

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -8,7 +8,7 @@ import numpy as np
 from astropy.time import Time, TimeDelta
 
 
-class TestTimeComparisons():
+class TestTimeComparisons:
     """Test Comparisons of Time and TimeDelta classes"""
 
     def setup(self):

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -6,13 +6,14 @@ from astropy.coordinates import EarthLocation, SkyCoord, solar_system_ephemeris
 from astropy.time import Time, TimeDelta
 
 try:
-    import jplephem  # pylint: disable=W0611
+    import jplephem  # pylint: disable=W0611  # noqa
 except ImportError:
     HAS_JPLEPHEM = False
 else:
     HAS_JPLEPHEM = True
 
 
+@pytest.mark.remote_data
 class TestHelioBaryCentric():
     """
     Verify time offsets to the solar system barycentre and the heliocentre.
@@ -26,7 +27,8 @@ class TestHelioBaryCentric():
         wht = EarthLocation(342.12*u.deg, 28.758333333333333*u.deg, 2327*u.m)
         self.obstime = Time("2013-02-02T23:00", location=wht)
         self.obstime2 = Time("2013-08-02T23:00", location=wht)
-        self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"], location=wht)
+        self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"],
+                               location=wht)
         self.star = SkyCoord("08:08:08 +32:00:00", unit=(u.hour, u.degree),
                              frame='icrs')
 
@@ -54,12 +56,12 @@ class TestHelioBaryCentric():
         assert bval_arr[0]-bval1 < 1. * u.us
         assert bval_arr[1]-bval2 < 1. * u.us
 
-    @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')
     def test_ephemerides(self):
         bval1 = self.obstime.light_travel_time(self.star, 'barycentric')
         with solar_system_ephemeris.set('jpl'):
-            bval2 = self.obstime.light_travel_time(self.star, 'barycentric', ephemeris='jpl')
+            bval2 = self.obstime.light_travel_time(self.star, 'barycentric',
+                                                   ephemeris='jpl')
         # should differ by less than 0.1 ms, but not be the same
         assert abs(bval1 - bval2) < 1. * u.ms
         assert abs(bval1 - bval2) > 1. * u.us

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -9,7 +9,8 @@ import pytest
 from datetime import timedelta
 
 from astropy.time import (Time, TimeDelta, OperandTypeError, ScaleValueError,
-                TIME_SCALES, STANDARD_TIME_SCALES, TIME_DELTA_SCALES)
+                          TIME_SCALES, STANDARD_TIME_SCALES, TIME_DELTA_SCALES)
+from astropy.utils.exceptions import ErfaWarning
 from astropy import units as u
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
@@ -79,15 +80,18 @@ class TestTimeDelta():
         dt = TimeDelta(100.0, format='jd')
         dt2 = TimeDelta([100.0, 200.0], format='jd')
 
-        out = t + dt
+        with pytest.warns(ErfaWarning):
+            out = t + dt
         assert allclose_jd(out.mjd, 100.0)
         assert out.isscalar
 
-        out = t + dt2
+        with pytest.warns(ErfaWarning):
+            out = t + dt2
         assert allclose_jd(out.mjd, [100.0, 200.0])
         assert not out.isscalar
 
-        out = t2 + dt
+        with pytest.warns(ErfaWarning):
+            out = t2 + dt
         assert allclose_jd(out.mjd, [100.0, 101.0])
         assert not out.isscalar
 
@@ -100,15 +104,18 @@ class TestTimeDelta():
         assert not out.isscalar
 
         # Reverse the argument order
-        out = dt + t
+        with pytest.warns(ErfaWarning):
+            out = dt + t
         assert allclose_jd(out.mjd, 100.0)
         assert out.isscalar
 
-        out = dt2 + t
+        with pytest.warns(ErfaWarning):
+            out = dt2 + t
         assert allclose_jd(out.mjd, [100.0, 200.0])
         assert not out.isscalar
 
-        out = dt + t2
+        with pytest.warns(ErfaWarning):
+            out = dt + t2
         assert allclose_jd(out.mjd, [100.0, 101.0])
         assert not out.isscalar
 
@@ -124,15 +131,18 @@ class TestTimeDelta():
         dt = TimeDelta(100.0, format='jd')
         dt2 = TimeDelta([100.0, 200.0], format='jd')
 
-        out = t - dt
+        with pytest.warns(ErfaWarning):
+            out = t - dt
         assert allclose_jd(out.mjd, -100.0)
         assert out.isscalar
 
-        out = t - dt2
+        with pytest.warns(ErfaWarning):
+            out = t - dt2
         assert allclose_jd(out.mjd, [-100.0, -200.0])
         assert not out.isscalar
 
-        out = t2 - dt
+        with pytest.warns(ErfaWarning):
+            out = t2 - dt
         assert allclose_jd(out.mjd, [-100.0, -99.0])
         assert not out.isscalar
 
@@ -195,6 +205,7 @@ class TestTimeDelta():
         with pytest.raises(TypeError):
             self.dt * object()
 
+    @pytest.mark.remote_data
     def test_keep_properties(self):
         # closes #1924 (partially)
         dt = TimeDelta(1000., format='sec')
@@ -276,6 +287,7 @@ class TestTimeDeltaScales():
         with pytest.raises(ScaleValueError):
             TimeDelta([0., 1., 10.], format='sec', scale='utc')
 
+    @pytest.mark.remote_data
     @pytest.mark.parametrize(('scale1', 'scale2'),
                              list(itertools.product(STANDARD_TIME_SCALES,
                                                     STANDARD_TIME_SCALES)))

--- a/astropy/time/tests/test_guess.py
+++ b/astropy/time/tests/test_guess.py
@@ -5,7 +5,7 @@ import pytest
 from astropy.time import Time
 
 
-class TestGuess():
+class TestGuess:
     """Test guessing the input value format"""
 
     def test_guess1(self):

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -3,20 +3,21 @@
 import functools
 import numpy as np
 
+from astropy.io.fits.verify import VerifyWarning
 from astropy.utils.compat import NUMPY_LT_1_14
 from astropy.tests.helper import pytest
 from astropy.time import Time
 from astropy.table import Table
 
 try:
-    import h5py  # pylint: disable=W0611
+    import h5py  # pylint: disable=W0611  # noqa
 except ImportError:
     HAS_H5PY = False
 else:
     HAS_H5PY = True
 
 try:
-    import yaml  # pylint: disable=W0611
+    import yaml  # pylint: disable=W0611  # noqa
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -94,6 +95,7 @@ def test_str():
     assert t.masked is False
 
 
+@pytest.mark.remote_data
 def test_transform():
     t = Time(['2000:001', '2000:002'])
     t[1] = np.ma.masked
@@ -113,8 +115,10 @@ def test_transform():
 
 def test_masked_input():
     v0 = np.ma.MaskedArray([[1, 2], [3, 4]])  # No masked elements
-    v1 = np.ma.MaskedArray([[1, 2], [3, 4]], mask=[[True, False], [False, False]])
-    v2 = np.ma.MaskedArray([[10, 20], [30, 40]], mask=[[False, False], [False, True]])
+    v1 = np.ma.MaskedArray([[1, 2], [3, 4]],
+                           mask=[[True, False], [False, False]])
+    v2 = np.ma.MaskedArray([[10, 20], [30, 40]],
+                           mask=[[False, False], [False, True]])
 
     # Init from various combinations of masked arrays
     t = Time(v0, format='cxcsec')
@@ -158,7 +162,8 @@ def test_serialize_fits_masked(tmpdir):
     fn = str(tmpdir.join('tempfile.fits'))
     t = Table([tm])
     t.write(fn)
-    t2 = Table.read(fn, astropy_native=True)
+    with pytest.warns(VerifyWarning):
+        t2 = Table.read(fn, astropy_native=True)
 
     # Time FITS handling does not current round-trip format in FITS
     t2['col0'].format = tm.format

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -7,6 +7,7 @@ import pytest
 import numpy as np
 
 from astropy.time import Time
+from astropy.utils import iers
 
 
 @pytest.fixture(scope="module", params=[True, False])
@@ -17,7 +18,7 @@ def masked(request):
     yield use_masked_data
 
 
-class TestManipulation():
+class TestManipulation:
     """Manipulation of Time objects, ensuring attributes are done correctly."""
 
     def setup(self):
@@ -291,7 +292,7 @@ class TestManipulation():
         assert np.may_share_memory(t2_broadcast.location, self.t2.location)
 
 
-class TestArithmetic():
+class TestArithmetic:
     """Arithmetic on Time objects, using both doubles."""
     kwargs = ({}, {'axis': None}, {'axis': 0}, {'axis': 1}, {'axis': 2})
     functions = ('min', 'max', 'sort')
@@ -420,16 +421,16 @@ class TestArithmetic():
             assert np.all(self.t0.sort(-1)[:, :, -1] == self.t0.max(-1))
 
 
-@pytest.mark.remote_data
 def test_regression():
     # For #5225, where a time with a single-element delta_ut1_utc could not
     # be copied, flattened, or ravelled. (For copy, it is in test_basic.)
-    t = Time(49580.0, scale='tai', format='mjd')
-    t_ut1 = t.ut1
-    t_ut1_copy = copy.deepcopy(t_ut1)
-    assert type(t_ut1_copy.delta_ut1_utc) is np.ndarray
-    t_ut1_flatten = t_ut1.flatten()
-    assert type(t_ut1_flatten.delta_ut1_utc) is np.ndarray
-    t_ut1_ravel = t_ut1.ravel()
-    assert type(t_ut1_ravel.delta_ut1_utc) is np.ndarray
-    assert t_ut1_copy.delta_ut1_utc == t_ut1.delta_ut1_utc
+    with iers.conf.set_temp('auto_download', False):
+        t = Time(49580.0, scale='tai', format='mjd')
+        t_ut1 = t.ut1
+        t_ut1_copy = copy.deepcopy(t_ut1)
+        assert type(t_ut1_copy.delta_ut1_utc) is np.ndarray
+        t_ut1_flatten = t_ut1.flatten()
+        assert type(t_ut1_flatten.delta_ut1_utc) is np.ndarray
+        t_ut1_ravel = t_ut1.ravel()
+        assert type(t_ut1_ravel.delta_ut1_utc) is np.ndarray
+        assert t_ut1_copy.delta_ut1_utc == t_ut1.delta_ut1_utc

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -420,6 +420,7 @@ class TestArithmetic():
             assert np.all(self.t0.sort(-1)[:, :, -1] == self.t0.max(-1))
 
 
+@pytest.mark.remote_data
 def test_regression():
     # For #5225, where a time with a single-element delta_ut1_utc could not
     # be copied, flattened, or ravelled. (For copy, it is in test_basic.)

--- a/astropy/time/tests/test_pickle.py
+++ b/astropy/time/tests/test_pickle.py
@@ -6,7 +6,7 @@ import numpy as np
 from astropy.time import Time
 
 
-class TestPickle():
+class TestPickle:
     """Basic pickle test of time"""
 
     def test_pickle(self):

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 
 from astropy.time import Time, TimeDelta
+from astropy.utils import iers
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
@@ -33,7 +34,8 @@ def test_addition():
     t_dt = t + dt_tiny
     assert t_dt.jd1 == t.jd1 and t_dt.jd2 != t.jd2
 
-    # Check that the addition is exactly reversed by the corresponding subtraction
+    # Check that the addition is exactly reversed by the corresponding
+    # subtraction
     t2 = t_dt - dt_tiny
     assert t2.jd1 == t.jd1 and t2.jd2 == t.jd2
 
@@ -62,8 +64,9 @@ def test_init_variations():
 
 def test_precision_exceeds_64bit():
     """
-    Check that Time object really holds more precision than float64 by looking at the
-    (naively) summed 64-bit result and asserting equality at the bit level.
+    Check that Time object really holds more precision than float64 by looking
+    at the (naively) summed 64-bit result and asserting equality at the
+    bit level.
     """
     t1 = Time(1.23456789e11, format='cxcsec')
     t2 = t1 + dt_tiny
@@ -101,9 +104,9 @@ def test_jd1_is_mult_of_one():
 @pytest.mark.xfail
 def test_precision_neg():
     """
-    Check precision when jd1 is negative.  Currently fails because ERFA routines use a
-    test like jd1 > jd2 to decide which component to update.  Should be
-    abs(jd1) > abs(jd2).
+    Check precision when jd1 is negative.  Currently fails because ERFA
+    routines use a test like jd1 > jd2 to decide which component to update.
+    Should be abs(jd1) > abs(jd2).
     """
     t1 = Time(-100000.123456, format='jd', scale='tt')
     assert np.round(t1.jd1) == t1.jd1
@@ -122,12 +125,12 @@ def test_precision_epoch():
     assert allclose_sec(dt.sec, np.round(dt.sec))
 
 
-@pytest.mark.remote_data
 def test_leap_seconds_rounded_correctly():
     """Regression tests against #2083, where a leap second was rounded
     incorrectly by the underlying ERFA routine."""
-    t = Time(['2012-06-30 23:59:59.413',
-              '2012-07-01 00:00:00.413'], scale='ut1', precision=3).utc
-    assert np.all(t.iso == np.array(['2012-06-30 23:59:60.000',
-                                     '2012-07-01 00:00:00.000']))
+    with iers.conf.set_temp('auto_download', False):
+        t = Time(['2012-06-30 23:59:59.413',
+                  '2012-07-01 00:00:00.413'], scale='ut1', precision=3).utc
+        assert np.all(t.iso == np.array(['2012-06-30 23:59:60.000',
+                                         '2012-07-01 00:00:00.000']))
     # with the bug, both yielded '2012-06-30 23:59:60.000'

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -122,6 +122,7 @@ def test_precision_epoch():
     assert allclose_sec(dt.sec, np.round(dt.sec))
 
 
+@pytest.mark.remote_data
 def test_leap_seconds_rounded_correctly():
     """Regression tests against #2083, where a leap second was rounded
     incorrectly by the underlying ERFA routine."""

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -12,7 +12,7 @@ allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol
 
 
-class TestTimeQuantity():
+class TestTimeQuantity:
     """Test Interaction of Time with Quantities"""
 
     def test_valid_quantity_input(self):
@@ -101,7 +101,7 @@ class TestTimeQuantity():
             Time(100000., format='cxcsec') > 10.*u.second
 
 
-class TestTimeDeltaQuantity():
+class TestTimeDeltaQuantity:
     """Test interaction of TimeDelta with Quantities"""
     def test_valid_quantity_input(self):
         """Test that TimeDelta can take quantity input."""
@@ -262,7 +262,7 @@ class TestTimeDeltaQuantity():
             t0 + np.arange(4.) * u.s
 
 
-class TestDeltaAttributes():
+class TestDeltaAttributes:
     def test_delta_ut1_utc(self):
         t = Time('2010-01-01 00:00:00', format='iso', scale='utc', precision=6)
         t.delta_ut1_utc = 0.3 * u.s

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -75,6 +75,7 @@ class TestST():
                '2012-07-01 12:00:00'], scale='utc')
     t2 = Time(t1, location=('120d', '10d'))
 
+    @pytest.mark.remote_data
     def test_gmst(self):
         """Compare Greenwich Mean Sidereal Time with what was found earlier
         """
@@ -84,6 +85,7 @@ class TestST():
         gmst = self.t1.sidereal_time('mean', 'greenwich')
         assert allclose_hours(gmst.value, gmst_compare)
 
+    @pytest.mark.remote_data
     def test_gst(self):
         """Compare Greenwich Apparent Sidereal Time with what was found earlier
         """
@@ -93,18 +95,21 @@ class TestST():
         gst = self.t1.sidereal_time('apparent', 'greenwich')
         assert allclose_hours(gst.value, gst_compare)
 
+    @pytest.mark.remote_data
     def test_gmst_gst_close(self):
         """Check that Mean and Apparent are within a few seconds."""
         gmst = self.t1.sidereal_time('mean', 'greenwich')
         gst = self.t1.sidereal_time('apparent', 'greenwich')
         assert within_2_seconds(gst.value, gmst.value)
 
+    @pytest.mark.remote_data
     def test_gmst_independent_of_self_location(self):
         """Check that Greenwich time does not depend on self.location"""
         gmst1 = self.t1.sidereal_time('mean', 'greenwich')
         gmst2 = self.t2.sidereal_time('mean', 'greenwich')
         assert allclose_hours(gmst1.value, gmst2.value)
 
+    @pytest.mark.remote_data
     @pytest.mark.parametrize('kind', ('mean', 'apparent'))
     def test_lst(self, kind):
         """Compare Local Sidereal Time with what was found earlier,
@@ -138,6 +143,7 @@ class TestModelInterpretation():
     """Check that models are different, and that wrong models are recognized"""
     t = Time(['2012-06-30 12:00:00'], scale='utc', location=('120d', '10d'))
 
+    @pytest.mark.remote_data
     @pytest.mark.parametrize('kind', ('mean', 'apparent'))
     def test_model_uniqueness(self, kind):
         """Check models give different answers, yet are close."""

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -19,10 +19,10 @@ else:
     HAS_IERS_A = True
 
 
-class TestTimeUT1():
+@pytest.mark.remote_data
+class TestTimeUT1:
     """Test Time.ut1 using IERS tables"""
 
-    @pytest.mark.remote_data
     def test_utc_to_ut1(self):
         "Test conversion of UTC to UT1, making sure to include a leap second"""
         t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
@@ -42,7 +42,6 @@ class TestTimeUT1():
 
         tnow.ut1
 
-    @pytest.mark.remote_data
     def test_ut1_to_utc(self):
         """Also test the reverse, around the leap second
         (round-trip test closes #2077)"""
@@ -59,7 +58,6 @@ class TestTimeUT1():
         t_back = t.utc.ut1
         assert allclose_jd(t.jd, t_back.jd)
 
-    @pytest.mark.remote_data
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS
         (closes #1924 partially)"""
@@ -72,7 +70,7 @@ class TestTimeUT1():
 
 
 @pytest.mark.skipif('not HAS_IERS_A')
-class TestTimeUT1_IERSA():
+class TestTimeUT1_IERSA:
     def test_ut1_iers_A(self):
         tnow = Time.now()
         iers_a = iers.IERS_A.open()
@@ -83,7 +81,7 @@ class TestTimeUT1_IERSA():
 
 
 @pytest.mark.remote_data
-class TestTimeUT1_IERS_Auto():
+class TestTimeUT1_IERS_Auto:
     def test_ut1_iers_auto(self):
         tnow = Time.now()
         iers_a = iers.IERS_Auto.open()

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -42,6 +42,7 @@ class TestTimeUT1():
 
         tnow.ut1
 
+    @pytest.mark.remote_data
     def test_ut1_to_utc(self):
         """Also test the reverse, around the leap second
         (round-trip test closes #2077)"""
@@ -58,6 +59,7 @@ class TestTimeUT1():
         t_back = t.utc.ut1
         assert allclose_jd(t.jd, t_back.jd)
 
+    @pytest.mark.remote_data
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS
         (closes #1924 partially)"""

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -5,6 +5,7 @@ import pytest
 import numpy as np
 
 from astropy.time import Time
+from astropy.utils.iers import conf as iers_conf
 from astropy.utils.iers import iers  # used in testing
 
 allclose_jd = functools.partial(np.allclose, rtol=0, atol=1e-9)
@@ -19,10 +20,10 @@ else:
     HAS_IERS_A = True
 
 
-@pytest.mark.remote_data
 class TestTimeUT1:
     """Test Time.ut1 using IERS tables"""
 
+    @pytest.mark.remote_data
     def test_utc_to_ut1(self):
         "Test conversion of UTC to UT1, making sure to include a leap second"""
         t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
@@ -45,28 +46,30 @@ class TestTimeUT1:
     def test_ut1_to_utc(self):
         """Also test the reverse, around the leap second
         (round-trip test closes #2077)"""
-        t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
-                  '2012-07-01 00:00:00', '2012-07-01 00:00:01',
-                  '2012-07-01 12:00:00'], scale='ut1')
-        t_utc_jd = t.utc.jd
-        t_comp = np.array([2456109.0000010049,
-                           2456109.4999836441,
-                           2456109.4999952177,
-                           2456109.5000067917,
-                           2456109.9999952167])
-        assert allclose_jd(t_utc_jd, t_comp)
-        t_back = t.utc.ut1
-        assert allclose_jd(t.jd, t_back.jd)
+        with iers_conf.set_temp('auto_download', False):
+            t = Time(['2012-06-30 12:00:00', '2012-06-30 23:59:59',
+                      '2012-07-01 00:00:00', '2012-07-01 00:00:01',
+                      '2012-07-01 12:00:00'], scale='ut1')
+            t_utc_jd = t.utc.jd
+            t_comp = np.array([2456109.0000010049,
+                               2456109.4999836441,
+                               2456109.4999952177,
+                               2456109.5000067917,
+                               2456109.9999952167])
+            assert allclose_jd(t_utc_jd, t_comp)
+            t_back = t.utc.ut1
+            assert allclose_jd(t.jd, t_back.jd)
 
     def test_delta_ut1_utc(self):
         """Accessing delta_ut1_utc should try to get it from IERS
         (closes #1924 partially)"""
-        t = Time('2012-06-30 12:00:00', scale='utc')
-        assert not hasattr(t, '_delta_ut1_utc')
-        # accessing delta_ut1_utc calculates it
-        assert allclose_sec(t.delta_ut1_utc, -0.58682110003124965)
-        # and keeps it around
-        assert allclose_sec(t._delta_ut1_utc, -0.58682110003124965)
+        with iers_conf.set_temp('auto_download', False):
+            t = Time('2012-06-30 12:00:00', scale='utc')
+            assert not hasattr(t, '_delta_ut1_utc')
+            # accessing delta_ut1_utc calculates it
+            assert allclose_sec(t.delta_ut1_utc, -0.58682110003124965)
+            # and keeps it around
+            assert allclose_sec(t._delta_ut1_utc, -0.58682110003124965)
 
 
 @pytest.mark.skipif('not HAS_IERS_A')

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -129,7 +129,7 @@ can only have scales in which one day is always equal to 86400 seconds.
    '2007-01-01T04:21:49.579' '2008-01-01T10:54:33.386'
    '2008-12-31T17:27:17.193' '2010-01-01T00:00:00.000']>
 
-  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude [6.68050179, 6.70281947] hourangle>
 
 Using `astropy.time`
@@ -571,9 +571,9 @@ no explicit longitude is given.
 
   >>> t = Time('2001-03-22 00:01:44.732327132980', scale='utc',
   ...          location=('120d', '40d'))
-  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 12. hourangle>
-  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 20. hourangle>
 
 .. note:: In future versions, we hope to add the possibility to add observatory
@@ -892,7 +892,7 @@ longitude).::
   ...          location=(-155.933222*u.deg, 19.48125*u.deg))
   >>> t.utc.iso
   '2006-01-15 21:24:37.500'
-  >>> t.ut1.iso
+  >>> t.ut1.iso  # doctest: +REMOTE_DATA
   '2006-01-15 21:24:37.834'
   >>> t.tai.iso
   '2006-01-15 21:25:10.500'
@@ -916,15 +916,15 @@ transformations, ERFA C-library routines are used under the hood, which support
 calculations following different IAU resolutions.  Sample usage::
 
   >>> t = Time('2006-01-15 21:24:37.5', scale='utc', location=('120d', '45d'))
-  >>> t.sidereal_time('mean')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('mean')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 13.08952187 hourangle>
-  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 13.08950368 hourangle>
-  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent', 'greenwich')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 5.08950368 hourangle>
-  >>> t.sidereal_time('apparent', '-90d')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent', '-90d')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 23.08950368 hourangle>
-  >>> t.sidereal_time('apparent', '-90d', 'IAU1994')  # doctest: +FLOAT_CMP
+  >>> t.sidereal_time('apparent', '-90d', 'IAU1994')  # doctest: +FLOAT_CMP +REMOTE_DATA
   <Longitude 23.08950365 hourangle>
 
 Time Deltas
@@ -1050,17 +1050,17 @@ calculate light travel times to the barycentre as follows::
     >>> from astropy import time, coordinates as coord, units as u
     >>> ip_peg = coord.SkyCoord("23:23:08.55", "+18:24:59.3",
     ...                         unit=(u.hourangle, u.deg), frame='icrs')
-    >>> greenwich = coord.EarthLocation.of_site('greenwich')
+    >>> greenwich = coord.EarthLocation.of_site('greenwich')  # doctest: +REMOTE_DATA
     >>> times = time.Time([56325.95833333, 56325.978254], format='mjd',
-    ...                   scale='utc', location=greenwich)
-    >>> ltt_bary = times.light_travel_time(ip_peg)
-    >>> ltt_bary # doctest: +FLOAT_CMP
+    ...                   scale='utc', location=greenwich)  # doctest: +REMOTE_DATA
+    >>> ltt_bary = times.light_travel_time(ip_peg)  # doctest: +REMOTE_DATA
+    >>> ltt_bary # doctest: +FLOAT_CMP +REMOTE_DATA
     <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]>
 
 If you desire the light travel time to the heliocentre instead then use::
 
-    >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric')
-    >>> ltt_helio # doctest: +FLOAT_CMP
+    >>> ltt_helio = times.light_travel_time(ip_peg, 'heliocentric') # doctest: +REMOTE_DATA
+    >>> ltt_helio # doctest: +FLOAT_CMP +REMOTE_DATA
     <TimeDelta object: scale='tdb' format='jd' value=[-0.00376576 -0.00376712]>
 
 The method returns an |TimeDelta| object, which can be added to
@@ -1073,7 +1073,7 @@ continually changes at the heliocentre. Thus, the use of a relativistic
 timescale like TDB is not particularly appropriate, and, historically,
 times corrected to the heliocentre are given in the UTC timescale::
 
-    >>> times_heliocentre = times.utc + ltt_helio
+    >>> times_heliocentre = times.utc + ltt_helio  # doctest: +REMOTE_DATA
 
 Corrections to the barycentre are more precise than the heliocentre,
 because the barycenter is a fixed point where gravity is constant. For
@@ -1083,7 +1083,7 @@ whose tick rate is related to the rate that a clock would tick at the
 barycentre. For this reason, barycentric corrected times normally use
 the TDB timescale::
 
-    >>> time_barycentre = times.tdb + ltt_bary
+    >>> time_barycentre = times.tdb + ltt_bary  # doctest: +REMOTE_DATA
 
 By default, the light travel time is calculated using the position and velocity
 of Earth and the Sun from built-in `ERFA <https://github.com/liberfa/erfa>`_ routines,


### PR DESCRIPTION
As part of work for #7928 . The warnings were captured by removing the line in `setup.cfg` to suppress pytest warnings and then add this in the same section:

```
[pytest]
filterwarnings =
    error
```

And then run tests with `python setup.py -P time`. Most of the changes are to handle `ErfaWarning` and tests accessing IERS tables (which require download) but not marked as `remote_data`.