### PR TITLE
Limit sphinx version for LTS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,8 @@ pip-run: &pip-install
   command: |
     python3 -m venv venv
     . venv/bin/activate
-    pip install -q -r pip-requirements-doc
+    pip install "matplotlib<3.1"
+    pip install -r pip-requirements-doc
 
 jobs:
   32bit_py2:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,15 +70,6 @@ matrix:
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES='jplephem'
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # runs for a long time. The sphinx build also has some additional
-        # dependencies. Using a more stringent locale than UTF-8.
-        - os: linux
-          env: SETUP_CMD='build_docs -w'
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx-gallery>=0.1.12 pillow --no-deps jplephem'
-               LC_CTYPE=C LC_ALL=C LANG=C
-
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -362,7 +362,8 @@ Building documentation
 Building the documentation requires the Astropy source code and some additional
 packages:
 
-    - `Sphinx <http://sphinx.pocoo.org>`_ (and its dependencies) 1.0 or later
+    - `Sphinx <http://sphinx.pocoo.org>`_ (and its dependencies) 1.0 or
+      later but earlier than 2.1.
 
     - `Graphviz <http://www.graphviz.org>`_
 

--- a/pip-requirements-doc
+++ b/pip-requirements-doc
@@ -12,6 +12,6 @@ mpmath
 matplotlib
 scipy
 pillow
-sphinx
+sphinx<2.1
 sphinx-gallery
 jplephem


### PR DESCRIPTION
There are 180+ warnings issues when using Sphinx 2.1 on the LTS branch, none of those are an issue on master. Current workaround to limit the sphinx version to <2.1 for LTS.