### PR TITLE
Added codecov.yml and disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
Don't think we need the CI to run on this so I've ``[ci skip]``-ed this. I also think it's worth backporting in case we open PRs to old branches.