### PR TITLE
Deprecate InheritDocstring and remove its usage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -244,6 +244,9 @@ astropy.utils
 
 - Removed the deprecated ``astropy.utils.compat.numpy`` module. [#8910]
 
+- Deprecated ``InheritDocstrings`` as it is natively supported by
+  Sphinx 1.7 or higher. [#8881]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -20,7 +20,6 @@ from astropy.extern.configobj import configobj, validate
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy.utils import find_current_module
 from astropy.utils.introspection import resolve_name
-from astropy.utils.misc import InheritDocstrings
 from .paths import get_config_dir
 
 
@@ -157,7 +156,7 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
                 item.set(item.defaultvalue)
 
 
-class ConfigItem(metaclass=InheritDocstrings):
+class ConfigItem:
     """
     A setting and associated value stored in a configuration file.
 

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -9,12 +9,11 @@ from astropy.units.core import Unit, UnitsError
 from astropy.units.quantity import Quantity
 from astropy.utils import lazyproperty
 from astropy.utils.exceptions import AstropyUserWarning
-from astropy.utils.misc import InheritDocstrings
 
 __all__ = ['Constant', 'EMConstant']
 
 
-class ConstantMeta(InheritDocstrings):
+class ConstantMeta(type):
     """Metaclass for the :class:`Constant`. The primary purpose of this is to
     wrap the double-underscore methods of :class:`Quantity` which is the
     superclass of :class:`Constant`.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -20,7 +20,8 @@ from .distances import Distance
 from astropy._erfa import ufunc as erfa_ufunc
 from astropy.utils import ShapedLikeNDArray, classproperty
 
-from astropy.utils.misc import InheritDocstrings
+from astropy.utils import deprecated_attribute
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.compat import NUMPY_LT_1_14
 
 __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",
@@ -403,7 +404,7 @@ def _make_getter(component):
 # be combined with a ShapedLikeNDArray subclass (which is an ABC).  Without it:
 # "TypeError: metaclass conflict: the metaclass of a derived class must be a
 #  (non-strict) subclass of the metaclasses of all its bases"
-class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
+class MetaBaseRepresentation(abc.ABCMeta):
     def __init__(cls, name, bases, dct):
         super().__init__(name, bases, dct)
 
@@ -1924,7 +1925,7 @@ class CylindricalRepresentation(BaseRepresentation):
         return CartesianRepresentation(x=x, y=y, z=z, copy=False)
 
 
-class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
+class MetaBaseDifferential(abc.ABCMeta):
     """Set default ``attr_classes`` and component getters on a Differential.
 
     For these, the components are those of the base representation prefixed

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -10,7 +10,6 @@ import functools
 import operator
 from collections import OrderedDict
 import inspect
-import warnings
 
 import numpy as np
 import astropy.units as u
@@ -19,9 +18,6 @@ from .angles import Angle, Longitude, Latitude
 from .distances import Distance
 from astropy._erfa import ufunc as erfa_ufunc
 from astropy.utils import ShapedLikeNDArray, classproperty
-
-from astropy.utils import deprecated_attribute
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.compat import NUMPY_LT_1_14
 
 __all__ = ["BaseRepresentationOrDifferential", "BaseRepresentation",

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -21,7 +21,6 @@ from astropy import __version__ as astropy_version
 from astropy.utils.collections import HomogeneousList
 from astropy.utils.xml.writer import XMLWriter
 from astropy.utils.exceptions import AstropyDeprecationWarning
-from astropy.utils.misc import InheritDocstrings
 
 from . import converters
 from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
@@ -405,7 +404,7 @@ class _DescriptionProperty:
 
 ######################################################################
 # ELEMENT CLASSES
-class Element(metaclass=InheritDocstrings):
+class Element(metaclass=type):
     """
     A base class for all classes that represent XML elements in the
     VOTABLE file.

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -4,12 +4,10 @@
 # STDLIB
 import io
 import re
-import sys
 import gzip
 import base64
 import codecs
 import urllib.request
-import warnings
 
 # THIRD-PARTY
 import numpy as np
@@ -20,7 +18,6 @@ from astropy.io import fits
 from astropy import __version__ as astropy_version
 from astropy.utils.collections import HomogeneousList
 from astropy.utils.xml.writer import XMLWriter
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from . import converters
 from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
@@ -404,7 +401,7 @@ class _DescriptionProperty:
 
 ######################################################################
 # ELEMENT CLASSES
-class Element(metaclass=type):
+class Element:
     """
     A base class for all classes that represent XML elements in the
     VOTABLE file.

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -34,7 +34,7 @@ from astropy.table import Table
 from astropy.units import Quantity, UnitsError, dimensionless_unscaled
 from astropy.units.utils import quantity_asanyarray
 from astropy.utils import (sharedmethod, find_current_module,
-                           InheritDocstrings, OrderedDescriptorContainer,
+                           OrderedDescriptorContainer,
                            check_broadcast, IncompatibleShapeError, isiterable)
 from astropy.utils.codegen import make_function_with_signature
 from astropy.utils.exceptions import AstropyDeprecationWarning
@@ -82,7 +82,7 @@ def _model_oper(oper, **kwargs):
     return _opfunc
 
 
-class _ModelMeta(OrderedDescriptorContainer, InheritDocstrings, abc.ABCMeta):
+class _ModelMeta(OrderedDescriptorContainer, abc.ABCMeta):
     """
     Metaclass for Model.
 

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -15,7 +15,7 @@ __all__ = ['BinnedTimeSeries']
 
 
 @autocheck_required_columns
-class BinnedTimeSeries(BaseTimeSeries, metaclass=type):
+class BinnedTimeSeries(BaseTimeSeries):
     """
     A class to represent binned time series data in tabular form.
 

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -8,7 +8,6 @@ from astropy.table import groups, Table, QTable
 from astropy.time import Time, TimeDelta
 from astropy import units as u
 from astropy.units import Quantity
-from astropy.utils.misc import InheritDocstrings
 
 from astropy.timeseries.core import BaseTimeSeries, autocheck_required_columns
 
@@ -16,7 +15,7 @@ __all__ = ['BinnedTimeSeries']
 
 
 @autocheck_required_columns
-class BinnedTimeSeries(BaseTimeSeries, metaclass=InheritDocstrings):
+class BinnedTimeSeries(BaseTimeSeries, metaclass=type):
     """
     A class to represent binned time series data in tabular form.
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -485,7 +485,7 @@ class UnitsWarning(AstropyWarning):
     """
 
 
-class UnitBase(metaclass=type):
+class UnitBase:
     """
     Abstract base class for units.
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from astropy.utils.decorators import lazyproperty
 from astropy.utils.exceptions import AstropyWarning
-from astropy.utils.misc import isiterable, InheritDocstrings
+from astropy.utils.misc import isiterable
 from .utils import (is_effectively_unity, sanitize_scale, validate_power,
                     resolve_fractions)
 from . import format as unit_format
@@ -485,7 +485,7 @@ class UnitsWarning(AstropyWarning):
     """
 
 
-class UnitBase(metaclass=InheritDocstrings):
+class UnitBase(metaclass=type):
     """
     Abstract base class for units.
 
@@ -1755,7 +1755,7 @@ class UnrecognizedUnit(IrreducibleUnit):
         return False
 
 
-class _UnitMetaClass(InheritDocstrings):
+class _UnitMetaClass(type):
     """
     This metaclass exists because the Unit constructor should
     sometimes return instances that already exist.  This "overrides"

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -2,10 +2,8 @@
 
 import os
 
-from astropy.utils.misc import InheritDocstrings
 
-
-class _FormatterMeta(InheritDocstrings):
+class _FormatterMeta(type):
     registry = {}
 
     def __new__(mcls, name, bases, members):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -197,7 +197,7 @@ class QuantityInfo(QuantityInfoBase):
         return out
 
 
-class Quantity(np.ndarray, metaclass=type):
+class Quantity(np.ndarray):
     """A `~astropy.units.Quantity` represents a number with some associated unit.
 
     See also: http://docs.astropy.org/en/stable/units/quantity.html

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -23,7 +23,7 @@ from .format.latex import Latex
 from astropy.utils.compat import NUMPY_LT_1_14, NUMPY_LT_1_16, NUMPY_LT_1_17
 from astropy.utils.compat.misc import override__dir__
 from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyWarning
-from astropy.utils.misc import isiterable, InheritDocstrings
+from astropy.utils.misc import isiterable
 from astropy.utils.data_info import ParentDtypeInfo
 from astropy import config as _config
 from .quantity_helper import (converters_and_unit, can_have_arbitrary_unit,
@@ -197,7 +197,7 @@ class QuantityInfo(QuantityInfoBase):
         return out
 
 
-class Quantity(np.ndarray, metaclass=InheritDocstrings):
+class Quantity(np.ndarray, metaclass=type):
     """A `~astropy.units.Quantity` represents a number with some associated unit.
 
     See also: http://docs.astropy.org/en/stable/units/quantity.html

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -1391,10 +1391,6 @@ def test_quantity_fraction_power():
     assert q.dtype.kind == 'f'
 
 
-def test_inherit_docstrings():
-    assert u.Quantity.argmax.__doc__ == np.ndarray.argmax.__doc__
-
-
 def test_quantity_from_table():
     """
     Checks that units from tables are respected when converted to a Quantity.

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -715,10 +715,6 @@ def test_fractional_powers():
     assert x.powers[0] == Fraction(7, 6)
 
 
-def test_inherit_docstrings():
-    assert u.UnrecognizedUnit.is_unity.__doc__ == u.UnitBase.is_unity.__doc__
-
-
 def test_sqrt_mag():
     sqrt_mag = u.mag ** 0.5
     assert hasattr(sqrt_mag.decompose().scale, 'imag')

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -22,6 +22,8 @@ from itertools import zip_longest
 from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 
+from astropy.utils.decorators import deprecated
+
 
 __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
            'find_api_page', 'is_path_hidden', 'walk_skip_hidden',
@@ -489,6 +491,7 @@ def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
     return ''
 
 
+@deprecated('4.0', alternative='Sphinx>=1.7 automatically inherits docstring')
 class InheritDocstrings(type):
     """
     This metaclass makes methods of a class automatically have their

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -506,14 +506,18 @@ class InheritDocstrings(type):
 
     For example::
 
+        >>> import warnings
         >>> from astropy.utils.misc import InheritDocstrings
-        >>> class A(metaclass=InheritDocstrings):
-        ...     def wiggle(self):
-        ...         "Wiggle the thingamajig"
-        ...         pass
-        >>> class B(A):
-        ...     def wiggle(self):
-        ...         pass
+        >>> with warnings.catch_warnings():
+        ...     # Ignore deprecation warning
+        ...     warnings.simplefilter('ignore')
+        ...     class A(metaclass=InheritDocstrings):
+        ...         def wiggle(self):
+        ...             "Wiggle the thingamajig"
+        ...             pass
+        ...     class B(A):
+        ...         def wiggle(self):
+        ...             pass
         >>> B.wiggle.__doc__
         u'Wiggle the thingamajig'
     """

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -9,6 +9,7 @@ import pytest
 import numpy as np
 
 from astropy.utils import data, misc
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_isiterable():
@@ -74,6 +75,7 @@ def test_JsonCustomEncoder():
     assert newd == tmpd
 
 
+@pytest.mark.filterwarnings("ignore:AstropyDeprecationWarning")
 def test_inherit_docstrings():
     class Base(metaclass=misc.InheritDocstrings):
         def __call__(self, *args):

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -75,17 +75,17 @@ def test_JsonCustomEncoder():
     assert newd == tmpd
 
 
-@pytest.mark.filterwarnings("ignore:AstropyDeprecationWarning")
 def test_inherit_docstrings():
-    class Base(metaclass=misc.InheritDocstrings):
-        def __call__(self, *args):
-            "FOO"
-            pass
+    with pytest.warns(AstropyDeprecationWarning, match="inherits docstring"):
+        class Base(metaclass=misc.InheritDocstrings):
+            def __call__(self, *args):
+                "FOO"
+                pass
 
-        @property
-        def bar(self):
-            "BAR"
-            pass
+            @property
+            def bar(self):
+                "BAR"
+                pass
 
     class Subclass(Base):
         def __call__(self, *args):

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -16,7 +16,7 @@ __all__ = ['BaseInterval', 'ManualInterval', 'MinMaxInterval',
            'ZScaleInterval']
 
 
-class BaseInterval(BaseTransform, metaclass=type):
+class BaseInterval(BaseTransform):
     """
     Base class for the interval classes, which, when called with an
     array of values, return an interval computed following different

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -5,11 +5,9 @@ Classes that deal with computing intervals from arrays of values based on
 various criteria.
 """
 
-
 import abc
 import numpy as np
 
-from astropy.utils.misc import InheritDocstrings
 from .transform import BaseTransform
 
 
@@ -18,7 +16,7 @@ __all__ = ['BaseInterval', 'ManualInterval', 'MinMaxInterval',
            'ZScaleInterval']
 
 
-class BaseInterval(BaseTransform, metaclass=InheritDocstrings):
+class BaseInterval(BaseTransform, metaclass=type):
     """
     Base class for the interval classes, which, when called with an
     array of values, return an interval computed following different

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -44,7 +44,7 @@ def _prepare(values, clip=True, out=None):
             return out
 
 
-class BaseStretch(BaseTransform, metaclass=type):
+class BaseStretch(BaseTransform):
     """
     Base class for the stretch classes, which, when called with an array
     of values in the range [0:1], return an transformed array of values,

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -5,10 +5,8 @@ Classes that deal with stretching, i.e. mapping a range of [0:1] values onto
 another set of [0:1] values with a transformation
 """
 
-
 import numpy as np
 
-from astropy.utils.misc import InheritDocstrings
 from .transform import BaseTransform
 from .transform import CompositeTransform
 
@@ -46,7 +44,7 @@ def _prepare(values, clip=True, out=None):
             return out
 
 
-class BaseStretch(BaseTransform, metaclass=InheritDocstrings):
+class BaseStretch(BaseTransform, metaclass=type):
     """
     Base class for the stretch classes, which, when called with an array
     of values in the range [0:1], return an transformed array of values,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ plot_pre_code = ""
 # -- General configuration ----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.1'
+needs_sphinx = '1.7'
 
 # To perform a Sphinx version check that needs to be more specific than
 # major.minor, call `check_sphinx_version("x.y.z")` here.


### PR DESCRIPTION
Fix #7167

**TODO**

- [x] Check doc build and compare with existing doc. Are property and method both inheriting properly?
- [x] Pin `sphinx>=1.7`. Also see astropy/sphinx-astropy#24
- [x] Add change log.
- [x] ~Exclude `InheritDocstring` from `doctest` or~ catch the warning there. 
- [x] Catch `AstropyDeprecationWarning` in `test_inherit_docstrings()`.