### PR TITLE
Quantity __array_function__ updates

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# Licensed under a 3-clause BSD style license. See LICENSE.rst except
+# for parts explicitly labelled as being (largely) copies of numpy
+# implementations; for those, see licenses/NUMPY_LICENSE.rst.
 """Helpers for overriding numpy functions.
 
 We override numpy functions in `~astropy.units.Quantity.__array_function__`.

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -396,7 +396,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
         condlist = [condlist]
 
     if any(isinstance(c, Quantity) for c in condlist):
-        raise TypeError("cannot have quantity in condlist.")
+        raise NotImplementedError
 
     condlist = np.array(condlist, dtype=bool)
     n = len(condlist)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1333,18 +1333,18 @@ class TestHistogramFunctions(metaclass=CoverageMeta):
         expected_h, expected_bx, expected_by = np.histogram2d(x.value, y.value)
         expected_bx = expected_bx * x.unit
         expected_by = expected_by * y.unit
-        assert np.all(out_h == expected_h)
-        assert np.all(out_bx == expected_bx)
-        assert np.all(out_by == expected_by)
+        assert_array_equal(out_h, expected_h)
+        assert_array_equal(out_bx, expected_bx)
+        assert_array_equal(out_by, expected_by)
         outd_h, outd_bx, outd_by = np.histogram2d(x, y, density=True)
         expectedd_h, expectedd_bx, expectedd_by = np.histogram2d(
             x.value, y.value, density=True)
         expectedd_h = expectedd_h / x.unit / y.unit
         expectedd_bx = expectedd_bx * x.unit
         expectedd_by = expectedd_by * y.unit
-        assert np.all(outd_h == expectedd_h)
-        assert np.all(outd_bx == expectedd_bx)
-        assert np.all(outd_by == expectedd_by)
+        assert_array_equal(outd_h, expectedd_h)
+        assert_array_equal(outd_bx, expectedd_bx)
+        assert_array_equal(outd_by, expectedd_by)
         weights = np.arange(1., 6.) * u.g
         outw_h, outw_bx, outw_by = np.histogram2d(x, y, weights=weights)
         expectedw_h, expectedw_bx, expectedw_by = np.histogram2d(
@@ -1352,9 +1352,9 @@ class TestHistogramFunctions(metaclass=CoverageMeta):
         expectedw_h = expectedw_h * weights.unit
         expectedw_bx = expectedw_bx * x.unit
         expectedw_by = expectedw_by * y.unit
-        assert np.all(outw_h == expectedw_h)
-        assert np.all(outw_bx == expectedw_bx)
-        assert np.all(outw_by == expectedw_by)
+        assert_array_equal(outw_h, expectedw_h)
+        assert_array_equal(outw_bx, expectedw_bx)
+        assert_array_equal(outw_by, expectedw_by)
 
     @pytest.mark.xfail
     def test_histogramdd(self):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -712,7 +712,8 @@ class TestUfuncLike(InvariantUnitTestSetup):
     def test_unwrap(self):
         q = [0., 3690., -270., 690.] * u.deg
         out = np.unwrap(q)
-        expected = np.rad2deg(np.unwrap(q.to_value(u.rad))) * u.deg
+        expected = (np.unwrap(q.to_value(u.rad)) * u.rad).to(q.unit)
+        assert out.unit == expected.unit
         assert np.allclose(out, expected, atol=1*u.urad, rtol=0)
         with pytest.raises(u.UnitsError):
             np.unwrap([1., 2.]*u.m)


### PR DESCRIPTION
Note: this should only be merged if the `numpy-dev` travis run passes.

Fixes recent failures for `histogram2d`, `i0`, and `block` and adds support for `piecewise`