### PR TITLE
Removing python 3.5 testing as well as changing required python to 3.6+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,12 +19,6 @@ jobs:
               mkdir -p $HOME/.astropy/config/
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
       - run:
-          name: Install dependencies for Python 3.5
-          command: /opt/python/cp35-cp35m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2
-      - run:
-          name: Run tests for Python 3.5
-          command: PYTHONHASHSEED=42 /opt/python/cp35-cp35m/bin/python setup.py test --parallel=4 -a "--durations=50"
-      - run:
           name: Install dependencies for Python 3.6
           command: /opt/python/cp36-cp36m/bin/pip install numpy scipy "pytest<5" pytest-astropy pytest-xdist Cython jinja2
       - run:

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
         # time.
         # Run this test using native pytest
         - os: linux
-          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.13
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
                INSTALL_CMD='python setup.py build_ext --inplace'
                PIP_DEPENDENCIES='pytest-astropy'
                TEST_CMD='pytest --open-files --doctest-rst'

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -322,6 +322,8 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Versions of Python <3.6 are no longer supported. [#8955]
+
 - Matplotlib 2.1 and later is now required. [#8787]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,6 +93,7 @@ minversion = 3.1
 testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern"
 doctest_plus = enabled
+text_file_format = rst
 open_files_ignore = "astropy.log" "/etc/hosts"
 remote_data_strict = true
 addopts = -p no:warnings

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ zip_safe = False
 tests_require = pytest-astropy
 setup_requires = numpy>=1.13
 install_requires = numpy>=1.13
-python_requires = >=3.5
+python_requires = >=3.6
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
Since v4.0 LTS will require python 3.6+ we can remove testing older versions now.

Merging this now means that PRs assuming python 3.6+ compatibility can move forward.