### PR TITLE
Limit pytest version to be <5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,19 +20,19 @@ jobs:
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
       - run:
           name: Install dependencies for Python 3.5
-          command: /opt/python/cp35-cp35m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp35-cp35m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.5
           command: PYTHONHASHSEED=42 /opt/python/cp35-cp35m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.6
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.6
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp37-cp37m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2 pandas
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ environment:
                           # to the matrix section.
         CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 html5lib jinja2 pyyaml matplotlib scikit-image pytz pandas"
         PIP_DEPENDENCIES: "objgraph asdf"
+        PYTEST_VERSION: "<5"
 
     matrix:
         - PYTHON_VERSION: "3.7"


### PR DESCRIPTION
There are several issues coming up when switching to use pytest 5.0, so this PR is a temporarily workaround to have a passing CI for unrelated PRs while making sure everything works.