### PR TITLE
Resolve str AssertionErrors on ExceptionInfo objects in pytest 5

### DIFF
--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -650,13 +650,13 @@ def test_latitude():
     with pytest.raises(TypeError) as excinfo:
         lon = Longitude(10, 'deg')
         lat = Latitude(lon)
-    assert "A Latitude angle cannot be created from a Longitude angle" in str(excinfo)
+    assert "A Latitude angle cannot be created from a Longitude angle" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         lon = Longitude(10, 'deg')
         lat = Latitude([20], 'deg')
         lat[0] = lon
-    assert "A Longitude angle cannot be assigned to a Latitude angle" in str(excinfo)
+    assert "A Longitude angle cannot be assigned to a Latitude angle" in str(excinfo.value)
 
     # Check we can work around the Lat vs Long checks by casting explicitly to Angle.
     lon = Longitude(10, 'deg')
@@ -738,13 +738,13 @@ def test_longitude():
     with pytest.raises(TypeError) as excinfo:
         lat = Latitude(10, 'deg')
         lon = Longitude(lat)
-    assert "A Longitude angle cannot be created from a Latitude angle" in str(excinfo)
+    assert "A Longitude angle cannot be created from a Latitude angle" in str(excinfo.value)
 
     with pytest.raises(TypeError) as excinfo:
         lat = Latitude(10, 'deg')
         lon = Longitude([20], 'deg')
         lon[0] = lat
-    assert "A Latitude angle cannot be assigned to a Longitude angle" in str(excinfo)
+    assert "A Latitude angle cannot be assigned to a Longitude angle" in str(excinfo.value)
 
     # Check we can work around the Lat vs Long checks by casting explicitly to Angle.
     lat = Latitude(10, 'deg')

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -303,8 +303,8 @@ def test_of_address(google_api_key):
         loc = EarthLocation.of_address("New York, NY")
     except NameResolveError as e:
         # API limit might surface even here in Travis CI.
-        if 'unknown failure with' not in str(e):
-            pytest.xfail(str(e))
+        if 'unknown failure with' not in str(e.value):
+            pytest.xfail(str(e.value))
     else:
         assert quantity_allclose(loc.lat, NYC_lat, atol=NYC_tol)
         assert quantity_allclose(loc.lon, NYC_lon, atol=NYC_tol)
@@ -323,7 +323,7 @@ def test_of_address(google_api_key):
             # Buffer above sometimes insufficient to get around API limit but
             # we also do not want to drag things out with time.sleep(0.195),
             # where 0.195 was empirically determined on some physical machine.
-            pytest.xfail(str(e))
+            pytest.xfail(str(e.value))
         else:
             assert quantity_allclose(loc.lat, NYC_lat, atol=NYC_tol)
             assert quantity_allclose(loc.lon, NYC_lon, atol=NYC_tol)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -63,7 +63,7 @@ def test_frame_attribute_descriptor():
     # Make sure setting values via public attribute fails
     with pytest.raises(AttributeError) as err:
         t.attr_none = 5
-    assert 'Cannot set frame attribute' in str(err)
+    assert 'Cannot set frame attribute' in str(err.value)
 
 
 def test_frame_subclass_attribute_descriptor():
@@ -171,7 +171,7 @@ def test_no_data_nonscalar_frames():
     with pytest.raises(ValueError) as exc:
         AltAz(obstime=Time('2012-01-01') + np.arange(10.) * u.day,
               temperature=np.ones((3,)) * u.deg_C)
-    assert 'inconsistent shapes' in str(exc)
+    assert 'inconsistent shapes' in str(exc.value)
 
 
 def test_frame_repr():
@@ -519,18 +519,18 @@ def test_time_inputs():
 
     with pytest.raises(ValueError) as err:
         c = FK4(1 * u.deg, 2 * u.deg, equinox=1.5)
-    assert 'Invalid time input' in str(err)
+    assert 'Invalid time input' in str(err.value)
 
     with pytest.raises(ValueError) as err:
         c = FK4(1 * u.deg, 2 * u.deg, obstime='hello')
-    assert 'Invalid time input' in str(err)
+    assert 'Invalid time input' in str(err.value)
 
     # A vector time should work if the shapes match, but we don't automatically
     # broadcast the basic data (just like time).
     FK4([1, 2] * u.deg, [2, 3] * u.deg, obstime=['J2000', 'J2001'])
     with pytest.raises(ValueError) as err:
         FK4(1 * u.deg, 2 * u.deg, obstime=['J2000', 'J2001'])
-    assert 'shape' in str(err)
+    assert 'shape' in str(err.value)
 
 
 def test_is_frame_attr_default():
@@ -600,7 +600,7 @@ def test_representation():
     for attr in ('ra', 'dec', 'distance'):
         with pytest.raises(AttributeError) as err:
             getattr(icrs, attr)
-        assert 'object has no attribute' in str(err)
+        assert 'object has no attribute' in str(err.value)
 
     # Testing when `_representation` set to `CylindricalRepresentation`.
     icrs.representation_type = r.CylindricalRepresentation
@@ -621,7 +621,7 @@ def test_representation():
     for attr in ('x', 'y', 'z'):
         with pytest.raises(AttributeError) as err:
             getattr(icrs, attr)
-        assert 'object has no attribute' in str(err)
+        assert 'object has no attribute' in str(err.value)
 
     # Testing setter input using text argument for cylindrical.
     icrs.representation_type = 'cylindrical'
@@ -631,11 +631,11 @@ def test_representation():
 
     with pytest.raises(ValueError) as err:
         icrs.representation_type = 'WRONG'
-    assert 'but must be a BaseRepresentation class' in str(err)
+    assert 'but must be a BaseRepresentation class' in str(err.value)
 
     with pytest.raises(ValueError) as err:
         icrs.representation_type = ICRS
-    assert 'but must be a BaseRepresentation class' in str(err)
+    assert 'but must be a BaseRepresentation class' in str(err.value)
 
 
 def test_represent_as():
@@ -706,11 +706,11 @@ def test_dynamic_attrs():
 
     with pytest.raises(AttributeError) as err:
         c.blahblah
-    assert "object has no attribute 'blahblah'" in str(err)
+    assert "object has no attribute 'blahblah'" in str(err.value)
 
     with pytest.raises(AttributeError) as err:
         c.ra = 1
-    assert "Cannot set any frame attribute" in str(err)
+    assert "Cannot set any frame attribute" in str(err.value)
 
     c.blahblah = 1
     assert c.blahblah == 1
@@ -1013,12 +1013,12 @@ def test_missing_component_error_names():
 
     with pytest.raises(TypeError) as e:
         ICRS(ra=150 * u.deg)
-    assert "missing 1 required positional argument: 'dec'" in str(e)
+    assert "missing 1 required positional argument: 'dec'" in str(e.value)
 
     with pytest.raises(TypeError) as e:
         ICRS(ra=150*u.deg, dec=-11*u.deg,
              pm_ra=100*u.mas/u.yr, pm_dec=10*u.mas/u.yr)
-    assert "pm_ra_cosdec" in str(e)
+    assert "pm_ra_cosdec" in str(e.value)
 
 
 def test_non_spherical_representation_unit_creation(unitphysics):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -543,7 +543,7 @@ class TestCartesianRepresentation:
         with pytest.raises(ValueError) as exc:
             CartesianRepresentation(x=[1, 2, 3] * u.pc, y=[2, 3, 4] * u.pc,
                                     z=[3, 4, 5] * u.pc, xyz_axis=0)
-        assert 'xyz_axis should only be set' in str(exc)
+        assert 'xyz_axis should only be set' in str(exc.value)
 
     def test_init_one_array_yz_fail(self):
         with pytest.raises(ValueError) as exc:

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -147,7 +147,7 @@ def test_coord_init_string():
 
     with pytest.raises(ValueError) as err:
         SkyCoord('1d 2d 3d')
-    assert "Cannot parse first argument data" in str(err)
+    assert "Cannot parse first argument data" in str(err.value)
 
     sc1 = SkyCoord('8 00 00 +5 00 00.0', unit=(u.hour, u.deg), frame='icrs')
     assert isinstance(sc1, SkyCoord)
@@ -232,7 +232,7 @@ def test_coord_init_unit():
     for unit in ('deg,deg,deg,deg', [u.deg, u.deg, u.deg, u.deg], None):
         with pytest.raises(ValueError) as err:
             SkyCoord(1, 2, unit=unit)
-        assert 'Unit keyword must have one to three unit values' in str(err)
+        assert 'Unit keyword must have one to three unit values' in str(err.value)
 
     for unit in ('m', (u.m, u.deg), ''):
         with pytest.raises(u.UnitsError) as err:
@@ -253,11 +253,11 @@ def test_coord_init_list():
 
     with pytest.raises(ValueError) as err:
         SkyCoord(['1d 2d 3d'])
-    assert "Cannot parse first argument data" in str(err)
+    assert "Cannot parse first argument data" in str(err.value)
 
     with pytest.raises(ValueError) as err:
         SkyCoord([('1d', '2d', '3d')])
-    assert "Cannot parse first argument data" in str(err)
+    assert "Cannot parse first argument data" in str(err.value)
 
     sc = SkyCoord([1 * u.deg, 1 * u.deg], [2 * u.deg, 2 * u.deg])
     assert allclose(sc.ra, Angle('1d'))
@@ -265,7 +265,7 @@ def test_coord_init_list():
 
     with pytest.raises(ValueError) as err:
         SkyCoord([1 * u.deg, 2 * u.deg])  # this list is taken as RA w/ missing dec
-    assert "One or more elements of input sequence does not have a length" in str(err)
+    assert "One or more elements of input sequence does not have a length" in str(err.value)
 
 
 def test_coord_init_array():
@@ -296,7 +296,7 @@ def test_coord_init_representation():
 
     with pytest.raises(ValueError) as err:
         SkyCoord(coord, frame='icrs', ra='1d')
-    assert "conflicts with keyword argument 'ra'" in str(err)
+    assert "conflicts with keyword argument 'ra'" in str(err.value)
 
     coord = CartesianRepresentation(1 * u.one, 2 * u.one, 3 * u.one)
     sc = SkyCoord(coord, frame='icrs')
@@ -328,7 +328,7 @@ def test_frame_init():
 
     with pytest.raises(ValueError) as err:
         SkyCoord(C_ICRS, frame='galactic')
-    assert 'Cannot override frame=' in str(err)
+    assert 'Cannot override frame=' in str(err.value)
 
 
 def test_attr_inheritance():
@@ -383,7 +383,7 @@ def test_attr_conflicts():
     # Not OK if attrs don't match
     with pytest.raises(ValueError) as err:
         SkyCoord(sc, equinox='J1999', obstime='J2002')
-    assert "Coordinate attribute 'obstime'=" in str(err)
+    assert "Coordinate attribute 'obstime'=" in str(err.value)
 
     # Same game but with fk4 which has equinox and obstime frame attrs
     sc = SkyCoord(1, 2, frame='fk4', unit='deg', equinox='J1999', obstime='J2001')
@@ -394,12 +394,12 @@ def test_attr_conflicts():
     # Not OK if SkyCoord attrs don't match
     with pytest.raises(ValueError) as err:
         SkyCoord(sc, equinox='J1999', obstime='J2002')
-    assert "Frame attribute 'obstime' has conflicting" in str(err)
+    assert "Frame attribute 'obstime' has conflicting" in str(err.value)
 
     # Not OK because sc.frame has different attrs
     with pytest.raises(ValueError) as err:
         SkyCoord(sc.frame, equinox='J1999', obstime='J2002')
-    assert "Frame attribute 'obstime' has conflicting" in str(err)
+    assert "Frame attribute 'obstime' has conflicting" in str(err.value)
 
 
 def test_frame_attr_getattr():
@@ -877,7 +877,7 @@ def test_units():
 
     with pytest.raises(u.UnitsError) as err:
         SkyCoord(1, 2, 3, unit=(u.m, u.m), representation_type='cartesian')
-    assert 'should have matching physical types' in str(err)
+    assert 'should have matching physical types' in str(err.value)
 
     SkyCoord(1, 2, 3, unit=(u.m, u.km, u.pc), representation_type='cartesian')
     assert_quantities_allclose(sc, (1*u.m, 2*u.km, 3*u.pc), ('x', 'y', 'z'))
@@ -1053,7 +1053,7 @@ def test_init_with_frame_instance_keyword():
     # Check duplicate arguments
     with pytest.raises(ValueError) as err:
         c = SkyCoord(3 * u.deg, 4 * u.deg, frame=FK5(equinox='J2010'), equinox='J2001')
-    assert "Cannot specify frame attribute 'equinox'" in str(err)
+    assert "Cannot specify frame attribute 'equinox'" in str(err.value)
 
 
 def test_guess_from_table():

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -411,8 +411,8 @@ A B C
 """
     with pytest.raises(InconsistentTableError) as e:
         table = FastBasic().read(text)
-    assert 'InconsistentTableError: Number of header columns (3) ' \
-           'inconsistent with data columns in data line 2' in str(e)
+    assert 'Number of header columns (3) ' \
+           'inconsistent with data columns in data line 2' in str(e.value)
 
 
 def test_too_many_cols2():
@@ -423,8 +423,8 @@ aaa,bbb
 """
     with pytest.raises(InconsistentTableError) as e:
         table = FastCsv().read(text)
-    assert 'InconsistentTableError: Number of header columns (2) ' \
-           'inconsistent with data columns in data line 0' in str(e)
+    assert 'Number of header columns (2) ' \
+           'inconsistent with data columns in data line 0' in str(e.value)
 
 
 def test_too_many_cols3():
@@ -435,8 +435,8 @@ aaa,bbb
 """
     with pytest.raises(InconsistentTableError) as e:
         table = FastCsv().read(text)
-    assert 'InconsistentTableError: Number of header columns (2) ' \
-           'inconsistent with data columns in data line 0' in str(e)
+    assert 'Number of header columns (2) ' \
+           'inconsistent with data columns in data line 0' in str(e.value)
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -750,17 +750,17 @@ A\tB\tC
     with pytest.raises(ValueError) as e:
         text = 'A\tB\tC\nN\tS\tN\n4\tb\ta'  # C column contains non-numeric data
         read_rdb(text, parallel=parallel)
-    assert 'Column C failed to convert' in str(e)
+    assert 'Column C failed to convert' in str(e.value)
 
     with pytest.raises(ValueError) as e:
         text = 'A\tB\tC\nN\tN\n1\t2\t3'  # not enough types specified
         read_rdb(text, parallel=parallel)
-    assert 'mismatch between number of column names and column types' in str(e)
+    assert 'mismatch between number of column names and column types' in str(e.value)
 
     with pytest.raises(ValueError) as e:
         text = 'A\tB\tC\nN\tN\t5\n1\t2\t3'  # invalid type for column C
         read_rdb(text, parallel=parallel)
-    assert 'type definitions do not all match [num](N|S)' in str(e)
+    assert 'type definitions do not all match [num](N|S)' in str(e.value)
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -794,7 +794,7 @@ A B C
         # tries to begin in the middle of quoted field
         read_basic(text, data_start=4, parallel=parallel)
     assert 'header columns (3) inconsistent with data columns in data line 0' \
-        in str(e)
+        in str(e.value)
 
     table = read_basic(text, data_start=5, parallel=parallel)
     # ignore commented line
@@ -864,7 +864,7 @@ def test_strip_line_trailing_whitespace(parallel, read_basic):
     with pytest.raises(InconsistentTableError) as e:
         ascii.read(StringIO(text), format='fast_basic', guess=False)
     assert 'header columns (3) inconsistent with data columns in data line 0' \
-        in str(e)
+        in str(e.value)
 
     text = 'a b c\n 1 2 3   \t \n 4 5 6 '
     table = read_basic(text, parallel=parallel)
@@ -1149,7 +1149,7 @@ def test_fortran_reader(parallel, guess):
         ascii.read(text.format(*(6*('D'))), format='basic', guess=guess,
                    fast_reader={'use_fast_converter': False,
                                 'parallel': parallel, 'exponent_style': 'D'})
-    assert 'fast_reader: exponent_style requires use_fast_converter' in str(e)
+    assert 'fast_reader: exponent_style requires use_fast_converter' in str(e.value)
 
     # Enable multiprocessing and the fast converter iterate over
     # all style-exponent combinations, with auto-detection

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -213,7 +213,7 @@ def test_csv_ecsv_colnames_mismatch():
     lines[header_index] = 'a b d'
     with pytest.raises(ValueError) as err:
         ascii.read(lines, format='ecsv')
-    assert "column names from ECSV header ['a', 'b', 'c']" in str(err)
+    assert "column names from ECSV header ['a', 'b', 'c']" in str(err.value)
 
 
 @pytest.mark.skipif('not HAS_YAML')
@@ -435,7 +435,7 @@ def test_ecsv_but_no_yaml_warning():
 
     with pytest.raises(ascii.InconsistentTableError) as exc:
         ascii.read(SIMPLE_LINES, format='ecsv')
-    assert "PyYAML package is required" in str(exc)
+    assert "PyYAML package is required" in str(exc.value)
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -173,12 +173,12 @@ def test_identify_table_fail():
     with pytest.raises(core.InconsistentTableError) as err:
         Table.read(table_in, format='ascii.html', htmldict={'table_id': 'bad_id'},
                    guess=False)
-    assert str(err).endswith("ERROR: HTML table id 'bad_id' not found")
+    assert err.match("ERROR: HTML table id 'bad_id' not found$")
 
     with pytest.raises(core.InconsistentTableError) as err:
         Table.read(table_in, format='ascii.html', htmldict={'table_id': 3},
                    guess=False)
-    assert str(err).endswith("ERROR: HTML table number 3 not found")
+    assert err.match("ERROR: HTML table number 3 not found$")
 
 
 @pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1408,7 +1408,7 @@ def test_read_chunks_chunk_size_too_small():
     with pytest.raises(ValueError) as err:
         ascii.read(fpath, header_start=1, data_start=3,
                    fast_reader={'chunk_size': 10})
-    assert 'no newline found in chunk (chunk_size too small?)' in str(err)
+    assert 'no newline found in chunk (chunk_size too small?)' in str(err.value)
 
 
 def test_read_chunks_table_changes():

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -399,7 +399,7 @@ def check_write_table(test_def, table, fast_writer):
     try:
         ascii.write(table, out, fast_writer=fast_writer, **test_def['kwargs'])
     except ValueError as e:  # if format doesn't have a fast writer, ignore
-        if 'not in the list of formats with fast writers' not in str(e):
+        if 'not in the list of formats with fast writers' not in str(e.value):
             raise e
         return
     print('Expected:\n{}'.format(test_def['out']))
@@ -421,7 +421,7 @@ def check_write_table_via_table(test_def, table, fast_writer):
     try:
         table.write(out, format=format, fast_writer=fast_writer, **test_def['kwargs'])
     except ValueError as e:  # if format doesn't have a fast writer, ignore
-        if 'not in the list of formats with fast writers' not in str(e):
+        if 'not in the list of formats with fast writers' not in str(e.value):
             raise e
         return
     print('Expected:\n{}'.format(test_def['out']))

--- a/astropy/io/fits/tests/test_compression_failures.py
+++ b/astropy/io/fits/tests/test_compression_failures.py
@@ -24,35 +24,35 @@ class TestCompressionFunction(FitsTestCase):
         hdu._header['ZCMPTYPE'] = 'fun'
         with pytest.raises(ValueError) as exc:
             compress_hdu(hdu)
-        assert 'Unrecognized compression type: fun' in str(exc)
+        assert 'Unrecognized compression type: fun' in str(exc.value)
 
     def test_zbitpix_unknown(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         hdu._header['ZBITPIX'] = 13
         with pytest.raises(ValueError) as exc:
             compress_hdu(hdu)
-        assert 'Invalid value for BITPIX: 13' in str(exc)
+        assert 'Invalid value for BITPIX: 13' in str(exc.value)
 
     def test_data_none(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         hdu.data = None
         with pytest.raises(TypeError) as exc:
             compress_hdu(hdu)
-        assert 'CompImageHDU.data must be a numpy.ndarray' in str(exc)
+        assert 'CompImageHDU.data must be a numpy.ndarray' in str(exc.value)
 
     def test_missing_internal_header(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         del hdu._header
         with pytest.raises(AttributeError) as exc:
             compress_hdu(hdu)
-        assert '_header' in str(exc)
+        assert '_header' in str(exc.value)
 
     def test_invalid_tform(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)))
         hdu._header['TFORM1'] = 'TX'
         with pytest.raises(RuntimeError) as exc:
             compress_hdu(hdu)
-        assert 'TX' in str(exc) and 'TFORM' in str(exc)
+        assert 'TX' in str(exc.value) and 'TFORM' in str(exc.value)
 
     def test_invalid_zdither(self):
         hdu = fits.CompImageHDU(np.ones((10, 10)), quantize_method=1)
@@ -66,7 +66,7 @@ class TestCompressionFunction(FitsTestCase):
         del hdu._header[kw]
         with pytest.raises(KeyError) as exc:
             compress_hdu(hdu)
-        assert kw in str(exc)
+        assert kw in str(exc.value)
 
     @pytest.mark.parametrize('kw', ['ZNAXIS', 'ZVAL1', 'ZVAL2', 'ZBLANK', 'BLANK'])
     def test_header_value_int_overflow(self, kw):
@@ -102,7 +102,7 @@ class TestCompressionFunction(FitsTestCase):
         hdu._header[kw] = -1
         with pytest.raises(ValueError) as exc:
             compress_hdu(hdu)
-        assert '{} should not be negative.'.format(kw) in str(exc)
+        assert '{} should not be negative.'.format(kw) in str(exc.value)
 
     @pytest.mark.parametrize(
         ('kw', 'limit'),
@@ -113,7 +113,7 @@ class TestCompressionFunction(FitsTestCase):
         hdu._header[kw] = limit + 1
         with pytest.raises(ValueError) as exc:
             compress_hdu(hdu)
-        assert kw in str(exc)
+        assert kw in str(exc.value)
 
     @pytest.mark.parametrize('kw', ['TTYPE1', 'TFORM1', 'ZCMPTYPE', 'ZNAME1',
                                     'ZQUANTIZ'])

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -638,7 +638,7 @@ def test_error_for_mixins_but_no_yaml(tmpdir):
     t = Table([mixin_cols['sc']])
     with pytest.raises(TypeError) as err:
         t.write(filename)
-    assert "cannot write type SkyCoord column 'col0' to FITS without PyYAML" in str(err)
+    assert "cannot write type SkyCoord column 'col0' to FITS without PyYAML" in str(err.value)
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -121,7 +121,7 @@ table: !<tag:astropy.org:astropy/table/table-1.0.0>
     with pytest.raises(ValueError) as err:
         with asdf.open(buff) as ff:
             pass
-    assert 'Inconsistent data column lengths' in str(err)
+    assert 'Inconsistent data column lengths' in str(err.value)
 
 
 def test_masked_table(tmpdir):

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -588,8 +588,8 @@ def test_fail_meta_serialize(tmpdir):
 
     with pytest.raises(Exception) as err:
         t1.write(test_file, path='the_table', serialize_meta=True)
-    assert "cannot represent an object" in str(err)
-    assert "<class 'str'>" in str(err)
+    assert "cannot represent an object" in str(err.value)
+    assert "<class 'str'>" in str(err.value)
 
 
 @pytest.mark.skipif('not HAS_H5PY')
@@ -848,7 +848,7 @@ def test_error_for_mixins_but_no_yaml(tmpdir):
     t = Table([mixin_cols['sc']])
     with pytest.raises(TypeError) as err:
         t.write(filename, path='root', serialize_meta=True)
-    assert "cannot write type SkyCoord column 'col0' to HDF5 without PyYAML" in str(err)
+    assert "cannot write type SkyCoord column 'col0' to HDF5 without PyYAML" in str(err.value)
 
 
 @pytest.mark.skipif('not HAS_YAML or not HAS_H5PY')

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -57,7 +57,7 @@ def test_ccddata_unit_cannot_be_set_to_none():
 def test_ccddata_meta_header_conflict():
     with pytest.raises(ValueError) as exc:
         CCDData([1, 2, 3], unit='', meta={1: 1}, header={2: 2})
-        assert "can't have both header and meta." in str(exc)
+        assert "can't have both header and meta." in str(exc.value)
 
 
 def test_ccddata_simple():

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -48,7 +48,7 @@ def test_freedman_bin_width(N=10000, rseed=0):
     test_x = [1, 2, 3] + [4] * 100 + [5, 6, 7]
     with pytest.raises(ValueError) as e:
         freedman_bin_width(test_x, return_bins=True)
-        assert 'Please use another bin method' in str(e)
+        assert 'Please use another bin method' in str(e.value)
 
     # data with small IQR but not too small
     test_x = np.asarray([1, 2, 3] * 100 + [4] + [5, 6, 7], dtype=np.float32)

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -252,7 +252,7 @@ def test_lost_parent_error():
     c = table.Column([1, 2, 3], name='a')
     with pytest.raises(AttributeError) as err:
         c[:].info.name
-    assert 'failed access "info" attribute' in str(err)
+    assert 'failed access "info" attribute' in str(err.value)
 
 
 def test_info_serialize_method():

--- a/astropy/table/tests/test_init_table.py
+++ b/astropy/table/tests/test_init_table.py
@@ -452,7 +452,7 @@ class TestInitFromRows():
     def test_init_with_rows_and_data(self, table_type):
         with pytest.raises(ValueError) as err:
             table_type(data=[[1]], rows=[[1]])
-        assert "Cannot supply both `data` and `rows` values" in str(err)
+        assert "Cannot supply both `data` and `rows` values" in str(err.value)
 
 
 @pytest.mark.usefixtures('table_type')

--- a/astropy/table/tests/test_item_access.py
+++ b/astropy/table/tests/test_item_access.py
@@ -222,11 +222,11 @@ class TestTableItems(BaseTestItems):
 
         with pytest.raises(KeyError) as err:
             self.t[['xxxx']]
-        assert "KeyError: 'xxxx'" in str(err)
+        assert "'xxxx'" in str(err.value)
 
         with pytest.raises(KeyError) as err:
             self.t[['xxxx', 'yyyy']]
-        assert "KeyError: 'xxxx'" in str(err)
+        assert "'xxxx'" in str(err.value)
 
     def test_np_where(self, table_data):
         """Select rows using output of np.where"""

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -519,8 +519,8 @@ class TestJoin():
             for join_type in ('outer', 'left', 'right'):
                 with pytest.raises(NotImplementedError) as err:
                     table.join(t1, t2, join_type='outer')
-                assert ('join requires masking' in str(err) or
-                        'join unavailable' in str(err))
+                assert ('join requires masking' in str(err.value) or
+                        'join unavailable' in str(err.value))
 
 
 class TestSetdiff():
@@ -759,11 +759,11 @@ class TestVStack():
             table.vstack([self.t1, self.t3], join_type='inner')
         assert ("The 'b' columns have incompatible types: {0}"
                 .format([self.t1['b'].dtype.name, self.t3['b'].dtype.name])
-                in str(excinfo))
+                in str(excinfo.value))
 
         with pytest.raises(TableMergeError) as excinfo:
             table.vstack([self.t1, self.t3], join_type='outer')
-        assert "The 'b' columns have incompatible types:" in str(excinfo)
+        assert "The 'b' columns have incompatible types:" in str(excinfo.value)
 
         with pytest.raises(TableMergeError):
             table.vstack([self.t1, self.t2], join_type='exact')
@@ -772,7 +772,7 @@ class TestVStack():
         t1_reshape['b'].shape = [2, 1]
         with pytest.raises(TableMergeError) as excinfo:
             table.vstack([self.t1, t1_reshape])
-        assert "have different shape" in str(excinfo)
+        assert "have different shape" in str(excinfo.value)
 
     def test_vstack_one_masked(self, operation_table_type):
         if operation_table_type is QTable:
@@ -938,7 +938,7 @@ class TestVStack():
             with pytest.raises(NotImplementedError) as err:
                 table.vstack([t, t])
             assert ('vstack unavailable for mixin column type(s): {}'
-                    .format(cls_name) in str(err))
+                    .format(cls_name) in str(err.value))
 
         # Check for outer stack which requires masking.  Only Time supports
         # this currently.
@@ -957,8 +957,8 @@ class TestVStack():
         else:
             with pytest.raises(NotImplementedError) as err:
                 table.vstack([t, t2], join_type='outer')
-            assert ('vstack requires masking' in str(err) or
-                    'vstack unavailable' in str(err))
+            assert ('vstack requires masking' in str(err.value) or
+                    'vstack unavailable' in str(err.value))
 
 
 class TestHStack():
@@ -1210,7 +1210,7 @@ class TestHStack():
         else:
             with pytest.raises(NotImplementedError) as err:
                 table.hstack([t1, t2], join_type='outer')
-            assert 'hstack requires masking' in str(err)
+            assert 'hstack requires masking' in str(err.value)
 
 
 def test_unique(operation_table_type):
@@ -1379,15 +1379,15 @@ def test_masking_required_exception():
 
     with pytest.raises(NotImplementedError) as err:
         table.vstack([t1, t2], join_type='outer')
-    assert 'vstack requires masking' in str(err)
+    assert 'vstack requires masking' in str(err.value)
 
     with pytest.raises(NotImplementedError) as err:
         table.hstack([t1, t2], join_type='outer')
-    assert 'hstack requires masking' in str(err)
+    assert 'hstack requires masking' in str(err.value)
 
     with pytest.raises(NotImplementedError) as err:
         table.join(t1, t2, join_type='outer')
-    assert 'join requires masking' in str(err)
+    assert 'join requires masking' in str(err.value)
 
 
 def test_stack_columns():

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -252,17 +252,17 @@ def test_row_tuple_column_slice():
     # Bad column name
     with pytest.raises(KeyError) as err:
         t[1]['a', 'not_there']
-    assert "KeyError: 'not_there'" in str(err)
+    assert "'not_there'" in str(err.value)
 
     # Too many values
     with pytest.raises(ValueError) as err:
         t[1]['a', 'b'] = 1 * u.m, 2, 3
-    assert 'right hand side must be a sequence' in str(err)
+    assert 'right hand side must be a sequence' in str(err.value)
 
     # Something without a length
     with pytest.raises(ValueError) as err:
         t[1]['a', 'b'] = 1
-    assert 'right hand side must be a sequence' in str(err)
+    assert 'right hand side must be a sequence' in str(err.value)
 
 
 def test_row_tuple_column_slice_transaction():
@@ -277,7 +277,7 @@ def test_row_tuple_column_slice_transaction():
     # First one succeeds but second fails.
     with pytest.raises(ValueError) as err:
         t[1]['a', 'b'] = (-1, -1 * u.s)  # Bad unit
-    assert "'s' (time) and 'm' (length) are not convertible" in str(err)
+    assert "'s' (time) and 'm' (length) are not convertible" in str(err.value)
     assert t[1] == tc[1]
 
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1795,7 +1795,7 @@ class TestPandas:
 
         with pytest.raises(ValueError) as err:
             t.to_pandas(index='not a column')
-        assert 'index must be None, False' in str(err)
+        assert 'index must be None, False' in str(err.value)
 
     def test_mixin_pandas_masked(self):
         tm = Time([1, 2, 3], format='cxcsec')
@@ -1985,7 +1985,7 @@ class Test__Astropy_Table__():
         object, exception is raised"""
         with pytest.raises(TypeError) as err:
             table.Table([[1]], extra_meta='extra!')
-        assert '__init__() got unexpected keyword argument' in str(err)
+        assert '__init__() got unexpected keyword argument' in str(err.value)
 
 
 def test_table_meta_copy():

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -987,7 +987,7 @@ def test_len_size():
         len(t4)
     # Ensure we're not just getting the old error of
     # "object of type 'float' has no len()".
-    assert 'Time' in str(err)
+    assert 'Time' in str(err.value)
 
 
 def test_TimeFormat_scale():
@@ -1102,7 +1102,7 @@ def test_replicate_value_error():
     t1 = Time('2007:001', scale='tai')
     with pytest.raises(ValueError) as err:
         t1.replicate(format='definitely_not_a_valid_format')
-    assert 'format must be one of' in str(err)
+    assert 'format must be one of' in str(err.value)
 
 
 def test_remove_astropy_time():
@@ -1114,7 +1114,7 @@ def test_remove_astropy_time():
     assert 'astropy_time' not in t1.FORMATS
     with pytest.raises(ValueError) as err:
         Time(t1, format='astropy_time')
-    assert 'format must be one of' in str(err)
+    assert 'format must be one of' in str(err.value)
 
 
 def test_isiterable():
@@ -1271,11 +1271,11 @@ def test_writeable_flag():
     t.writeable = False
     with pytest.raises(ValueError) as err:
         t[1] = 5.0
-    assert 'Time object is read-only. Make a copy()' in str(err)
+    assert 'Time object is read-only. Make a copy()' in str(err.value)
 
     with pytest.raises(ValueError) as err:
         t[:] = 5.0
-    assert 'Time object is read-only. Make a copy()' in str(err)
+    assert 'Time object is read-only. Make a copy()' in str(err.value)
 
     t.writeable = True
     t[1] = 10.0
@@ -1285,14 +1285,14 @@ def test_writeable_flag():
     t = Time('2000:001', scale='utc')
     with pytest.raises(ValueError) as err:
         t[()] = '2000:002'
-    assert 'scalar Time object is read-only.' in str(err)
+    assert 'scalar Time object is read-only.' in str(err.value)
 
     # Transformed attribute is not writeable
     t = Time(['2000:001', '2000:002'], scale='utc')
     t2 = t.tt  # t2 is read-only now because t.tt is cached
     with pytest.raises(ValueError) as err:
         t2[0] = '2005:001'
-    assert 'Time object is read-only. Make a copy()' in str(err)
+    assert 'Time object is read-only. Make a copy()' in str(err.value)
 
 
 def test_setitem_location():
@@ -1309,7 +1309,7 @@ def test_setitem_location():
         t[0, 0] = Time(-1, format='cxcsec')
     assert ('cannot set to Time with different location: '
             'expected location={} and '
-            'got location=None'.format(loc[0])) in str(err)
+            'got location=None'.format(loc[0])) in str(err.value)
 
     # Succeeds because the right hand side correctly sets location
     t[0, 0] = Time(-2, format='cxcsec', location=loc[0])
@@ -1320,7 +1320,7 @@ def test_setitem_location():
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
             'expected location={} and '
-            'got location={}'.format(loc[0], loc[1])) in str(err)
+            'got location={}'.format(loc[0], loc[1])) in str(err.value)
 
     # Fails because the Time has None location and RHS has defined location
     t = Time([[1, 2], [3, 4]], format='cxcsec')
@@ -1328,7 +1328,7 @@ def test_setitem_location():
         t[0, 0] = Time(-2, format='cxcsec', location=loc[1])
     assert ('cannot set to Time with different location: '
             'expected location=None and '
-            'got location={}'.format(loc[1])) in str(err)
+            'got location={}'.format(loc[1])) in str(err.value)
 
     # Broadcasting works
     t = Time([[1, 2], [3, 4]], format='cxcsec', location=loc)
@@ -1369,7 +1369,7 @@ def test_setitem_from_python_objects():
     t[0] = '2001:001'
     with pytest.raises(ValueError) as err:
         t[0] = 100
-    assert 'cannot convert value to a compatible Time object' in str(err)
+    assert 'cannot convert value to a compatible Time object' in str(err.value)
 
 
 def test_setitem_from_time_objects():
@@ -1619,20 +1619,20 @@ def test_insert_exceptions():
     tm = Time(1, format='unix')
     with pytest.raises(TypeError) as err:
         tm.insert(0, 50)
-    assert 'cannot insert into scalar' in str(err)
+    assert 'cannot insert into scalar' in str(err.value)
 
     tm = Time([1, 2], format='unix')
     with pytest.raises(ValueError) as err:
         tm.insert(0, 50, axis=1)
-    assert 'axis must be 0' in str(err)
+    assert 'axis must be 0' in str(err.value)
 
     with pytest.raises(TypeError) as err:
         tm.insert(slice(None), 50)
-    assert 'obj arg must be an integer' in str(err)
+    assert 'obj arg must be an integer' in str(err.value)
 
     with pytest.raises(IndexError) as err:
         tm.insert(-100, 50)
-    assert 'index -100 is out of bounds for axis 0 with size 2' in str(err)
+    assert 'index -100 is out of bounds for axis 0 with size 2' in str(err.value)
 
 
 def test_datetime64_no_format():

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -515,7 +515,7 @@ def test_timedelta_setitem():
 
     with pytest.raises(ValueError) as err:
         t[1] = 1 * u.m
-    assert 'cannot convert value to a compatible TimeDelta' in str(err)
+    assert 'cannot convert value to a compatible TimeDelta' in str(err.value)
 
 
 def test_timedelta_setitem_sec():
@@ -535,7 +535,7 @@ def test_timedelta_setitem_sec():
 
     with pytest.raises(ValueError) as err:
         t[1] = 1 * u.m
-    assert 'cannot convert value to a compatible TimeDelta' in str(err)
+    assert 'cannot convert value to a compatible TimeDelta' in str(err.value)
 
 
 def test_timedelta_mask():

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -61,12 +61,12 @@ def test_mask_not_writeable():
     t = Time('2000:001')
     with pytest.raises(AttributeError) as err:
         t.mask = True
-    assert "can't set attribute" in str(err)
+    assert "can't set attribute" in str(err.value)
 
     t = Time(['2000:001'])
     with pytest.raises(ValueError) as err:
         t.mask[0] = True
-    assert "assignment destination is read-only" in str(err)
+    assert "assignment destination is read-only" in str(err.value)
 
 
 def test_str():

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -364,9 +364,9 @@ def test_deprecated_did_you_mean_units():
     try:
         u.Unit('ANGSTROM', format='vounit')
     except ValueError as e:
-        assert 'angstrom (deprecated)' in str(e)
-        assert '0.1nm' in str(e)
-        assert str(e).count('0.1nm') == 1
+        assert 'angstrom (deprecated)' in str(e.value)
+        assert '0.1nm' in str(e.value)
+        assert str(e.value).count('0.1nm') == 1
 
     with catch_warnings() as w:
         u.Unit('angstrom', format='vounit')

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -267,7 +267,7 @@ class TestIERS_Auto():
             with catch_warnings(iers.IERSStaleWarning) as warns:
                 with pytest.raises(ValueError) as err:
                     dat.ut1_utc(Time(60000, format='mjd').jd)
-            assert 'interpolating from IERS_Auto using predictive values' in str(err)
+            assert 'interpolating from IERS_Auto using predictive values' in str(err.value)
             assert len(warns) == 1
             assert 'IERS_Auto predictive values are older' in str(warns[0].message)
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -188,7 +188,7 @@ def test_local_data_obj(filename):
             with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
                 f.readline()
                 # assert f.read().rstrip() == b'CONTENT'
-        assert ' format files are not supported' in str(e)
+        assert ' format files are not supported' in str(e.value)
     else:
         with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
             f.readline()
@@ -234,7 +234,7 @@ def test_local_data_obj_invalid(bad_compressed):
         with pytest.raises(ValueError) as e:
             with get_readable_fileobj(bad_compressed, encoding='binary') as f:
                 f.read()
-        assert ' format files are not supported' in str(e)
+        assert ' format files are not supported' in str(e.value)
     else:
         with get_readable_fileobj(bad_compressed, encoding='binary') as f:
             assert f.read().rstrip().endswith(b'invalid')

--- a/astropy/utils/tests/test_xml.py
+++ b/astropy/utils/tests/test_xml.py
@@ -88,7 +88,7 @@ def test_escape_xml_without_bleach():
     with pytest.raises(ValueError) as err:
         with w.xml_cleaning_method('bleach_clean'):
             pass
-    assert 'bleach package is required when HTML escaping is disabled' in str(err)
+    assert 'bleach package is required when HTML escaping is disabled' in str(err.value)
 
 
 @pytest.mark.skipif('not HAS_BLEACH')

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -884,7 +884,7 @@ def test_wcs_sub_error_message():
     w = _wcs.Wcsprm()
     with pytest.raises(TypeError) as e:
         w.sub('latitude')
-    assert str(e).endswith("axes must None, a sequence or an integer")
+    assert e.match("axes must None, a sequence or an integer$")
 
 
 def test_wcs_sub():


### PR DESCRIPTION
Attempt to fix errors of the kind
```
>       assert "A Latitude angle cannot be created from a Longitude angle" in str(excinfo)
E       AssertionError: assert 'A Latitude angle cannot be created from a Longitude angle' in '<ExceptionInfo TypeError tblen=2>'
E        +  where '<ExceptionInfo TypeError tblen=2>' = str(<ExceptionInfo TypeError tblen=2>)
```
that started to appear with pytest 5.0.0 as discussed in #8934.
General remedy is to call `str(excinfo.value)` rather than `str(excinfo)`, but there are a few cases where `excinfo` has no method `value` - see in particular patches to `io` and `table`. Apparently some hand-crafted or derived exceptions like `FileNotFoundError` or `fits.VerifyError` still return a plain string instead of an `ExceptionInfo`, but I could not find any hints in the pytest docs how to properly declare exception classes to better handle this.
Also `excinfo.value` does not contain the exception name, but since this is generally checked against immediately before, I think it can be safely omitted from the string comparison.
On the plus side, `ExceptionInfo` provides its own `match` method, simplifying some `re` comparisons (cf. `test_html.py` and `test_wcsprm.py`).
Tested with pytest 5.0.0 on Python 3.5 and 3.8; 4 unrelated `visualisation.wcsaxes` failures that turn up identically with pytest 3.10.1.