### PR TITLE
Add a ``to_value`` method to ``TimeDelta``.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- ``TimeDelta`` gained a ``to_value`` method, so that it becomes easier to
+  use it wherever a ``Quantity`` with units of time could be used. [#8762]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2157,6 +2157,10 @@ class TimeDelta(Time):
         return u.Quantity(self._time.jd1 + self._time.jd2,
                           u.day).to(*args, **kwargs)
 
+    def to_value(self, *args, **kwargs):
+        return u.Quantity(self._time.jd1 + self._time.jd2,
+                          u.day).to_value(*args, **kwargs)
+
     def _make_value_equivalent(self, item, value):
         """Coerce setitem value into an equivalent TimeDelta object"""
         if not isinstance(value, TimeDelta):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2153,13 +2153,58 @@ class TimeDelta(Time):
         # since other has already had a chance to look at us.
         return other / self.to(u.day)
 
-    def to(self, *args, **kwargs):
-        return u.Quantity(self._time.jd1 + self._time.jd2,
-                          u.day).to(*args, **kwargs)
+    def to(self, unit, equivalencies=[]):
+        """
+        Convert to a quantity in the specified unit.
 
-    def to_value(self, *args, **kwargs):
+        Parameters
+        ----------
+        unit : `~astropy.units.UnitBase` instance, str
+            The unit to convert to.
+        equivalencies : list of equivalence pairs, optional
+            A list of equivalence pairs to try if the units are not directly
+            convertible (see :ref:`unit_equivalencies`). If `None`, no
+            equivalencies will be applied at all, not even any set globallyq
+            or within a context.
+
+        Returns
+        -------
+        quantity : `~astropy.units.Quantity`
+            The quantity in the units specified.
+
+        See also
+        --------
+        to_value : get the numerical value in a given unit.
+        """
         return u.Quantity(self._time.jd1 + self._time.jd2,
-                          u.day).to_value(*args, **kwargs)
+                          u.day).to(unit, equivalencies=equivalencies)
+
+    def to_value(self, unit, equivalencies=[]):
+        """
+        The numerical value in the specified unit.
+
+        Parameters
+        ----------
+        unit : `~astropy.units.UnitBase` instance or str, optional
+            The unit in which the value should be given.
+        equivalencies : list of equivalence pairs, optional
+            A list of equivalence pairs to try if the units are not directly
+            convertible (see :ref:`unit_equivalencies`). If `None`, no
+            equivalencies will be applied at all, not even any set globally
+            or within a context.
+
+        Returns
+        -------
+        value : `~numpy.ndarray` or scalar
+            The value in the units specified.
+
+        See also
+        --------
+        to : Convert to a `~astropy.units.Quantity` instance in a given unit.
+        value : The time value in the current format.
+        """
+        return u.Quantity(self._time.jd1 + self._time.jd2,
+                          u.day).to_value(unit, equivalencies=equivalencies)
 
     def _make_value_equivalent(self, item, value):
         """Coerce setitem value into an equivalent TimeDelta object"""

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -127,9 +127,13 @@ class TestTimeDeltaQuantity():
         q = 500.25*u.day
         dt = TimeDelta(q)
         assert dt.to(u.day) == q
+        assert dt.to_value(u.day) == q.value
         assert dt.to(u.second).value == q.to_value(u.second)
+        assert dt.to_value(u.second) == q.to_value(u.second)
         with pytest.raises(u.UnitsError):
             dt.to(u.m)
+        with pytest.raises(u.UnitsError):
+            dt.to_value(u.m)
 
     def test_valid_quantity_operations1(self):
         """Check adding/substracting/comparing a time-valued quantity works


### PR DESCRIPTION
Makes using `TimeDelta` easier in places where a `Quantity` with units of time could be used. Does raise a more general question of how far one should extend this, and whether one should do the same for `Column`. But seems good in itself and would have been done at the time if `Quantity` had had the `to_value` method already.

fixes #8732