### PR TITLE
Removing numpy prerelease test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -131,11 +131,6 @@ matrix:
                MATPLOTLIB_VERSION=2.1
                EVENT_TYPE='push pull_request cron'
 
-        # Try pre-release version of Numpy without optional dependencies
-        - os: linux
-          env: NUMPY_VERSION=prerelease
-               EVENT_TYPE='push pull_request cron'
-
         # Do a PEP8/pyflakes test with flake8
         - os: linux
           stage: Initial tests


### PR DESCRIPTION
Since this was added years ago we've switched to test against numpy dev, imo no need to run the 2+ min job that most of the time does nothing for all commits when we already test against latest and greatest numpy master branch.

Merge if @mhvk is happy with the idea.

