### PR TITLE
Do not attempt to delete WCS keywords twice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -333,6 +333,9 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Do not attempt to delete repeated distortion keywords multiple times when
+  loading distortions with ``_read_distortion_kw`` and
+  ``_read_det2im_kw``. [#8777]
 
 
 Other Changes and Additions

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -783,7 +783,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     tables[i] = d_lookup
                 else:
                     warnings.warn('Polynomial distortion is not implemented.\n', AstropyUserWarning)
-                for key in list(header):
+                for key in set(header):
                     if key.startswith(dp + str('.')):
                         del header[key]
             else:
@@ -935,7 +935,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                     d_lookup = DistortionLookupTable(d_data, d_crpix, d_crval, d_cdelt)
                     tables[i] = d_lookup
 
-                    for key in list(header):
+                    for key in set(header):
                         if key.startswith(dp + str('.')):
                             del header[key]
                 else:


### PR DESCRIPTION
Dr. Peter Maksym has reported an issue (on STScI's "Service Now")  due to which `astrodrizzle` would crash when run on on image to which a WCS was applied from a headerlet. The reason as reported by Dr. Peter Maksym is that `apply_headerlet` appends  `D2IM1.*` and `D2IM2.*` keywords to the header. However, when `astropy.wcs.WCS()` attempts to load the WCS, it attempts to delete all instances of `D2IM1.NAXES` *multiple times*. Therefore, when a WCS object is being constructed, `astropy.wcs.WCS()` crashes because of missing `D2IM1.NAXES`.

This PR enhances existing code and makes it more robust to situations such as this.