### PR TITLE
Ensure that always abs(time.jd2)<=0.5.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -305,6 +305,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Corrected small rounding errors that could cause the ``jd2`` values in
+  ``Time`` to fall outside the range of -0.5 to 0.5. [#8763]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -15,6 +15,14 @@ allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
 dt_tiny = TimeDelta(2. ** -52, format='jd')
 
 
+def test_abs_jd2_always_less_than_half():
+    """Make jd2 approach +/-0.5, and check that it doesn't go over."""
+    t1 = Time(2400000.5, [-2**-52, +2**-52], format='jd')
+    assert np.all(abs(t1.jd2) < 0.5)
+    t2 = Time(2400000., [0.5-2**-52, 0.5+2**-52], format='jd')
+    assert np.all(abs(t2.jd2) < 0.5)
+
+
 def test_addition():
     """Check that an addition at the limit of precision (2^-52) is seen"""
     t = Time(2455555., 0.5, format='jd', scale='utc')

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -88,13 +88,12 @@ def test_iso_init():
     assert allclose_jd2(dt.jd2, 13. / 24. + 1e-8 / 86400. - 1.0)
 
 
-def test_jd1_is_mult_of_half_or_one():
+def test_jd1_is_mult_of_one():
     """
-    Check that jd1 is a multiple of 0.5 (note the difference from when Time is created
-    with a format like 'jd' or 'cxcsec', where jd1 is a multiple of 1.0).
+    Check that jd1 is a multiple of 1.
     """
     t1 = Time('2000:001:00:00:00.00000001', scale='tai')
-    assert np.round(t1.jd1 * 2) == t1.jd1 * 2
+    assert np.round(t1.jd1) == t1.jd1
     t1 = Time(1.23456789, 12345678.90123456, format='jd', scale='tai')
     assert np.round(t1.jd1) == t1.jd1
 

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -11,15 +11,18 @@ allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
 allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
                                  atol=2. ** -52 * 24 * 3600)  # 20 ps atol
 
-
-dt_tiny = TimeDelta(2. ** -52, format='jd')
+tiny = 2. ** -52
+dt_tiny = TimeDelta(tiny, format='jd')
 
 
 def test_abs_jd2_always_less_than_half():
     """Make jd2 approach +/-0.5, and check that it doesn't go over."""
-    t1 = Time(2400000.5, [-2**-52, +2**-52], format='jd')
+    t1 = Time(2400000.5, [-tiny, +tiny], format='jd')
+    assert np.all(t1.jd1 % 1 == 0)
     assert np.all(abs(t1.jd2) < 0.5)
-    t2 = Time(2400000., [0.5-2**-52, 0.5+2**-52], format='jd')
+    t2 = Time(2400000., [[0.5-tiny, 0.5+tiny],
+                         [-0.5-tiny, -0.5+tiny]], format='jd')
+    assert np.all(t2.jd1 % 1 == 0)
     assert np.all(abs(t2.jd2) < 0.5)
 
 

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -49,6 +49,12 @@ def day_frac(val1, val2, factor=None, divisor=None):
     day = np.round(sum12)
     extra, frac = two_sum(sum12, -day)
     frac += extra + err12
+    # Our fraction can now have gotten >0.5 or <-0.5, which means we would
+    # loose one bit of precision. So, correct for that.
+    excess = np.round(frac)
+    day += excess
+    extra, frac = two_sum(sum12, -day)
+    frac += extra + err12
     return day, frac
 
 

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -12,14 +12,24 @@ from astropy import units as u
 
 
 def day_frac(val1, val2, factor=None, divisor=None):
-    """
-    Return the sum of ``val1`` and ``val2`` as two float64s, an integer part
-    and the fractional remainder.  If ``factor`` is given, then multiply the
-    sum by it.  If ``divisor`` is given, then divide the sum by it.
+    """Return the sum of ``val1`` and ``val2`` as two float64s.
+
+    The returned floats are an integer part and the fractional remainder,
+    with the latter guaranteed to be within -0.5 and 0.5 (inclusive on
+    either side, as the integer is rounded to even).
 
     The arithmetic is all done with exact floating point operations so no
-    precision is lost to rounding error.  This routine assumes the sum is less
-    than about 1e16, otherwise the ``frac`` part will be greater than 1.0.
+    precision is lost to rounding error.  It is assumed the sum is less
+    than about 1e16, otherwise the remainder will be greater than 1.0.
+
+    Parameters
+    ----------
+    val1, val2 : array of float
+        Values to be summed.
+    factor : float, optional
+        If given, multiply the sum by it.
+    divisor : float, optional
+        If given, divide the sum by it.
 
     Returns
     -------


### PR DESCRIPTION
Not sure this is strictly a bug, since we do not guarantee a particular implementation of jd1 and jd2, but this is more consistent and will make the precision very slightly better.

Found while implementing a double-precision `Phase` class where I did want to ensure that the fractional phase in cycles was strictly in the range `-0.5<=fraction<=0.5` (https://github.com/mhvk/scintillometry/pull/77)