### PR TITLE
TST: Fix dtype compatibility in io.fits.utils with numpy-dev

### DIFF
--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -765,7 +765,7 @@ def _words_group(input, strlen):
     words = []
     nblanks = input.count(' ')
     nmax = max(nblanks, len(input) // strlen + 1)
-    arr = np.frombuffer((input + ' ').encode('utf8'), dtype=(bytes, 1))
+    arr = np.frombuffer((input + ' ').encode('utf8'), dtype='S1')
 
     # locations of the blanks
     blank_loc = np.nonzero(arr == b' ')[0]
@@ -902,7 +902,7 @@ def _rstrip_inplace(array):
     # View the array as appropriate integers. The last dimension will
     # equal the number of characters in each string.
     bpc = 1 if dt.kind == 'S' else 4
-    dt_int = "{0}{1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
+    dt_int = "({0},){1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
     b = array.view(dt_int, np.ndarray)
     # For optimal speed, work in chunks of the internal ufunc buffer size.
     bufsize = np.getbufsize()


### PR DESCRIPTION
Example log: https://travis-ci.org/astropy/astropy/jobs/538455547 

The numpy-dev job caught one more warning than expected:
```
_________________ TestSingleTable.test_simple_meta_conflicting _________________
self = <astropy.io.fits.tests.test_connect.TestSingleTable object at 0x7f9b100eacc0>
tmpdir = local('/tmp/pytest-of-travis/pytest-0/test_simple_meta_conflicting0')
    def test_simple_meta_conflicting(self, tmpdir):
        filename = str(tmpdir.join('test_simple.fits'))
        t1 = Table(self.data)
        t1.meta['ttype1'] = 'spam'
        with catch_warnings() as l:
            t1.write(filename, overwrite=True)
>       assert len(l) == 1
E       assert 2 == 1
E        +  where 2 = len([<warnings.WarningMessage object at 0x7f9b0fe06550>, <warnings.WarningMessage object at 0x7f9b0fe06c88>])
astropy/io/fits/tests/test_connect.py:90: AssertionError
```

This PR tried to get more information on that extra warning. And also it disables installing matplotlib dev for the same job due to matplotlib/matplotlib#14370 .