### PR TITLE
Minor fix for Python 3.8

### DIFF
--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -4,7 +4,8 @@
 # STDLIB
 import time
 import warnings
-from collections import Iterable, OrderedDict
+from collections import OrderedDict
+from collections.abc import Iterable
 from functools import partial, wraps
 
 # THIRD-PARTY


### PR DESCRIPTION
This is just to avoid a deprecation warning.