### PR TITLE
Allow initialization of zero-size Times for all formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -408,6 +408,8 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Allow ``Time`` to be initialized with an empty value for all formats. [#8854]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -619,7 +619,7 @@ class TimeDatetime(TimeUnique):
         """Convert datetime object contained in val1 to jd1, jd2"""
         # Iterate through the datetime objects, getting year, month, etc.
         iterator = np.nditer([val1, None, None, None, None, None, None],
-                             flags=['refs_ok'],
+                             flags=['refs_ok', 'zerosize_ok'],
                              op_dtypes=[object] + 5*[np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             dt = val.item()
@@ -670,7 +670,7 @@ class TimeDatetime(TimeUnique):
         isecs = ihmsfs['s']
         ifracs = ihmsfs['f']
         iterator = np.nditer([iys, ims, ids, ihrs, imins, isecs, ifracs, None],
-                             flags=['refs_ok'],
+                             flags=['refs_ok', 'zerosize_ok'],
                              op_dtypes=7*[iys.dtype] + [object])
 
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
@@ -808,6 +808,7 @@ class TimeString(TimeUnique):
         to_string = (str if val1.dtype.kind == 'U' else
                      lambda x: str(x.item(), encoding='ascii'))
         iterator = np.nditer([val1, None, None, None, None, None, None],
+                             flags=['zerosize_ok'],
                              op_dtypes=[val1.dtype] + 5*[np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             val = to_string(val)
@@ -841,7 +842,8 @@ class TimeString(TimeUnique):
         isecs = ihmsfs['s']
         ifracs = ihmsfs['f']
         for iy, im, id, ihr, imin, isec, ifracsec in np.nditer(
-                [iys, ims, ids, ihrs, imins, isecs, ifracs]):
+                [iys, ims, ids, ihrs, imins, isecs, ifracs],
+                flags=['zerosize_ok']):
             if has_yday:
                 yday = datetime.datetime(iy, im, id).timetuple().tm_yday
 
@@ -1158,7 +1160,8 @@ class TimeEpochDateString(TimeString):
         # Be liberal in what we accept: convert bytes to ascii.
         to_string = (str if val1.dtype.kind == 'U' else
                      lambda x: str(x.item(), encoding='ascii'))
-        iterator = np.nditer([val1, None], op_dtypes=[val1.dtype, np.double])
+        iterator = np.nditer([val1, None], op_dtypes=[val1.dtype, np.double],
+                             flags=['zerosize_ok'])
         for val, years in iterator:
             try:
                 time_str = to_string(val)
@@ -1256,7 +1259,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
         iterator = np.nditer([val1, None],
-                             flags=['refs_ok'],
+                             flags=['refs_ok', 'zerosize_ok'],
                              op_dtypes=[object] + [np.double])
 
         for val, sec in iterator:
@@ -1268,7 +1271,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     @property
     def value(self):
         iterator = np.nditer([self.jd1 + self.jd2, None],
-                             flags=['refs_ok'],
+                             flags=['refs_ok', 'zerosize_ok'],
                              op_dtypes=[self.jd1.dtype] + [object])
 
         for jd, out in iterator:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -93,6 +93,25 @@ class TestBasic:
         assert t4.isscalar is False
         assert t4.shape == np.broadcast(val, val2).shape
 
+    @pytest.mark.parametrize('format_', Time.FORMATS)
+    def test_empty_value(self, format_):
+        t = Time([], format=format_)
+        assert t.size == 0
+        assert t.shape == (0,)
+        assert t.format == format_
+        t_value = t.value
+        assert t_value.size == 0
+        assert t_value.shape == (0,)
+        t2 = Time(t_value, format=format_)
+        assert t2.size == 0
+        assert t2.shape == (0,)
+        assert t2.format == format_
+        t3 = t2.tai
+        assert t3.size == 0
+        assert t3.shape == (0,)
+        assert t3.format == format_
+        assert t3.scale == 'tai'
+
     @pytest.mark.parametrize('value', [2455197.5, [2455197.5]])
     def test_copy_time(self, value):
         """Test copying the values of a Time object by passing it into the
@@ -478,6 +497,8 @@ class TestBasic:
             Time(times, format='iso', scale='utc')
         with pytest.raises(ValueError):
             Time('2000:001', format='jd', scale='utc')
+        with pytest.raises(ValueError):  # unguessable
+            Time([])
         with pytest.raises(ValueError):
             Time([50000.0], ['bad'], format='mjd', scale='tai')
         with pytest.raises(ValueError):


### PR DESCRIPTION
Seeing astro-bot warn about #7868 again, I thought I would just take it over and make a PR that uses a bit less special-casing for zero-size (though still more than I'd like, but hard to avoid).

Milestoned this for 3.2.1 as I think it may be hard to backport.
 
Fixes #7866

