### PR TITLE
Add BITPIX=64 to doc

### DIFF
--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -22,6 +22,7 @@ BITPIX values in FITS images and the numpy data types:
     8         numpy.uint8 (note it is UNsigned integer)
     16        numpy.int16
     32        numpy.int32
+    64        numpy.int64
     -32       numpy.float32
     -64       numpy.float64
 


### PR DESCRIPTION
`BITPIX=64` is supported but not documented in the table. This PR documents it.

https://github.com/astropy/astropy/blob/17c635af2ca87b8ede081e1b1f2271c0d8baab95/astropy/io/fits/hdu/base.py#L34-L35