### PR TITLE
Use latest pytest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ jobs:
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
       - run:
           name: Install dependencies for Python 3.6
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.6
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp37-cp37m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
         # Set defaults to avoid repeating in most cases
         - PYTHON_VERSION=3.6
         - NUMPY_VERSION=stable
-        - PYTEST_VERSION=3.10
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
@@ -97,13 +96,11 @@ matrix:
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same
         # time.
-        # Run this test using native pytest
         - os: linux
           env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
                INSTALL_CMD='python setup.py build_ext --inplace'
                PIP_DEPENDENCIES='pytest-astropy'
                TEST_CMD='pytest --open-files --doctest-rst'
-               PYTEST_VERSION=3.7
           script:
             - $INSTALL_CMD
             - $TEST_CMD
@@ -115,7 +112,6 @@ matrix:
         - os: linux
           env: SETUP_CMD='test --remote-data=astropy --readonly'
                LC_CTYPE=C.ascii LC_ALL=C
-               PYTEST_VERSION=4.4
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
                INSTALL_WITH_PIP=True
                EXTRAS_INSTALL="test,all"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
                           # to the matrix section.
         CONDA_DEPENDENCIES: "Cython scipy h5py beautifulsoup4 html5lib jinja2 pyyaml matplotlib scikit-image pytz pandas"
         PIP_DEPENDENCIES: "objgraph asdf"
-        PYTEST_VERSION: "<5"
 
     matrix:
         - PYTHON_VERSION: "3.7"

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -73,3 +73,4 @@ def pytest_unconfigure(config):
 
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
 PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
+PYTEST_HEADER_MODULES['asdf'] = 'asdf'

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1889,7 +1889,7 @@ class TestReplaceColumn(SetupData):
 
         with pytest.raises(ValueError) as exc:
             t.replace_column('a', [1, 2])
-        assert "length of new column must match table length" in str(exc)
+        assert "length of new column must match table length" in str(exc.value)
 
     def test_replace_column(self, table_types):
         """Replace existing column with a new column"""


### PR DESCRIPTION
This PR removes the version limitations for pytest as now locally everything passes with v5.0.0

closes #8934 