### PR TITLE
Fix quantity_support when multiple context managers are nested

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2297,6 +2297,9 @@ astropy.visualization
   does not detect subclasses in its ``units`` framework. With this,
   ``Angle`` and other subclasses work correctly. [#8818]
 
+- Fixed ``quantity_support`` to work properly if multiple context managers
+  are nested. [#8844]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -97,6 +97,7 @@ def test_quantity_subclass():
         assert plt.gca().yaxis.get_units() == u.kg
 
 
+@pytest.mark.skipif('not HAS_PLT')
 def test_nested():
 
     with quantity_support():

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -95,3 +95,24 @@ def test_quantity_subclass():
 
         assert plt.gca().xaxis.get_units() == u.deg
         assert plt.gca().yaxis.get_units() == u.kg
+
+
+def test_nested():
+
+    with quantity_support():
+
+        with quantity_support():
+
+            fig = plt.figure()
+            ax = fig.add_subplot(1, 1, 1)
+            ax.scatter(Angle([1, 2, 3], u.deg), [3, 4, 5] * u.kg)
+
+            assert ax.xaxis.get_units() == u.deg
+            assert ax.yaxis.get_units() == u.kg
+
+        fig = plt.figure()
+        ax = fig.add_subplot(1, 1, 1)
+        ax.scatter(Angle([1, 2, 3], u.arcsec), [3, 4, 5] * u.pc)
+
+        assert ax.xaxis.get_units() == u.arcsec
+        assert ax.yaxis.get_units() == u.pc

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -67,8 +67,13 @@ def quantity_support(format='latex_inline'):
         _all_issubclass_quantity = all_issubclass(u.Quantity)
 
         def __init__(self):
-            self._remove = u.Quantity not in units.registry
+
+            # Keep track of original converter in case the context manager is
+            # used in a nested way.
+            self._original_converter = {}
+
             for cls in self._all_issubclass_quantity:
+                self._original_converter[cls] = units.registry.get(cls)
                 units.registry[cls] = self
 
         @staticmethod
@@ -108,8 +113,10 @@ def quantity_support(format='latex_inline'):
             return self
 
         def __exit__(self, type, value, tb):
-            if self._remove:
-                for cls in self._all_issubclass_quantity:
+            for cls in self._all_issubclass_quantity:
+                if self._original_converter[cls] is None:
                     del units.registry[cls]
+                else:
+                    units.registry[cls] = self._original_converter[cls]
 
     return MplQuantityConverter()


### PR DESCRIPTION
Whether deliberately or accidentally, it's possible for ``quantity_support`` to be used multiple times in a nested way - if so, then the current way of removing the class from the units registry can cause issues once the deepest context manager in the nested statements exits.