### PR TITLE
TST: Skip cat test on Windows

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1040,7 +1040,7 @@ class TestHDUListFunctions(FitsTestCase):
             assert len(hdul) == 5
             assert hdu_popped is hdu1
 
-    # Skip due to ttps://github.com/astropy/astropy/issues/8916
+    # Skip due to https://github.com/astropy/astropy/issues/8916
     @pytest.mark.skipif('sys.platform.startswith("win32")')
     def test_write_hdulist_to_stream(self):
         """

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1040,12 +1040,14 @@ class TestHDUListFunctions(FitsTestCase):
             assert len(hdul) == 5
             assert hdu_popped is hdu1
 
+    # Skip due to ttps://github.com/astropy/astropy/issues/8916
+    @pytest.mark.skipif('sys.platform.startswith("win32")')
     def test_write_hdulist_to_stream(self):
         """
         Unit test for https://github.com/astropy/astropy/issues/7435
-        Ensure that an HDUList can be written to a stream in Python 2
+        to ensure that an HDUList can be written to a stream.
         """
-        data = np.array([[1,2,3],[4,5,6]])
+        data = np.array([[1, 2, 3], [4, 5, 6]])
         hdu = fits.PrimaryHDU(data)
         hdulist = fits.HDUList([hdu])
 


### PR DESCRIPTION
Fix #8916 . This also means that #7435 is no longer tested on Appveyor though it had not failed before. Unless we can find out how to check if `cat` is available without introducing complexity to the test, this will have to do.

😼 