### PR TITLE
Fix Moffat1D and Moffat2D FWHM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+- ``Moffat1D.fwhm`` and ``Moffat2D.fwhm`` will return a positive  value when
+  ``gamma`` is negative. [#8801, #8815]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,8 +43,6 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
-- ``Moffat1D.fwhm`` and ``Moffat2D.fwhm`` will return a positive  value when
-  ``gamma`` is negative. [#8801, #8815]
 
 astropy.nddata
 ^^^^^^^^^^^^^^
@@ -2258,6 +2256,9 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+
+- ``Moffat1D.fwhm`` and ``Moffat2D.fwhm`` will return a positive value when
+  ``gamma`` is negative. [#8801, #8815]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2266,7 +2266,7 @@ class Moffat1D(Fittable1DModel):
         Derivation of the formula is available in
         `this notebook by Yoonsoo Bach <http://nbviewer.jupyter.org/github/ysbach/AO_2017/blob/master/04_Ground_Based_Concept.ipynb#1.2.-Moffat>`_.
         """
-        return 2.0 * self.gamma * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
+        return 2.0 * np.abs(self.gamma) * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
 
     @staticmethod
     def evaluate(x, amplitude, x_0, gamma, alpha):
@@ -2343,7 +2343,7 @@ class Moffat2D(Fittable2DModel):
         Derivation of the formula is available in
         `this notebook by Yoonsoo Bach <http://nbviewer.jupyter.org/github/ysbach/AO_2017/blob/master/04_Ground_Based_Concept.ipynb#1.2.-Moffat>`_.
         """
-        return 2.0 * self.gamma * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
+        return 2.0 * np.abs(self.gamma) * np.sqrt(2.0 ** (1.0 / self.alpha) - 1.0)
 
     @staticmethod
     def evaluate(x, y, amplitude, x_0, y_0, gamma, alpha):

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -3,7 +3,7 @@
 
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 
 from astropy.modeling import models, InputParameterError
 from astropy.coordinates import Angle
@@ -117,12 +117,14 @@ def test_Gaussian2D_invalid_inputs():
         models.Gaussian2D(theta=0, cov_matrix=cov_matrix)
 
 
-def test_moffat_fwhm():
+@pytest.mark.parametrize('gamma', (10, -10))
+def test_moffat_fwhm(gamma):
     ans = 34.641016151377542
-    kwargs = {'gamma': 10, 'alpha': 0.5}
+    kwargs = {'gamma': gamma, 'alpha': 0.5}
     m1 = models.Moffat1D(**kwargs)
     m2 = models.Moffat2D(**kwargs)
     assert_allclose([m1.fwhm, m2.fwhm], ans)
+    assert_array_less(0, [m1.fwhm, m2.fwhm])
 
 
 def test_RedshiftScaleFactor():


### PR DESCRIPTION
Modified the method `fwhm` to use the absolute value of `gamma` in the calculation of the full width at half maximum of the `Moffat1D` and `Moffat2D` 
fixes #8801 