### PR TITLE
Fix sign error in galactocentric matrix 1

### DIFF
--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -37,9 +37,9 @@ specified by the ICRS position :math:`(\alpha_{\rm GC}, \delta_{\rm GC})`:
 
    \begin{aligned}
        \boldsymbol{R}_1 &= \begin{bmatrix}
-         \cos\delta_{\rm GC}& 0 & -\sin\delta_{\rm GC}\\
+         \cos\delta_{\rm GC}& 0 & \sin\delta_{\rm GC}\\
          0 & 1 & 0 \\
-         \sin\delta_{\rm GC}& 0 & \cos\delta_{\rm GC}\end{bmatrix}\\
+         -\sin\delta_{\rm GC}& 0 & \cos\delta_{\rm GC}\end{bmatrix}\\
        \boldsymbol{R}_2 &=
        \begin{bmatrix}
          \cos\alpha_{\rm GC}& \sin\alpha_{\rm GC}& 0\\


### PR DESCRIPTION
After auditing the math in the Galactocentric transformation, and reviewing #8645, it looks like there is a bug in the documentation describing the first matrix used in the transformation.

This fixes #8645.