### PR TITLE
Take into account units for comparisons between Column and Quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,6 +313,10 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Comparisons between ``Column`` instances and ``Quantity`` will now
+  correctly take into account the unit (as was already the case for
+  regular operations such as addition). [#8904]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -971,6 +971,7 @@ class Column(BaseColumn):
             # future numpy versions will do so.  NUMPY_LT_1_13 to get the
             # attention of future maintainers to check (by deleting or versioning
             # the if block below).  See #6899 discussion.
+            # 2019-06-21: still needed with numpy 1.16.
             if (isinstance(self, MaskedColumn) and self.dtype.kind == 'U' and
                     isinstance(other, MaskedColumn) and other.dtype.kind == 'S'):
                 self, other = other, self
@@ -978,7 +979,11 @@ class Column(BaseColumn):
 
             if self.dtype.char == 'S':
                 other = self._encode_str(other)
-            return getattr(self.data, op)(other)
+
+            # Now just let the regular ndarray.__eq__, etc., take over.
+            result = getattr(super(), op)(other)
+            # But we should not return Column instances for this case.
+            return result.data if isinstance(result, Column) else result
 
         return _compare
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -152,6 +152,16 @@ class TestColumn():
         assert np.all(c.data == np.array([100, 200, 300]))
         assert np.all(c.unit == u.cm)
 
+    def test_quantity_comparison(self, Column):
+        # regression test for gh-6532
+        c = Column([1, 2100, 3], unit='Hz')
+        q = 2 * u.kHz
+        check = c < q
+        assert np.all(check == [True, False, True])
+        # This already worked, but just in case.
+        check = q >= c
+        assert np.all(check == [True, False, True])
+
     def test_attrs_survive_getitem_after_change(self, Column):
         """
         Test for issue #3023: when calling getitem with a MaskedArray subclass


### PR DESCRIPTION
This was already the case for regular operations such as addition.

fixes #6532