### PR TITLE
Fixed using differentials with HCRS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2340,6 +2340,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed bug that prevented using differentials with HCRS<->ICRS
+  transformations. [#8794]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.coordinates.transformations import FunctionTransformWithFiniteDifference, AffineTransform
 from astropy.coordinates.representation import (SphericalRepresentation, CartesianRepresentation,
-                              UnitSphericalRepresentation)
+                              UnitSphericalRepresentation, CartesianDifferential)
 from astropy import _erfa as erfa
 
 from .icrs import ICRS
@@ -290,6 +290,7 @@ def hcrs_to_icrs(hcrs_coo, icrs_frame):
         from astropy.coordinates.solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_coo.obstime)
+        bary_sun_vel = bary_sun_vel.represent_as(CartesianDifferential)
         bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
     else:
@@ -310,7 +311,9 @@ def icrs_to_hcrs(icrs_coo, hcrs_frame):
         from astropy.coordinates.solar_system import get_body_barycentric_posvel
         bary_sun_pos, bary_sun_vel = get_body_barycentric_posvel('sun',
                                                                  hcrs_frame.obstime)
-        bary_sun_pos = -bary_sun_pos.with_differentials(-bary_sun_vel)
+        bary_sun_pos = -bary_sun_pos
+        bary_sun_vel = -bary_sun_vel.represent_as(CartesianDifferential)
+        bary_sun_pos = bary_sun_pos.with_differentials(bary_sun_vel)
 
     else:
         from astropy.coordinates.solar_system import get_body_barycentric

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -293,7 +293,8 @@ def test_lsr_sanity():
 
 
 def test_hcrs_icrs_differentials():
-    # Arbitrary numbers
+    # Regression to ensure that we can transform velocities from HCRS to LSR.
+    # Numbers taken from the original issue, gh-6835.
     hcrs = HCRS(ra=8.67*u.deg, dec=53.09*u.deg, distance=117*u.pc,
                 pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
                 radial_velocity=23.42*u.km/u.s)

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -290,3 +290,21 @@ def test_lsr_sanity():
     gal_icrs = vel.transform_to(Galactic).cartesian.xyz
     assert allclose(gal_icrs.to(u.km/u.s, u.dimensionless_angles()),
                     -lsr.v_bary.d_xyz)
+
+
+def test_hcrs_icrs_differentials():
+    # Arbitrary numbers
+    hcrs = HCRS(ra=8.67*u.deg, dec=53.09*u.deg, distance=117*u.pc,
+                pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
+                radial_velocity=23.42*u.km/u.s)
+    icrs = hcrs.transform_to(ICRS)
+
+    # The position and velocity should not change much
+    assert allclose(hcrs.cartesian.xyz, icrs.cartesian.xyz, rtol=1e-8)
+    assert allclose(hcrs.velocity.d_xyz, icrs.velocity.d_xyz, rtol=1e-2)
+
+    hcrs2 = icrs.transform_to(HCRS)
+
+    # The values should round trip
+    assert allclose(hcrs.cartesian.xyz, hcrs2.cartesian.xyz, rtol=1e-12)
+    assert allclose(hcrs.velocity.d_xyz, hcrs2.velocity.d_xyz, rtol=1e-12)


### PR DESCRIPTION
This PR fixes a long-standing bug in the HCRS<->ICRS transformations (see #6835) that crashes when trying to use differentials across those transformations.  `.with_differentials()` expects a `*Differential`, but is instead passed a `CartesianRepresentation` of the velocity.  The velocity is now converted to a `CartesianDifferential` first.

Fixes #6835