### PR TITLE
Fix reading of empty BinTableHDU when stored in a gzip-compressed file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2258,6 +2258,8 @@ astropy.io.fits
   a ``Header`` object. [#8840]
 
 - Fix ``Header.fromfile`` to work on FITS files. [#8713]
+- Fix reading of empty ``BinTableHDU`` when stored in a gzip-compressed file.
+  [#8848]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3271,3 +3271,19 @@ def test_new_column_attributes_preserved(tmpdir):
 
     assert hdu2.header['RA'] == 1.5
     assert hdu2.header['DEC'] == 3.0
+
+
+def test_empty_table(tmpdir):
+    ofile = str(tmpdir.join('emptytable.fits'))
+    hdu = fits.BinTableHDU(header=None, data=None, name='TEST')
+    hdu.writeto(ofile)
+
+    with fits.open(ofile) as hdul:
+        assert hdul['TEST'].data.size == 0
+
+    ofile = str(tmpdir.join('emptytable.fits.gz'))
+    hdu = fits.BinTableHDU(header=None, data=None, name='TEST')
+    hdu.writeto(ofile, overwrite=True)
+
+    with fits.open(ofile) as hdul:
+        assert hdul['TEST'].data.size == 0

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -591,10 +591,13 @@ def _array_from_file(infile, dtype, count):
         # their underlying file object, instead of the decompressed bytes
         read_size = np.dtype(dtype).itemsize * count
         s = infile.read(read_size)
-        array = np.frombuffer(s, dtype=dtype, count=count)
-        # copy is needed because np.frombuffer returns a read-only view of the
-        # underlying buffer
-        array = array.copy()
+        if s == b'':
+            array = np.ndarray(buffer=b'', dtype=np.dtype([]), shape=(0,))
+        else:
+            array = np.frombuffer(s, dtype=dtype, count=count)
+            # copy is needed because np.frombuffer returns a read-only view
+            # of the underlying buffer
+            array = array.copy()
         return array
 
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -591,13 +591,10 @@ def _array_from_file(infile, dtype, count):
         # their underlying file object, instead of the decompressed bytes
         read_size = np.dtype(dtype).itemsize * count
         s = infile.read(read_size)
-        if s == b'':
-            array = np.ndarray(buffer=b'', dtype=np.dtype([]), shape=(0,))
-        else:
-            array = np.frombuffer(s, dtype=dtype, count=count)
-            # copy is needed because np.frombuffer returns a read-only view
-            # of the underlying buffer
-            array = array.copy()
+        array = np.ndarray(buffer=s, dtype=dtype, shape=(count,))
+        # copy is needed because np.frombuffer returns a read-only view of the
+        # underlying buffer
+        array = array.copy()
         return array
 
 


### PR DESCRIPTION
Fix #8802.