### PR TITLE
Removed deprecated funcsigs and futures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Removed deprecated ``funcsigs`` and ``futures`` from
+  ``astropy.utils.compat``. [#8909]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/compat/funcsigs.py
+++ b/astropy/utils/compat/funcsigs.py
@@ -1,9 +1,0 @@
-from inspect import signature, Parameter, Signature, BoundArguments
-
-__all__ = ['BoundArguments', 'Parameter', 'Signature', 'signature']
-
-import warnings
-from astropy.utils.exceptions import AstropyDeprecationWarning
-
-warnings.warn("astropy.utils.compat.funcsigs is now deprecated - "
-              "use inspect instead", AstropyDeprecationWarning)

--- a/astropy/utils/compat/futures/__init__.py
+++ b/astropy/utils/compat/futures/__init__.py
@@ -1,7 +1,0 @@
-from concurrent.futures import *
-
-import warnings
-from astropy.utils.exceptions import AstropyDeprecationWarning
-
-warnings.warn("astropy.utils.compat.futures is now deprecated - "
-              "use concurrent.futures instead", AstropyDeprecationWarning)

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ show-response = 1
 [tool:pytest]
 minversion = 3.1
 testpaths = "astropy" "docs"
-norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern" "astropy[\/]utils[\/]compat[\/]futures"
+norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern"
 doctest_plus = enabled
 open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true


### PR DESCRIPTION
These has been deprecated in 3.0 as part of the Python2 removal.

Addressing part of #8888