### PR TITLE
Copy editing: constants and convolution packages

### DIFF
--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -11,24 +11,24 @@ Introduction
 
 `astropy.constants` contains a number of physical constants useful in
 Astronomy. Constants are `~astropy.units.Quantity` objects with
-additional meta-data describing their provenance and uncertainties.
+additional metadata describing their provenance and uncertainties.
 
 Getting Started
 ===============
 
-To use the constants in S.I. units, you can import the constants directly from
-the `astropy.constants` sub-package::
+To use the constants in International System of Units (SI units), you can
+import the constants directly from the `astropy.constants` sub-package::
 
     >>> from astropy.constants import G
 
-or, if you want to avoid having to explicitly import all the constants you
-need, you can simply do:
+Or, if you want to avoid having to explicitly import all of the constants you
+need, you can do:
 
     >>> from astropy import constants as const
 
-and then subsequently use for example ``const.G``. Constants are fully-fledged
-`~astropy.units.Quantity` objects, so you can easily convert them to
-different units for example::
+and then subsequently use, for example, ``const.G``. Constants are fully-fledged
+`~astropy.units.Quantity` objects, so you can conveniently convert them to
+different units. For example::
 
     >>> print(const.c)
       Name   = Speed of light in vacuum
@@ -43,7 +43,7 @@ different units for example::
     >>> print(const.c.to('pc/yr'))  # doctest: +FLOAT_CMP
     0.306601393788 pc / yr
 
-and you can use them in conjunction with unit and other non-constant
+You can then use them in conjunction with unit and other nonconstant
 `~astropy.units.Quantity` objects::
 
     >>> from astropy import units as u
@@ -51,12 +51,13 @@ and you can use them in conjunction with unit and other non-constant
     >>> print(F.to(u.N))  # doctest: +FLOAT_CMP
     0.3675671602160826 N
 
-It is possible to convert most constants to cgs using e.g.::
+It is possible to convert most constants to Centimeter-Gram-Second (CGS) units
+using, for example::
 
     >>> const.c.cgs  # doctest: +FLOAT_CMP
     <Quantity   2.99792458e+10 cm / s>
 
-However, some constants are defined with different physical dimensions in cgs
+However, some constants are defined with different physical dimensions in CGS
 and cannot be directly converted. Because of this ambiguity, such constants
 cannot be used in expressions without specifying a system::
 
@@ -71,11 +72,11 @@ cannot be used in expressions without specifying a system::
 
 .. _astropy-constants-prior:
 
-Collections of constants (and prior versions)
+Collections of Constants (and Prior Versions)
 =============================================
 
 Constants are organized into version modules. The constants for
-Astropy 1.3 can be accessed in the ``astropyconst13`` module.
+``astropy`` 1.3 can be accessed in the ``astropyconst13`` module.
 For example:
 
     >>> from astropy.constants import astropyconst13 as const
@@ -97,8 +98,8 @@ Physical CODATA constants are in modules with names like ``codata2010`` or
       Unit  = J s
       Reference = CODATA 2010
 
-Astronomical constants defined (primarily) by the IAU are collected in
-modules with names like ``iau2012`` or ``iau2015``:
+Astronomical constants defined (primarily) by the International Astronomical
+Union (IAU) are collected in modules with names like ``iau2012`` or ``iau2015``:
 
     >>> from astropy.constants import iau2012 as const
     >>> print(const.L_sun)
@@ -119,7 +120,7 @@ modules with names like ``iau2012`` or ``iau2015``:
 The astronomical and physical constants are combined into modules with
 names like ``astropyconst13`` and ``astropyconst20``. To temporarily set
 constants to an older version (e.g., for regression testing), a context
-manager is available, as follows:
+manager is available as follows:
 
     >>> from astropy import constants as const
     >>> with const.set_enabled_constants('astropyconst13'):
@@ -143,8 +144,8 @@ manager is available, as follows:
     quantities should be constructed with constants instead of units.
 
 .. note that if this section gets too long, it should be moved to a separate
-   doc page - see the top of performance.inc.rst for the instructions on how to do
-   that
+   doc page - see the top of performance.inc.rst for the instructions on how to
+   do that
 .. include:: performance.inc.rst
 
 Reference/API

--- a/docs/constants/performance.inc.rst
+++ b/docs/constants/performance.inc.rst
@@ -1,7 +1,7 @@
 .. note that if this is changed from the default approach of using an *include*
    (in index.rst) to a separate performance page, the header needs to be changed
    from === to ***, the filename extension needs to be changed from .inc.rst to
-   .rst, and a link needs to be added in the subpackage toctree
+   .rst, and a link needs to be added in the sub-package toctree
 
 .. _astropy-constants-performance:
 

--- a/docs/convolution/index.rst
+++ b/docs/convolution/index.rst
@@ -1,20 +1,20 @@
 .. _astropy_convolve:
 
 *************************************************
-Convolution and filtering (`astropy.convolution`)
+Convolution and Filtering (`astropy.convolution`)
 *************************************************
 
 Introduction
 ============
 
-`astropy.convolution` provides convolution functions and kernels that offers
-improvements compared to the scipy `scipy.ndimage` convolution routines,
+`astropy.convolution` provides convolution functions and kernels that offer
+improvements compared to the SciPy `scipy.ndimage` convolution routines,
 including:
 
 * Proper treatment of NaN values (ignoring them during convolution and
   replacing NaN pixels with interpolated values)
 
-* A single function for 1-D, 2-D, and 3-D convolution
+* A single function for 1D, 2D, and 3D convolution
 
 * Improved options for the treatment of edges
 
@@ -22,9 +22,9 @@ including:
 
 * Built-in kernels that are commonly used in Astronomy
 
-The following thumbnails show the difference between Scipy's and
-Astropy's convolve functions on an Astronomical image that contains NaN
-values. Scipy's function essentially returns NaN for all pixels that are
+The following thumbnails show the difference between ``scipy`` and
+``astropy`` convolve functions on an astronomical image that contains NaN
+values. ``scipy``'s function essentially returns NaN for all pixels that are
 within a kernel of any NaN value, which is often not the desired result.
 
 .. plot::
@@ -47,7 +47,7 @@ within a kernel of any NaN value, which is often not the desired result.
     hdu = fits.open(filename)[0]
 
     # Scale the file to have reasonable numbers
-    # (this is mostly so that colorbars don't have too many digits)
+    # (this is mostly so that colorbars do not have too many digits)
     # Also, we crop it so you can see individual pixels
     img = hdu.data[50:90, 60:100] * 1e5
 
@@ -56,7 +56,7 @@ within a kernel of any NaN value, which is often not the desired result.
     # brightest pixels to NaN to simulate a "saturated" data set
     img[img > 2e1] = np.nan
 
-    # We also create a copy of the data and set those NaNs to zero.  We'll
+    # We also create a copy of the data and set those NaNs to zero.  We will
     # use this for the scipy convolution
     img_zerod = img.copy()
     img_zerod[np.isnan(img)] = 0
@@ -136,10 +136,10 @@ within a kernel of any NaN value, which is often not the desired result.
 The following sections describe how to make use of the convolution functions,
 and how to use built-in convolution kernels:
 
-Getting started
+Getting Started
 ===============
 
-Two convolution functions are provided.  They are imported as::
+Two convolution functions are provided. They are imported as::
 
     from astropy.convolution import convolve, convolve_fft
 
@@ -148,19 +148,18 @@ and are both used as::
     result = convolve(image, kernel)
     result = convolve_fft(image, kernel)
 
-:func:`~astropy.convolution.convolve` is implemented as a
-direct convolution algorithm, while
-:func:`~astropy.convolution.convolve_fft` uses a fast Fourier
-transform (FFT). Thus, the former is better for small kernels, while the latter
+:func:`~astropy.convolution.convolve` is implemented as a direct convolution
+algorithm, while :func:`~astropy.convolution.convolve_fft` uses a Fast Fourier
+Transform (FFT). Thus, the former is better for small kernels, while the latter
 is much more efficient for larger kernels.
 
-For example, to convolve a 1-d dataset with a user-specified kernel, you can do::
+For example, to convolve a 1D dataset with a user-specified kernel, you can do::
 
     >>> from astropy.convolution import convolve
     >>> convolve([1, 4, 5, 6, 5, 7, 8], [0.2, 0.6, 0.2])  # doctest: +FLOAT_CMP
     array([1.4, 3.6, 5. , 5.6, 5.6, 6.8, 6.2])
 
-Notice that the end points are set to zero - by default, points that are too
+Notice that the end points are set to zero — by default, points that are too
 close to the boundary to have a convolved value calculated are set to zero.
 However, the :func:`~astropy.convolution.convolve` function allows for a
 ``boundary`` argument that can be used to specify alternate behaviors. For
@@ -176,7 +175,8 @@ The values at the end are computed assuming that any value below the first
 point is ``1``, and any value above the last point is ``8``. For a more
 detailed discussion of boundary treatment, see :doc:`using`.
 
-This module also includes built-in kernels that can be imported as e.g.::
+This module also includes built-in kernels that can be imported as, for
+example::
 
     >>> from astropy.convolution import Gaussian1DKernel
 
@@ -184,7 +184,8 @@ To use a kernel, first create a specific instance of the kernel::
 
     >>> gauss = Gaussian1DKernel(stddev=2)
 
-``gauss`` is not an array, but a kernel object. The underlying array can be retrieved with::
+``gauss`` is not an array, but a kernel object. The underlying array can be
+retrieved with::
 
     >>> gauss.array  # doctest: +FLOAT_CMP
     array([6.69151129e-05, 4.36341348e-04, 2.21592421e-03,
@@ -225,10 +226,11 @@ The kernel can then be used directly when calling
     plt.show()
 
 
-Using astropy's convolution to replace bad data
------------------------------------------------
-Astropy's convolution methods can be used to replace bad data with values
-interpolated from their neighbors.  Kernel-based interpolation is useful for
+Using ``astropy``'s Convolution to Replace Bad Data
+---------------------------------------------------
+
+``astropy``'s convolution methods can be used to replace bad data with values
+interpolated from their neighbors. Kernel-based interpolation is useful for
 handling images with a few bad pixels or for interpolating sparsely sampled
 images.
 
@@ -239,23 +241,23 @@ The interpolation tool is implemented and used as::
 
 Some contexts in which you might want to use kernel-based interpolation include:
 
- * images with saturated pixels.  Generally, these are the highest-intensity
+ * Images with saturated pixels. Generally, these are the highest-intensity
    regions in the imaged area, and the interpolated values are not reliable,
-   but this can be useful for display purposes
- * images with flagged pixels, e.g., with a few small regions affected by cosmic
-   rays or other spurious signals that require those pixels to be flagged out.
+   but this can be useful for display purposes.
+ * Images with flagged pixels (e.g., a few small regions affected by cosmic
+   rays or other spurious signals that require those pixels to be flagged out).
    If the affected region is small enough, the resulting interpolation will have
-   a small effect on source statistics and may allow for robust source finding
-   algorithms to be run on the resulting data
- * sparsely sampled images such as those constructed with single-pixel
-   detectors.  Such images will only have a few discrete points sampled across
+   a small effect on source statistics and may allow for robust source-finding
+   algorithms to be run on the resulting data.
+ * Sparsely sampled images such as those constructed with single-pixel
+   detectors. Such images will only have a few discrete points sampled across
    the imaged area, but an approximation of the extended sky emission can still
    be constructed.
 
 .. note::
     Care must be taken to ensure that the kernel is large enough to completely
-    cover potential contiguous regions of ``NaN`` values.
-    An ``AstropyUserWarning`` is raised if ``NaN`` values are detected post
+    cover potential contiguous regions of NaN values.
+    An ``AstropyUserWarning`` is raised if NaN values are detected post-
     convolution, in which case the kernel size should be increased.
 
 The script below shows an example of kernel interpolation to fill in
@@ -314,9 +316,9 @@ flagged-out pixels:
    ax2.set_yticklabels([])
 
 This script shows the power of this technique for reconstructing images from
-sparse sampling.  Note that the image is not perfect - the pointlike sources
-are sometimes missed - but the extended structure is very well recovered (by
-eye).
+sparse sampling. Note that the image is not perfect: the pointlike sources
+are sometimes missed, but the extended structure is very well recovered by
+eye.
 
 .. plot::
    :context:
@@ -380,14 +382,14 @@ eye).
 
 .. _astropy_convolve_compat:
 
-A note on backward compatibility (pre v2.0)
+A Note on Backward Compatibility (pre v2.0)
 -------------------------------------------
 
-The behavior of astropy's direct convolution
-(:func:`~astropy.convolution.convolve`) changed in version 2.0.  Generally, the
-old version is undesirable.  However, to recover the behavior of the old
-(astropy version <2.0) direct convolution function, you can interpolate and
-then convolve, e.g.:
+The behavior of ``astropy``'s direct convolution
+(:func:`~astropy.convolution.convolve`) changed in version 2.0. Generally, the
+old version is undesirable. However, to recover the behavior of the old
+(``astropy`` version <2.0) direct convolution function, you can interpolate and
+then convolve, for example:
 
 .. code-block:: python
 
@@ -397,11 +399,11 @@ then convolve, e.g.:
 
 Note that the default behavior of both `~astropy.convolution.convolve` and
 `~astropy.convolution.convolve_fft` is to perform *normalized convolution* and
-interpolate NaNs during that process.  The example given in this note, and what
-was previously done only in direct convolution in old versions of astropy, does
-a two-step process: first, it replaces the NaNs with their interpolated values
-while leaving all non-NaN values unchanged, then it convolves the resulting
-image with the specified kernel.
+interpolate NaNs during that process. The example given in this note, and what
+was previously done only in direct convolution in old versions of ``astropy``
+now does a two-step process: first, it replaces the NaNs with their
+interpolated values while leaving all non-NaN values unchanged, then it
+convolves the resulting image with the specified kernel.
 
 Using `astropy.convolution`
 ===========================
@@ -413,9 +415,9 @@ Using `astropy.convolution`
    kernels.rst
    non_normalized_kernels.rst
 
-.. note that if this section gets too long, it should be moved to a separate 
-   doc page - see the top of performance.inc.rst for the instructions on how to do
-   that
+.. note that if this section gets too long, it should be moved to a separate
+   doc page - see the top of performance.inc.rst for the instructions on how to
+   do that
 .. include:: performance.inc.rst
 
 Reference/API

--- a/docs/convolution/kernels.rst
+++ b/docs/convolution/kernels.rst
@@ -10,7 +10,7 @@ from arrays or combine existing kernels to match specific applications.
 
 Every filter kernel is characterized by its response function. For time series
 we speak of an "impulse response function" or for images we call it "point
-spread function". This response function is given for every kernel by a
+spread function." This response function is given for every kernel by a
 `~astropy.modeling.FittableModel`, which is evaluated on a grid with
 :func:`~astropy.convolution.discretize_model` to obtain a kernel
 array, which can be used for discrete convolution with the binned data.
@@ -38,8 +38,8 @@ with a standard deviation of 2 pixels:
 >>> gauss_kernel = Gaussian1DKernel(2)
 >>> smoothed_data_gauss = convolve(data_1D, gauss_kernel)
 
-Smoothing the same data with a `~astropy.convolution.Box1DKernel` of
-width 5 pixels:
+Smoothing the same data with a `~astropy.convolution.Box1DKernel` of width 5
+pixels:
 
 >>> box_kernel = Box1DKernel(5)
 >>> smoothed_data_box = convolve(data_1D, box_kernel)
@@ -76,21 +76,21 @@ The following plot illustrates the results:
     plt.show()
 
 
-Beside the astropy convolution functions
+Beside the ``astropy`` convolution functions
 `~astropy.convolution.convolve` and
 `~astropy.convolution.convolve_fft`, it is also possible to use
-the kernels with Numpy or Scipy convolution by passing the ``array`` attribute.
-This will be faster in most cases than the astropy convolution, but will not
-work properly if ``NaN`` values are present in the data.
+the kernels with ``numpy`` or ``scipy`` convolution by passing the ``array``
+attribute. This will be faster in most cases than the ``astropy`` convolution,
+but will not work properly if NaN values are present in the data.
 
 >>> smoothed = np.convolve(data_1D, box_kernel.array)
 
 2D Kernels
 ----------
 
-As all 2D kernels are symmetric it is sufficient to specify the width in one
+As all 2D kernels are symmetric, it is sufficient to specify the width in one
 direction. Therefore the use of 2D kernels is basically the same as for 1D
-kernels. We consider a small Gaussian shaped source of amplitude one in the
+kernels. Here we consider a small Gaussian-shaped source of amplitude 1 in the
 middle of the image and add 10% noise:
 
 >>> import numpy as np
@@ -135,8 +135,9 @@ This is what the original image looks like:
     plt.colorbar()
     plt.show()
 
-The following plot illustrates the differences between several 2D kernels applied to the simulated data.
-Note that it has a slightly different color scale compared to the original image.
+The following plot illustrates the differences between several 2D kernels
+applied to the simulated data. Note that it has a slightly different color
+scale compared to the original image.
 
 .. plot::
 
@@ -183,9 +184,9 @@ Note that it has a slightly different color scale compared to the original image
 
 
 The Gaussian kernel has better smoothing properties compared to the Box and the
-Tophat. The Box filter is not isotropic and can produce artifact (the source
-appears rectangular). The Mexican-Hat filter removes noise and slowly varying
-structures (i.e. background) , but produces a negative ring around the source.
+Top Hat. The Box filter is not isotropic and can produce artifacts (the source
+appears rectangular). The Mexican Hat filter removes noise and slowly varying
+structures (i.e., background), but produces a negative ring around the source.
 The best choice for the filter strongly depends on the application.
 
 
@@ -216,30 +217,34 @@ Kernel Arithmetics
 
 Addition and Subtraction
 ------------------------
-As convolution is a linear operation, kernels can be added or subtracted from each other.
-They can also be multiplied with some number. One basic example would be the definition
-of a Difference of Gaussian filter:
+
+As convolution is a linear operation, kernels can be added or subtracted from
+each other. They can also be multiplied with some number. One basic example
+would be the definition of a Difference of Gaussian filter:
 
 >>> from astropy.convolution import Gaussian1DKernel
 >>> gauss_1 = Gaussian1DKernel(10)
 >>> gauss_2 = Gaussian1DKernel(16)
 >>> DoG = gauss_2 - gauss_1
 
-Another application is to convolve faked data with an instrument response function model.
-E.g. if the response function can be be described by the weighted sum of two Gaussians:
+Another application is to convolve faked data with an instrument response
+function model. For example, if the response function can be described by
+the weighted sum of two Gaussians:
 
 >>> gauss_1 = Gaussian1DKernel(10)
 >>> gauss_2 = Gaussian1DKernel(16)
 >>> SoG = 4 * gauss_1 + gauss_2
 
-Most times it will be necessary to normalize the resulting kernel by calling explicitly:
+Most times it will be necessary to normalize the resulting kernel by calling
+explicitly:
 
 >>> SoG.normalize()
 
 
 Convolution
 -----------
-Furthermore two kernels can be convolved with each other, which is useful when
+
+Furthermore, two kernels can be convolved with each other, which is useful when
 data is filtered with two different kinds of kernels or to create a new,
 special kernel:
 
@@ -273,13 +278,13 @@ You would rather do the following:
 ...     warnings.simplefilter('ignore')  # Ignore warning for doctest
 ...     smoothed_gauss_box = convolve(data_1D, convolve(box, gauss))
 
-Which, in most cases, will also be faster than the first method, because only
-one convolution with the, most times, larger data array will be necessary.
+Which, in most cases, will also be faster than the first method because only
+one convolution with the often times larger data array will be necessary.
 
 Discretization
 ==============
 
-To obtain the kernel array for discrete convolution, the kernels response
+To obtain the kernel array for discrete convolution, the kernel's response
 function is evaluated on a grid with
 :func:`~astropy.convolution.discretize_model`. For the
 discretization step the following modes are available:
@@ -290,8 +295,8 @@ discretization step the following modes are available:
    >>> from astropy.convolution import Gaussian1DKernel
    >>> gauss_center = Gaussian1DKernel(3, mode='center')
 
-* Mode ``'linear_interp'`` takes the values at the corners of the bin and linearly
-  interpolates the value at the center:
+* Mode ``'linear_interp'`` takes the values at the corners of the bin and
+  linearly interpolates the value at the center:
 
   >>> gauss_interp = Gaussian1DKernel(3, mode='linear_interp')
 
@@ -303,13 +308,13 @@ discretization step the following modes are available:
 
 * Mode ``'integrate'`` integrates the function over the pixel using
   ``scipy.integrate.quad`` and ``scipy.integrate.dblquad``. This mode is very
-  slow and only recommended when highest accuracy is required.
+  slow and is only recommended when the highest accuracy is required.
 
 .. doctest-requires:: scipy
 
     >>> gauss_integrate = Gaussian1DKernel(3, mode='integrate')
 
-Especially in the range where the kernel width is in order of only a few pixels
+Especially in the range where the kernel width is in order of only a few pixels,
 it can be advantageous to use the mode ``oversample`` or ``integrate`` to
 conserve the integral on a subpixel scale.
 
@@ -317,17 +322,17 @@ conserve the integral on a subpixel scale.
 Normalization
 =============
 
-The kernel models are normalized per default, i.e.
-:math:`\int_{-\infty}^{\infty} f(x) dx = 1`. But because of the limited kernel
-array size the normalization for kernels with an infinite response can differ
+The kernel models are normalized per default (i.e.,
+:math:`\int_{-\infty}^{\infty} f(x) dx = 1`). But because of the limited kernel
+array size, the normalization for kernels with an infinite response can differ
 from one. The value of this deviation is stored in the kernel's ``truncation``
 attribute.
 
 The normalization can also differ from one, especially for small kernels, due
 to the discretization step. This can be partly controlled by the ``mode``
-argument, when initializing the kernel (See also
-:func:`~astropy.convolution.discretize_model`). Setting the
-``mode`` to ``'oversample'`` allows to conserve the normalization even on the
+argument, when initializing the kernel. (See also
+:func:`~astropy.convolution.discretize_model`.) Setting the
+``mode`` to ``'oversample'`` allows us to conserve the normalization even on the
 subpixel scale.
 
 The kernel arrays can be renormalized explicitly by calling either the
@@ -339,5 +344,5 @@ version of the kernel.
 
 Note that for :class:`~astropy.convolution.MexicanHat1DKernel`
 and :class:`~astropy.convolution.MexicanHat2DKernel` there is
-:math:`\int_{-\infty}^{\infty} f(x) dx = 0`. To define a proper normalization
+:math:`\int_{-\infty}^{\infty} f(x) dx = 0`. To define a proper normalization,
 both filters are derived from a normalized Gaussian function.

--- a/docs/convolution/non_normalized_kernels.rst
+++ b/docs/convolution/non_normalized_kernels.rst
@@ -1,16 +1,16 @@
-*************************************
-Convolving with un-normalized kernels
-*************************************
+************************************
+Convolving with Unnormalized Kernels
+************************************
 
 There are some tasks, such as source finding, where you want to apply a filter
 with a kernel that is not normalized.
 
-For data that are well-behaved (contain no missing or infinite values), this is
-easy and can be done in one step::
+For data that are well-behaved (contain no missing or infinite values), this
+can be done in one step::
 
     convolve(image, kernel)
 
-For example, we can try to run a commonly-used peak enhancing kernel:
+For example, we can try to run a commonly used peak enhancing kernel:
 
 .. plot::
    :context: reset
@@ -51,8 +51,8 @@ For example, we can try to run a commonly-used peak enhancing kernel:
                     interpolation='nearest', cmap='viridis')
 
 If you have an image with missing values (NaNs), you have to replace them with
-real values first.  Often, the best way to do this is to replace the NaN values
-with interpolated values.  In the example below, we use a Gaussian kernel
+real values first. Often, the best way to do this is to replace the NaN values
+with interpolated values. In the example below, we use a Gaussian kernel
 with a size similar to that of our peak-finding kernel to replace the bad data
 before applying the peak-finding kernel.
 

--- a/docs/convolution/performance.inc.rst
+++ b/docs/convolution/performance.inc.rst
@@ -1,7 +1,7 @@
 .. note that if this is changed from the default approach of using an *include*
    (in index.rst) to a separate performance page, the header needs to be changed
    from === to ***, the filename extension needs to be changed from .inc.rst to
-   .rst, and a link needs to be added in the subpackage toctree
+   .rst, and a link needs to be added in the sub-package toctree
 
 .. _astropy-convolution-performance:
 

--- a/docs/convolution/using.rst
+++ b/docs/convolution/using.rst
@@ -1,10 +1,10 @@
-Using the convolution functions
+Using the Convolution Functions
 *******************************
 
 Overview
 ========
 
-Two convolution functions are provided.  They are imported as::
+Two convolution functions are provided. They are imported as::
 
     >>> from astropy.convolution import convolve, convolve_fft
 
@@ -15,29 +15,29 @@ and are both used as::
 
 :func:`~astropy.convolution.convolve` is implemented as a
 direct convolution algorithm, while
-:func:`~astropy.convolution.convolve_fft` uses a fast Fourier
-transform (FFT). Thus, the former is better for small kernels, while the latter
+:func:`~astropy.convolution.convolve_fft` uses a Fast Fourier
+Transform (FFT). Thus, the former is better for small kernels, while the latter
 is much more efficient for larger kernels.
 
-The input images and kernels should be lists or Numpy arrays with either both
-1, 2, or 3 dimensions (and the number of dimensions should be the same for the
-image and kernel). The result is a Numpy array with the same dimensions as the
-input image. The convolution is always done as floating point.
+The input images and kernels should be lists or ``numpy`` arrays with either 1,
+2, or 3 dimensions (and the number of dimensions should be the same for the
+image and kernel). The result is a ``numpy`` array with the same dimensions as
+the input image. The convolution is always done as floating point.
 
 The :func:`~astropy.convolution.convolve` function takes an
 optional ``boundary=`` argument describing how to perform the convolution at
 the edge of the array. The values for ``boundary`` can be:
 
 * ``None``: set the result values to zero where the kernel extends beyond the
-  edge of the array (default)
+  edge of the array (default).
 
 * ``'fill'``: set values outside the array boundary to a constant. If this
   option is specified, the constant should be specified using the
   ``fill_value=`` argument, which defaults to zero.
 
-* ``'wrap'``: assume that the boundaries are periodic
+* ``'wrap'``: assume that the boundaries are periodic.
 
-* ``'extend'`` : set values outside the array to the nearest array value
+* ``'extend'`` : set values outside the array to the nearest array value.
 
 By default, the kernel is not normalized. To normalize it prior to convolution,
 use::
@@ -65,21 +65,21 @@ interpolated using the kernel::
     >>> convolve([1, 4, 5, 6, np.nan, 7, 8], [0.2, 0.6, 0.2], boundary='extend')  # doctest: +FLOAT_CMP
     array([1.6 , 3.6 , 5.  , 5.75, 6.5 , 7.25, 7.8 ])
 
-Kernels and arrays can be specified either as lists or as Numpy
-arrays. The following examples show how to construct a 1-d array as a
+Kernels and arrays can be specified either as lists or as ``numpy``
+arrays. The following examples show how to construct a 1D array as a
 list::
 
     >>> kernel = [0, 1, 0]
     >>> result = convolve(spectrum, kernel)  # doctest: +SKIP
 
-a 2-d array as a list::
+a 2D array as a list::
 
     >>> kernel = [[0, 1, 0],
     ...           [1, 2, 1],
     ...           [0, 1, 0]]
     >>> result = convolve(image, kernel)  # doctest: +SKIP
 
-and a 3-d array as a list::
+and a 3D array as a list::
 
     >>> kernel = [[[0, 0, 0], [0, 2, 0], [0, 0, 0]],
     ...           [[0, 1, 0], [2, 3, 2], [0, 1, 0]],
@@ -89,6 +89,6 @@ and a 3-d array as a list::
 Kernels
 =======
 
-The above examples uses custom kernels, but `astropy.convolution` also
+The above examples use custom kernels, but `astropy.convolution` also
 includes a number of built-in kernels, which are described in
 :doc:`kernels`.


### PR DESCRIPTION
A first pass at copy editing the documentation constants and convolution packages.

A question that came up while I was working on this: I just added a line to the style guide about not using abbreviations for general and scientific terms, but here I noticed some commonly used abbreviations (3D, SI units, CGS, etc.).

How strict do we want to be about writing out commonly know abbreviated terms every time used, or just the first time used? If I created a glossary to go with the style guide or new user materials, would that allow us to use abbreviations more, or do we want to not use them at all? It would be helpful to know everyone's opinion on this!