### PR TITLE
Allow erfa routines to take float32 input also on older numpy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,6 +257,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Representations with ``float32`` coordinates can now be transformed,
+  although the output will always be ``float64``. [#8759]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -230,3 +230,11 @@ def test_structs():
     ri, di = erfa.atciqz(2.71, 0.174, am[0])
     np.testing.assert_allclose(ri, 2.709994899247599271)
     np.testing.assert_allclose(di, 0.1728740720983623469)
+
+
+def test_float32_input():
+    # Regression test for gh-8615
+    xyz = np.array([[1, 0, 0], [0.9, 0.1, 0]])
+    out64 = erfa.p2s(xyz)
+    out32 = erfa.p2s(xyz.astype('f4'))
+    np.testing.assert_allclose(out32, out64, rtol=1.e-5)

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -590,7 +590,7 @@ fail:
  * have fixed dimensions.
  *
  * Rather than just go for our type resolver, we check here whether
- * any double input with core dimensions has dimension equal to 3.  Here,
+ * any non-void input with core dimensions has dimension equal to 3.  Here,
  * we already know that all core dimensions are equal, so we have to check
  * only one.
  */
@@ -605,7 +605,7 @@ static int ErfaUFuncD3CheckTypeResolver(PyUFuncObject *ufunc,
     for (i = 0; i < ufunc->nin; i++) {
         if (ufunc->core_num_dims[i]) {
             PyArrayObject *op = operands[i];
-            if (PyArray_DESCR(op)->type_num == NPY_DOUBLE) {
+            if (PyArray_DESCR(op)->type_num != NPY_VOID) {
                 /* last dimension is should always be 3 */
                 int last_dim = PyArray_DIMS(op)[PyArray_NDIM(op)-1];
                 if (last_dim != 3) {

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -646,3 +646,18 @@ def test_regression_8276():
         finally:
             baseframe.frame_transform_graph = old_transform_graph
     assert "missing 1 required positional argument: 'default'" in str(excinfo.value)
+
+
+def test_regression_8615():
+    # note this is a "higher-level" symptom of the problem
+    # _erfa/tests/test_erfa:test_float32_input is testing for, but is kept here
+    # due to being a more practical version of the issue.
+
+    crf = CartesianRepresentation(np.array([3, 0, 4], dtype=float) * u.pc)
+    srf = SphericalRepresentation.from_cartesian(crf)  # does not error in 8615
+
+    cr = CartesianRepresentation(np.array([3, 0, 4], dtype='f4') * u.pc)
+    sr = SphericalRepresentation.from_cartesian(cr)  # errors in 8615
+
+    assert_quantity_allclose(sr.distance, 5 * u.pc)
+    assert_quantity_allclose(srf.distance, 5 * u.pc)


### PR DESCRIPTION
Note that output will always be float64, which is not necessarily ideal for coordinate transformations (but essential for the `erfa` routines dealing with times). With this, older and newer numpy behave consistently.

fixes #8615

p.s. I'm setting the milestone at 3.2.1 as this is not critical, but it could quite obviously go in 3.2 as well.