### PR TITLE
Fix edge-case bugs in overlap slices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2308,6 +2308,14 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Fixed a bug in ``overlap_slices`` where the ``"strict"`` mode was
+  too strict for a small array along the upper edge of the large array.
+  [#8901]
+
+- Fixed a bug in ``overlap_slices`` where a ``NoOverlapError`` would
+  be incorrectly raised for a 0-shaped small array at the origin.
+  [#8901]
+
 astropy.stats
 ^^^^^^^^^^^^^
 

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -102,7 +102,7 @@ def overlap_slices(large_array_shape, small_array_shape, position,
                    for (pos, small_shape) in zip(position, small_array_shape)]
 
     for e_max in indices_max:
-        if e_max <= 0:
+        if e_max < 0:
             raise NoOverlapError('Arrays do not overlap.')
     for e_min, large_shape in zip(indices_min, large_array_shape):
         if e_min >= large_shape:
@@ -113,7 +113,7 @@ def overlap_slices(large_array_shape, small_array_shape, position,
             if e_min < 0:
                 raise PartialOverlapError('Arrays overlap only partially.')
         for e_max, large_shape in zip(indices_max, large_array_shape):
-            if e_max >= large_shape:
+            if e_max > large_shape:
                 raise PartialOverlapError('Arrays overlap only partially.')
 
     # Set up slices


### PR DESCRIPTION
This PR fixes two related edge-case bugs in `overlap_slices`:

```python
>>> from astropy.nddata import overlap_slices
>>> slc1, slc2 = overlap_slices((10, 10), (3, 3), (8, 8))
>>> slc1
(slice(7, 10, None), slice(7, 10, None))
>>> data = np.ones((10, 10))
>>> data[slc1]
array([[1., 1., 1.],
       [1., 1., 1.],
       [1., 1., 1.]])

>>> slc1, slc2 = overlap_slices((10, 10), (3, 3), (8, 8), mode='strict')
PartialOverlapError: Arrays overlap only partially.
```
The `PartialOverlapError` is incorrect because the arrays fully overlap as seen in the example without `mode='strict'`.

The second related bug concerns small arrays shaped as `(0, 0)` at the origin:

```python
>>> overlap_slices((10, 10), (0, 0), (5, 5))
((slice(5, 5, None), slice(5, 5, None)),
 (slice(0, 0, None), slice(0, 0, None)))

>>> overlap_slices((10, 10), (0, 0), (0, 0))
NoOverlapError: Arrays do not overlap.
```

Instead, the last example should return:
```
((slice(0, 0, None), slice(0, 0, None)),
 (slice(0, 0, None), slice(0, 0, None)))
```