### PR TITLE
Fix determination of current module in astropy.constants

### DIFF
--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -13,7 +13,6 @@ A typical use case might be::
     <Quantity 0.510998927603161 MeV>
 
 """
-import inspect
 from contextlib import contextmanager
 
 from astropy.utils import find_current_module
@@ -66,7 +65,6 @@ def set_enabled_constants(modname):
     """
 
     # Re-import here because these were deleted from namespace on init.
-    import inspect
     import warnings
     from . import utils as _utils
 
@@ -97,7 +95,7 @@ def set_enabled_constants(modname):
 
 
 # Clean up namespace
-del inspect
+del find_current_module
 del contextmanager
 del _utils
 del _lines

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -66,6 +66,7 @@ def set_enabled_constants(modname):
 
     # Re-import here because these were deleted from namespace on init.
     import warnings
+    from astropy.utils import find_current_module
     from . import utils as _utils
 
     # NOTE: Update this when default changes.

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -16,6 +16,8 @@ A typical use case might be::
 import inspect
 from contextlib import contextmanager
 
+from astropy.utils import find_current_module
+
 # Hack to make circular imports with units work
 try:
     from astropy import units
@@ -38,7 +40,7 @@ _lines = [
 ]
 
 # NOTE: Update this when default changes.
-_utils._set_c(codata2014, iau2015, inspect.getmodule(inspect.currentframe()),
+_utils._set_c(codata2014, iau2015, find_current_module(),
               not_in_module_only=True, doclines=_lines, set_class=True)
 
 _lines.append(_lines[1])
@@ -76,7 +78,7 @@ def set_enabled_constants(modname):
         raise ValueError(
             'Context manager does not currently handle {}'.format(modname))
 
-    module = inspect.getmodule(inspect.currentframe())
+    module = find_current_module()
 
     # Ignore warnings about "Constant xxx already has a definition..."
     with warnings.catch_warnings():

--- a/astropy/constants/astropyconst13.py
+++ b/astropy/constants/astropyconst13.py
@@ -5,10 +5,11 @@ See :mod:`astropy.constants` for a complete listing of constants
 defined in Astropy.
 """
 import inspect
+from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2010, iau2012
 
-_utils._set_c(codata2010, iau2012, inspect.getmodule(inspect.currentframe()))
+_utils._set_c(codata2010, iau2012, find_current_module())
 
 # Clean up namespace
 del inspect

--- a/astropy/constants/astropyconst13.py
+++ b/astropy/constants/astropyconst13.py
@@ -4,7 +4,6 @@ Astronomical and physics constants for Astropy v1.3 and earlier.
 See :mod:`astropy.constants` for a complete listing of constants
 defined in Astropy.
 """
-import inspect
 from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2010, iau2012
@@ -12,5 +11,5 @@ from . import codata2010, iau2012
 _utils._set_c(codata2010, iau2012, find_current_module())
 
 # Clean up namespace
-del inspect
+del find_current_module
 del _utils

--- a/astropy/constants/astropyconst20.py
+++ b/astropy/constants/astropyconst20.py
@@ -3,7 +3,6 @@
 Astronomical and physics constants for Astropy v2.0.  See :mod:`astropy.constants`
 for a complete listing of constants defined in Astropy.
 """
-import inspect
 from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2014, iau2015
@@ -11,5 +10,5 @@ from . import codata2014, iau2015
 _utils._set_c(codata2014, iau2015, find_current_module())
 
 # Clean up namespace
-del inspect
+del find_current_module
 del _utils

--- a/astropy/constants/astropyconst20.py
+++ b/astropy/constants/astropyconst20.py
@@ -4,10 +4,11 @@ Astronomical and physics constants for Astropy v2.0.  See :mod:`astropy.constant
 for a complete listing of constants defined in Astropy.
 """
 import inspect
+from astropy.utils import find_current_module
 from . import utils as _utils
 from . import codata2014, iau2015
 
-_utils._set_c(codata2014, iau2015, inspect.getmodule(inspect.currentframe()))
+_utils._set_c(codata2014, iau2015, find_current_module())
 
 # Clean up namespace
 del inspect


### PR DESCRIPTION
While working on https://github.com/astropy/astropy/pull/8795 I noticed that astropy.constants should be using ``find_current_module`` instead of trying to do it itself. The current way isn't wrong but since we have to work around various corner cases in ``find_current_module`` it makes sense to always use it. This doesn't really warrant a changelog entry but it would be nice if it were backported to 3.2.x as it will be useful when bundling apps (which I'm working on in https://github.com/astropy/astropy/pull/8795)

@stargaser should look at this though to make sure these changes are actually correct!