### PR TITLE
Remove ccd_data fixture from nddata tests

### DIFF
--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -20,14 +20,16 @@ from astropy.utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
 from astropy.nddata.ccddata import CCDData
 from astropy.table import Table
 
+DEFAULT_DATA_SIZE = 100
 
 with NumpyRNGContext(123):
-    _random_array = np.random.normal(size=[100, 100])
+    _random_array = np.random.normal(size=[DEFAULT_DATA_SIZE, DEFAULT_DATA_SIZE])
 
 
 def create_ccd_data():
     """
-    Return a CCDData object of size 100x100 with units of ADU.
+    Return a CCDData object of size DEFAULT_DATA_SIZE x DEFAULT_DATA_SIZE
+    with units of ADU.
     """
     data = _random_array.copy()
     fake_meta = {'my_key': 42, 'your_key': 'not 42'}
@@ -60,8 +62,8 @@ def test_ccddata_meta_header_conflict():
 
 def test_ccddata_simple():
     ccd_data = create_ccd_data()
-    assert ccd_data.shape == (100, 100)
-    assert ccd_data.size == 10000
+    assert ccd_data.shape == (DEFAULT_DATA_SIZE, DEFAULT_DATA_SIZE)
+    assert ccd_data.size == DEFAULT_DATA_SIZE * DEFAULT_DATA_SIZE
     assert ccd_data.dtype == np.dtype(float)
 
 
@@ -77,8 +79,8 @@ def test_initialize_from_FITS(tmpdir):
     filename = tmpdir.join('afile.fits').strpath
     hdulist.writeto(filename)
     cd = CCDData.read(filename, unit=u.electron)
-    assert cd.shape == (100, 100)
-    assert cd.size == 10000
+    assert cd.shape == (DEFAULT_DATA_SIZE, DEFAULT_DATA_SIZE)
+    assert cd.size == DEFAULT_DATA_SIZE * DEFAULT_DATA_SIZE
     assert np.issubdtype(cd.data.dtype, np.floating)
     for k, v in hdu.header.items():
         assert cd.meta[k] == v

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1,5 +1,4 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-# This module implements the base CCDData class.
 
 import textwrap
 
@@ -321,7 +320,6 @@ def test_copy(ccd_data):
 @pytest.mark.parametrize('with_uncertainty', [
                          True,
                          False])
-@pytest.mark.data_unit(u.adu)
 def test_mult_div_overload(ccd_data, operand, with_uncertainty,
                            operation, affects_uncertainty):
     if with_uncertainty:
@@ -372,7 +370,6 @@ def test_mult_div_overload(ccd_data, operand, with_uncertainty,
 @pytest.mark.parametrize('with_uncertainty', [
                          True,
                          False])
-@pytest.mark.data_unit(u.adu)
 def test_add_sub_overload(ccd_data, operand, expect_failure, with_uncertainty,
                           operation, affects_uncertainty):
     if with_uncertainty:

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -20,52 +20,21 @@ from astropy.utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
 from astropy.nddata.ccddata import CCDData
 from astropy.table import Table
 
-# If additional pytest markers are defined the key in the dictionary below
-# should be the name of the marker.
-DEFAULTS = {
-    'seed': 123,
-    'data_size': 100,
-    'data_scale': 1.0,
-    'data_mean': 0.0
-}
 
-DEFAULT_SEED = 123
-DEFAULT_DATA_SIZE = 100
-DEFAULT_DATA_SCALE = 1.0
-
-
-def value_from_markers(key, request):
-    m = request.node.get_closest_marker(key)
-    if m is not None:
-        return m.args[0]
-    else:
-        return DEFAULTS[key]
-
-
-@pytest.fixture
-def ccd_data(request):
+def create_ccd_data(data_size=100, data_scale=1.0, data_mean=0.0, seed=123):
     """
     Return a CCDData object with units of ADU.
 
-    The size of the data array is 100x100 but can be changed using the marker
-    @pytest.mark.data_size(N) on the test function, where N should be the
-    desired dimension.
+    The size of the data array is 100x100 but can be changed using the
+    argument ``data_size``.
 
     Data values are initialized to random numbers drawn from a normal
-    distribution with mean of 0 and scale 1.
-
-    The scale can be changed with the marker @pytest.marker.scale(s) on the
-    test function, where s is the desired scale.
-
-    The mean can be changed with the marker @pytest.marker.scale(m) on the
-    test function, where m is the desired mean.
+    distribution with mean of 0 and scale 1 (or customized with ``data_mean``
+    or ``data_scale``.
     """
-    size = value_from_markers('data_size', request)
-    scale = value_from_markers('data_scale', request)
-    mean = value_from_markers('data_mean', request)
-
-    with NumpyRNGContext(DEFAULTS['seed']):
-        data = np.random.normal(loc=mean, size=[size, size], scale=scale)
+    with NumpyRNGContext(seed):
+        data = np.random.normal(
+            loc=data_mean, size=[data_size, data_size], scale=data_scale)
 
     fake_meta = {'my_key': 42, 'your_key': 'not 42'}
     ccd = CCDData(data, unit=u.adu)
@@ -83,7 +52,8 @@ def test_ccddata_must_have_unit():
         CCDData(np.zeros([100, 100]))
 
 
-def test_ccddata_unit_cannot_be_set_to_none(ccd_data):
+def test_ccddata_unit_cannot_be_set_to_none():
+    ccd_data = create_ccd_data()
     with pytest.raises(TypeError):
         ccd_data.unit = None
 
@@ -94,8 +64,8 @@ def test_ccddata_meta_header_conflict():
         assert "can't have both header and meta." in str(exc)
 
 
-@pytest.mark.data_size(10)
-def test_ccddata_simple(ccd_data):
+def test_ccddata_simple():
+    ccd_data = create_ccd_data(data_size=10)
     assert ccd_data.shape == (10, 10)
     assert ccd_data.size == 100
     assert ccd_data.dtype == np.dtype(float)
@@ -106,8 +76,8 @@ def test_ccddata_init_with_string_electron_unit():
     assert ccd.unit is u.electron
 
 
-@pytest.mark.data_size(10)
-def test_initialize_from_FITS(ccd_data, tmpdir):
+def test_initialize_from_FITS(tmpdir):
+    ccd_data = create_ccd_data(data_size=10)
     hdu = fits.PrimaryHDU(ccd_data)
     hdulist = fits.HDUList([hdu])
     filename = tmpdir.join('afile.fits').strpath
@@ -185,16 +155,18 @@ def test_initialize_from_fits_with_extension(tmpdir):
     np.testing.assert_array_equal(ccd.data, fake_img2)
 
 
-def test_write_unit_to_hdu(ccd_data, tmpdir):
+def test_write_unit_to_hdu():
+    ccd_data = create_ccd_data()
     ccd_unit = ccd_data.unit
     hdulist = ccd_data.to_hdu()
     assert 'bunit' in hdulist[0].header
     assert hdulist[0].header['bunit'] == ccd_unit.to_string()
 
 
-def test_initialize_from_FITS_bad_keyword_raises_error(ccd_data, tmpdir):
+def test_initialize_from_FITS_bad_keyword_raises_error(tmpdir):
     # There are two fits.open keywords that are not permitted in ccdproc:
     #     do_not_scale_image_data and scale_back
+    ccd_data = create_ccd_data()
     filename = tmpdir.join('test.fits').strpath
     ccd_data.write(filename)
 
@@ -205,7 +177,8 @@ def test_initialize_from_FITS_bad_keyword_raises_error(ccd_data, tmpdir):
         CCDData.read(filename, unit=ccd_data.unit, scale_back=True)
 
 
-def test_ccddata_writer(ccd_data, tmpdir):
+def test_ccddata_writer(tmpdir):
+    ccd_data = create_ccd_data()
     filename = tmpdir.join('test.fits').strpath
     ccd_data.write(filename)
 
@@ -213,7 +186,8 @@ def test_ccddata_writer(ccd_data, tmpdir):
     np.testing.assert_array_equal(ccd_data.data, ccd_disk.data)
 
 
-def test_ccddata_meta_is_case_sensitive(ccd_data):
+def test_ccddata_meta_is_case_sensitive():
+    ccd_data = create_ccd_data()
     key = 'SoMeKEY'
     ccd_data.meta[key] = 10
     assert key.lower() not in ccd_data.meta
@@ -221,12 +195,14 @@ def test_ccddata_meta_is_case_sensitive(ccd_data):
     assert key in ccd_data.meta
 
 
-def test_ccddata_meta_is_not_fits_header(ccd_data):
+def test_ccddata_meta_is_not_fits_header():
+    ccd_data = create_ccd_data()
     ccd_data.meta = {'OBSERVER': 'Edwin Hubble'}
     assert not isinstance(ccd_data.meta, fits.Header)
 
 
-def test_fromMEF(ccd_data, tmpdir):
+def test_fromMEF(tmpdir):
+    ccd_data = create_ccd_data()
     hdu = fits.PrimaryHDU(ccd_data)
     hdu2 = fits.PrimaryHDU(2 * ccd_data.data)
     hdulist = fits.HDUList(hdu)
@@ -241,7 +217,7 @@ def test_fromMEF(ccd_data, tmpdir):
     np.testing.assert_array_equal(cd.data, 2 * ccd_data.data)
 
 
-def test_metafromheader(ccd_data):
+def test_metafromheader():
     hdr = fits.header.Header()
     hdr['observer'] = 'Edwin Hubble'
     hdr['exptime'] = '3600'
@@ -274,25 +250,29 @@ def test_metafromstring_fail():
         CCDData(np.ones((5, 5)), meta=hdr, unit=u.adu)
 
 
-def test_setting_bad_uncertainty_raises_error(ccd_data):
+def test_setting_bad_uncertainty_raises_error():
+    ccd_data = create_ccd_data()
     with pytest.raises(TypeError):
         # Uncertainty is supposed to be an instance of NDUncertainty
         ccd_data.uncertainty = 10
 
 
-def test_setting_uncertainty_with_array(ccd_data):
+def test_setting_uncertainty_with_array():
+    ccd_data = create_ccd_data()
     ccd_data.uncertainty = None
     fake_uncertainty = np.sqrt(np.abs(ccd_data.data))
     ccd_data.uncertainty = fake_uncertainty.copy()
     np.testing.assert_array_equal(ccd_data.uncertainty.array, fake_uncertainty)
 
 
-def test_setting_uncertainty_wrong_shape_raises_error(ccd_data):
+def test_setting_uncertainty_wrong_shape_raises_error():
+    ccd_data = create_ccd_data()
     with pytest.raises(ValueError):
         ccd_data.uncertainty = np.random.random(size=(3, 4))
 
 
-def test_to_hdu(ccd_data):
+def test_to_hdu():
+    ccd_data = create_ccd_data()
     ccd_data.meta = {'observer': 'Edwin Hubble'}
     fits_hdulist = ccd_data.to_hdu()
     assert isinstance(fits_hdulist, fits.HDUList)
@@ -301,7 +281,8 @@ def test_to_hdu(ccd_data):
     np.testing.assert_array_equal(fits_hdulist[0].data, ccd_data.data)
 
 
-def test_copy(ccd_data):
+def test_copy():
+    ccd_data = create_ccd_data()
     ccd_copy = ccd_data.copy()
     np.testing.assert_array_equal(ccd_copy.data, ccd_data.data)
     assert ccd_copy.unit == ccd_data.unit
@@ -320,8 +301,9 @@ def test_copy(ccd_data):
 @pytest.mark.parametrize('with_uncertainty', [
                          True,
                          False])
-def test_mult_div_overload(ccd_data, operand, with_uncertainty,
+def test_mult_div_overload(operand, with_uncertainty,
                            operation, affects_uncertainty):
+    ccd_data = create_ccd_data()
     if with_uncertainty:
         ccd_data.uncertainty = StdDevUncertainty(np.ones_like(ccd_data))
     method = ccd_data.__getattribute__(operation)
@@ -370,8 +352,9 @@ def test_mult_div_overload(ccd_data, operand, with_uncertainty,
 @pytest.mark.parametrize('with_uncertainty', [
                          True,
                          False])
-def test_add_sub_overload(ccd_data, operand, expect_failure, with_uncertainty,
+def test_add_sub_overload(operand, expect_failure, with_uncertainty,
                           operation, affects_uncertainty):
+    ccd_data = create_ccd_data()
     if with_uncertainty:
         ccd_data.uncertainty = StdDevUncertainty(np.ones_like(ccd_data))
     method = ccd_data.__getattribute__(operation)
@@ -410,7 +393,8 @@ def test_add_sub_overload(ccd_data, operand, expect_failure, with_uncertainty,
         assert result.unit == ccd_data.unit
 
 
-def test_arithmetic_overload_fails(ccd_data):
+def test_arithmetic_overload_fails():
+    ccd_data = create_ccd_data()
     with pytest.raises(TypeError):
         ccd_data.multiply("five")
 
@@ -460,7 +444,8 @@ def test_arithmetic_with_wcs_compare_fail():
         ccd1.divide(ccd2, compare_wcs=return_diff_smaller_1).wcs
 
 
-def test_arithmetic_overload_ccddata_operand(ccd_data):
+def test_arithmetic_overload_ccddata_operand():
+    ccd_data = create_ccd_data()
     ccd_data.uncertainty = StdDevUncertainty(np.ones_like(ccd_data))
     operand = ccd_data.copy()
     result = ccd_data.add(operand)
@@ -571,7 +556,8 @@ def test_history_preserved_if_metadata_is_fits_header(tmpdir):
     assert ccd_read.header['history'] == hdu.header['history']
 
 
-def test_infol_logged_if_unit_in_fits_header(ccd_data, tmpdir):
+def test_infol_logged_if_unit_in_fits_header(tmpdir):
+    ccd_data = create_ccd_data()
     tmpfile = tmpdir.join('temp.fits')
     ccd_data.write(tmpfile.strpath)
     log.setLevel('INFO')
@@ -581,13 +567,14 @@ def test_infol_logged_if_unit_in_fits_header(ccd_data, tmpdir):
         assert explicit_unit_name in log_list[0].message
 
 
-def test_wcs_attribute(ccd_data, tmpdir):
+def test_wcs_attribute(tmpdir):
     """
     Check that WCS attribute gets added to header, and that if a CCDData
     object is created from a FITS file with a header, and the WCS attribute
     is modified, then the CCDData object is turned back into an hdu, the
     WCS object overwrites the old WCS information in the header.
     """
+    ccd_data = create_ccd_data()
     tmpfile = tmpdir.join('temp.fits')
     # This wcs example is taken from the astropy.wcs docs.
     wcs = WCS(naxis=2)
@@ -785,13 +772,15 @@ def test_read_wcs_not_creatable(tmpdir):
     assert ccd.wcs is None
 
 
-def test_header(ccd_data):
+def test_header():
+    ccd_data = create_ccd_data()
     a = {'Observer': 'Hubble'}
     ccd = CCDData(ccd_data, header=a)
     assert ccd.meta == a
 
 
-def test_wcs_arithmetic(ccd_data):
+def test_wcs_arithmetic():
+    ccd_data = create_ccd_data()
     ccd_data.wcs = 5
     result = ccd_data.multiply(1.0)
     assert result.wcs == 5
@@ -799,7 +788,8 @@ def test_wcs_arithmetic(ccd_data):
 
 @pytest.mark.parametrize('operation',
                          ['multiply', 'divide', 'add', 'subtract'])
-def test_wcs_arithmetic_ccd(ccd_data, operation):
+def test_wcs_arithmetic_ccd(operation):
+    ccd_data = create_ccd_data()
     ccd_data2 = ccd_data.copy()
     ccd_data.wcs = 5
     method = ccd_data.__getattribute__(operation)
@@ -847,7 +837,8 @@ def test_wcs_sip_handling():
 
 @pytest.mark.parametrize('operation',
                          ['multiply', 'divide', 'add', 'subtract'])
-def test_mask_arithmetic_ccd(ccd_data, operation):
+def test_mask_arithmetic_ccd(operation):
+    ccd_data = create_ccd_data()
     ccd_data2 = ccd_data.copy()
     ccd_data.mask = (ccd_data.data > 0)
     method = ccd_data.__getattribute__(operation)
@@ -855,8 +846,9 @@ def test_mask_arithmetic_ccd(ccd_data, operation):
     np.testing.assert_equal(result.mask, ccd_data.mask)
 
 
-def test_write_read_multiextensionfits_mask_default(ccd_data, tmpdir):
+def test_write_read_multiextensionfits_mask_default(tmpdir):
     # Test that if a mask is present the mask is saved and loaded by default.
+    ccd_data = create_ccd_data()
     ccd_data.mask = ccd_data.data > 10
     filename = tmpdir.join('afile.fits').strpath
     ccd_data.write(filename)
@@ -869,8 +861,9 @@ def test_write_read_multiextensionfits_mask_default(ccd_data, tmpdir):
     'uncertainty_type',
     [StdDevUncertainty, VarianceUncertainty, InverseVariance])
 def test_write_read_multiextensionfits_uncertainty_default(
-        ccd_data, tmpdir, uncertainty_type):
+        tmpdir, uncertainty_type):
     # Test that if a uncertainty is present it is saved and loaded by default.
+    ccd_data = create_ccd_data()
     ccd_data.uncertainty = uncertainty_type(ccd_data.data * 10)
     filename = tmpdir.join('afile.fits').strpath
     ccd_data.write(filename)
@@ -885,8 +878,9 @@ def test_write_read_multiextensionfits_uncertainty_default(
     'uncertainty_type',
     [StdDevUncertainty, VarianceUncertainty, InverseVariance])
 def test_write_read_multiextensionfits_uncertainty_different_uncertainty_key(
-        ccd_data, tmpdir, uncertainty_type):
+        tmpdir, uncertainty_type):
     # Test that if a uncertainty is present it is saved and loaded by default.
+    ccd_data = create_ccd_data()
     ccd_data.uncertainty = uncertainty_type(ccd_data.data * 10)
     filename = tmpdir.join('afile.fits').strpath
     ccd_data.write(filename, key_uncertainty_type='Blah')
@@ -897,8 +891,9 @@ def test_write_read_multiextensionfits_uncertainty_different_uncertainty_key(
                                   ccd_after.uncertainty.array)
 
 
-def test_write_read_multiextensionfits_not(ccd_data, tmpdir):
+def test_write_read_multiextensionfits_not(tmpdir):
     # Test that writing mask and uncertainty can be disabled
+    ccd_data = create_ccd_data()
     ccd_data.mask = ccd_data.data > 10
     ccd_data.uncertainty = StdDevUncertainty(ccd_data.data * 10)
     filename = tmpdir.join('afile.fits').strpath
@@ -908,8 +903,9 @@ def test_write_read_multiextensionfits_not(ccd_data, tmpdir):
     assert ccd_after.mask is None
 
 
-def test_write_read_multiextensionfits_custom_ext_names(ccd_data, tmpdir):
+def test_write_read_multiextensionfits_custom_ext_names(tmpdir):
     # Test writing mask, uncertainty in another extension than default
+    ccd_data = create_ccd_data()
     ccd_data.mask = ccd_data.data > 10
     ccd_data.uncertainty = StdDevUncertainty(ccd_data.data * 10)
     filename = tmpdir.join('afile.fits').strpath
@@ -957,13 +953,15 @@ def test_read_old_style_multiextensionfits(tmpdir):
     assert isinstance(ccd.uncertainty, StdDevUncertainty)
 
 
-def test_wcs(ccd_data):
+def test_wcs():
+    ccd_data = create_ccd_data()
     ccd_data.wcs = 5
     assert ccd_data.wcs == 5
 
 
-def test_recognized_fits_formats_for_read_write(ccd_data, tmpdir):
+def test_recognized_fits_formats_for_read_write(tmpdir):
     # These are the extensions that are supposed to be supported.
+    ccd_data = create_ccd_data()
     supported_extensions = ['fit', 'fits', 'fts']
 
     for ext in supported_extensions:


### PR DESCRIPTION
Fixes #8879

This removes the `ccd_data` fixture entirely and replaces it with a helper function.

After investigating the code I found that caching or memoizing the function doesn't really make sense because the returned value is sometimes modified. But since almost all code used the same size I decided to just generate the array once and then use a copy of that in the `create_ccd_data` function.

Probably not perfect but at least the fixture should be removed. Is there some additional code somewhere in the test-setup that references the fixture? I checked `conftest` and the `__init__.py` files but maybe I forgot something?