### PR TITLE
Simplify and speed up Table replace_column()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Improved the implementation of ``Table.replace_column()`` to provide
+  a speed-up of 5-10 times for wide tables. [#8902]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -835,16 +835,16 @@ class Table:
             return
 
         cols = []
-        def_names = _auto_names(n_cols)
+        default_names = _auto_names(n_cols)
 
-        for col, name, def_name, dtype in zip(data, names, def_names, dtype):
-            col = self._convert_data_to_col(col, copy, def_name, dtype, name)
+        for col, name, default_name, dtype in zip(data, names, default_names, dtype):
+            col = self._convert_data_to_col(col, copy, default_name, dtype, name)
 
             cols.append(col)
 
         self._init_from_cols(cols)
 
-    def _convert_data_to_col(self, data, copy=True, def_name=None, dtype=None, name=None):
+    def _convert_data_to_col(self, data, copy=True, default_name=None, dtype=None, name=None):
         """
         Convert any allowed sequence data ``col`` to a column object that can be used
         directly in the self.columns dict.  This could be a Column, MaskedColumn,
@@ -870,7 +870,7 @@ class Table:
             Input column data
         copy : bool
             Make a copy
-        def_name : str
+        default_name : str
             Default name
         dtype : np.dtype or None
             Data dtype
@@ -890,13 +890,14 @@ class Table:
 
         # Get the final column name using precedence.  Some objects may not
         # have an info attribute.
-        if hasattr(data, 'info'):
-            name = name or data.info.name or def_name
-        else:
-            name = name or def_name
+        if name is None:
+            if hasattr(data, 'info'):
+                name = data.info.name or default_name
+            else:
+                name = default_name
 
         if isinstance(data, Column):
-            # If col is a subclass of self.ColumnClass, then "upgrade" to ColumnClass,
+            # If self.ColumnClass is a subclass of col, then "upgrade" to ColumnClass,
             # otherwise just use the original class.  The most common case is a
             # table with masked=True and ColumnClass=MaskedColumn.  Then a Column
             # gets upgraded to MaskedColumn, but the converse (pre-4.0) behavior

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -908,15 +908,12 @@ class Table:
             else:
                 col_cls = data.__class__
 
-            col = col_cls(name=name, data=data, dtype=dtype,
-                          copy=copy, copy_indices=self._init_indices)
-
         elif self._is_mixin_for_table(data):
             # Copy the mixin column attributes if they exist since the copy below
             # may not get this attribute.
             col = col_copy(data, copy_indices=self._init_indices) if copy else data
-
             col.info.name = name
+            return col
 
         elif isinstance(data, np.ma.MaskedArray):
             # Require that col_cls be a subclass of MaskedColumn, remembering
@@ -925,17 +922,16 @@ class Table:
             col_cls = (self.ColumnClass
                        if issubclass(self.ColumnClass, self.MaskedColumn)
                        else self.MaskedColumn)
-            col = col_cls(name=name, data=data, dtype=dtype,
-                          copy=copy, copy_indices=self._init_indices)
 
         elif isinstance(data, np.ndarray) or isiterable(data):
-            col = self.ColumnClass(name=name, data=data, dtype=dtype,
-                                   copy=copy, copy_indices=self._init_indices)
+            col_cls = self.ColumnClass
 
         else:
             raise ValueError('Elements in list initialization must be '
                              'either Column or list-like')
 
+        col = col_cls(name=name, data=data, dtype=dtype,
+                      copy=copy, copy_indices=self._init_indices)
         return col
 
     def _init_from_ndarray(self, data, names, dtype, n_cols, copy):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -50,8 +50,12 @@ Things to remember:
   an object into the columns dict since an existing column may
   be part of another Table and have parent_table set to point at that
   table.  Dropping that column into `columns` of this Table will cause
-  a problem for the old one so it needs to be copied.  Currently
-  replace_column is always making a copy
+  a problem for the old one so the column object needs to be copied (but
+  not necessarily the data).
+
+  Currently replace_column is always making a copy of both object and
+  data if parent_table is set.  This could be improved but requires a
+  generic way to copy a mixin object but not the data.
 
 - Be aware of column objects that have indices set.
 """
@@ -842,9 +846,17 @@ class Table:
 
         The final column name is determined by::
 
-          name or data.info.name or def_name
+            name or data.info.name or def_name
 
         If ``data`` has no ``info`` then ``name = name or def_name``.
+
+        The behavior of ``copy`` for Column objects is:
+        - copy=True: new class instance with a copy of data and deep copy of meta
+        - copy=False: new class instance with same data and a key-only copy of meta
+
+        For mixin columns:
+        - copy=True: new class instance with copy of data and deep copy of meta
+        - copy=False: original instance (no copy at all)
 
         Parameters
         ----------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -890,7 +890,7 @@ class Table:
 
         # Get the final column name using precedence.  Some objects may not
         # have an info attribute.
-        if name is None:
+        if not name:
             if hasattr(data, 'info'):
                 name = data.info.name or default_name
             else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2011,7 +2011,9 @@ class Table:
         col = self._convert_data_to_col(col, name=name, copy=copy)
         self._set_col_parent_table_and_mask(col)
 
-        if len(col) != len(self[name]):
+        # Ensure that new column is the right length, unless it is the only column
+        # in which case re-sizing is allowed.
+        if len(self.columns) > 1 and len(col) != len(self[name]):
             raise ValueError('length of new column must match table length')
 
         self.columns._setitem_validated(name, col)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1997,6 +1997,14 @@ class Table:
         """
         Replace column ``name`` with the new ``col`` object.
 
+        The behavior of ``copy`` for Column objects is:
+        - copy=True: new class instance with a copy of data and deep copy of meta
+        - copy=False: new class instance with same data and a key-only copy of meta
+
+        For mixin columns:
+        - copy=True: new class instance with copy of data and deep copy of meta
+        - copy=False: original instance (no copy at all)
+
         Parameters
         ----------
         name : str

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1981,7 +1981,7 @@ class Table:
                        .format(name, changed_attrs))
                 warnings.warn(msg, TableReplaceWarning, stacklevel=3)
 
-    def replace_column(self, name, col):
+    def replace_column(self, name, col, copy=True):
         """
         Replace column ``name`` with the new ``col`` object.
 
@@ -1991,6 +1991,8 @@ class Table:
             Name of column to replace
         col : column object (list, ndarray, Column, etc)
             New column object to replace the existing column
+        copy : bool
+            Make copy of the input ``col``, default=True
 
         Examples
         --------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -33,6 +33,28 @@ from .connect import TableRead, TableWrite
 from . import conf
 
 
+_implementation_notes = """
+This string has informal notes concerning Table implementation for developers.
+
+Things to remember:
+
+- Table has customizable attributes ColumnClass, Column, MaskedColumn.
+  Table.Column is normally just column.Column (same w/ MaskedColumn)
+  but in theory they can be different.  Table.ColumnClass is the default
+  class used to create new non-mixin columns, and this is a function of
+  the Table.masked attribute.  Column creation / manipulation in a Table
+  needs to respect these.
+
+- Column objects that get inserted into the Table.columns attribute must
+  have the info.parent_table attribute set correctly.  Beware just dropping
+  an object into the columns dict.  Be aware that an existing column may
+  be part of another Table and have parent_table set to point at that
+  table.  Dropping that column into `columns` of this Table will cause
+  a problem for the old one so it needs to be copied.
+
+- Be aware of column objects that have indices set.
+"""
+
 __doctest_skip__ = ['Table.read', 'Table.write', 'Table._read',
                     'Table.convert_bytestring_to_unicode',
                     'Table.convert_unicode_to_bytestring',
@@ -794,7 +816,7 @@ class Table:
         return
 
     def _init_from_list(self, data, names, dtype, n_cols, copy):
-        """Initialize table from a list of columns.  A column can be a
+        """Initialize table from a list of column data.  A column can be a
         Column object, np.ndarray, mixin, or any other iterable object.
         """
         if data and all(isinstance(row, dict) for row in data):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -879,7 +879,7 @@ class Table:
         # Structured ndarray gets viewed as a mixin unless already a valid
         # mixin class
         if (isinstance(data, np.ndarray) and len(data.dtype) > 1 and
-                not self._add_as_mixin_column(data)):
+                not self._is_mixin_for_table(data)):
             data = data.view(NdarrayMixin)
 
         # Get the final column name using precedence.  Some objects may not
@@ -904,7 +904,7 @@ class Table:
             col = col_cls(name=name, data=data, dtype=dtype,
                           copy=copy, copy_indices=self._init_indices)
 
-        elif self._add_as_mixin_column(data):
+        elif self._is_mixin_for_table(data):
             # Copy the mixin column attributes if they exist since the copy below
             # may not get this attribute.
             col = col_copy(data, copy_indices=self._init_indices) if copy else data
@@ -1154,7 +1154,7 @@ class Table:
         else:
             return False
 
-    def _add_as_mixin_column(self, col):
+    def _is_mixin_for_table(self, col):
         """
         Determine if ``col`` should be added to the table directly as
         a mixin column.
@@ -1490,13 +1490,13 @@ class Table:
             NewColumn = self.MaskedColumn if self.masked else self.Column
             # If value doesn't have a dtype and won't be added as a mixin then
             # convert to a numpy array.
-            if not hasattr(value, 'dtype') and not self._add_as_mixin_column(value):
+            if not hasattr(value, 'dtype') and not self._is_mixin_for_table(value):
                 value = np.asarray(value)
 
             # Structured ndarray gets viewed as a mixin (unless already a valid
             # mixin class).
             if (isinstance(value, np.ndarray) and len(value.dtype) > 1 and
-                    not self._add_as_mixin_column(value)):
+                    not self._is_mixin_for_table(value)):
                 value = value.view(NdarrayMixin)
 
             # Make new column and assign the value.  If the table currently
@@ -1508,7 +1508,7 @@ class Table:
             # = 1.
             name = item
             # If this is a column-like object that could be added directly to table
-            if isinstance(value, BaseColumn) or self._add_as_mixin_column(value):
+            if isinstance(value, BaseColumn) or self._is_mixin_for_table(value):
                 # If we're setting a new column to a scalar, broadcast it.
                 # (things will fail in _init_from_cols if this doesn't work)
                 if (len(self) > 0 and (getattr(value, 'isscalar', False) or
@@ -3200,7 +3200,7 @@ class QTable(Table):
 
     """
 
-    def _add_as_mixin_column(self, col):
+    def _is_mixin_for_table(self, col):
         """
         Determine if ``col`` should be added to the table directly as
         a mixin column.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -12,6 +12,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.io import fits
+from astropy.table import Table
 from astropy.tests.helper import (assert_follows_unicode_guidelines,
                                   ignore_warnings, catch_warnings)
 
@@ -1910,6 +1911,12 @@ class TestReplaceColumn(SetupData):
             assert t['a'].meta == {}
             assert t['a'].format is None
 
+        # Special case: replacing the only column can resize table
+        del t['b']
+        assert len(t) == 3
+        t['a'] = [1, 2]
+        assert len(t) == 2
+
     def test_replace_index_column(self, table_types):
         """Replace index column and generate expected exception"""
         self._setup(table_types)
@@ -1920,6 +1927,13 @@ class TestReplaceColumn(SetupData):
             t.replace_column('a', [1, 2, 3])
         assert err.value.args[0] == 'cannot replace a table index column'
 
+    def test_replace_column_no_copy(self):
+        t = Table([[1, 2], [3, 4]], names=['a', 'b'])
+        a = np.array([1.5, 2.5])
+        t.replace_column('a', a, copy=False)
+        assert t['a'][0] == a[0]
+        t['a'][0] = 10
+        assert t['a'][0] == a[0]
 
 class Test__Astropy_Table__():
     """

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1935,6 +1935,7 @@ class TestReplaceColumn(SetupData):
         t['a'][0] = 10
         assert t['a'][0] == a[0]
 
+
 class Test__Astropy_Table__():
     """
     Test initializing a Table subclass from a table-like object that

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1886,6 +1886,10 @@ class TestReplaceColumn(SetupData):
         with pytest.raises(ValueError):
             t.replace_column('not there', [1, 2, 3])
 
+        with pytest.raises(ValueError) as exc:
+            t.replace_column('a', [1, 2])
+        assert "length of new column must match table length" in str(exc)
+
     def test_replace_column(self, table_types):
         """Replace existing column with a new column"""
         self._setup(table_types)


### PR DESCRIPTION
This builds on #8789 to simplify and speed up replacing a column.  The speed up is about a factor of 8 for a simple table with 20 columns (e.g. from 420 us to 54 us).

Along the way it adds a new internal method that factors out the whole processing of turning arbitrary sequence data into something suitable for inclusion in the columns dict.  This is independently a good thing and will see more use beyond this PR.

Once #8789 is merged I will rebase and the diffs here will clean up.

It will also supercede #8702 as a fix for #8642.

Closes #8702 
Fixes #8642 
