### PR TITLE
Fixes to io.ascii fast reader when used in multiprocessing 'spawn' mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fixed the fast reader when used in parallel and with the multiprocessing
+  'spawn' method (which is the default on MacOS X with Python 3.8 and later).
+  [#8853]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -275,8 +275,8 @@ astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
 - Fixed the fast reader when used in parallel and with the multiprocessing
-  'spawn' method (which is the default on MacOS X with Python 3.8 and later).
-  [#8853]
+  'spawn' method (which is the default on MacOS X with Python 3.8 and later),
+  and enable parallel fast reader on Windows. [#8853]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -881,6 +881,7 @@ def _read_chunk(CParser self, start, end, try_int,
         delete_tokenizer(chunk_tokenizer)
         queue.pop()
         queue.put((None, e, i))
+        return
 
     reconvert_cols = reconvert_queue.get()
     for col in reconvert_cols:

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -224,8 +224,6 @@ cdef class CParser:
 
         if fast_reader:
             raise core.FastOptionsError("Invalid parameter in fast_reader dict")
-        if parallel and os.name == 'nt':
-            raise NotImplementedError("Multiprocessing is not yet supported on Windows")
 
         if comment is None:
             comment = '\x00' # tokenizer ignores all comments if comment='\x00'

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -889,6 +889,12 @@ def _read_chunk(CParser self, start, end, try_int,
     delete_tokenizer(chunk_tokenizer)
     reconvert_queue.put(reconvert_cols) # return to the queue for other processes
 
+    # Since we already deallocated the tokenizer above, we should make sure we
+    # set self.tokenizer to NULL to avoid deallocating the tokenizer again
+    # inside __dealloc__.
+    self.tokenizer = NULL
+
+
 cdef class FastWriter:
     """
     A fast Cython writing class for writing tables

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -203,7 +203,10 @@ cdef class CParser:
                   fill_include_names=None,
                   fill_exclude_names=None,
                   fill_extra_cols=0,
-                  fast_reader=True):
+                  fast_reader=None):
+
+        if fast_reader is None:
+          fast_reader = {}
 
         # Handle fast_reader parameter
         expchar = fast_reader.pop('exponent_style', 'E').upper()
@@ -811,13 +814,15 @@ cdef class CParser:
 
     def __reduce__(self):
         cdef bytes source_ptr = self.source_ptr if self.source_ptr else b''
+        fast_reader = dict(expchar=chr(self.tokenizer.expchar),
+                           use_fast_converter=self.tokenizer.use_fast_converter,
+                           parallel=False)
         return (_copy_cparser, (source_ptr, self.source_bytes, self.use_cols, self.fill_names,
                                 self.fill_values, self.tokenizer.strip_whitespace_lines,
                                 self.tokenizer.strip_whitespace_fields,
                                 dict(delimiter=chr(self.tokenizer.delimiter),
                                 comment=chr(self.tokenizer.comment),
                                 quotechar=chr(self.tokenizer.quotechar),
-                                expchar=chr(self.tokenizer.expchar),
                                 header_start=self.header_start,
                                 data_start=self.data_start,
                                 data_end=self.data_end,
@@ -828,8 +833,7 @@ cdef class CParser:
                                 fill_include_names=self.fill_include_names,
                                 fill_exclude_names=self.fill_exclude_names,
                                 fill_extra_cols=self.tokenizer.fill_extra_cols,
-                                use_fast_converter=self.tokenizer.use_fast_converter,
-                                parallel=False)))
+                                fast_reader=fast_reader)))
 
 def _copy_cparser(bytes src_ptr, bytes source_bytes, use_cols, fill_names, fill_values,
                   strip_whitespace_lines, strip_whitespace_fields, kwargs):

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -813,11 +813,11 @@ cdef class CParser:
         return self.header_names
 
     def __reduce__(self):
-        cdef bytes source_ptr = self.source_ptr if self.source_ptr else b''
+        cdef bytes source = self.source_ptr if self.source_ptr else self.source_bytes
         fast_reader = dict(exponent_style=chr(self.tokenizer.expchar),
                            use_fast_converter=self.tokenizer.use_fast_converter,
                            parallel=False)
-        return (_copy_cparser, (source_ptr, self.source_bytes, self.use_cols, self.fill_names,
+        return (_copy_cparser, (source, self.use_cols, self.fill_names,
                                 self.fill_values, self.fill_empty, self.tokenizer.strip_whitespace_lines,
                                 self.tokenizer.strip_whitespace_fields,
                                 dict(delimiter=chr(self.tokenizer.delimiter),
@@ -835,20 +835,19 @@ cdef class CParser:
                                 fill_extra_cols=self.tokenizer.fill_extra_cols,
                                 fast_reader=fast_reader)))
 
-def _copy_cparser(bytes src_ptr, bytes source_bytes, use_cols, fill_names, fill_values,
+def _copy_cparser(bytes source, use_cols, fill_names, fill_values,
                   fill_empty, strip_whitespace_lines, strip_whitespace_fields, kwargs):
+
     parser = CParser(None, strip_whitespace_lines, strip_whitespace_fields, **kwargs)
+
     parser.use_cols = use_cols
     parser.fill_names = fill_names
     parser.fill_values = fill_values
     parser.fill_empty = fill_empty
 
-    if src_ptr:
-        parser.tokenizer.source = src_ptr
-    else:
-        parser.tokenizer.source = source_bytes
-        parser.tokenizer.source_len = <size_t>len(source_bytes)
-        parser.source_bytes = source_bytes
+    parser.tokenizer.source = source
+    parser.tokenizer.source_len = <size_t>len(source)
+    parser.source_bytes = source
 
     return parser
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -847,6 +847,9 @@ def _copy_cparser(bytes src_ptr, bytes source_bytes, use_cols, fill_names, fill_
         parser.tokenizer.source = src_ptr
     else:
         parser.tokenizer.source = source_bytes
+        parser.tokenizer.source_len = <size_t>len(source_bytes)
+        parser.source_bytes = source_bytes
+
     return parser
 
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -818,7 +818,7 @@ cdef class CParser:
                            use_fast_converter=self.tokenizer.use_fast_converter,
                            parallel=False)
         return (_copy_cparser, (source_ptr, self.source_bytes, self.use_cols, self.fill_names,
-                                self.fill_values, self.tokenizer.strip_whitespace_lines,
+                                self.fill_values, self.fill_empty, self.tokenizer.strip_whitespace_lines,
                                 self.tokenizer.strip_whitespace_fields,
                                 dict(delimiter=chr(self.tokenizer.delimiter),
                                 comment=chr(self.tokenizer.comment),
@@ -836,11 +836,12 @@ cdef class CParser:
                                 fast_reader=fast_reader)))
 
 def _copy_cparser(bytes src_ptr, bytes source_bytes, use_cols, fill_names, fill_values,
-                  strip_whitespace_lines, strip_whitespace_fields, kwargs):
+                  fill_empty, strip_whitespace_lines, strip_whitespace_fields, kwargs):
     parser = CParser(None, strip_whitespace_lines, strip_whitespace_fields, **kwargs)
     parser.use_cols = use_cols
     parser.fill_names = fill_names
     parser.fill_values = fill_values
+    parser.fill_empty = fill_empty
 
     if src_ptr:
         parser.tokenizer.source = src_ptr

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -814,7 +814,7 @@ cdef class CParser:
 
     def __reduce__(self):
         cdef bytes source_ptr = self.source_ptr if self.source_ptr else b''
-        fast_reader = dict(expchar=chr(self.tokenizer.expchar),
+        fast_reader = dict(exponent_style=chr(self.tokenizer.expchar),
                            use_fast_converter=self.tokenizer.use_fast_converter,
                            parallel=False)
         return (_copy_cparser, (source_ptr, self.source_bytes, self.use_cols, self.fill_names,

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -72,8 +72,6 @@ def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=Fa
     if parallel:
         if TRAVIS:
             pytest.xfail("Multiprocessing can sometimes fail on Travis CI")
-        elif os.name == 'nt':
-            pytest.xfail("Multiprocessing is currently unsupported on Windows")
         t6 = ascii.read(table, format=format, guess=False, fast_reader={
             'parallel': True}, **kwargs)
         assert_table_equal(t1, t6, check_meta=check_meta)
@@ -1030,9 +1028,7 @@ def test_read_big_table2(tmpdir):
 # fast_reader configurations: False| 'use_fast_converter'=False|True
 @pytest.mark.parametrize('fast_reader', [False, dict(use_fast_converter=False),
                                          dict(use_fast_converter=True)])
-# Catch Windows environment since we cannot use _read() with custom fast_reader
-@pytest.mark.parametrize("parallel", [False,
-    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows"))])
+@pytest.mark.parametrize("parallel", [False, True])
 def test_data_out_of_range(parallel, fast_reader, guess):
     """
     Numbers with exponents beyond float64 range (|~4.94e-324 to 1.7977e+308|)
@@ -1089,11 +1085,7 @@ def test_data_out_of_range(parallel, fast_reader, guess):
 
 
 @pytest.mark.parametrize("guess", [True, False])
-# catch Windows environment since we cannot use _read() with custom fast_reader
-@pytest.mark.parametrize("parallel", [
-    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
-    False])
-
+@pytest.mark.parametrize("parallel", [False, True])
 def test_int_out_of_range(parallel, guess):
     """
     Integer numbers outside int range shall be returned as string columns
@@ -1131,10 +1123,7 @@ def test_int_out_of_range(parallel, guess):
 
 
 @pytest.mark.parametrize("guess", [True, False])
-@pytest.mark.parametrize("parallel", [
-    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
-    False])
-
+@pytest.mark.parametrize("parallel", [False, True])
 def test_fortran_reader(parallel, guess):
     """
     Make sure that ascii.read() can read Fortran-style exponential notation
@@ -1178,9 +1167,7 @@ def test_fortran_reader(parallel, guess):
 
 
 @pytest.mark.parametrize("guess", [True, False])
-@pytest.mark.parametrize("parallel", [
-    pytest.param(True, marks=pytest.mark.xfail(os.name == 'nt', reason="Multiprocessing is currently unsupported on Windows")),
-    False])
+@pytest.mark.parametrize("parallel", [False, True])
 def test_fortran_invalid_exp(parallel, guess):
     """
     Test Fortran-style exponential notation in the fast_reader with invalid
@@ -1348,9 +1335,6 @@ def test_read_empty_basic_table_with_comments(fast_reader):
     # comment 2
     col1 col2
     """
-    if os.name == 'nt' and fast_reader and fast_reader.get('parallel'):
-        pytest.xfail("Multiprocessing is currently unsupported on Windows")
-
     t = ascii.read(dat, fast_reader=fast_reader)
     assert t.meta['comments'] == ['comment 1', 'comment 2']
     assert len(t) == 0


### PR DESCRIPTION
This is a partial fix for https://github.com/astropy/astropy/issues/8851 but it might be worth already getting these changes in master, as I believe they are correct and will be needed whatever the full fix is. Basically it looks like the call to CParser in ``__reduce__`` used an old API. With these changes, the example shown in https://github.com/astropy/astropy/issues/8851 works but there are still memory deallocation warnings and issues with performance - but I think those could be dealt with in a separate PR.

Unfortunately I don't really know what the best way is to test this automatically since the multiprocessing starting mode has to be set globally. This will effectively get tested implicitly once we start to have Python 3.8 MacOS X builds.