### PR TITLE
Move asdf schema_tester pytest plugin to top-level conftest.py

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -7,9 +7,7 @@ making use of astropy's test runner).
 import os
 import builtins
 import tempfile
-from importlib.util import find_spec
 
-import astropy
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
@@ -19,12 +17,6 @@ except ImportError:
     HAS_MATPLOTLIB = False
 else:
     HAS_MATPLOTLIB = True
-
-if find_spec('asdf') is not None:
-    from asdf import __version__ as asdf_version
-    if asdf_version >= astropy.__minimum_asdf_version__:
-        pytest_plugins = ['asdf.tests.schema_tester']
-        PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
 
 enable_deprecations_as_exceptions(
     include_astropy_deprecations=False,

--- a/conftest.py
+++ b/conftest.py
@@ -3,12 +3,27 @@
 # This file is the main file used when running tests with pytest directly,
 # in particular if running e.g. ``pytest docs/``.
 
+from importlib.util import find_spec
 import os
+import pkg_resources
 import tempfile
+
+from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
+import astropy
 
 pytest_plugins = [
     'astropy.tests.plugins.display',
 ]
+
+if find_spec('asdf') is not None:
+    from asdf import __version__ as asdf_version
+    if asdf_version >= astropy.__minimum_asdf_version__:
+        entry_points = []
+        for entry_point in pkg_resources.iter_entry_points('pytest11'):
+            entry_points.append(entry_point.name)
+        if "asdf_schema_tester" not in entry_points:
+            pytest_plugins += ['asdf.tests.schema_tester']
+        PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
 
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.


### PR DESCRIPTION
Having pytest plugins outside of the top-level `conftest.py` has been deprecated for a while.  In `pytest 4.6.3` it is finally a hard failure.

This PR fixes that, and also makes it future-proof, as the current dev `asdf` schema tester gets installed via `entry_points` instead of via a direct import of the package.  This is the preferred way according to the `pytest` folks.  So this fix will work with both released and dev versions of `asdf`.

Resolves #8836.