### PR TITLE
Numpy-dev problems: Quantity casting / offset_by

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -319,6 +319,9 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Fixed a bug that prevented ``EarthLocation`` from being initialized with
+  numpy >=1.17. [#8849]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -296,7 +296,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                 if not copy:
                     return value
 
-                if not np.can_cast(np.float32, value.dtype):
+                if not (np.can_cast(np.float32, value.dtype) or
+                        value.dtype.fields):
                     dtype = float
 
             return np.array(value, dtype=dtype, copy=copy, order=order,
@@ -376,7 +377,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                             "Numpy numeric type.")
 
         # by default, cast any integer, boolean, etc., to float
-        if dtype is None and (not np.can_cast(np.float32, value.dtype)
+        if dtype is None and (not (np.can_cast(np.float32, value.dtype)
+                                   or value.dtype.fields)
                               or value.dtype.kind == 'O'):
             value = value.astype(float)
 


### PR DESCRIPTION
fixes #8841 

Part of the problem is that `np.can_cast` now (correctly) decides that a `float32` cannot be cast to a structured array. This breaks `EarthLocation`, which is a `Quantity` subclass that uses a structured dtype internally. We remain fully backwards compatible by simply allowing all structured dtypes - which seems reasonable since the user very much has to know what they're doing to use them...

A more minor problem also fixed (first commit) is a new `DeprecationWarning`; that is dealt with using a small refactor (which arguably makes the code a little cleaner).