### PR TITLE
DOC: Use RTD v2 YAML and make dependencies configurable again

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,17 +3,17 @@ version: 2
 build:
   image: latest
 
-# Install special pinning for RTD first, if any.
-# Then install regular dependencies.
+# Install regular dependencies.
+# Then, install special pinning for RTD.
 python:
   version: 3.6
   install:
-    - requirements: docs/rtd_requirements.txt
     - method: pip
       path: .
       extra_requirements:
         - docs
         - all
+    - requirements: docs/rtd_requirements.txt
 
 submodules:
   include: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,22 @@
+version: 2
+
 build:
   image: latest
 
+# Install special pinning for RTD first, if any.
+# Then install regular dependencies.
 python:
   version: 3.6
-  pip_install: true
-  extra_requirements: ['docs', 'all']
+  install:
+    - requirements: docs/rtd_requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+        - all
+
+submodules:
+  include: all
 
 # Don't build any extra formats
 formats: []

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,0 +1,1 @@
+matplotlib<3.1


### PR DESCRIPTION
Fix #8820 by:

* Upgrading RTD YAML to [v2](https://docs.readthedocs.io/en/stable/config-file/v2.htm).
* Adding back `docs/rtd_requirements.txt` but only for special pinning required for RTD; otherwise, dependencies still come from `setup.cfg`.

Pro: Allow RTD-only customization, as needed, without touching `setup.cfg`.
Con: Re-introduced "requirements.txt" that Tom R worked so hard to get rid of.

**Proof of Concept**

https://readthedocs.org/projects/astropy-pllim/builds/9206227/ (ignore the timeout, because my fork did not get the special timeout extension, so it still caps at 900s or so)

Expand the fourth `/home/docs/checkouts/readthedocs.org/user_builds/...` log, the one right before `cat docs/conf.py` and you will see this:

```
Collecting matplotlib<3.1 (from -r docs/rtd_requirements.txt (line 1))
...
Installing collected packages: matplotlib
  Found existing installation: matplotlib 3.1.0
    Uninstalling matplotlib-3.1.0:
      Successfully uninstalled matplotlib-3.1.0
Successfully installed matplotlib-3.0.3
```

Even when my fork timed out, I find the above log promising. However, we will not know for sure until we merge this. 🎲 

p.s. I am also not sure what milestone this should be at.