### PR TITLE
Fix find_current_module so that it can work in application bundles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2436,6 +2436,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fix ``find_current_module`` so that it works properly if astropy is being used
+  inside a bundle such as that produced by PyInstaller. [#8845]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2439,6 +2439,9 @@ astropy.utils
 - Fix ``find_current_module`` so that it works properly if astropy is being used
   inside a bundle such as that produced by PyInstaller. [#8845]
 
+- Fix path to renamed classes, which previously included duplicate path/module
+  information under certain circumstances. [#8845]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -207,7 +207,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
             >>> from astropy.modeling.models import Rotation2D
             >>> SkyRotation = Rotation2D.rename('SkyRotation')
             >>> SkyRotation
-            <class '__main__.SkyRotation'>
+            <class 'astropy.modeling.core.SkyRotation'>
             Name: SkyRotation (Rotation2D)
             Inputs: ('x', 'y')
             Outputs: ('x', 'y')
@@ -227,13 +227,7 @@ class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
 
         new_cls = type(name, (cls,), {})
         new_cls.__module__ = modname
-
-        if hasattr(cls, '__qualname__'):
-            if new_cls.__module__ == '__main__':
-                # __main__ is not added to a class's qualified name
-                new_cls.__qualname__ = name
-            else:
-                new_cls.__qualname__ = '{0}.{1}'.format(modname, name)
+        new_cls.__qualname__ = name
 
         return new_cls
 

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -297,6 +297,11 @@ def _get_module_from_frame(frm):
         if filename in inspect.modulesbyfile:
             return sys.modules.get(inspect.modulesbyfile[filename])
 
+        # On Windows, inspect.modulesbyfile appears to have filenames stored
+        # in lowercase, so we check for this case too.
+        if filename.lower() in inspect.modulesbyfile:
+            return sys.modules.get(inspect.modulesbyfile[filename.lower()])
+
     # Otherwise there are still some even trickier things that might be possible
     # to track down the module, but we'll leave those out unless we find a case
     # where it's really necessary.  So return None if the module is not found.

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -5,10 +5,12 @@
 
 import inspect
 import re
+import sys
 import types
+import pkgutil
 import importlib
+import zipimport
 from distutils.version import LooseVersion
-
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',
            'isinstancemethod']
@@ -239,7 +241,7 @@ def find_current_module(depth=1, finddiff=False):
             return None
 
     if finddiff:
-        currmod = inspect.getmodule(frm)
+        currmod = _get_module_from_frame(frm)
         if finddiff is True:
             diffmods = [currmod]
         else:
@@ -256,12 +258,50 @@ def find_current_module(depth=1, finddiff=False):
 
         while frm:
             frmb = frm.f_back
-            modb = inspect.getmodule(frmb)
+            modb = _get_module_from_frame(frmb)
             if modb not in diffmods:
                 return modb
             frm = frmb
     else:
-        return inspect.getmodule(frm)
+        return _get_module_from_frame(frm)
+
+
+def _get_module_from_frame(frm):
+    """Uses inspect.getmodule() to get the module that the current frame's
+    code is running in.
+
+    However, this does not work reliably for code imported from a zip file,
+    so this provides a fallback mechanism for that case which is less
+    reliable in general, but more reliable than inspect.getmodule() for this
+    particular case.
+    """
+
+    mod = inspect.getmodule(frm)
+    if mod is not None:
+        return mod
+
+    # Check to see if we're importing from a zip file
+    if '__file__' in frm.f_globals and '__name__' in frm.f_globals:
+        # First ensure that __file__ is available in globals; this is cheap to
+        # check to bail out immediately if this fails
+        loader = pkgutil.get_loader(frm.f_globals['__name__'])
+        filename = frm.f_globals['__file__']
+        if isinstance(loader, zipimport.zipimporter):
+            # Using __file__ from the frame's globals and getting it into the
+            # form of an absolute path name (absolute for the zip file that is)
+            # with .py at the end works pretty well for looking up the module
+            # using the same means as inspect.getmodule
+            if filename[-4:].lower() in ('.pyc', '.pyo'):
+                filename = filename[:-4] + '.py'
+            filename = os.path.realpath(os.path.abspath(filename))
+            if filename in inspect.modulesbyfile:
+                return sys.modules.get(inspect.modulesbyfile[filename])
+
+    # Otherwise there are still some even trickier things that might be
+    # possible to track down the module, but we'll leave those out unless we
+    # find a case where it's really necessary.  So return None if the module is
+    # not found.
+    return None
 
 
 def find_mod_objs(modname, onlylocals=False):

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -8,9 +8,7 @@ import re
 import os
 import sys
 import types
-import pkgutil
 import importlib
-import zipimport
 from distutils.version import LooseVersion
 
 __all__ = ['resolve_name', 'minversion', 'find_current_module',

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -5,6 +5,7 @@
 
 import inspect
 import re
+import os
 import sys
 import types
 import pkgutil
@@ -280,27 +281,27 @@ def _get_module_from_frame(frm):
     if mod is not None:
         return mod
 
-    # Check to see if we're importing from a zip file
-    if '__file__' in frm.f_globals and '__name__' in frm.f_globals:
-        # First ensure that __file__ is available in globals; this is cheap to
-        # check to bail out immediately if this fails
-        loader = pkgutil.get_loader(frm.f_globals['__name__'])
-        filename = frm.f_globals['__file__']
-        if isinstance(loader, zipimport.zipimporter):
-            # Using __file__ from the frame's globals and getting it into the
-            # form of an absolute path name (absolute for the zip file that is)
-            # with .py at the end works pretty well for looking up the module
-            # using the same means as inspect.getmodule
-            if filename[-4:].lower() in ('.pyc', '.pyo'):
-                filename = filename[:-4] + '.py'
-            filename = os.path.realpath(os.path.abspath(filename))
-            if filename in inspect.modulesbyfile:
-                return sys.modules.get(inspect.modulesbyfile[filename])
+    # Check to see if we're importing from a bundle file. First ensure that
+    # __file__ is available in globals; this is cheap to check to bail out
+    # immediately if this fails
 
-    # Otherwise there are still some even trickier things that might be
-    # possible to track down the module, but we'll leave those out unless we
-    # find a case where it's really necessary.  So return None if the module is
-    # not found.
+    if '__file__' in frm.f_globals and '__name__' in frm.f_globals:
+
+        filename = frm.f_globals['__file__']
+
+        # Using __file__ from the frame's globals and getting it into the form
+        # of an absolute path name with .py at the end works pretty well for
+        # looking up the module using the same means as inspect.getmodule
+
+        if filename[-4:].lower() in ('.pyc', '.pyo'):
+            filename = filename[:-4] + '.py'
+        filename = os.path.realpath(os.path.abspath(filename))
+        if filename in inspect.modulesbyfile:
+            return sys.modules.get(inspect.modulesbyfile[filename])
+
+    # Otherwise there are still some even trickier things that might be possible
+    # to track down the module, but we'll leave those out unless we find a case
+    # where it's really necessary.  So return None if the module is not found.
     return None
 
 

--- a/astropy/utils/tests/test_introspection.py
+++ b/astropy/utils/tests/test_introspection.py
@@ -2,6 +2,7 @@
 
 # namedtuple is needed for find_mod_objs so it can have a non-local module
 from collections import namedtuple
+from unittest import mock
 
 import pytest
 
@@ -73,3 +74,19 @@ def test_minversion():
         assert minversion(test_module, version)
     for version in bad_versions:
         assert not minversion(test_module, version)
+
+
+def test_find_current_module_bundle():
+    """
+    Tests that the `find_current_module` function would work if used inside
+    an application bundle. Since we can't test this directly, we test what
+    would happen if inspect.getmodule returned `None`, which is what happens
+    inside PyInstaller and py2app bundles.
+    """
+    with mock.patch('inspect.getmodule', return_value=None):
+        mod1 = 'astropy.utils.introspection'
+        mod2 = 'astropy.utils.tests.test_introspection'
+        mod3 = 'astropy.utils.tests.test_introspection'
+        assert find_current_module(0).__name__ == mod1
+        assert find_current_module(1).__name__ == mod2
+        assert find_current_module(0, True).__name__ == mod3


### PR DESCRIPTION
As part of work on making it possible to use astropy in application bundles (#8795) I had to re-use a fix @embray originally wrote in #960 but since that PR never got merged, I thought I'd open a dedicated PR for this fix with a test. Essentially the goal here is to make sure that ``find_current_module`` works even if ``inspect.getmodule`` doesn't work, which can happen if astropy is packaged up inside a bundle created by e.g. ``pyinstaller`` or ``py2app``.