### PR TITLE
Use __array_function__ to make most numpy functions work on Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,11 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- For numpy 1.17 and later, the new ``__array_function__`` protocol is used to
+  ensure that all top-level numpy functions interact properly with
+  ``Quantity``, preserving units also in operations like ``np.concatenate``.
+  [#8808]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -2018,7 +2018,10 @@ class AffineTransformation2D(Model):
             raise ValueError("Expected input arrays to have the same shape")
 
         shape = x.shape or (1,)
-        inarr = np.vstack([x.flatten(), y.flatten(), np.ones(x.size)])
+        # Use asarray to ensure loose the units.
+        inarr = np.vstack([np.asarray(x).ravel(),
+                           np.asarray(y).ravel(),
+                           np.ones(x.size, x.dtype)])
 
         if inarr.shape[0] != 3 or inarr.ndim != 2:
             raise ValueError("Incompatible input shapes")

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1459,8 +1459,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     def __array_function__(self, function, types, args, kwargs):
         wrapped = function.__wrapped__
         if function in FUNCTION_HELPERS:
-            helper_info = FUNCTION_HELPERS[function](*args, **kwargs)
-            if helper_info is NotImplemented:
+            try:
+                helper_info = FUNCTION_HELPERS[function](*args, **kwargs)
+            except NotImplementedError:
                 return NotImplemented
 
             args, kwargs, unit, out = helper_info

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -498,12 +498,13 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         out : `~astropy.units.Quantity`
            With units set.
         """
-        if isinstance(result, tuple):
+        if isinstance(result, (tuple, list)):
             if out is None:
                 out = (None,) * len(result)
-            return tuple(self._result_as_quantity(result_, unit_, out_)
-                         for (result_, unit_, out_) in
-                         zip(result, unit, out))
+            return result.__class__(
+                self._result_as_quantity(result_, unit_, out_)
+                for (result_, unit_, out_) in
+                zip(result, unit, out))
 
         if out is None:
             # View the result array as a Quantity with the proper unit.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1506,6 +1506,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             try:
                 helper_info = FUNCTION_HELPERS[function](*args, **kwargs)
             except NotImplementedError:
+                # We return NotImplemented, which is proper, even though
+                # if an ndarray is also present, it gets a chance as well
+                # and may just coerce us to object.
                 return NotImplemented
 
             args, kwargs, unit, out = helper_info

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1501,7 +1501,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         # implementation.
         if function in SUBCLASS_SAFE_FUNCTIONS:
             return super().__array_function__(function, types, args, kwargs)
-        if function in FUNCTION_HELPERS:
+
+        elif function in FUNCTION_HELPERS:
             try:
                 helper_info = FUNCTION_HELPERS[function](*args, **kwargs)
             except NotImplementedError:
@@ -1514,12 +1515,20 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                 return result
 
             return self._result_as_quantity(result, unit, out=out)
+
         elif function in DISPATCHED_FUNCTIONS:
             return DISPATCHED_FUNCTIONS[function](*args, **kwargs)
+
         elif function in UNSUPPORTED_FUNCTIONS:
             return NotImplemented
 
-        return function.__wrapped__(*args, **kwargs)
+        else:
+            warnings.warn("function '{}' is not known to Quantity. Will "
+                          "run it anyway, but please raise an issue at "
+                          "https://github.com/astropy/astropy/issues."
+                          .format(function.__name__))
+
+            return super().__array_function__(function, types, args, kwargs)
 
     # Calculation -- override ndarray methods to take into account units.
     # We use the corresponding numpy functions to evaluate the results, since

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -29,7 +29,7 @@ from astropy import config as _config
 from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
                               check_output)
 from .quantity_helper.function_helpers import (
-    INVARIANT_FUNCTIONS, FUNCTION_HELPERS, DISPATCHED_FUNCTIONS)
+    FUNCTION_HELPERS, DISPATCHED_FUNCTIONS)
 
 
 __all__ = ["Quantity", "SpecificTypeQuantity",
@@ -1458,9 +1458,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
     def __array_function__(self, function, types, args, kwargs):
         wrapped = function.__wrapped__
-        if function in INVARIANT_FUNCTIONS:
-            return self._wrap_function(wrapped, *args[1:], **kwargs)
-        elif function in FUNCTION_HELPERS:
+        if function in FUNCTION_HELPERS:
             helper_info = FUNCTION_HELPERS[function](*args, **kwargs)
             if helper_info is NotImplemented:
                 return NotImplemented

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1526,10 +1526,11 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             return NotImplemented
 
         else:
-            warnings.warn("function '{}' is not known to Quantity. Will "
-                          "run it anyway, but please raise an issue at "
-                          "https://github.com/astropy/astropy/issues."
-                          .format(function.__name__))
+            warnings.warn("function '{}' is not known to astropy's Quantity. "
+                          "Will run it anyway, hoping it will treat ndarray "
+                          "subclasses correctly. Please raise an issue at "
+                          "https://github.com/astropy/astropy/issues. "
+                          .format(function.__name__), AstropyWarning)
 
             return super().__array_function__(function, types, args, kwargs)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1453,6 +1453,17 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
     def argmin(self, axis=None, out=None):
         return self.view(np.ndarray).argmin(axis, out=out)
 
+    _INVARIANT_FUNCTIONS = {
+        np.copy, np.asfarray, np.empty_like, np.zeros_like,
+        np.real_if_close, np.tril, np.triu,
+        np.sort_complex}
+
+    def __array_function__(self, function, types, args, kwargs):
+        wrapped = function.__wrapped__
+        if function in self._INVARIANT_FUNCTIONS:
+            return self._wrap_function(wrapped, *args[1:], **kwargs)
+        return wrapped(*args, **kwargs)
+
     # Calculation -- override ndarray methods to take into account units.
     # We use the corresponding numpy functions to evaluate the results, since
     # the methods do not always allow calling with keyword arguments.

--- a/astropy/units/quantity_helper/__init__.py
+++ b/astropy/units/quantity_helper/__init__.py
@@ -6,8 +6,8 @@ units for a given ufunc, given input units.
 """
 from .converters import *
 # By importing helpers, all the unit conversion functions needed for
-# numpy ufuncs are defined.
-from . import helpers
+# numpy ufuncs and functions are defined.
+from . import helpers, function_helpers
 # For scipy.special and erfa, importing the helper modules ensures
 # the definitions are added as modules to UFUNC_HELPERS, to be loaded
 # on demand.

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -470,3 +470,41 @@ def histogram2d(x, y, bins=10, range=None, normed=None, weights=None,
 
     return ((x.value, y.value, bins, range, normed, weights, density), {},
             (unit, x.unit, y.unit), None)
+
+
+@function_helper
+def diff(a, n=1, axis=-1, prepend=np._NoValue, append=np._NoValue):
+    a = _as_quantity(a)
+    if prepend is not np._NoValue:
+        prepend = _as_quantity(prepend).to_value(a.unit)
+    if append is not np._NoValue:
+        append = _as_quantity(append).to_value(a.unit)
+    return (a.value, n, axis, prepend, append), {}, a.unit, None
+
+
+@function_helper
+def gradient(f, *varargs, **kwargs):
+    f = _as_quantity(f)
+    axis = kwargs.get('axis', None)
+    if axis is None:
+        n_axis = f.ndim
+    elif isinstance(axis, tuple):
+        n_axis = len(axis)
+    else:
+        n_axis = 1
+
+    if varargs:
+        varargs = _as_quantities(*varargs)
+        if len(varargs) == 1 and n_axis > 1:
+            varargs = varargs * n_axis
+
+    if varargs:
+        units = [f.unit / q.unit for q in varargs]
+        varargs = tuple(q.value for q in varargs)
+    else:
+        units = [f.unit] * n_axis
+
+    if len(units) == 1:
+        units = units[0]
+
+    return (f.value,) + varargs, kwargs, units, None

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -294,3 +294,25 @@ def percentile(a, q, *args, **kwargs):
 @function_helper
 def count_nonzero(a, *args, **kwargs):
     return (a.value,) + args, kwargs, None, None
+
+
+def one_two(one, two):
+    from astropy.units import Quantity
+    if isinstance(one, Quantity):
+        return one.value, one._to_own_unit(two), one.unit
+
+    else:
+        unit = getattr(one, 'unit', dimensionless_unscaled)
+        return one, two.to_value(unit), unit
+
+
+@function_helper
+def array_equal(a1, a2):
+    a1, a2, unit = one_two(a1, a2)
+    return (a1, a2), {}, None, None
+
+
+@function_helper
+def array_equiv(a1, a2):
+    a1, a2, unit = one_two(a1, a2)
+    return (a1, a2), {}, None, None

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -24,10 +24,57 @@ else:
     ARRAY_FUNCTION_ENABLED = getattr(np.core.overrides,
                                      'ENABLE_ARRAY_FUNCTION', True)
 
+SUBCLASS_SAFE_FUNCTIONS = {
+    np.alen, np.shape, np.size, np.ndim,
+    np.reshape, np.ravel, np.moveaxis, np.rollaxis, np.swapaxes,
+    np.transpose, np.atleast_1d, np.atleast_2d, np.atleast_3d,
+    np.expand_dims, np.squeeze, np.broadcast_to, np.broadcast_arrays,
+    np.flip, np.fliplr, np.flipud, np.rot90,
+    np.argmin, np.argmax, np.argsort, np.lexsort, np.searchsorted,
+    np.nonzero, np.argwhere, np.flatnonzero,
+    np.take_along_axis, np.put_along_axis,
+    np.diag_indices_from, np.triu_indices_from, np.tril_indices_from,
+    np.real, np.imag, np.diag, np.diagonal, np.diagflat,
+    np.empty_like, np.zeros_like,
+    np.compress, np.extract, np.delete, np.trim_zeros, np.roll, np.take,
+    np.put, np.fill_diagonal, np.tile, np.repeat,
+    np.split, np.array_split, np.hsplit, np.vsplit, np.dsplit,
+    np.stack, np.column_stack, np.hstack, np.vstack, np.dstack, np.block,
+    np.amax, np.amin, np.ptp, np.sum, np.cumsum,
+    np.prod, np.product, np.cumprod, np.cumproduct,
+    np.round, np.around,
+    np.fix, np.angle, np.i0, np.clip,
+    np.isposinf, np.isneginf, np.isreal, np.iscomplex,
+    np.average, np.mean, np.std, np.var, np.median, np.trace,
+    np.nanmax, np.nanmin, np.nanargmin, np.nanargmax, np.nanmean,
+    np.nanmedian, np.nansum, np.nancumsum, np.nanstd, np.nanvar,
+    np.nanprod, np.nancumprod,
+    np.einsum_path, np.trapz, np.linspace,
+    np.sort, np.msort, np.partition, np.meshgrid,
+    np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
+    np.iscomplexobj, np.isrealobj,
+    np.shares_memory, np.may_share_memory,
+}
+# Implemented as methods that return NotImplementedError
+# TODO: move to UNSUPPORTED? Would raise TypeError instead.
+SUBCLASS_SAFE_FUNCTIONS |= {
+    np.all, np.any, np.sometrue, np.alltrue}
 
-UNSUPPORTED_FUNCTIONS = {np.packbits, np.unpackbits, np.unravel_index,
-                         np.ravel_multi_index, np.ix_, np.cov,
-                         np.corrcoef}
+# Subclass safe, but possibly better if overridden or with different
+# default arguments.
+# TODO: decide on desired behaviour.
+SUBCLASS_SAFE_FUNCTIONS |= {
+    np.isclose, np.allclose,
+    np.array2string, np.array_repr, np.array_str}
+
+UNSUPPORTED_FUNCTIONS = {
+    np.packbits, np.unpackbits, np.unravel_index,
+    np.ravel_multi_index, np.ix_, np.cov, np.corrcoef,
+    np.busday_count, np.busday_offset, np.datetime_as_string,
+    np.is_busday}
+# TODO: the following can be supported but need work & thought.
+UNSUPPORTED_FUNCTIONS |= {
+    np.histogramdd, np.piecewise}
 FUNCTION_HELPERS = {}
 DISPATCHED_FUNCTIONS = {}
 

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Helpers for overriding numpy functions for Quantity."""
+
+import numpy as np
+
+from astropy.units.core import (
+    UnitsError, UnitConversionError, UnitTypeError,
+    dimensionless_unscaled, get_current_unit_registry)
+from .helpers import _d, get_converter
+
+
+INVARIANT_FUNCTIONS = {
+        np.copy, np.asfarray, np.empty_like, np.zeros_like,
+        np.real_if_close, np.tril, np.triu,
+        np.sort_complex, np.broadcast_to}
+UNSUPPORTED_FUNCTIONS = set()
+FUNCTION_HELPERS = {}
+DISPATCHED_FUNCTIONS = {}
+
+
+def function_helper(f):
+    FUNCTION_HELPERS[getattr(np, f.__name__.replace('_helper', ''))] = f
+    return f
+
+
+def dispatched_function(f):
+    DISPATCHED_FUNCTIONS[getattr(np, f.__name__)] = f
+    return f
+
+
+@dispatched_function
+def broadcast_arrays(*args, subok=True):
+    return np.broadcast_arrays.__wrapped__(*args, subok=subok)
+
+
+@function_helper
+def sinc_helper(x):
+    from astropy.units.si import radian
+    try:
+        x = x << radian
+    except UnitsError:
+        raise UnitTypeError("Can only apply 'sinc' function to "
+                            "quantities with angle units")
+    return (x,), {}, dimensionless_unscaled, None
+
+
+@dispatched_function
+def unwrap(p, discont=None, axis=-1):
+    from astropy.units.si import radian
+    if discont is None:
+        discont = np.pi << radian
+
+    try:
+        p = p << radian
+        discont = discont.to_value(radian)
+    except UnitsError:
+        raise UnitTypeError("Can only apply 'unwrap' function to "
+                            "quantities with angle units")
+
+    return p._wrap_function(np.unwrap.__wrapped__, discont, axis=axis)
+
+
+@function_helper
+def argpartition(a, kth, **kwargs):
+    return (a.value, kth), kwargs, None, None
+
+
+@function_helper
+def full_like(a, fill_value, **kwargs):
+    unit = a.unit if kwargs.get('subok', True) else None
+    return (a.value, a._to_own_unit(fill_value)), kwargs, unit, None
+
+
+@function_helper
+def putmask(a, mask, values):
+    from astropy.units.quantity import Quantity
+    if isinstance(a, Quantity):
+        return (a.value, mask, a._to_own_unit(values)), {}, a.unit, None
+        a = a.value
+    elif isinstance(values, Quantity):
+        return (a, mask, values.to_value(dimensionless_unscaled)), {}, None, None
+    else:
+        return NotImplemented

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -552,7 +552,8 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
             (unit, a.unit), None)
 
 
-@function_helper
+# histogram_bin_edges was only introduced in numpy 1.15.
+@function_helper(helps=getattr(np, 'histogram_bin_edges', ()))
 def histogram_bin_edges(a, bins=10, range=None, weights=None):
     # weights is currently unused
     a = _as_quantity(a)

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -529,3 +529,17 @@ def geomspace(start, stop, *args, **kwargs):
     # Get unit from end point as for linspace.
     (stop, start), unit = _quantities2arrays(stop, start)
     return (start, stop) + args, kwargs, unit, None
+
+
+@function_helper
+def interp(x, xp, fp, *args, **kwargs):
+    from astropy.units import Quantity
+
+    (x, xp), _ = _quantities2arrays(x, xp)
+    if isinstance(fp, Quantity):
+        unit = fp.unit
+        fp = fp.value
+    else:
+        unit = None
+
+    return (x, xp, fp) + args, kwargs, unit, None

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -90,9 +90,12 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.iscomplexobj, np.isrealobj,
     np.shares_memory, np.may_share_memory}
 
-# Implemented as methods that currently return NotImplementedError.
-# TODO: move to UNSUPPORTED? Would raise TypeError instead.
+# Implemented as methods on Quantity:
+# np.ediff1d is from setops, but we support it anyway; the others
+# currently return NotImplementedError.
+# TODO: move latter to UNSUPPORTED? Would raise TypeError instead.
 SUBCLASS_SAFE_FUNCTIONS |= {
+    np.ediff1d,
     np.all, np.any, np.sometrue, np.alltrue}
 
 # Subclass safe, but possibly better if overridden (e.g., with different
@@ -127,7 +130,7 @@ IGNORED_FUNCTIONS = {
     np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
     np.polymul, np.polysub, np.polyval, np.roots, np.vander,
     # setops
-    np.ediff1d, np.in1d, np.intersect1d, np.isin, np.setdiff1d,
+    np.in1d, np.intersect1d, np.isin, np.setdiff1d,
     np.setxor1d, np.union1d, np.unique,
     # financial
     np.fv, np.ipmt, np.irr, np.mirr, np.nper, np.npv, np.pmt, np.ppmt,

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -186,8 +186,11 @@ def invariant_m_helper(m, *args, **kwargs):
     return (m.view(np.ndarray),) + args, kwargs, m.unit, None
 
 
-# Not really logical to allow ones_like (what is the point of it?),
-# but keeping it since it used to work without __array_function__.
+# Note that ones_like does *not* work by default (unlike zeros_like) since if
+# one creates an empty array with a unit, one cannot just fill it with unity.
+# Indeed, in this respect, it is a bit of an odd function for Quantity. On the
+# other hand, it matches the idea that a unit is the same as the quantity with
+# that unit and value of 1. Also, it used to work without __array_function__.
 @function_helper
 def ones_like(a, *args, **kwargs):
     subok = args[2] if len(args) > 2 else kwargs.pop('subok', True)

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -48,8 +48,6 @@ def invariant_a_helper(a, *args, **kwargs):
 
 FUNCTION_HELPERS[np.copy] = invariant_a_helper
 FUNCTION_HELPERS[np.asfarray] = invariant_a_helper
-FUNCTION_HELPERS[np.zeros_like] = invariant_a_helper
-FUNCTION_HELPERS[np.ones_like] = invariant_a_helper
 FUNCTION_HELPERS[np.real_if_close] = invariant_a_helper
 FUNCTION_HELPERS[np.sort_complex] = invariant_a_helper
 FUNCTION_HELPERS[np.resize] = invariant_a_helper
@@ -65,7 +63,19 @@ FUNCTION_HELPERS[np.triu] = invariant_m_helper
 
 @function_helper
 def empty_like(prototype, *args, **kwargs):
-    return (prototype.view(np.ndarray),) + args, kwargs, prototype.unit, None
+    subok = args[2] if len(args) > 2 else kwargs.pop('subok', True)
+    unit = prototype.unit if subok else None
+    return (prototype.view(np.ndarray),) + args, kwargs, unit, None
+
+
+@function_helper
+def zeros_like(a, *args, **kwargs):
+    return empty_like(a, *args, **kwargs)
+
+
+@function_helper
+def ones_like(a, *args, **kwargs):
+    return empty_like(a, *args, **kwargs)
 
 
 @function_helper

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -35,7 +35,7 @@ import numpy as np
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_17
+from astropy.utils.compat import NUMPY_LT_1_17, NUMPY_LT_1_15
 from astropy.utils import isiterable
 
 
@@ -67,7 +67,6 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.flip, np.fliplr, np.flipud, np.rot90,
     np.argmin, np.argmax, np.argsort, np.lexsort, np.searchsorted,
     np.nonzero, np.argwhere, np.flatnonzero,
-    np.take_along_axis, np.put_along_axis,
     np.diag_indices_from, np.triu_indices_from, np.tril_indices_from,
     np.real, np.imag, np.diag, np.diagonal, np.diagflat,
     np.empty_like, np.zeros_like,
@@ -89,6 +88,10 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
     np.iscomplexobj, np.isrealobj,
     np.shares_memory, np.may_share_memory}
+
+if not NUMPY_LT_1_15:
+    SUBCLASS_SAFE_FUNCTIONS |= {np.take_along_axis, np.put_along_axis}
+
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others
@@ -414,7 +417,7 @@ def where(condition, *args):
 
 # Quantile was only introduced in numpy 1.15.
 @function_helper(helps=({np.quantile, np.nanquantile}
-                        if hasattr(np, 'quantile') else ()))
+                        if not NUMPY_LT_1_15 else ()))
 def quantile(a, q, *args, q_unit=dimensionless_unscaled, **kwargs):
     if len(args) > 2:
         out = args[1]
@@ -553,7 +556,7 @@ def histogram(a, bins=10, range=None, normed=None, weights=None,
 
 
 # histogram_bin_edges was only introduced in numpy 1.15.
-@function_helper(helps=getattr(np, 'histogram_bin_edges', ()))
+@function_helper(helps=np.histogram_bin_edges if not NUMPY_LT_1_15 else ())
 def histogram_bin_edges(a, bins=10, range=None, weights=None):
     # weights is currently unused
     a = _as_quantity(a)

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -508,3 +508,24 @@ def gradient(f, *varargs, **kwargs):
         units = units[0]
 
     return (f.value,) + varargs, kwargs, units, None
+
+
+@function_helper
+def logspace(start, stop, *args, **kwargs):
+    from astropy.units import LogQuantity, dex
+    if (not isinstance(start, LogQuantity) or
+            not isinstance(stop, LogQuantity)):
+        raise NotImplementedError
+
+    # Get unit from end point as for linspace.
+    stop = stop.to(dex(stop.unit.physical_unit))
+    start = start.to(stop.unit)
+    unit = stop.unit.physical_unit
+    return (start.value, stop.value) + args, kwargs, unit, None
+
+
+@function_helper
+def geomspace(start, stop, *args, **kwargs):
+    # Get unit from end point as for linspace.
+    (stop, start), unit = _quantities2arrays(stop, start)
+    return (start, stop) + args, kwargs, unit, None

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1558,29 +1558,6 @@ class TestSpecificTypeQuantity:
         assert type(res2) is u.Quantity
 
 
-@pytest.mark.skipif('not HAS_MATPLOTLIB')
-@pytest.mark.xfail('MATPLOTLIB_LT_15')
-class TestQuantityMatplotlib:
-    """Test if passing matplotlib quantities works.
-
-    TODO: create PNG output and check against reference image
-          once `astropy.wcsaxes` is merged, which provides
-          the machinery for this.
-
-    See https://github.com/astropy/astropy/issues/1881
-    See https://github.com/astropy/astropy/pull/2139
-    """
-
-    def test_plot(self):
-        data = u.Quantity([4, 5, 6], 's')
-        plt.plot(data)
-
-    def test_scatter(self):
-        x = u.Quantity([4, 5, 6], 'second')
-        y = [1, 3, 4] * u.m
-        plt.scatter(x, y)
-
-
 def test_unit_class_override():
     class MyQuantity(u.Quantity):
         pass

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -331,15 +331,6 @@ class TestQuantityStatsFuncs:
         assert np.all(q1.ediff1d() == np.array([1., 2., 6.]) * u.m)
         assert np.all(np.ediff1d(q1) == np.array([1., 2., 6.]) * u.m)
 
-    @pytest.mark.xfail
-    def test_dot_func(self):
-
-        q1 = np.array([1., 2., 4., 10.]) * u.m
-        q2 = np.array([3., 4., 5., 6.]) * u.s
-        q3 = np.dot(q1, q2)
-        assert q3.value == np.dot(q1.value, q2.value)
-        assert q3.unit == u.m * u.s
-
     def test_dot_meth(self):
 
         q1 = np.array([1., 2., 4., 10.]) * u.m

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,6 +1,7 @@
 import inspect
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 import pytest
 
@@ -139,16 +140,14 @@ class TestShapeManipulation(InvariantUnitTestSetup):
     def test_rot90(self):
         self.check(np.rot90)
 
-    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
-                       reason="Needs __array_function__ support")
     def test_broadcast_to(self):
-        self.check(np.broadcast_to, (3, 3, 3))
+        # TODO: should we change the default for subok?
+        self.check(np.broadcast_to, (3, 3, 3), subok=True)
 
-    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
-                       reason="Needs __array_function__ support")
     def test_broadcast_arrays(self):
+        # TODO: should we change the default for subok?
         q2 = np.ones((3, 3, 3)) / u.s
-        o1, o2 = np.broadcast_arrays(self.q, q2)
+        o1, o2 = np.broadcast_arrays(self.q, q2, subok=True)
         assert isinstance(o1, u.Quantity)
         assert isinstance(o2, u.Quantity)
         assert o1.shape == o2.shape == (3, 3, 3)
@@ -236,20 +235,31 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
                        reason="Needs __array_function__ support")
     def test_copy(self):
         self.check(np.copy)
+        # Also as kwarg
+        copy = np.copy(a=self.q)
+        assert_array_equal(copy, self.q)
 
     @pytest.mark.xfail(NO_ARRAY_FUNCTION,
                        reason="Needs __array_function__ support")
     def test_asfarray(self):
         self.check(np.asfarray)
+        farray = np.asfarray(a=self.q)
+        assert_array_equal(farray, self.q)
 
     def test_empty_like(self):
         o = np.empty_like(self.q)
         assert o.shape == (3, 3)
         assert isinstance(o, u.Quantity)
         assert o.unit == self.q.unit
+        o2 = np.empty_like(prototype=self.q)
+        assert o2.shape == (3, 3)
+        assert isinstance(o2, u.Quantity)
+        assert o2.unit == self.q.unit
 
     def test_zeros_like(self):
         self.check(np.zeros_like)
+        o2 = np.zeros_like(a=self.q)
+        assert_array_equal(o2, self.q * 0.)
 
     def test_ones_like(self):
         self.check(np.ones_like)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -254,12 +254,15 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
     def test_ones_like(self):
         self.check(np.ones_like)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_full_like(self):
         o = np.full_like(self.q, 0.5 * u.km)
         expected = np.empty_like(self.q.value) * u.m
         expected[...] = 0.5 * u.km
         assert np.all(o == expected)
+        with pytest.raises(u.UnitsError):
+            np.full_like(self.q, 0.5 * u.s)
 
 
 class TestAccessingParts(InvariantUnitTestSetup):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1012,11 +1012,22 @@ class TestIntDiffFunctions(metaclass=CoverageMeta):
         x = np.arange(10.) * u.m
         out = np.diff(x, prepend=-12.5*u.cm, append=1*u.km)
         expected = np.diff(x.value, prepend=-0.125, append=1000.) * x.unit
+        assert np.all(out == expected)
         x = np.arange(10.) * u.m
         out = np.diff(x, prepend=-12.5*u.cm, append=1*u.km, n=2)
         expected = np.diff(x.value, prepend=-0.125, append=1000.,
                            n=2) * x.unit
         assert np.all(out == expected)
+
+    def test_ediff1d(self):
+        # ediff1d works always as it calls the Quantity method.
+        x = np.arange(10.) * u.m
+        out = np.ediff1d(x)
+        expected = np.ediff1d(x.value) * u.m
+        assert np.all(out == expected)
+        out2 = np.ediff1d(x, to_begin=-12.5*u.cm, to_end=1*u.km)
+        expected2 = np.ediff1d(x.value, to_begin=-0.125, to_end=1000.) * x.unit
+        assert np.all(out2 == expected2)
 
     def test_gradient(self):
         # Simple gradient works out of the box.
@@ -1455,7 +1466,8 @@ poly_functions = {
 untested_functions |= poly_functions
 
 setops_functions = {f for f in all_wrapped_functions.values()
-                    if f in np.lib.arraysetops.__dict__.values()}
+                    if (f in np.lib.arraysetops.__dict__.values() and
+                        f is not np.ediff1d)}
 untested_functions |= setops_functions
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -344,7 +344,8 @@ class TestSettingParts(metaclass=CoverageMeta):
         expected = np.array([0.5, 1., 1.5])
         assert np.all(a == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_place(self):
         q = np.arange(3.) * u.m
         np.place(q, [True, False, True], [50, 150] * u.cm)
@@ -352,10 +353,11 @@ class TestSettingParts(metaclass=CoverageMeta):
         expected = [50, 100, 150] * u.cm
         assert np.all(q == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_copyto(self):
         q = np.arange(3.) * u.m
-        np.place(q, [50, 0, 150] * u.cm, where=[True, False, True])
+        np.copyto(q, [50, 0, 150] * u.cm, where=[True, False, True])
         assert q.unit == u.m
         expected = [50, 100, 150] * u.cm
         assert np.all(q == expected)
@@ -630,6 +632,14 @@ class TestUfuncLike(InvariantUnitTestSetup):
         q = np.array([-np.inf, +np.inf, np.nan, 3., 4.]) * u.m
         out = np.nan_to_num(q)
         expected = np.nan_to_num(q.value) * q.unit
+        assert np.all(out == expected)
+
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
+    def test_nan_to_num_complex(self):
+        q = np.array([-np.inf, +np.inf, np.nan, 3., 4.]) * u.m
+        out = np.nan_to_num(q, nan=1.*u.km, posinf=2.*u.km, neginf=-2*u.km)
+        expected = [-2000., 2000., 1000., 3., 4.] * u.m
         assert np.all(out == expected)
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -887,7 +887,8 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
     """
     Test functions that are similar to gufuncs
     """
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_cross(self):
         q1 = np.arange(6.).reshape(2, 3) * u.m
         q2 = np.array([4., 5., 6.]) / u.s
@@ -895,35 +896,40 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
         expected = np.cross(q1.value, q2.value) * u.m / u.s
         assert np.all(o == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_outer(self):
         q1 = np.array([1, 2, 3]) * u.m
         q2 = np.array([1, 2]) / u.s
         o = np.outer(q1, q2)
         assert np.all(o == np.array([[1, 2], [2, 4], [3, 6]]) * u.m / u.s)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_inner(self):
         q1 = np.array([1, 2, 3]) * u.m
         q2 = np.array([4, 5, 6]) / u.s
         o = np.inner(q1, q2)
         assert o == 32 * u.m / u.s
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_dot(self):
         q1 = np.array([1., 2., 3.]) * u.m
         q2 = np.array([4., 5., 6.]) / u.s
         o = np.dot(q1, q2)
         assert o == 32. * u.m / u.s
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_vdot(self):
         q1 = np.array([1j, 2j, 3j]) * u.m
         q2 = np.array([4j, 5j, 6j]) / u.s
         o = np.vdot(q1, q2)
         assert o == (32. + 0j) * u.m / u.s
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_tensordot(self):
         # From the docstring example
         a = np.arange(60.).reshape(3, 4, 5) * u.m
@@ -933,7 +939,8 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
                                 axes=([1, 0], [0, 1])) * u.m / u.s
         assert np.all(c == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_kron(self):
         q1 = np.eye(2) * u.m
         q2 = np.ones(2) / u.s

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1080,7 +1080,8 @@ class TestSpaceFunctions(metaclass=CoverageMeta):
 
 
 class TestInterpolationFunctions(metaclass=CoverageMeta):
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_interp(self):
         x = np.array([1250., 2750.]) * u.m
         xp = np.arange(5.) * u.km
@@ -1091,6 +1092,8 @@ class TestInterpolationFunctions(metaclass=CoverageMeta):
 
     @pytest.mark.xfail
     def test_piecewise(self):
+        # TODO: this needs a proper own implementation to take care of the
+        # unit of the output of possible functions.
         x = np.linspace(-2.5, 2.5, 6) * u.m
         out = np.piecewise(x, [x < 0, x >= 0], [-1*u.s, 1*u.day])
         expected = np.piecewise(x.value, [x.value < 0, x.value >= 0],

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -139,13 +139,15 @@ class TestShapeManipulation(InvariantUnitTestSetup):
     def test_rot90(self):
         self.check(np.rot90)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_broadcast_to(self):
         self.check(np.broadcast_to, (3, 3, 3))
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_broadcast_arrays(self):
-        q2 = np.ones(3, 3, 3) / u.s
+        q2 = np.ones((3, 3, 3)) / u.s
         o1, o2 = np.broadcast_arrays(self.q, q2)
         assert isinstance(o1, u.Quantity)
         assert isinstance(o2, u.Quantity)
@@ -530,13 +532,16 @@ class TestUfuncLike(InvariantUnitTestSetup):
                            qmax.to_value(self.q.unit)) * self.q.unit
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_sinc(self):
         q = [0., 3690., -270., 690.] * u.deg
         out = np.sinc(q)
         expected = np.sinc(q.to_value(u.radian)) * u.one
         assert isinstance(out, u.Quantity)
         assert np.all(out == expected)
+        with pytest.raises(u.UnitsError):
+            np.sinc(1.*u.one)
 
     @pytest.mark.xfail
     def test_where(self):
@@ -583,12 +588,17 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_triu(self):
         self.check(np.triu)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_unwrap(self):
         q = [0., 3690., -270., 690.] * u.deg
         out = np.unwrap(q)
-        expected = np.rad2deg(q.to_value(u.rad)) * u.deg
+        expected = np.rad2deg(np.unwrap(q.to_value(u.rad))) * u.deg
         assert np.allclose(out, expected, atol=1*u.urad, rtol=0)
+        with pytest.raises(u.UnitsError):
+            np.unwrap([1., 2.]*u.m)
+        with pytest.raises(u.UnitsError):
+            np.unwrap(q, discont=1.*u.m)
 
     def test_nan_to_num(self):
         q = np.array([-np.inf, +np.inf, np.nan, 3., 4.]) * u.m

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -948,7 +948,8 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
         expected = np.kron(q1.value, q2.value) * u.m / u.s
         assert np.all(o == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_einsum(self):
         q1 = np.arange(9.).reshape(3, 3) * u.m
         o = np.einsum('...i', q1)
@@ -1207,35 +1208,40 @@ class TestBitAndIndexFunctions(metaclass=CoverageMeta):
         self.q = np.arange(3) * u.m
         self.uint_q = u.Quantity(np.arange(3), 'm', dtype='u1')
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_packbits(self):
         with pytest.raises(TypeError):
             np.packbits(self.q)
         with pytest.raises(TypeError):
             np.packbits(self.uint_q)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_unpackbits(self):
         with pytest.raises(TypeError):
             np.unpackbits(self.q)
         with pytest.raises(TypeError):
             np.unpackbits(self.uint_q)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_unravel_index(self):
         with pytest.raises(TypeError):
-            np.unravel_index((self.q,), 3)
+            np.unravel_index(self.q, 3)
         with pytest.raises(TypeError):
-            np.unravel_index((self.uint_q,), 3)
+            np.unravel_index(self.uint_q, 3)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_ravel_multi_index(self):
         with pytest.raises(TypeError):
             np.ravel_multi_index((self.q,), 3)
         with pytest.raises(TypeError):
             np.ravel_multi_index((self.uint_q,), 3)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_ix_(self):
         with pytest.raises(TypeError):
             np.ix_(self.q)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1167,6 +1167,14 @@ class TestMeshGrid(metaclass=CoverageMeta):
         assert np.all(o2 == e2 * q2.unit)
 
 
+class TestMemoryFunctions(NoUnitTestSetup):
+    def test_shares_memory(self):
+        self.check(np.shares_memory, self.q.value)
+
+    def test_may_share_memory(self):
+        self.check(np.may_share_memory, self.q.value)
+
+
 function_functions = {
     np.apply_along_axis, np.apply_over_axes,
     }
@@ -1186,11 +1194,6 @@ deprecated_functions = {
     np.asscalar, np.rank
     }
 CoverageMeta.covered |= deprecated_functions
-
-memory_functions = {
-    np.shares_memory, np.may_share_memory
-    }
-CoverageMeta.covered |= memory_functions
 
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}
 CoverageMeta.covered |= io_functions

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -866,14 +866,16 @@ class TestNanFunctions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.nancumprod(self.q)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_nanquantile(self):
         self.check(np.nanquantile, 0.5)
         o = np.nanquantile(self.q, 50 * u.percent)
         expected = np.nanquantile(self.q.value, 0.5) * u.m
         assert np.all(o == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_nanpercentile(self):
         self.check(np.nanpercentile, 0.5)
         o = np.nanpercentile(self.q, 0.5 * u.one)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1126,11 +1126,55 @@ class TestSortFunctions(BasicTestSetup):
 
 check |= get_covered_functions(TestSortFunctions)
 
-string_functions = {np.array_repr, np.array_str, np.array2string}
-check |= string_functions
 
-bit_functions = {np.packbits, np.unpackbits}
-check |= bit_functions
+class TestStringFunctions:
+    def setup(self):
+        self.q = np.arange(3.) * u.Jy
+
+    @pytest.mark.xfail
+    def test_array_repr(self):
+        out = np.array_repr(self.q)
+        expected = (np.array_repr(self.q.value)[:-1] +
+                    ', {!r})'.format(str(self.q.unit)))
+        assert out == expected
+
+    @pytest.mark.xfail
+    def test_array_str(self):
+        out = np.array_str(self.q)
+        expected = str(self.q)
+        assert out == expected
+
+    @pytest.mark.xfail
+    def test_array2string(self):
+        out = np.array2string(self.q)
+        expected = str(self.q)
+        assert out == expected
+
+
+check |= get_covered_functions(TestStringFunctions)
+
+
+class TestBitFunctions:
+    def setup(self):
+        self.q = np.arange(3) * u.m
+        self.uint_q = u.Quantity(np.arange(3), 'm', dtype='u1')
+
+    @pytest.mark.xfail
+    def test_packbits(self):
+        with pytest.raises(TypeError):
+            np.packbits(self.q)
+        with pytest.raises(TypeError):
+            np.packbits(self.uint_q)
+
+    @pytest.mark.xfail
+    def test_unpackbits(self):
+        with pytest.raises(TypeError):
+            np.unpackbits(self.q)
+        with pytest.raises(TypeError):
+            np.unpackbits(self.uint_q)
+
+
+check |= get_covered_functions(TestBitFunctions)
 
 index_functions = {np.ravel_multi_index, np.unravel_index}
 check |= index_functions

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -996,7 +996,8 @@ class TestNumericalFunctions(metaclass=CoverageMeta):
         expected = np.diff(x.value) * u.m
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_diff_prepend_append(self):
         x = np.arange(10.) * u.m
         out = np.diff(x, prepend=-12.5*u.cm, append=1*u.km)
@@ -1008,21 +1009,36 @@ class TestNumericalFunctions(metaclass=CoverageMeta):
         assert np.all(out == expected)
 
     def test_gradient(self):
-        # Simple diff works out of the box.
+        # Simple gradient works out of the box.
         x = np.arange(10.) * u.m
         out = np.gradient(x)
         expected = np.gradient(x.value) * u.m
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_gradient_spacing(self):
-        # Simple diff works out of the box.
+        # Simple gradient works out of the box.
         x = np.arange(10.) * u.m
         spacing = 10. * u.s
         out = np.gradient(x, spacing)
         expected = np.gradient(x.value, spacing.value) * (x.unit /
                                                           spacing.unit)
         assert np.all(out == expected)
+        f = np.array([[1, 2, 6], [3, 4, 5]]) * u.m
+        dx = 2. * u.s
+        y = [1., 1.5, 3.5] * u.GHz
+        dfdx, dfdy = np.gradient(f, dx, y)
+        exp_dfdx, exp_dfdy = np.gradient(f.value, dx.value, y.value)
+        exp_dfdx = exp_dfdx * f.unit / dx.unit
+        exp_dfdy = exp_dfdy * f.unit / y.unit
+        assert np.all(dfdx == exp_dfdx)
+        assert np.all(dfdy == exp_dfdy)
+
+        dfdx2 = np.gradient(f, dx, axis=0)
+        assert np.all(dfdx2 == exp_dfdx)
+        dfdy2 = np.gradient(f, y, axis=1)
+        assert np.all(dfdy2 == exp_dfdy)
 
     def test_linspace(self):
         # Note: linspace gets unit of end point, not superlogical.

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -972,7 +972,7 @@ class TestVariousProductFunctions(metaclass=CoverageMeta):
         assert o[0] == ['einsum_path', (0, 1)]
 
 
-class TestNumericalFunctions(metaclass=CoverageMeta):
+class TestIntDiffFunctions(metaclass=CoverageMeta):
     def test_trapz(self):
         y = np.arange(9.) * u.m / u.s
         out = np.trapz(y)
@@ -1040,6 +1040,8 @@ class TestNumericalFunctions(metaclass=CoverageMeta):
         dfdy2 = np.gradient(f, y, axis=1)
         assert np.all(dfdy2 == exp_dfdy)
 
+
+class TestSpaceFunctions(metaclass=CoverageMeta):
     def test_linspace(self):
         # Note: linspace gets unit of end point, not superlogical.
         out = np.linspace(1000.*u.m, 10.*u.km, 5)
@@ -1052,28 +1054,32 @@ class TestNumericalFunctions(metaclass=CoverageMeta):
         expected = np.linspace(q1.to_value(q2.unit), q2.value, 5) * q2.unit
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_logspace(self):
         unit = u.m / u.s**2
         out = np.logspace(10.*u.dex(unit), 20*u.dex(unit), 10)
-        expected = np.logspace(10., 20.) * u.Jy
+        expected = np.logspace(10., 20., 10) * unit
         assert np.all(out == expected)
         out = np.logspace(10.*u.STmag, 20*u.STmag, 10)
-        expected = np.logspace(10., 20., base=10.**(-0.4)) * u.ST
-        assert np.all(out == expected)
+        expected = np.logspace(10., 20., 10, base=10.**(-0.4)) * u.ST
+        assert u.allclose(out, expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_geomspace(self):
         out = np.geomspace(1000.*u.m, 10.*u.km, 5)
         expected = np.geomspace(1, 10, 5) * u.km
         assert np.all(out == expected)
 
-        q1 = np.arange(6.).reshape(2, 3) * u.m
+        q1 = np.arange(1., 7.).reshape(2, 3) * u.m
         q2 = 10000. * u.cm
         out = np.geomspace(q1, q2, 5)
         expected = np.geomspace(q1.to_value(q2.unit), q2.value, 5) * q2.unit
         assert np.all(out == expected)
 
+
+class TestInterpolationFunctions(metaclass=CoverageMeta):
     @pytest.mark.xfail
     def test_interp(self):
         x = np.array([1250., 2750.]) * u.m

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -595,14 +595,16 @@ class TestUfuncLike(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.sinc(1.*u.one)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_where(self):
         out = np.where([True, False, True], self.q, 1. * u.km)
         expected = np.where([True, False, True], self.q.value,
                             1000.) * self.q.unit
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_choose(self):
         # from np.choose docstring
         a = np.array([0, 1]).reshape((2, 1, 1))
@@ -613,7 +615,8 @@ class TestUfuncLike(InvariantUnitTestSetup):
         expected = np.choose(a, (q1.value, q2.to_value(q1.unit))) * u.cm
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_select(self):
         q = self.q
         out = np.select([q < 0.55 * u.m, q > 1. * u.m],

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -182,7 +182,8 @@ class TestArgFunctions(NoUnitTestSetup):
     def test_argwhere(self):
         self.check(np.argwhere)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_argpartition(self):
         self.check(np.argpartition, 2)
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1096,7 +1096,7 @@ class TestStringFunctions(metaclass=CoverageMeta):
         assert out == expected
 
 
-class TestBitFunctions(metaclass=CoverageMeta):
+class TestBitAndIndexFunctions(metaclass=CoverageMeta):
     def setup(self):
         self.q = np.arange(3) * u.m
         self.uint_q = u.Quantity(np.arange(3), 'm', dtype='u1')
@@ -1115,9 +1115,20 @@ class TestBitFunctions(metaclass=CoverageMeta):
         with pytest.raises(TypeError):
             np.unpackbits(self.uint_q)
 
+    @pytest.mark.xfail
+    def test_unravel_index(self):
+        with pytest.raises(TypeError):
+            np.unravel_index((self.q,), 3)
+        with pytest.raises(TypeError):
+            np.unravel_index((self.uint_q,), 3)
 
-index_functions = {np.ravel_multi_index, np.unravel_index}
-CoverageMeta.covered |= index_functions
+    @pytest.mark.xfail
+    def test_ravel_multi_index(self):
+        with pytest.raises(TypeError):
+            np.ravel_multi_index((self.q,), 3)
+        with pytest.raises(TypeError):
+            np.ravel_multi_index((self.uint_q,), 3)
+
 
 dtype_functions = {
     np.common_type, np.result_type, np.can_cast, np.min_scalar_type,

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -193,10 +193,38 @@ class TestCopyAndCreation(BasicTestSetup):
 check |= get_covered_functions(TestCopyAndCreation)
 
 
-different_views = {
-    np.diag, np.diagonal, np.compress, np.extract, np.diagflat, np.place
-    }
-check |= different_views
+class TestAccessingParts(BasicTestSetup):
+    def test_diag(self):
+        self.check(np.diag)
+
+    def test_diagonal(self):
+        self.check(np.diagonal)
+
+    def test_diagflat(self):
+        self.check(np.diagflat)
+
+    def test_compress(self):
+        o = np.compress([True, False, True], self.q, axis=0)
+        expected = np.compress([True, False, True], self.q.value,
+                               axis=0) * self.q.unit
+        assert np.all(o == expected)
+
+    def test_extract(self):
+        o = np.extract([True, False, True], self.q)
+        expected = np.extract([True, False, True],
+                              self.q.value) * self.q.unit
+        assert np.all(o == expected)
+
+    @pytest.mark.xfail
+    def test_place(self):
+        q = np.arange(3.) * u.m
+        np.place(q, [True, False, True], [50, 150] * u.cm)
+        assert q.unit == u.m
+        expected = [50, 100, 150] * u.cm
+        assert np.all(q == expected)
+
+
+check |= get_covered_functions(TestAccessingParts)
 
 joining_and_splitting = {
     np.concatenate, np.stack, np.column_stack, np.dstack, np.hstack,

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -6,7 +6,11 @@ from numpy.testing import assert_array_equal
 import pytest
 
 from astropy import units as u
-from astropy.utils.compat import NUMPY_LT_1_17 as NO_ARRAY_FUNCTION
+from astropy.units.quantity_helper.function_helpers import (
+    ARRAY_FUNCTION_ENABLED)
+
+
+NO_ARRAY_FUNCTION = not ARRAY_FUNCTION_ENABLED
 
 
 # To get the functions that could be covered, we look for those that

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -744,14 +744,20 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_median(self):
         self.check(np.median)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_quantile(self):
         self.check(np.quantile, 0.5)
         o = np.quantile(self.q, 50 * u.percent)
         expected = np.quantile(self.q.value, 0.5) * u.m
         assert np.all(o == expected)
+        # For ndarray input, we return a Quantity.
+        o2 = np.quantile(self.q.value, 50 * u.percent)
+        assert o2.unit == u.dimensionless_unscaled
+        assert np.all(o2 == expected.value)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_percentile(self):
         self.check(np.percentile, 0.5)
         o = np.percentile(self.q, 0.5 * u.one)
@@ -761,14 +767,17 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_trace(self):
         self.check(np.trace)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_count_nonzero(self):
         q1 = np.arange(9.).reshape(3, 3) * u.m
         o = np.count_nonzero(q1)
+        assert type(o) is not u.Quantity
         assert o == 8
         o = np.count_nonzero(q1, axis=1)
         # Returns integer Quantity with units of m
-        assert o == np.array([2, 3, 3])
+        assert type(o) is np.ndarray
+        assert np.all(o == np.array([2, 3, 3]))
 
     def test_allclose(self):
         q1 = np.arange(3.) * u.m

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 
 from astropy import units as u
-from astropy.utils.compat import NUMPY_LT_1_17
+from astropy.utils.compat import NUMPY_LT_1_17 as NO_ARRAY_FUNCTION
 
 
 # To get the functions that could be covered, we look for those that
@@ -229,11 +229,13 @@ class TestRealImag(InvariantUnitTestSetup):
 
 
 class TestCopyAndCreation(InvariantUnitTestSetup):
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_copy(self):
         self.check(np.copy)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_asfarray(self):
         self.check(np.asfarray)
 
@@ -563,18 +565,21 @@ class TestUfuncLike(InvariantUnitTestSetup):
                              [q.value, q.value], default=-1000) * u.m
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_real_if_close(self):
         q = np.array([1+0j, 0+1j, 1+1j, 0+0j]) * u.m
         out = np.real_if_close(q)
         expected = np.real_if_close(q.value) * u.m
         assert np.all(out == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_tril(self):
         self.check(np.tril)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_triu(self):
         self.check(np.triu)
 
@@ -1056,7 +1061,8 @@ class TestSortFunctions(InvariantUnitTestSetup):
     def test_sort(self):
         self.check(np.sort)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_sort_complex(self):
         self.check(np.sort_complex)
 
@@ -1221,7 +1227,7 @@ setops_functions = {f for f in all_wrapped_functions.values()
 CoverageMeta.covered |= setops_functions
 
 
-@pytest.mark.xfail(NUMPY_LT_1_17,
+@pytest.mark.xfail(NO_ARRAY_FUNCTION,
                    reason="no __array_function__ wrapping in numpy<1.17")
 def test_completeness():
     assert set(all_wrapped_functions.values()) == CoverageMeta.covered

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -798,7 +798,8 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         with pytest.raises(u.UnitsError):
             np.allclose(q1, q2, atol=0, rtol=1. * u.s)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_array_equal(self):
         q1 = np.arange(3.) * u.m
         q2 = q1.to(u.cm)
@@ -806,7 +807,8 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
         q3 = q1.value * u.cm
         assert not np.array_equal(q1, q3)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_array_equiv(self):
         q1 = np.array([[0., 1., 2.]]*3) * u.m
         q2 = q1[0].to(u.cm)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -259,6 +259,8 @@ class TestCopyAndCreation(InvariantUnitTestSetup):
         assert o2.shape == (3, 3)
         assert isinstance(o2, u.Quantity)
         assert o2.unit == self.q.unit
+        o3 = np.empty_like(self.q, subok=False)
+        assert type(o3) is np.ndarray
 
     def test_zeros_like(self):
         self.check(np.zeros_like)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -314,13 +314,25 @@ class TestSettingParts(metaclass=CoverageMeta):
         expected = [50, 100, 150] * u.cm
         assert np.all(q == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_putmask(self):
         q = np.arange(3.) * u.m
-        np.putmask(q, [True, False, True], [50, 0, 150] * u.cm)
+        mask = [True, False, True]
+        values = [50, 0, 150] * u.cm
+        np.putmask(q, mask, values)
         assert q.unit == u.m
         expected = [50, 100, 150] * u.cm
         assert np.all(q == expected)
+        with pytest.raises(u.UnitsError):
+            np.putmask(q, mask, values.value)
+        with pytest.raises(u.UnitsError):
+            np.putmask(q.value, mask, values)
+        a = np.arange(3.)
+        values = [50, 0, 150] * u.percent
+        np.putmask(a, mask, values)
+        expected = np.array([0.5, 1., 1.5])
+        assert np.all(a == expected)
 
     @pytest.mark.xfail
     def test_place(self):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -57,13 +57,82 @@ class TestShapeInformation:
 check |= get_covered_functions(TestShapeInformation)
 
 
-shape_manipulation = {
-    np.reshape, np.ravel,
-    np.moveaxis, np.rollaxis, np.swapaxes, np.transpose,
-    np.atleast_1d, np.atleast_2d, np.atleast_3d,
-    np.expand_dims, np.squeeze,
-    np.flip, np.fliplr, np.flipud, np.rot90}
-check |= shape_manipulation
+class TestShapeManipulation:
+    def setup(self):
+        self.q = np.arange(9.).reshape(3, 3) * u.m
+
+    def check(self, func, *args, **kwargs):
+        o = func(self.q, *args, **kwargs)
+        expected = func(self.q.value, *args, **kwargs) * self.q.unit
+        assert o.shape == expected.shape
+        assert np.all(o == expected)
+
+    # Note: do not parametrize the below, since test names are used
+    # to check coverage.
+    def test_reshape(self):
+        self.check(np.reshape, (9, 1))
+
+    def test_ravel(self):
+        self.check(np.ravel)
+
+    def test_moveaxis(self):
+        self.check(np.moveaxis, 0, 1)
+
+    def test_rollaxis(self):
+        self.check(np.rollaxis, 0, 2)
+
+    def test_swapaxes(self):
+        self.check(np.swapaxes, 0, 1)
+
+    def test_transpose(self):
+        self.check(np.transpose)
+
+    def test_atleast_1d(self):
+        q = 1. * u.m
+        o, so = np.atleast_1d(q, self.q)
+        assert o.shape == (1,)
+        assert o == q
+        expected = np.atleast_1d(self.q.value) * u.m
+        assert np.all(so == expected)
+
+    def test_atleast_2d(self):
+        q = 1. * u.m
+        o, so = np.atleast_2d(q, self.q)
+        assert o.shape == (1, 1)
+        assert o == q
+        expected = np.atleast_2d(self.q.value) * u.m
+        assert np.all(so == expected)
+
+    def test_atleast_3d(self):
+        q = 1. * u.m
+        o, so = np.atleast_3d(q, self.q)
+        assert o.shape == (1, 1, 1)
+        assert o == q
+        expected = np.atleast_3d(self.q.value) * u.m
+        assert np.all(so == expected)
+
+    def test_expand_dims(self):
+        self.check(np.expand_dims, 1)
+
+    def test_squeeze(self):
+        o = np.squeeze(self.q[:, np.newaxis, :])
+        assert o.shape == (3, 3)
+        assert np.all(o == self.q)
+
+    def test_flip(self):
+        self.check(np.flip)
+
+    def test_fliplr(self):
+        self.check(np.fliplr)
+
+    def test_flipud(self):
+        self.check(np.flipud)
+
+    def test_rot90(self):
+        self.check(np.rot90)
+
+
+check |= get_covered_functions(TestShapeManipulation)
 
 shape_indexing = {
     np.diag_indices_from, np.tril_indices_from, np.triu_indices_from

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1175,6 +1175,24 @@ class TestMemoryFunctions(NoUnitTestSetup):
         self.check(np.may_share_memory, self.q.value)
 
 
+class TestDatetimeFunctions(BasicTestSetup):
+    def test_busday_count(self):
+        with pytest.raises(TypeError):
+            np.busday_count(self.q, self.q)
+
+    def test_busday_offset(self):
+        with pytest.raises(TypeError):
+            np.busday_offset(self.q, self.q)
+
+    def test_datetime_as_string(self):
+        with pytest.raises(TypeError):
+            np.datetime_as_string(self.q)
+
+    def test_is_busday(self):
+        with pytest.raises(TypeError):
+            np.is_busday(self.q)
+
+
 function_functions = {
     np.apply_along_axis, np.apply_over_axes,
     }
@@ -1183,12 +1201,6 @@ CoverageMeta.covered |= function_functions
 financial_functions = {f for f in all_wrapped_functions.values()
                        if f in np.lib.financial.__dict__.values()}
 CoverageMeta.covered |= financial_functions
-
-datetime_functions = {
-    np.busday_count, np.busday_offset, np.datetime_as_string,
-    np.is_busday,
-    }
-CoverageMeta.covered |= datetime_functions.copy()
 
 deprecated_functions = {
     np.asscalar, np.rank

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -406,6 +406,43 @@ class TestSplit:
 check |= get_covered_functions(TestSplit)
 
 
+class TestUfuncReductions(BasicTestSetup):
+    def test_amax(self):
+        self.check(np.amax)
+
+    def test_amin(self):
+        self.check(np.amin)
+
+    def test_sum(self):
+        self.check(np.sum)
+
+    def test_any(self):
+        with pytest.raises(NotImplementedError):
+            np.any(self.q)
+
+    def test_all(self):
+        with pytest.raises(NotImplementedError):
+            np.all(self.q)
+
+    def test_sometrue(self):
+        with pytest.raises(NotImplementedError):
+            np.sometrue(self.q)
+
+    def test_alltrue(self):
+        with pytest.raises(NotImplementedError):
+            np.alltrue(self.q)
+
+    def test_prod(self):
+        with pytest.raises(u.UnitsError):
+            np.prod(self.q)
+
+    def test_product(self):
+        with pytest.raises(u.UnitsError):
+            np.product(self.q)
+
+
+check |= get_covered_functions(TestUfuncReductions)
+
 ufunc_like = {
     np.angle, np.around, np.round_, np.ptp, np.fix, np.i0,
     np.clip, np.sinc, np.where, np.choose, np.select,
@@ -415,17 +452,16 @@ ufunc_like = {
 }
 check |= ufunc_like
 
-ufunc_reductions = {
-    np.any, np.all, np.amax, np.amin, np.sum, np.prod, np.product,
-    np.alltrue, np.sometrue
-    }
-check |= ufunc_reductions
-
 ufunc_nanreductions = {
     np.nanmax, np.nanmin, np.nanmean, np.nanmedian, np.nansum, np.nanprod,
     np.nanpercentile, np.nanquantile, np.nanstd, np.nanvar,
     }
 check |= ufunc_nanreductions
+
+ufunc_nanaccumulations = {
+    np.nancumsum, np.nancumprod
+    }
+check |= ufunc_nanaccumulations
 
 
 class TestReductionLikeFunctions(BasicTestSetup):
@@ -518,11 +554,6 @@ ufunc_accumulations = {
     np.cumsum, np.cumprod, np.cumproduct
     }
 check |= ufunc_accumulations
-
-ufunc_accumulation_like = {
-    np.nancumsum, np.nancumprod
-    }
-check |= ufunc_accumulation_like
 
 
 class TestVariousProductFunctions:

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -11,7 +11,7 @@ from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
     FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS)
-from astropy.utils.compat import NUMPY_LT_1_15
+from astropy.utils.compat import NUMPY_LT_1_14, NUMPY_LT_1_15, NUMPY_LT_1_16
 
 
 NO_ARRAY_FUNCTION = not ARRAY_FUNCTION_ENABLED
@@ -129,6 +129,8 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         expected = np.atleast_3d(self.q.value) * u.m
         assert np.all(so == expected)
 
+    @pytest.mark.xfail(NUMPY_LT_1_16,
+                       reason="expand_dims used asarray in numpy <1.16")
     def test_expand_dims(self):
         self.check(np.expand_dims, 1)
 
@@ -137,6 +139,8 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         assert o.shape == (3, 3)
         assert np.all(o == self.q)
 
+    @pytest.mark.xfail(NUMPY_LT_1_15,
+                       reason="flip needs axis argument in numpy <1.15")
     def test_flip(self):
         self.check(np.flip)
 
@@ -200,6 +204,8 @@ class TestArgFunctions(NoUnitTestSetup):
 
 
 class TestAlongAxis(BasicTestSetup):
+    @pytest.mark.skip(NUMPY_LT_1_15,
+                      reason="take_long_axis added in numpy 1.15")
     def test_take_along_axis(self):
         indices = np.expand_dims(np.argmax(self.q, axis=0), axis=0)
         out = np.take_along_axis(self.q, indices, axis=0)
@@ -207,6 +213,8 @@ class TestAlongAxis(BasicTestSetup):
                                       axis=0) * self.q.unit
         assert np.all(out == expected)
 
+    @pytest.mark.skip(NUMPY_LT_1_15,
+                      reason="put_long_axis added in numpy 1.15")
     def test_put_along_axis(self):
         q = self.q.copy()
         indices = np.expand_dims(np.argmax(self.q, axis=0), axis=0)
@@ -572,6 +580,8 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_fix(self):
         self.check(np.fix)
 
+    @pytest.mark.xfail(NUMPY_LT_1_16,
+                       reason="angle used asarray in numpy <1.16")
     def test_angle(self):
         q = np.array([1+0j, 0+1j, 1+1j, 0+0j]) * u.m
         out = np.angle(q)
@@ -778,8 +788,9 @@ class TestReductionLikeFunctions(InvariantUnitTestSetup):
     def test_trace(self):
         self.check(np.trace)
 
-    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
-                       reason="Needs __array_function__ support")
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION and not NUMPY_LT_1_14,
+                       reason=("Needs __array_function__ support "
+                               "(or numpy < 1.14)"))
     def test_count_nonzero(self):
         q1 = np.arange(9.).reshape(3, 3) * u.m
         o = np.count_nonzero(q1)
@@ -1064,6 +1075,8 @@ class TestIntDiffFunctions(metaclass=CoverageMeta):
 
 
 class TestSpaceFunctions(metaclass=CoverageMeta):
+    @pytest.mark.xfail(NUMPY_LT_1_16,
+                       reason="No array-like start, top in numpy <1.16")
     def test_linspace(self):
         # Note: linspace gets unit of end point, not superlogical.
         out = np.linspace(1000.*u.m, 10.*u.km, 5)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -394,31 +394,38 @@ class TestConcatenate(metaclass=CoverageMeta):
         assert o.shape == expected.shape
         assert np.all(o == expected)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_concatenate(self):
         self.check(np.concatenate)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_stack(self):
         self.check(np.stack)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_column_stack(self):
         self.check(np.column_stack)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_hstack(self):
         self.check(np.hstack)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_vstack(self):
         self.check(np.vstack)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_dstack(self):
         self.check(np.dstack)
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_block(self):
         self.check(np.block)
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 
 import pytest
@@ -5,10 +7,162 @@ import pytest
 from astropy import units as u
 
 
-class TestQuantityLinAlgFuncs:
+def get_covered_functions(cls):
+    covered = []
+    for k, v in cls.__dict__.items():
+        if inspect.isfunction(v) and k.startswith('test'):
+            f = k.replace('test_', '')
+            if f in all_numpy_functions:
+                covered.append(all_numpy_functions[f])
+
+    return set(covered)
+
+
+all_numpy_functions = {name: f for name, f in np.__dict__.items()
+                       if callable(f) and hasattr(f, '__wrapped__') and
+                       f is not np.printoptions}
+check = set()
+
+copying_and_creation = {
+    np.copy, np.asfarray,
+    np.empty_like, np.ones_like, np.zeros_like, np.full_like,
+    }
+check |= copying_and_creation
+
+shape_information = {
+    np.alen, np.shape, np.size, np.ndim
+    }
+check |= shape_information
+
+property_getters = {
+    np.real, np.imag
+    }
+check |= property_getters
+
+different_views = {
+    np.diag, np.diagonal, np.compress, np.extract, np.diagflat, np.place
+    }
+check |= different_views
+
+shape_manipulation = {
+    np.reshape, np.ravel,
+    np.moveaxis, np.rollaxis, np.swapaxes, np.transpose,
+    np.atleast_1d, np.atleast_2d, np.atleast_3d,
+    np.expand_dims, np.squeeze,
+    np.flip, np.fliplr, np.flipud, np.rot90}
+check |= shape_manipulation
+
+shape_indexing = {
+    np.diag_indices_from, np.tril_indices_from, np.triu_indices_from
+    }
+check |= shape_indexing
+
+broadcast_functions = {
+    np.broadcast_to, np.broadcast_arrays,
+    }
+check |= broadcast_functions
+
+joining_and_splitting = {
+    np.concatenate, np.stack, np.column_stack, np.dstack, np.hstack,
+    np.vstack, np.block,
+    np.split, np.array_split, np.dsplit, np.hsplit, np.vsplit,
+    np.tile, np.repeat, np.pad}
+check |= joining_and_splitting
+
+accessing_elements = {
+    np.delete, np.insert, np.append, np.resize, np.trim_zeros, np.flatnonzero,
+    np.roll, np.put, np.putmask, np.take, np.fill_diagonal,
+    }
+check |= accessing_elements
+
+ufunc_like = {
+    np.angle, np.around, np.round_, np.ptp, np.fix, np.i0,
+    np.clip, np.sinc, np.where, np.choose, np.select,
+    np.isneginf, np.isposinf, np.isclose, np.nan_to_num,
+    np.isreal, np.iscomplex, np.real_if_close,
+    np.tril, np.triu, np.unwrap, np.copyto,
+}
+check |= ufunc_like
+
+ufunc_reductions = {
+    np.any, np.all, np.amax, np.amin, np.sum, np.prod, np.product,
+    np.alltrue, np.sometrue
+    }
+check |= ufunc_reductions
+
+ufunc_reduction_like = {
+    np.quantile, np.percentile,
+    np.allclose, np.array_equal, np.array_equiv, np.count_nonzero,
+    np.nanmax, np.nanmin, np.nanmean, np.nanmedian, np.nansum, np.nanprod,
+    np.nanpercentile, np.nanquantile, np.nanstd, np.nanvar,
+    }
+check |= ufunc_reduction_like
+
+
+class TestReductionLikeFunctions:
+    def test_average(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        q2 = np.eye(3) / u.s
+        o = np.average(q1, weights=q2)
+        expected = np.average(q1.value, weights=q2.value) * u.m
+        assert np.all(o == expected)
+
+    def test_mean(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.mean(q1)
+        expected = np.mean(q1.value) * u.m
+        assert np.all(o == expected)
+
+    def test_std(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.std(q1)
+        expected = np.std(q1.value) * u.m
+        assert np.all(o == expected)
+
+    def test_var(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.var(q1)
+        expected = np.var(q1.value) * u.m ** 2
+        assert np.all(o == expected)
+
+    def test_median(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.median(q1)
+        expected = np.median(q1.value) * u.m
+        assert np.all(o == expected)
+
+    def test_trace(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.trace(q1)
+        expected = np.trace(q1.value) * u.m
+        assert np.all(o == expected)
+
+
+check |= get_covered_functions(TestReductionLikeFunctions)
+
+
+ufunc_accumulations = {
+    np.cumsum, np.cumprod, np.cumproduct
+    }
+check |= ufunc_accumulations
+
+ufunc_accumulation_like = {
+    np.nancumsum, np.nancumprod
+    }
+check |= ufunc_accumulation_like
+
+
+class TestVariousProductFunctions:
     """
-    Test linear algebra functions
+    Test functions that are similar to gufuncs
     """
+    @pytest.mark.xfail
+    def test_cross(self):
+        q1 = np.arange(6.).reshape(2, 3) * u.m
+        q2 = np.array([4., 5., 6.]) / u.s
+        o = np.cross(q1, q2)
+        expected = np.cross(q1.value, q2.value) * u.m / u.s
+        assert np.all(o == expected)
 
     @pytest.mark.xfail
     def test_outer(self):
@@ -32,8 +186,130 @@ class TestQuantityLinAlgFuncs:
         assert o == 32. * u.m / u.s
 
     @pytest.mark.xfail
-    def test_matmul(self):
-        q1 = np.eye(3) * u.m
-        q2 = np.array([4., 5., 6.]) / u.s
-        o = np.matmul(q1, q2)
-        assert o == q2 / u.s
+    def test_vdot(self):
+        q1 = np.array([1j, 2j, 3j]) * u.m
+        q2 = np.array([4j, 5j, 6j]) / u.s
+        o = np.vdot(q1, q2)
+        assert o == (32. + 0j) * u.m / u.s
+
+    @pytest.mark.xfail
+    def test_tensordot(self):
+        # From the docstring example
+        a = np.arange(60.).reshape(3, 4, 5) * u.m
+        b = np.arange(24.).reshape(4, 3, 2) / u.s
+        c = np.tensordot(a, b, axes=([1, 0], [0, 1]))
+        expected = np.tensordot(a.value, b.value,
+                                axes=([1, 0], [0, 1])) * u.m / u.s
+        assert np.all(c == expected)
+
+    @pytest.mark.xfail
+    def test_kron(self):
+        q1 = np.eye(2) * u.m
+        q2 = np.ones(2) / u.s
+        o = np.kron(q1, q2)
+        expected = np.kron(q1.value, q2.value) * u.m / u.s
+        assert np.all(o == expected)
+
+    @pytest.mark.xfail
+    def test_einsum(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.einsum('...i', q1)
+        assert np.all(o == q1)
+        o = np.einsum('ii', q1)
+        expected = np.einsum('ii', q1.value) * u.m
+        assert np.all(o == expected)
+        q2 = np.eye(3) / u.s
+        o = np.einsum('ij,jk', q1, q2)
+        assert np.all(o == q1 / u.s)
+
+    def test_einsum_path(self):
+        q1 = np.arange(9.).reshape(3, 3) * u.m
+        o = np.einsum_path('...i', q1)
+        assert o[0] == ['einsum_path', (0,)]
+        o = np.einsum_path('ii', q1)
+        assert o[0] == ['einsum_path', (0,)]
+        q2 = np.eye(3) / u.s
+        o = np.einsum_path('ij,jk', q1, q2)
+        assert o[0] == ['einsum_path', (0, 1)]
+
+
+check |= get_covered_functions(TestVariousProductFunctions)
+
+gufunc_like = {
+    np.interp,
+    np.linspace, np.logspace, np.geomspace,
+    np.bincount, np.digitize, np.histogram, np.histogram2d, np.histogramdd,
+    np.histogram_bin_edges, np.diff, np.gradient,
+    np.cov, np.corrcoef, np.piecewise, np.convolve, np.correlate,
+    np.sort, np.sort_complex, np.lexsort, np.msort, np.partition, np.trapz,
+    np.searchsorted
+    }
+check |= gufunc_like
+
+arg_functions = {
+    np.argmax, np.argmin, np.argpartition, np.argsort, np.argwhere,
+    np.nonzero, np.nanargmin, np.nanargmax,
+    np.take_along_axis, np.put_along_axis
+    }
+check |= arg_functions
+
+string_functions = {np.array_repr, np.array_str, np.array2string}
+check |= string_functions
+
+bit_functions = {np.packbits, np.unpackbits}
+check |= bit_functions
+
+index_functions = {np.ravel_multi_index, np.unravel_index}
+check |= index_functions
+
+dtype_functions = {
+    np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
+    np.iscomplexobj, np.isrealobj,
+    }
+check |= dtype_functions
+
+mesh_functions = {np.ix_, np.meshgrid}
+check |= mesh_functions
+
+function_functions = {
+    np.apply_along_axis, np.apply_over_axes,
+    }
+check |= function_functions
+
+financial_functions = {f for f in all_numpy_functions.values()
+                       if f in np.lib.financial.__dict__.values()}
+check |= financial_functions
+
+datetime_functions = {
+    np.busday_count, np.busday_offset, np.datetime_as_string,
+    np.is_busday,
+    }
+check |= datetime_functions.copy()
+
+deprecated_functions = {
+    np.asscalar, np.rank
+    }
+check |= deprecated_functions
+
+memory_functions = {
+    np.shares_memory, np.may_share_memory
+    }
+check |= memory_functions
+
+io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}
+check |= io_functions
+
+poly_functions = {
+    np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
+    np.polymul, np.polysub, np.polyval, np.roots, np.vander
+    }
+check |= poly_functions
+
+setops_functions = {f for f in all_numpy_functions.values()
+                    if f in np.lib.arraysetops.__dict__.values()}
+check |= setops_functions
+
+
+@pytest.mark.xfail
+def test_completeness():
+    assert set(all_numpy_functions.values()) == check

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,7 +7,7 @@ from astropy.utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
-           'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
+           'NUMPY_LT_1_15', 'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -15,5 +15,6 @@ __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
 NUMPY_LT_1_14 = not minversion('numpy', '1.14')
 NUMPY_LT_1_14_1 = not minversion('numpy', '1.14.1')
 NUMPY_LT_1_14_2 = not minversion('numpy', '1.14.2')
+NUMPY_LT_1_15 = not minversion('numpy', '1.15')
 NUMPY_LT_1_16 = not minversion('numpy', '1.16')
 NUMPY_LT_1_17 = not minversion('numpy', '1.17')

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -33,18 +33,18 @@ Quantities are subclassed from NumPy's `~numpy.ndarray` and in some NumPy
 operations (and in SciPy operations using NumPy internally) the subclass is
 ignored, which means that either a plain array is returned, or a
 `~astropy.units.quantity.Quantity` without units.
-E.g.::
+E.g., prior to astropy 4.0 and numpy 1.17::
 
     >>> import astropy.units as u
     >>> import numpy as np
     >>> q = u.Quantity(np.arange(10.), u.m)
-    >>> np.dot(q,q) # doctest: +FLOAT_CMP
+    >>> np.dot(q,q) # doctest: +SKIP
     285.0
-    >>> np.hstack((q,q)) # doctest: +FLOAT_CMP
+    >>> np.hstack((q,q)) # doctest: +SKIP
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 0., 1., 2., 3., 4., 5.,
                6., 7., 8., 9.] (Unit not initialised)>
 
-::
+And for all versions::
 
     >>> ratio = (3600 * u.s) / (1 * u.h)
     >>> ratio # doctest: +FLOAT_CMP
@@ -66,7 +66,8 @@ Workarounds are available for some cases. For the above::
     <Quantity [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 0., 1., 2., 3., 4., 5.,
                6., 7., 8., 9.] m>
 
-An incomplete list of specific functions which are known to exhibit this behavior follows:
+An incomplete list of specific functions which are known to exhibit
+this behavior (prior to astropy 4.0 and numpy 1.17) follows:
 
 * `numpy.dot`
 * `numpy.hstack`, `numpy.vstack`, ``numpy.c_``, ``numpy.r_``, `numpy.append`

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -274,10 +274,9 @@ This method is also useful for more complicated arithmetic:
 Numpy functions
 ===============
 
-|quantity| objects are actually full Numpy arrays (the |quantity|
-object class inherits from and extends the ``numpy.ndarray`` class), and
-we have tried to ensure that most Numpy functions behave properly with
-quantities:
+|quantity| objects are actually full Numpy arrays (the |quantity| class
+inherits from and extends :class:`numpy.ndarray`), and we have tried to ensure
+that Numpy functions behave properly with quantities:
 
     >>> q = np.array([1., 2., 3., 4.]) * u.m / u.s
     >>> np.mean(q)
@@ -285,7 +284,7 @@ quantities:
     >>> np.std(q)  # doctest: +FLOAT_CMP
     <Quantity 1.11803399 m / s>
 
-including functions that only accept specific units such as angles:
+This includes functions that only accept specific units such as angles:
 
     >>> q = 30. * u.deg
     >>> np.sin(q)  # doctest: +FLOAT_CMP
@@ -299,7 +298,16 @@ or dimensionless quantities:
     >>> np.exp(-h * nu / (k_B * T))  # doctest: +FLOAT_CMP
     <Quantity 0.99521225>
 
-(see `Dimensionless quantities`_ for more details).
+(see `Dimensionless quantities`_ below for more details).
+
+.. note:: With numpy versions older than 1.17, a number of mostly
+          non-arithmetic functions have :ref:`known issues <quantity_issues>`,
+          either ignoring the unit (e.g., ``np.dot``) or not reinitializing it
+          properly (e.g., ``np.hstack``).  This propagates to more complex
+          functions such as ``np.linalg.norm``.
+
+          Support for functions from other packages, such as ``scipy``, is
+          more incomplete (contributions to improve this welcomed!).
 
 Dimensionless quantities
 ========================
@@ -502,21 +510,6 @@ It can also be used for in-place conversion::
     >>> a  # doctest: +FLOAT_CMP
     array([-100.,  100.,  200.,  300.,  400.])
 
-Known issues with conversion to numpy arrays
-============================================
-
-Since |quantity| objects are Numpy arrays, we are not able to ensure
-that only dimensionless quantities are converted to Numpy arrays:
-
-    >>> np.array([1, 2, 3] * u.m)  # doctest: +FLOAT_CMP
-    array([1., 2., 3.])
-
-Similarly, while most numpy functions work properly, a few have :ref:`known
-issues <quantity_issues>`, either ignoring the unit (e.g., ``np.dot``) or
-not reinitializing it properly (e.g., ``np.hstack``).  This propagates to
-more complex functions such as ``np.linalg.norm`` and
-``scipy.integrate.odeint``.
-
 Subclassing Quantity
 ====================
 
@@ -539,4 +532,7 @@ Another method that is meant to be overridden by subclasses, one specific to
 called to decide which type of subclass to return, based on the unit of the
 quantity that is to be created.  It is used, e.g., in
 :class:`~astropy.coordinates.Angle` to return a |quantity| if a calculation
-returns a unit other than an angular one.
+returns a unit other than an angular one.  The implementation of this is via
+:class:`~astropy.units.SpecificTypeQuantity`, which more generally allows one
+to construct |quantity| subclasses that have methods that are useful only for
+a specific physical type.

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -33,13 +33,14 @@ package.
 # you're free at 11:00 pm local time, and you want to know if it will be up.
 # Astropy can answer that.
 #
-# Make print work the same in all versions of Python, set up numpy,
-# matplotlib, and use a nicer set of plot parameters:
+# Import numpy and matplotlib. For the latter, use a nicer set of plot
+# parameters and set up support for plotting/converting quantities.
 
 import numpy as np
 import matplotlib.pyplot as plt
-from astropy.visualization import astropy_mpl_style
+from astropy.visualization import astropy_mpl_style, quantity_support
 plt.style.use(astropy_mpl_style)
+quantity_support()
 
 
 ##############################################################################
@@ -140,15 +141,15 @@ plt.plot(delta_midnight, moonaltazs_July12_to_13.alt, color=[0.75]*3, ls='--', l
 plt.scatter(delta_midnight, m33altazs_July12_to_13.alt,
             c=m33altazs_July12_to_13.az, label='M33', lw=0, s=8,
             cmap='viridis')
-plt.fill_between(delta_midnight.to('hr').value, 0, 90,
+plt.fill_between(delta_midnight, 0*u.deg, 90*u.deg,
                  sunaltazs_July12_to_13.alt < -0*u.deg, color='0.5', zorder=0)
-plt.fill_between(delta_midnight.to('hr').value, 0, 90,
+plt.fill_between(delta_midnight, 0*u.deg, 90*u.deg,
                  sunaltazs_July12_to_13.alt < -18*u.deg, color='k', zorder=0)
 plt.colorbar().set_label('Azimuth [deg]')
 plt.legend(loc='upper left')
-plt.xlim(-12, 12)
-plt.xticks(np.arange(13)*2 -12)
-plt.ylim(0, 90)
+plt.xlim(-12*u.hour, 12*u.hour)
+plt.xticks((np.arange(13)*2-12)*u.hour)
+plt.ylim(0*u.deg, 90*u.deg)
 plt.xlabel('Hours from EDT Midnight')
 plt.ylabel('Altitude [deg]')
 plt.show()


### PR DESCRIPTION
In numpy 1.17, a new `__array_function__` protocol is being introduced that allows one to overwrite every function in numpy. This PR applies it to `Quantity`, so that things like `np.contatenate(q1, q2)` "just work"!

I think it is mostly complete, though (EDIT) ~I need to be a bit smarter about how to *not* support things like polynomials, financial functions, etc.~ functions in `linalg`, etc., are not yet included - those I'd like to do separately.

Have a look especially at `test_quantity_non_ufuncs` to see what now works.

One thing I've noticed so far is that this *breaks* straight plotting with quantities with different units for x and y (at least `plt.scatter`) since that internally tries to stick the 2 axes together. We may need to turn on `quantity_support` by default...

(EDIT, solved) ~There are also a number of failures in `models` - I'm hoping those are just smoking out minor bugs in the implementation, but haven't looked in detail yet.~

fixes #1273, fixes #5842