### PR TITLE
Added regression test for setting unit and replacing column on timeseries

### DIFF
--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -44,6 +44,13 @@ class CommonTimeSeriesTests:
     def test_add_row(self):
         self.series.add_row(self._row)
 
+    def test_set_unit(self):
+        self.series['d'] = [1, 2, 3]
+        self.series['d'].unit = 's'
+
+    def test_replace_column(self):
+        self.series.replace_column('c', [1, 3, 4])
+
     def test_required_after_stacking(self):
         # When stacking, we have to temporarily relax the checking of the
         # columns in the time series, but we need to make sure that the


### PR DESCRIPTION
This is just a regression test for https://github.com/astropy/astropy/issues/8642 - I think this requires changes made in 4.0 to pass (e.g. https://github.com/astropy/astropy/pull/8902) so I think we'll just have to go with that and not bother about backporting a fix to 3.2.x.