### PR TITLE
Added property to BaseCoordinateFrame for cylindrical representation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,10 @@ astropy.coordinates
   as input. The ephemeris can now be selected by either keyword (e.g. 'jpl',
   'de430'), URL or file path. [#8767]
 
+- Added a ``cylindrical`` property to ``SkyCoord`` for shorthand access to a
+  ``CylindricalRepresentation`` of the coordinate, as is already available
+  for other common representations. [#8857]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1652,6 +1652,17 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         return self.represent_as('cartesian', in_frame_units=True)
 
     @property
+    def cylindrical(self):
+        """
+        Shorthand for a cylindrical representation of the coordinates in this
+        object.
+        """
+
+        # TODO: if representations are updated to use a full transform graph,
+        #       the representation aliases should not be hard-coded like this
+        return self.represent_as('cylindrical', in_frame_units=True)
+
+    @property
     def spherical(self):
         """
         Shorthand for a spherical representation of the coordinates in this

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -584,6 +584,7 @@ def test_representation():
     # Create some representation objects.
     icrs_cart = icrs.cartesian
     icrs_spher = icrs.spherical
+    icrs_cyl = icrs.cylindrical
 
     # Testing when `_representation` set to `CartesianRepresentation`.
     icrs.representation_type = r.CartesianRepresentation
@@ -625,7 +626,16 @@ def test_representation():
     icrs.representation_type = 'cylindrical'
 
     assert icrs.representation_type is r.CylindricalRepresentation
+    assert icrs_cyl.rho == icrs.rho
+    assert icrs_cyl.phi == icrs.phi
+    assert icrs_cyl.z == icrs.z
     assert icrs.data == data
+
+    # Testing that an ICRS object in CylindricalRepresentation must not have spherical attributes.
+    for attr in ('ra', 'dec', 'distance'):
+        with pytest.raises(AttributeError) as err:
+            getattr(icrs, attr)
+        assert 'object has no attribute' in str(err)
 
     with pytest.raises(ValueError) as err:
         icrs.representation_type = 'WRONG'
@@ -686,6 +696,10 @@ def test_shorthand_representations():
     rep = rep.with_differentials(dif)
 
     icrs = ICRS(rep)
+
+    cyl = icrs.cylindrical
+    assert isinstance(cyl, r.CylindricalRepresentation)
+    assert isinstance(cyl.differentials['s'], r.CylindricalDifferential)
 
     sph = icrs.spherical
     assert isinstance(sph, r.SphericalRepresentation)


### PR DESCRIPTION
This PR fills in the omission where `BaseCoordinateFrame` has the shorthand-for-representation properties `.cartesian`, `.spherical`, and `.sphericalcoslat`, but no analogous `.cylindrical`.  I copied the TODO message from the other properties.