### PR TITLE
Explicitly use 'fork' method for multiprocessing in io.ascii

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2271,6 +2271,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Make sure that the fast reader, when used in parallel mode, uses the
+  'fork' method for multiprocessing, regardless of the global default.
+  [#8852]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -444,9 +444,15 @@ cdef class CParser:
         chunkindices.append(source_len)
         cdef list processes = []
 
+        # FIXME: In Python 3.8, multiprocessing defaults to 'spawn' instead of
+        # 'fork' but this currently causes issues for the code here, so we
+        # explicitly use 'fork'. See https://github.com/astropy/astropy/issues/8851
+        # for more details.
+        ctx = multiprocessing.get_context('fork')
+
         # Create and start N parallel processes to read the N chunks
         for i in range(N):
-            process = multiprocessing.Process(target=_read_chunk, args=(self,
+            process = ctx.Process(target=_read_chunk, args=(self,
                 chunkindices[i], chunkindices[i + 1],
                 try_int, try_float, try_string, queue, reconvert_queue, i))
             processes.append(process)


### PR DESCRIPTION
This is a workaround for the issue described in https://github.com/astropy/astropy/issues/8851 - ideally we would fix the underlying cause, but this will at least keep things working once Python 3.8 if we don't.

This will need a changelog entry but I'll wait until the 2.0.15 sections are created in the changelog.