### PR TITLE
Fix crash loading WCS from headers with duplicate SIP keywords.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -249,7 +249,6 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
-- Fixed a crash while loading a WCS from headers containing duplicate SIP keywords. [#8893]
 
 Other Changes and Additions
 ---------------------------
@@ -338,6 +337,8 @@ astropy.visualization
 
 astropy.wcs
 ^^^^^^^^^^^
+
+- Fixed a crash while loading a WCS from headers containing duplicate SIP keywords. [#8893]
 
 
 Other Changes and Additions

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -249,6 +249,8 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fixed a crash while loading a WCS from headers containing duplicate SIP keywords. [#8893]
+
 Other Changes and Additions
 ---------------------------
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -1000,7 +1000,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         """
         # Never pass SIP coefficients to wcslib
         # CTYPE must be passed with -SIP to wcslib
-        for key in (m.group() for m in map(SIP_KW.match, list(header))
+        for key in set(m.group() for m in map(SIP_KW.match, list(header))
                     if m is not None):
             del header[key]
 


### PR DESCRIPTION
Proposed here changes fix a crash when loading WCS from headers containing duplicate SIP coefficients. The fix consists in using `set` to get only unique keywords.