### PR TITLE
Remove deprecated renamed arguments in stats package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,6 +169,12 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Removed the ``iters`` keyword from sigma clipping stats functions.
+  [#8948]
+
+- Renamed the ``a`` parameter to ``data`` in biweight stat functions.
+  [#8948]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -8,14 +8,12 @@ Tukey's biweight function.
 import numpy as np
 
 from .funcs import median_absolute_deviation
-from astropy.utils.decorators import deprecated_renamed_argument
 
 
 __all__ = ['biweight_location', 'biweight_scale', 'biweight_midvariance',
            'biweight_midcovariance', 'biweight_midcorrelation']
 
 
-@deprecated_renamed_argument('a', 'data', '2.0')
 def biweight_location(data, c=6.0, M=None, axis=None):
     r"""
     Compute the biweight location.
@@ -230,7 +228,6 @@ def biweight_scale(data, c=9.0, M=None, axis=None, modify_sample_size=False):
                              modify_sample_size=modify_sample_size))
 
 
-@deprecated_renamed_argument('a', 'data', '2.0')
 def biweight_midvariance(data, c=9.0, M=None, axis=None,
                          modify_sample_size=False):
     r"""
@@ -378,7 +375,6 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
     return n * f1 / f2
 
 
-@deprecated_renamed_argument('a', 'data', '2.0')
 def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
     r"""
     Compute the biweight midcovariance between pairs of multiple

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 
 from astropy.utils import isiterable
-from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
 
@@ -207,7 +206,6 @@ class SigmaClip:
     standard deviation is higher.
     """
 
-    @deprecated_renamed_argument('iters', 'maxiters', '3.1')
     def __init__(self, sigma=3., sigma_lower=None, sigma_upper=None,
                  maxiters=5, cenfunc='median', stdfunc='std'):
 
@@ -474,7 +472,6 @@ class SigmaClip:
                                             copy=copy)
 
 
-@deprecated_renamed_argument('iters', 'maxiters', '3.1')
 def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
                cenfunc='median', stdfunc='std', axis=None, masked=True,
                return_bounds=False, copy=True):
@@ -651,7 +648,6 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
                    return_bounds=return_bounds, copy=copy)
 
 
-@deprecated_renamed_argument('iters', 'maxiters', '3.1')
 def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
                         sigma_lower=None, sigma_upper=None, maxiters=5,
                         cenfunc='median', stdfunc='std', std_ddof=0,


### PR DESCRIPTION
This PR:

* Removes deprecated_renamed_argument from biweight.py, which was added in 2.0 release
* Remove deprecated_renamed_argument from sigma_clipping.py, which was added in 3.1 release 

Addresses part of #8888 