### PR TITLE
Only create unit from the columns unit if the to_string worked.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,6 +313,9 @@ astropy.io.fits
 - Fixes bug where an invalid TRPOS<n> keyword was being generated for FITS
   time column when no location was available. [#8784]
 
+- Fixed a wrong exception when converting a Table with a unit that is not FITS
+  compliant and not convertible to a string using ``format='fits'``. [#8906]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -527,9 +527,10 @@ def table_to_hdu(table, character_as_bytes=False):
                 warnings.warn(
                     "The unit '{0}' could not be saved to FITS format".format(
                         unit.to_string()), AstropyUserWarning)
-
-            # Try creating a Unit to issue a warning if the unit is not FITS compliant
-            Unit(col.unit, format='fits', parse_strict='warn')
+            else:
+                # Try creating a Unit to issue a warning if the unit is not
+                # FITS compliant
+                Unit(col.unit, format='fits', parse_strict='warn')
 
     # Column-specific override keywords for coordinate columns
     coord_meta = table.meta.pop('__coordinate_columns__', {})

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -113,6 +113,17 @@ class TestSingleTable:
         assert t2['a'].unit == u.m
         assert t2['c'].unit == u.km / u.s
 
+    def test_with_custom_units(self, tmpdir):
+        filename = str(tmpdir.join('test_with_units.fits'))
+        t1 = QTable(self.data)
+        bandpass_sol_lum = u.def_unit('bandpass_sol_lum')
+        with u.add_enabled_units(bandpass_sol_lum):
+            t1['a'].unit = bandpass_sol_lum
+            t1.write(filename, overwrite=True)
+            t2 = QTable.read(filename)
+            assert equal_data(t1, t2)
+            assert t2['a'].unit == bandpass_sol_lum
+
     @pytest.mark.parametrize('table_type', (Table, QTable))
     def test_with_format(self, table_type, tmpdir):
         filename = str(tmpdir.join('test_with_format.fits'))

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -113,17 +113,6 @@ class TestSingleTable:
         assert t2['a'].unit == u.m
         assert t2['c'].unit == u.km / u.s
 
-    def test_with_custom_units(self, tmpdir):
-        filename = str(tmpdir.join('test_with_units.fits'))
-        t1 = QTable(self.data)
-        bandpass_sol_lum = u.def_unit('bandpass_sol_lum')
-        with u.add_enabled_units(bandpass_sol_lum):
-            t1['a'].unit = bandpass_sol_lum
-            t1.write(filename, overwrite=True)
-            t2 = QTable.read(filename)
-            assert equal_data(t1, t2)
-            assert t2['a'].unit == bandpass_sol_lum
-
     @pytest.mark.parametrize('table_type', (Table, QTable))
     def test_with_format(self, table_type, tmpdir):
         filename = str(tmpdir.join('test_with_format.fits'))

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 
 from astropy.io import fits
+from astropy import units as u
 from astropy.table import Table
 from astropy.io.fits import printdiff
 from astropy.tests.helper import catch_warnings
@@ -64,6 +65,16 @@ class TestConvenience(FitsTestCase):
         assert isinstance(hdu, fits.BinTableHDU)
         filename = self.temp('test_table_to_hdu.fits')
         hdu.writeto(filename, overwrite=True)
+
+    def test_table_non_stringifyable_unit_to_hdu(self):
+        table = Table([[1, 2, 3], ['a', 'b', 'c'], [2.3, 4.5, 6.7]],
+                      names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])
+        table['a'].unit = u.core.IrreducibleUnit("test")
+
+        with catch_warnings() as w:
+            fits.table_to_hdu(table)
+            assert len(w) == 1
+            assert str(w[0].message).startswith("The unit 'test' could not be saved to FITS format")
 
     def test_table_to_hdu_convert_comment_convention(self):
         """


### PR DESCRIPTION
Otherwise the unit would be None which would result in an unexpected
(and unnecessary) Exception.

Related: #8897

I'm not sure how much this actually fixes, however since `col.unit` is always `None` in case the `try` block fails - but it seems to make sense only to do the `Unit` call when it succeeded.

