### PR TITLE
Retain units when applying bounding box in model evaluation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,6 +250,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Ensure unit information is properly applied to models evaluated with a
+  bounding box. [#8799]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -250,9 +250,6 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
-- Ensure unit information is properly applied to models evaluated with a
-  bounding box. [#8799]
-
 astropy.nddata
 ^^^^^^^^^^^^^^
 
@@ -347,6 +344,9 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+
+- Ensure unit information is properly applied to models evaluated with a
+  bounding box. [#8799]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -823,7 +823,7 @@ class Model(metaclass=_ModelMeta):
                 # If the valid results is a quantity, ensure unit information
                 #  is retained.
                 if valid_result_unit is not None:
-                    outputs = Quantity(outputs, valid_result_unit)
+                    outputs = Quantity(outputs, valid_result_unit, copy=False)
         else:
             outputs = self.evaluate(*chain(inputs, parameters))
         if self.n_outputs == 1:

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -802,6 +802,8 @@ class Model(metaclass=_ModelMeta):
                     else:
                         args.append(input[valid_ind])
                 valid_result = self.evaluate(*chain(args, parameters))
+                valid_result_unit = getattr(valid_result, 'unit', None)
+
                 if self.n_outputs == 1:
                     valid_result = [valid_result]
                 # combine the valid results with the ``fill_value`` values
@@ -818,6 +820,10 @@ class Model(metaclass=_ModelMeta):
                     outputs = np.asarray(result[0])
                 else:
                     outputs = [np.asarray(r) for r in result]
+                # If the valid results is a quantity, ensure unit information
+                #  is retained.
+                if valid_result_unit is not None:
+                    outputs = Quantity(outputs, valid_result_unit)
         else:
             outputs = self.evaluate(*chain(inputs, parameters))
         if self.n_outputs == 1:

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -9,6 +9,7 @@ from astropy.modeling.core import Model, custom_model
 from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
 import astropy.units as u
+from astropy.tests.helper import assert_quantity_allclose
 
 try:
     import scipy  # pylint: disable=W0611
@@ -398,3 +399,5 @@ def test_units_with_bounding_box():
 
     assert isinstance(t(10), u.Quantity)
     assert isinstance(t(10, with_bounding_box=True), u.Quantity)
+
+    assert_quantity_allclose(t(10), t(10, with_bounding_box=True))

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose
 from astropy.modeling.core import Model, custom_model
 from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
+import astropy.units as u
 
 
 class NonFittableModel(Model):
@@ -380,3 +381,12 @@ def test_compound_deepcopy():
     assert id(model._submodels[0]) != id(new_model._submodels[0])
     assert id(model._submodels[1]) != id(new_model._submodels[1])
     assert id(model._submodels[2]) != id(new_model._submodels[2])
+
+
+def test_units_with_bounding_box():
+    points = np.arange(10, 20)
+    table = np.arange(10) * u.Angstrom
+    t = models.Tabular1D(points, lookup_table=table)
+
+    assert isinstance(t(10), u.Quantity)
+    assert isinstance(t(10, with_bounding_box=True), u.Quantity)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -10,6 +10,13 @@ from astropy.modeling.parameters import Parameter
 from astropy.modeling import models
 import astropy.units as u
 
+try:
+    import scipy  # pylint: disable=W0611
+except ImportError:
+    HAS_SCIPY = False
+else:
+    HAS_SCIPY = True
+
 
 class NonFittableModel(Model):
     """An example class directly subclassing Model for testing."""
@@ -383,6 +390,7 @@ def test_compound_deepcopy():
     assert id(model._submodels[2]) != id(new_model._submodels[2])
 
 
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_units_with_bounding_box():
     points = np.arange(10, 20)
     table = np.arange(10) * u.Angstrom


### PR DESCRIPTION
Addresses #8798 by re-applying unit information to the results of the model evaluation in cases where the bounding box is being applied.

Related to astropy/specutils#462.

EDIT: Fix #8798 