### PR TITLE
Try to ensure we get fewer deprecationwarnings from comparisons.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -325,6 +325,8 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Ensure we call numpy equality functions in a way that reduces the number
+  of ``DeprecationWarning``. [#8755]
 
 
 3.2 (unreleased)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -836,16 +836,15 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         else:
             return value
 
-    # Equality (return False if units do not match) needs to be handled
-    # explicitly for numpy >=1.9, since it no longer traps errors.
+    # Equality needs to be handled explicitly as ndarray.__eq__ gives
+    # DeprecationWarnings on any error, which is distracting.  On the other
+    # hand, for structured arrays, the ufunc does not work, so we do use
+    # __eq__ and live with the warnings.
     def __eq__(self, other):
         try:
-            try:
+            if self.dtype.kind == 'V':
                 return super().__eq__(other)
-            except DeprecationWarning:
-                # We treat the DeprecationWarning separately, since it may
-                # mask another Exception.  But we do not want to just use
-                # np.equal, since super's __eq__ treats recarrays correctly.
+            else:
                 return np.equal(self, other)
         except UnitsError:
             return False
@@ -854,9 +853,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
     def __ne__(self, other):
         try:
-            try:
+            if self.dtype.kind == 'V':
                 return super().__ne__(other)
-            except DeprecationWarning:
+            else:
                 return np.not_equal(self, other)
         except UnitsError:
             return True


### PR DESCRIPTION
It is all a bit tricky to get right, but the extra tests should help. @pllim - is it useful to explicitly ensure we don't get `DeprecationWarning`, as I do here? Or shall we leave that to your PR?

fixes #8752