### PR TITLE
Do not import units in units.function to avoid sphinx warnings.

### DIFF
--- a/astropy/units/function/__init__.py
+++ b/astropy/units/function/__init__.py
@@ -7,4 +7,3 @@ are some function of a physical unit, such as magnitudes and decibels.
 """
 from .core import *
 from .logarithmic import *
-from .units import *

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -82,8 +82,8 @@ Units that "cancel out" become a special unit called the
 
     >>> u.m / u.m
     Unit(dimensionless)
-    
-To create a simple :ref:`dimensionless quantity <doc_dimensionless_unit>`, 
+
+To create a simple :ref:`dimensionless quantity <doc_dimensionless_unit>`,
 multiply a value by the unscaled dimensionless unit::
 
     >>> q = 1.0 * u.dimensionless_unscaled


### PR DESCRIPTION
In `units.function.__init__`, an import for function units was done, which led to a lot of missing link warnings. Since units should not be accessed via `units.function` anyway, just remove that import.