### PR TITLE
Add an attribute to frame classes to retrieve all component names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ astropy.coordinates
   as input. The ephemeris can now be selected by either keyword (e.g. 'jpl',
   'de430'), URL or file path. [#8767]
 
+- Added a ``.component_names`` attribute to all frame classes (and ``SkyCoord``)
+  that returns a list of all component names of a given frame (e.g., position
+  components like ``ra`` and velocity components like ``pm_ra_cosdec``). [#8953]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This adds a new `.component_names` attribute that returns a list of strings containing all position and velocity component names for a given frame class or `SkyCoord` instance. This also adds support for `which='all'` in both `get_representation_component_units()` and `get_representation_component_names()`, which then return the component units and component name mappings for all components simultaneously.

In the current PR, I also made a slight API change that is worth discussing (before I add a changelog entry, in case I should revert). I noticed a discrepancy in master that:
```python
>>> c = coord.SkyCoord(1*u.deg, 2*u.deg)
>>> c.get_representation_component_units()
OrderedDict([('ra', Unit("deg")), ('dec', Unit("deg"))])
>>> c.get_representation_component_names()
OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
```

That is, `.get_representation_component_units()` does not return a key for `distance` because that unit is None. In this PR, I've changed the behavior of `.get_representation_component_units()`:
```python
>>> c.get_representation_component_units()
OrderedDict([('ra', Unit("deg")), ('dec', Unit("deg")), ('distance', None)])
```

This fixes #8373 