### PR TITLE
Fix concatenation of representations when units are not the same.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -268,6 +268,9 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix concatenation of representations for cases where the units were different.
+  [#8877]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -270,19 +270,15 @@ def _concatenate_components(reps_difs, names):
     """
     values = []
     for name in names:
-        data_vals = []
-        for x in reps_difs:
-            data_val = getattr(x, name)
-            data_vals.append(data_val.reshape(1, ) if x.isscalar else data_val)
-        concat_vals = np.concatenate(data_vals)
-
-        # Hack because np.concatenate doesn't fully work with Quantity
-        if isinstance(concat_vals, u.Quantity):
-            concat_vals._unit = data_val.unit
-
+        unit0 = getattr(reps_difs[0], name).unit
+        # Go via to_value because np.concatenate doesn't work with Quantity
+        data_vals = [getattr(x, name).to_value(unit0) for x in reps_difs]
+        concat_vals = np.concatenate(np.atleast_1d(*data_vals))
+        concat_vals = concat_vals << unit0
         values.append(concat_vals)
 
     return values
+
 
 def concatenate_representations(reps):
     """

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -163,3 +163,15 @@ def test_concatenate_representations():
     # Check that passing in a single object fails
     with pytest.raises(TypeError):
         concatenate_representations(reps[0])
+
+
+def test_concatenate_representations_different_units():
+    from astropy.coordinates.funcs import concatenate_representations
+    from astropy.coordinates import representation as r
+
+    reps = [r.CartesianRepresentation([1, 2, 3.]*u.pc),
+            r.CartesianRepresentation([1, 2, 3.]*u.kpc)]
+    concat = concatenate_representations(reps)
+    assert concat.shape == (2,)
+    assert np.all(concat.xyz ==
+                  ([[1., 2., 3.], [1000., 2000., 3000.]] * u.pc).T)


### PR DESCRIPTION
After looking at code following https://github.com/astropy/astropy/issues/8610#issuecomment-503767466

Test fails on current master...

