### PR TITLE
Update Matplotlib CI configuration and drop support for Matplotlib 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install C++ compiler
+          command: apt install -y g++
+      - run:
           name: Install Python dependencies, including developer version of Matplotlib
           command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,18 +37,9 @@ jobs:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
 
-  image-tests-mpl202:
-    docker:
-      - image: astropy/image-tests-py35-mpl202:1.4
-    steps:
-      - checkout
-      - run:
-          name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
-
   image-tests-mpl212:
     docker:
-      - image: astropy/image-tests-py35-mpl212:1.4
+      - image: astropy/image-tests-py36-mpl212:1.5
     steps:
       - checkout
       - run:
@@ -57,16 +48,25 @@ jobs:
 
   image-tests-mpl222:
     docker:
-      - image: astropy/image-tests-py35-mpl222:1.4
+      - image: astropy/image-tests-py36-mpl222:1.5
     steps:
       - checkout
       - run:
           name: Run tests
           command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
 
-  image-tests-mpl300:
+  image-tests-mpl302:
     docker:
-      - image: astropy/image-tests-py35-mpl300:1.4
+      - image: astropy/image-tests-py36-mpl302:1.5
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+
+  image-tests-mpl310:
+    docker:
+      - image: astropy/image-tests-py36-mpl310:1.5
     steps:
       - checkout
       - run:
@@ -75,12 +75,9 @@ jobs:
 
   image-tests-mpldev:
     docker:
-      - image: astropy/image-tests-py36-base:1.1
+      - image: astropy/image-tests-py36-base:1.2
     steps:
       - checkout
-      - run:
-          name: Install apt dependencies
-          command: apt-get install -y libfreetype6-dev libpng12-dev pkg-config cm-super
       - run:
           name: Install Python dependencies, including developer version of Matplotlib
           command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
@@ -129,10 +126,10 @@ workflows:
       - egg-info-37
       - html-docs
       - 32bit
-      - image-tests-mpl202
       - image-tests-mpl212
       - image-tests-mpl222
-      - image-tests-mpl300
+      - image-tests-mpl302
+      - image-tests-mpl310
       - image-tests-mpldev
 
 notify:

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,7 +128,7 @@ matrix:
                PIP_DEPENDENCIES="scikit-image codecov objgraph jplephem bintrees sortedcontainers $ASDF_PIP_DEP"
                LC_CTYPE=C.ascii LC_ALL=C
                CFLAGS='--coverage -fno-inline-functions -O0'
-               MATPLOTLIB_VERSION=2.0
+               MATPLOTLIB_VERSION=2.1
                EVENT_TYPE='push pull_request cron'
 
         # Try pre-release version of Numpy without optional dependencies

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,9 +241,7 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
-
-
+- Matplotlib 2.1 and later is now required. [#8787]
 
 
 3.2.1 (unreleased)

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,8 +45,33 @@ asdf_extensions =
     astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension
 
 [options.extras_require]
-test = pytest-astropy; pytest-xdist; pytest-mpl; objgraph; ipython; coverage; skyfield
-all = scipy; h5py; beautifulsoup4; html5lib; bleach; PyYAML; pandas; bintrees; sortedcontainers; pytz; jplephem; matplotlib>=2.0; scikit-image; mpmath; asdf>=2.3; bottleneck; ipython; pytest
+test =
+    pytest-astropy
+    pytest-xdist
+    pytest-mpl
+    objgraph
+    ipython
+    coverage
+    skyfield
+all =
+    scipy
+    h5py
+    beautifulsoup4
+    html5lib
+    bleach
+    PyYAML
+    pandas
+    bintrees
+    sortedcontainers
+    pytz
+    jplephem
+    matplotlib>=2.1
+    scikit-image
+    mpmath
+    asdf>=2.3
+    bottleneck
+    ipython
+    pytest
 docs = sphinx-astropy
 
 [build_sphinx]


### PR DESCRIPTION
This PR:

* Drops support for Matplotlib 2.0
* Updates CircleCI Matplotlib configurations to use Python 3.6
* Adds a Matplotlib 3.1 configuration.

