### PR TITLE
Refactor: Use explicit keyword argument instead of popping it of the catch-all kwargs

### DIFF
--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -107,8 +107,7 @@ class TableWrite(registry.UnifiedReadWrite):
     def __init__(self, instance, cls):
         super().__init__(instance, cls, 'write')
 
-    def __call__(self, *args, **kwargs):
-        serialize_method = kwargs.pop('serialize_method', None)
+    def __call__(self, *args, serialize_method=None, **kwargs):
         instance = self._instance
         with serialize_method_as(instance, serialize_method):
             registry.write(instance, *args, **kwargs)


### PR DESCRIPTION
Not sure if this is something that has been missed when we removed the Python 2 support. But I think it's much clearer to use an explicit keyword-argument instead of the generic `**kwargs`.