### PR TITLE
Invalid TRPOS<n> keyword not generated for FITS time column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,7 +292,8 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
-- Invalid TRPOS<n> keyword is not generated for FITS time column. [#8784]
+- Fixes bug where an invalid TRPOS<n> keyword was being generated for FITS
+time column when no location was available. [#8784]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -453,6 +453,8 @@ astropy.io.fits
 - Allow ``Header.fromstring`` and ``Card.fromstring`` to accept ``bytes``.
   [#8707]
 
+- Invalid TRPOS<n> keyword is not generated for FITS time column. [#8784]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -293,7 +293,7 @@ astropy.io.fits
 ^^^^^^^^^^^^^^^
 
 - Fixes bug where an invalid TRPOS<n> keyword was being generated for FITS
-time column when no location was available. [#8784]
+  time column when no location was available. [#8784]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -292,6 +292,8 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Invalid TRPOS<n> keyword is not generated for FITS time column. [#8784]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
@@ -452,8 +454,6 @@ astropy.io.fits
 
 - Allow ``Header.fromstring`` and ``Card.fromstring`` to accept ``bytes``.
   [#8707]
-
-- Invalid TRPOS<n> keyword is not generated for FITS time column. [#8784]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -536,9 +536,13 @@ def table_to_hdu(table, character_as_bytes=False):
     for col_name, col_info in coord_meta.items():
         col = table_hdu.columns[col_name]
         # Set the column coordinate attributes from data saved earlier.
-        # Note: have to set all three, even if we have no data.
-        for attr in 'coord_type', 'coord_unit', 'time_ref_pos':
+        # Note: have to set these, even if we have no data.
+        for attr in 'coord_type', 'coord_unit':
             setattr(col, attr, col_info.get(attr, None))
+        trpos = col_info.get('time_ref_pos', None)
+        if trpos is not None:
+            setattr(col, 'time_ref_pos', trpos)
+            
 
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -542,7 +542,6 @@ def table_to_hdu(table, character_as_bytes=False):
         trpos = col_info.get('time_ref_pos', None)
         if trpos is not None:
             setattr(col, 'time_ref_pos', trpos)
-            
 
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -255,17 +255,11 @@ def _verify_column_info(column_info, global_info):
         else:
             column_info['location'] = None
 
-    # Since TRPOSn is not specified, global reference position is
-    # considered.
+    # Warn user about ignoring global reference position when TRPOSn is
+    # not specified
     elif global_info['TREFPOS'] == 'TOPOCENTER':
 
-        if global_info['location'] is None:
-            warnings.warn(
-                'Time column reference position "TRPOSn" is not specified. The '
-                'default value for it is "TOPOCENTER", but due to unspecified '
-                'observatory position, reference position will be ignored.',
-                AstropyUserWarning)
-        else:
+        if global_info['location'] is not None:
             warnings.warn(
                 'Time column reference position "TRPOSn" is not specified. The '
                 'default value for it is "TOPOCENTER", and the observatory position '

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -259,13 +259,20 @@ def _verify_column_info(column_info, global_info):
     # considered.
     elif global_info['TREFPOS'] == 'TOPOCENTER':
 
-        column_info['location'] = global_info['location']
-        if column_info['location'] is None:
+        if global_info['location'] is None:
             warnings.warn(
                 'Time column reference position "TRPOSn" is not specified. The '
                 'default value for it is "TOPOCENTER", but due to unspecified '
                 'observatory position, reference position will be ignored.',
                 AstropyUserWarning)
+        else:
+            warnings.warn(
+                'Time column reference position "TRPOSn" is not specified. The '
+                'default value for it is "TOPOCENTER", and the observatory position '
+                'has been specified. However, for supporting column-specific location, '
+                'reference position will be ignored for this column.',
+                AstropyUserWarning)
+        column_info['location'] = None
     else:
         column_info['location'] = None
 
@@ -541,6 +548,7 @@ def time_to_fits(table):
 
         # Time column reference position
         if getattr(col, 'location') is None:
+            coord_meta[col.info.name]['time_ref_pos'] = None
             if location is not None:
                 warnings.warn(
                     'Time Column "{}" has no specified location, but global Time '

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -65,7 +65,7 @@ class TestFitsTime(FitsTestCase):
                           '"TRPOSn" is not specified. The default value for it is '
                           '"TOPOCENTER", and the observatory position has been specified.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
-                              astropy_native=True)
+                                  astropy_native=True)
 
         assert (tm['a'].location == t['a'].location).all()
         assert tm['b'].location == t['b'].location

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -60,7 +60,7 @@ class TestFitsTime(FitsTestCase):
         # Check that a blank value for the "TRPOSn" keyword is not generated
         hdr = fits.getheader(self.temp('time.fits'), 1)
         assert hdr.get('TRPOS2', None) is None
-        
+
         with pytest.warns(AstropyUserWarning, match='Time column reference position '
                           '"TRPOSn" is not specified. The default value for it is '
                           '"TOPOCENTER", and the observatory position has been specified.'):

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -194,12 +194,8 @@ class TestFitsTime(FitsTestCase):
         # back using native astropy objects; thus, ensure its round-trip
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
-        with pytest.warns(AstropyUserWarning, match='Time column reference '
-                          'position "TRPOSn" is not specified. The default '
-                          'value for it is "TOPOCENTER", but due to unspecified '
-                          'observatory position, reference position will be ignored.'):
-            tm = table_types.read(self.temp('time.fits'), format='fits',
-                                  astropy_native=True)
+        tm = table_types.read(self.temp('time.fits'), format='fits',
+                              astropy_native=True)
 
         # Test DATE
         assert isinstance(tm.meta['DATE'], Time)
@@ -219,12 +215,8 @@ class TestFitsTime(FitsTestCase):
 
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
-        with pytest.warns(AstropyUserWarning, match='Time column reference '
-                          'position "TRPOSn" is not specified. The default value '
-                          'for it is "TOPOCENTER", but due to unspecified observatory '
-                          'position, reference position will be ignored.'):
-            tm = table_types.read(self.temp('time.fits'), format='fits',
-                                  astropy_native=True)
+        tm = table_types.read(self.temp('time.fits'), format='fits',
+                              astropy_native=True)
 
         # Test DATE
         assert isinstance(tm.meta['DATE'], Time)
@@ -437,7 +429,8 @@ class TestFitsTime(FitsTestCase):
             assert ('observatory position is not properly specified' in
                     str(w[0].message))
 
-        # Default value for time reference position is "TOPOCENTER"
+        # Warning for default value of time reference position "TOPOCENTER"
+        # not generated when there is no specified observatory position.
         c = fits.Column(name='datetime', format='A29', coord_type='TT',
                         array=self.time)
 
@@ -445,6 +438,4 @@ class TestFitsTime(FitsTestCase):
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
         with catch_warnings() as w:
             tm = table_types.read(self.temp('time.fits'), astropy_native=True)
-            assert len(w) == 1
-            assert ('"TRPOSn" is not specified. The default value for '
-                    'it is "TOPOCENTER"' in str(w[0].message))
+            assert len(w) == 0

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -57,10 +57,15 @@ class TestFitsTime(FitsTestCase):
                           'specified location, but global Time Position is present'):
             t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
-        with pytest.warns(fits.verify.VerifyWarning,
-                          match='Invalid keyword for column 2'):
+        # Check that a blank value for the "TRPOSn" keyword is not generated
+        hdr = fits.getheader(self.temp('time.fits'), 1)
+        assert hdr.get('TRPOS2', None) is None
+        
+        with pytest.warns(AstropyUserWarning, match='Time column reference position '
+                          '"TRPOSn" is not specified. The default value for it is '
+                          '"TOPOCENTER", and the observatory position has been specified.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
-                                  astropy_native=True)
+                              astropy_native=True)
 
         assert (tm['a'].location == t['a'].location).all()
         assert tm['b'].location == t['b'].location
@@ -170,6 +175,7 @@ class TestFitsTime(FitsTestCase):
             assert coord_info[colname]['coord_unit'] == 'd'
 
         assert coord_info['a']['time_ref_pos'] == 'TOPOCENTER'
+        assert coord_info['b']['time_ref_pos'] == None
 
         assert len(hdr) == 0
 
@@ -188,8 +194,10 @@ class TestFitsTime(FitsTestCase):
         # back using native astropy objects; thus, ensure its round-trip
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
-        with pytest.warns(fits.verify.VerifyWarning,
-                          match='Invalid keyword for column 1'):
+        with pytest.warns(AstropyUserWarning, match='Time column reference '
+                          'position "TRPOSn" is not specified. The default '
+                          'value for it is "TOPOCENTER", but due to unspecified '
+                          'observatory position, reference position will be ignored.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
                                   astropy_native=True)
 
@@ -211,8 +219,10 @@ class TestFitsTime(FitsTestCase):
 
         t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
-        with pytest.warns(fits.verify.VerifyWarning,
-                          match='Invalid keyword for column 1'):
+        with pytest.warns(AstropyUserWarning, match='Time column reference '
+                          'position "TRPOSn" is not specified. The default value '
+                          'for it is "TOPOCENTER", but due to unspecified observatory '
+                          'position, reference position will be ignored.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
                                   astropy_native=True)
 

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -164,9 +164,7 @@ def test_serialize_fits_masked(tmpdir):
     t = Table([tm])
     t.write(fn)
 
-    # Warning is a bug; https://github.com/astropy/astropy/issues/8773
-    with pytest.warns(VerifyWarning):
-        t2 = Table.read(fn, astropy_native=True)
+    t2 = Table.read(fn, astropy_native=True)
 
     # Time FITS handling does not current round-trip format in FITS
     t2['col0'].format = tm.format


### PR DESCRIPTION
This fixes issue #8773. I had to make a few minor changes to the FITS TIME machinery to handle default values. Have added a small test too!

@taldcroft Do check!

Fixes #8773