### PR TITLE
Set arrays writable flag to True before broadcasting

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -241,6 +241,9 @@ class EarthLocation(u.Quantity):
             raise u.UnitsError("Geocentric coordinate units should all be "
                                "consistent.")
 
+        x.flags.writable = True
+        y.flags.writable = True
+        z.flags.writable = True
         x, y, z = np.broadcast_arrays(x, y, z)
         struc = np.empty(x.shape, cls._location_dtype)
         struc['x'], struc['y'], struc['z'] = x, y, z

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -627,9 +627,12 @@ class BoxLeastSquares(BasePeriodogram):
         """
 
         # Validate shapes of inputs
+        t.flags.writable = True
+        y.flags.writable = True
         if dy is None:
             t, y = np.broadcast_arrays(t, y, subok=True)
         else:
+            dy.flags.writable = True
             t, y, dy = np.broadcast_arrays(t, y, dy, subok=True)
         if t.ndim != 1:
             raise ValueError("Inputs (t, y, dy) must be 1-dimensional")

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -132,9 +132,12 @@ class LombScargle(BasePeriodogram):
 
     def _validate_inputs(self, t, y, dy):
         # Validate shapes of inputs
+        t.flags.writable = True
+        y.flags.writable = True
         if dy is None:
             t, y = np.broadcast_arrays(t, y, subok=True)
         else:
+            dy.flags.writable = True
             t, y, dy = np.broadcast_arrays(t, y, dy, subok=True)
         if t.ndim != 1:
             raise ValueError("Inputs (t, y, dy) must be 1-dimensional")

--- a/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
@@ -45,7 +45,11 @@ def lombscargle_chi2(t, y, dy, frequency, normalization='standard',
     """
     if dy is None:
         dy = 1
+    else:
+        dy.flags.writable = True
 
+    t.flags.writable = True
+    y.flags.writable = True
     t, y, dy = np.broadcast_arrays(t, y, dy)
     frequency = np.asarray(frequency)
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
@@ -57,6 +57,10 @@ def lombscargle_cython(t, y, dy, frequency, normalization='standard',
     if dy is None:
         dy = 1
 
+    t.flags.writable = True
+    y.flags.writable = True
+    dy.flags.writable = True
+
     t, y, dy = np.broadcast_arrays(t, y, dy)
     t = np.asarray(t, dtype=DTYPE, order='C')
     y = np.asarray(y, dtype=DTYPE, order='C')

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -57,8 +57,12 @@ def lombscargle_fast(t, y, dy, f0, df, Nf,
     """
     if dy is None:
         dy = 1
+    else:
+        dy.flags.writable = True
 
     # Validate and setup input data
+    t.flags.writable = True
+    y.flags.writable = True
     t, y, dy = np.broadcast_arrays(t, y, dy)
     if t.ndim != 1:
         raise ValueError("t, y, dy should be one dimensional")

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -52,8 +52,12 @@ def lombscargle_fastchi2(t, y, dy, f0, df, Nf, normalization='standard',
 
     if dy is None:
         dy = 1
+    else:
+        dy.flags.writable = True
 
     # Validate and setup input data
+    t.flags.writable = True
+    y.flags.writable = True
     t, y, dy = np.broadcast_arrays(t, y, dy)
     if t.ndim != 1:
         raise ValueError("t, y, dy should be one dimensional")

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -41,6 +41,8 @@ def lombscargle_scipy(t, y, frequency, normalization='standard',
     except ImportError:
         raise ImportError("scipy must be installed to use lombscargle_scipy")
 
+    t.flags.writable = True
+    y.flags.writable = True
     t, y = np.broadcast_arrays(t, y)
 
     # Scipy requires floating-point input

--- a/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
@@ -41,7 +41,11 @@ def lombscargle_slow(t, y, dy, frequency, normalization='standard',
     """
     if dy is None:
         dy = 1
+    else:
+        dy.flags.writable = True
 
+    t.flags.writable = True
+    y.flags.writable = True
     t, y, dy = np.broadcast_arrays(t, y, dy)
     frequency = np.asarray(frequency)
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -48,6 +48,8 @@ def extirpolate(x, y, N=None, M=4):
     This code is based on the C implementation of spread() presented in
     Numerical Recipes in C, Second Edition (Press et al. 1989; p.583).
     """
+    x.flags.writable = True
+    y.flags.writable = True
     x, y = map(np.ravel, np.broadcast_arrays(x, y))
 
     if N is None:
@@ -123,6 +125,8 @@ def trig_sum(t, h, df, N, f0=0, freq_factor=1,
 
     if df <= 0:
         raise ValueError("df must be positive")
+    t.flags.writable = True
+    h.flags.writable = True
     t, h = map(np.ravel, np.broadcast_arrays(t, h))
 
     if use_fft:

--- a/astropy/timeseries/periodograms/lombscargle/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/utils.py
@@ -27,6 +27,9 @@ def compute_chi2_ref(y, dy=None, center_data=True, fit_mean=True):
     """
     if dy is None:
         dy = 1
+    else:
+        dy.flags.writable = True
+    y.flags.writable = True
     y, dy = np.broadcast_arrays(y, dy)
     w = dy ** -2.0
     if center_data or fit_mean:


### PR DESCRIPTION
Fix #8935 

Trying to follow the hint over at numpy/numpy#12609 to explicitly set `arr.flags.writable = True` before passing them into `np.broadcast_arrays`. I am not 100% sure this will work, so need to check the numpy-dev job carefully.