### PR TITLE
Minor: changelog correction

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1239,7 +1239,7 @@ astropy.wcs
 - Added the abstract base class for the low-level WCS API described in APE 14
   (https://doi.org/10.5281/zenodo.1188875). [#7325]
 
-- Add ``WCS.contains()`` function to check if the WCS footprint contains a given sky coordinate. [#7273]
+- Add ``WCS.footprint_contains()`` function to check if the WCS footprint contains a given sky coordinate. [#7273]
 
 - Added the abstract base class for the high-level WCS API described in APE 14
   (https://doi.org/10.5281/zenodo.1188875). [#7325]


### PR DESCRIPTION
The changelog entry about `WCS.footprint_contains` incorrectly said `WCS.contains`

EDIT: Fix the change log of #7273