### PR TITLE
Fixed residual relative import

### DIFF
--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1397,7 +1397,7 @@ def test_quantity_from_table():
     This also generically checks the use of *anything* with a `unit` attribute
     passed into Quantity
     """
-    from... table import Table
+    from astropy.table import Table
 
     t = Table(data=[np.arange(5), np.arange(5)], names=['a', 'b'])
     t['a'].unit = u.kpc


### PR DESCRIPTION
I found a leftover relative import that hadn't been converted over to an absolute import at the end of last year (because of the missing space before ``...``).