### PR TITLE
Smarter rewriting of component names in Frame repr

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2272,6 +2272,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug where the string representation of a ``BaseCoordinateFrame``
+  object could become garbled under specific circumstances when the frame
+  defines custom component names via ``RepresentationMapping``. [#8869]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1367,8 +1367,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             data = self.represent_as(rep_cls, dif_cls, in_frame_units=True)
 
             data_repr = repr(data)
-            for nmpref, nmrepr in self.representation_component_names.items():
-                data_repr = data_repr.replace(nmrepr, nmpref)
+            # Generate the list of component names out of the repr string
+            part1, _, remainder = data_repr.partition('(')
+            if remainder != '':
+                comp_str, _, part2 = remainder.partition(')')
+                comp_names = comp_str.split(', ')
+                # Swap in frame-specific component names
+                invnames = dict([(nmrepr, nmpref) for nmpref, nmrepr
+                                 in self.representation_component_names.items()])
+                for i, name in enumerate(comp_names):
+                    comp_names[i] = invnames.get(name, name)
+                # Reassemble the repr string
+                data_repr = part1 + '(' + ', '.join(comp_names) + ')' + part2
 
         else:
             data = self.data

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1044,3 +1044,25 @@ def test_attribute_repr():
         attrtest = Attribute(default=Spam())
 
     assert "TEST REPR" in repr(TestFrame())
+
+
+def test_component_names_repr():
+    from astropy.coordinates.baseframe import BaseCoordinateFrame, RepresentationMapping
+
+    # Frame class with new component names that includes a name swap
+    class NameChangeFrame(BaseCoordinateFrame):
+        default_representation = r.PhysicsSphericalRepresentation
+
+        frame_specific_representation_info = {
+            r.PhysicsSphericalRepresentation: [
+                RepresentationMapping('phi', 'theta', u.deg),
+                RepresentationMapping('theta', 'phi', u.arcsec),
+                RepresentationMapping('r', 'JUSTONCE', u.AU)]
+        }
+    frame = NameChangeFrame(0*u.deg, 0*u.arcsec, 0*u.AU)
+
+    # Check for the new names in the Frame repr
+    assert "(theta, phi, JUSTONCE)" in repr(frame)
+
+    # Check that the letter "r" has not been replaced more than once in the Frame repr
+    assert repr(frame).count("JUSTONCE") == 1


### PR DESCRIPTION
This one's a fun one!  When using `RepresentationMapping` to define frame-specific component names, the existing code does a simple string search-and-replace when generating the `Frame` repr.  While this frequently works since component names are typically unusual, it fails spectacularly when trying to define a frame-specific name for `r` in `PhysicsSphericalRepresentation` because the letter "r" is so common.  Here's what happens when replacing `r` with `DISTANCE`:
```
<SkyCoord (...): Data:
<PhysicsSpheDISTANCEicalRepDISTANCEesentation (phi, theta, DISTANCE) in (deg, aDISTANCEcsec, AU)
    (26.56505118, 304.06207554, 1.01396421)>>
```
instead of the intended:
```
<SkyCoord (...): (phi, theta, DISTANCE) in (deg, arcsec, AU)
    (26.56505118, 304.06207554, 1.01396421)>
```
Note that the replacing of letters in the name of the representation class throws off later code intended to strip it out, and a letter in a unit name was replaced as well.

This PR performs the replacement of component names more intelligently.