### PR TITLE
Simplify and speed up table add_column(s)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,10 +62,19 @@ astropy.table
 ^^^^^^^^^^^^^
 
 - Improved the implementation of ``Table.replace_column()`` to provide
-  a speed-up of 5-10 times for wide tables. [#8902]
+  a speed-up of 5 to 10 times for wide tables.  The method can now accept
+  any input which convertible to a column of the correct length, not just
+  ``Column`` subclasses.[#8902]
 
-- Improved the implementation of ``Table.add_column() to provide a speed-up
-  of XXX when adding a column to wide tables.
+- Improved the implementation of ``Table.add_column()`` to provide a speed-up
+  of 2 to 10 (or more) when adding a column to tables, with increasing benefit
+  as the number of columns increases.  The method can now accept any input
+  which is convertible to a column of the correct length, not just ``Column``
+  subclasses. [#8933]
+
+- Changed the implementation of ``Table.add_columns()`` to use the new
+  ``Table.add_column()`` method.  In most cases the performance is similar
+  or slightly faster to the previous implemenation. [#8933]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ astropy.table
 - Improved the implementation of ``Table.replace_column()`` to provide
   a speed-up of 5-10 times for wide tables. [#8902]
 
+- Improved the implementation of ``Table.add_column() to provide a speed-up
+  of XXX when adding a column to wide tables.
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,9 +186,7 @@ astropy.table
 - Changed implementation of ``Table.add_column()`` and ``Table.add_columns()``
   methods.  Now it is possible add any object(s) which can be converted or broadcasted
   to a valid column for the table.  ``Table.__setitem__`` now just calls
-  ``add_column``.  One change is that a value with ``shape = (1,)`` is no longer
-  broadcasted to the column shape. E.g. ``t['a'] = [1]`` used to be the same as
-  ``t['a'] = [1, 1, 1]`` for a length=3 table, but now raises an exception.
+  ``add_column``.
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -183,6 +183,13 @@ astropy.table
   were added. See the ``Masking change in astropy 4.0`` section within
   `<https://docs.astropy.org/en/v4.0/table/masking.html>`_ for details. [#8789]
 
+- Changed implementation of ``Table.add_column()`` and ``Table.add_columns()``
+  methods.  Now it is possible add any object(s) which can be converted or broadcasted
+  to a valid column for the table.  ``Table.__setitem__`` now just calls
+  ``add_column``.  One change is that a value with ``shape = (1,)`` is no longer
+  broadcasted to the column shape. E.g. ``t['a'] = [1]`` used to be the same as
+  ``t['a'] = [1, 1, 1]`` for a length=3 table, but now raises an exception.
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1763,8 +1763,13 @@ class Table:
         if not hasattr(col, 'dtype') and not self._is_mixin_for_table(col):
             col = np.asarray(col)
 
+        # Convert col data to acceptable object for insertion into self.columns.
+        # Note that along with the lines above and below, this allows broadcasting
+        # of scalars to the correct shape for adding to table.
+        col = self._convert_data_to_col(col, name=name, copy=copy,
+                                        default_name=default_name)
+
         # Make col data shape correct for scalars
-        # if isinstance(col, BaseColumn) or self._is_mixin_for_table(col):
         if (len(self) > 0 and (getattr(col, 'isscalar', False) or
                               getattr(col, 'shape', None) == () or
                               len(col) == 1)):
@@ -1775,10 +1780,6 @@ class Table:
             elif isinstance(col, ShapedLikeNDArray):
                 col = col._apply(np.broadcast_to, shape=new_shape,
                                    subok=True)
-
-        # Convert col data to acceptable object for insertion into self.columns
-        col = self._convert_data_to_col(col, name=name, copy=copy,
-                                        default_name=default_name)
 
         name = col.info.name
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1733,6 +1733,9 @@ class Table:
             Uniquify column name if it already exist. Default is False.
         copy : bool
             Make a copy of the new column. Default is True.
+        default_name : str or `None`
+            Name to use if both ``name`` and ``col.info.name`` are not available.
+            Defaults to ``col{number_of_columns}``.
 
         Examples
         --------

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1771,6 +1771,10 @@ class Table:
                 col = col._apply(np.broadcast_to, shape=new_shape,
                                    subok=True)
 
+            # broadcast_to() results in a read-only array.  Apparently it only changes
+            # the view to look like the broadcasted array.  So copy.
+            col = col_copy(col)
+
         name = col.info.name
 
         # Ensure that new column is the right length

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1762,8 +1762,7 @@ class Table:
 
         # Make col data shape correct for scalars.  The second test is to allow
         # broadcasting an N-d element to a column, e.g. t['new'] = [[1, 2]].
-        if ((len(col.shape) == 0 or (len(col.shape) > 1 and col.shape[0] == 1))
-                and len(self) > 0):
+        if (col.shape == () or col.shape[0] == 1) and len(self) > 0:
             new_shape = (len(self),) + getattr(col, 'shape', ())[1:]
             if isinstance(col, np.ndarray):
                 col = np.broadcast_to(col, shape=new_shape,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1769,10 +1769,10 @@ class Table:
         col = self._convert_data_to_col(col, name=name, copy=copy,
                                         default_name=default_name)
 
-        # Make col data shape correct for scalars
-        if (len(self) > 0 and (getattr(col, 'isscalar', False) or
-                              getattr(col, 'shape', None) == () or
-                              len(col) == 1)):
+        # Make col data shape correct for scalars.  The second test is to allow
+        # broadcasting an N-d element to a column, e.g. t['new'] = [[1, 2]].
+        if ((len(col.shape) == 0 or (len(col.shape) > 1 and col.shape[0] == 1))
+                and len(self) > 0):
             new_shape = (len(self),) + getattr(col, 'shape', ())[1:]
             if isinstance(col, np.ndarray):
                 col = np.broadcast_to(col, shape=new_shape,

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1783,7 +1783,7 @@ class Table:
 
         # Ensure that new column is the right length
         if len(self.columns) > 0 and len(col) != len(self):
-            raise ValueError('length of new column must match table length')
+            raise ValueError('Inconsistent data column lengths')
 
         if rename_duplicate:
             orig_name = name

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1764,6 +1764,7 @@ class Table:
             col = np.asarray(col)
 
         # Make col data shape correct for scalars
+        # if isinstance(col, BaseColumn) or self._is_mixin_for_table(col):
         if (len(self) > 0 and (getattr(col, 'isscalar', False) or
                               getattr(col, 'shape', None) == () or
                               len(col) == 1)):

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1895,21 +1895,18 @@ class Table:
         """
         if indexes is None:
             indexes = [len(self.columns)] * len(cols)
-        else:
-            if len(indexes) != len(cols):
-                raise ValueError('Number of indexes must match number of cols')
-        idxs_sort = np.argsort(indexes)
+        elif len(indexes) != len(cols):
+            raise ValueError('Number of indexes must match number of cols')
 
         if names is None:
             names = (None,) * len(cols)
-        else:
-            if len(names) != len(cols):
-                raise ValueError('Number of names must match number of cols')
+        elif len(names) != len(cols):
+            raise ValueError('Number of names must match number of cols')
 
         default_names = ['col{}'.format(ii + len(self.columns))
                          for ii in range(len(cols))]
 
-        for ii in reversed(idxs_sort):
+        for ii in reversed(np.argsort(indexes)):
             self.add_column(cols[ii], index=indexes[ii], name=names[ii],
                             default_name=default_names[ii],
                             rename_duplicate=rename_duplicate, copy=copy)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2345,3 +2345,7 @@ def test_broadcasting_8933():
     assert np.all(t['a'] == [[3, 4], [3, 4]])
     assert np.all(t['b'] == [5, 5])
     assert np.all(t['c'] == [1, 1])
+
+    # Test that broadcasted column is writeable
+    t['c'][1] = 10
+    assert np.all(t['c'] == [1, 10])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.io import fits
-from astropy.table import Table
+from astropy.table import Table, QTable, MaskedColumn
 from astropy.tests.helper import (assert_follows_unicode_guidelines,
                                   ignore_warnings, catch_warnings)
 
@@ -1935,6 +1935,11 @@ class TestReplaceColumn(SetupData):
         t['a'][0] = 10
         assert t['a'][0] == a[0]
 
+    def test_replace_with_masked_col_with_units_in_qtable(self):
+        """This is a small regression from #8902"""
+        t = QTable([[1, 2], [3, 4]], names=['a', 'b'])
+        t['a'] = MaskedColumn([5, 6], unit='m')
+        assert isinstance(t['a'], u.Quantity)
 
 class Test__Astropy_Table__():
     """

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1941,6 +1941,7 @@ class TestReplaceColumn(SetupData):
         t['a'] = MaskedColumn([5, 6], unit='m')
         assert isinstance(t['a'], u.Quantity)
 
+
 class Test__Astropy_Table__():
     """
     Test initializing a Table subclass from a table-like object that

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2333,3 +2333,16 @@ def test_tolist():
     assert t['c'].tolist() == [['foo', 'bar'], ['hello', 'world']]
     assert isinstance(t['a'].tolist()[0][0], int)
     assert isinstance(t['c'].tolist()[0][0], str)
+
+
+def test_broadcasting_8933():
+    """Small API change re: broadcasting in #8933"""
+    t = table.Table([[1, 2]])  # Length=2 table
+    t['a'] = [[3, 4]]  # Can broadcast if ndim > 1 and shape[0] == 1
+    t['b'] = 5
+    assert np.all(t['a'] == [[3, 4], [3, 4]])
+    assert np.all(t['b'] == [5, 5])
+
+    with pytest.raises(ValueError) as exc:
+        t['c'] = [1]  # This broadcasted to [1, 1] before #8933, but should not have.
+    assert 'Inconsistent data column lengths' in str(exc)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2337,13 +2337,11 @@ def test_tolist():
 
 
 def test_broadcasting_8933():
-    """Small API change re: broadcasting in #8933"""
+    """Explicitly check re-work of code related to broadcasting in #8933"""
     t = table.Table([[1, 2]])  # Length=2 table
     t['a'] = [[3, 4]]  # Can broadcast if ndim > 1 and shape[0] == 1
     t['b'] = 5
+    t['c'] = [1]  # Treat as broadcastable scalar, not length=1 array (which would fail)
     assert np.all(t['a'] == [[3, 4], [3, 4]])
     assert np.all(t['b'] == [5, 5])
-
-    with pytest.raises(ValueError) as exc:
-        t['c'] = [1]  # This broadcasted to [1, 1] before #8933, but should not have.
-    assert 'Inconsistent data column lengths' in str(exc)
+    assert np.all(t['c'] == [1, 1])

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -185,6 +185,16 @@ class TimeSeries(BaseTimeSeries):
                 return out
         return super().__getitem__(item)
 
+    def add_column(self, *args, **kwargs):
+        """
+        See :meth:`~astropy.table.Table.add_column`.
+        """
+        # Note that the docstring is inherited from QTable
+        result = super().add_column(*args, **kwargs)
+        if len(self.indices) == 0 and 'time' in self.colnames:
+            self.add_index('time')
+        return result
+
     def add_columns(self, *args, **kwargs):
         """
         See :meth:`~astropy.table.Table.add_columns`.


### PR DESCRIPTION
This uses the new `_convert_data_to_col` method to simplify and speed up `add_column` so the time for adding is independent of the number of existing table columns.   Details to come, but it is a factor of at least a two or more faster for tables with 20 or more columns.  If you are building a wide table one column at a time the improvement can be a factor of 10 or more.

This flips the previous structure, so that `add_columns` is just calling `add_column` for each new column, instead of `add_column` calling `add_columns` with a one-element list of the new column.  I haven't done timing on `add_columns`, and that might end up being a bit slower.  I think this use-case is less common though.

This implementation allows the data supplied to `add_column(s)` to be any legal data, not just a `Column` or mixin.

This now replaces all the custom `__setitem__` logic so that `t['a'] = data` just calls `t.add_column(data, name='a', copy=True)`.  Before the two paths were essentially independent code-wise, with subtle and not-so-subtle differences.