### PR TITLE
Let scalar Quantity.value return a numpy scalar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,12 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- For consistency with ``ndarray``, scalar ``Quantity.value`` will now return
+  a numpy scalar rather than a python one.  This should help keep track of
+  precision better, but may lead to unexpected results for the rare cases
+  where numpy scalars behave differently than python ones (e.g., taking the
+  square root of a negative number). [#8876]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1524,3 +1524,13 @@ def test_distance_warning(recwarn):
     # second check is because the "originating" ValueError says the above,
     # while the representation one includes the below
     assert 'you must explicitly pass' in str(excinfo.value)
+
+
+def test_dtype_preservation_in_indexing():
+    # Regression test for issue
+    xyz = np.array([[1, 0, 0], [0.9, 0.1, 0]], dtype='f4')
+    cr = CartesianRepresentation(xyz, xyz_axis=-1, unit="km")
+    assert cr.xyz.dtype == xyz.dtype
+    cr0 = cr[0]
+    # This used to fail.
+    assert cr0.xyz.dtype == xyz.dtype

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1527,7 +1527,7 @@ def test_distance_warning(recwarn):
 
 
 def test_dtype_preservation_in_indexing():
-    # Regression test for issue
+    # Regression test for issue #8614 (fixed in #8876)
     xyz = np.array([[1, 0, 0], [0.9, 0.1, 0]], dtype='f4')
     cr = CartesianRepresentation(xyz, xyz_axis=-1, unit="km")
     assert cr.xyz.dtype == xyz.dtype

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -722,8 +722,8 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                     # not in-place!
                     value = value * scale
 
-        return value if self.shape else (value[()] if self.dtype.fields
-                                         else value.item())
+        # Index with empty tuple to decay array scalars in to numpy scalars.
+        return value[()]
 
     value = property(to_value,
                      doc="""The numerical value of this instance.

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -7,6 +7,7 @@
 import copy
 import pickle
 import decimal
+import numbers
 from fractions import Fraction
 
 import pytest
@@ -1075,7 +1076,7 @@ def test_arrays():
         len(qseclen0array)
     with pytest.raises(TypeError):
         qseclen0array[0]
-    assert isinstance(qseclen0array.value, int)
+    assert isinstance(qseclen0array.value, numbers.Integral)
 
     a = np.array([(1., 2., 3.), (4., 5., 6.), (7., 8., 9.)],
                  dtype=[('x', float),

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -178,6 +178,11 @@ def sanitize_scale(scale):
     if scale.__class__ is float:
         return scale
 
+    # We cannot have numpy scalars, since they don't autoconvert to
+    # complex if necessary.  They are also slower.
+    if hasattr(scale, 'dtype'):
+        scale = scale.item()
+
     # All classes that scale can be (int, float, complex, Fraction)
     # have an "imag" attribute.
     if scale.imag:


### PR DESCRIPTION
Benefits: more consistent with `ndarray`, fixes odd problems like #8614.

Disadvantages: numpy scalars do not always behave the same as python ones. E.g., `(-4.) ** 0.5` returns a complex number (`0+2j`), but `np.float_(-4.) ** 0.5` returns `nan`.

fixes #8614 

EDIT: @astrofrog - requested your review since this goes back a *long* time...

EDIT: partially addresses #6389 as well; but fully addressing it would require returning an array scalar.