### PR TITLE
Fix astropy so that it can be used in app bundles, and add CI to prevent regression

### DIFF
--- a/.pyinstaller/hooks/hook-skyfield.py
+++ b/.pyinstaller/hooks/hook-skyfield.py
@@ -1,0 +1,2 @@
+from PyInstaller.utils.hooks import collect_data_files
+datas = collect_data_files('skyfield')

--- a/.pyinstaller/hooks/hook-skyfield.py
+++ b/.pyinstaller/hooks/hook-skyfield.py
@@ -1,2 +1,5 @@
+# NOTE: this hook should be added to
+# https://github.com/pyinstaller/pyinstaller-hooks-contrib
+# once that repository is ready for pull requests
 from PyInstaller.utils.hooks import collect_data_files
 datas = collect_data_files('skyfield')

--- a/.pyinstaller/run_astropy_tests.py
+++ b/.pyinstaller/run_astropy_tests.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import pytest
+import shutil
+import astropy  # noqa
+
+ROOT = os.path.join(os.path.dirname(__file__), '../')
+
+# Make sure we don't allow any arguments to be passed - some tests call
+# sys.executable which becomes this script when producing a pyinstaller
+# bundle, but we should just error in this case since this is not the
+# regular Python interpreter.
+if len(sys.argv) > 1:
+    print("Extra arguments passed, exiting early")
+    sys.exit(1)
+
+# Copy over the astropy 'tests' directories and their contents
+for root, dirnames, _ in os.walk(os.path.join(ROOT, 'astropy')):
+    for dirname in dirnames:
+        final_dir = os.path.relpath(os.path.join(root.replace('astropy', 'astropy_tests'), dirname), ROOT)
+        # We only copy over 'tests' directories, but not astropy/tests (only
+        # astropy/tests/tests) since that is not just a directory with tests.
+        if dirname == 'tests' and root != 'astropy':
+            shutil.copytree(os.path.join(root, dirname), final_dir, dirs_exist_ok=True)
+        else:
+            # Create empty __init__.py files so that 'astropy_tests' still
+            # behaves like a single package, otherwise pytest gets confused
+            # by the different conftest.py files.
+            init_filename = os.path.join(final_dir, '__init__.py')
+            if not os.path.exists(os.path.join(final_dir, '__init__.py')):
+                os.makedirs(final_dir, exist_ok=True)
+                with open(os.path.join(final_dir, '__init__.py'), 'w') as f:
+                    f.write("#")
+
+# Add the top-level __init__.py file
+with open(os.path.join('astropy_tests', '__init__.py'), 'w') as f:
+    f.write("#")
+
+# Copy the top-level conftest.py
+shutil.copy2(os.path.join(ROOT, 'astropy', 'conftest.py'),
+             os.path.join('astropy_tests', 'conftest.py'))
+
+# We skip a few tests, which are generally ones that rely on explicitly
+# checking the name of the current module (which ends up starting with
+# astropy_tests rather than astropy).
+
+SKIP_TESTS = ['test_exception_logging_origin',
+              'test_log',
+              'test_configitem',
+              'test_config_noastropy_fallback',
+              'test_no_home',
+              'test_path',
+              'test_rename_path',
+              'test_data_name_third_party_package',
+              'test_pkg_finder',
+              'test_wcsapi_extension',
+              'test_find_current_module_bundle',
+              'test_download_parallel_fills_cache']
+
+# Run the tests!
+sys.exit(pytest.main(['astropy_tests',
+                      '-k ' + ' and '.join('not ' + test for test in SKIP_TESTS)],
+                     plugins=['pytest_doctestplus.plugin',
+                              'pytest_openfiles.plugin',
+                              'pytest_remotedata.plugin',
+                              'pytest_mpl.plugin',
+                              'pytest_astropy_header.display']))

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,7 +188,7 @@ matrix:
           stage: Cron tests
           env: SETUP_METHOD='apt'
 
-        # Regularly make sure that astropy can be used
+        # Regularly make sure that astropy can be used in application bundles
         - language: python
           python: 3.8
           dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -190,7 +190,8 @@ matrix:
 
         # Regularly make sure that astropy can be used
         - language: python
-          python: 3.7
+          python: 3.8
+          dist: bionic
           name: bundling with pyinstaller
           stage: Cron tests
           env: TOXENV="pyinstaller"

--- a/.travis.yml
+++ b/.travis.yml
@@ -188,6 +188,13 @@ matrix:
           stage: Cron tests
           env: SETUP_METHOD='apt'
 
+        # Regularly make sure that astropy can be used
+        - language: python
+          python: 3.7
+          name: bundling with pyinstaller
+          stage: Cron tests
+          env: TOXENV="pyinstaller"
+
     allow_failures:
         - language: python
           python: 3.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -625,6 +625,9 @@ Other Changes and Additions
 - Improved the speed of sorting a large ``Table`` on a single column by a factor
   of around 5. [#10103]
 
+- Ensure that astropy can be used inside Application bundles built with
+  pyinstaller. [#8795]
+
 4.0.1 (2020-03-27)
 ==================
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -407,7 +407,7 @@ def test_no_home():
 
     retcode = subprocess.check_call(
         [sys.executable, '-c', 'import astropy'],
-        env=env, timeout=5)
+        env=env)
 
     assert retcode == 0
 

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -407,7 +407,7 @@ def test_no_home():
 
     retcode = subprocess.check_call(
         [sys.executable, '-c', 'import astropy'],
-        env=env)
+        env=env, timeout=5)
 
     assert retcode == 0
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -338,8 +338,8 @@ def test_match_catalog_nan():
 @pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
                     reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_nounit():
-    from .. import ICRS, CartesianRepresentation
-    from ..matching import match_coordinates_sky
+    from astropy.coordinates import ICRS, CartesianRepresentation
+    from astropy.coordinates.matching import match_coordinates_sky
 
     i1 = ICRS([[1], [2], [3]], representation_type=CartesianRepresentation)
     i2 = ICRS([[1], [2], [4, 5]], representation_type=CartesianRepresentation)

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -11,11 +11,11 @@ from astropy.io import fits
 from astropy import units as u
 from astropy.table import Table
 from astropy.io.fits import printdiff
+from astropy.io.fits.connect import REMOVE_KEYWORDS
 from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import FitsTestCase
-from ..connect import REMOVE_KEYWORDS
 
 
 class TestConvenience(FitsTestCase):

--- a/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/test_fits.py
@@ -12,7 +12,7 @@ from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
 
-from ...tests.helpers import run_schema_example_test
+from astropy.io.misc.asdf.tags.tests.helpers import run_schema_example_test
 
 
 def test_complex_structure(tmpdir):

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -15,7 +15,7 @@ asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf.tests import helpers
 from asdf.tags.core.ndarray import NDArrayType
 
-from ...tests.helpers import run_schema_example_test
+from astropy.io.misc.asdf.tags.tests.helpers import run_schema_example_test
 
 
 def test_table(tmpdir):

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -17,8 +17,6 @@ from astropy.modeling.models import (Const1D, Shift, Scale, Rotation2D, Gaussian
                                      Identity, Mapping,
                                      Tabular1D, fix_inputs)
 import astropy.units as u
-from ..core import CompoundModel
-
 
 try:
     import scipy

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import math_functions
+from astropy.modeling import math_functions
 
 x = np.linspace(-20, 360, 100)
 

--- a/tox.ini
+++ b/tox.ini
@@ -134,3 +134,27 @@ skip_install = true
 description = check code style, e.g. with flake8
 deps = flake8
 commands = flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
+
+[testenv:pyinstaller]
+# Check that astropy can be included in a PyInstaller bundle without any issues. This
+# also serves as a test that tests do not import anything from outside the tests
+# directories with relative imports, since we copy the tests out to a separate directory
+# to run them.
+description = check that astropy can be included in a pyinstaller bundle
+changedir = .pyinstaller
+deps =
+    git+https://github.com/pyinstaller/pyinstaller.git#egg=pyinstaller
+    pytest<5.4
+    pytest-mpl
+extras = test
+commands =
+    pyinstaller --onefile run_astropy_tests.py \
+                --distpath . \
+                --additional-hooks-dir hooks \
+                --exclude-module tkinter \
+                --hidden-import pytest \
+                --hidden-import pytest_openfiles.plugin \
+                --hidden-import pytest_remotedata.plugin \
+                --hidden-import pytest_doctestplus.plugin \
+                --hidden-import pytest_mpl.plugin
+    ./run_astropy_tests


### PR DESCRIPTION
With applications like [pyinstaller](https://www.pyinstaller.org/), it's easy to build application bundles for different platforms. Unfortunately, astropy doesn't work out of the box with these and requires some tweaking due to various issues. In the past, @embray actually opened a PR to fix this (https://github.com/astropy/astropy/pull/960) but this was never finished.

Since it would be nice for this to work cleanly, I've decided to start off by adding a CircleCI job that will test that this works correctly and that we don't regress in future. I'll then work on fixing issues, and will see if I can cherry pick or adapt any of the solutions from https://github.com/astropy/astropy/pull/960. So this is just a WIP for now.

UPDATE: this is now ready, see https://github.com/astropy/astropy/pull/8795#issuecomment-623552977

EDIT: Fix #7052 