### PR TITLE
Quantity __array_function__ support for histograms, arraysetops functions and apply_{along, over}_axis

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -135,9 +135,6 @@ IGNORED_FUNCTIONS = {
     # Polynomials
     np.poly, np.polyadd, np.polyder, np.polydiv, np.polyfit, np.polyint,
     np.polymul, np.polysub, np.polyval, np.roots, np.vander,
-    # setops
-    np.in1d, np.intersect1d, np.isin, np.setdiff1d,
-    np.setxor1d, np.union1d, np.unique,
     # financial
     np.fv, np.ipmt, np.irr, np.mirr, np.nper, np.npv, np.pmt, np.ppmt,
     np.pv, np.rate}
@@ -770,3 +767,38 @@ def interp(x, xp, fp, *args, **kwargs):
         unit = None
 
     return (x, xp, fp) + args, kwargs, unit, None
+
+
+@function_helper
+def unique(ar, return_index=False, return_inverse=False,
+           return_counts=False, axis=None):
+    unit = ar.unit
+    n_index = sum(bool(i) for i in
+                  (return_index, return_inverse, return_counts))
+    if n_index:
+        unit = [unit] + n_index * [None]
+
+    return (ar.value, return_index, return_inverse, return_counts,
+            axis), {}, unit, None
+
+
+@function_helper
+def intersect1d(ar1, ar2, assume_unique=False, return_indices=False):
+    (ar1, ar2), unit = _quantities2arrays(ar1, ar2)
+    if return_indices:
+        unit = [unit, None, None]
+    return (ar1, ar2, assume_unique, return_indices), {}, unit, None
+
+
+@function_helper(helps=(np.setxor1d, np.union1d, np.setdiff1d))
+def twosetop(ar1, ar2, *args, **kwargs):
+    (ar1, ar2), unit = _quantities2arrays(ar1, ar2)
+    return (ar1, ar2) + args, kwargs, unit, None
+
+
+@function_helper(helps=(np.isin, np.in1d))
+def setcheckop(ar1, ar2, *args, **kwargs):
+    # This tests whether ar1 is in ar2, so we should change the unit of
+    # a1 to that of a2.
+    (ar2, ar1), unit = _quantities2arrays(ar2, ar1)
+    return (ar1, ar2) + args, kwargs, None, None

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -91,7 +91,8 @@ SUBCLASS_SAFE_FUNCTIONS |= {
     np.sort, np.msort, np.partition, np.meshgrid,
     np.common_type, np.result_type, np.can_cast, np.min_scalar_type,
     np.iscomplexobj, np.isrealobj,
-    np.shares_memory, np.may_share_memory}
+    np.shares_memory, np.may_share_memory,
+    np.apply_along_axis}
 
 if not NUMPY_LT_1_15:
     SUBCLASS_SAFE_FUNCTIONS |= {np.take_along_axis, np.put_along_axis}
@@ -114,7 +115,7 @@ SUBCLASS_SAFE_FUNCTIONS |= {
 
 # TODO: could be supported but need work & thought.
 UNSUPPORTED_FUNCTIONS |= {
-    np.apply_along_axis, np.apply_over_axes}
+    np.apply_over_axes}
 
 # Nonsensical for quantities.
 UNSUPPORTED_FUNCTIONS |= {

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -224,6 +224,13 @@ class TestAlongAxis(BasicTestSetup):
         expected = expected * q.unit
         assert np.all(q == expected)
 
+    @pytest.mark.parametrize('axis', (0, 1))
+    def test_apply_along_axis(self, axis):
+        out = np.apply_along_axis(np.square, axis, self.q)
+        expected = np.apply_along_axis(np.square, axis,
+                                       self.q.value) * self.q.unit ** 2
+        assert_array_equal(out, expected)
+
 
 class TestIndicesFrom(NoUnitTestSetup):
     def test_diag_indices_from(self):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -231,6 +231,18 @@ class TestAlongAxis(BasicTestSetup):
                                        self.q.value) * self.q.unit ** 2
         assert_array_equal(out, expected)
 
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
+    @pytest.mark.parametrize('axes', ((1,), (0,), (0, 1)))
+    def test_apply_over_axes(self, axes):
+        def function(x, axis):
+            return np.sum(np.square(x), axis)
+
+        out = np.apply_over_axes(function, self.q, axes)
+        expected = np.apply_over_axes(function, self.q.value, axes)
+        expected = expected * self.q.unit ** (2 * len(axes))
+        assert_array_equal(out, expected)
+
 
 class TestIndicesFrom(NoUnitTestSetup):
     def test_diag_indices_from(self):
@@ -1734,9 +1746,7 @@ untested_functions |= poly_functions
                    reason="no __array_function__ wrapping in numpy<1.17")
 def test_testing_completeness():
     assert not CoverageMeta.covered.intersection(untested_functions)
-    assert all_wrapped == (CoverageMeta.covered |
-                           should_be_tested_functions |
-                           untested_functions)
+    assert all_wrapped == (CoverageMeta.covered | untested_functions)
 
 
 class TestFunctionHelpersCompleteness:


### PR DESCRIPTION
fixes the regression noted by @StanczakDominik in https://github.com/astropy/astropy/issues/8825#issuecomment-504402818

It is not completely clear how useful set operators are for multi-argument functions where units are converted, but I decided to include them anyway. User beware and all that.

~Note that this includes #8884 and #8894 since otherwise I get failures. Just look at the ~last~ third-but-last commit only.~

EDIT: I now also included coverage for the unrelated `np.apply_along_axis` (which worked anyway) and `np.apply_over_axes` - I did not want to make yet another PR on top of this stack of three...
EDIT: now includes updates also for histograms, so all the additions are together.