### PR TITLE
Make CODATA2018 the constants default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ astropy.constants
 
 - The version of constants can be specified via ScienceState in a way
   that ``constants`` and ``units`` will be consistent. [#8517]
+
 - Default constants now use CODATA 2018 and IAU 2015 definitions. [#8761]
 
 astropy.convolution

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ astropy.constants
 
 - The version of constants can be specified via ScienceState in a way
   that ``constants`` and ``units`` will be consistent. [#8517]
+- Default constants now use CODATA 2018 and IAU 2015 definitions. [#8761]
 
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -212,7 +212,7 @@ class physical_constants(base_constants_version):
     The version of physical constants to use
     """
     # Maintainers: update when new constants are added
-    _value = 'codata2014'
+    _value = 'codata2018'
 
     _versions = dict(codata2018='codata2018', codata2014='codata2014',
                      codata2010='codata2010', astropyconst40='codata2018',

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -26,9 +26,9 @@ del units
 from .constant import Constant, EMConstant  # noqa
 from . import si  # noqa
 from . import cgs  # noqa
-from .config import codata, iaudata
+from .config import codata, iaudata  # noqa
 
-from . import utils as _utils
+from . import utils as _utils  # noqa
 
 # for updating the constants module docstring
 _lines = [
@@ -61,7 +61,7 @@ def set_enabled_constants(modname):
 
     Parameters
     ----------
-    modname : {'astropyconst13'}
+    modname : {'astropyconst13', 'astropyconst20'}
         Name of the module containing an older version.
 
     """

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -42,7 +42,7 @@ _lines = [
 with warnings.catch_warnings():
     warnings.filterwarnings('ignore', 'Constant .*already has a definition')
     _utils._set_c(codata, iaudata, find_current_module(),
-                  not_in_module_only=False, doclines=_lines, set_class=True)
+                  not_in_module_only=True, doclines=_lines, set_class=True)
 
 _lines.append(_lines[1])
 

--- a/astropy/constants/astropyconst20.py
+++ b/astropy/constants/astropyconst20.py
@@ -7,7 +7,6 @@ from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2014, iau2015
 
-
 codata = codata2014
 iaudata = iau2015
 

--- a/astropy/constants/astropyconst40.py
+++ b/astropy/constants/astropyconst40.py
@@ -4,12 +4,15 @@ Astronomical and physics constants for Astropy v4.0.
 See :mod:`astropy.constants` for a complete listing of constants defined
 in Astropy.
 """
-import inspect
+from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2018, iau2015
 
-_utils._set_c(codata2018, iau2015, inspect.getmodule(inspect.currentframe()))
+codata = codata2018
+iaudata = iau2015
+
+_utils._set_c(codata, iaudata, find_current_module())
 
 # Clean up namespace
-del inspect
+del find_current_module
 del _utils

--- a/astropy/constants/astropyconst40.py
+++ b/astropy/constants/astropyconst40.py
@@ -1,0 +1,15 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Astronomical and physics constants for Astropy v4.0.
+See :mod:`astropy.constants` for a complete listing of constants defined
+in Astropy.
+"""
+import inspect
+from . import utils as _utils
+from . import codata2018, iau2015
+
+_utils._set_c(codata2018, iau2015, inspect.getmodule(inspect.currentframe()))
+
+# Clean up namespace
+del inspect
+del _utils

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -7,7 +7,7 @@ for a complete listing of constants defined in Astropy.
 import numpy as np
 
 from .constant import Constant
-from .codata2018 import G
+from .config import codata
 
 # ASTRONOMICAL CONSTANTS
 
@@ -52,9 +52,9 @@ GM_sun = IAU2015('GM_sun', 'Nominal solar mass parameter', 1.3271244e20,
                  'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Solar mass (derived from mass parameter and gravitational constant)
-M_sun = IAU2015('M_sun', "Solar mass", GM_sun.value / G.value,
-                'kg', ((G.uncertainty / G.value) *
-                       (GM_sun.value / G.value)),
+M_sun = IAU2015('M_sun', "Solar mass", GM_sun.value / codata.G.value,
+                'kg', ((codata.G.uncertainty / codata.G.value) *
+                       (GM_sun.value / codata.G.value)),
                 "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Solar radius
@@ -69,9 +69,9 @@ GM_jup = IAU2015('GM_jup', 'Nominal Jupiter mass parameter', 1.2668653e17,
                  'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Jupiter mass (derived from mass parameter and gravitational constant)
-M_jup = IAU2015('M_jup', "Jupiter mass", GM_jup.value / G.value,
-                'kg', ((G.uncertainty / G.value) *
-                       (GM_jup.value / G.value)),
+M_jup = IAU2015('M_jup', "Jupiter mass", GM_jup.value / codata.G.value,
+                'kg', ((codata.G.uncertainty / codata.G.value) *
+                       (GM_jup.value / codata.G.value)),
                 "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Jupiter equatorial radius
@@ -84,9 +84,9 @@ GM_earth = IAU2015('GM_earth', 'Nominal Earth mass parameter', 3.986004e14,
 
 # Earth mass (derived from mass parameter and gravitational constant)
 M_earth = IAU2015('M_earth', "Earth mass",
-                  GM_earth.value / G.value,
-                  'kg', ((G.uncertainty / G.value) *
-                         (GM_earth.value / G.value)),
+                  GM_earth.value / codata.G.value,
+                  'kg', ((codata.G.uncertainty / codata.G.value) *
+                         (GM_earth.value / codata.G.value)),
                   "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Earth equatorial radius

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -55,7 +55,8 @@ GM_sun = IAU2015('GM_sun', 'Nominal solar mass parameter', 1.3271244e20,
 M_sun = IAU2015('M_sun', "Solar mass", GM_sun.value / codata.G.value,
                 'kg', ((codata.G.uncertainty / codata.G.value) *
                        (GM_sun.value / codata.G.value)),
-                "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                system='si')
 
 # Solar radius
 R_sun = IAU2015('R_sun', "Nominal solar radius", 6.957e8, 'm', 0.0,
@@ -72,7 +73,8 @@ GM_jup = IAU2015('GM_jup', 'Nominal Jupiter mass parameter', 1.2668653e17,
 M_jup = IAU2015('M_jup', "Jupiter mass", GM_jup.value / codata.G.value,
                 'kg', ((codata.G.uncertainty / codata.G.value) *
                        (GM_jup.value / codata.G.value)),
-                "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                system='si')
 
 # Jupiter equatorial radius
 R_jup = IAU2015('R_jup', "Nominal Jupiter equatorial radius", 7.1492e7,
@@ -87,7 +89,8 @@ M_earth = IAU2015('M_earth', "Earth mass",
                   GM_earth.value / codata.G.value,
                   'kg', ((codata.G.uncertainty / codata.G.value) *
                          (GM_earth.value / codata.G.value)),
-                  "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                  "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                  system='si')
 
 # Earth equatorial radius
 R_earth = IAU2015('R_earth', "Nominal Earth equatorial radius", 6.3781e6,

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -7,7 +7,7 @@ for a complete listing of constants defined in Astropy.
 import numpy as np
 
 from .constant import Constant
-from .codata2014 import G
+from .codata2018 import G
 
 # ASTRONOMICAL CONSTANTS
 
@@ -22,73 +22,73 @@ class IAU2015(Constant):
 
 # Astronomical Unit
 au = IAU2015('au', "Astronomical Unit", 1.49597870700e11, 'm', 0.0,
-              "IAU 2012 Resolution B2", system='si')
+             "IAU 2012 Resolution B2", system='si')
 
 # Parsec
 
 pc = IAU2015('pc', "Parsec", au.value / np.tan(np.radians(1. / 3600.)), 'm',
-              au.uncertainty / np.tan(np.radians(1. / 3600.)),
-              "Derived from au", system='si')
+             au.uncertainty / np.tan(np.radians(1. / 3600.)),
+             "Derived from au", system='si')
 
 # Kiloparsec
 kpc = IAU2015('kpc', "Kiloparsec",
-               1000. * au.value / np.tan(np.radians(1. / 3600.)), 'm',
-               1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
-               "Derived from au", system='si')
+              1000. * au.value / np.tan(np.radians(1. / 3600.)), 'm',
+              1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
+              "Derived from au", system='si')
 
 # Luminosity
 L_bol0 = IAU2015('L_bol0', "Luminosity for absolute bolometric magnitude 0",
-                  3.0128e28, "W", 0.0, "IAU 2015 Resolution B 2", system='si')
+                 3.0128e28, "W", 0.0, "IAU 2015 Resolution B 2", system='si')
 
 
 # SOLAR QUANTITIES
 
 # Solar luminosity
 L_sun = IAU2015('L_sun', "Nominal solar luminosity", 3.828e26,
-                 'W', 0.0, "IAU 2015 Resolution B 3", system='si')
+                'W', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Solar mass parameter
 GM_sun = IAU2015('GM_sun', 'Nominal solar mass parameter', 1.3271244e20,
-                  'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
+                 'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Solar mass (derived from mass parameter and gravitational constant)
 M_sun = IAU2015('M_sun', "Solar mass", GM_sun.value / G.value,
-                 'kg', ((G.uncertainty / G.value) *
-                        (GM_sun.value / G.value)),
-                 "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                'kg', ((G.uncertainty / G.value) *
+                       (GM_sun.value / G.value)),
+                "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Solar radius
 R_sun = IAU2015('R_sun', "Nominal solar radius", 6.957e8, 'm', 0.0,
-                 "IAU 2015 Resolution B 3", system='si')
+                "IAU 2015 Resolution B 3", system='si')
 
 
 # OTHER SOLAR SYSTEM QUANTITIES
 
 # Jupiter mass parameter
 GM_jup = IAU2015('GM_jup', 'Nominal Jupiter mass parameter', 1.2668653e17,
-                  'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
+                 'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Jupiter mass (derived from mass parameter and gravitational constant)
 M_jup = IAU2015('M_jup', "Jupiter mass", GM_jup.value / G.value,
-                 'kg', ((G.uncertainty / G.value) *
-                        (GM_jup.value / G.value)),
-                 "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                'kg', ((G.uncertainty / G.value) *
+                       (GM_jup.value / G.value)),
+                "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Jupiter equatorial radius
 R_jup = IAU2015('R_jup', "Nominal Jupiter equatorial radius", 7.1492e7,
-                 'm', 0.0, "IAU 2015 Resolution B 3", system='si')
+                'm', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Earth mass parameter
 GM_earth = IAU2015('GM_earth', 'Nominal Earth mass parameter', 3.986004e14,
-                  'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
+                   'm3 / (s2)', 0.0, "IAU 2015 Resolution B 3", system='si')
 
 # Earth mass (derived from mass parameter and gravitational constant)
 M_earth = IAU2015('M_earth', "Earth mass",
-                   GM_earth.value / G.value,
-                 'kg', ((G.uncertainty / G.value) *
-                        (GM_earth.value / G.value)),
-                 "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
+                  GM_earth.value / G.value,
+                  'kg', ((G.uncertainty / G.value) *
+                         (GM_earth.value / G.value)),
+                  "IAU 2015 Resolution B 3 + CODATA 2014", system='si')
 
 # Earth equatorial radius
 R_earth = IAU2015('R_earth', "Nominal Earth equatorial radius", 6.3781e6,
-                   'm', 0.0, "IAU 2015 Resolution B 3", system='si')
+                  'm', 0.0, "IAU 2015 Resolution B 3", system='si')

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -1,12 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-
 import copy
 
 import pytest
 
 from astropy.constants import Constant
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity as Q
 
 
@@ -37,7 +36,7 @@ def test_h():
     assert abs(h.cgs.value - 6.626e-27) < 1e-31
 
     # make sure it has the necessary attributes and they're not blank
-    assert h.uncertainty
+    assert h.uncertainty == 0  # CODATA 2018 set h to exact value
     assert h.name
     assert h.reference
     assert h.unit
@@ -65,7 +64,11 @@ def test_e():
     assert isinstance(e.gauss, Q)
     assert isinstance(e.esu, Q)
 
-    assert e.si * E == Q(100, 'eV/m')
+    # We cannot use == comparison because:
+    # e.si * E = <Quantity 1.60217663e-17 C V / m>
+    # (e.si * E).to(u.eV / u.m) = <Quantity 100.00000082 eV / m>
+    assert_quantity_allclose(e.si * E, Q(100, 'eV/m'))
+
     assert e.gauss * E == Q(e.gauss.value * E.value, 'Fr V/m')
     assert e.esu * E == Q(e.esu.value * E.value, 'Fr V/m')
 

--- a/astropy/constants/tests/test_constant.py
+++ b/astropy/constants/tests/test_constant.py
@@ -5,7 +5,6 @@ import copy
 import pytest
 
 from astropy.constants import Constant
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity as Q
 
 
@@ -64,11 +63,7 @@ def test_e():
     assert isinstance(e.gauss, Q)
     assert isinstance(e.esu, Q)
 
-    # We cannot use == comparison because:
-    # e.si * E = <Quantity 1.60217663e-17 C V / m>
-    # (e.si * E).to(u.eV / u.m) = <Quantity 100.00000082 eV / m>
-    assert_quantity_allclose(e.si * E, Q(100, 'eV/m'))
-
+    assert e.si * E == Q(100, 'eV/m')
     assert e.gauss * E == Q(e.gauss.value * E.value, 'Fr V/m')
     assert e.esu * E == Q(e.esu.value * E.value, 'Fr V/m')
 

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -161,7 +161,10 @@ def test_context_manager():
     with const.set_enabled_constants('astropyconst13'):
         assert const.h.value == 6.62606957e-34  # CODATA2010
 
-    assert const.h.value == 6.626070040e-34  # CODATA2014
+    with const.set_enabled_constants('astropyconst20'):
+        assert const.h.value == 6.626070040e-34  # CODATA2014
+
+    assert const.h.value == 6.62607015e-34  # CODATA2018
 
     with pytest.raises(ImportError):
         with const.set_enabled_constants('notreal'):

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -5,6 +5,7 @@ import copy
 import pytest
 
 from astropy.constants import Constant
+from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity as Q
 
 
@@ -59,7 +60,10 @@ def test_e():
     assert isinstance(e.gauss, Q)
     assert isinstance(e.esu, Q)
 
-    assert e.si * E == Q(100, 'eV/m')
+    # Cannot use == comparison here because conversion to eV
+    # uses constants.si.e value that can vary over time.
+    assert_quantity_allclose(e.si * E, Q(100, 'eV/m'))
+
     assert e.gauss * E == Q(e.gauss.value * E.value, 'Fr V/m')
     assert e.esu * E == Q(e.esu.value * E.value, 'Fr V/m')
 

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -47,25 +47,26 @@ def test_h():
 
 def test_e():
 
-    from astropy.constants.astropyconst13 import e
+    from astropy.constants.astropyconst13 import e as e_13
 
     # A test quantity
     E = Q(100.00000348276221, 'V/m')
 
     # e.cgs is too ambiguous and should not work at all
     with pytest.raises(TypeError):
-        e.cgs * E
+        e_13.cgs * E
 
-    assert isinstance(e.si, Q)
-    assert isinstance(e.gauss, Q)
-    assert isinstance(e.esu, Q)
+    assert isinstance(e_13.si, Q)
+    assert isinstance(e_13.gauss, Q)
+    assert isinstance(e_13.esu, Q)
 
     # Cannot use == comparison here because conversion to eV
-    # uses constants.si.e value that can vary over time.
-    assert_quantity_allclose(e.si * E, Q(100, 'eV/m'))
+    # uses constants.si.e that is taken from the current set of constants,
+    # which is not the same as that of astropy 1.3.
+    assert_quantity_allclose(e_13.si * E, Q(100, 'eV/m'))
 
-    assert e.gauss * E == Q(e.gauss.value * E.value, 'Fr V/m')
-    assert e.esu * E == Q(e.esu.value * E.value, 'Fr V/m')
+    assert e_13.gauss * E == Q(e_13.gauss.value * E.value, 'Fr V/m')
+    assert e_13.esu * E == Q(e_13.esu.value * E.value, 'Fr V/m')
 
 
 def test_g0():

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -60,11 +60,6 @@ def test_e():
     assert isinstance(e_13.gauss, Q)
     assert isinstance(e_13.esu, Q)
 
-    # Cannot use == comparison here because conversion to eV
-    # uses constants.si.e that is taken from the current set of constants,
-    # which is not the same as that of astropy 1.3.
-    assert_quantity_allclose(e_13.si * E, Q(100, 'eV/m'))
-
     assert e_13.gauss * E == Q(e_13.gauss.value * E.value, 'Fr V/m')
     assert e_13.esu * E == Q(e_13.esu.value * E.value, 'Fr V/m')
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1086,19 +1086,20 @@ def test_neg_distmod():
 def test_critical_density():
     # WMAP7 but with Omega_relativistic = 0
     # These tests will fail if astropy.const starts returning non-mks
-    #  units by default; see the comment at the top of core.py
+    #  units by default; see the comment at the top of core.py.
+    # critical_density0 is inversely proportional to G.
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     fac = (const.G / const.codata2014.G).to(u.dimensionless_unscaled).value
-    assert allclose(tcos.critical_density0,
-                    9.309668456020899e-30 * fac * (u.g / u.cm**3))
+    assert allclose(tcos.critical_density0 * fac,
+                    9.309668456020899e-30 * (u.g / u.cm**3))
     assert allclose(tcos.critical_density0,
                     tcos.critical_density(0))
     assert allclose(
-        tcos.critical_density([1, 5]),
-        [2.70352772e-29 * fac, 5.53739080e-28 * fac] * (u.g / u.cm**3))
+        tcos.critical_density([1, 5]) * fac,
+        [2.70352772e-29, 5.53739080e-28] * (u.g / u.cm**3))
     assert allclose(
-        tcos.critical_density([1., 5.]),
-        [2.70352772e-29 * fac, 5.53739080e-28 * fac] * (u.g / u.cm**3))
+        tcos.critical_density([1., 5.]) * fac,
+        [2.70352772e-29, 5.53739080e-28] * (u.g / u.cm**3))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -11,7 +11,7 @@ from astropy.utils.compat import NUMPY_LT_1_14
 from astropy import units as u
 
 try:
-    import scipy  # pylint: disable=W0611
+    import scipy  # pylint: disable=W0611  # noqa
 except ImportError:
     HAS_SCIPY = False
 else:
@@ -1088,13 +1088,13 @@ def test_critical_density():
     #  units by default; see the comment at the top of core.py
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
     assert allclose(tcos.critical_density0,
-                    9.309668456020899e-30 * u.g / u.cm**3)
+                    9.309361588325364e-30 * u.g / u.cm**3)
     assert allclose(tcos.critical_density0,
                     tcos.critical_density(0))
     assert allclose(tcos.critical_density([1, 5]),
-                    [2.70352772e-29, 5.53739080e-28] * u.g / u.cm**3)
+                    [2.70343861e-29, 5.53720827e-28] * u.g / u.cm**3)
     assert allclose(tcos.critical_density([1., 5.]),
-                    [2.70352772e-29, 5.53739080e-28] * u.g / u.cm**3)
+                    [2.70343861e-29, 5.53720827e-28] * u.g / u.cm**3)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1084,12 +1084,14 @@ def test_neg_distmod():
 
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_critical_density():
+    from astropy.constants import codata2014
+
     # WMAP7 but with Omega_relativistic = 0
     # These tests will fail if astropy.const starts returning non-mks
     #  units by default; see the comment at the top of core.py.
     # critical_density0 is inversely proportional to G.
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
-    fac = (const.G / const.codata2014.G).to(u.dimensionless_unscaled).value
+    fac = (const.G / codata2014.G).to(u.dimensionless_unscaled).value
     assert allclose(tcos.critical_density0 * fac,
                     9.309668456020899e-30 * (u.g / u.cm**3))
     assert allclose(tcos.critical_density0,

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -8,6 +8,7 @@ import numpy as np
 from astropy.cosmology import core, funcs
 from astropy.units import allclose
 from astropy.utils.compat import NUMPY_LT_1_14
+from astropy import constants as const
 from astropy import units as u
 
 try:
@@ -1087,14 +1088,17 @@ def test_critical_density():
     # These tests will fail if astropy.const starts returning non-mks
     #  units by default; see the comment at the top of core.py
     tcos = core.FlatLambdaCDM(70.4, 0.272, Tcmb0=0.0)
+    fac = (const.G / const.codata2014.G).to(u.dimensionless_unscaled).value
     assert allclose(tcos.critical_density0,
-                    9.309361588325364e-30 * u.g / u.cm**3)
+                    9.309668456020899e-30 * fac * (u.g / u.cm**3))
     assert allclose(tcos.critical_density0,
                     tcos.critical_density(0))
-    assert allclose(tcos.critical_density([1, 5]),
-                    [2.70343861e-29, 5.53720827e-28] * u.g / u.cm**3)
-    assert allclose(tcos.critical_density([1., 5.]),
-                    [2.70343861e-29, 5.53720827e-28] * u.g / u.cm**3)
+    assert allclose(
+        tcos.critical_density([1, 5]),
+        [2.70352772e-29 * fac, 5.53739080e-28 * fac] * (u.g / u.cm**3))
+    assert allclose(
+        tcos.critical_density([1., 5.]),
+        [2.70352772e-29 * fac, 5.53739080e-28 * fac] * (u.g / u.cm**3))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/modeling/tests/test_blackbody.py
+++ b/astropy/modeling/tests/test_blackbody.py
@@ -34,8 +34,8 @@ class TestBlackbody1D:
         b = BlackBody1D(temperature=temperature,
                         bolometric_flux=bolometric_flux)
 
-        assert_quantity_allclose(b(1.4 * u.micron), 4734464.498937388 * u.Jy)
-        assert_quantity_allclose(b(214.13747 * u.THz), 4734464.498937388 * u.Jy)
+        assert_quantity_allclose(b(1.4 * u.micron), 4734463.93280426 * u.Jy)
+        assert_quantity_allclose(b(214.13747 * u.THz), 4734463.93280426 * u.Jy)
 
     @pytest.mark.skipif('not HAS_SCIPY')
     def test_fit(self):
@@ -49,8 +49,8 @@ class TestBlackbody1D:
 
         b_fit = fitter(b, wav, fnu)
 
-        assert_quantity_allclose(b_fit.temperature, 2840.744774408546 * u.K)
-        assert_quantity_allclose(b_fit.bolometric_flux, 6.821837296857152e-08 * u.erg / u.cm**2 / u.s)
+        assert_quantity_allclose(b_fit.temperature, 2840.7438339457754 * u.K)
+        assert_quantity_allclose(b_fit.bolometric_flux, 6.821837075583734e-08 * u.erg / u.cm**2 / u.s)
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -9,6 +9,7 @@ import warnings
 
 # LOCAL
 from astropy.constants import si as _si
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import isiterable
 from . import si
 from . import cgs
@@ -561,7 +562,7 @@ def brightness_temperature(frequency, beam_area=None):
         warnings.warn("The inputs to `brightness_temperature` have changed. "
                       "Frequency is now the first input, and angular area "
                       "is the second, optional input.",
-                      DeprecationWarning)
+                      AstropyDeprecationWarning)
         frequency, beam_area = beam_area, frequency
 
     nu = frequency.to(si.GHz, spectral())

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -681,10 +681,8 @@ def test_temperature():
 def test_temperature_energy():
     x = 1000 * u.K
     y = (x * constants.k_B).to(u.keV)
-    assert_allclose(
-        x.to_value(u.keV, u.temperature_energy()), y.value, rtol=1e-6)
-    assert_allclose(
-        y.to_value(u.K, u.temperature_energy()), x.value, rtol=1e-6)
+    assert_allclose(x.to_value(u.keV, u.temperature_energy()), y.value)
+    assert_allclose(y.to_value(u.K, u.temperature_energy()), x.value)
 
 
 def test_molar_mass_amu():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -681,8 +681,10 @@ def test_temperature():
 def test_temperature_energy():
     x = 1000 * u.K
     y = (x * constants.k_B).to(u.keV)
-    assert_allclose(x.to_value(u.keV, u.temperature_energy()), y.value)
-    assert_allclose(y.to_value(u.K, u.temperature_energy()), x.value)
+    assert_allclose(
+        x.to_value(u.keV, u.temperature_energy()), y.value, rtol=1e-6)
+    assert_allclose(
+        y.to_value(u.K, u.temperature_energy()), x.value, rtol=1e-6)
 
 
 def test_molar_mass_amu():

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -127,8 +127,8 @@ the default version of constants. When using prior versions of the constants
 in this manner, quantities should be constructed with constants instead of units.
 
 To ensure consistent use of a prior version of constants in other Astropy
-packages (such as `astropy.units`) that import constants, the physical and
-astronomical constants versions should be set via ScienceState classes.
+packages (such as `astropy.units`) that import ``constants``, the physical and
+astronomical constants versions should be set via ``ScienceState`` classes.
 These must be set before the first import of either `astropy.constants` or
 `astropy.units`.  For example, you can use the CODATA2010 physical constants and the
 IAU 2012 astronomical constants:
@@ -157,6 +157,8 @@ The versions may also be set using values referring to the version modules:
     <ScienceState astronomical_constants: 'iau2012'>
     >>> astronomical_constants.get()  # doctest: +SKIP
     'iau2012'
+
+.. The doctest should not be skipped, ideally. See https://github.com/astropy/astropy/issues/8781
 
 If either `astropy.constants` or `astropy.units` have already been imported, a
 ``RuntimeError`` will be raised.

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -35,7 +35,7 @@ different units. For example::
       Value  = 299792458.0
       Uncertainty  = 0.0
       Unit  = m / s
-      Reference = CODATA 2014
+      Reference = CODATA 2018
 
     >>> print(const.c.to('km/s'))
     299792.458 km / s
@@ -76,27 +76,27 @@ Collections of Constants (and Prior Versions)
 =============================================
 
 Constants are organized into version modules. The constants for
-``astropy`` 1.3 can be accessed in the ``astropyconst13`` module.
+``astropy`` 2.0 can be accessed in the ``astropyconst20`` module.
 For example:
 
-    >>> from astropy.constants import astropyconst13 as const
+    >>> from astropy.constants import astropyconst20 as const
     >>> print(const.e)
       Name   = Electron charge
-      Value  = 1.602176565e-19
-      Uncertainty  = 3.5e-27
+      Value  = 1.6021766208e-19
+      Uncertainty  = 9.8e-28
       Unit  = C
-      Reference = CODATA 2010
+      Reference = CODATA 2014
 
-Physical CODATA constants are in modules with names like ``codata2010`` or
-``codata2014``:
+Physical CODATA constants are in modules with names like ``codata2010``,
+``codata2014``, or ``codata2018``:
 
-    >>> from astropy.constants import codata2010 as const
+    >>> from astropy.constants import codata2014 as const
     >>> print(const.h)
       Name   = Planck constant
-      Value  = 6.62606957e-34
-      Uncertainty  = 2.9e-41
+      Value  = 6.62607004e-34
+      Uncertainty  = 8.1e-42
       Unit  = J s
-      Reference = CODATA 2010
+      Reference = CODATA 2014
 
 Astronomical constants defined (primarily) by the International Astronomical
 Union (IAU) are collected in modules with names like ``iau2012`` or ``iau2015``:
@@ -118,7 +118,8 @@ Union (IAU) are collected in modules with names like ``iau2012`` or ``iau2015``:
       Reference = IAU 2015 Resolution B 3
 
 The astronomical and physical constants are combined into modules with
-names like ``astropyconst13`` and ``astropyconst20`` for different versions.
+names like ``astropyconst13``, ``astropyconst20``, and ``astropyconst40``
+for different versions.
 However, importing these prior version modules directly will lead to
 inconsistencies with other subpackages that have already imported
 `astropy.constants`. Notably, `astropy.units` will have already used
@@ -180,10 +181,10 @@ for regression testing), a context manager is available, as follows:
       Reference = CODATA 2010
     >>> print(const.h)
       Name   = Planck constant
-      Value  = 6.62607004e-34
-      Uncertainty  = 8.1e-42
+      Value  = 6.62607015e-34
+      Uncertainty  = 0.0
       Unit  = J s
-      Reference = CODATA 2014
+      Reference = CODATA 2018
 
 The context manager may be used at any time in a Python session, but it
 uses the prior version only for `astropy.constants`, and not for any

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -146,8 +146,8 @@ You can see how the density parameters evolve with redshift as well::
 
   >>> from astropy.cosmology import WMAP7   # WMAP 7-year cosmology
   >>> WMAP7.Om([0, 1.0, 2.0]), WMAP7.Ode([0., 1.0, 2.0])  # doctest: +FLOAT_CMP
-  (array([0.272     , 0.74898524, 0.90905239]),
-   array([0.72791572, 0.25055061, 0.0901026 ]))
+  (array([0.272     , 0.74898522, 0.90905234]),
+   array([0.72791572, 0.2505506 , 0.0901026 ]))
 
 Note that these do not quite add up to one, even though WMAP7 assumes a
 flat universe, because photons and neutrinos are included. Also note
@@ -339,8 +339,8 @@ can be found as a function of redshift::
   (4.985694972799396e-05, 3.442154948307989e-05)
   >>> z = [0, 1.0, 2.0]
   >>> WMAP7.Ogamma(z), WMAP7.Onu(z)  # doctest: +FLOAT_CMP
-  (array([4.98586899e-05, 2.74583989e-04, 4.99898824e-04]),
-   array([3.44227509e-05, 1.89574501e-04, 3.45133270e-04]))
+  (array([4.98603986e-05, 2.74593395e-04, 4.99915942e-04]),
+   array([3.44239306e-05, 1.89580995e-04, 3.45145089e-04]))
 
 If you want to exclude photons and neutrinos from your calculations, you can
 set ``Tcmb0`` to 0 (which is also the default)::
@@ -358,7 +358,7 @@ Universe) but setting ``Neff`` to 0::
   >>> from astropy.cosmology import FlatLambdaCDM
   >>> cos = FlatLambdaCDM(70.4, 0.272, Tcmb0=2.725, Neff=0)
   >>> cos.Ogamma([0, 1, 2])  # Photons are still present  # doctest: +FLOAT_CMP
-  array([4.98586899e-05, 2.74632798e-04, 5.00069284e-04])
+  array([4.98603986e-05, 2.74642208e-04, 5.00086413e-04])
   >>> cos.Onu([0, 1, 2])  # But not neutrinos  # doctest: +FLOAT_CMP
   array([0., 0., 0.])
 
@@ -386,7 +386,7 @@ value is provided, all of the species are assumed to have the same mass.
   >>> cosmo.m_nu  # doctest: +FLOAT_CMP
   <Quantity [0.  , 0.05, 0.1 ] eV>
   >>> cosmo.Onu([0, 1.0, 15.0])  # doctest: +FLOAT_CMP
-  array([0.00327   , 0.00896814, 0.01257904])
+  array([0.00327011, 0.00896845, 0.01257946])
   >>> cosmo.Onu(1) * cosmo.critical_density(1)  # doctest: +FLOAT_CMP
   <Quantity 2.444380380370406e-31 g / cm3>
 

--- a/docs/cosmology/index.rst
+++ b/docs/cosmology/index.rst
@@ -49,7 +49,7 @@ redshifts as input:
 
   >>> from astropy.cosmology import WMAP9 as cosmo
   >>> cosmo.comoving_distance([0.5, 1.0, 1.5])  # doctest: +FLOAT_CMP
-  <Quantity [1916.06942039, 3363.0706321 , 4451.74754107] Mpc>
+  <Quantity [1916.06941724, 3363.07062107, 4451.7475201 ] Mpc>
 
 You can create your own FLRW-like cosmology using one of the cosmology
 classes::
@@ -128,7 +128,7 @@ They also accept arrays of redshifts:
 .. doctest-requires:: scipy
 
   >>> cosmo.age([0.5, 1, 1.5]).value  # doctest: +FLOAT_CMP
-  array([8.4212803 , 5.74698037, 4.19645387])
+  array([8.42128013, 5.74698021, 4.19645373])
 
 See the `~astropy.cosmology.FLRW` and
 `~astropy.cosmology.FlatLambdaCDM` object docstring for all of the

--- a/docs/units/standard_units.rst
+++ b/docs/units/standard_units.rst
@@ -39,11 +39,11 @@ all the existing predefined units of a given type::
   [
     M_e          | 9.10938e-31 kg  |                                  ,
     M_p          | 1.67262e-27 kg  |                                  ,
-    earthMass    | 5.97236e+24 kg  | M_earth, Mearth                  ,
+    earthMass    | 5.97217e+24 kg  | M_earth, Mearth                  ,
     g            | 0.001 kg        | gram                             ,
-    jupiterMass  | 1.89819e+27 kg  | M_jup, Mjup, M_jupiter, Mjupiter ,
+    jupiterMass  | 1.89812e+27 kg  | M_jup, Mjup, M_jupiter, Mjupiter ,
     kg           | irreducible     | kilogram                         ,
-    solMass      | 1.98848e+30 kg  | M_sun, Msun                      ,
+    solMass      | 1.98841e+30 kg  | M_sun, Msun                      ,
     t            | 1000 kg         | tonne                            ,
     u            | 1.66054e-27 kg  | Da, Dalton                       ,
   ]
@@ -162,7 +162,7 @@ For example::
    Unit(dimensionless with a scale of 1000.0)
    >>> (u.km / u.m).decompose() == u.dimensionless_unscaled
    False
-   
+
 As an example of why you might want to create a scaled dimensionless
 quantity, say you will be doing many calculations with some big
 unitless number, ``big_unitless_num = 20000000  # 20 million``,
@@ -179,7 +179,7 @@ to keep track of the scaling factor, e.g.::
    >>> some_measurement = 5.0 * u.cm
    >>> some_measurement * big_unitless_num  # doctest: +FLOAT_CMP
    <Quantity 100. 1e+06 cm>
-     
+
 To determine if a unit is dimensionless (but regardless of the scale),
 use the `~astropy.units.core.UnitBase.physical_type` property::
 


### PR DESCRIPTION
This is a follow up of #8595 to make CODATA2018 values the default values in `astropy.constants`. This is a breaking change and should not be backported.

TODO:
- [x] Wait for #8517 to get merged first.
- [x] Decide if new values are acceptable. Is deriving some constants on-the-fly from other constants not desirable given the resulting diff?
- [x] Have a consensus on whether this goes in 3.2 or 4.0. Adjust code accordingly if we re-milestone to 3.2.

xref: closes #8155