### PR TITLE
Avoid warning with keywords not provided by the user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -277,6 +277,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Avoid reporting a warning with ``BinTableHDU.from_columns`` with keywords that
+  are not provided by the user.  [#8838]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -324,7 +324,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 # warning for at least one major version.
                 if header is not None:
                     future_ignore = set()
-                    for keyword in self._header.keys():
+                    for keyword in header.keys():
                         match = TDEF_RE.match(keyword)
                         try:
                             base_keyword = match.group('label')

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -340,9 +340,7 @@ class TestFitsTime(FitsTestCase):
                  ('OBSGEO-Z', 4077985)]
 
         # Explicitly create a FITS Binary Table
-        with pytest.warns(AstropyDeprecationWarning, match='should be set via '
-                          'the Column objects: TCTYPn, TRPOSn'):
-            bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
+        bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
 
         tm = table_types.read(self.temp('time.fits'), astropy_native=True)
@@ -356,9 +354,7 @@ class TestFitsTime(FitsTestCase):
         cards = [('OBSGEO-L', 0), ('OBSGEO-B', 0), ('OBSGEO-H', 0)]
 
         # Explicitly create a FITS Binary Table
-        with pytest.warns(AstropyDeprecationWarning, match='should be set via '
-                          'the Column objects: TCTYPn, TRPOSn'):
-            bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
+        bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
 
         tm = table_types.read(self.temp('time.fits'), astropy_native=True)
@@ -382,9 +378,7 @@ class TestFitsTime(FitsTestCase):
 
         cards = [('OBSGEO-L', 0), ('OBSGEO-B', 0), ('OBSGEO-H', 0)]
 
-        with pytest.warns(AstropyDeprecationWarning, match='should be set via '
-                          'the Column objects: TCTYPn, TCUNIn, TRPOSn'):
-            bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
+        bhdu = fits.BinTableHDU.from_columns([c], header=fits.Header(cards))
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
 
         with catch_warnings() as w:


### PR DESCRIPTION
Fix #8830. In the code added in #7157 a check is done on `header` but
then it iterates on `self._header` which is updated with the coldefs. So
I think that we can iterate on `header` instead, to avoid reporting
warnings for keywords that were not provided by the user.

cc @astrofrog 