### PR TITLE
Fix to distribution

### DIFF
--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -268,3 +268,7 @@ class Distribution:
         bin_edges = np.array(bin_edges)
         be_shape = self.shape + (bin_edges.size//self.size,)
         return nhists.reshape(nh_shape), bin_edges.reshape(be_shape)
+
+    def to(self, *args, **kwargs):
+        tod = self.distribution.to(*args, **kwargs)
+        return self.__class__(tod)

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -316,3 +316,12 @@ def test_array_repr_latex():
 
     distr = Distribution(arr)
     assert distr._repr_latex_() is None
+
+
+def test_to():
+    distr = Distribution(np.random.randn(2, 100)*u.km)
+    distrm = distr.to(u.m)
+
+    assert distr.unit == u.km
+    assert distrm.unit == u.m
+    assert_quantity_allclose(distr.pdf_mean, distrm.pdf_mean)


### PR DESCRIPTION
This is a first try at addressing #8863.  It does work in addressing the proximate cause, *but* it seems like a bit of a cheat.  I can't help but think there's a cleaner way that actually *uses* the `numpy` `dtype`machinery instead of basically working around it.  @mhvk do you have any insight into this? 

The core problem seems to be that there's no straightofrward way to re-scale the distributions with non-standard dtypes - e.g., the following fails:
```
>>> distr = unc.Distribution(np.random.randn(2, 100)*u.km)
>>> arr = np.array(distr)
>>> arr
array(..., dtype=[('samples', '<f8', (100,))])
>>> 1000*arr
TypeError: invalid type promotion
```
and the unit machinery seems to be relying on this somehow.