### PR TITLE
TST: Get rid of io.votable test warnings

### DIFF
--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import io
 
 # THIRD-PARTY
@@ -40,9 +39,8 @@ def test_oversize_char():
 
 def test_char_mask():
     config = {'verify': 'exception'}
-    field = tree.Field(
-        None, name='c', datatype='char',
-        config=config)
+    field = tree.Field(None, name='c', arraysize='1', datatype='char',
+                       config=config)
     c = converters.get_converter(field, config=config)
     assert c.output("Foo", True) == ''
 
@@ -61,9 +59,8 @@ def test_oversize_unicode():
 
 def test_unicode_mask():
     config = {'verify': 'exception'}
-    field = tree.Field(
-        None, name='c', datatype='unicodeChar',
-        config=config)
+    field = tree.Field(None, name='c', arraysize='1', datatype='unicodeChar',
+                       config=config)
     c = converters.get_converter(field, config=config)
     assert c.output("Foo", True) == ''
 
@@ -94,8 +91,11 @@ def test_float_mask_permissive():
     field = tree.Field(
         None, name='c', datatype='float',
         config=config)
+
+    # config needs to be also passed into parse() to work.
+    # https://github.com/astropy/astropy/issues/8775
     c = converters.get_converter(field, config=config)
-    assert c.parse('null') == (c.null, True)
+    assert c.parse('null', config=config) == (c.null, True)
 
 
 @raises(exceptions.E02)
@@ -147,7 +147,7 @@ def test_complex():
         None, name='c', datatype='doubleComplex',
         config=config)
     c = converters.get_converter(field, config=config)
-    x = c.parse("1 2 3")
+    c.parse("1 2 3")
 
 
 @raises(exceptions.E04)
@@ -157,7 +157,7 @@ def test_bit():
         None, name='c', datatype='bit',
         config=config)
     c = converters.get_converter(field, config=config)
-    x = c.parse("T")
+    c.parse("T")
 
 
 def test_bit_mask():
@@ -197,7 +197,7 @@ def test_invalid_type():
     field = tree.Field(
         None, name='c', datatype='foobar',
         config=config)
-    c = converters.get_converter(field, config=config)
+    converters.get_converter(field, config=config)
 
 
 def test_precision():

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -13,7 +13,7 @@ from astropy.config import set_temp_config, reload_config
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree, conf
-from astropy.io.votable.exceptions import VOWarning
+from astropy.io.votable.exceptions import VOWarning, W39
 from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
@@ -67,7 +67,9 @@ def test_table(tmpdir):
         if 'arraysize' in d:
             assert field.arraysize == d['arraysize']
 
-    writeto(votable2, os.path.join(str(tmpdir), "through_table.xml"))
+    # W39: Bit values can not be masked
+    with pytest.warns(W39):
+        writeto(votable2, os.path.join(str(tmpdir), "through_table.xml"))
 
 
 def test_read_through_table_interface(tmpdir):
@@ -82,7 +84,10 @@ def test_read_through_table_interface(tmpdir):
     assert t['float'].format is None
 
     fn = os.path.join(str(tmpdir), "table_interface.xml")
-    t.write(fn, table_id='FOO', format='votable')
+
+    # W39: Bit values can not be masked
+    with pytest.warns(W39):
+        t.write(fn, table_id='FOO', format='votable')
 
     with open(fn, 'rb') as fd:
         t2 = Table.read(fd, format='votable', table_id='FOO')

--- a/astropy/io/votable/tests/tree_test.py
+++ b/astropy/io/votable/tests/tree_test.py
@@ -1,5 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# LOCAL
+
 from astropy.io.votable import exceptions
 from astropy.io.votable import tree
 from astropy.tests.helper import raises
@@ -8,7 +8,7 @@ from astropy.tests.helper import raises
 @raises(exceptions.W07)
 def test_check_astroyear_fail():
     config = {'verify': 'exception'}
-    field = tree.Field(None, name='astroyear')
+    field = tree.Field(None, name='astroyear', arraysize='1')
     tree.check_astroyear('X2100', field, config)
 
 
@@ -28,4 +28,5 @@ def test_make_Fields():
     table = tree.Table(votable)
     resource.tables.append(table)
 
-    table.fields.extend([tree.Field(votable, name='Test', datatype="float", unit="mag")])
+    table.fields.extend([tree.Field(
+        votable, name='Test', datatype="float", unit="mag")])


### PR DESCRIPTION
This should get rid of the rest of `io.votable` test warnings. Follow up of #8715 and as part of work for #7928 . The warnings were captured by removing the line in `setup.cfg` to suppress pytest warnings and then add this in the same section:

```
[pytest]
filterwarnings =
    error
```

And then run tests with `python setup.py -P io.votable`. Most of the changes are to handle `VOWarning` emitted when writing VO table back out or parsing specific fields.