### PR TITLE
Ensure that MaskedColumn.data returns a plain MaskedArray.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ astropy.table
 - Improved the implementation of ``Table.replace_column()`` to provide
   a speed-up of 5-10 times for wide tables. [#8902]
 
+- ``MaskedColumn.data`` will now return a plain ``MaskedArray`` rather than
+  the previous (unintended) ``masked_BaseColumn``. [#8855]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1272,10 +1272,12 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
 
     @property
     def data(self):
-        out = self.view(ma.MaskedArray)
-        # The following is necessary because of a bug in Numpy, which was
-        # fixed in numpy/numpy#2703. The fix should be included in Numpy 1.8.0.
-        out.fill_value = self.fill_value
+        """The plain MaskedArray data held by this column."""
+        out = self.view(np.ma.MaskedArray)
+        # By default, a MaskedArray view will set the _baseclass to be the
+        # same as that of our own class, i.e., BaseColumn.  Since we want
+        # to return a plain MaskedArray, we reset the baseclass accordingly.
+        out._baseclass = np.ndarray
         return out
 
     def filled(self, fill_value=None):


### PR DESCRIPTION
Previously this was instead a masked_BaseColumn, which caused a number of performance hits, e.g., because slicing would go through multiple rounds of ``__array_finalize__``. This PR includes a regression check for that count.

fixes #6721