### PR TITLE
Correctly handle masking in add_row() after #8789

### DIFF
--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -647,6 +647,10 @@ class BaseColumnInfo(DataInfo):
             raise TableMergeError('columns have different shapes')
         out['shape'] = uniq_shapes.pop()
 
+        # "Merged" output name is the supplied name
+        if name is not None:
+            out['name'] = name
+
         return out
 
 


### PR DESCRIPTION
I noticed that `add_row()` was not updated correctly handle the Table mask behavior change in #8789.  In particular it was setting the whole Table to be masked if a column became masked, except that the new `_set_masked()` method is not really doing that job any more.

This is basically a follow-on to #8789 and only affects dev, hence no change log entry required.

The change in `data_info.py` is a little out of scope, but this is basically fixing an issue where `insert` in a mixin column would return an object without `info.name` set correctly (at least for `Time`, it seems to be OK for `Quantity` which I did not totally understand).  This was being handled by `add_row()`, but I think it's better to put this into the lower level behavior.  I think this issue about `insert` is so obscure that it does not warrant a change log entry, but if anyone objects I can do that.

OK, it fixes another (never-before-reported and obscure) bug:
```
In [3]: tm = Time([1], format='cxcsec')
In [4]: t = Table([tm])
In [5]: t.add_row((tm,), mask=(True,))  # this should work!
INFO: Upgrading Table to masked Table. Use Table.filled() to convert to unmasked table. [astropy.table.table]
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
~/miniconda3/lib/python3.6/site-packages/astropy/table/table.py in insert_row(self, index, vals, mask)
   2514                     if self.masked:
-> 2515                         newcol.mask = FalseArray(newcol.shape)
   2516 

AttributeError: can't set attribute
```
