### PR TITLE
Bug fixes in WCSAxes.plot_coord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -569,6 +569,7 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Silence numpy runtime warnings in ``WCSAxes`` when drawing grids. [#8882]
+- Fix incorrect transformation behavior in ``WCSAxes.plot_coord`` and correctly handle when input coordinates are not already in spherical representations. [#8927]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -569,7 +569,9 @@ astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
 - Silence numpy runtime warnings in ``WCSAxes`` when drawing grids. [#8882]
-- Fix incorrect transformation behavior in ``WCSAxes.plot_coord`` and correctly handle when input coordinates are not already in spherical representations. [#8927]
+- Fix incorrect transformation behavior in ``WCSAxes.plot_coord`` and correctly
+  handle when input coordinates are not already in spherical representations.
+  [#8927]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -10,6 +10,7 @@ from matplotlib.artist import Artist
 from matplotlib.axes import Axes, subplot_class_factory
 from matplotlib.transforms import Affine2D, Bbox, Transform
 
+import astropy.units as u
 from astropy.coordinates import SkyCoord, BaseCoordinateFrame
 from astropy.wcs import WCS
 
@@ -296,9 +297,9 @@ class WCSAxes(Axes):
             plot_data = []
             for coord in self.coords:
                 if coord.coord_type == 'longitude':
-                    plot_data.append(frame0.spherical.lon.to_value(coord.coord_unit))
+                    plot_data.append(frame0.spherical.lon.to_value(u.deg))
                 elif coord.coord_type == 'latitude':
-                    plot_data.append(frame0.spherical.lat.to_value(coord.coord_unit))
+                    plot_data.append(frame0.spherical.lat.to_value(u.deg))
                 else:
                     raise NotImplementedError("Coordinates cannot be plotted with this "
                                               "method because the WCS does not represent longitude/latitude.")

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -292,9 +292,9 @@ class WCSAxes(Axes):
             plot_data = []
             for coord in self.coords:
                 if coord.coord_type == 'longitude':
-                    plot_data.append(frame0.data.lon.to_value(coord.coord_unit))
+                    plot_data.append(frame0.spherical.lon.to_value(coord.coord_unit))
                 elif coord.coord_type == 'latitude':
-                    plot_data.append(frame0.data.lat.to_value(coord.coord_unit))
+                    plot_data.append(frame0.spherical.lat.to_value(coord.coord_unit))
                 else:
                     raise NotImplementedError("Coordinates cannot be plotted with this "
                                               "method because the WCS does not represent longitude/latitude.")

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -289,6 +289,10 @@ class WCSAxes(Axes):
             if isinstance(frame0, SkyCoord):
                 frame0 = frame0.frame
 
+            native_frame = self._transform_pixel2world.frame_out
+            # Transform to the native frame of the plot
+            frame0 = frame0.transform_to(native_frame)
+
             plot_data = []
             for coord in self.coords:
                 if coord.coord_type == 'longitude':
@@ -303,7 +307,7 @@ class WCSAxes(Axes):
                 raise TypeError("The 'transform' keyword argument is not allowed,"
                                 " as it is automatically determined by the input coordinate frame.")
 
-            transform = self.get_transform(frame0)
+            transform = self.get_transform(native_frame)
             kwargs.update({'transform': transform})
 
             args = tuple(plot_data) + args[1:]

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -313,7 +313,7 @@ class WCSAxes(Axes):
 
             args = tuple(plot_data) + args[1:]
 
-        super().plot(*args, **kwargs)
+        return super().plot(*args, **kwargs)
 
     def reset_wcs(self, wcs=None, slices=None, transform=None, coord_meta=None):
         """

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -152,17 +152,13 @@ class TestDisplayWorldCoordinate(BaseImageTests):
         string_pixel = ax._display_world_coords(0.523412, 0.523412)
         assert string_pixel == "0.523412 0.523412 (pixel)"
 
-    @pytest.mark.remote_data(source='astropy')
     def test_plot_coord_3d_transform(self):
-        filename = get_pkg_data_filename('galactic_center/gc_msx_e.fits')
-        wcs = WCS(filename)
-        data = fits.getdata(filename)
+        wcs = WCS(self.msx_header)
 
         coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame='galactocentric')
 
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1, projection=wcs)
-        ax.imshow(data)
         point, = ax.plot_coord(coord, 'ro')
 
         np.testing.assert_allclose(point.get_xydata()[0], [0, 0], atol=1e-4)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -1,21 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
-import pytest
+import matplotlib.lines
 import matplotlib.pyplot as plt
+import pytest
 from matplotlib import rc_context
 from matplotlib.patches import Circle, Rectangle
 
 import numpy as np
 
 from astropy import units as u
-from astropy.io import fits
-from astropy.wcs import WCS
 from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from astropy.visualization.wcsaxes import WCSAxes
 from astropy.visualization.wcsaxes.frame import EllipticalFrame
 from astropy.visualization.wcsaxes.patches import SphericalCircle
+from astropy.wcs import WCS
 
 from . import datasets
 
@@ -285,7 +286,11 @@ class TestBasic(BaseImageTests):
         ax.set_ylim(-0.5, 720.5)
 
         c = SkyCoord(266 * u.deg, -29 * u.deg)
-        ax.plot_coord(c, 'o')
+        lines = ax.plot_coord(c, 'o')
+
+        # Test that plot_coord returns the results from ax.plot
+        assert isinstance(lines, list)
+        assert isinstance(lines[0], matplotlib.lines.Line2D)
 
         # In previous versions, all angle axes defaulted to being displayed in
         # degrees. We now automatically show RA axes in hour angle units, but

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -2,22 +2,23 @@
 import os
 
 import pytest
-import numpy as np
-
 import matplotlib.pyplot as plt
-from matplotlib.patches import Circle, Rectangle
 from matplotlib import rc_context
+from matplotlib.patches import Circle, Rectangle
+
+import numpy as np
 
 from astropy import units as u
 from astropy.io import fits
 from astropy.wcs import WCS
+from astropy.utils.data import get_pkg_data_filename
 from astropy.coordinates import SkyCoord
-
-from astropy.visualization.wcsaxes.patches import SphericalCircle
-from astropy.visualization.wcsaxes import WCSAxes
-from . import datasets
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
+from astropy.visualization.wcsaxes import WCSAxes
 from astropy.visualization.wcsaxes.frame import EllipticalFrame
+from astropy.visualization.wcsaxes.patches import SphericalCircle
+
+from . import datasets
 
 
 class BaseImageTests:
@@ -742,4 +743,20 @@ class TestBasic(BaseImageTests):
         ax.coords[1].display_minor_ticks(True)
         ax.coords[1].tick_params(which='minor', length=6)
 
+        return fig
+
+    @pytest.mark.remote_data(source='astropy')
+    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                                   tolerance=0, style={})
+    def test_plot_coord_3d_transform(self):
+        filename = get_pkg_data_filename('galactic_center/gc_msx_e.fits')
+        wcs = WCS(filename)
+        data = fits.getdata(filename)
+
+        coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame='galactocentric')
+
+        fig = plt.figure()
+        ax = fig.add_subplot(1, 1, 1, projection=wcs)
+        ax.imshow(data)
+        ax.plot_coord(coord, 'ro')
         return fig

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -11,7 +11,6 @@ import numpy as np
 from astropy import units as u
 from astropy.io import fits
 from astropy.wcs import WCS
-from astropy.utils.data import get_pkg_data_filename
 from astropy.coordinates import SkyCoord
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from astropy.visualization.wcsaxes import WCSAxes
@@ -743,20 +742,4 @@ class TestBasic(BaseImageTests):
         ax.coords[1].display_minor_ticks(True)
         ax.coords[1].tick_params(which='minor', length=6)
 
-        return fig
-
-    @pytest.mark.remote_data(source='astropy')
-    @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
-                                   tolerance=0, style={})
-    def test_plot_coord_3d_transform(self):
-        filename = get_pkg_data_filename('galactic_center/gc_msx_e.fits')
-        wcs = WCS(filename)
-        data = fits.getdata(filename)
-
-        coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame='galactocentric')
-
-        fig = plt.figure()
-        ax = fig.add_subplot(1, 1, 1, projection=wcs)
-        ax.imshow(data)
-        ax.plot_coord(coord, 'ro')
         return fig

--- a/setup.cfg
+++ b/setup.cfg
@@ -126,4 +126,4 @@ known_numpy = numpy
 multi_line_output = 0
 balanced_wrapping = True
 include_trailing_comma = false
-length_sort = True
+length_sort_stdlib = true


### PR DESCRIPTION
This fixes two bugs in `plot_coord`:

1) It more correctly uses `.spherical` rather than `.data` to get `lon` and `lat`.
2) It does the frame transform on the input coordinate frame rather than relying on the matplotlib transforms later.

The latter is a fix because the matplotlib transforms are only ever two dimensional, and it should not be assumed that the input coordinate to `plot_coord` is two dimensional, as it can be in any frame transformable to the native frame of the plot.

I can't really think of a way to test this with just the astropy frames, if anyone has any suggestions of a transformation which would work in 3D but not 2D in astropy frames that would be great.

ping @ayshih 