### PR TITLE
Let quantity_support also support Quantity subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2281,6 +2281,10 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed ``quantity_support`` to work around the fact that matplotlib
+  does not detect subclasses in its ``units`` framework. With this,
+  ``Angle`` and other subclasses work correctly. [#8818]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -13,6 +13,7 @@ else:
     HAS_PLT = True
 
 from astropy import units as u
+from astropy.coordinates import Angle
 from astropy.visualization.units import quantity_support
 
 
@@ -75,3 +76,22 @@ def test_incompatible_units():
             plt.plot([105, 210, 315] * u.kg)
 
     plt.clf()
+
+
+@pytest.mark.skipif('not HAS_PLT')
+def test_quantity_subclass():
+    """Check that subclasses are recognized.
+
+    This sadly is not done by matplotlib.units itself, though
+    there is a PR to change it:
+    https://github.com/matplotlib/matplotlib/pull/13536
+    """
+    plt.figure()
+
+    with quantity_support():
+        plt.scatter(Angle([1, 2, 3], u.deg), [3, 4, 5] * u.kg)
+        plt.scatter([105, 210, 315] * u.arcsec, [3050, 3025, 3010] * u.g)
+        plt.plot(Angle([105, 210, 315], u.arcsec), [3050, 3025, 3010] * u.g)
+
+        assert plt.gca().xaxis.get_units() == u.deg
+        assert plt.gca().yaxis.get_units() == u.kg

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -35,6 +35,9 @@ def quantity_support(format='latex_inline'):
     from astropy import units as u
     # import Angle just so we have a more or less complete list of Quantity
     # subclasses loaded - matplotlib needs them all separately!
+    # NOTE: in matplotlib >=3.2, subclasses will be recognized automatically,
+    # and once that becomes our minimum version, we can remove this,
+    # adding just u.Quantity itself to the registry.
     from astropy.coordinates import Angle  # noqa
 
     from matplotlib import units


### PR DESCRIPTION
Found while debugging plotting problems with `__array_function__` enabled in #8808.

Note that this would be fixed by https://github.com/matplotlib/matplotlib/pull/13536; once that is in, we should include a version check.

EDIT: above matplotlib PR is merged, for inclusion in 3.2. I've added a comment in the file.