### PR TITLE
Change behavior of Table regarding masked columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,11 +120,17 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Masked column handling has changed, see ``astropy.table`` entry below. [#8789]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Masked column handling has changed, see ``astropy.table`` entry below. [#8789]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
+
+- Masked column handling has changed, see ``astropy.table`` entry below. [#8789]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
@@ -151,6 +157,16 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+
+- The handling of masked columns in the ``Table`` class has changed in a way
+  that may impact program behavior. Now a ``Table`` with ``masked=False`` may
+  contain both ``Column`` and ``MaskedColumn`` objects, and adding a masked
+  column or row to a table no longer "upgrades" the table and columns to masked.
+  This means that tables with masked data which are read via ``Table.read()``
+  will now always have ``masked=False``, though specific columns will be masked as
+  needed. Two new table properties ``has_masked_columns`` and ``has_masked_values``
+  were added. See the ``Masking change in astropy 4.0`` section within
+  `<https://docs.astropy.org/en/v4.0/table/masking.html>`_ for details. [#8789]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -985,7 +985,8 @@ class TableOutputter(BaseOutputter):
         # FloatType) for each col.
         self._convert_vals(cols)
 
-        t_cols = [numpy.ma.MaskedArray(x.data, mask=x.mask) if hasattr(x, 'mask')
+        t_cols = [numpy.ma.MaskedArray(x.data, mask=x.mask)
+                  if hasattr(x, 'mask') and numpy.any(x.mask)
                   else x.data for x in cols]
         out = Table(t_cols, names=[x.name for x in cols], meta=meta['table'])
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -985,15 +985,11 @@ class TableOutputter(BaseOutputter):
         # FloatType) for each col.
         self._convert_vals(cols)
 
-        # If there are any values that were filled and tagged with a mask bit then this
-        # will be a masked table.  Otherwise use a plain table.
-        masked = any(hasattr(col, 'mask') and numpy.any(col.mask) for col in cols)
+        t_cols = [numpy.ma.MaskedArray(x.data, mask=x.mask) if hasattr(x, 'mask')
+                  else x.data for x in cols]
+        out = Table(t_cols, names=[x.name for x in cols], meta=meta['table'])
 
-        out = Table([x.data for x in cols], names=[x.name for x in cols], masked=masked,
-                    meta=meta['table'])
         for col, out_col in zip(cols, out.columns.values()):
-            if masked and hasattr(col, 'mask'):
-                out_col.data.mask = col.mask
             for attr in ('format', 'unit', 'description'):
                 if hasattr(col, attr):
                     setattr(out_col, attr, getattr(col, attr))

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -906,14 +906,16 @@ def test_line_endings(parallel, read_basic, read_commented_header, read_rdb):
         table = read_commented_header(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
 
-    expected = Table([[1, 4, 7], [2, 5, 8], [3, 6, 9]], names=('a', 'b', 'c'), masked=True)
+    expected = Table([MaskedColumn([1, 4, 7]), [2, 5, 8], MaskedColumn([3, 6, 9])],
+                     names=('a', 'b', 'c'))
     expected['a'][0] = np.ma.masked
     expected['c'][0] = np.ma.masked
     text = 'a\tb\tc\nN\tN\tN\n\t2\t\n4\t5\t6\n7\t8\t9\n'
     for newline in ('\r\n', '\r'):
         table = read_rdb(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
-        assert np.all(table == expected)
+        # TO DO : deal with this
+        # assert np.all(table == expected)
 
 
 @pytest.mark.parametrize("parallel", [True, False])

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -914,8 +914,7 @@ def test_line_endings(parallel, read_basic, read_commented_header, read_rdb):
     for newline in ('\r\n', '\r'):
         table = read_rdb(text.replace('\n', newline), parallel=parallel)
         assert_table_equal(table, expected)
-        # TO DO : deal with this
-        # assert np.all(table == expected)
+        assert np.all(table == expected)
 
 
 @pytest.mark.parametrize("parallel", [True, False])

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -458,7 +458,7 @@ def test_round_trip_masked_table_default(tmpdir):
     t.write(filename)
 
     t2 = Table.read(filename)
-    assert t2.masked is True
+    assert t2.masked is False
     assert t2.colnames == t.colnames
     for name in t2.colnames:
         # From formal perspective the round-trip columns are the "same"
@@ -487,7 +487,7 @@ def test_round_trip_masked_table_serialize_mask(tmpdir):
     t.write(filename, serialize_method='data_mask')
 
     t2 = Table.read(filename)
-    assert t2.masked is True
+    assert t2.masked is False
     assert t2.colnames == t.colnames
     for name in t2.colnames:
         assert np.all(t2[name].mask == t[name].mask)

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -105,7 +105,7 @@ def test_missing_data():
                 '<tr><td>1</td></tr>',
                 '</table>']
     dat = Table.read(table_in, format='ascii.html')
-    assert dat.masked is True
+    assert dat.masked is False
     assert np.all(dat['A'].mask == [True, False])
     assert dat['A'].dtype.kind == 'i'
 
@@ -116,7 +116,7 @@ def test_missing_data():
                 '<tr><td>1</td></tr>',
                 '</table>']
     dat = Table.read(table_in, format='ascii.html', fill_values=[('...', '0')])
-    assert dat.masked is True
+    assert dat.masked is False
     assert np.all(dat['A'].mask == [True, False])
     assert dat['A'].dtype.kind == 'i'
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -546,7 +546,7 @@ def test_default_missing(fast_reader):
                        '1,3,,',
                        '2, , 4.0 , ss '])
     dat = ascii.read(table, fast_reader=fast_reader)
-    assert dat.masked is True
+    assert dat.masked is False
     assert dat.pformat() == [' a   b   c   d ',
                              '--- --- --- ---',
                              '  1   3  --  --',
@@ -566,7 +566,7 @@ def test_default_missing(fast_reader):
                        '  1   3        ',
                        '  2     4.0  ss'])
     dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine)
-    assert dat.masked is True
+    assert dat.masked is False
     assert dat.pformat() == [' a   b   c   d ',
                              '--- --- --- ---',
                              '  1   3  --  --',

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -464,7 +464,7 @@ def test_fill_values_exclude_names(fast_reader):
 
 def check_fill_values(data):
     """compare array column by column with expectation """
-    assert_true((data['a'].mask == [False, False]).all())
+    assert not hasattr(data['a'], 'mask')
     assert_true((data['a'] == ['1', 'a']).all())
     assert_true((data['b'].mask == [False, True]).all())
     # Check that masked value is "do not care" in comparison

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -211,10 +211,12 @@ def test_guess_all_files():
 def test_daophot_indef():
     """Test that INDEF is correctly interpreted as a missing value"""
     table = ascii.read('data/daophot2.dat', Reader=ascii.Daophot)
-    for colname in table.colnames:
-        # Three columns have all INDEF values and are masked
-        mask_value = colname in ('OTIME', 'MAG', 'MERR', 'XAIRMASS')
-        assert np.all(table[colname].mask == mask_value)
+    for col in table.itercols():
+        # Four columns have all INDEF values and are masked, rest are normal Column
+        if col.name in ('OTIME', 'MAG', 'MERR', 'XAIRMASS'):
+            assert np.all(col.mask)
+        else:
+            assert not hasattr(col, 'mask')
 
 
 def test_daophot_types():
@@ -489,7 +491,7 @@ def test_masking_Cds():
     data = ascii.read(f,
                            **testfile['opts'])
     assert_true(data['AK'].mask[0])
-    assert_true(not data['Fit'].mask[0])
+    assert not hasattr(data['Fit'], 'mask')
 
 
 def test_null_Ipac():

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -684,7 +684,7 @@ def test_round_trip_masked_table_serialize_mask(tmpdir, method):
         t.write(filename, serialize_method='data_mask')
 
     t2 = Table.read(filename)
-    assert t2.masked is True
+    assert t2.masked is False
     assert t2.colnames == t.colnames
     for name in t2.colnames:
         assert np.all(t2[name].mask == t[name].mask)

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -871,7 +871,7 @@ def test_round_trip_masked_table_default(tmpdir):
     t.write(filename, format='hdf5', path='root', serialize_meta=True)
 
     t2 = Table.read(filename)
-    assert t2.masked is True
+    assert t2.masked is False
     assert t2.colnames == t.colnames
     for name in t2.colnames:
         assert np.all(t2[name].mask == t[name].mask)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -556,8 +556,10 @@ class Table:
     @property
     def mask(self):
         # Dynamic view of available masks
-        if self.masked:
-            mask_table = Table([col.mask for col in self.columns.values()],
+        if (self.masked or
+                any(hasattr(col, 'mask') for col in self.itercols())):
+            mask_table = Table([getattr(col, 'mask', FalseArray(col.shape))
+                                for col in self.itercols()],
                                names=self.colnames, copy=False)
 
             # Set hidden attribute to force inplace setitem so that code like

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -355,7 +355,7 @@ class Table:
         table_array : np.ndarray (unmasked) or np.ma.MaskedArray (masked)
             Copy of table as a numpy structured array
         """
-        masked = any(isinstance(col, MaskedColumn) for col in self.itercols())
+        masked = self.masked or any(isinstance(col, MaskedColumn) for col in self.itercols())
         empty_init = ma.empty if masked else np.empty
         if len(self.columns) == 0:
             return empty_init(0, dtype=None)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -387,6 +387,10 @@ class Table:
             # byte order where applicable
             data[col.info.name] = col
 
+            # For masked out, masked mixin columns need to set output mask attribute.
+            if masked and has_info_class(col, MixinInfo) and hasattr(col, 'mask'):
+                data[col.info.name].mask = col.mask
+
         return data
 
     def __init__(self, data=None, masked=False, names=None, dtype=None,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2759,7 +2759,7 @@ class Table:
         if isinstance(other, Table):
             other = other.as_array()
 
-        if self.masked:
+        if self.has_masked_columns:
             if isinstance(other, np.ma.MaskedArray):
                 result = self.as_array() == other
             else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3116,7 +3116,15 @@ class QTable(Table):
         return has_info_class(col, MixinInfo)
 
     def _convert_col_for_table(self, col):
-        if (isinstance(col, Column) and getattr(col, 'unit', None) is not None):
+        if isinstance(col, Column) and getattr(col, 'unit', None) is not None:
+            # What to do with MaskedColumn with units: leave as MaskedColumn or
+            # turn into Quantity and drop mask?  Assuming we have masking support
+            # in Quantity someday, let's drop the mask (consistent with legacy
+            # behavior) but issue a warning.
+            if isinstance(col, MaskedColumn) and np.any(col.mask):
+                warnings.warn("dropping mask in Quantity column '{}': "
+                              "masked Quantity not supported".format(col.info.name))
+
             # We need to turn the column into a quantity, or a subclass
             # identified in the unit (such as u.mag()).
             q_cls = getattr(col.unit, '_quantity_class', Quantity)

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.ma as ma
 
 from astropy.table import Column, MaskedColumn, Table
+from astropy.time import Time
 
 
 class SetupData:
@@ -430,3 +431,22 @@ def test_mask_copy():
     c2.mask[0] = True
     assert np.all(c.mask == [False, True])
     assert np.all(c2.mask == [True, True])
+
+
+def test_masked_as_array_with_mixin():
+    """Test that as_array() works with a masked mixin column"""
+    t = Table()
+    t['a'] = Time([1, 2], format='cxcsec')
+    t['b'] = [3, 4]
+
+    # With no mask, the output should be ndarray
+    ta = t.as_array()
+    assert isinstance(ta, np.ndarray) and not isinstance(ta, np.ma.MaskedArray)
+
+    # With a mask, output is MaskedArray
+    t['a'][1] = np.ma.masked
+    ta = t.as_array()
+    assert isinstance(ta, np.ma.MaskedArray)
+    assert np.all(ta['a'].mask == [False, True])
+    assert np.isclose(ta['a'][0].cxcsec, 1.0)
+    assert np.all(ta['b'].mask == False)

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -7,8 +7,9 @@ import pytest
 import numpy as np
 import numpy.ma as ma
 
-from astropy.table import Column, MaskedColumn, Table
+from astropy.table import Column, MaskedColumn, Table, QTable
 from astropy.time import Time
+import astropy.units as u
 
 
 class SetupData:
@@ -434,10 +435,11 @@ def test_mask_copy():
 
 
 def test_masked_as_array_with_mixin():
-    """Test that as_array() works with a masked mixin column"""
+    """Test that as_array() and Table.mask attr work with masked mixin columns"""
     t = Table()
     t['a'] = Time([1, 2], format='cxcsec')
     t['b'] = [3, 4]
+    t['c'] = [5, 6] * u.m
 
     # With no mask, the output should be ndarray
     ta = t.as_array()
@@ -450,3 +452,10 @@ def test_masked_as_array_with_mixin():
     assert np.all(ta['a'].mask == [False, True])
     assert np.isclose(ta['a'][0].cxcsec, 1.0)
     assert np.all(ta['b'].mask == False)
+    assert np.all(ta['c'].mask == False)
+
+    # Check table ``mask`` property
+    tm = t.mask
+    assert np.all(tm['a'] == [False, True])
+    assert np.all(tm['b'] == False)
+    assert np.all(tm['c'] == False)

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -215,6 +215,8 @@ class TestAddColumn:
         assert t.masked
         t.add_column(MaskedColumn(name='b', data=[4, 5, 6], mask=[1, 0, 1]))
         assert t.masked
+        assert isinstance(t['a'], MaskedColumn)
+        assert isinstance(t['b'], MaskedColumn)
         assert np.all(t['a'] == np.array([1, 2, 3]))
         assert np.all(t['a'].mask == np.array([0, 1, 0], bool))
         assert np.all(t['b'] == np.array([4, 5, 6]))
@@ -226,9 +228,11 @@ class TestAddColumn:
         t.add_column(Column(name='a', data=[1, 2, 3]))
         assert not t.masked
         t.add_column(MaskedColumn(name='b', data=[4, 5, 6], mask=[1, 0, 1]))
-        assert t.masked
+        assert not t.masked  # Changed in 4.0, table no longer auto-upgrades
+        assert isinstance(t['a'], Column)  # Was MaskedColumn before 4.0
+        assert isinstance(t['b'], MaskedColumn)
         assert np.all(t['a'] == np.array([1, 2, 3]))
-        assert np.all(t['a'].mask == np.array([0, 0, 0], bool))
+        assert not hasattr(t['a'], 'mask')
         assert np.all(t['b'] == np.array([4, 5, 6]))
         assert np.all(t['b'].mask == np.array([1, 0, 1], bool))
 
@@ -239,6 +243,8 @@ class TestAddColumn:
         assert t.masked
         t.add_column(MaskedColumn(name='b', data=[4, 5, 6], mask=[1, 0, 1]))
         assert t.masked
+        assert isinstance(t['a'], MaskedColumn)
+        assert isinstance(t['b'], MaskedColumn)
         assert np.all(t['a'] == np.array([1, 2, 3]))
         assert np.all(t['a'].mask == np.array([0, 0, 0], bool))
         assert np.all(t['b'] == np.array([4, 5, 6]))

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -171,13 +171,13 @@ class TestTableInit(SetupData):
     """Initializing a table"""
 
     def test_mask_true_if_any_input_masked(self):
-        """Masking is True if any input is masked"""
+        """Masking is always False if initial masked arg is not True"""
         t = Table([self.ca, self.a])
-        assert t.masked is True
+        assert t.masked is False  # True before astropy 4.0
         t = Table([self.ca])
         assert t.masked is False
         t = Table([self.ca, ma.array([1, 2, 3])])
-        assert t.masked is True
+        assert t.masked is False  # True before astropy 4.0
 
     def test_mask_false_if_no_input_masked(self):
         """Masking not true if not (requested or input requires mask)"""

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -173,7 +173,7 @@ class TestMaskedColumnInit(SetupData):
 class TestTableInit(SetupData):
     """Initializing a table"""
 
-    def test_mask_true_if_any_input_masked(self):
+    def test_mask_false_if_input_mask_not_true(self):
         """Masking is always False if initial masked arg is not True"""
         t = Table([self.ca, self.a])
         assert t.masked is False  # True before astropy 4.0

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -8,6 +8,7 @@ import numpy as np
 import numpy.ma as ma
 
 from astropy.table import Column, MaskedColumn, Table, QTable
+from astropy.tests.helper import catch_warnings
 from astropy.time import Time
 import astropy.units as u
 
@@ -459,3 +460,23 @@ def test_masked_as_array_with_mixin():
     assert np.all(tm['a'] == [False, True])
     assert np.all(tm['b'] == False)
     assert np.all(tm['c'] == False)
+
+
+def test_masked_column_with_unit_in_qtable():
+    """Test that adding a MaskedColumn with a unit to QTable issues warning"""
+    t = QTable()
+    with catch_warnings() as w:
+        t['a'] = MaskedColumn([1, 2])
+    assert len(w) == 0
+    assert isinstance(t['a'], MaskedColumn)
+
+    with catch_warnings() as w:
+        t['b'] = MaskedColumn([1, 2], unit=u.m)
+    assert len(w) == 0
+    assert isinstance(t['b'], u.Quantity)
+
+    with catch_warnings() as w:
+        t['c'] = MaskedColumn([1, 2], unit=u.m, mask=[True, False])
+    assert len(w) == 1
+    assert "dropping mask in Quantity column 'c'"
+    assert isinstance(t['b'], u.Quantity)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -452,8 +452,7 @@ class TestJoin():
 
         assert np.all(t12['b'].mask == [[True, False],
                                         [False, False]])
-        assert np.all(t12['c'].mask == [[False, False],
-                                        [False, False]])
+        assert not hasattr(t12['c'], 'mask')
 
         t12 = table.join(t1, t2, join_type='outer')
         assert np.all(t12['b'].mask == [[True, False],
@@ -1408,11 +1407,11 @@ def test_stack_columns():
 
     t = table.hstack([mc, q])
     assert t.__class__ is table.QTable
-    assert t.masked is True
+    assert t.masked is False
 
     t = table.hstack([c, mc])
     assert t.__class__ is table.Table
-    assert t.masked is True
+    assert t.masked is False
 
     t = table.vstack([q, q])
     assert t.__class__ is table.QTable

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1856,7 +1856,8 @@ class TestPandas:
 
         for name, column in t.columns.items():
             assert np.all(column.data == t2[name].data)
-            assert np.all(column.mask == t2[name].mask)
+            if hasattr(t2[name], 'mask'):
+                assert np.all(column.mask == t2[name].mask)
             # Masked integer type comes back as float.  Nothing we can do about this.
             if column.dtype.kind == 'i':
                 if np.any(column.mask):
@@ -1942,7 +1943,7 @@ class Test__Astropy_Table__():
     def test_simple_1(self):
         """Make a SimpleTable and convert to Table, QTable with copy=False, True"""
         for table_cls in (table.Table, table.QTable):
-            col_c_class = u.Quantity if table_cls is table.QTable else table.MaskedColumn
+            col_c_class = u.Quantity if table_cls is table.QTable else table.Column
             for cpy in (False, True):
                 st = self.SimpleTable()
                 # Test putting in a non-native kwarg `extra_meta` to Table initializer
@@ -1954,7 +1955,7 @@ class Test__Astropy_Table__():
                 vals = t['c'].value if table_cls is table.QTable else t['c']
                 assert np.all(st.columns[2].value == vals)
 
-                assert isinstance(t['a'], table.MaskedColumn)
+                assert isinstance(t['a'], table.Column)
                 assert isinstance(t['b'], table.MaskedColumn)
                 assert isinstance(t['c'], col_c_class)
                 assert t['c'].unit is u.m

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -502,6 +502,7 @@ class IERS_A(IERS):
         # Read in as a regular Table, including possible masked columns.
         # Columns will be filled and converted to Quantity in cls.__init__.
         iers_a = Table.read(file, format='cds', readme=readme)
+        iers_a = Table(iers_a, masked=True, copy=False)
 
         # Combine the A and B data for UT1-UTC and PM columns
         table = cls._combine_a_b_columns(iers_a)

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -233,8 +233,9 @@ The details of this change are discussed in the sections below.
 
 .. Note::
 
-   For most applications we now recommend using the default |Table| behavior with
-   ``masked=False`` to allow heterogenous column types.
+   For most applications, even those with masked column data, we now recommend using
+   the default |Table| behavior which allows heterogenous column types.  This implies
+   creating tables *without* specifying the ``masked`` keyword argument.
 
 Meaning of the ``masked`` table attribute
 -----------------------------------------
@@ -306,4 +307,4 @@ explicit version below:
 .. doctest-skip::
 
   >> dat = Table.read('data.fits')
-  >> dat['new_column'] = MaskedColumn([1, 2, 3, 4, 5])
+  >> dat['new_column'] = np.ma.MaskedArray([1, 2, 3, 4, 5])

--- a/docs/table/masking.rst
+++ b/docs/table/masking.rst
@@ -247,7 +247,7 @@ adding a new column:
 - ``masked=False`` : each column is added based on the type or contents of the data.
 
 The behavior associated with the ``masked`` attribute has *not changed* in version 4.0.
-What has changed is that from 4.0 onward a table with ``masked=False`` might contain
+What has changed is that from 4.0 onward a table with ``masked=False`` may contain
 |MaskedColumn| columns.
 
 It is important to recognize that the ``masked`` attribute for a table does not imply


### PR DESCRIPTION
Aka allow MaskedColumn and Column in the same table.  This is a WIP but would like initial big-picture (API) feedback before going too much further.  From the #7496 description (and see also #3665).

Currently if any column in a table is a MaskedColumn, then all other columns are "upgraded" to be masked as well. This happens on initialization and if a MaskedColumn is added or any column in an existing table is converted from Column to MaskedColumn. *This is entirely a holdover from the original implementation of table using a numpy structured array.*

The implementation of this is relatively straightforward, the main reservation is about stability and breaking code.

The main API changes are:

- In order to automatically add new columns as MaskedColumn, one must supply `masked=True` when creating the table. Currently this happens automatically if any of the columns are masked.
- Adding a MaskedColumn to an unmasked table would not automatically "upgrade" other columns.  This is a *feature* of the new implementation.
- The `Table.masked` attribute reflects only the behavior when adding a new column.  So if `masked` is true then non-mixin columns are always converted to `MaskedColumn` [1], but with `masked=False` then the column is added as whatever it is.

Previous there was discussion about issuing a warning if column would have been upgraded.  I think this would be an annoyance because it will happen in situations that are not actually a problem, but instead just *different*.  My feeling is that the small cross section of code that relied on the old behavior will *break*, which is not ideal but not as bad as silently doing something wrong (which is where warnings make sense).  But discussion would be good!

One thing to consider for this PR is allowing:
```
t = Table.read(filename, format=format, masked=True)  # MaskedColumns needed
```
This is a nicer version of the current workaround:
```
t  = Table.read(filename, format=format)
t = Table(t, masked=True)
```

Closes #7496 

[1] - this is not *always* true, see code, but in most cases that will be true.

To Do:

- [x] Change log
- [x] Docs explaining the change
- [x] Some additional tests
- [x] Question: does `masked=True` round-trip through I/O? Answer: NO, see comment later.