### PR TITLE
Table operations always return unmasked table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -203,6 +203,10 @@ astropy.table
   were added. See the ``Masking change in astropy 4.0`` section within
   `<https://docs.astropy.org/en/v4.0/table/masking.html>`_ for details. [#8789]
 
+- Table operation functions such as ``join``, ``vstack``, ``hstack``, etc now
+  always return a table with ``masked=False``, though the individual columns may
+  be masked as necessary. [#8957]
+
 - Changed implementation of ``Table.add_column()`` and ``Table.add_columns()``
   methods.  Now it is possible add any object(s) which can be converted or broadcasted
   to a valid column for the table.  ``Table.__setitem__`` now just calls

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -946,7 +946,6 @@ def _hstack(arrays, join_type='outer', uniq_col_name='{col_name}_{table_name}',
     # If there are any output rows where one or more input arrays are missing
     # then the output must be masked.  If any input arrays are masked then
     # output is masked.
-    # masked = any(getattr(arr, 'masked', False) for arr in arrays) or len(set(arr_lens)) > 1
 
     n_rows = max(arr_lens)
     out = _get_out_class(arrays)()

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -472,20 +472,21 @@ def unique(input_table, keys=None, silent=False, keep='first'):
         if len(set(keys)) != len(keys):
             raise ValueError("duplicate key names")
 
-    if input_table.masked:
-        nkeys = 0
-        for key in keys[:]:
-            if np.any(input_table[key].mask):
-                if not silent:
-                    raise ValueError(
-                        "cannot use columns with masked values as keys; "
-                        "remove column '{0}' from keys and rerun "
-                        "unique()".format(key))
-                del keys[keys.index(key)]
-        if len(keys) == 0:
-            raise ValueError("no column remained in ``keys``; "
-                             "unique() cannot work with masked value "
-                             "key columns")
+    # Check for columns with masked values
+    nkeys = 0
+    for key in keys[:]:
+        col = input_table[key]
+        if hasattr(col, 'mask') and np.any(col.mask):
+            if not silent:
+                raise ValueError(
+                    "cannot use columns with masked values as keys; "
+                    "remove column '{0}' from keys and rerun "
+                    "unique()".format(key))
+            del keys[keys.index(key)]
+    if len(keys) == 0:
+        raise ValueError("no column remained in ``keys``; "
+                         "unique() cannot work with masked value "
+                         "key columns")
 
     grouped_table = input_table.group_by(keys)
     indices = grouped_table.groups.indices

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -772,14 +772,6 @@ def _join(left, right, keys=None, join_type='inner',
     return out
 
 
-def unmask_table_columns(tbl):
-    if tbl.masked:
-        tbl._set_masked(False)
-        for col in tbl.itercols():
-            if isinstance(col, MaskedColumn) and not np.any(col.mask):
-                tbl[col.name] = Column(col, copy=False)
-
-
 def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='warn'):
     """
     Stack Tables vertically (by rows)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -973,10 +973,10 @@ class Table:
             if isinstance(col, Column) and not isinstance(col, self.MaskedColumn):
                 col_cls = self.MaskedColumn
         else:
-             if isinstance(col, MaskedColumn):
+            if isinstance(col, MaskedColumn):
                 if not isinstance(col, self.MaskedColumn):
                     col_cls = self.MaskedColumn
-             elif isinstance(col, Column) and not isinstance(col, self.Column):
+            elif isinstance(col, Column) and not isinstance(col, self.Column):
                 col_cls = self.Column
 
         return col_cls
@@ -990,7 +990,8 @@ class Table:
         """
         if isinstance(col, Column) and not isinstance(col, self.ColumnClass):
             col_cls = self._get_col_cls_for_table(col)
-            col = col_cls(col, copy=False)
+            if col_cls is not col.__class__:
+                col = col_cls(col, copy=False)
 
         return col
 
@@ -2735,7 +2736,8 @@ class Table:
                    Jo  Miller  15
                   Max  Miller  12
 
-        Sorting according to standard sorting rules, first 'firstname' then 'tel', in reverse order::
+        Sorting according to standard sorting rules, first 'firstname' then 'tel',
+        in reverse order::
 
             >>> t.sort(['firstname', 'tel'], reverse=True)
             >>> print(t)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -122,7 +122,8 @@ class TestJoin():
 
         # Left join
         t12 = table.join(t1, t2, join_type='left')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
+        assert t12.masked is False
         assert sort_eq(t12.pformat(), [' a   b   c   d ',
                                        '--- --- --- ---',
                                        '  0 foo  L1  --',
@@ -133,7 +134,8 @@ class TestJoin():
 
         # Right join
         t12 = table.join(t1, t2, join_type='right')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
+        assert t12.masked is False
         assert sort_eq(t12.pformat(), [' a   b   c   d ',
                                        '--- --- --- ---',
                                        '  1 foo  L2  R1',
@@ -143,7 +145,8 @@ class TestJoin():
 
         # Outer join
         t12 = table.join(t1, t2, join_type='outer')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
+        assert t12.masked is False
         assert sort_eq(t12.pformat(), [' a   b   c   d ',
                                        '--- --- --- ---',
                                        '  0 foo  L1  --',
@@ -189,7 +192,7 @@ class TestJoin():
 
         # Left join
         t12 = table.join(t1, t2, join_type='left', keys='a')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
         assert sort_eq(t12.pformat(), [' a  b_1  c  b_2  d ',
                                        '--- --- --- --- ---',
                                        '  0 foo  L1  --  --',
@@ -201,7 +204,7 @@ class TestJoin():
 
         # Right join
         t12 = table.join(t1, t2, join_type='right', keys='a')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
         assert sort_eq(t12.pformat(), [' a  b_1  c  b_2  d ',
                                        '--- --- --- --- ---',
                                        '  1 foo  L2 foo  R1',
@@ -213,7 +216,7 @@ class TestJoin():
 
         # Outer join
         t12 = table.join(t1, t2, join_type='outer', keys='a')
-        assert t12.masked is True
+        assert t12.has_masked_columns is True
         assert sort_eq(t12.pformat(), [' a  b_1  c  b_2  d ',
                                        '--- --- --- --- ---',
                                        '  0 foo  L1  --  --',
@@ -232,9 +235,9 @@ class TestJoin():
         t1m = operation_table_type(self.t1, masked=True)
         t2 = self.t2
 
-        # Result should be masked even though not req'd by inner join
+        # Result table is never masked
         t1m2 = table.join(t1m, t2, join_type='inner')
-        assert t1m2.masked is True
+        assert t1m2.masked is False
 
         # Result should match non-masked result
         t12 = table.join(t1, t2)
@@ -271,9 +274,9 @@ class TestJoin():
         t2 = self.t2
         t2m = operation_table_type(self.t2, masked=True)
 
-        # Result should be masked even though not req'd by inner join
+        # Result table is never masked
         t1m2m = table.join(t1m, t2m, join_type='inner')
-        assert t1m2m.masked is True
+        assert t1m2m.masked is False
 
         # Result should match non-masked result
         t12 = table.join(t1, t2)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -650,6 +650,7 @@ class TestVStack():
         t2 = self.t1.copy()
         t2.meta.clear()
         out = table.vstack([self.t1, t2['a']])
+        assert out.masked is False
         assert out.pformat() == [' a   b ',
                                  '--- ---',
                                  '0.0 foo',
@@ -739,6 +740,7 @@ class TestVStack():
         t2 = self.t2
         t4 = self.t4
         t12 = table.vstack([t1, t2], join_type='outer')
+        assert t12.masked is False
         assert t12.pformat() == [' a   b   c ',
                                  '--- --- ---',
                                  '0.0 foo  --',
@@ -747,6 +749,7 @@ class TestVStack():
                                  '3.0 sez   5']
 
         t124 = table.vstack([t1, t2, t4], join_type='outer')
+        assert t124.masked is False
         assert t124.pformat() == [' a   b   c ',
                                   '--- --- ---',
                                   '0.0 foo  --',
@@ -784,12 +787,14 @@ class TestVStack():
         t1 = self.t1
         t4 = self.t4
         t4['b'].mask[1] = True
-        assert table.vstack([t1, t4]).pformat() == [' a   b ',
-                                                    '--- ---',
-                                                    '0.0 foo',
-                                                    '1.0 bar',
-                                                    '0.0 foo',
-                                                    '1.0  --']
+        t14 = table.vstack([t1, t4])
+        assert t14.masked is False
+        assert t14.pformat() == [' a   b ',
+                                 '--- ---',
+                                 '0.0 foo',
+                                 '1.0 bar',
+                                 '0.0 foo',
+                                 '1.0  --']
 
     def test_col_meta_merge_inner(self, operation_table_type):
         self._setup(operation_table_type)
@@ -1003,6 +1008,7 @@ class TestHStack():
         """
         self._setup(operation_table_type)
         out = table.hstack([self.t1, self.t1])
+        assert out.masked is False
         assert out.pformat() == ['a_1 b_1 a_2 b_2',
                                  '--- --- --- ---',
                                  '0.0 foo 0.0 foo',
@@ -1011,6 +1017,7 @@ class TestHStack():
     def test_stack_rows(self, operation_table_type):
         self._setup(operation_table_type)
         out = table.hstack([self.t1[0], self.t2[1]])
+        assert out.masked is False
         assert out.pformat() == ['a_1 b_1 a_2 b_2  c ',
                                  '--- --- --- --- ---',
                                  '0.0 foo 3.0 sez   5']
@@ -1096,6 +1103,7 @@ class TestHStack():
         assert out.pformat() == out_list.pformat()
 
         out = table.hstack([t1, t2, t3, t4], join_type='outer')
+        assert out.masked is False
         assert out.pformat() == ['a_1 b_1 a_2 b_2  c   d   e   f   g ',
                                  '--- --- --- --- --- --- --- --- ---',
                                  '0.0 foo 2.0 pez   4 4.0   7 0.0 foo',
@@ -1103,6 +1111,7 @@ class TestHStack():
                                  ' --  --  --  --  -- 6.0   9  --  --']
 
         out = table.hstack([t1, t2, t3, t4], join_type='inner')
+        assert out.masked is False
         assert out.pformat() == ['a_1 b_1 a_2 b_2  c   d   e   f   g ',
                                  '--- --- --- --- --- --- --- --- ---',
                                  '0.0 foo 2.0 pez   4 4.0   7 0.0 foo',
@@ -1123,10 +1132,11 @@ class TestHStack():
         t2 = operation_table_type(t1, copy=True, masked=True)
         t2.meta.clear()
         t2['b'].mask[1] = True
-        assert table.hstack([t1, t2]).pformat() == ['a_1 b_1 a_2 b_2',
-                                                    '--- --- --- ---',
-                                                    '0.0 foo 0.0 foo',
-                                                    '1.0 bar 1.0  --']
+        out = table.hstack([t1, t2])
+        assert out.pformat() == ['a_1 b_1 a_2 b_2',
+                                 '--- --- --- ---',
+                                 '0.0 foo 0.0 foo',
+                                 '1.0 bar 1.0  --']
 
     def test_table_col_rename(self, operation_table_type):
         self._setup(operation_table_type)
@@ -1305,6 +1315,7 @@ def test_unique(operation_table_type):
         "remove column 'a' from keys and rerun unique()")
 
     t1_mu = table.unique(t1_m, silent=True)
+    assert t1_mu.masked is False
     assert t1_mu.pformat() == [' a   b   c   d ',
                                '--- --- --- ---',
                                '  0   a 0.0   4',
@@ -1321,6 +1332,7 @@ def test_unique(operation_table_type):
     # Test that multiple masked key columns get removed in the correct
     # order
     t1_mu = table.unique(t1_m, keys=['d', 'a', 'b'], silent=True)
+    assert t1_mu.masked is False
     assert t1_mu.pformat() == [' a   b   c   d ',
                                '--- --- --- ---',
                                '  2   a 4.0  --',


### PR DESCRIPTION
Closes #8942 

This implementation is not the fastest since it just does a post-facto fix of the table.  But this is simple (i.e. reliable) and not a terrible performance hit.