### PR TITLE
Make coordinates.solar_system_ephemeris accept local ephemeris file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
  - Changed ``coordinates.solar_system_ephemeris`` to also accept local files
-   as input. The ephemeris can not be selected by either keyword (e.g. 'jpl',
+   as input. The ephemeris can now be selected by either keyword (e.g. 'jpl',
    'de430'), URL or file path. [#8767]
 
 astropy.cosmology

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+ - Changed ``coordinates.solar_system_ephemeris`` to also accept local files
+   as input. The ephemeris can not be selected by either keyword (e.g. 'jpl',
+   'de430'), URL or file path. [#8767]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -161,7 +161,7 @@ def _get_kernel(value):
     if value.lower() == 'jpl':
         value = DEFAULT_JPL_EPHEMERIS
 
-    elif value.lower() in ('de430', 'de432s'):
+    if value.lower() in ('de430', 'de432s'):
         value = ('http://naif.jpl.nasa.gov/pub/naif/generic_kernels'
                  '/spk/planets/{:s}.bsp'.format(value.lower()))
 


### PR DESCRIPTION
Make `coordinates.solar_system_ephemeris` accept local ephemeris file as input.

New dependency of `os.path` is needed, because tests revealed that standard Windows paths would pass through `urlparse` without throwing an error. I therefore switched to use `os.path.isfile` to test if the input was a file path.

Fixes #8750