### PR TITLE
Use Python 3.7 for Circle CI images for Matplotlib 3.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
   image-tests-mpl302:
     docker:
-      - image: astropy/image-tests-py36-mpl302:1.5
+      - image: astropy/image-tests-py37-mpl302:1.5
     steps:
       - checkout
       - run:
@@ -66,7 +66,7 @@ jobs:
 
   image-tests-mpl310:
     docker:
-      - image: astropy/image-tests-py36-mpl310:1.5
+      - image: astropy/image-tests-py37-mpl310:1.5
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
   image-tests-mpldev:
     docker:
-      - image: astropy/image-tests-py36-base:1.2
+      - image: astropy/image-tests-py37-base:1.2
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Based on a suggestion by @bsipocz, I've updated the CircleCI images for Matplotlib 3.0 and 3.1 to use Python 3.7. I think it's valuable to keep testing the older versions with Python 3.6.