### PR TITLE
Corrected the message to work with None values in world_axis_physical_types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -736,6 +736,9 @@ astropy.wcs
   loading distortions with ``_read_distortion_kw`` and
   ``_read_det2im_kw``. [#8777]
 
+- Added ``None`` to be displayed as a ``world_axis_physical_types`` in
+  the ``WCS`` repr, as ``None`` values are now supported in ``APE14``. [#8811]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -312,16 +312,18 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         # Find largest between header size and value length
         world_dim_width = max(9, len(str(self.world_n_dim)))
-        world_typ_width = max(13, max(len(x) for x in self.world_axis_physical_types))
+        world_typ_width = max(13, max(len(x) if x is not None else 0 for x in self.world_axis_physical_types))
 
         s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') + '  ' +
               ('{0:' + str(world_typ_width) + 's}').format('Physical Type') + '  ' +
                'Units\n')
 
         for iwrl in range(self.world_n_dim):
-            s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
-                  ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +
-                  '{0:s}'.format(self.world_axis_units[iwrl] + '\n'))
+            
+            if self.world_axis_physical_types[iwrl] is not None:
+                s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
+                      ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +
+                      '{0:s}'.format(self.world_axis_units[iwrl] + '\n'))
 
         s += '\n'
 

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -324,7 +324,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
                 s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
                       ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +
                       '{0:s}'.format(self.world_axis_units[iwrl] + '\n'))
-
+            else:
+                s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
+                      ('{0:' + str(world_typ_width) + 's}').format('None') + '  ' +
+                      '{0:s}'.format('unknown' + '\n'))
         s += '\n'
 
         # Axis correlation matrix

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -319,7 +319,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
                'Units\n')
 
         for iwrl in range(self.world_n_dim):
-            
+
             if self.world_axis_physical_types[iwrl] is not None:
                 s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
                       ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +


### PR DESCRIPTION
This PR addresses the issue of displaying correct message of wcs when one/more values of `world_axis_physical_types` contains `None` values.
## Previous Issue
When I run commands as - 
```
from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS
wcs1 = SlicedLowLevelWCS(wt, [])
wcs1
```
I get the following
Error - 
```
~/ndcub/vnv/lib/python3.7/site-packages/astropy-4.0.dev24714-py3.7-linux-x86_64.egg/astropy/wcs/wcsapi/low_level_api.py in __str__(self)
    313         # Find largest between header size and value length
    314         world_dim_width = max(9, len(str(self.world_n_dim)))
--> 315         world_typ_width = max(13, max(len(x) for x in self.world_axis_physical_types))
    316 
    317         s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') + '  ' +

~/ndcub/vnv/lib/python3.7/site-packages/astropy-4.0.dev24714-py3.7-linux-x86_64.egg/astropy/wcs/wcsapi/low_level_api.py in <genexpr>(.0)
    313         # Find largest between header size and value length
    314         world_dim_width = max(9, len(str(self.world_n_dim)))
--> 315         world_typ_width = max(13, max(len(x) for x in self.world_axis_physical_types))
    316 
    317         s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') + '  ' +

TypeError: object of type 'NoneType' has no len()

```
My WCS object contains a `world_physical_value` as `None` type.

I think @Cadair can provide more context to this issue. 

## Current Output

```
SlicedLowLevelWCS Transformation

This transformation has 4 pixel and 4 world dimensions

Array shape (Numpy order): (1, 2, 3, 4)

Pixel Dim  Data size  Bounds
        0          4  None
        1          3  None
        2          2  None
        3          1  None

World Dim  Physical Type                   Units
        0  time                            min
        1  em.wl                           m
        2  custom:pos.helioprojective.lat  deg
        3  None                            unknown

Correlation between pixel and world axes:

               Pixel Dim
World Dim    0    1    2    3
        0  yes   no   no   no
        1   no  yes   no   no
        2   no   no  yes  yes
        3   no   no  yes  yes

```