### PR TITLE
Convert format and % strings to  f-strings

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -38,8 +38,8 @@ class UnsupportedPythonError(Exception):
 
 
 # This is the same check as the one at the top of setup.py
-if sys.version_info < tuple((int(val) for val in __minimum_python_version__.split('.'))):
-    raise UnsupportedPythonError("Astropy does not support Python < {}".format(__minimum_python_version__))
+if sys.version_info < tuple(int(val) for val in __minimum_python_version__.split('.')):
+    raise UnsupportedPythonError(f"Astropy does not support Python < {__minimum_python_version__}")
 
 
 def _is_astropy_source(path=None):
@@ -92,7 +92,7 @@ except ImportError:
 if 'dev' in __version__:
     online_docs_root = 'http://docs.astropy.org/en/latest/'
 else:
-    online_docs_root = 'http://docs.astropy.org/en/{0}/'.format(__version__)
+    online_docs_root = f'http://docs.astropy.org/en/{__version__}/'
 
 
 def _check_numpy():
@@ -113,7 +113,7 @@ def _check_numpy():
         requirement_met = minversion(numpy, __minimum_numpy_version__)
 
     if not requirement_met:
-        msg = ("Numpy version {0} or later must be installed to use "
+        msg = ("Numpy version {} or later must be installed to use "
                "Astropy".format(__minimum_numpy_version__))
         raise ImportError(msg)
 
@@ -201,7 +201,7 @@ class base_constants_version(ScienceState):
                 self._parent._value = self._value
 
             def __repr__(self):
-                return ('<ScienceState {0}: {1!r}>'
+                return ('<ScienceState {}: {!r}>'
                         .format(self._parent.__name__, self._parent._value))
 
         ctx = _Context(cls, cls._value)
@@ -324,7 +324,7 @@ def _rebuild_extensions():
 
     if sp.returncode != 0:
         raise OSError('Running setup.py build_ext --inplace failed '
-                      'with error code {0}: try rerunning this command '
+                      'with error code {}: try rerunning this command '
                       'manually to check what the error was.'.format(
                           sp.returncode))
 
@@ -348,7 +348,7 @@ def _get_bibtex():
     with open(citation_file, 'r') as citation:
         refs = citation.read().split('@ARTICLE')[1:]
         if len(refs) == 0: return ''
-        bibtexreference = "@ARTICLE{0}".format(refs[0])
+        bibtexreference = "@ARTICLE{}".format(refs[0])
     return bibtexreference
 
 
@@ -389,7 +389,7 @@ def online_help(query):
     else:
         version = 'v' + version
 
-    url = 'http://docs.astropy.org/en/{0}/search.html?{1}'.format(
+    url = 'http://docs.astropy.org/en/{}/search.html?{}'.format(
         version, urlencode({'q': query}))
 
     webbrowser.open(url)

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -141,7 +141,7 @@ class ArgumentDoc:
             self.doc = None
 
     def __repr__(self):
-        return "    {0:15} {1:15} {2}".format(self.name, self.type, self.doc)
+        return f"    {self.name:15} {self.type:15} {self.doc}"
 
 
 class Variable:
@@ -224,7 +224,7 @@ class Variable:
 
     @property
     def cshape(self):
-        return ''.join(['[{0}]'.format(s) for s in self.shape])
+        return ''.join([f'[{s}]' for s in self.shape])
 
     @property
     def signature_shape(self):
@@ -294,7 +294,7 @@ class Argument(Variable):
             return '*_'+self.name
 
     def __repr__(self):
-        return "Argument('{0}', name='{1}', ctype='{2}', inout_state='{3}')".format(self.definition, self.name, self.ctype, self.inout_state)
+        return f"Argument('{self.definition}', name='{self.name}', ctype='{self.ctype}', inout_state='{self.inout_state}')"
 
 
 class ReturnDoc:
@@ -324,7 +324,7 @@ class ReturnDoc:
             self.statuscodes = None
 
     def __repr__(self):
-        return "Return value, type={0:15}, {1}, {2}".format(self.type, self.descr, self.doc)
+        return f"Return value, type={self.type:15}, {self.descr}, {self.doc}"
 
 
 class Return(Variable):
@@ -337,7 +337,7 @@ class Return(Variable):
         self.doc = doc
 
     def __repr__(self):
-        return "Return(name='{0}', ctype='{1}', inout_state='{2}')".format(self.name, self.ctype, self.inout_state)
+        return f"Return(name='{self.name}', ctype='{self.ctype}', inout_state='{self.inout_state}')"
 
     @property
     def doc_info(self):
@@ -386,7 +386,7 @@ class Function:
             else:
                 filecontents = f.read()
 
-        pattern = r"\n([^\n]+{0} ?\([^)]+\)).+?(/\*.+?\*/)".format(name)
+        pattern = fr"\n([^\n]+{name} ?\([^)]+\)).+?(/\*.+?\*/)"
         p = re.compile(pattern, flags=re.DOTALL | re.MULTILINE)
 
         search = p.search(filecontents)
@@ -396,7 +396,7 @@ class Function:
         self.args = []
         for arg in re.search(r"\(([^)]+)\)", self.cfunc).group(1).split(', '):
             self.args.append(Argument(arg, self.doc))
-        self.ret = re.search("^(.*){0}".format(name), self.cfunc).group(1).strip()
+        self.ret = re.search(f"^(.*){name}", self.cfunc).group(1).strip()
         if self.ret != 'void':
             self.args.append(Return(self.ret, self.doc))
 
@@ -496,7 +496,7 @@ class Function:
                                                args=', '.join(argnames))
 
     def __repr__(self):
-        return "Function(name='{0}', pyname='{1}', filename='{2}', filepath='{3}')".format(self.name, self.pyname, self.filename, self.filepath)
+        return f"Function(name='{self.name}', pyname='{self.pyname}', filename='{self.filename}', filepath='{self.filepath}')"
 
 
 class Constant:
@@ -555,12 +555,12 @@ class ExtraFunction(Function):
                                  '{}'.format(self.prototype, pathfordoc))
 
         self.args = []
-        argset = re.search(r"{0}\(([^)]+)?\)".format(self.name),
+        argset = re.search(fr"{self.name}\(([^)]+)?\)",
                            self.prototype).group(1)
         if argset is not None:
             for arg in argset.split(', '):
                 self.args.append(Argument(arg, self.doc))
-        self.ret = re.match("^(.*){0}".format(self.name),
+        self.ret = re.match(f"^(.*){self.name}",
                             self.prototype).group(1).strip()
         if self.ret != 'void':
             self.args.append(Return(self.ret, self.doc))
@@ -586,13 +586,13 @@ def main(srcdir=DEFAULT_ERFA_LOC, outfn='core.py', ufuncfn='ufunc.c',
     env = Environment(loader=FileSystemLoader(templateloc))
 
     def prefix(a_list, pre):
-        return [pre+'{0}'.format(an_element) for an_element in a_list]
+        return [pre+f'{an_element}' for an_element in a_list]
 
     def postfix(a_list, post):
-        return ['{0}'.format(an_element)+post for an_element in a_list]
+        return [f'{an_element}'+post for an_element in a_list]
 
     def surround(a_list, pre, post):
-        return [pre+'{0}'.format(an_element)+post for an_element in a_list]
+        return [pre+f'{an_element}'+post for an_element in a_list]
     env.filters['prefix'] = prefix
     env.filters['postfix'] = postfix
     env.filters['surround'] = surround
@@ -621,7 +621,7 @@ def main(srcdir=DEFAULT_ERFA_LOC, outfn='core.py', ufuncfn='ufunc.c',
         r'/\* (\w*)/(\w*) \*/\n(.*?)\n\n', erfa_h,
         flags=re.DOTALL | re.MULTILINE)
     for section, subsection, functions in section_subsection_functions:
-        print_("{0}.{1}".format(section, subsection))
+        print_(f"{section}.{subsection}")
         # Right now, we compile everything, but one could be more selective.
         # In particular, at the time of writing (2018-06-11), what was
         # actually require for astropy was not quite everything, but:
@@ -636,7 +636,7 @@ def main(srcdir=DEFAULT_ERFA_LOC, outfn='core.py', ufuncfn='ufunc.c',
             func_names = re.findall(r' (\w+)\(.*?\);', functions,
                                     flags=re.DOTALL)
             for name in func_names:
-                print_("{0}.{1}.{2}...".format(section, subsection, name))
+                print_(f"{section}.{subsection}.{name}...")
                 if multifilserc:
                     # easy because it just looks in the file itself
                     cdir = (srcdir if section != 'Extra' else
@@ -716,7 +716,7 @@ if __name__ == '__main__':
                          'can be found or to a single erfa.c file '
                          '(which must be in the same directory as '
                          'erfa.h). Defaults to the builtin astropy '
-                         'erfa: "{0}"'.format(DEFAULT_ERFA_LOC))
+                         'erfa: "{}"'.format(DEFAULT_ERFA_LOC))
     ap.add_argument('-o', '--output', default='core.py',
                     help='The output filename for the pure-python output.')
     ap.add_argument('-u', '--ufunc', default='ufunc.c',

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -114,7 +114,7 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
         """
         if hasattr(self, attr):
             return self.__class__.__dict__[attr].set_temp(value)
-        raise AttributeError("No configuration parameter '{0}'".format(attr))
+        raise AttributeError(f"No configuration parameter '{attr}'")
 
     def reload(self, attr=None):
         """
@@ -129,7 +129,7 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
         if attr is not None:
             if hasattr(self, attr):
                 return self.__class__.__dict__[attr].reload()
-            raise AttributeError("No configuration parameter '{0}'".format(attr))
+            raise AttributeError(f"No configuration parameter '{attr}'")
 
         for item in self.__class__.__dict__.values():
             if isinstance(item, ConfigItem):
@@ -150,7 +150,7 @@ class ConfigNamespace(metaclass=_ConfigNamespaceMeta):
                 prop = self.__class__.__dict__[attr]
                 prop.set(prop.defaultvalue)
                 return
-            raise AttributeError("No configuration parameter '{0}'".format(attr))
+            raise AttributeError(f"No configuration parameter '{attr}'")
 
         for item in self.__class__.__dict__.values():
             if isinstance(item, ConfigItem):
@@ -356,7 +356,7 @@ class ConfigItem(metaclass=InheritDocstrings):
         return baseobj.get(self.name)
 
     def __repr__(self):
-        out = '<{0}: name={1!r} value={2!r} at 0x{3:x}>'.format(
+        out = '<{}: name={!r} value={!r} at 0x{:x}>'.format(
             self.__class__.__name__, self.name, self(), id(self))
         return out
 
@@ -390,7 +390,7 @@ class ConfigItem(metaclass=InheritDocstrings):
             if section == '':
                 return 'at the top-level'
             else:
-                return 'in section [{0}]'.format(section)
+                return f'in section [{section}]'
 
         options = []
         sec = get_config(self.module)
@@ -411,8 +411,8 @@ class ConfigItem(metaclass=InheritDocstrings):
                 else:
                     new_module = ''
                 warn(
-                    "Config parameter '{0}' {1} of the file '{2}' "
-                    "is deprecated. Use '{3}' {4} instead.".format(
+                    "Config parameter '{}' {} of the file '{}' "
+                    "is deprecated. Use '{}' {} instead.".format(
                         name, section_name(module), get_config_filename(filename),
                         self.name, section_name(new_module)),
                     AstropyDeprecationWarning)
@@ -425,8 +425,8 @@ class ConfigItem(metaclass=InheritDocstrings):
         if len(options) > 1:
             filename, sec = self.module.split('.', 1)
             warn(
-                "Config parameter '{0}' {1} of the file '{2}' is "
-                "given by more than one alias ({3}). Using the first.".format(
+                "Config parameter '{}' {} of the file '{}' is "
+                "given by more than one alias ({}). Using the first.".format(
                     self.name, section_name(sec), get_config_filename(filename),
                     ', '.join([
                         '.'.join(x[1:3]) for x in options if x[1] is not None])),
@@ -528,7 +528,7 @@ def get_config(packageormod=None, reload=False):
             msg = ('Configuration defaults will be used due to ')
             errstr = '' if len(e.args) < 1 else (':' + str(e.args[0]))
             msg += e.__class__.__name__ + errstr
-            msg += ' on {0}'.format(cfgfn)
+            msg += f' on {cfgfn}'
             warn(ConfigurationMissingWarning(msg))
 
             # This caches the object, so if the file becomes accessible, this
@@ -686,7 +686,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
     # spamming `~/.astropy/config`.
     if 'dev' not in version and cfgfn is not None:
         template_path = path.join(
-            get_config_dir(), '{0}.{1}.cfg'.format(pkg, version))
+            get_config_dir(), f'{pkg}.{version}.cfg')
         needs_template = not path.exists(template_path)
     else:
         needs_template = False
@@ -700,10 +700,10 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None):
             # changes, display a warning.
             if not identical and not doupdate:
                 warn(
-                    "The configuration options in {0} {1} may have changed, "
+                    "The configuration options in {} {} may have changed, "
                     "your configuration file was not updated in order to "
                     "preserve local changes.  A new configuration template "
-                    "has been saved to '{2}'.".format(
+                    "has been saved to '{}'.".format(
                         pkg, version, template_path),
                     ConfigurationChangedWarning)
 

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -48,10 +48,10 @@ class ConstantMeta(InheritDocstrings):
                         name_lower in self._has_incompatible_units):
                     systems = sorted([x for x in instances if x])
                     raise TypeError(
-                        'Constant {0!r} does not have physically compatible '
+                        'Constant {!r} does not have physically compatible '
                         'units across all systems of units and cannot be '
                         'combined with other values without specifying a '
-                        'system (eg. {1}.{2})'.format(self.abbrev, self.abbrev,
+                        'system (eg. {}.{})'.format(self.abbrev, self.abbrev,
                                                       systems[0]))
 
                 return meth(self, *args, **kwargs)
@@ -87,7 +87,7 @@ class Constant(Quantity, metaclass=ConstantMeta):
         if reference is None:
             reference = getattr(cls, 'default_reference', None)
             if reference is None:
-                raise TypeError("{} requires a reference.".format(cls))
+                raise TypeError(f"{cls} requires a reference.")
         name_lower = name.lower()
         instances = cls._registry.setdefault(name_lower, {})
         # By-pass Quantity initialization, since units may not yet be
@@ -95,8 +95,8 @@ class Constant(Quantity, metaclass=ConstantMeta):
         inst = np.array(value).view(cls)
 
         if system in instances:
-                warnings.warn('Constant {0!r} already has a definition in the '
-                              '{1!r} system from {2!r} reference'.format(
+                warnings.warn('Constant {!r} already has a definition in the '
+                              '{!r} system from {!r} reference'.format(
                               name, system, reference), AstropyUserWarning)
         for c in instances.values():
             if system is not None and not hasattr(c.__class__, system):
@@ -118,17 +118,17 @@ class Constant(Quantity, metaclass=ConstantMeta):
         return inst
 
     def __repr__(self):
-        return ('<{0} name={1!r} value={2} uncertainty={3} unit={4!r} '
-                'reference={5!r}>'.format(self.__class__, self.name, self.value,
+        return ('<{} name={!r} value={} uncertainty={} unit={!r} '
+                'reference={!r}>'.format(self.__class__, self.name, self.value,
                                           self.uncertainty, str(self.unit),
                                           self.reference))
 
     def __str__(self):
-        return ('  Name   = {0}\n'
-                '  Value  = {1}\n'
-                '  Uncertainty  = {2}\n'
-                '  Unit  = {3}\n'
-                '  Reference = {4}'.format(self.name, self.value,
+        return ('  Name   = {}\n'
+                '  Value  = {}\n'
+                '  Uncertainty  = {}\n'
+                '  Unit  = {}\n'
+                '  Reference = {}'.format(self.name, self.value,
                                            self.uncertainty, self.unit,
                                            self.reference))
 

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -55,7 +55,7 @@ GM_sun = IAU2015('GM_sun', 'Nominal solar mass parameter', 1.3271244e20,
 M_sun = IAU2015('M_sun', "Solar mass", GM_sun.value / codata.G.value,
                 'kg', ((codata.G.uncertainty / codata.G.value) *
                        (GM_sun.value / codata.G.value)),
-                "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                f"IAU 2015 Resolution B 3 + {codata.G.reference}",
                 system='si')
 
 # Solar radius
@@ -73,7 +73,7 @@ GM_jup = IAU2015('GM_jup', 'Nominal Jupiter mass parameter', 1.2668653e17,
 M_jup = IAU2015('M_jup', "Jupiter mass", GM_jup.value / codata.G.value,
                 'kg', ((codata.G.uncertainty / codata.G.value) *
                        (GM_jup.value / codata.G.value)),
-                "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                f"IAU 2015 Resolution B 3 + {codata.G.reference}",
                 system='si')
 
 # Jupiter equatorial radius
@@ -89,7 +89,7 @@ M_earth = IAU2015('M_earth', "Earth mass",
                   GM_earth.value / codata.G.value,
                   'kg', ((codata.G.uncertainty / codata.G.value) *
                          (GM_earth.value / codata.G.value)),
-                  "IAU 2015 Resolution B 3 + {}".format(codata.G.reference),
+                  f"IAU 2015 Resolution B 3 + {codata.G.reference}",
                   system='si')
 
 # Earth equatorial radius

--- a/astropy/constants/utils.py
+++ b/astropy/constants/utils.py
@@ -76,5 +76,5 @@ def _set_c(codata, iaudata, module, not_in_module_only=True, doclines=None,
         setattr(module, _c.abbrev, value)
 
         if doclines is not None:
-            doclines.append('{0:^10} {1:^14.9g} {2:^16} {3}'.format(
+            doclines.append('{:^10} {:^14.9g} {:^16} {}'.format(
                 _c.abbrev, _c.value, _c._unit_string, _c.name))

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -173,7 +173,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
     '''
 
     if boundary not in BOUNDARY_OPTIONS:
-        raise ValueError("Invalid boundary option: must be one of {0}"
+        raise ValueError("Invalid boundary option: must be one of {}"
                          .format(BOUNDARY_OPTIONS))
 
     if nan_treatment not in ('interpolate', 'fill'):
@@ -276,7 +276,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
         if kernel_sum < 1. / MAX_NORMALIZATION or kernel_sums_to_zero:
             raise ValueError("The kernel can't be normalized, because its sum is "
-                            "close to zero. The sum of the given kernel is < {0}"
+                            "close to zero. The sum of the given kernel is < {}"
                             .format(1. / MAX_NORMALIZATION))
 
     # Mark the NaN values so we can replace them later if interpolate_nan is
@@ -604,7 +604,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     if normalize_kernel is True:
         if kernel.sum() < 1. / MAX_NORMALIZATION:
             raise Exception("The kernel can't be normalized, because its sum is "
-                            "close to zero. The sum of the given kernel is < {0}"
+                            "close to zero. The sum of the given kernel is < {}"
                             .format(1. / MAX_NORMALIZATION))
         kernel_scale = kernel.sum()
         normalized_kernel = kernel / kernel_scale
@@ -640,7 +640,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
     elif boundary == 'fill':
         # create a boundary region at least as large as the kernel
         if psf_pad is False:
-            warnings.warn("psf_pad was set to {0}, which overrides the "
+            warnings.warn("psf_pad was set to {}, which overrides the "
                           "boundary='fill' setting.".format(psf_pad),
                           AstropyUserWarning)
         else:
@@ -858,6 +858,6 @@ def convolve_models(model, kernel, mode='convolve_fft', **kwargs):
     elif mode == 'convolve':
         BINARY_OPERATORS['convolve'] = _make_arithmetic_operator(partial(convolve, **kwargs))
     else:
-        raise ValueError('Mode {} is not supported.'.format(mode))
+        raise ValueError(f'Mode {mode} is not supported.')
 
     return _CompoundModelMeta._from_operator(mode, model, kernel)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -902,7 +902,7 @@ def test_astropy_convolution_against_scipy():
 
 @pytest.mark.skipif('not HAS_PANDAS')
 def test_regression_6099():
-    wave = np.array((np.linspace(5000, 5100, 10)))
+    wave = np.array(np.linspace(5000, 5100, 10))
     boxcar = 3
     nonseries_result = convolve(wave, np.ones((boxcar,))/boxcar)
 

--- a/astropy/convolution/tests/test_convolve_models.py
+++ b/astropy/convolution/tests/test_convolve_models.py
@@ -25,7 +25,7 @@ class TestConvolve1DModels:
         model = models.Gaussian1D(1, 0, 1)
         model_conv = convolve_models(model, kernel, mode=mode)
         x = np.arange(-5, 6)
-        ans = eval("{}(model(x), kernel(x))".format(mode))
+        ans = eval(f"{mode}(model(x), kernel(x))")
 
         assert_allclose(ans, model_conv(x), atol=1e-5)
 

--- a/astropy/convolution/tests/test_convolve_speeds.py
+++ b/astropy/convolution/tests/test_convolve_speeds.py
@@ -31,7 +31,7 @@ kernel = np.random.random([%i]*%i)""") % (2 ** ii - 1, ndims, 2 ** ii - 1, ndims
                 if ii <= max_exponents_linear[ndims]:
                     for convolve_type, extra in zip(("", "_fft"),
                                               ("", "fft_pad=False")):
-                        statement = "convolve{}(array, kernel, boundary='fill', {})".format(convolve_type, extra)
+                        statement = f"convolve{convolve_type}(array, kernel, boundary='fill', {extra})"
                         besttime = min(timeit.Timer(stmt=statement, setup=setup).repeat(3, 10))
                         print("%17f" % (besttime), end=' ')
                 else:
@@ -57,7 +57,7 @@ kernel = np.random.random([%i]*%i)""") % (2 ** ii, ndims, 2 ** ii, ndims)
                     if convolve_type == "":
                         print("%17s" % ("-"), end=' ')
                     else:
-                        statement = "convolve{}(array, kernel, boundary='fill')".format(convolve_type)
+                        statement = f"convolve{convolve_type}(array, kernel, boundary='fill')"
                         besttime = min(timeit.Timer(stmt=statement, setup=setup).repeat(3, 10))
                         print("%17f" % (besttime), end=' ')
             else:

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -127,7 +127,7 @@ class _AngleParser:
             t.value = u.Unit(t.value)
             return t
         t_SIMPLE_UNIT.__doc__ = '|'.join(
-            '(?:{0})'.format(x) for x in cls._get_simple_unit_names())
+            f'(?:{x})' for x in cls._get_simple_unit_names())
 
         t_COLON = ':'
         t_DEGREE = r'd(eg(ree(s)?)?)?|°'
@@ -141,7 +141,7 @@ class _AngleParser:
         # Error handling rule
         def t_error(t):
             raise ValueError(
-                "Invalid character at col {0}".format(t.lexpos))
+                f"Invalid character at col {t.lexpos}")
 
         lexer_exists = os.path.exists(os.path.join(os.path.dirname(__file__),
                                       'angle_lextab.py'))
@@ -305,11 +305,11 @@ class _AngleParser:
                 angle, lexer=self._lexer, debug=debug)
         except ValueError as e:
             if str(e):
-                raise ValueError("{0} in angle {1!r}".format(
+                raise ValueError("{} in angle {!r}".format(
                     str(e), angle))
             else:
                 raise ValueError(
-                    "Syntax error parsing angle {0!r}".format(angle))
+                    f"Syntax error parsing angle {angle!r}")
 
         if unit is None and found_unit is None:
             raise u.UnitsError("No unit specified")
@@ -629,7 +629,7 @@ def sexagesimal_to_string(values, precision=None, pad=False, sep=(':',),
         literal.append('{1:02d}{sep[1]}')
     if fields == 3:
         if precision is None:
-            last_value = '{0:.4f}'.format(abs(values[2]))
+            last_value = '{:.4f}'.format(abs(values[2]))
             last_value = last_value.rstrip('0').rstrip('.')
         else:
             last_value = '{0:.{precision}f}'.format(

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -120,7 +120,7 @@ class Angle(u.SpecificTypeQuantity):
         elif unit == u.degree:
             return util.dms_to_degrees(*angle)
         else:
-            raise u.UnitsError("Can not parse '{0}' as unit '{1}'"
+            raise u.UnitsError("Can not parse '{}' as unit '{}'"
                                .format(angle, unit))
 
     @staticmethod
@@ -253,7 +253,7 @@ class Angle(u.SpecificTypeQuantity):
 
         if sep == 'fromunit':
             if format not in separators:
-                raise ValueError("Unknown format '{0}'".format(format))
+                raise ValueError(f"Unknown format '{format}'")
             seps = separators[format]
             if unit in seps:
                 sep = seps[unit]
@@ -266,7 +266,7 @@ class Angle(u.SpecificTypeQuantity):
                 if precision is not None:
                     func = ("{0:0." + str(precision) + "f}").format
                 else:
-                    func = '{0:g}'.format
+                    func = '{:g}'.format
             else:
                 if sep == 'fromunit':
                     sep = 'dms'
@@ -281,7 +281,7 @@ class Angle(u.SpecificTypeQuantity):
                 if precision is not None:
                     func = ("{0:0." + str(precision) + "f}").format
                 else:
-                    func = '{0:g}'.format
+                    func = '{:g}'.format
             else:
                 if sep == 'fromunit':
                     sep = 'hms'
@@ -296,7 +296,7 @@ class Angle(u.SpecificTypeQuantity):
                 if precision is not None:
                     func = ("{0:1." + str(precision) + "f}").format
                 else:
-                    func = "{0:g}".format
+                    func = "{:g}".format
             elif sep == 'fromunit':
                 values = self.to_value(unit)
                 unit_string = unit.to_string(format=format)
@@ -310,11 +310,11 @@ class Angle(u.SpecificTypeQuantity):
                     func = plain_unit_format
                 else:
                     def plain_unit_format(val):
-                        return "{0:g}{1}".format(val, unit_string)
+                        return f"{val:g}{unit_string}"
                     func = plain_unit_format
             else:
                 raise ValueError(
-                    "'{0}' can not be represented in sexagesimal "
+                    "'{}' can not be represented in sexagesimal "
                     "notation".format(
                         unit.name))
 
@@ -327,7 +327,7 @@ class Angle(u.SpecificTypeQuantity):
             if alwayssign and not s.startswith('-'):
                 s = '+' + s
             if format == 'latex':
-                s = '${0}$'.format(s)
+                s = f'${s}$'
             return s
 
         format_ufunc = np.vectorize(do_format, otypes=['U'])
@@ -528,7 +528,7 @@ class Latitude(Angle):
         upper = u.degree.to(angles.unit, 90.0)
         if np.any(angles.value < lower) or np.any(angles.value > upper):
             raise ValueError('Latitude angle(s) must be within -90 deg <= angle <= 90 deg, '
-                             'got {0}'.format(angles.to(u.degree)))
+                             'got {}'.format(angles.to(u.degree)))
 
     def __setitem__(self, item, value):
         # Forbid assigning a Long to a Lat.

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -117,8 +117,8 @@ class Attribute(OrderedDescriptor):
                 except ValueError:
                     # raise more informative exception.
                     raise ValueError(
-                        "attribute {0} should be scalar or have shape {1}, "
-                        "but is has shape {2} and could not be broadcast."
+                        "attribute {} should be scalar or have shape {}, "
+                        "but is has shape {} and could not be broadcast."
                         .format(self.name, instance_shape, out.shape))
 
                 converted = True
@@ -182,7 +182,7 @@ class TimeAttribute(Attribute):
                 out = Time(value)
             except Exception as err:
                 raise ValueError(
-                    'Invalid time input {0}={1!r}\n{2}'.format(self.name,
+                    'Invalid time input {}={!r}\n{}'.format(self.name,
                                                                value, err))
             converted = True
 
@@ -247,7 +247,7 @@ class CartesianRepresentationAttribute(Attribute):
             # if it's a CartesianRepresentation, get the xyz Quantity
             value = getattr(value, 'xyz', value)
             if not hasattr(value, 'unit'):
-                raise TypeError('tried to set a {0} with something that does '
+                raise TypeError('tried to set a {} with something that does '
                                 'not have a unit.'
                                 .format(self.__class__.__name__))
 
@@ -317,8 +317,8 @@ class QuantityAttribute(Attribute):
             oldvalue = value
             value = u.Quantity(oldvalue, self.unit, copy=False)
             if self.shape is not None and value.shape != self.shape:
-                raise ValueError('The provided value has shape "{0}", but '
-                                 'should have shape "{1}"'.format(value.shape,
+                raise ValueError('The provided value has shape "{}", but '
+                                 'should have shape "{}"'.format(value.shape,
                                                                   self.shape))
             converted = oldvalue is not value
             return value, converted
@@ -371,7 +371,7 @@ class EarthLocationAttribute(Attribute):
             from .builtin_frames import ITRS
 
             if not hasattr(value, 'transform_to'):
-                raise ValueError('"{0}" was passed into an '
+                raise ValueError('"{}" was passed into an '
                                  'EarthLocationAttribute, but it does not have '
                                  '"transform_to" method'.format(value))
             itrsobj = value.transform_to(ITRS)
@@ -426,7 +426,7 @@ class CoordinateAttribute(Attribute):
             return value, False
         else:
             if not hasattr(value, 'transform_to'):
-                raise ValueError('"{0}" was passed into a '
+                raise ValueError('"{}" was passed into a '
                                  'CoordinateAttribute, but it does not have '
                                  '"transform_to" method'.format(value))
             transformedobj = value.transform_to(self._frame)
@@ -487,8 +487,8 @@ class DifferentialAttribute(Attribute):
 
         if not isinstance(value, self.allowed_classes):
             raise TypeError('Tried to set a DifferentialAttribute with '
-                            'an unsupported Differential type {0}. Allowed '
-                            'classes are: {1}'
+                            'an unsupported Differential type {}. Allowed '
+                            'classes are: {}'
                             .format(value.__class__,
                                     self.allowed_classes))
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -55,8 +55,8 @@ def _get_repr_cls(value):
     elif (not isinstance(value, type) or
           not issubclass(value, r.BaseRepresentation)):
         raise ValueError(
-            'Representation is {0!r} but must be a BaseRepresentation class '
-            'or one of the string aliases {1}'.format(
+            'Representation is {!r} but must be a BaseRepresentation class '
+            'or one of the string aliases {}'.format(
                 value, list(r.REPRESENTATION_CLASSES)))
     return value
 
@@ -74,8 +74,8 @@ def _get_diff_cls(value):
     elif (not isinstance(value, type) or
           not issubclass(value, r.BaseDifferential)):
         raise ValueError(
-            'Differential is {0!r} but must be a BaseDifferential class '
-            'or one of the string aliases {1}'.format(
+            'Differential is {!r} but must be a BaseDifferential class '
+            'or one of the string aliases {}'.format(
                 value, list(r.DIFFERENTIAL_CLASSES)))
     return value
 
@@ -114,8 +114,8 @@ def _get_repr_classes(base, **differentials):
               (not isinstance(differential_type, type) or
                not issubclass(differential_type, r.BaseDifferential))):
             raise ValueError(
-                'Differential is {0!r} but must be a BaseDifferential class '
-                'or one of the string aliases {1}'.format(
+                'Differential is {!r} but must be a BaseDifferential class '
+                'or one of the string aliases {}'.format(
                     differential_type, list(r.DIFFERENTIAL_CLASSES)))
         repr_classes[name] = differential_type
     return repr_classes
@@ -474,7 +474,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                                      'with the representation object passed in '
                                      'to the frame initializer. Only a single '
                                      'velocity differential is supported. Got: '
-                                     '{0}'.format(diffs))
+                                     '{}'.format(diffs))
 
         elif self.representation_type:
             representation_cls = self.get_representation_cls()
@@ -519,7 +519,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                         for frame_name, repr_name in names.items():
                             msg = msg.replace(repr_name, frame_name)
                         msg = msg.replace('__init__()',
-                                          '{0}()'.format(self.__class__.__name__))
+                                          f'{self.__class__.__name__}()')
                         e.args = (msg,)
                         raise e
 
@@ -557,13 +557,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     for frame_name, repr_name in names.items():
                         msg = msg.replace(repr_name, frame_name)
                     msg = msg.replace('__init__()',
-                                      '{0}()'.format(self.__class__.__name__))
+                                      f'{self.__class__.__name__}()')
                     e.args = (msg,)
                     raise
 
         if len(args) > 0:
             raise TypeError(
-                '{0}.__init__ had {1} remaining unhandled arguments'.format(
+                '{}.__init__ had {} remaining unhandled arguments'.format(
                     self.__class__.__name__, len(args)))
 
         if representation_data is None and differential_data is not None:
@@ -594,7 +594,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         if kwargs:
             raise TypeError(
-                'Coordinate frame got unexpected keywords: {0}'.format(
+                'Coordinate frame got unexpected keywords: {}'.format(
                     list(kwargs)))
 
         # We do ``is None`` because self._data might evaluate to false for
@@ -612,7 +612,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                     except ValueError:
                         raise ValueError(
                             "non-scalar attributes with inconsistent "
-                            "shapes: {0}".format(shapes))
+                            "shapes: {}".format(shapes))
 
                     # Above, we checked that it is possible to broadcast all
                     # shapes.  By getting and thus validating the attributes,
@@ -669,7 +669,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         check if data is present on this frame object.
         """
         if self._data is None:
-            raise ValueError('The frame object "{0!r}" does not have '
+            raise ValueError('The frame object "{!r}" does not have '
                              'associated data'.format(self))
         return self._data
 
@@ -1332,13 +1332,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         data_repr = self._data_repr()
 
         if frameattrs:
-            frameattrs = ' ({0})'.format(frameattrs)
+            frameattrs = f' ({frameattrs})'
 
         if data_repr:
-            return '<{0} Coordinate{1}: {2}>'.format(self.__class__.__name__,
+            return '<{} Coordinate{}: {}>'.format(self.__class__.__name__,
                                                      frameattrs, data_repr)
         else:
-            return '<{0} Frame{1}>'.format(self.__class__.__name__,
+            return '<{} Frame{}>'.format(self.__class__.__name__,
                                            frameattrs)
 
     def _data_repr(self):
@@ -1565,7 +1565,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
                 if attr in repr_attr_names:
                     raise AttributeError(
-                        'Cannot set any frame attribute {0}'.format(attr))
+                        f'Cannot set any frame attribute {attr}')
 
         super().__setattr__(attr, value)
 
@@ -1766,10 +1766,10 @@ class GenericFrame(BaseCoordinateFrame):
         if '_' + name in self.__dict__:
             return getattr(self, '_' + name)
         else:
-            raise AttributeError('no {0}'.format(name))
+            raise AttributeError(f'no {name}')
 
     def __setattr__(self, name, value):
         if name in self.get_frame_attr_names():
-            raise AttributeError("can't set frame attribute '{0}'".format(name))
+            raise AttributeError(f"can't set frame attribute '{name}'")
         else:
             super().__setattr__(name, value)

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -114,17 +114,17 @@ def make_transform_graph_docs(transform_graph):
     from astropy.coordinates.transformations import trans_to_color
     html_list_items = []
     for cls, color in trans_to_color.items():
-        block = u"""
+        block = """
             <li style='list-style: none;'>
                 <p style="font-size: 12px;line-height: 24px;font-weight: normal;color: #848484;padding: 0;margin: 0;">
-                    <b>{0}:</b>
-                    <span style="font-size: 24px; color: {1};"><b>➝</b></span>
+                    <b>{}:</b>
+                    <span style="font-size: 24px; color: {};"><b>➝</b></span>
                 </p>
             </li>
         """.format(cls.__name__, color)
         html_list_items.append(block)
 
-    graph_legend = u"""
+    graph_legend = """
     .. raw:: html
 
         <ul>

--- a/astropy/coordinates/calculation.py
+++ b/astropy/coordinates/calculation.py
@@ -119,7 +119,7 @@ def horoscope(birthday, corrected=True, chinese=False):
         zodiac_sign = _get_zodiac(birthday.year)
         url = ('https://www.horoscope.com/us/horoscopes/yearly/'
                '{}-chinese-horoscope-{}.aspx'.format(today.year, zodiac_sign))
-        summ_title_sfx = 'in {}'.format(today.year)
+        summ_title_sfx = f'in {today.year}'
 
         try:
             with urlopen(url) as f:

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -39,7 +39,7 @@ def _check_ellipsoid(ellipsoid=None, default='WGS84'):
     if ellipsoid is None:
         ellipsoid = default
     if ellipsoid not in ELLIPSOIDS:
-        raise ValueError('Ellipsoid {0} not among known ones ({1})'
+        raise ValueError('Ellipsoid {} not among known ones ({})'
                          .format(ellipsoid, ELLIPSOIDS))
     return ellipsoid
 
@@ -193,7 +193,7 @@ class EarthLocation(u.Quantity):
             except Exception as exc_geodetic:
                 raise TypeError('Coordinates could not be parsed as either '
                                 'geocentric or geodetic, with respective '
-                                'exceptions "{0}" and "{1}"'
+                                'exceptions "{}" and "{}"'
                                 .format(exc_geocentric, exc_geodetic))
         return self
 
@@ -422,13 +422,13 @@ class EarthLocation(u.Quantity):
         if use_google: # Google
             pars = urllib.parse.urlencode({'address': address,
                                            'key': google_api_key})
-            geo_url = ("https://maps.googleapis.com/maps/api/geocode/json?{0}"
+            geo_url = ("https://maps.googleapis.com/maps/api/geocode/json?{}"
                        .format(pars))
 
         else: # OpenStreetMap
             pars = urllib.parse.urlencode({'q': address,
                                            'format': 'json'})
-            geo_url = ("https://nominatim.openstreetmap.org/search?{0}"
+            geo_url = ("https://nominatim.openstreetmap.org/search?{}"
                        .format(pars))
 
         # get longitude and latitude location
@@ -448,10 +448,10 @@ class EarthLocation(u.Quantity):
             lon = float(loc['lon'])
 
         if get_height:
-            pars = {'locations': '{lat:.8f},{lng:.8f}'.format(lat=lat, lng=lon),
+            pars = {'locations': f'{lat:.8f},{lon:.8f}',
                     'key': google_api_key}
             pars = urllib.parse.urlencode(pars)
-            ele_url = ("https://maps.googleapis.com/maps/api/elevation/json?{0}"
+            ele_url = ("https://maps.googleapis.com/maps/api/elevation/json?{}"
                        .format(pars))
 
             err_str = ("Unable to retrieve elevation for address '{address}'; "
@@ -751,7 +751,7 @@ class EarthLocation(u.Quantity):
             try:
                 GMs.append(_masses[body].to(u.m**3/u.s**2, [M_GM_equivalency]))
             except KeyError as exc:
-                raise KeyError('body "{}" does not have a mass!'.format(body))
+                raise KeyError(f'body "{body}" does not have a mass!')
             except u.UnitsError as exc:
                 exc.args += ('"masses" argument values must be masses or '
                              'gravitational parameters',)

--- a/astropy/coordinates/errors.py
+++ b/astropy/coordinates/errors.py
@@ -44,7 +44,7 @@ class IllegalHourError(RangeError):
         self.hour = hour
 
     def __str__(self):
-        return "An invalid value for 'hours' was found ('{0}'); must be in the range [0,24).".format(self.hour)
+        return f"An invalid value for 'hours' was found ('{self.hour}'); must be in the range [0,24)."
 
 
 class IllegalHourWarning(AstropyWarning):
@@ -60,7 +60,7 @@ class IllegalHourWarning(AstropyWarning):
         self.alternativeactionstr = alternativeactionstr
 
     def __str__(self):
-        message = "'hour' was found  to be '{0}', which is not in range (-24, 24).".format(self.hour)
+        message = f"'hour' was found  to be '{self.hour}', which is not in range (-24, 24)."
         if self.alternativeactionstr is not None:
             message += ' ' + self.alternativeactionstr
         return message
@@ -87,7 +87,7 @@ class IllegalMinuteError(RangeError):
         self.minute = minute
 
     def __str__(self):
-        return "An invalid value for 'minute' was found ('{0}'); should be in the range [0,60).".format(self.minute)
+        return f"An invalid value for 'minute' was found ('{self.minute}'); should be in the range [0,60)."
 
 
 class IllegalMinuteWarning(AstropyWarning):
@@ -103,7 +103,7 @@ class IllegalMinuteWarning(AstropyWarning):
         self.alternativeactionstr = alternativeactionstr
 
     def __str__(self):
-        message = "'minute' was found  to be '{0}', which is not in range [0,60).".format(self.minute)
+        message = f"'minute' was found  to be '{self.minute}', which is not in range [0,60)."
         if self.alternativeactionstr is not None:
             message += ' ' + self.alternativeactionstr
         return message
@@ -129,7 +129,7 @@ class IllegalSecondError(RangeError):
         self.second = second
 
     def __str__(self):
-        return "An invalid value for 'second' was found ('{0}'); should be in the range [0,60).".format(self.second)
+        return f"An invalid value for 'second' was found ('{self.second}'); should be in the range [0,60)."
 
 
 class IllegalSecondWarning(AstropyWarning):
@@ -145,7 +145,7 @@ class IllegalSecondWarning(AstropyWarning):
         self.alternativeactionstr = alternativeactionstr
 
     def __str__(self):
-        message = "'second' was found  to be '{0}', which is not in range [0,60).".format(self.second)
+        message = f"'second' was found  to be '{self.second}', which is not in range [0,60)."
         if self.alternativeactionstr is not None:
             message += ' ' + self.alternativeactionstr
         return message
@@ -166,9 +166,9 @@ class ConvertError(Exception):
 
 class UnknownSiteException(KeyError):
     def __init__(self, site, attribute, close_names=None):
-        message = "Site '{0}' not in database. Use {1} to see available sites.".format(site, attribute)
+        message = f"Site '{site}' not in database. Use {attribute} to see available sites."
         if close_names:
-            message += " Did you mean one of: '{0}'?'".format("', '".join(close_names))
+            message += " Did you mean one of: '{}'?'".format("', '".join(close_names))
         self.site = site
         self.attribute = attribute
         self.close_names = close_names

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -250,7 +250,7 @@ def get_constellation(coord, short_name=False, constellation_list='iau'):
         if np.sum(notided) == 0:
             break
     else:
-        raise ValueError('Could not find constellation for coordinates {0}'.format(constel_coord[notided]))
+        raise ValueError('Could not find constellation for coordinates {}'.format(constel_coord[notided]))
 
     if short_name:
         names = ctable['name'][constellidx]
@@ -368,7 +368,7 @@ def concatenate(coords):
     for sc in scs[1:]:
         if not sc.is_equivalent_frame(scs[0]):
             raise ValueError("All inputs must have equivalent frames: "
-                             "{0} != {1}".format(sc, scs[0]))
+                             "{} != {}".format(sc, scs[0]))
 
     # TODO: this can be changed to SkyCoord.from_representation() for a speed
     # boost when we switch to using classmethods

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -440,7 +440,7 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt='kdtree', forceunit=None):
     if isinstance(attrname_or_kdt, str):
         kdt = coord.cache.get(attrname_or_kdt, None)
         if kdt is not None and not isinstance(kdt, KDTree):
-            raise TypeError('The `attrname_or_kdt` "{0}" is not a scipy KD tree!'.format(attrname_or_kdt))
+            raise TypeError(f'The `attrname_or_kdt` "{attrname_or_kdt}" is not a scipy KD tree!')
     elif isinstance(attrname_or_kdt, KDTree):
         kdt = attrname_or_kdt
         attrname_or_kdt = None

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -50,7 +50,7 @@ class sesame_database(ScienceState):
     @classmethod
     def validate(cls, value):
         if value not in ['all', 'simbad', 'ned', 'vizier']:
-            raise ValueError("Unknown database '{0}'".format(value))
+            raise ValueError(f"Unknown database '{value}'")
         return value
 
 
@@ -173,7 +173,7 @@ def get_icrs_coordinates(name, parse=False):
 
     # All Sesame URL's failed...
     else:
-        messages = ["{url}: {e.reason}".format(url=url, e=e)
+        messages = [f"{url}: {e.reason}"
                     for url, e in zip(urls, exceptions)]
         raise NameResolveError("All Sesame queries failed. Unable to "
                                "retrieve coordinates. See errors per URL "
@@ -183,9 +183,9 @@ def get_icrs_coordinates(name, parse=False):
 
     if ra is None and dec is None:
         if db == "A":
-            err = "Unable to find coordinates for name '{0}'".format(name)
+            err = f"Unable to find coordinates for name '{name}'"
         else:
-            err = "Unable to find coordinates for name '{0}' in database {1}"\
+            err = "Unable to find coordinates for name '{}' in database {}"\
                   .format(name, database)
 
         raise NameResolveError(err)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -128,20 +128,20 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 attrs.append(args.pop(0) if args else kwargs.pop(component))
             except KeyError:
                 raise TypeError('__init__() missing 1 required positional '
-                                'argument: {0!r}'.format(component))
+                                'argument: {!r}'.format(component))
 
         copy = args.pop(0) if args else kwargs.pop('copy', True)
 
         if args:
-            raise TypeError('unexpected arguments: {0}'.format(args))
+            raise TypeError(f'unexpected arguments: {args}')
 
         if kwargs:
             for component in components:
                 if component in kwargs:
                     raise TypeError("__init__() got multiple values for "
-                                    "argument {0!r}".format(component))
+                                    "argument {!r}".format(component))
 
-            raise TypeError('unexpected keyword arguments: {0}'.format(kwargs))
+            raise TypeError(f'unexpected keyword arguments: {kwargs}')
 
         # Pass attributes through the required initializing classes.
         attrs = [self.attr_classes[component](attr, copy=copy)
@@ -153,7 +153,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 c_str = ' and '.join(components)
             else:
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
-            raise ValueError("Input parameters {0} cannot be broadcast"
+            raise ValueError("Input parameters {} cannot be broadcast"
                              .format(c_str))
         # Set private attributes for the attributes. (If not defined explicitly
         # on the class, the metaclass will define properties to access these.)
@@ -358,13 +358,13 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         if len(units_set) == 1:
             unitstr = units_set.pop().to_string()
         else:
-            unitstr = '({0})'.format(
+            unitstr = '({})'.format(
                 ', '.join([self._units[component].to_string()
                            for component in self.components]))
         return unitstr
 
     def __str__(self):
-        return '{0} {1:s}'.format(_array2string(self._values), self._unitstr)
+        return '{} {:s}'.format(_array2string(self._values), self._unitstr)
 
     def __repr__(self):
         prefixstr = '    '
@@ -372,11 +372,11 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         diffstr = ''
         if getattr(self, 'differentials', None):
-            diffstr = '\n (has differentials w.r.t.: {0})'.format(
+            diffstr = '\n (has differentials w.r.t.: {})'.format(
                 ', '.join([repr(key) for key in self.differentials.keys()]))
 
         unitstr = ('in ' + self._unitstr) if self._unitstr else '[dimensionless]'
-        return '<{0} ({1}) {2:s}\n{3}{4}{5}>'.format(
+        return '<{} ({}) {:s}\n{}{}{}>'.format(
             self.__class__.__name__, ', '.join(self.components),
             unitstr, prefixstr, arrstr, diffstr)
 
@@ -418,7 +418,7 @@ class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
         repr_name = cls.get_name()
 
         if repr_name in REPRESENTATION_CLASSES:
-            raise ValueError("Representation class {0} already defined"
+            raise ValueError("Representation class {} already defined"
                              .format(repr_name))
 
         REPRESENTATION_CLASSES[repr_name] = cls
@@ -429,7 +429,7 @@ class MetaBaseRepresentation(InheritDocstrings, abc.ABCMeta):
             if not hasattr(cls, component):
                 setattr(cls, component,
                         property(_make_getter(component),
-                                 doc=("The '{0}' component of the points(s)."
+                                 doc=("The '{}' component of the points(s)."
                                       .format(component))))
 
 
@@ -515,8 +515,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
             else:
                 expected_key = diff._get_deriv_key(self)
                 if key != expected_key:
-                    raise ValueError("For differential object '{0}', expected "
-                                     "unit key = '{1}' but received key = '{2}'"
+                    raise ValueError("For differential object '{}', expected "
+                                     "unit key = '{}' but received key = '{}'"
                                      .format(repr(diff), expected_key, key))
 
             # For now, we are very rigid: differentials must have the same shape
@@ -527,8 +527,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
                 # TODO: message of IncompatibleShapeError is not customizable,
                 #       so use a valueerror instead?
                 raise ValueError("Shape of differentials must be the same "
-                                 "as the shape of the representation ({0} vs "
-                                 "{1})".format(diff.shape, self.shape))
+                                 "as the shape of the representation ({} vs "
+                                 "{})".format(diff.shape, self.shape))
 
         return differentials
 
@@ -538,8 +538,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
         supported when a representation has differentials attached.
         """
         if self.differentials:
-            raise TypeError("Operation '{0}' is not supported when "
-                            "differentials are attached to a {1}."
+            raise TypeError("Operation '{}' is not supported when "
+                            "differentials are attached to a {}."
                             .format(op_name, self.__class__.__name__))
 
     @property
@@ -617,7 +617,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
                        "as a dictionary with keys equal to a string "
                        "representation of the unit of the derivative "
                        "for each differential stored with this "
-                       "representation object ({0})"
+                       "representation object ({})"
                        .format(self.differentials))
 
         new_diffs = dict()
@@ -629,9 +629,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
             except Exception:
                 if (differential_class[k] not in
                         new_rep._compatible_differentials):
-                    raise TypeError("Desired differential class {0} is not "
+                    raise TypeError("Desired differential class {} is not "
                                     "compatible with the desired "
-                                    "representation class {1}"
+                                    "representation class {}"
                                     .format(differential_class[k],
                                             new_rep.__class__))
                 else:
@@ -1003,7 +1003,7 @@ class CartesianRepresentation(BaseRepresentation):
                              "i.e., y and z should not be not given.")
 
         if y is None or z is None:
-            raise ValueError("x, y, and z are required to instantiate {0}"
+            raise ValueError("x, y, and z are required to instantiate {}"
                              .format(self.__class__.__name__))
 
         if unit is not None:
@@ -1193,7 +1193,7 @@ class CartesianRepresentation(BaseRepresentation):
             other_c = other.to_cartesian()
         except Exception:
             raise TypeError("cannot only take dot product with another "
-                            "representation, not a {0} instance."
+                            "representation, not a {} instance."
                             .format(type(other)))
         # erfa pdp: p-vector inner (=scalar=dot) product.
         return erfa_ufunc.pdp(self.get_xyz(xyz_axis=-1),
@@ -1217,7 +1217,7 @@ class CartesianRepresentation(BaseRepresentation):
             other_c = other.to_cartesian()
         except Exception:
             raise TypeError("cannot only take cross product with another "
-                            "representation, not a {0} instance."
+                            "representation, not a {} instance."
                             .format(type(other)))
         # erfa pxp: p-vector outer (=vector=cross) product.
         sxo = erfa_ufunc.pxp(self.get_xyz(xyz_axis=-1),
@@ -1466,7 +1466,7 @@ class RadialRepresentation(BaseRepresentation):
     def unit_vectors(self):
         """Cartesian unit vectors are undefined for radial representation."""
         raise NotImplementedError('Cartesian unit vectors are undefined for '
-                                  '{0} instances'.format(self.__class__))
+                                  '{} instances'.format(self.__class__))
 
     def scale_factors(self):
         l = np.broadcast_to(1.*u.one, self.shape, subok=True)
@@ -1474,7 +1474,7 @@ class RadialRepresentation(BaseRepresentation):
 
     def to_cartesian(self):
         """Cannot convert radial representation to cartesian."""
-        raise NotImplementedError('cannot convert {0} instance to cartesian.'
+        raise NotImplementedError('cannot convert {} instance to cartesian.'
                                   .format(self.__class__))
 
     @classmethod
@@ -1715,7 +1715,7 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
             raise ValueError('Inclination angle(s) must be within '
                              '0 deg <= angle <= 180 deg, '
-                             'got {0}'.format(theta.to(u.degree)))
+                             'got {}'.format(theta.to(u.degree)))
 
         if self._r.unit.physical_type == 'length':
             self._r = self._r.view(Distance)
@@ -1950,7 +1950,7 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
 
         repr_name = cls.get_name()
         if repr_name in DIFFERENTIAL_CLASSES:
-            raise ValueError("Differential class {0} already defined"
+            raise ValueError("Differential class {} already defined"
                              .format(repr_name))
 
         DIFFERENTIAL_CLASSES[repr_name] = cls
@@ -1961,7 +1961,7 @@ class MetaBaseDifferential(InheritDocstrings, abc.ABCMeta):
             if not hasattr(cls, component):
                 setattr(cls, component,
                         property(_make_getter(component),
-                                 doc=("Component '{0}' of the Differential."
+                                 doc=("Component '{}' of the Differential."
                                       .format(component))))
 
 
@@ -1995,8 +1995,8 @@ class BaseDifferential(BaseRepresentationOrDifferential,
     @classmethod
     def _check_base(cls, base):
         if cls not in base._compatible_differentials:
-            raise TypeError("Differential class {0} is not compatible with the "
-                            "base (representation) class {1}"
+            raise TypeError("Differential class {} is not compatible with the "
+                            "base (representation) class {}"
                             .format(cls, base.__class__))
 
     def _get_deriv_key(self, base):
@@ -2011,7 +2011,7 @@ class BaseDifferential(BaseRepresentationOrDifferential,
 
         for name in base.components:
             comp = getattr(base, name)
-            d_comp = getattr(self, 'd_{0}'.format(name), None)
+            d_comp = getattr(self, f'd_{name}', None)
             if d_comp is not None:
                 d_unit = comp.unit / d_comp.unit
 
@@ -2263,7 +2263,7 @@ class CartesianDifferential(BaseDifferential):
                              "i.e., d_y and d_z should not be not given.")
 
         if d_y is None or d_z is None:
-            raise ValueError("d_x, d_y, and d_z are required to instantiate {0}"
+            raise ValueError("d_x, d_y, and d_z are required to instantiate {}"
                              .format(self.__class__.__name__))
 
         if unit is not None:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -430,7 +430,7 @@ class SkyCoord(ShapedLikeNDArray):
         # Get the composite transform to the new frame
         trans = frame_transform_graph.get_transform(self.frame.__class__, new_frame_cls)
         if trans is None:
-            raise ConvertError('Cannot transform from {0} to {1}'
+            raise ConvertError('Cannot transform from {} to {}'
                                .format(self.frame.__class__, new_frame_cls))
 
         # Make a generic frame which will accept all the frame kwargs that
@@ -596,14 +596,14 @@ class SkyCoord(ShapedLikeNDArray):
                 return self.transform_to(attr)
 
         # Fail
-        raise AttributeError("'{0}' object has no attribute '{1}'"
+        raise AttributeError("'{}' object has no attribute '{}'"
                              .format(self.__class__.__name__, attr))
 
     def __setattr__(self, attr, val):
         # This is to make anything available through __getattr__ immutable
         if '_sky_coord_frame' in self.__dict__:
             if self.frame.name == attr:
-                raise AttributeError("'{0}' is immutable".format(attr))
+                raise AttributeError(f"'{attr}' is immutable")
 
             if not attr.startswith('_') and hasattr(self._sky_coord_frame, attr):
                 setattr(self._sky_coord_frame, attr, val)
@@ -611,7 +611,7 @@ class SkyCoord(ShapedLikeNDArray):
 
             frame_cls = frame_transform_graph.lookup_name(attr)
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
-                raise AttributeError("'{0}' is immutable".format(attr))
+                raise AttributeError(f"'{attr}' is immutable")
 
         if attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be set, but only via a private
@@ -630,7 +630,7 @@ class SkyCoord(ShapedLikeNDArray):
         # mirror __setattr__ above
         if '_sky_coord_frame' in self.__dict__:
             if self.frame.name == attr:
-                raise AttributeError("'{0}' is immutable".format(attr))
+                raise AttributeError(f"'{attr}' is immutable")
 
             if not attr.startswith('_') and hasattr(self._sky_coord_frame,
                                                     attr):
@@ -639,7 +639,7 @@ class SkyCoord(ShapedLikeNDArray):
 
             frame_cls = frame_transform_graph.lookup_name(attr)
             if frame_cls is not None and self.frame.is_transformable_to(frame_cls):
-                raise AttributeError("'{0}' is immutable".format(attr))
+                raise AttributeError(f"'{attr}' is immutable")
 
         if attr in frame_transform_graph.frame_attributes:
             # All possible frame attributes can be deleted, but need to remove
@@ -733,7 +733,7 @@ class SkyCoord(ShapedLikeNDArray):
             lonargs.update(styles[style]['lonargs'])
             latargs.update(styles[style]['latargs'])
         else:
-            raise ValueError('Invalid style.  Valid options are: {0}'.format(",".join(styles)))
+            raise ValueError('Invalid style.  Valid options are: {}'.format(",".join(styles)))
 
         lonargs.update(kwargs)
         latargs.update(kwargs)
@@ -1647,8 +1647,8 @@ class SkyCoord(ShapedLikeNDArray):
 
         for k, v in comp_kwargs.items():
             if k in coord_kwargs:
-                raise ValueError('Found column "{0}" in table, but it was '
-                                 'already provided as "{1}" keyword to '
+                raise ValueError('Found column "{}" in table, but it was '
+                                 'already provided as "{}" keyword to '
                                  'guess_from_table function.'.format(v.name, k))
             else:
                 coord_kwargs[k] = v

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -39,8 +39,8 @@ def _get_frame_class(frame):
     if isinstance(frame, str):
         frame_names = frame_transform_graph.get_names()
         if frame not in frame_names:
-            raise ValueError('Coordinate frame name "{0}" is not a known '
-                             'coordinate frame ({1})'
+            raise ValueError('Coordinate frame name "{}" is not a known '
+                             'coordinate frame ({})'
                              .format(frame, sorted(frame_names)))
         frame_cls = frame_transform_graph.lookup_name(frame)
 
@@ -49,7 +49,7 @@ def _get_frame_class(frame):
 
     else:
         raise ValueError("Coordinate frame must be a frame name or frame "
-                         "class, not a '{0}'".format(frame.__class__.__name__))
+                         "class, not a '{}'".format(frame.__class__.__name__))
 
     return frame_cls
 
@@ -113,7 +113,7 @@ def _get_frame_without_data(args, kwargs):
                 # sure that no frame attributes were specified as kwargs - this
                 # would require a potential three-way merge:
                 if attr in kwargs:
-                    raise ValueError("Cannot specify frame attribute '{0}' "
+                    raise ValueError("Cannot specify frame attribute '{}' "
                                      "directly as an argument to SkyCoord "
                                      "because a frame instance was passed in. "
                                      "Either pass a frame class, or modify the "
@@ -162,11 +162,11 @@ def _get_frame_without_data(args, kwargs):
                 if (attr in kwargs and
                         not coord_frame_obj.is_frame_attr_default(attr) and
                         np.any(kwargs[attr] != getattr(coord_frame_obj, attr))):
-                    raise ValueError("Frame attribute '{0}' has conflicting "
+                    raise ValueError("Frame attribute '{}' has conflicting "
                                      "values between the input coordinate data "
                                      "and either keyword arguments or the "
                                      "frame specification (frame=...): "
-                                     "{1} =/= {2}"
+                                     "{} =/= {}"
                                      .format(attr,
                                              getattr(coord_frame_obj, attr),
                                              kwargs[attr]))
@@ -179,8 +179,8 @@ def _get_frame_without_data(args, kwargs):
             if frame_cls is None:
                 frame_cls = coord_frame_cls
             elif frame_cls is not coord_frame_cls:
-                raise ValueError("Cannot override frame='{0}' of input "
-                                 "coordinate with new frame='{1}'. Instead, "
+                raise ValueError("Cannot override frame='{}' of input "
+                                 "coordinate with new frame='{}'. Instead, "
                                  "transform the coordinate."
                                  .format(coord_frame_cls.__name__,
                                          frame_cls.__name__))
@@ -191,7 +191,7 @@ def _get_frame_without_data(args, kwargs):
     # By now, frame_cls should be set - if it's not, something went wrong
     if not issubclass(frame_cls, BaseCoordinateFrame):
         # We should hopefully never get here...
-        raise ValueError('Frame class has unexpected type: {0}'
+        raise ValueError('Frame class has unexpected type: {}'
                          .format(frame_cls.__name__))
 
     for attr in frame_cls.frame_attributes:
@@ -257,16 +257,16 @@ def _parse_coordinate_data(frame, args, kwargs):
             lon_name = frame_names[0]
             lat_name = frame_names[1]
 
-            if 'pm_{0}'.format(lon_name) in list(kwargs.keys()):
+            if f'pm_{lon_name}' in list(kwargs.keys()):
                 pm_message = ('\n\n By default, most frame classes expect '
                               'the longitudinal proper motion to include '
                               'the cos(latitude) term, named '
-                              '`pm_{0}_cos{1}`. Did you mean to pass in '
+                              '`pm_{}_cos{}`. Did you mean to pass in '
                               'this component?'
                               .format(lon_name, lat_name))
 
-        raise ValueError('Unrecognized keyword argument(s) {0}{1}'
-                         .format(', '.join("'{0}'".format(key)
+        raise ValueError('Unrecognized keyword argument(s) {}{}'
+                         .format(', '.join(f"'{key}'"
                                            for key in kwargs),
                                  pm_message))
 
@@ -479,7 +479,7 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             for sc in scs[1:]:
                 if not sc.is_equivalent_frame(scs[0]):
                     raise ValueError("List of inputs don't have equivalent "
-                                     "frames: {0} != {1}".format(sc, scs[0]))
+                                     "frames: {} != {}".format(sc, scs[0]))
 
             # Now use the first to determine if they are all UnitSpherical
             allunitsphrepr = isinstance(scs[0].data, UnitSphericalRepresentation)
@@ -530,14 +530,14 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
                 raise ValueError('One or more elements of input sequence does not have a length')
 
             if len(n_coords) > 1:
-                raise ValueError('Input coordinate values must have same number of elements, found {0}'
+                raise ValueError('Input coordinate values must have same number of elements, found {}'
                                  .format(n_coords))
             n_coords = n_coords[0]
 
             # Must have no more coord inputs than representation attributes
             if n_coords > n_attr_names:
-                raise ValueError('Input coordinates have {0} values but '
-                                 'representation {1} only accepts {2}'
+                raise ValueError('Input coordinates have {} values but '
+                                 'representation {} only accepts {}'
                                  .format(n_coords,
                                          frame.representation_type.get_name(),
                                          n_attr_names))
@@ -562,8 +562,8 @@ def _parse_coordinate_arg(coords, frame, units, init_kwargs):
             components[frame_attr_name] = repr_attr_class(value, unit=unit,
                                                           copy=False)
     except Exception as err:
-        raise ValueError('Cannot parse first argument data "{0}" for attribute '
-                         '{1}'.format(value, frame_attr_name), err)
+        raise ValueError('Cannot parse first argument data "{}" for attribute '
+                         '{}'.format(value, frame_attr_name), err)
     return skycoord_kwargs, components
 
 
@@ -642,14 +642,14 @@ def _parse_ra_dec(coord_str):
         if match_j:
             coord = match_j.groups()
             if len(coord[0].split('.')[0]) == 7:
-                coord = ('{0} {1} {2}'.
+                coord = ('{} {} {}'.
                          format(coord[0][0:3], coord[0][3:5], coord[0][5:]),
-                         '{0} {1} {2}'.
+                         '{} {} {}'.
                          format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
             else:
-                coord = ('{0} {1} {2}'.
+                coord = ('{} {} {}'.
                          format(coord[0][0:2], coord[0][2:4], coord[0][4:]),
-                         '{0} {1} {2}'.
+                         '{} {} {}'.
                          format(coord[1][0:3], coord[1][3:5], coord[1][5:]))
         else:
             coord = PLUS_MINUS_RE.split(coord_str)

--- a/astropy/coordinates/solar_system.py
+++ b/astropy/coordinates/solar_system.py
@@ -228,7 +228,7 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
         elif body == 'moon':
             if get_velocity:
                 raise KeyError("the Moon's velocity cannot be calculated with "
-                               "the '{0}' ephemeris.".format(ephemeris))
+                               "the '{}' ephemeris.".format(ephemeris))
             return calc_moon(time).cartesian
 
         else:
@@ -239,8 +239,8 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
                 try:
                     body_index = PLAN94_BODY_NAME_TO_PLANET_INDEX[body]
                 except KeyError:
-                    raise KeyError("{0}'s position and velocity cannot be "
-                                   "calculated with the '{1}' ephemeris."
+                    raise KeyError("{}'s position and velocity cannot be "
+                                   "calculated with the '{}' ephemeris."
                                    .format(body, ephemeris))
                 body_pv_helio = erfa.plan94(jd1, jd2, body_index)
                 body_pv_bary = erfa.pvppv(body_pv_helio, sun_pv_bary)
@@ -258,8 +258,8 @@ def _get_body_barycentric_posvel(body, time, ephemeris=None,
             try:
                 kernel_spec = BODY_NAME_TO_KERNEL_SPEC[body.lower()]
             except KeyError:
-                raise KeyError("{0}'s position cannot be calculated with "
-                               "the {1} ephemeris.".format(body, ephemeris))
+                raise KeyError("{}'s position cannot be calculated with "
+                               "the {} ephemeris.".format(body, ephemeris))
         else:
             # otherwise, assume the user knows what their doing and intentionally
             # passed in a kernel chain

--- a/astropy/coordinates/tests/accuracy/generate_ref_ast.py
+++ b/astropy/coordinates/tests/accuracy/generate_ref_ast.py
@@ -30,7 +30,7 @@ def ref_fk4_no_e_fk4(fnout='fk4_no_e_fk4.csv'):
     dec = np.degrees(np.arcsin(np.random.uniform(-1., 1., N)))
 
     # Generate random observation epoch and equinoxes
-    obstime = ["B{0:7.2f}".format(x) for x in np.random.uniform(1950., 2000., N)]
+    obstime = [f"B{x:7.2f}" for x in np.random.uniform(1950., 2000., N)]
 
     ra_fk4ne, dec_fk4ne = [], []
     ra_fk4, dec_fk4 = [], []
@@ -63,7 +63,7 @@ def ref_fk4_no_e_fk4(fnout='fk4_no_e_fk4.csv'):
     t.add_column(Column(name='ra_fk4', data=ra_fk4))
     t.add_column(Column(name='dec_fk4', data=dec_fk4))
     f = open(os.path.join('data', fnout), 'wb')
-    f.write("# This file was generated with the {0} script, and the reference "
+    f.write("# This file was generated with the {} script, and the reference "
             "values were computed using AST\n".format(os.path.basename(__file__)))
     t.write(f, format='ascii', delimiter=',')
 
@@ -87,9 +87,9 @@ def ref_fk4_no_e_fk5(fnout='fk4_no_e_fk5.csv'):
     dec = np.degrees(np.arcsin(np.random.uniform(-1., 1., N)))
 
     # Generate random observation epoch and equinoxes
-    obstime = ["B{0:7.2f}".format(x) for x in np.random.uniform(1950., 2000., N)]
-    equinox_fk4 = ["B{0:7.2f}".format(x) for x in np.random.uniform(1925., 1975., N)]
-    equinox_fk5 = ["J{0:7.2f}".format(x) for x in np.random.uniform(1975., 2025., N)]
+    obstime = [f"B{x:7.2f}" for x in np.random.uniform(1950., 2000., N)]
+    equinox_fk4 = [f"B{x:7.2f}" for x in np.random.uniform(1925., 1975., N)]
+    equinox_fk5 = [f"J{x:7.2f}" for x in np.random.uniform(1975., 2025., N)]
 
     ra_fk4, dec_fk4 = [], []
     ra_fk5, dec_fk5 = [], []
@@ -124,7 +124,7 @@ def ref_fk4_no_e_fk5(fnout='fk4_no_e_fk5.csv'):
     t.add_column(Column(name='ra_fk4', data=ra_fk4))
     t.add_column(Column(name='dec_fk4', data=dec_fk4))
     f = open(os.path.join('data', fnout), 'wb')
-    f.write("# This file was generated with the {0} script, and the reference "
+    f.write("# This file was generated with the {} script, and the reference "
             "values were computed using AST\n".format(os.path.basename(__file__)))
     t.write(f, format='ascii', delimiter=',')
 
@@ -148,8 +148,8 @@ def ref_galactic_fk4(fnout='galactic_fk4.csv'):
     lat = np.degrees(np.arcsin(np.random.uniform(-1., 1., N)))
 
     # Generate random observation epoch and equinoxes
-    obstime = ["B{0:7.2f}".format(x) for x in np.random.uniform(1950., 2000., N)]
-    equinox_fk4 = ["J{0:7.2f}".format(x) for x in np.random.uniform(1975., 2025., N)]
+    obstime = [f"B{x:7.2f}" for x in np.random.uniform(1950., 2000., N)]
+    equinox_fk4 = [f"J{x:7.2f}" for x in np.random.uniform(1975., 2025., N)]
 
     lon_gal, lat_gal = [], []
     ra_fk4, dec_fk4 = [], []
@@ -183,7 +183,7 @@ def ref_galactic_fk4(fnout='galactic_fk4.csv'):
     t.add_column(Column(name='lon_gal', data=lon_gal))
     t.add_column(Column(name='lat_gal', data=lat_gal))
     f = open(os.path.join('data', fnout), 'wb')
-    f.write("# This file was generated with the {0} script, and the reference "
+    f.write("# This file was generated with the {} script, and the reference "
             "values were computed using AST\n".format(os.path.basename(__file__)))
     t.write(f, format='ascii', delimiter=',')
 
@@ -207,8 +207,8 @@ def ref_icrs_fk5(fnout='icrs_fk5.csv'):
     dec = np.degrees(np.arcsin(np.random.uniform(-1., 1., N)))
 
     # Generate random observation epoch and equinoxes
-    obstime = ["B{0:7.2f}".format(x) for x in np.random.uniform(1950., 2000., N)]
-    equinox_fk5 = ["J{0:7.2f}".format(x) for x in np.random.uniform(1975., 2025., N)]
+    obstime = [f"B{x:7.2f}" for x in np.random.uniform(1950., 2000., N)]
+    equinox_fk5 = [f"J{x:7.2f}" for x in np.random.uniform(1975., 2025., N)]
 
     ra_icrs, dec_icrs = [], []
     ra_fk5, dec_fk5 = [], []
@@ -242,7 +242,7 @@ def ref_icrs_fk5(fnout='icrs_fk5.csv'):
     t.add_column(Column(name='ra_icrs', data=ra_icrs))
     t.add_column(Column(name='dec_icrs', data=dec_icrs))
     f = open(os.path.join('data', fnout), 'wb')
-    f.write("# This file was generated with the {0} script, and the reference "
+    f.write("# This file was generated with the {} script, and the reference "
             "values were computed using AST\n".format(os.path.basename(__file__)))
     t.write(f, format='ascii', delimiter=',')
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -275,33 +275,33 @@ def test_angle_formatting():
     assert str(angle) == angle.to_string()
 
     res = 'Angle as HMS: 3h36m29.7888s'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour)) == res
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour)) == res
 
     res = 'Angle as HMS: 3:36:29.7888'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, sep=":")) == res
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour, sep=":")) == res
 
     res = 'Angle as HMS: 3:36:29.79'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, sep=":",
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour, sep=":",
                                       precision=2)) == res
 
     # Note that you can provide one, two, or three separators passed as a
     # tuple or list
 
     res = 'Angle as HMS: 3h36m29.7888s'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour,
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour,
                                                    sep=("h", "m", "s"),
                                                    precision=4)) == res
 
     res = 'Angle as HMS: 3-36|29.7888'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, sep=["-", "|"],
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour, sep=["-", "|"],
                                                    precision=4)) == res
 
     res = 'Angle as HMS: 3-36-29.7888'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, sep="-",
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour, sep="-",
                                                     precision=4)) == res
 
     res = 'Angle as HMS: 03h36m29.7888s'
-    assert "Angle as HMS: {0}".format(angle.to_string(unit=u.hour, precision=4,
+    assert "Angle as HMS: {}".format(angle.to_string(unit=u.hour, precision=4,
                                                   pad=True)) == res
 
     # Same as above, in degrees
@@ -309,40 +309,40 @@ def test_angle_formatting():
     angle = Angle("3 36 29.78880", unit=u.degree)
 
     res = 'Angle as DMS: 3d36m29.7888s'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree)) == res
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree)) == res
 
     res = 'Angle as DMS: 3:36:29.7888'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, sep=":")) == res
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree, sep=":")) == res
 
     res = 'Angle as DMS: 3:36:29.79'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, sep=":",
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree, sep=":",
                                       precision=2)) == res
 
     # Note that you can provide one, two, or three separators passed as a
     # tuple or list
 
     res = 'Angle as DMS: 3d36m29.7888s'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree,
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree,
                                                    sep=("d", "m", "s"),
                                                    precision=4)) == res
 
     res = 'Angle as DMS: 3-36|29.7888'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, sep=["-", "|"],
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree, sep=["-", "|"],
                                                    precision=4)) == res
 
     res = 'Angle as DMS: 3-36-29.7888'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, sep="-",
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree, sep="-",
                                                     precision=4)) == res
 
     res = 'Angle as DMS: 03d36m29.7888s'
-    assert "Angle as DMS: {0}".format(angle.to_string(unit=u.degree, precision=4,
+    assert "Angle as DMS: {}".format(angle.to_string(unit=u.degree, precision=4,
                                                   pad=True)) == res
 
     res = 'Angle as rad: 0.0629763rad'
-    assert "Angle as rad: {0}".format(angle.to_string(unit=u.radian)) == res
+    assert "Angle as rad: {}".format(angle.to_string(unit=u.radian)) == res
 
     res = 'Angle as rad decimal: 0.0629763'
-    assert "Angle as rad decimal: {0}".format(angle.to_string(unit=u.radian, decimal=True)) == res
+    assert "Angle as rad decimal: {}".format(angle.to_string(unit=u.radian, decimal=True)) == res
 
     # check negative angles
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -109,8 +109,8 @@ def test_all_arg_options(kwargs):
 ])
 def test_expected_arg_names(cls, lon, lat):
     kwargs = {lon: 37.4*u.deg, lat: -55.8*u.deg, 'distance': 150*u.pc,
-              'pm_{0}_cos{1}'.format(lon, lat): -21.2*u.mas/u.yr,
-              'pm_{0}'.format(lat): 17.1*u.mas/u.yr,
+              f'pm_{lon}_cos{lat}': -21.2*u.mas/u.yr,
+              f'pm_{lat}': 17.1*u.mas/u.yr,
               'radial_velocity': 105.7*u.km/u.s}
     frame = cls(**kwargs)
 

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -61,7 +61,7 @@ def test_constellations(recwarn):
     # non-ASCII character
     bootest = SkyCoord(15*u.hour, 30*u.deg, frame='icrs')
     boores = get_constellation(bootest)
-    assert boores == u'Boötes'
+    assert boores == 'Boötes'
     assert isinstance(boores, str) or getattr(boores, 'shape', None) == tuple()
 
 

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -113,8 +113,8 @@ def test_iau_fullstack(fullstack_icrs, fullstack_fiducial_altaz,
 
     adras = np.abs(fullstack_icrs.ra - icrs2.ra)[msk]
     addecs = np.abs(fullstack_icrs.dec - icrs2.dec)[msk]
-    assert np.all(adras < tol), 'largest RA change is {0} mas, > {1}'.format(np.max(adras.arcsec*1000), tol)
-    assert np.all(addecs < tol), 'largest Dec change is {0} mas, > {1}'.format(np.max(addecs.arcsec*1000), tol)
+    assert np.all(adras < tol), 'largest RA change is {} mas, > {}'.format(np.max(adras.arcsec*1000), tol)
+    assert np.all(addecs < tol), 'largest Dec change is {} mas, > {}'.format(np.max(addecs.arcsec*1000), tol)
 
     # check that we're consistent with the ERFA alt/az result
     xp, yp = u.Quantity(iers.IERS_Auto.open().pm_xy(fullstack_times)).to_value(u.radian)

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1423,7 +1423,7 @@ def unitphysics():
             if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
                 raise ValueError('Inclination angle(s) must be within '
                                  '0 deg <= angle <= 180 deg, '
-                                 'got {0}'.format(theta.to(u.degree)))
+                                 'got {}'.format(theta.to(u.degree)))
 
         @property
         def phi(self):

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1173,7 +1173,7 @@ def test_nd_skycoord_to_string():
     c = SkyCoord(np.ones((2, 2)), 1, unit=('deg', 'deg'))
     ts = c.to_string()
     assert np.all(ts.shape == c.shape)
-    assert np.all(ts == u'1 1')
+    assert np.all(ts == '1 1')
 
 
 def test_equiv_skycoord():

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -193,7 +193,7 @@ class TransformGraph:
                 if attr in tosys.frame_attributes:
                     invalid_frames.update([tosys])
 
-            raise ValueError("Frame(s) {0} contain invalid attribute names: {1}"
+            raise ValueError("Frame(s) {} contain invalid attribute names: {}"
                              "\nFrame attributes can not conflict with *any* of"
                              " the frame data component names (see"
                              " `frame_transform_graph.frame_component_names`)."
@@ -235,7 +235,7 @@ class TransformGraph:
                         del agraph[b]
                         break
             else:
-                raise ValueError('Could not find transform {0} in the '
+                raise ValueError('Could not find transform {} in the '
                                  'graph'.format(transform))
 
         else:
@@ -246,8 +246,8 @@ class TransformGraph:
                 if curr is transform:
                     self._graph[fromsys].pop(tosys)
                 else:
-                    raise ValueError('Current transform from {0} to {1} is not '
-                                     '{2}'.format(fromsys, tosys, transform))
+                    raise ValueError('Current transform from {} to {} is not '
+                                     '{}'.format(fromsys, tosys, transform))
         self.invalidate_cache()
 
     def find_shortest_path(self, fromsys, tosys):
@@ -524,14 +524,14 @@ class TransformGraph:
             labelstr_fmt = '[ {0} {1} ]'
 
             if priorities:
-                priority_part = 'label = "{0}"'.format(weights)
+                priority_part = f'label = "{weights}"'
             else:
                 priority_part = ''
 
-            color_part = 'color = "{0}"'.format(color)
+            color_part = f'color = "{color}"'
 
             labelstr = labelstr_fmt.format(priority_part, color_part)
-            lines.append('{0} -> {1}{2};'.format(enm1, enm2, labelstr))
+            lines.append(f'{enm1} -> {enm2}{labelstr};')
 
         lines.append('')
         lines.append('overlap=false')
@@ -815,8 +815,8 @@ class FunctionTransform(CoordinateTransform):
     def __call__(self, fromcoord, toframe):
         res = self.func(fromcoord, toframe)
         if not isinstance(res, self.tosys):
-            raise TypeError('the transformation function yielded {0} but '
-                'should have been of type {1}'.format(res, self.tosys))
+            raise TypeError('the transformation function yielded {} but '
+                'should have been of type {}'.format(res, self.tosys))
         if fromcoord.data.differentials and not res.data.differentials:
             warn("Applied a FunctionTransform to a coordinate frame with "
                  "differentials, but the FunctionTransform does not handle "
@@ -1016,7 +1016,7 @@ class BaseAffineTransform(CoordinateTransform):
         if isinstance(data, UnitSphericalRepresentation) and offset is not None:
             raise TypeError("Position information stored on coordinate frame "
                             "is insufficient to do a full-space position "
-                            "transformation (representation class: {0})"
+                            "transformation (representation class: {})"
                             .format(data.__class__))
 
         elif (has_velocity and (unit_vel_diff or rad_vel_diff) and
@@ -1025,7 +1025,7 @@ class BaseAffineTransform(CoordinateTransform):
             # that we need to do a velocity offset
             raise TypeError("Velocity information stored on coordinate frame "
                             "is insufficient to do a full-space velocity "
-                            "transformation (differential class: {0})"
+                            "transformation (differential class: {})"
                             .format(data.differentials['s'].__class__))
 
         elif len(data.differentials) > 1:
@@ -1035,7 +1035,7 @@ class BaseAffineTransform(CoordinateTransform):
             raise ValueError("Representation passed to AffineTransform contains"
                              " multiple associated differentials. Only a single"
                              " differential with velocity units is presently"
-                             " supported (differentials: {0})."
+                             " supported (differentials: {})."
                              .format(str(data.differentials)))
 
         # If the representation is a UnitSphericalRepresentation, and this is

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -294,9 +294,9 @@ class FLRW(Cosmology, metaclass=ABCMeta):
     def _namelead(self):
         """ Helper function for constructing __repr__"""
         if self.name is None:
-            return "{0}(".format(self.__class__.__name__)
+            return f"{self.__class__.__name__}("
         else:
-            return "{0}(name=\"{1}\", ".format(self.__class__.__name__,
+            return "{}(name=\"{}\", ".format(self.__class__.__name__,
                                                self.name)
 
     def __repr__(self):

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1613,7 +1613,7 @@ def test_z_at_value_roundtrip():
     for name, func in methods:
         if name.startswith('_') or name in skip:
             continue
-        print('Round-trip testing {0}'.format(name))
+        print(f'Round-trip testing {name}')
         fval = func(z)
         # we need zmax here to pick the right solution for
         # angular_diameter_distance and related methods.

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -337,7 +337,7 @@ class RdbHeader(TabHeader):
             raise core.InconsistentTableError('RDB header mismatch between number of column names and column types.')
 
         if any(not re.match(r'\d*(N|S)$', x, re.IGNORECASE) for x in raw_types):
-            raise core.InconsistentTableError('RDB types definitions do not all match [num](N|S): {}'.format(raw_types))
+            raise core.InconsistentTableError(f'RDB types definitions do not all match [num](N|S): {raw_types}')
 
         self._set_cols_from_names()
         for col, raw_type in zip(self.cols, raw_types):

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -85,7 +85,7 @@ class CdsHeader(core.BaseHeader):
                                 break
 
             else:
-                raise core.InconsistentTableError("Can't find table {0} in {1}".format(
+                raise core.InconsistentTableError("Can't find table {} in {}".format(
                     self.data.table_name, self.readme))
 
         found_line = False
@@ -149,7 +149,7 @@ class CdsHeader(core.BaseHeader):
                 if cols:
                     cols[-1].description += line.strip()
                 else:
-                    raise ValueError('Line "{}" not parsable as CDS header'.format(line))
+                    raise ValueError(f'Line "{line}" not parsable as CDS header')
 
         self.names = [x.name for x in cols]
 

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -41,15 +41,15 @@ def _get_connectors_table():
 
         io_format = 'ascii.' + cls._format_name
         description = getattr(cls, '_description', '')
-        class_link = ':class:`~{0}.{1}`'.format(cls.__module__, cls.__name__)
+        class_link = f':class:`~{cls.__module__}.{cls.__name__}`'
         suffix = getattr(cls, '_io_registry_suffix', '')
         can_write = 'Yes' if getattr(cls, '_io_registry_can_write', True) else ''
 
         rows.append((io_format, suffix, can_write,
-                     '{0}: {1}'.format(class_link, description)))
+                     f'{class_link}: {description}'))
     out = Table(list(zip(*rows)), names=('Format', 'Suffix', 'Write', 'Description'))
     for colname in ('Format', 'Description'):
         width = max(len(x) for x in out[colname])
-        out[colname].format = '%-{0}s'.format(width)
+        out[colname].format = f'%-{width}s'
 
     return out

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -653,7 +653,7 @@ class BaseHeader:
             for name in self.colnames:
                 if (_is_number(name) or len(name) == 0
                         or name[0] in bads or name[-1] in bads):
-                    raise InconsistentTableError('Column name {0!r} does not meet strict name requirements'
+                    raise InconsistentTableError('Column name {!r} does not meet strict name requirements'
                                                  .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
@@ -661,8 +661,8 @@ class BaseHeader:
                              .format(list(self.colnames)))
 
         if names is not None and len(names) != len(self.colnames):
-            raise InconsistentTableError('Length of names argument ({0}) does not match number'
-                             ' of table columns ({1})'.format(len(names), len(self.colnames)))
+            raise InconsistentTableError('Length of names argument ({}) does not match number'
+                             ' of table columns ({})'.format(len(names), len(self.colnames)))
 
 
 class BaseData:
@@ -963,12 +963,12 @@ class BaseOutputter:
                 except OverflowError as err:
                     # Overflow during conversion (most likely an int that doesn't fit in native C long).
                     # Put string at the top of the converters list for the next while iteration.
-                    warnings.warn("OverflowError converting to {0} for column {1}, using string instead."
+                    warnings.warn("OverflowError converting to {} for column {}, using string instead."
                                   .format(converter_type.__name__, col.name), AstropyWarning)
                     col.converters.insert(0, convert_numpy(numpy.str))
                     last_err = err
                 except IndexError:
-                    raise ValueError('Column {} failed to convert: {}'.format(col.name, last_err))
+                    raise ValueError(f'Column {col.name} failed to convert: {last_err}')
 
 
 class TableOutputter(BaseOutputter):
@@ -1022,7 +1022,7 @@ class MetaBaseReader(type):
 
         for io_format in io_formats:
             func = functools.partial(connect.io_read, io_format)
-            header = "ASCII reader '{}' details\n".format(io_format)
+            header = f"ASCII reader '{io_format}' details\n"
             func.__doc__ = (inspect.cleandoc(READ_DOCSTRING).strip() + '\n\n' +
                             header + re.sub('.', '=', header) + '\n')
             func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
@@ -1030,7 +1030,7 @@ class MetaBaseReader(type):
 
             if dct.get('_io_registry_can_write', True):
                 func = functools.partial(connect.io_write, io_format)
-                header = "ASCII writer '{}' details\n".format(io_format)
+                header = f"ASCII writer '{io_format}' details\n"
                 func.__doc__ = (inspect.cleandoc(WRITE_DOCSTRING).strip() + '\n\n' +
                                 header + re.sub('.', '=', header) + '\n')
                 func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
@@ -1396,7 +1396,7 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     if 'fast_reader' in kwargs:
         if kwargs['fast_reader']['enable'] == 'force':
             raise ParameterError('fast_reader required with ' +
-                                 '{0}, but this is not a fast C reader: {1}'
+                                 '{}, but this is not a fast C reader: {}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
             del kwargs['fast_reader']  # Otherwise ignore fast_reader parameter
@@ -1496,10 +1496,10 @@ def _get_writer(Writer, fast_writer, **kwargs):
 
     if issubclass(Writer, FastBasic):  # Fast writers handle args separately
         return Writer(**kwargs)
-    elif fast_writer and 'fast_{0}'.format(Writer._format_name) in FAST_CLASSES:
+    elif fast_writer and f'fast_{Writer._format_name}' in FAST_CLASSES:
         # Switch to fast writer
         kwargs['fast_writer'] = fast_writer
-        return FAST_CLASSES['fast_{0}'.format(Writer._format_name)](**kwargs)
+        return FAST_CLASSES[f'fast_{Writer._format_name}'](**kwargs)
 
     writer_kwargs = dict([k, v] for k, v in kwargs.items() if k not in extra_writer_pars)
     writer = Writer(**writer_kwargs)

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -56,7 +56,7 @@ class EcsvHeader(basic.BasicHeader):
 
         for col in self.cols:
             if len(getattr(col, 'shape', ())) > 1:
-                raise ValueError("ECSV format does not support multidimensional column '{0}'"
+                raise ValueError("ECSV format does not support multidimensional column '{}'"
                                  .format(col.info.name))
 
         # Now assemble the header dict that will be serialized by the YAML dumper
@@ -69,7 +69,7 @@ class EcsvHeader(basic.BasicHeader):
         if self.splitter.delimiter != ' ':
             header['delimiter'] = self.splitter.delimiter
 
-        header_yaml_lines = (['%ECSV {0}'.format(ECSV_VERSION),
+        header_yaml_lines = ([f'%ECSV {ECSV_VERSION}',
                               '---']
                              + meta.get_yaml_from_header(header))
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -150,7 +150,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
                     len(name) == 0 or
                     name[0] in bads or
                     name[-1] in bads):
-                    raise ValueError('Column name {0!r} does not meet strict name requirements'
+                    raise ValueError('Column name {!r} does not meet strict name requirements'
                                      .format(name))
         # When guessing require at least two columns
         if self.guessing and len(names) <= 1:
@@ -343,7 +343,7 @@ class FastRdb(FastBasic):
 
         if any(not re.match(r'\d*(N|S)$', x, re.IGNORECASE) for x in types):
             raise core.InconsistentTableError('RDB type definitions do not all match '
-                             '[num](N|S): {0}'.format(types))
+                             '[num](N|S): {}'.format(types))
 
         try_int = {}
         try_float = {}

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -137,7 +137,7 @@ class FixedWidthHeader(basic.BasicHeader):
                     # purity here.
                 charset = self.set_of_position_line_characters.union(set([self.splitter.delimiter, ' ']))
                 if not set(line).issubset(charset):
-                    raise InconsistentTableError('Characters in position line must be part of {0}'.format(charset))
+                    raise InconsistentTableError(f'Characters in position line must be part of {charset}')
                 vals, self.col_starts, col_ends = self.get_fixedwidth_params(line)
                 self.col_ends = [x - 1 if x is not None else None for x in col_ends]
 

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -100,11 +100,11 @@ class HTMLInputter(core.BaseInputter):
                 break
         else:
             if isinstance(self.html['table_id'], int):
-                err_descr = 'number {0}'.format(self.html['table_id'])
+                err_descr = 'number {}'.format(self.html['table_id'])
             else:
-                err_descr = "id '{0}'".format(self.html['table_id'])
+                err_descr = "id '{}'".format(self.html['table_id'])
             raise core.InconsistentTableError(
-                'ERROR: HTML table {0} not found'.format(err_descr))
+                f'ERROR: HTML table {err_descr} not found')
 
         # Get all table rows
         soup_list = [SoupString(x) for x in table.find_all('tr')]

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -24,14 +24,14 @@ from astropy.table.pprint import get_auto_format_func
 
 class IpacFormatErrorDBMS(Exception):
     def __str__(self):
-        return '{0}\nSee {1}'.format(
+        return '{}\nSee {}'.format(
             super().__str__(),
             'http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/DBMSrestriction.html')
 
 
 class IpacFormatError(Exception):
     def __str__(self):
-        return '{0}\nSee {1}'.format(
+        return '{}\nSee {}'.format(
             super().__str__(),
             'http://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html')
 
@@ -229,26 +229,26 @@ class IpacHeader(fixedwidth.FixedWidthHeader):
             doublenames = [x for x in countnamelist if countnamelist[x] > 1]
             if doublenames != []:
                 raise IpacFormatE('IPAC DBMS tables are not case sensitive. '
-                                  'This causes duplicate column names: {0}'.format(doublenames))
+                                  'This causes duplicate column names: {}'.format(doublenames))
 
         for name in namelist:
             m = re.match(r'\w+', name)
             if m.end() != len(name):
-                raise IpacFormatE('{0} - Only alphanumeric characters and _ '
+                raise IpacFormatE('{} - Only alphanumeric characters and _ '
                                   'are allowed in column names.'.format(name))
             if self.DBMS and not(name[0].isalpha() or (name[0] == '_')):
-                raise IpacFormatE('Column name cannot start with numbers: {}'.format(name))
+                raise IpacFormatE(f'Column name cannot start with numbers: {name}')
             if self.DBMS:
                 if name in ['x', 'y', 'z', 'X', 'Y', 'Z']:
-                    raise IpacFormatE('{0} - x, y, z, X, Y, Z are reserved names and '
+                    raise IpacFormatE('{} - x, y, z, X, Y, Z are reserved names and '
                                       'cannot be used as column names.'.format(name))
                 if len(name) > 16:
                     raise IpacFormatE(
-                        '{0} - Maximum length for column name is 16 characters'.format(name))
+                        f'{name} - Maximum length for column name is 16 characters')
             else:
                 if len(name) > 40:
                     raise IpacFormatE(
-                        '{0} - Maximum length for column name is 40 characters.'.format(name))
+                        f'{name} - Maximum length for column name is 40 characters.')
 
         dtypelist = []
         unitlist = []
@@ -493,7 +493,7 @@ class Ipac(basic.Basic):
             for keyword in keydict:
                 try:
                     val = keydict[keyword]['value']
-                    lines.append('\\{0}={1!r}'.format(keyword.strip(), val))
+                    lines.append('\\{}={!r}'.format(keyword.strip(), val))
                     # meta is not standardized: Catch some common Errors.
                 except TypeError:
                     warn("Table metadata keyword {0} has been skipped.  "

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -101,7 +101,7 @@ def raises(*exceptions):
             except exceptions:
                 pass
             else:
-                message = "{}() did not raise {}".format(name, valid)
+                message = f"{name}() did not raise {valid}"
                 raise AssertionError(message)
         newfunc = make_decorator(func)(newfunc)
         return newfunc

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -76,7 +76,7 @@ def _read(tmpdir, table, Reader=None, format=None, parallel=False, check_meta=Fa
             'parallel': True}, **kwargs)
         assert_table_equal(t1, t6, check_meta=check_meta)
 
-    filename = str(tmpdir.join('table{0}.txt'.format(_filename_counter)))
+    filename = str(tmpdir.join(f'table{_filename_counter}.txt'))
     _filename_counter += 1
 
     with open(filename, 'wb') as f:
@@ -956,7 +956,7 @@ def test_fast_tab_with_names(parallel, read_tab):
     content = """#
 \tdecDeg\tRate_pn_offAxis\tRate_mos2_offAxis\tObsID\tSourceID\tRADeg\tversion\tCounts_pn\tRate_pn\trun\tRate_mos1\tRate_mos2\tInserted_pn\tInserted_mos2\tbeta\tRate_mos1_offAxis\trcArcsec\tname\tInserted\tCounts_mos1\tInserted_mos1\tCounts_mos2\ty\tx\tCounts\toffAxis\tRot
 -3.007559\t0.0000\t0.0010\t0013140201\t0\t213.462574\t0\t2\t0.0002\t0\t0.0001\t0.0001\t0\t1\t0.66\t0.0217\t3.0\tfakeXMMXCS J1413.8-0300\t3\t1\t2\t1\t398.000\t127.000\t5\t13.9\t72.3\t"""
-    head = ['A{0}'.format(i) for i in range(28)]
+    head = [f'A{i}' for i in range(28)]
     table = read_tab(content, data_start=1,
                      parallel=parallel, names=head)
 
@@ -977,12 +977,12 @@ def test_read_big_table(tmpdir):
     NB_COLS = 500
     filename = str(tmpdir.join("big_table.csv"))
 
-    print("Creating a {} rows table ({} columns).".format(NB_ROWS, NB_COLS))
+    print(f"Creating a {NB_ROWS} rows table ({NB_COLS} columns).")
     data = np.random.random(NB_ROWS)
     t = Table(data=[data]*NB_COLS, names=[str(i) for i in range(NB_COLS)])
     data = None
 
-    print("Saving the table to {}".format(filename))
+    print(f"Saving the table to {filename}")
     t.write(filename, format='ascii.csv', overwrite=True)
     t = None
 
@@ -1007,11 +1007,11 @@ def test_read_big_table2(tmpdir):
     NB_ROWS = (2**32 // 2) // 10 + 5
     filename = str(tmpdir.join("big_table.csv"))
 
-    print("Creating a {} rows table.".format(NB_ROWS))
+    print(f"Creating a {NB_ROWS} rows table.")
     data = np.full(2**32 // 2 // 10 + 5, int(1e9), dtype=np.int32)
     t = Table(data=[data], names=['a'], copy=False)
 
-    print("Saving the table to {}".format(filename))
+    print(f"Saving the table to {filename}")
     t.write(filename, format='ascii.csv', overwrite=True)
     t = None
 
@@ -1096,7 +1096,7 @@ def test_int_out_of_range(parallel, guess):
     imax = np.iinfo(int).max-1
     huge = '{:d}'.format(imax+2)
 
-    text = 'P M S\n {:d} {:d} {:s}'.format(imax, imin, huge)
+    text = f'P M S\n {imax:d} {imin:d} {huge:s}'
     expected = Table([[imax], [imin], [huge]], names=('P', 'M', 'S'))
     table = ascii.read(text, format='basic', guess=guess,
                        fast_reader={'parallel': parallel})

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -728,9 +728,9 @@ def test_read_html_unicode():
     """
     Test reading an HTML table with unicode values
     """
-    table_in = [u'<table>',
-                u'<tr><td>&#x0394;</td></tr>',
-                u'<tr><td>Δ</td></tr>',
-                u'</table>']
+    table_in = ['<table>',
+                '<tr><td>&#x0394;</td></tr>',
+                '<tr><td>Δ</td></tr>',
+                '</table>']
     dat = Table.read(table_in, format='ascii.html')
-    assert np.all(dat['col1'] == [u'Δ', u'Δ'])
+    assert np.all(dat['col1'] == ['Δ', 'Δ'])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -156,7 +156,7 @@ def test_read_all_files(fast_reader):
             test_opts = testfile['opts'].copy()
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
-            if ('Reader' in test_opts and 'fast_{0}'.format(test_opts['Reader']._format_name)
+            if ('Reader' in test_opts and 'fast_{}'.format(test_opts['Reader']._format_name)
                     in core.FAST_CLASSES):  # has fast version
                 if 'Inputter' not in test_opts:  # fast reader doesn't allow this
                     test_opts['fast_reader'] = fast_reader
@@ -178,11 +178,11 @@ def test_read_all_files_via_table(fast_reader):
             if 'guess' not in test_opts:
                 test_opts['guess'] = guess
             if 'Reader' in test_opts:
-                format = 'ascii.{0}'.format(test_opts['Reader']._format_name)
+                format = 'ascii.{}'.format(test_opts['Reader']._format_name)
                 del test_opts['Reader']
             else:
                 format = 'ascii'
-            if 'fast_{0}'.format(format) in core.FAST_CLASSES:
+            if f'fast_{format}' in core.FAST_CLASSES:
                 test_opts['fast_reader'] = fast_reader
             table = Table.read(testfile['name'], format=format, **test_opts)
             assert_equal(table.dtype.names, testfile['cols'])
@@ -1235,7 +1235,7 @@ def test_non_C_locale_with_fast_reader():
                            fast_reader=fast_reader)
             assert t['a'].dtype.kind == 'f'
     except locale.Error as e:
-        pytest.skip('Locale error: {}'.format(e))
+        pytest.skip(f'Locale error: {e}')
     finally:
         locale.setlocale(locale.LC_ALL, current)
 
@@ -1312,8 +1312,8 @@ def text_aastex_no_trailing_backslash():
 @pytest.mark.parametrize('encoding', ['utf8', 'latin1', 'cp1252'])
 def test_read_with_encoding(tmpdir, encoding):
     data = {
-        'commented_header': u'# à b è \n 1 2 héllo',
-        'csv': u'à,b,è\n1,2,héllo'
+        'commented_header': '# à b è \n 1 2 héllo',
+        'csv': 'à,b,è\n1,2,héllo'
     }
 
     testfile = str(tmpdir.join('test.txt'))

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -413,7 +413,7 @@ def check_write_table_via_table(test_def, table, fast_writer):
 
     test_def = copy.deepcopy(test_def)
     if 'Writer' in test_def['kwargs']:
-        format = 'ascii.{0}'.format(test_def['kwargs']['Writer']._format_name)
+        format = 'ascii.{}'.format(test_def['kwargs']['Writer']._format_name)
         del test_def['kwargs']['Writer']
     else:
         format = 'ascii'

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -89,7 +89,7 @@ def _probably_html(table, maxchars=100000):
             return True
 
         # Look for <TABLE .. >, <TR .. >, <TD .. > tag openers.
-        if all(re.search(r'< \s* {0} [^>]* >'.format(element), table, re.IGNORECASE | re.VERBOSE)
+        if all(re.search(fr'< \s* {element} [^>]* >', table, re.IGNORECASE | re.VERBOSE)
                for element in ('table', 'tr', 'td')):
             return True
 
@@ -178,13 +178,13 @@ def get_reader(Reader=None, Inputter=None, Outputter=None, **kwargs):
 
 def _get_format_class(format, ReaderWriter, label):
     if format is not None and ReaderWriter is not None:
-        raise ValueError('Cannot supply both format and {0} keywords'.format(label))
+        raise ValueError(f'Cannot supply both format and {label} keywords')
 
     if format is not None:
         if format in core.FORMAT_CLASSES:
             ReaderWriter = core.FORMAT_CLASSES[format]
         else:
-            raise ValueError('ASCII format {0!r} not in allowed list {1}'
+            raise ValueError('ASCII format {!r} not in allowed list {}'
                              .format(format, sorted(core.FORMAT_CLASSES)))
     return ReaderWriter
 
@@ -296,9 +296,9 @@ def read(table, guess=None, **kwargs):
         # Try the fast reader version of `format` first if applicable.  Note that
         # if user specified a fast format (e.g. format='fast_basic') this test
         # will fail and the else-clause below will be used.
-        if fast_reader['enable'] and 'fast_{0}'.format(format) in core.FAST_CLASSES:
+        if fast_reader['enable'] and f'fast_{format}' in core.FAST_CLASSES:
             fast_kwargs = copy.deepcopy(new_kwargs)
-            fast_kwargs['Reader'] = core.FAST_CLASSES['fast_{0}'.format(format)]
+            fast_kwargs['Reader'] = core.FAST_CLASSES[f'fast_{format}']
             fast_reader_rdr = get_reader(**fast_kwargs)
             try:
                 dat = fast_reader_rdr.read(table)
@@ -365,10 +365,10 @@ def _guess(table, read_kwargs, format, fast_reader):
     full_list_guess = _get_guess_kwargs_list(read_kwargs)
 
     # If a fast version of the reader is available, try that before the slow version
-    if (fast_reader['enable'] and format is not None and 'fast_{0}'.format(format) in
+    if (fast_reader['enable'] and format is not None and f'fast_{format}' in
         core.FAST_CLASSES):
         fast_kwargs = copy.deepcopy(read_kwargs)
-        fast_kwargs['Reader'] = core.FAST_CLASSES['fast_{0}'.format(format)]
+        fast_kwargs['Reader'] = core.FAST_CLASSES[f'fast_{format}']
         full_list_guess = [fast_kwargs] + full_list_guess
     else:
         fast_kwargs = None
@@ -385,7 +385,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
                                 'status': 'Disabled: reader only available in fast version',
-                                'dt': '{0:.3f} ms'.format(0.0)})
+                                'dt': '{:.3f} ms'.format(0.0)})
             continue
 
         # If user required a fast reader then skip all non-fast readers
@@ -394,7 +394,7 @@ def _guess(table, read_kwargs, format, fast_reader):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
                                 'status': 'Disabled: no fast version of reader available',
-                                'dt': '{0:.3f} ms'.format(0.0)})
+                                'dt': '{:.3f} ms'.format(0.0)})
             continue
 
         guess_kwargs_ok = True  # guess_kwargs are consistent with user_kwargs?
@@ -448,14 +448,14 @@ def _guess(table, read_kwargs, format, fast_reader):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': reader.__class__,
                                 'status': 'Success (guessing)',
-                                'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
+                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
             return dat
 
         except guess_exception_classes as err:
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
-                                'status': '{0}: {1}'.format(err.__class__.__name__,
+                                'status': '{}: {}'.format(err.__class__.__name__,
                                                             str(err)),
-                                'dt': '{0:.3f} ms'.format((time.time() - t0) * 1000)})
+                                'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
             failed_kwargs.append(guess_kwargs)
     else:
         # Failed all guesses, try the original read_kwargs without column requirements
@@ -470,7 +470,7 @@ def _guess(table, read_kwargs, format, fast_reader):
 
         except guess_exception_classes as err:
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
-                                'status': '{0}: {1}'.format(err.__class__.__name__,
+                                'status': '{}: {}'.format(err.__class__.__name__,
                                                             str(err))})
             failed_kwargs.append(read_kwargs)
             lines = ['\nERROR: Unable to guess table format with the guesses listed below:']
@@ -480,7 +480,7 @@ def _guess(table, read_kwargs, format, fast_reader):
                 reader_repr = repr(kwargs.get('Reader', basic.Basic))
                 keys_vals = ['Reader:' + re.search(r"\.(\w+)'>", reader_repr).group(1)]
                 kwargs_sorted = ((key, kwargs[key]) for key in sorted_keys)
-                keys_vals.extend(['{}: {!r}'.format(key, val) for key, val in kwargs_sorted])
+                keys_vals.extend([f'{key}: {val!r}' for key, val in kwargs_sorted])
                 lines.append(' '.join(keys_vals))
 
             msg = ['',
@@ -749,7 +749,7 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
                     "Use the argument 'overwrite=True' in the future.".format(
                         output), AstropyDeprecationWarning)
             elif not overwrite:
-                raise OSError("{} already exists".format(output))
+                raise OSError(f"{output} already exists")
 
     if output is None:
         output = sys.stdout

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -125,10 +125,10 @@ class Card(_Verify):
 
     _rvkc_identifier = r'[a-zA-Z_]\w*'
     _rvkc_field = _rvkc_identifier + r'(\.\d+)?'
-    _rvkc_field_specifier_s = r'{}(\.{})*'.format(_rvkc_field, _rvkc_field)
+    _rvkc_field_specifier_s = fr'{_rvkc_field}(\.{_rvkc_field})*'
     _rvkc_field_specifier_val = (r'(?P<keyword>{}): (?P<val>{})'.format(
             _rvkc_field_specifier_s, _numr_FSC))
-    _rvkc_keyword_val = r'\'(?P<rawval>{})\''.format(_rvkc_field_specifier_val)
+    _rvkc_keyword_val = fr'\'(?P<rawval>{_rvkc_field_specifier_val})\''
     _rvkc_keyword_val_comm = (r' *{} *(/ *(?P<comm>[ -~]*))?$'.format(
             _rvkc_keyword_val))
 
@@ -266,11 +266,11 @@ class Card(_Verify):
                         'standard; a HIERARCH card will be created.'.format(
                             keyword), VerifyWarning)
             else:
-                raise ValueError('Illegal keyword name: {!r}.'.format(keyword))
+                raise ValueError(f'Illegal keyword name: {keyword!r}.')
             self._keyword = keyword
             self._modified = True
         else:
-            raise ValueError('Keyword name {!r} is not a string.'.format(keyword))
+            raise ValueError(f'Keyword name {keyword!r} is not a string.')
 
     @property
     def value(self):
@@ -318,7 +318,7 @@ class Card(_Verify):
                           (str, int, float, complex, bool, Undefined,
                            np.floating, np.integer, np.complexfloating,
                            np.bool_)):
-            raise ValueError('Illegal value: {!r}.'.format(value))
+            raise ValueError(f'Illegal value: {value!r}.')
 
         if isinstance(value, float) and (np.isnan(value) or np.isinf(value)):
             raise ValueError("Floating point {!r} values are not allowed "
@@ -416,7 +416,7 @@ class Card(_Verify):
         if self._rawvalue is not None:
             return self._rawvalue
         elif self.field_specifier is not None:
-            self._rawvalue = '{}: {}'.format(self.field_specifier, self.value)
+            self._rawvalue = f'{self.field_specifier}: {self.value}'
             return self._rawvalue
         else:
             return self.value
@@ -900,7 +900,7 @@ class Card(_Verify):
             idigt = translate(imag.group('digt'), FIX_FP_TABLE, ' ')
             if imag.group('sign') is not None:
                 idigt = imag.group('sign') + idigt
-            value = '({}, {})'.format(rdigt, idigt)
+            value = f'({rdigt}, {idigt})'
         self._valuestring = value
         # The value itself has not been modified, but its serialized
         # representation (as stored in self._valuestring) has been changed, so
@@ -913,7 +913,7 @@ class Card(_Verify):
                 return '{:{len}}'.format(self.keyword.split('.', 1)[0],
                                          len=KEYWORD_LENGTH)
             elif self._hierarch:
-                return 'HIERARCH {} '.format(self.keyword)
+                return f'HIERARCH {self.keyword} '
             else:
                 return '{:{len}}'.format(self.keyword, len=KEYWORD_LENGTH)
         else:
@@ -936,10 +936,10 @@ class Card(_Verify):
         elif (self._valuestring and not self._valuemodified and
               isinstance(self.value, float_types)):
             # Keep the existing formatting for float/complex numbers
-            value = '{:>20}'.format(self._valuestring)
+            value = f'{self._valuestring:>20}'
         elif self.field_specifier:
             value = _format_value(self._value).strip()
-            value = "'{}: {}'".format(self.field_specifier, value)
+            value = f"'{self.field_specifier}: {value}'"
         else:
             value = _format_value(value)
 
@@ -953,7 +953,7 @@ class Card(_Verify):
         if not self.comment:
             return ''
         else:
-            return ' / {}'.format(self._comment)
+            return f' / {self._comment}'
 
     def _format_image(self):
         keyword = self._format_keyword()
@@ -990,7 +990,7 @@ class Card(_Verify):
                                  'too long'.format(self.keyword))
 
         if len(output) <= self.length:
-            output = '{:80}'.format(output)
+            output = f'{output:80}'
         else:
             # longstring case (CONTINUE card)
             # try not to use CONTINUE if the string value can fit in one line.
@@ -1052,7 +1052,7 @@ class Card(_Verify):
                     headstr = "CONTINUE  '&' / "
 
                 comment = headstr + comment_format.format(word)
-                output.append('{:80}'.format(comment))
+                output.append(f'{comment:80}')
 
         return ''.join(output)
 
@@ -1122,7 +1122,7 @@ class Card(_Verify):
             if not self._keywd_FSC_RE.match(keyword):
                 errs.append(self.run_option(
                     option,
-                    err_text='Illegal keyword name {!r}'.format(keyword),
+                    err_text=f'Illegal keyword name {keyword!r}',
                     fixable=False))
 
         # verify the value, it may be fixable
@@ -1217,15 +1217,15 @@ def _format_value(value):
             return "''"
         else:
             exp_val_str = value.replace("'", "''")
-            val_str = "'{:8}'".format(exp_val_str)
-            return '{:20}'.format(val_str)
+            val_str = f"'{exp_val_str:8}'"
+            return f'{val_str:20}'
 
     # must be before int checking since bool is also int
     elif isinstance(value, (bool, np.bool_)):
         return '{:>20}'.format(repr(value)[0])  # T or F
 
     elif _is_int(value):
-        return '{:>20d}'.format(value)
+        return f'{value:>20d}'
 
     elif isinstance(value, (float, np.floating)):
         return '{:>20}'.format(_format_float(value))
@@ -1233,7 +1233,7 @@ def _format_value(value):
     elif isinstance(value, (complex, np.complexfloating)):
         val_str = '({}, {})'.format(_format_float(value.real),
                                     _format_float(value.imag))
-        return '{:>20}'.format(val_str)
+        return f'{val_str:>20}'
 
     elif isinstance(value, Undefined):
         return ''
@@ -1244,7 +1244,7 @@ def _format_value(value):
 def _format_float(value):
     """Format a floating number to make sure it gets the decimal point."""
 
-    value_str = '{:.16G}'.format(value)
+    value_str = f'{value:.16G}'
     if '.' not in value_str and 'E' not in value_str:
         value_str += '.0'
     elif 'E' in value_str:

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -293,7 +293,7 @@ class _ColumnFormat(_BaseColumnFormat):
         else:
             repeat = str(self.repeat)
 
-        return '{}{}{}'.format(repeat, self.format, self.option)
+        return f'{repeat}{self.format}{self.option}'
 
 
 class _AsciiColumnFormat(_BaseColumnFormat):
@@ -355,9 +355,9 @@ class _AsciiColumnFormat(_BaseColumnFormat):
         """
 
         if self.format in ('E', 'F', 'D'):
-            return '{}{}.{}'.format(self.format, self.width, self.precision)
+            return f'{self.format}{self.width}.{self.precision}'
 
-        return '{}{}'.format(self.format, self.width)
+        return f'{self.format}{self.width}'
 
 
 class _FormatX(str):
@@ -375,7 +375,7 @@ class _FormatX(str):
 
     @property
     def tform(self):
-        return '{}X'.format(self.repeat)
+        return f'{self.repeat}X'
 
 
 # TODO: Table column formats need to be verified upon first reading the file;
@@ -407,7 +407,7 @@ class _FormatP(str):
     def from_tform(cls, format):
         m = cls._format_re.match(format)
         if not m or m.group('dtype') not in FITS2NUMPY:
-            raise VerifyError('Invalid column format: {}'.format(format))
+            raise VerifyError(f'Invalid column format: {format}')
         repeat = m.group('repeat')
         array_dtype = m.group('dtype')
         max = m.group('max')
@@ -419,7 +419,7 @@ class _FormatP(str):
     def tform(self):
         repeat = '' if self.repeat is None else self.repeat
         max = '' if self.max is None else self.max
-        return '{}{}{}({})'.format(repeat, self._format_code, self.format, max)
+        return f'{repeat}{self._format_code}{self.format}({max})'
 
 
 class _FormatQ(_FormatP):
@@ -503,7 +503,7 @@ class ColumnAttribute:
         return self
 
     def __repr__(self):
-        return "{0}('{1}')".format(self.__class__.__name__, self._keyword)
+        return f"{self.__class__.__name__}('{self._keyword}')"
 
 
 class Column(NotifierMixin):
@@ -826,7 +826,7 @@ class Column(NotifierMixin):
                 'It is strongly recommended that column names contain only '
                 'upper and lower-case ASCII letters, digits, or underscores '
                 'for maximum compatibility with other software '
-                '(got {0!r}).'.format(name), VerifyWarning)
+                '(got {!r}).'.format(name), VerifyWarning)
 
         # This ensures that the new name can fit into a single FITS card
         # without any special extension like CONTINUE cards or the like.
@@ -938,7 +938,7 @@ class Column(NotifierMixin):
             format = cls(format)
             recformat = format.recformat
         except VerifyError:
-            raise VerifyError('Illegal format `{}`.'.format(format))
+            raise VerifyError(f'Illegal format `{format}`.')
 
         return format, recformat
 
@@ -1774,7 +1774,7 @@ class ColDefs(NotifierMixin):
         """
 
         if new_name != col_name and new_name in self.names:
-            raise ValueError('New name {} already exists.'.format(new_name))
+            raise ValueError(f'New name {new_name} already exists.')
         else:
             self.change_attrib(col_name, 'name', new_name)
 
@@ -1836,7 +1836,7 @@ class ColDefs(NotifierMixin):
                     output.write("'{}' is not an attribute of the column "
                                  "definitions.\n".format(attr))
                     continue
-                output.write("{}:\n".format(attr))
+                output.write(f"{attr}:\n")
                 output.write('    {}\n'.format(getattr(self, attr + 's')))
             else:
                 ret[attr] = getattr(self, attr + 's')
@@ -1945,7 +1945,7 @@ class _VLF(np.ndarray):
                 input = [chararray.array(x, itemsize=1) for x in input]
             except Exception:
                 raise ValueError(
-                    'Inconsistent input data array: {0}'.format(input))
+                    f'Inconsistent input data array: {input}')
 
         a = np.array(input, dtype=object)
         self = np.ndarray.__new__(cls, shape=(len(input),), buffer=a,
@@ -2015,11 +2015,11 @@ def _get_index(names, key):
             if count == 1:
                 indx = names.index(_key)
             elif count == 0:
-                raise KeyError("Key '{}' does not exist.".format(key))
+                raise KeyError(f"Key '{key}' does not exist.")
             else:              # multiple match
-                raise KeyError("Ambiguous key name '{}'.".format(key))
+                raise KeyError(f"Ambiguous key name '{key}'.")
     else:
-        raise KeyError("Illegal key '{!r}'.".format(key))
+        raise KeyError(f"Illegal key '{key!r}'.")
 
     return indx
 
@@ -2153,7 +2153,7 @@ def _parse_tformat(tform):
         # TODO: Maybe catch this error use a default type (bytes, maybe?) for
         # unrecognized column types.  As long as we can determine the correct
         # byte width somehow..
-        raise VerifyError('Format {!r} is not recognized.'.format(tform))
+        raise VerifyError(f'Format {tform!r} is not recognized.')
 
     if repeat == '':
         repeat = 1
@@ -2172,7 +2172,7 @@ def _parse_ascii_tformat(tform, strict=False):
 
     match = TFORMAT_ASCII_RE.match(tform.strip())
     if not match:
-        raise VerifyError('Format {!r} is not recognized.'.format(tform))
+        raise VerifyError(f'Format {tform!r} is not recognized.')
 
     # Be flexible on case
     format = match.group('format')
@@ -2317,7 +2317,7 @@ def _convert_fits2record(format):
     elif dtype == 'F':
         output_format = 'f8'
     else:
-        raise ValueError('Illegal format `{}`.'.format(format))
+        raise ValueError(f'Illegal format `{format}`.')
 
     return output_format
 
@@ -2361,7 +2361,7 @@ def _convert_record2fits(format):
             repeat = ''
         output_format = repeat + NUMPY2FITS[recformat]
     else:
-        raise ValueError('Illegal format `{}`.'.format(format))
+        raise ValueError(f'Illegal format `{format}`.')
 
     return output_format
 
@@ -2486,11 +2486,11 @@ def _parse_tdisp_format(tdisp):
     try:
         tdisp_re = TDISP_RE_DICT[fmt_key]
     except KeyError:
-        raise VerifyError('Format {} is not recognized.'.format(tdisp))
+        raise VerifyError(f'Format {tdisp} is not recognized.')
 
     match = tdisp_re.match(tdisp.strip())
     if not match or match.group('formatc') is None:
-        raise VerifyError('Format {} is not recognized.'.format(tdisp))
+        raise VerifyError(f'Format {tdisp} is not recognized.')
 
     formatc = match.group('formatc')
     width = match.group('width')
@@ -2535,7 +2535,7 @@ def _fortran_to_python_format(tdisp):
         return fmt.format(width=width, precision=precision)
 
     except KeyError:
-        raise VerifyError('Format {} is not recognized.'.format(format_type))
+        raise VerifyError(f'Format {format_type} is not recognized.')
 
 
 def python_to_tdisp(format_string, logical_dtype = False):

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -167,7 +167,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
             if hdu is None:
                 warnings.warn("hdu= was not specified but multiple tables"
                               " are present, reading in first available"
-                              " table (hdu={0})".format(first(tables)),
+                              " table (hdu={})".format(first(tables)),
                               AstropyUserWarning)
                 hdu = first(tables)
 
@@ -178,7 +178,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
             if hdu in tables:
                 table = tables[hdu]
             else:
-                raise ValueError("No table found in hdu={0}".format(hdu))
+                raise ValueError(f"No table found in hdu={hdu}")
 
         elif len(tables) == 1:
             table = tables[first(tables)]
@@ -391,7 +391,7 @@ def write_table_fits(input, output, overwrite=False):
         if overwrite:
             os.remove(output)
         else:
-            raise OSError("File exists: {0}".format(output))
+            raise OSError(f"File exists: {output}")
 
     table_hdu.writeto(output)
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -460,7 +460,7 @@ def table_to_hdu(table, character_as_bytes=False):
         unsupported_cols = table.columns.not_isinstance((BaseColumn, Quantity, Time))
         if unsupported_cols:
             unsupported_names = [col.info.name for col in unsupported_cols]
-            raise ValueError('cannot write table with mixin column(s) {0}'
+            raise ValueError('cannot write table with mixin column(s) {}'
                          .format(unsupported_names))
 
         time_cols = table.columns.isinstance(Time)
@@ -519,13 +519,13 @@ def table_to_hdu(table, character_as_bytes=False):
             except UnitScaleError:
                 scale = unit.scale
                 raise UnitScaleError(
-                    "The column '{0}' could not be stored in FITS format "
-                    "because it has a scale '({1})' that "
+                    "The column '{}' could not be stored in FITS format "
+                    "because it has a scale '({})' that "
                     "is not recognized by the FITS standard. Either scale "
                     "the data or change the units.".format(col.name, str(scale)))
             except ValueError:
                 warnings.warn(
-                    "The unit '{0}' could not be saved to FITS format".format(
+                    "The unit '{}' could not be saved to FITS format".format(
                         unit.to_string()), AstropyUserWarning)
             else:
                 # Try creating a Unit to issue a warning if the unit is not
@@ -547,7 +547,7 @@ def table_to_hdu(table, character_as_bytes=False):
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:
             warnings.warn(
-                "Meta-data keyword {0} will be ignored since it conflicts "
+                "Meta-data keyword {} will be ignored since it conflicts "
                 "with a FITS reserved keyword".format(key), AstropyUserWarning)
 
         # Convert to FITS format
@@ -560,7 +560,7 @@ def table_to_hdu(table, character_as_bytes=False):
                     table_hdu.header.append((key, item))
                 except ValueError:
                     warnings.warn(
-                        "Attribute `{0}` of type {1} cannot be added to "
+                        "Attribute `{}` of type {} cannot be added to "
                         "FITS Header - skipping".format(key, type(value)),
                         AstropyUserWarning)
         else:
@@ -568,7 +568,7 @@ def table_to_hdu(table, character_as_bytes=False):
                 table_hdu.header[key] = value
             except ValueError:
                 warnings.warn(
-                    "Attribute `{0}` of type {1} cannot be added to FITS "
+                    "Attribute `{}` of type {} cannot be added to FITS "
                     "Header - skipping".format(key, type(value)),
                     AstropyUserWarning)
     return table_hdu

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -157,7 +157,7 @@ class _BaseDiff:
 
         if isinstance(fileobj, str):
             if os.path.exists(fileobj) and not overwrite:
-                raise OSError("File {0} exists, aborting (pass in "
+                raise OSError("File {} exists, aborting (pass in "
                               "overwrite=True to overwrite)".format(fileobj))
             else:
                 filepath = fileobj
@@ -373,8 +373,8 @@ class FITSDiff(_BaseDiff):
                                        subsequent_indent='  ')
 
         self._fileobj.write('\n')
-        self._writeln(' fitsdiff: {}'.format(__version__))
-        self._writeln(' a: {}\n b: {}'.format(self.filenamea, self.filenameb))
+        self._writeln(f' fitsdiff: {__version__}')
+        self._writeln(f' a: {self.filenamea}\n b: {self.filenameb}')
 
         if self.ignore_hdus:
             ignore_hdus = ' '.join(sorted(self.ignore_hdus))
@@ -427,7 +427,7 @@ class FITSDiff(_BaseDiff):
                 self._writeln('Primary HDU:')
             else:
                 self._fileobj.write('\n')
-                self._writeln('Extension HDU {}:'.format(idx))
+                self._writeln(f'Extension HDU {idx}:')
             hdu_diff.report(self._fileobj, indent=self._indent + 1)
 
 
@@ -1066,8 +1066,8 @@ class ImageDataDiff(_BaseDiff):
             dimsb = ' x '.join(str(d) for d in
                                reversed(self.diff_dimensions[1]))
             self._writeln(' Data dimensions differ:')
-            self._writeln('  a: {}'.format(dimsa))
-            self._writeln('  b: {}'.format(dimsb))
+            self._writeln(f'  a: {dimsa}')
+            self._writeln(f'  b: {dimsb}')
             # For now we don't do any further comparison if the dimensions
             # differ; though in the future it might be nice to be able to
             # compare at least where the images intersect
@@ -1079,7 +1079,7 @@ class ImageDataDiff(_BaseDiff):
 
         for index, values in self.diff_pixels:
             index = [x + 1 for x in reversed(index)]
-            self._writeln(' Data differs at {}:'.format(index))
+            self._writeln(f' Data differs at {index}:')
             report_diff_values(values[0], values[1], fileobj=self._fileobj,
                                indent_width=self._indent + 1)
 
@@ -1158,7 +1158,7 @@ class RawDataDiff(ImageDataDiff):
             return
 
         for index, values in self.diff_bytes:
-            self._writeln(' Data differs at byte {}:'.format(index))
+            self._writeln(f' Data differs at byte {index}:')
             report_diff_values(values[0], values[1], fileobj=self._fileobj,
                                indent_width=self._indent + 1)
 
@@ -1480,7 +1480,7 @@ class TableDataDiff(_BaseDiff):
 
         if self.diff_values and self.numdiffs < self.diff_total:
             self._writeln(' ...{} additional difference(s) found.'.format(
-                                (self.diff_total - self.numdiffs)))
+                                self.diff_total - self.numdiffs))
 
         if self.diff_total > self.numdiffs:
             self._writeln(' ...')

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -84,7 +84,7 @@ def _normalize_fits_mode(mode):
                 "files must be opened in binary mode".format(mode))
         new_mode = FILE_MODES.get(mode)
         if new_mode not in IO_FITS_MODES:
-            raise ValueError("Mode '{}' not recognized".format(mode))
+            raise ValueError(f"Mode '{mode}' not recognized")
         mode = new_mode
     return mode
 
@@ -132,7 +132,7 @@ class _File:
         self._mmap = None
 
         if mode is not None and mode not in IO_FITS_MODES:
-            raise ValueError("Mode '{}' not recognized".format(mode))
+            raise ValueError(f"Mode '{mode}' not recognized")
         if isfile(fileobj):
             objmode = _normalize_fits_mode(fileobj_mode(fileobj))
             if mode is not None and mode != objmode:
@@ -151,7 +151,7 @@ class _File:
         elif isinstance(fileobj, http.client.HTTPResponse):
             if mode in ('ostream', 'append', 'update'):
                 raise ValueError(
-                    "Mode {} not supported for HTTPResponse".format(mode))
+                    f"Mode {mode} not supported for HTTPResponse")
             fileobj = io.BytesIO(fileobj.read())
         else:
             self.name = fileobj_name(fileobj)
@@ -265,7 +265,7 @@ class _File:
             dtype = np.dtype(dtype)
 
         if size and size % dtype.itemsize != 0:
-            raise ValueError('size {} not a multiple of {}'.format(size, dtype))
+            raise ValueError(f'size {size} not a multiple of {dtype}')
 
         if isinstance(shape, int):
             shape = (shape,)
@@ -437,7 +437,7 @@ class _File:
                         fileobj.close()
                     os.remove(self.name)
             else:
-                raise OSError("File {!r} already exists.".format(self.name))
+                raise OSError(f"File {self.name!r} already exists.")
 
     def _try_read_compressed(self, obj_or_name, magic, mode, ext=''):
         """Attempt to determine if the given file is compressed"""

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -65,7 +65,7 @@ class FITS_record:
             indx = _get_index(self.array.names, key)
 
             if indx < self.start or indx > self.end - 1:
-                raise KeyError("Key '{}' does not exist.".format(key))
+                raise KeyError(f"Key '{key}' does not exist.")
         elif isinstance(key, slice):
             return type(self)(self.array, self.row, key.start, key.stop,
                               key.step, self)
@@ -82,7 +82,7 @@ class FITS_record:
             indx = _get_index(self.array.names, key)
 
             if indx < self.start or indx > self.end - 1:
-                raise KeyError("Key '{}' does not exist.".format(key))
+                raise KeyError(f"Key '{key}' does not exist.")
         elif isinstance(key, slice):
             for indx in range(slice.start, slice.stop, slice.step):
                 indx = self._get_indx(indx)
@@ -755,7 +755,7 @@ class FITS_rec(np.recarray):
         for each attribute ``_update_column_<attr>``
         """
 
-        method_name = '_update_column_{0}'.format(attr)
+        method_name = f'_update_column_{attr}'
         if hasattr(self, method_name):
             # Right now this is so we can be lazy and not implement updaters
             # for every attribute yet--some we may not need at all, TBD
@@ -960,7 +960,7 @@ class FITS_rec(np.recarray):
                         test_overflow += bzero64
                     except OverflowError:
                         warnings.warn(
-                            "Overflow detected while applying TZERO{0:d}. "
+                            "Overflow detected while applying TZERO{:d}. "
                             "Returning unscaled data.".format(indx + 1))
                     else:
                         field = test_overflow
@@ -1182,9 +1182,9 @@ class FITS_rec(np.recarray):
                 _ascii_encode(input_field, out=output_field)
             except _UnicodeArrayEncodeError as exc:
                 raise ValueError(
-                    "Could not save column '{0}': Contains characters that "
+                    "Could not save column '{}': Contains characters that "
                     "cannot be encoded as ASCII as required by FITS, starting "
-                    "at the index {1!r} of the column, and the index {2} of "
+                    "at the index {!r} of the column, and the index {} of "
                     "the string at that location.".format(
                         self._coldefs[col_idx].name,
                         exc.index[0] if len(exc.index) == 1 else exc.index,
@@ -1309,7 +1309,7 @@ def _ascii_encode(inarray, out=None):
     the item that couldn't be encoded.
     """
 
-    out_dtype = np.dtype(('S{0}'.format(inarray.dtype.itemsize // 4),
+    out_dtype = np.dtype(('S{}'.format(inarray.dtype.itemsize // 4),
                          inarray.dtype.shape))
     if out is not None:
         out = out.view(out_dtype)

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -44,7 +44,7 @@ COLUMN_TIME_KEYWORDS = ('TCTYP', 'TCUNI', 'TRPOS')
 
 
 # Column-specific keywords regex
-COLUMN_TIME_KEYWORD_REGEXP = '({0})[0-9]+'.format(
+COLUMN_TIME_KEYWORD_REGEXP = '({})[0-9]+'.format(
     '|'.join(COLUMN_TIME_KEYWORDS))
 
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -87,7 +87,7 @@ def _hdu_class_from_header(cls, header):
             except Exception as exc:
                 warnings.warn(
                     'An exception occurred matching an HDU header to the '
-                    'appropriate HDU type: {0}'.format(exc),
+                    'appropriate HDU type: {}'.format(exc),
                     AstropyUserWarning)
                 warnings.warn('The HDU will be treated as corrupted.',
                               AstropyUserWarning)
@@ -1147,8 +1147,8 @@ class _ValidHDU(_BaseHDU, _Verify):
 
         # if the card does not exist
         if index is None:
-            err_text = "'{}' card does not exist.".format(keyword)
-            fix_text = "Fixed by inserting a new '{}' card.".format(keyword)
+            err_text = f"'{keyword}' card does not exist."
+            fix_text = f"Fixed by inserting a new '{keyword}' card."
             if fixable:
                 # use repr to accommodate both string and non-string types
                 # Boolean is also OK in this constructor
@@ -1346,7 +1346,7 @@ class _ValidHDU(_BaseHDU, _Verify):
             self._checksum_valid = self.verify_checksum()
             if not self._checksum_valid:
                 warnings.warn(
-                    'Checksum verification failed for HDU {0}.\n'.format(
+                    'Checksum verification failed for HDU {}.\n'.format(
                         (self.name, self.ver)), AstropyUserWarning)
 
         if 'DATASUM' in self._header:
@@ -1354,7 +1354,7 @@ class _ValidHDU(_BaseHDU, _Verify):
             self._datasum_valid = self.verify_datasum()
             if not self._datasum_valid:
                 warnings.warn(
-                    'Datasum verification failed for HDU {0}.\n'.format(
+                    'Datasum verification failed for HDU {}.\n'.format(
                         (self.name, self.ver)), AstropyUserWarning)
 
     def _get_timestamp(self):

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -160,7 +160,7 @@ class CompImageHeader(Header):
             keyword, index = key, None
 
         if key not in self:
-            raise KeyError("Keyword {!r} not found.".format(key))
+            raise KeyError(f"Keyword {key!r} not found.")
 
         super().__delitem__(key)
 
@@ -344,7 +344,7 @@ class CompImageHeader(Header):
                 is_naxisn = index > 0
 
         if is_naxisn:
-            return 'ZNAXIS{}'.format(index)
+            return f'ZNAXIS{index}'
 
         # If the keyword does not need to be remapped then just return the
         # original keyword
@@ -1633,7 +1633,7 @@ class CompImageHDU(BinTableHDU):
             # Convert the unsigned array to signed
             self.data = np.array(
                 self.data - _unsigned_zero(self.data.dtype),
-                dtype='=i{}'.format(self.data.dtype.itemsize))
+                dtype=f'=i{self.data.dtype.itemsize}')
             should_swap = False
         else:
             should_swap = not self.data.dtype.isnative

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -471,7 +471,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                 # Convert the unsigned array to signed
                 output = np.array(
                     self.data - _unsigned_zero(self.data.dtype),
-                    dtype='>i{}'.format(self.data.dtype.itemsize))
+                    dtype=f'>i{self.data.dtype.itemsize}')
                 should_swap = False
             else:
                 output = self.data
@@ -579,7 +579,7 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                 format = self.columns[0].dtype.name
 
         # Update the GCOUNT report
-        gcount = '{} Groups  {} Parameters'.format(self._gcount, self._pcount)
+        gcount = f'{self._gcount} Groups  {self._pcount} Parameters'
         return (name, ver, classname, length, shape, format, gcount)
 
 

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -145,7 +145,7 @@ def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
         kwargs['uint'] = conf.enable_uint
 
     if not name:
-        raise ValueError('Empty filename: {!r}'.format(name))
+        raise ValueError(f'Empty filename: {name!r}')
 
     return HDUList.fromfile(name, mode, memmap, save_backup, cache,
                             lazy_load_hdus, **kwargs)
@@ -333,10 +333,10 @@ class HDUList(list, _Verify):
                 raise ValueError('An element in the HDUList must be an HDU.')
             for item in hdu:
                 if not isinstance(item, _BaseHDU):
-                    raise ValueError('{} is not an HDU.'.format(item))
+                    raise ValueError(f'{item} is not an HDU.')
         else:
             if not isinstance(hdu, _BaseHDU):
-                raise ValueError('{} is not an HDU.'.format(hdu))
+                raise ValueError(f'{hdu} is not an HDU.')
 
         try:
             self._try_while_unread_hdus(super().__setitem__, _key, hdu)
@@ -565,7 +565,7 @@ class HDUList(list, _Verify):
         """
 
         if not isinstance(hdu, _BaseHDU):
-            raise ValueError('{} is not an HDU.'.format(hdu))
+            raise ValueError(f'{hdu} is not an HDU.')
 
         num_hdus = len(self)
 
@@ -732,7 +732,7 @@ class HDUList(list, _Verify):
                 break
 
         if (found is None):
-            raise KeyError('Extension {!r} not found.'.format(key))
+            raise KeyError(f'Extension {key!r} not found.')
         else:
             return found
 
@@ -758,7 +758,7 @@ class HDUList(list, _Verify):
 
         if abs(index) > len(self):
             raise IndexError(
-                'Extension {} is out of bound or not found.'.format(index))
+                f'Extension {index} is out of bound or not found.')
 
         return len(self) + index
 
@@ -985,7 +985,7 @@ class HDUList(list, _Verify):
         else:
             name = self._file.name
 
-        results = ['Filename: {}'.format(name),
+        results = [f'Filename: {name}',
                    'No.    Name      Ver    Type      Cards   Dimensions   Format']
 
         format = '{:3d}  {:10}  {:3} {:11}  {:5d}   {}   {}   {}'

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -570,7 +570,7 @@ class _ImageBaseHDU(_ValidHDU):
         # should be handled by the schema
         if not _is_int(self._blank):
             messages.append(
-                "Invalid value for 'BLANK' keyword in header: {0!r} "
+                "Invalid value for 'BLANK' keyword in header: {!r} "
                 "The 'BLANK' keyword must be an integer.  It will be "
                 "ignored in the meantime.".format(self._blank))
             self._blank = None
@@ -612,7 +612,7 @@ class _ImageBaseHDU(_ValidHDU):
                 # Convert the unsigned array to signed
                 output = np.array(
                     self.data - _unsigned_zero(self.data.dtype),
-                    dtype='>i{}'.format(self.data.dtype.itemsize))
+                    dtype=f'>i{self.data.dtype.itemsize}')
                 should_swap = False
             else:
                 output = self.data
@@ -783,7 +783,7 @@ class _ImageBaseHDU(_ValidHDU):
                     (self._orig_bscale != 1 or self._orig_bzero != 0)):
                 new_dtype = self._dtype_for_bitpix()
                 if new_dtype is not None:
-                    format += ' (rescales to {0})'.format(new_dtype.name)
+                    format += f' (rescales to {new_dtype.name})'
 
         # Display shape in FITS-order
         shape = tuple(reversed(self.shape))
@@ -804,7 +804,7 @@ class _ImageBaseHDU(_ValidHDU):
             # 16, 32 or 64
             if _is_pseudo_unsigned(self.data.dtype):
                 d = np.array(self.data - _unsigned_zero(self.data.dtype),
-                             dtype='i{}'.format(self.data.dtype.itemsize))
+                             dtype=f'i{self.data.dtype.itemsize}')
 
             # Check the byte order of the data.  If it is little endian we
             # must swap it before calculating the datasum.
@@ -1120,7 +1120,7 @@ class _IndexInfo:
                 self.offset = indx
                 self.contiguous = True
             else:
-                raise IndexError('Index {} out of range.'.format(indx))
+                raise IndexError(f'Index {indx} out of range.')
         elif isinstance(indx, slice):
             start, stop, step = indx.indices(naxis)
             self.npts = (stop - start) // step
@@ -1131,4 +1131,4 @@ class _IndexInfo:
             self.offset = 0
             self.contiguous = False
         else:
-            raise IndexError('Illegal index {}'.format(indx))
+            raise IndexError(f'Illegal index {indx}')

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -336,7 +336,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                         keys = ', '.join(x + 'n' for x in sorted(future_ignore))
                         warnings.warn("The following keywords are now recognized as special "
                                       "column-related attributes and should be set via the "
-                                      "Column objects: {0}. In future, these values will be "
+                                      "Column objects: {}. In future, these values will be "
                                       "dropped from manually specified headers automatically "
                                       "and replaced with values generated based on the "
                                       "Column objects.".format(keys), AstropyDeprecationWarning)
@@ -573,8 +573,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
             ncols = self._header['TFIELDS']
             format = ', '.join([self._header['TFORM' + str(j + 1)]
                                 for j in range(ncols)])
-            format = '[{}]'.format(format)
-        dims = "{}R x {}C".format(nrows, ncols)
+            format = f'[{format}]'
+        dims = f"{nrows}R x {ncols}C"
         ncards = len(self._header)
 
         return (self.name, self.ver, class_name, ncards, dims, format)
@@ -748,7 +748,7 @@ class TableHDU(_TableBaseHDU):
         dup = np.rec.find_duplicate(names)
 
         if dup:
-            raise ValueError("Duplicate field names: {}".format(dup))
+            raise ValueError(f"Duplicate field names: {dup}")
 
         # TODO: Determine if this extra logic is necessary--I feel like the
         # _AsciiColDefs class should be responsible for telling the table what
@@ -1089,7 +1089,7 @@ class BinTableHDU(_TableBaseHDU):
                         exist.append(f)
 
         if exist:
-            raise OSError('  '.join(["File '{}' already exists.".format(f)
+            raise OSError('  '.join([f"File '{f}' already exists."
                                      for f in exist]))
 
         # Process the data
@@ -1216,12 +1216,12 @@ class BinTableHDU(_TableBaseHDU):
                 return '{:{size}}'.format(val, size=itemsize)
             elif format in np.typecodes['AllInteger']:
                 # output integer
-                return '{:21d}'.format(val)
+                return f'{val:21d}'
             elif format in np.typecodes['Complex']:
-                return '{:21.15g}+{:.15g}j'.format(val.real, val.imag)
+                return f'{val.real:21.15g}+{val.imag:.15g}j'
             elif format in np.typecodes['Float']:
                 # output floating point
-                return '{:#21.15g}'.format(val)
+                return f'{val:#21.15g}'
 
         for row in self.data:
             line = []   # the line for this row of the table

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -227,7 +227,7 @@ class Header:
                 # if keyword is not present raise KeyError.
                 # To delete keyword without caring if they were present,
                 # Header.remove(Keyword) can be used with optional argument ignore_missing as True
-                raise KeyError("Keyword '{}' not found.".format(key))
+                raise KeyError(f"Keyword '{key}' not found.")
 
             for idx in reversed(indices[key]):
                 # Have to copy the indices list since it will be modified below
@@ -626,7 +626,7 @@ class Header:
                     trailing = repr(trailing).lstrip('ub')
                     # TODO: Pass this warning up to the validation framework
                     warnings.warn(
-                        'Unexpected bytes trailing END keyword: {0}; these '
+                        'Unexpected bytes trailing END keyword: {}; these '
                         'bytes will be replaced with spaces on write.'.format(
                             trailing), AstropyUserWarning)
                 else:
@@ -634,7 +634,7 @@ class Header:
                     warnings.warn(
                         'Missing padding to end of the FITS block after the '
                         'END keyword; additional spaces will be appended to '
-                        'the file upon writing to pad out to {0} '
+                        'the file upon writing to pad out to {} '
                         'bytes.'.format(BLOCK_SIZE), AstropyUserWarning)
 
                 # Sanitize out invalid END card now that the appropriate
@@ -824,7 +824,7 @@ class Header:
             A new :class:`Header` instance.
         """
 
-        tmp = Header((copy.copy(card) for card in self._cards))
+        tmp = Header(copy.copy(card) for card in self._cards)
         if strip:
             tmp._strip()
         return tmp
@@ -1365,7 +1365,7 @@ class Header:
         # We have to look before we leap, since otherwise _keyword_indices,
         # being a defaultdict, will create an entry for the nonexistent keyword
         if keyword not in self._keyword_indices:
-            raise KeyError("Keyword {!r} not found.".format(keyword))
+            raise KeyError(f"Keyword {keyword!r} not found.")
 
         return len(self._keyword_indices[keyword])
 
@@ -1528,7 +1528,7 @@ class Header:
                 while keyword in self._keyword_indices:
                     del self[self._keyword_indices[keyword][0]]
         elif not ignore_missing:
-            raise KeyError("Keyword '{}' not found.".format(keyword))
+            raise KeyError(f"Keyword '{keyword}' not found.")
 
     def rename_keyword(self, oldkeyword, newkeyword, force=False):
         """
@@ -1703,13 +1703,13 @@ class Header:
 
         if keyword and not indices:
             if len(keyword) > KEYWORD_LENGTH or '.' in keyword:
-                raise KeyError("Keyword {!r} not found.".format(keyword))
+                raise KeyError(f"Keyword {keyword!r} not found.")
             else:
                 # Maybe it's a RVKC?
                 indices = self._rvkc_indices.get(keyword, None)
 
         if not indices:
-            raise KeyError("Keyword {!r} not found.".format(keyword))
+            raise KeyError(f"Keyword {keyword!r} not found.")
 
         try:
             return indices[n]
@@ -2242,7 +2242,7 @@ class _HeaderCommentaryCards(_CardAccessor):
             n._indices = idx.indices(self._count)
             return n
         elif not isinstance(idx, int):
-            raise ValueError('{} index must be an integer'.format(self._keyword))
+            raise ValueError(f'{self._keyword} index must be an integer')
 
         idx = list(range(*self._indices))[idx]
         return self._header[(self._keyword, idx)]
@@ -2302,5 +2302,5 @@ def _check_padding(header_str, block_size, is_eof, check_block_size=True):
         # now, but maybe it shouldn't?
         actual_len = len(header_str) - block_size + BLOCK_SIZE
         # TODO: Pass this error to validation framework
-        raise ValueError('Header size is not multiple of {0}: {1}'
+        raise ValueError('Header size is not multiple of {}: {}'
                          .format(BLOCK_SIZE, actual_len))

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -145,7 +145,7 @@ def verify_checksums(filename):
             log.warning('BAD %r %s', filename, str(w.message))
             return 1
 
-    log.info('OK {!r}'.format(filename))
+    log.info(f'OK {filename!r}')
     return 0
 
 
@@ -191,7 +191,7 @@ def process_file(filename):
             update(filename)
         return checksum_errors + compliance_errors
     except Exception as e:
-        log.error('EXCEPTION {!r} .. {}'.format(filename, e))
+        log.error(f'EXCEPTION {filename!r} .. {e}')
         return 1
 
 
@@ -207,5 +207,5 @@ def main(args=None):
     for filename in fits_files:
         errors += process_file(filename)
     if errors:
-        log.warning('{} errors'.format(errors))
+        log.warning(f'{errors} errors')
     return int(bool(errors))

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -74,7 +74,7 @@ def handle_options(argv=None):
         if value and value[0] == '@':
             value = value[1:]
             if not os.path.exists(value):
-                log.warning('{} argument {} does not exist'.format(opt, value))
+                log.warning(f'{opt} argument {value} does not exist')
                 return
             try:
                 values = [v.strip() for v in open(value, 'r').readlines()]

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -157,9 +157,9 @@ class HeaderFormatter:
 
             if idx > 0:  # Separate HDUs by a blank line
                 result.append('\n')
-            result.append('# HDU {} in {}:\n'.format(hdu, self.filename))
+            result.append(f'# HDU {hdu} in {self.filename}:\n')
             for c in cards:
-                result.append('{}\n'.format(c))
+                result.append(f'{c}\n')
         return ''.join(result)
 
     def _get_cards(self, hdukey, keywords, compressed):
@@ -194,7 +194,7 @@ class HeaderFormatter:
             else:
                 header = self._hdulist[hdukey].header
         except (IndexError, KeyError):
-            message = '{0}: Extension {1} not found.'.format(self.filename,
+            message = '{}: Extension {} not found.'.format(self.filename,
                                                              hdukey)
             if self.verbose:
                 log.warning(message)

--- a/astropy/io/fits/tests/test_compression_failures.py
+++ b/astropy/io/fits/tests/test_compression_failures.py
@@ -102,7 +102,7 @@ class TestCompressionFunction(FitsTestCase):
         hdu._header[kw] = -1
         with pytest.raises(ValueError) as exc:
             compress_hdu(hdu)
-        assert '{} should not be negative.'.format(kw) in str(exc.value)
+        assert f'{kw} should not be negative.' in str(exc.value)
 
     @pytest.mark.parametrize(
         ('kw', 'limit'),

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -388,14 +388,14 @@ def test_unicode_column(tmpdir):
     https://github.com/astropy/astropy/pull/4228
     """
 
-    t = Table([np.array([u'a', u'b', u'cd'])])
+    t = Table([np.array(['a', 'b', 'cd'])])
     t.write(str(tmpdir.join('test.fits')), overwrite=True)
 
     with fits.open(str(tmpdir.join('test.fits'))) as hdul:
         assert np.all(hdul[1].data['col0'] == ['a', 'b', 'cd'])
         assert hdul[1].header['TFORM1'] == '2A'
 
-    t2 = Table([np.array([u'\N{SNOWMAN}'])])
+    t2 = Table([np.array(['\N{SNOWMAN}'])])
 
     with pytest.raises(UnicodeEncodeError):
         t2.write(str(tmpdir.join('test.fits')), overwrite=True)

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -137,7 +137,7 @@ class TestCore(FitsTestCase):
 
         header = fits.Header()
         comment = 'number of bits per data pixel'
-        card = fits.Card.fromstring('BITPIX  = 32 / {}'.format(comment))
+        card = fits.Card.fromstring(f'BITPIX  = 32 / {comment}')
         header.append(card)
 
         header['BITPIX'] = 32
@@ -531,7 +531,7 @@ class TestCore(FitsTestCase):
             # Add a bunch of header keywords so that the data will be forced to
             # new offsets within the file:
             for idx in range(40):
-                hdul1[1].header['TEST{}'.format(idx)] = 'test'
+                hdul1[1].header[f'TEST{idx}'] = 'test'
 
             hdul1.writeto(self.temp('test1.fits'))
             hdul1.writeto(self.temp('test2.fits'))

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -609,7 +609,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(data=data)
         idx = 1
         while len(hdu.header) < 34:
-            hdu.header['TEST{}'.format(idx)] = idx
+            hdu.header[f'TEST{idx}'] = idx
             idx += 1
         hdu.writeto(self.temp('temp.fits'), checksum=True)
 
@@ -633,7 +633,7 @@ class TestHDUListFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(data=data)
         idx = 1
         while len(str(hdu.header)) <= 2880:
-            hdu.header['TEST{}'.format(idx)] = idx
+            hdu.header[f'TEST{idx}'] = idx
             idx += 1
         orig_header = hdu.header.copy()
         hdu.writeto(self.temp('temp.fits'))
@@ -649,7 +649,7 @@ class TestHDUListFunctions(FitsTestCase):
         with fits.open(self.temp('temp.fits'), mode='update') as hdul:
             idx = 101
             while len(str(hdul[0].header)) <= 2880 * 2:
-                hdul[0].header['TEST{}'.format(idx)] = idx
+                hdul[0].header[f'TEST{idx}'] = idx
                 idx += 1
             # Touch something in the data too so that it has to be rewritten
             hdul[0].data[0] = 27
@@ -681,7 +681,7 @@ class TestHDUListFunctions(FitsTestCase):
         with fits.open(self.temp('temp.fits'), mode='update') as hdul:
             idx = 1
             while len(str(hdul[0].header)) <= 2880 * 2:
-                hdul[0].header['TEST{}'.format(idx)] = idx
+                hdul[0].header[f'TEST{idx}'] = idx
                 idx += 1
             hdul.flush()
             hdul.append(hdu)
@@ -952,7 +952,7 @@ class TestHDUListFunctions(FitsTestCase):
         import codecs
         filename = self.temp('not-fits-with-unicode.fits')
         with codecs.open(filename, mode='w', encoding='utf=8') as f:
-            f.write(u'Ce\xe7i ne marche pas')
+            f.write('Ce\xe7i ne marche pas')
 
         # This should raise an OSError because there is no end card.
         with pytest.raises(OSError):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1740,8 +1740,8 @@ class TestHeaderFunctions(FitsTestCase):
 
         with open(self.temp('test.fits'), 'rb') as f:
             out = f.read()
-        out = out.replace(b'hello', u'héllo'.encode('latin1'))
-        out = out.replace(b'BAR', u'BÀR'.encode('latin1'))
+        out = out.replace(b'hello', 'héllo'.encode('latin1'))
+        out = out.replace(b'BAR', 'BÀR'.encode('latin1'))
         with open(self.temp('test2.fits'), 'wb') as f2:
             f2.write(out)
 

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -747,24 +747,24 @@ class TestImageFunctions(FitsTestCase):
             if int_size == 64:
                 max_uint = np.uint64(int_size)
 
-            dtype = 'uint{}'.format(int_size)
+            dtype = f'uint{int_size}'
             arr = np.empty(100, dtype=dtype)
             arr.fill(max_uint)
             arr -= np.arange(100, dtype=dtype)
 
             uint_hdu = fits.PrimaryHDU(data=arr)
             assert np.all(uint_hdu.data == arr)
-            assert uint_hdu.data.dtype.name == 'uint{}'.format(int_size)
+            assert uint_hdu.data.dtype.name == f'uint{int_size}'
             assert 'BZERO' in uint_hdu.header
             assert uint_hdu.header['BZERO'] == (2 ** (int_size - 1))
 
-            filename = 'uint{}.fits'.format(int_size)
+            filename = f'uint{int_size}.fits'
             uint_hdu.writeto(self.temp(filename))
 
             with fits.open(self.temp(filename), uint=True) as hdul:
                 new_uint_hdu = hdul[0]
                 assert np.all(new_uint_hdu.data == arr)
-                assert new_uint_hdu.data.dtype.name == 'uint{}'.format(int_size)
+                assert new_uint_hdu.data.dtype.name == f'uint{int_size}'
                 assert 'BZERO' in new_uint_hdu.header
                 assert new_uint_hdu.header['BZERO'] == (2 ** (int_size - 1))
 
@@ -1620,7 +1620,7 @@ class TestCompressedImage(FitsTestCase):
                 hdr[keyword] = value
                 assert len(w) == 1
                 assert str(w[0].message).startswith(
-                        "Keyword {!r} is reserved".format(keyword))
+                        f"Keyword {keyword!r} is reserved")
                 assert keyword not in hdr
 
         with fits.open(self.data('comp.fits')) as hdul:

--- a/astropy/io/fits/tests/test_structured.py
+++ b/astropy/io/fits/tests/test_structured.py
@@ -25,10 +25,10 @@ def compare_arrays(arr1in, arr2in, verbose=False):
             if n1 not in arr1.dtype.names:
                 n1 = n1.upper()
                 if n1 not in arr1.dtype.names:
-                    raise ValueError('field name {} not found in array 1'.format(n2))
+                    raise ValueError(f'field name {n2} not found in array 1')
 
         if verbose:
-            sys.stdout.write("    testing field: '{}'\n".format(n2))
+            sys.stdout.write(f"    testing field: '{n2}'\n")
             sys.stdout.write('        shape...........')
         if arr2[n2].shape != arr1[n1].shape:
             nfail += 1
@@ -55,7 +55,7 @@ def compare_arrays(arr1in, arr2in, verbose=False):
         return True
     else:
         if verbose:
-            sys.stdout.write('{} differences found\n'.format(nfail))
+            sys.stdout.write(f'{nfail} differences found\n')
         return False
 
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -80,26 +80,26 @@ def comparerecords(a, b):
             isinstance(fieldb, type(fielda))):
             print("type(fielda): ", type(fielda), " fielda: ", fielda)
             print("type(fieldb): ", type(fieldb), " fieldb: ", fieldb)
-            print('field {0} type differs'.format(i))
+            print(f'field {i} type differs')
             return False
         if len(fielda) and isinstance(fielda[0], np.floating):
             if not comparefloats(fielda, fieldb):
                 print("fielda: ", fielda)
                 print("fieldb: ", fieldb)
-                print('field {0} differs'.format(i))
+                print(f'field {i} differs')
                 return False
         elif (isinstance(fielda, fits.column._VLF) or
               isinstance(fieldb, fits.column._VLF)):
             for row in range(len(fielda)):
                 if np.any(fielda[row] != fieldb[row]):
-                    print('fielda[{0}]: {1}'.format(row, fielda[row]))
-                    print('fieldb[{0}]: {1}'.format(row, fieldb[row]))
-                    print('field {0} differs in row {1}'.format(i, row))
+                    print('fielda[{}]: {}'.format(row, fielda[row]))
+                    print('fieldb[{}]: {}'.format(row, fieldb[row]))
+                    print(f'field {i} differs in row {row}')
         else:
             if np.any(fielda != fieldb):
                 print("fielda: ", fielda)
                 print("fieldb: ", fieldb)
-                print('field {0} differs'.format(i))
+                print(f'field {i} differs')
                 return False
     return True
 
@@ -386,9 +386,9 @@ class TestTableFunctions(FitsTestCase):
     def test_numpy_ndarray_to_bintablehdu_with_unicode(self):
         desc = np.dtype({'names': ['order', 'name', 'mag', 'Sp'],
                          'formats': ['int', 'U20', 'float32', 'U10']})
-        a = np.array([(1, u'Serius', -1.45, u'A1V'),
-                      (2, u'Canopys', -0.73, u'F0Ib'),
-                      (3, u'Rigil Kent', -0.1, u'G2V')], dtype=desc)
+        a = np.array([(1, 'Serius', -1.45, 'A1V'),
+                      (2, 'Canopys', -0.73, 'F0Ib'),
+                      (3, 'Rigil Kent', -0.1, 'G2V')], dtype=desc)
         hdu = fits.BinTableHDU(a)
         assert comparerecords(hdu.data, a.view(fits.FITS_rec))
         hdu.writeto(self.temp('toto.fits'), overwrite=True)
@@ -1564,7 +1564,7 @@ class TestTableFunctions(FitsTestCase):
         Regression test for https://github.com/astropy/astropy/issues/5204
         "Handle unicode FITS BinTable column names on Python 2"
         """
-        col = fits.Column(name=u'spam', format='E', array=[42.])
+        col = fits.Column(name='spam', format='E', array=[42.])
         # This used to raise a TypeError, now it works
         fits.BinTableHDU.from_columns([col])
 
@@ -2195,7 +2195,7 @@ class TestTableFunctions(FitsTestCase):
         """
 
         # Test an integer column with blank string as null
-        nullval1 = u' '
+        nullval1 = ' '
 
         c1 = fits.Column('F1', format='I8', null=nullval1,
                          array=np.array([0, 1, 2, 3, 4]),
@@ -2205,7 +2205,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Replace the 1st col, 3rd row, with a null field.
         with open(self.temp('ascii_null.fits'), mode='r+') as h:
-            nulled = h.read().replace(u'2       ', u'        ')
+            nulled = h.read().replace('2       ', '        ')
             h.seek(0)
             h.write(nulled)
 
@@ -2222,7 +2222,7 @@ class TestTableFunctions(FitsTestCase):
 
         # Replace the 1st col, 3rd row, with a null field.
         with open(self.temp('ascii_null2.fits'), mode='r+') as h:
-            nulled = h.read().replace(u'3.00000000', u'          ')
+            nulled = h.read().replace('3.00000000', '          ')
             h.seek(0)
             h.write(nulled)
 

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -33,7 +33,7 @@ class TestUintFunctions(FitsTestCase):
                 hdu = fits.PrimaryHDU(np.array([-3, -2, -1, 0, 1, 2, 3], dtype=np.int64))
                 hdu_number = 0
 
-            hdu.scale('int{0:d}'.format(bits), '', bzero=2 ** (bits-1))
+            hdu.scale(f'int{bits:d}', '', bzero=2 ** (bits-1))
 
             with ignore_warnings():
                 hdu.writeto(self.temp('tempfile.fits'), overwrite=True)
@@ -54,7 +54,7 @@ class TestUintFunctions(FitsTestCase):
                         # TODO: Enable these lines if CompImageHDUs ever grow
                         # .section support
                         sec = hdul[hdu_number].section[:1]
-                        assert sec.dtype.name == 'uint{}'.format(bits)
+                        assert sec.dtype.name == f'uint{bits}'
                         assert (sec == d1[:1]).all()
 
     @pytest.mark.parametrize('utype', ('u2', 'u4', 'u8'))

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -109,7 +109,7 @@ class TestUtilMode(FitsTestCase):
                             (1, 'r', 'rb'), (1, 'rb', 'rb')]
 
         for num, mode, res in num_mode_resmode:
-            filename = self.temp('test{0}.gz'.format(num))
+            filename = self.temp(f'test{num}.gz')
             with gzip.GzipFile(filename, mode) as fileobj:
                 assert util.fileobj_mode(fileobj) == res
 
@@ -122,7 +122,7 @@ class TestUtilMode(FitsTestCase):
                             (1, 'xb', 'xb'),
                             (1, 'rb', 'rb')]
         for num, mode, res in num_mode_resmode:
-            filename = self.temp('test1{0}.dat'.format(num))
+            filename = self.temp(f'test1{num}.dat')
             with open(filename, mode, buffering=0) as fileobj:
                 assert util.fileobj_mode(fileobj) == res
 
@@ -135,7 +135,7 @@ class TestUtilMode(FitsTestCase):
                             (1, 'x', 'x'),
                             (1, 'r', 'r'), (1, 'rb', 'rb')]
         for num, mode, res in num_mode_resmode:
-            filename = self.temp('test2{0}.dat'.format(num))
+            filename = self.temp(f'test2{num}.dat')
             with open(filename, mode) as fileobj:
                 assert util.fileobj_mode(fileobj) == res
 
@@ -151,7 +151,7 @@ class TestUtilMode(FitsTestCase):
                                (0, 'ab', 'ab'),
                                (0, 'a+b', 'ab+'),
                                (0, 'ab+', 'ab+')]:
-            filename = self.temp('test3{0}.dat'.format(num))
+            filename = self.temp(f'test3{num}.dat')
             with open(filename, mode) as fileobj:
                 assert util.fileobj_mode(fileobj) == res
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -124,7 +124,7 @@ class NotifierMixin:
         if self._listeners is None:
             return
 
-        method_name = '_update_{0}'.format(notification)
+        method_name = f'_update_{notification}'
         for listener in self._listeners.valuerefs():
             # Use valuerefs instead of itervaluerefs; see
             # https://github.com/astropy/astropy/issues/4015
@@ -291,7 +291,7 @@ def decode_ascii(s):
                           'file header and have been replaced by "?" '
                           'characters', AstropyUserWarning)
             s = s.decode('ascii', errors='replace')
-            return s.replace(u'\ufffd', '?')
+            return s.replace('\ufffd', '?')
     elif (isinstance(s, np.ndarray) and
           issubclass(s.dtype.type, np.bytes_)):
         # np.char.encode/decode annoyingly don't preserve the type of the
@@ -885,7 +885,7 @@ def get_testdata_filepath(filename):
         The path to the requested file.
     """
     return data.get_pkg_data_filename(
-        'io/fits/tests/data/{}'.format(filename), 'astropy')
+        f'io/fits/tests/data/{filename}', 'astropy')
 
 
 def _rstrip_inplace(array):
@@ -910,7 +910,7 @@ def _rstrip_inplace(array):
     # View the array as appropriate integers. The last dimension will
     # equal the number of characters in each string.
     bpc = 1 if dt.kind == 'S' else 4
-    dt_int = "({0},){1}u{2}".format(dt.itemsize // bpc, dt.byteorder, bpc)
+    dt_int = "({},){}u{}".format(dt.itemsize // bpc, dt.byteorder, bpc)
     b = array.view(dt_int, np.ndarray)
     # For optimal speed, work in chunks of the internal ufunc buffer size.
     bufsize = np.getbufsize()

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -41,7 +41,7 @@ class _Verify:
             fixable = False
         # fix the value
         elif not fixable:
-            text = 'Unfixable error: {}'.format(text)
+            text = f'Unfixable error: {text}'
         else:
             if fix:
                 fix()
@@ -65,7 +65,7 @@ class _Verify:
 
         opt = option.lower()
         if opt not in VERIFY_OPTIONS:
-            raise ValueError('Option {!r} not recognized.'.format(option))
+            raise ValueError(f'Option {option!r} not recognized.')
 
         if opt == 'ignore':
             return
@@ -161,7 +161,7 @@ class _ErrList(list):
                     if self.unit:
                         # This line is sort of a header for the next level in
                         # the hierarchy
-                        yield None, indent('{} {}:'.format(self.unit, element),
+                        yield None, indent(f'{self.unit} {element}:',
                                            shift=shift)
                     yield first_line
 

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -95,7 +95,7 @@ class TimeType(AstropyAsdfType):
             t = time.Time(node)
             fmt = _astropy_format_to_asdf_format.get(t.format, t.format)
             if fmt not in _guessable_formats:
-                raise ValueError("Invalid time '{0}'".format(node))
+                raise ValueError(f"Invalid time '{node}'")
             return t
 
         value = node['value']

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -48,12 +48,12 @@ class CompoundType(TransformType):
         left = yamlutil.tagged_tree_to_custom_tree(
             node['forward'][0], ctx)
         if not isinstance(left, modeling.Model):
-            raise TypeError("Unknown model type '{0}'".format(
+            raise TypeError("Unknown model type '{}'".format(
                 node['forward'][0]._tag))
         right = yamlutil.tagged_tree_to_custom_tree(
             node['forward'][1], ctx)
         if not isinstance(right, modeling.Model):
-            raise TypeError("Unknown model type '{0}'".format(
+            raise TypeError("Unknown model type '{}'".format(
                 node['forward'][1]._tag))
         model = getattr(left, oper)(right)
 
@@ -81,7 +81,7 @@ class CompoundType(TransformType):
         try:
             tag_name = 'transform/' + _operator_to_tag_mapping[tree.value]
         except KeyError:
-            raise ValueError("Unknown operator '{0}'".format(tree.value))
+            raise ValueError(f"Unknown operator '{tree.value}'")
 
         node = tagged.tag_object(cls.make_yaml_tag(tag_name), node, ctx=ctx)
         return node

--- a/astropy/io/misc/asdf/tags/transform/projections.py
+++ b/astropy/io/misc/asdf/tags/transform/projections.py
@@ -210,11 +210,11 @@ _generic_projections = {
 
 def make_projection_types():
     for tag_name, (name, params, version) in _generic_projections.items():
-        class_name = '{0}Type'.format(name)
-        types = ['astropy.modeling.projections.Pix2Sky_{0}'.format(name),
-                 'astropy.modeling.projections.Sky2Pix_{0}'.format(name)]
+        class_name = f'{name}Type'
+        types = [f'astropy.modeling.projections.Pix2Sky_{name}',
+                 f'astropy.modeling.projections.Sky2Pix_{name}']
 
-        members = {'name': 'transform/{0}'.format(tag_name),
+        members = {'name': f'transform/{tag_name}',
                    'types': types,
                    'params': params}
         if version:

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -100,9 +100,9 @@ def test_generic_projections(tmpdir):
     for tag_name, (name, params, version) in projections._generic_projections.items():
         tree = {
             'forward': util.resolve_name(
-                'astropy.modeling.projections.Sky2Pix_{0}'.format(name))(),
+                f'astropy.modeling.projections.Sky2Pix_{name}')(),
             'backward': util.resolve_name(
-                'astropy.modeling.projections.Pix2Sky_{0}'.format(name))()
+                f'astropy.modeling.projections.Pix2Sky_{name}')()
         }
 
         helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/io/misc/asdf/tags/unit/equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/equivalency.py
@@ -18,7 +18,7 @@ class EquivalencyType(AstropyType):
     def to_tree(cls, equiv, ctx):
         node = {}
         if not isinstance(equiv, Equivalency):
-            raise TypeError("'{0}' is not a valid Equivalency".format(equiv))
+            raise TypeError(f"'{equiv}' is not a valid Equivalency")
 
         eqs = []
         for e, kwargs in zip(equiv.name, equiv.kwargs):

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -24,7 +24,7 @@ class QuantityType(AstropyAsdfType):
             node['value'] = custom_tree_to_tagged_tree(quantity.value, ctx)
             node['unit'] = custom_tree_to_tagged_tree(quantity.unit, ctx)
             return node
-        raise TypeError("'{0}' is not a valid Quantity".format(quantity))
+        raise TypeError(f"'{quantity}' is not a valid Quantity")
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/astropy/io/misc/asdf/tags/unit/unit.py
+++ b/astropy/io/misc/asdf/tags/unit/unit.py
@@ -18,7 +18,7 @@ class UnitType(AstropyAsdfType):
             node = Unit(node, format='vounit', parse_strict='warn')
         if isinstance(node, UnitBase):
             return node.to_string(format='vounit')
-        raise TypeError("'{0}' is not a valid unit".format(node))
+        raise TypeError(f"'{node}' is not a valid unit")
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -99,7 +99,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
             try:
                 input = input[path]
             except (KeyError, ValueError):
-                raise OSError("Path {0} does not exist".format(path))
+                raise OSError(f"Path {path} does not exist")
 
         # `input` is now either a group or a dataset. If it is a group, we
         # will search for all structured arrays inside the group, and if there
@@ -112,14 +112,14 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
             arrays = _find_all_structured_arrays(input)
 
             if len(arrays) == 0:
-                raise ValueError("no table found in HDF5 group {0}".
+                raise ValueError("no table found in HDF5 group {}".
                                  format(path))
             elif len(arrays) > 0:
                 path = arrays[0] if path is None else path + '/' + arrays[0]
                 if len(arrays) > 1:
                     warnings.warn("path= was not specified but multiple tables"
                                   " are present, reading in first available"
-                                  " table (path={0})".format(path),
+                                  " table (path={})".format(path),
                                   AstropyUserWarning)
                 return read_table_hdf5(input, path=path)
 
@@ -293,7 +293,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
             if overwrite and not append:
                 os.remove(output)
             else:
-                raise OSError("File exists: {0}".format(output))
+                raise OSError(f"File exists: {output}")
 
         # Open the file for appending or writing
         f = h5py.File(output, 'a' if append else 'w')
@@ -318,7 +318,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
             # Delete only the dataset itself
             del output_group[name]
         else:
-            raise OSError("Table {0} already exists".format(path))
+            raise OSError(f"Table {path} already exists")
 
     # Encode any mixin columns as plain columns + appropriate metadata
     table = _encode_mixins(table)
@@ -368,7 +368,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
             try:
                 dset.attrs[key] = val
             except TypeError:
-                warnings.warn("Attribute `{0}` of type {1} cannot be written to "
+                warnings.warn("Attribute `{}` of type {} cannot be written to "
                               "HDF5 files - skipping. (Consider specifying "
                               "serialize_meta=True to write all meta data)".format(key, type(val)),
                               AstropyUserWarning)

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -553,7 +553,7 @@ def test_skip_meta(tmpdir):
         t1.write(test_file, path='the_table')
     assert len(w) == 1
     assert str(w[0].message).startswith(
-        "Attribute `f` of type {0} cannot be written to HDF5 files - skipping".format(type(t1.meta['f'])))
+        "Attribute `f` of type {} cannot be written to HDF5 files - skipping".format(type(t1.meta['f'])))
 
 
 @pytest.mark.skipif('not HAS_H5PY or not HAS_YAML')

--- a/astropy/io/misc/tests/test_pickle_helpers.py
+++ b/astropy/io/misc/tests/test_pickle_helpers.py
@@ -62,7 +62,7 @@ def test_fnpickling_protocol(tmpdir):
     obj2 = ToBePickled(obj1)
 
     for p in range(pickle.HIGHEST_PROTOCOL + 1):
-        fn = str(tmpdir.join('testp{}.pickle'.format(p)))
+        fn = str(tmpdir.join(f'testp{p}.pickle'))
         fnpickle(obj2, fn, protocol=p)
         res = fnunpickle(fn)
         assert res == obj2

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -187,14 +187,14 @@ def _skycoord_constructor(loader, node):
 # Straight from yaml's Representer
 def _complex_representer(self, data):
     if data.imag == 0.0:
-        data = u'%r' % data.real
+        data = '%r' % data.real
     elif data.real == 0.0:
-        data = u'%rj' % data.imag
+        data = '%rj' % data.imag
     elif data.imag > 0:
-        data = u'%r+%rj' % (data.real, data.imag)
+        data = f'{data.real!r}+{data.imag!r}j'
     else:
-        data = u'%r%rj' % (data.real, data.imag)
-    return self.represent_scalar(u'tag:yaml.org,2002:python/complex', data)
+        data = f'{data.real!r}{data.imag!r}j'
+    return self.represent_scalar('tag:yaml.org,2002:python/complex', data)
 
 
 def _complex_constructor(loader, node):
@@ -273,7 +273,7 @@ for np_type in [np.complex_, complex, np.complex64, np.complex128]:
     AstropyDumper.add_representer(np_type,
                                  _complex_representer)
 
-AstropyLoader.add_constructor(u'tag:yaml.org,2002:python/complex',
+AstropyLoader.add_constructor('tag:yaml.org,2002:python/complex',
                               _complex_constructor)
 AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',
                               AstropyLoader._construct_python_tuple)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -229,7 +229,7 @@ def register_reader(data_format, data_class, function, force=False):
     if not (data_format, data_class) in _readers or force:
         _readers[(data_format, data_class)] = function
     else:
-        raise IORegistryError("Reader for format '{0}' and class '{1}' is "
+        raise IORegistryError("Reader for format '{}' and class '{}' is "
                               'already defined'
                               ''.format(data_format, data_class.__name__))
 
@@ -252,7 +252,7 @@ def unregister_reader(data_format, data_class):
     if (data_format, data_class) in _readers:
         _readers.pop((data_format, data_class))
     else:
-        raise IORegistryError("No reader defined for format '{0}' and class '{1}'"
+        raise IORegistryError("No reader defined for format '{}' and class '{}'"
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -280,7 +280,7 @@ def register_writer(data_format, data_class, function, force=False):
     if not (data_format, data_class) in _writers or force:
         _writers[(data_format, data_class)] = function
     else:
-        raise IORegistryError("Writer for format '{0}' and class '{1}' is "
+        raise IORegistryError("Writer for format '{}' and class '{}' is "
                               'already defined'
                               ''.format(data_format, data_class.__name__))
 
@@ -303,7 +303,7 @@ def unregister_writer(data_format, data_class):
     if (data_format, data_class) in _writers:
         _writers.pop((data_format, data_class))
     else:
-        raise IORegistryError("No writer defined for format '{0}' and class '{1}'"
+        raise IORegistryError("No writer defined for format '{}' and class '{}'"
                               ''.format(data_format, data_class.__name__))
 
     if data_class not in _delayed_docs_classes:
@@ -358,7 +358,7 @@ def register_identifier(data_format, data_class, identifier, force=False):
     if not (data_format, data_class) in _identifiers or force:
         _identifiers[(data_format, data_class)] = identifier
     else:
-        raise IORegistryError("Identifier for format '{0}' and class '{1}' is "
+        raise IORegistryError("Identifier for format '{}' and class '{}' is "
                               'already defined'.format(data_format,
                                                        data_class.__name__))
 
@@ -378,8 +378,8 @@ def unregister_identifier(data_format, data_class):
     if (data_format, data_class) in _identifiers:
         _identifiers.pop((data_format, data_class))
     else:
-        raise IORegistryError("No identifier defined for format '{0}' and class"
-                              " '{1}'".format(data_format, data_class.__name__))
+        raise IORegistryError("No identifier defined for format '{}' and class"
+                              " '{}'".format(data_format, data_class.__name__))
 
 
 def identify_format(origin, data_class_required, path, fileobj, args, kwargs):
@@ -450,8 +450,8 @@ def get_reader(data_format, data_class):
     else:
         format_table_str = _get_format_table_str(data_class, 'Read')
         raise IORegistryError(
-            "No reader defined for format '{0}' and class '{1}'.\n\nThe "
-            "available formats are:\n\n{2}".format(
+            "No reader defined for format '{}' and class '{}'.\n\nThe "
+            "available formats are:\n\n{}".format(
                 data_format, data_class.__name__, format_table_str))
 
 
@@ -478,8 +478,8 @@ def get_writer(data_format, data_class):
     else:
         format_table_str = _get_format_table_str(data_class, 'Write')
         raise IORegistryError(
-            "No writer defined for format '{0}' and class '{1}'.\n\nThe "
-            "available formats are:\n\n{2}".format(
+            "No writer defined for format '{}' and class '{}'.\n\nThe "
+            "available formats are:\n\n{}".format(
                 data_format, data_class.__name__, format_table_str))
 
 
@@ -529,7 +529,7 @@ def read(cls, *args, format=None, **kwargs):
             try:
                 data = cls(data)
             except Exception:
-                raise TypeError('could not convert reader output to {0} '
+                raise TypeError('could not convert reader output to {} '
                                 'class.'.format(cls.__name__))
     finally:
         if ctx is not None:
@@ -598,10 +598,10 @@ def _get_valid_format(mode, cls, path, fileobj, args, kwargs):
         format_table_str = _get_format_table_str(cls, mode.capitalize())
         raise IORegistryError("Format could not be identified.\n"
                               "The available formats are:\n"
-                              "{0}".format(format_table_str))
+                              "{}".format(format_table_str))
     elif len(valid_formats) > 1:
         raise IORegistryError(
-            "Format is ambiguous - options are: {0}".format(
+            "Format is ambiguous - options are: {}".format(
                 ', '.join(sorted(valid_formats, key=itemgetter(0)))))
 
     return valid_formats[0]

--- a/astropy/io/votable/connect.py
+++ b/astropy/io/votable/connect.py
@@ -93,22 +93,22 @@ def read_table_votable(input, table_id=None, use_names_over_ids=False, verify=No
             if table_id is None:
                 raise ValueError(
                     "Multiple tables found: table id should be set via "
-                    "the table_id= argument. The available tables are {0}, "
-                    'or integers less than {1}.'.format(
+                    "the table_id= argument. The available tables are {}, "
+                    'or integers less than {}.'.format(
                         ', '.join(table_id_mapping.keys()), len(tables)))
             elif isinstance(table_id, str):
                 if table_id in table_id_mapping:
                     table = table_id_mapping[table_id]
                 else:
                     raise ValueError(
-                        "No tables with id={0} found".format(table_id))
+                        f"No tables with id={table_id} found")
             elif isinstance(table_id, int):
                 if table_id < len(tables):
                     table = tables[table_id]
                 else:
                     raise IndexError(
-                        "Table index {0} is out of range. "
-                        "{1} tables found".format(
+                        "Table index {} is out of range. "
+                        "{} tables found".format(
                             table_id, len(tables)))
         elif len(tables) == 1:
             table = tables[0]
@@ -151,7 +151,7 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
     unsupported_cols = input.columns.not_isinstance((BaseColumn, Quantity))
     if unsupported_cols:
         unsupported_names = [col.info.name for col in unsupported_cols]
-        raise ValueError('cannot write table with mixin column(s) {0} to VOTable'
+        raise ValueError('cannot write table with mixin column(s) {} to VOTable'
                          .format(unsupported_names))
 
     # Check if output file already exists
@@ -159,7 +159,7 @@ def write_table_votable(input, output, table_id=None, overwrite=False,
         if overwrite:
             os.remove(output)
         else:
-            raise OSError("File exists: {0}".format(output))
+            raise OSError(f"File exists: {output}")
 
     # Create a new VOTable file
     table_file = from_table(input, table_id=table_id)

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -314,10 +314,10 @@ class Char(Converter):
                 self.arraysize = int(field.arraysize)
             except ValueError:
                 vo_raise(E01, (field.arraysize, 'char', field.ID), config)
-            self.format = 'S{:d}'.format(self.arraysize)
+            self.format = f'S{self.arraysize:d}'
             self.binparse = self._binparse_fixed
             self.binoutput = self._binoutput_fixed
-            self._struct_format = ">{:d}s".format(self.arraysize)
+            self._struct_format = f">{self.arraysize:d}s"
 
         if config.get('verify', 'ignore') == 'exception':
             self.parse = self._ascii_parse
@@ -391,7 +391,7 @@ class UnicodeChar(Converter):
                 self.arraysize = int(field.arraysize)
             except ValueError:
                 vo_raise(E01, (field.arraysize, 'unicode', field.ID), config)
-            self.format = 'U{:d}'.format(self.arraysize)
+            self.format = f'U{self.arraysize:d}'
             self.binparse = self._binparse_fixed
             self.binoutput = self._binoutput_fixed
             self._struct_format = ">{:d}s".format(self.arraysize * 2)
@@ -747,7 +747,7 @@ class FloatingPoint(Numeric):
         elif np.isneginf(value):
             return '-InF'
         # Should never raise
-        vo_raise("Invalid floating point value '{}'".format(value))
+        vo_raise(f"Invalid floating point value '{value}'")
 
     def binoutput(self, value, mask):
         if mask:
@@ -1361,7 +1361,7 @@ def numpy_to_votable_dtype(dtype, shape):
     """
     if dtype.num not in numpy_dtype_to_field_mapping:
         raise TypeError(
-            "{0!r} can not be represented in VOTable".format(dtype))
+            f"{dtype!r} can not be represented in VOTable")
 
     if dtype.char == 'S':
         return {'datatype': 'char',

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -140,8 +140,8 @@ def warn_unknown_attrs(element, attrs, config, pos, good_attr=[], stacklevel=1):
 
 
 _warning_pat = re.compile(
-    (r":?(?P<nline>[0-9?]+):(?P<nchar>[0-9?]+): " +
-     r"((?P<warning>[WE]\d+): )?(?P<rest>.*)$"))
+    r":?(?P<nline>[0-9?]+):(?P<nchar>[0-9?]+): " +
+     r"((?P<warning>[WE]\d+): )?(?P<rest>.*)$")
 
 
 def parse_vowarning(line):
@@ -156,7 +156,7 @@ def parse_vowarning(line):
             result['is_warning'] = (warning[0].upper() == 'W')
             result['is_exception'] = not result['is_warning']
             result['number'] = int(match.group('warning')[1:])
-            result['doc_url'] = "io/votable/api_exceptions.html#{0}".format(
+            result['doc_url'] = "io/votable/api_exceptions.html#{}".format(
                 warning.lower())
         else:
             result['is_warning'] = False
@@ -1429,7 +1429,7 @@ def _build_doc_string():
         out = io.StringIO()
 
         for name, cls in classes:
-            out.write(".. _{}:\n\n".format(name))
+            out.write(f".. _{name}:\n\n")
             msg = "{}: {}".format(cls.__name__, cls.get_short_name())
             if not isinstance(msg, str):
                 msg = msg.decode('utf-8')

--- a/astropy/io/votable/table.py
+++ b/astropy/io/votable/table.py
@@ -141,7 +141,7 @@ def parse(source, columns=None, invalid='exception', verify=None,
     if isinstance(verify, bool):
         verify = 'exception' if verify else 'warn'
     elif verify not in VERIFY_OPTIONS:
-        raise ValueError('verify should be one of {0}'.format('/'.join(VERIFY_OPTIONS)))
+        raise ValueError('verify should be one of {}'.format('/'.join(VERIFY_OPTIONS)))
 
     if datatype_mapping is None:
         datatype_mapping = {}
@@ -288,7 +288,7 @@ def validate(source, output=None, xmllint=False, filename=None):
              issubclass(x.category, exceptions.VOWarning)] + lines
 
     content_buffer.seek(0)
-    output.write("Validation report for {0}\n\n".format(filename))
+    output.write(f"Validation report for {filename}\n\n")
 
     if len(lines):
         xml_lines = iterparser.xml_readlines(content_buffer)
@@ -307,7 +307,7 @@ def validate(source, output=None, xmllint=False, filename=None):
                 else:
                     color = 'red'
                 color_print(
-                    '{0:d}: '.format(w['nline']), '',
+                    '{:d}: '.format(w['nline']), '',
                     warning or 'EXC', color,
                     ': ', '',
                     textwrap.fill(

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -142,7 +142,7 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
 
     with open(
         get_pkg_data_filename(
-            'data/regression.bin.tabledata.truth.{0}.xml'.format(
+            'data/regression.bin.tabledata.truth.{}.xml'.format(
                 votable.version)),
             'rt', encoding='utf-8') as fd:
         truth = fd.readlines()

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -113,7 +113,7 @@ def _lookup_by_attr_factory(attr, unique, iterator, element_name, doc):
             if element is before:
                 if getattr(element, attr, None) == ref:
                     vo_raise(
-                        "{} references itself".format(element_name),
+                        f"{element_name} references itself",
                         element._config, element._pos, KeyError)
                 break
             if getattr(element, attr, None) == ref:
@@ -152,7 +152,7 @@ def _lookup_by_id_or_name_factory(iterator, element_name, doc):
             if element is before:
                 if ref in (element.ID, element.name):
                     vo_raise(
-                        "{} references itself".format(element_name),
+                        f"{element_name} references itself",
                         element._config, element._pos, KeyError)
                 break
             if ref in (element.ID, element.name):
@@ -1246,7 +1246,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
             i = 2
             new_id = field.ID
             while new_id in unique:
-                new_id = field.ID + "_{:d}".format(i)
+                new_id = field.ID + f"_{i:d}"
                 i += 1
             if new_id != field.ID:
                 vo_warn(W32, (field.ID, new_id), field._config, field._pos)
@@ -1263,7 +1263,7 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
                 implicit = False
             if new_name != field.ID:
                 while new_name in unique:
-                    new_name = field.name + " {:d}".format(i)
+                    new_name = field.name + f" {i:d}"
                     i += 1
 
             if (not implicit and
@@ -1790,7 +1790,7 @@ class FieldRef(SimpleElement, _UtypeProperty, _UcdProperty):
             if isinstance(field, Field) and field.ID == self.ref:
                 return field
         vo_raise(
-            "No field named '{}'".format(self.ref),
+            f"No field named '{self.ref}'",
             self._config, self._pos, KeyError)
 
 
@@ -1856,7 +1856,7 @@ class ParamRef(SimpleElement, _UtypeProperty, _UcdProperty):
             if isinstance(param, Param) and param.ID == self.ref:
                 return param
         vo_raise(
-            "No params named '{}'".format(self.ref),
+            f"No params named '{self.ref}'",
             self._config, self._pos, KeyError)
 
 
@@ -1898,7 +1898,7 @@ class Group(Element, _IDProperty, _NameProperty, _UtypeProperty,
         warn_unknown_attrs('GROUP', extra.keys(), config, pos)
 
     def __repr__(self):
-        return '<GROUP>... {0} entries ...</GROUP>'.format(len(self._entries))
+        return '<GROUP>... {} entries ...</GROUP>'.format(len(self._entries))
 
     @property
     def ref(self):
@@ -2139,7 +2139,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     "binary2 only supported in votable 1.3 or later",
                     self._config, self._pos)
         elif format not in ('tabledata', 'binary'):
-            vo_raise("Invalid format '{}'".format(format),
+            vo_raise(f"Invalid format '{format}'",
                      self._config, self._pos)
         self._format = format
 
@@ -2373,7 +2373,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     colnumbers = [names.index(x) for x in columns]
                 except ValueError:
                     raise ValueError(
-                        "Columns '{}' not found in fields list".format(columns))
+                        f"Columns '{columns}' not found in fields list")
             else:
                 raise TypeError("Invalid columns list")
 
@@ -2590,7 +2590,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     fd = codecs.EncodedFile(fd, 'base64')
                 else:
                     vo_raise(
-                        "Unknown encoding type '{}'".format(encoding),
+                        f"Unknown encoding type '{encoding}'",
                         self._config, self._pos, NotImplementedError)
             read = fd.read
 
@@ -2688,7 +2688,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                 fd = codecs.EncodedFile(fd, 'base64')
             else:
                 vo_raise(
-                    "Unknown encoding type '{}'".format(encoding),
+                    f"Unknown encoding type '{encoding}'",
                     self._config, self._pos, NotImplementedError)
 
         hdulist = fits.open(fd)
@@ -2728,7 +2728,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                         element.to_xml(w, **kwargs)
             elif kwargs['version_1_2_or_later']:
                 index = list(self._votable.iter_tables()).index(self)
-                group = Group(self, ID="_g{0}".format(index))
+                group = Group(self, ID=f"_g{index}")
                 group.to_xml(w, **kwargs)
 
             if len(self.array):
@@ -2862,7 +2862,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                 new_name = name
                 i = 2
                 while new_name in unique_names:
-                    new_name = '{0}{1}'.format(name, i)
+                    new_name = f'{name}{i}'
                     i += 1
                 unique_names.append(new_name)
             names = unique_names
@@ -3254,7 +3254,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
 
     def __repr__(self):
         n_tables = len(list(self.iter_tables()))
-        return '<VOTABLE>... {0} tables ...</VOTABLE>'.format(n_tables)
+        return f'<VOTABLE>... {n_tables} tables ...</VOTABLE>'
 
     @property
     def version(self):
@@ -3427,7 +3427,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
         if tabledata_format is not None:
             if tabledata_format.lower() not in (
                     'tabledata', 'binary', 'binary2'):
-                raise ValueError("Unknown format type '{0}'".format(format))
+                raise ValueError(f"Unknown format type '{format}'")
 
         kwargs = {
             'version': self.version,
@@ -3462,9 +3462,9 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
                         'xmlns:xsi':
                             "http://www.w3.org/2001/XMLSchema-instance",
                         'xsi:noNamespaceSchemaLocation':
-                            "http://www.ivoa.net/xml/VOTable/v{}".format(version),
+                            f"http://www.ivoa.net/xml/VOTable/v{version}",
                         'xmlns':
-                            "http://www.ivoa.net/xml/VOTable/v{}".format(version)}):
+                            f"http://www.ivoa.net/xml/VOTable/v{version}"}):
                 if self.description is not None:
                     w.element("DESCRIPTION", self.description, wrap=True)
                 element_sets = [self.coordinate_systems, self.params,
@@ -3516,7 +3516,7 @@ class VOTableFile(Element, _IDProperty, _DescriptionProperty):
             if i == idx:
                 return table
         raise IndexError(
-            "No table at index {:d} found in VOTABLE file.".format(idx))
+            f"No table at index {idx:d} found in VOTABLE file.")
 
     def iter_fields_and_params(self):
         """

--- a/astropy/io/votable/ucd.py
+++ b/astropy/io/votable/ucd.py
@@ -114,7 +114,7 @@ def parse_ucd(ucd, check_controlled_vocabulary=False, has_colon=False):
                 m.group(0), ucd))
 
     word_component_re = r'[A-Za-z0-9][A-Za-z0-9\-_]*'
-    word_re = r'{}(\.{})*'.format(word_component_re, word_component_re)
+    word_re = fr'{word_component_re}(\.{word_component_re})*'
 
     parts = ucd.split(';')
     words = []
@@ -123,15 +123,15 @@ def parse_ucd(ucd, check_controlled_vocabulary=False, has_colon=False):
         if colon_count == 1:
             ns, word = word.split(':', 1)
             if not re.match(word_component_re, ns):
-                raise ValueError("Invalid namespace '{}'".format(ns))
+                raise ValueError(f"Invalid namespace '{ns}'")
             ns = ns.lower()
         elif colon_count > 1:
-            raise ValueError("Too many colons in '{}'".format(word))
+            raise ValueError(f"Too many colons in '{word}'")
         else:
             ns = 'ivoa'
 
         if not re.match(word_re, word):
-            raise ValueError("Invalid word '{}'".format(word))
+            raise ValueError(f"Invalid word '{word}'")
 
         if ns == 'ivoa' and check_controlled_vocabulary:
             if i == 0:
@@ -141,7 +141,7 @@ def parse_ucd(ucd, check_controlled_vocabulary=False, has_colon=False):
                             "Secondary word '{}' is not valid as a primary "
                             "word".format(word))
                     else:
-                        raise ValueError("Unknown word '{}'".format(word))
+                        raise ValueError(f"Unknown word '{word}'")
             else:
                 if not _ucd_singleton.is_secondary(word):
                     if _ucd_singleton.is_primary(word):
@@ -149,7 +149,7 @@ def parse_ucd(ucd, check_controlled_vocabulary=False, has_colon=False):
                             "Primary word '{}' is not valid as a secondary "
                             "word".format(word))
                     else:
-                        raise ValueError("Unknown word '{}'".format(word))
+                        raise ValueError(f"Unknown word '{word}'")
 
         try:
             normalized_word = _ucd_singleton.normalize_capitalization(word)

--- a/astropy/io/votable/util.py
+++ b/astropy/io/votable/util.py
@@ -185,19 +185,19 @@ def coerce_range_list_param(p, frames=None, numeric=True):
             p)
 
         if match is None:
-            raise ValueError("'{}' is not a valid range list".format(p))
+            raise ValueError(f"'{p}' is not a valid range list")
 
         frame = match.groupdict()['frame']
         if frames is not None and frame is not None and frame not in frames:
             raise ValueError(
-                "'{}' is not a valid frame of reference".format(frame))
+                f"'{frame}' is not a valid frame of reference")
         return p, p.count(',') + p.count(';') + 1
 
     try:
         float(p)
         return str(p), 1
     except TypeError:
-        raise ValueError("'{}' is not a valid range list".format(p))
+        raise ValueError(f"'{p}' is not a valid range list")
 
 
 def version_compare(a, b):

--- a/astropy/io/votable/validator/html.py
+++ b/astropy/io/votable/validator/html.py
@@ -78,7 +78,7 @@ def write_source_line(w, line, nchar=0):
 
     w.write('  ')
     w.write(part1)
-    w.write('<span class="highlight">{}</span>'.format(char))
+    w.write(f'<span class="highlight">{char}</span>')
     w.write(part2)
     w.write('\n\n')
 
@@ -236,7 +236,7 @@ def write_table(basename, name, results, root="results", chunk_size=500):
                 else:
                     w.element(
                         'a', str(i+1),
-                        href='{}_{:02d}.html'.format(basename, i))
+                        href=f'{basename}_{i:02d}.html')
                 w.data(' ')
             if j < npages - 1:
                 w.element('a', '>>', href='{}_{:02d}.html'.format(basename, j+1))
@@ -245,7 +245,7 @@ def write_table(basename, name, results, root="results", chunk_size=500):
 
     for i, j in enumerate(range(0, max(len(results), 1), chunk_size)):
         subresults = results[j:j+chunk_size]
-        path = os.path.join(root, '{}_{:02d}.html'.format(basename, i))
+        path = os.path.join(root, f'{basename}_{i:02d}.html')
         with open(path, 'w', encoding='utf-8') as fd:
             w = XMLWriter(fd)
             with make_html_header(w):
@@ -280,7 +280,7 @@ def add_subset(w, basename, name, subresults, inside=['p'], total=None):
         with w.tag('td'):
             for element in inside:
                 w.start(element)
-            w.element('a', name, href='{}_00.html'.format(basename))
+            w.element('a', name, href=f'{basename}_00.html')
             for element in reversed(inside):
                 w.end(element)
         numbers = '{:d} ({:.2%})'.format(len(subresults), percentage)

--- a/astropy/io/votable/validator/main.py
+++ b/astropy/io/votable/validator/main.py
@@ -29,7 +29,7 @@ def get_urls(destdir, s):
     urls = []
     for type in types:
         filename = get_pkg_data_filename(
-            'data/urls/cone.{0}.dat.gz'.format(type))
+            f'data/urls/cone.{type}.dat.gz')
         with gzip.open(filename, 'rb') as fd:
             for url in fd.readlines():
                 next(s)
@@ -115,7 +115,7 @@ def make_validation_report(
     if stilts is not None:
         if not os.path.exists(stilts):
             raise ValueError(
-                '{0} does not exist.'.format(stilts))
+                f'{stilts} does not exist.')
 
     destdir = os.path.abspath(destdir)
 

--- a/astropy/io/votable/validator/result.py
+++ b/astropy/io/votable/validator/result.py
@@ -99,7 +99,7 @@ class Result:
         def fail(reason):
             reason = str(reason)
             with open(path, 'wb') as fd:
-                fd.write('FAILED: {0}\n'.format(reason).encode('utf-8'))
+                fd.write(f'FAILED: {reason}\n'.encode('utf-8'))
             self['network_error'] = reason
 
         r = None
@@ -338,7 +338,7 @@ def get_result_subsets(results, root, s=None):
             warning_descr = warning_class.get_short_name()
             tables.append(
                 (warning_code,
-                 '{}: {}'.format(warning_code, warning_descr),
+                 f'{warning_code}: {warning_descr}',
                  warning, ['ul', 'li']))
     tables.append(
         ('exceptions', 'Exceptions', has_exceptions))
@@ -351,7 +351,7 @@ def get_result_subsets(results, root, s=None):
             exception_descr = exception_class.get_short_name()
             tables.append(
                 (exception_code,
-                 '{}: {}'.format(exception_code, exception_descr),
+                 f'{exception_code}: {exception_descr}',
                  exc, ['ul', 'li']))
 
     return tables

--- a/astropy/io/votable/xmlutil.py
+++ b/astropy/io/votable/xmlutil.py
@@ -114,13 +114,13 @@ def validate_schema(filename, version='1.1'):
         as strings
     """
     if version not in ('1.0', '1.1', '1.2', '1.3'):
-        log.info('{0} has version {1}, using schema 1.1'.format(
+        log.info('{} has version {}, using schema 1.1'.format(
             filename, version))
         version = '1.1'
 
     if version in ('1.1', '1.2', '1.3'):
         schema_path = data.get_pkg_data_filename(
-            'data/VOTable.v{0}.xsd'.format(version))
+            f'data/VOTable.v{version}.xsd')
     else:
         schema_path = data.get_pkg_data_filename(
             'data/VOTable.dtd')

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -175,7 +175,7 @@ class AstropyLogger(Logger):
         # AstropyWarning.  The name of subclasses of AstropyWarning should
         # be displayed.
         if type(warning) not in (AstropyWarning, AstropyUserWarning):
-            message = '{0}: {1}'.format(warning.__class__.__name__, args[0])
+            message = '{}: {}'.format(warning.__class__.__name__, args[0])
         else:
             message = str(args[0])
 
@@ -251,7 +251,7 @@ class AstropyLogger(Logger):
 
         # include the the error type in the message.
         if len(value.args) > 0:
-            message = '{0}: {1}'.format(etype.__name__, str(value))
+            message = '{}: {}'.format(etype.__name__, str(value))
         else:
             message = str(etype.__name__)
 
@@ -498,8 +498,8 @@ class AstropyLogger(Logger):
                 fh = logging.FileHandler(log_file_path)
             except OSError as e:
                 warnings.warn(
-                    'log file {0!r} could not be opened for writing: '
-                    '{1}'.format(log_file_path, str(e)), RuntimeWarning)
+                    'log file {!r} could not be opened for writing: '
+                    '{}'.format(log_file_path, str(e)), RuntimeWarning)
             else:
                 formatter = logging.Formatter(conf.log_file_format)
                 fh.setFormatter(formatter)
@@ -543,7 +543,7 @@ class StreamHandler(logging.StreamHandler):
                 color_print(record.levelname, 'brown', end='', file=stream)
             else:
                 color_print(record.levelname, 'red', end='', file=stream)
-        record.message = "{0} [{1:s}]".format(record.msg, record.origin)
+        record.message = f"{record.msg} [{record.origin:s}]"
         print(": " + record.message, file=stream)
 
 

--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -306,7 +306,7 @@ def blackbody_nu(in_x, temperature):
 
     # Check if input values are physically possible
     if np.any(temp < 0):
-        raise ValueError('Temperature should be positive: {0}'.format(temp))
+        raise ValueError(f'Temperature should be positive: {temp}')
     if not np.all(np.isfinite(freq)) or np.any(freq <= 0):
         warnings.warn('Input contains invalid wavelength/frequency value(s)',
                       AstropyUserWarning)

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -448,7 +448,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
         # failures below. Ultimately, np.linalg.lstsq can't handle >2D matrices,
         # so just raise a slightly more informative error when this happens:
         if lhs.ndim > 2:
-            raise ValueError('{0} gives unsupported >2D derivative matrix for '
+            raise ValueError('{} gives unsupported >2D derivative matrix for '
                              'this x/y'.format(type(model_copy).__name__))
 
         # Subtract any terms fixed by the user from (a copy of) the RHS, in
@@ -639,7 +639,7 @@ class FittingWithOutlierRemoval:
         else:
             if not hasattr(self.fitter, 'supports_masked_input') or \
                self.fitter.supports_masked_input is not True:
-                raise ValueError("{0} cannot fit model sets with masked "
+                raise ValueError("{} cannot fit model sets with masked "
                                  "values".format(type(self.fitter).__name__))
 
             # Fitters use their input model's model_set_axis to determine how
@@ -1450,7 +1450,7 @@ def populate_entry_points(entry_points):
         else:
             if not inspect.isclass(entry_point):
                 warnings.warn(AstropyUserWarning(
-                    'Modeling entry point {0} expected to be a '
+                    'Modeling entry point {} expected to be a '
                     'Class.' .format(name)))
             else:
                 if issubclass(entry_point, Fitter):
@@ -1459,7 +1459,7 @@ def populate_entry_points(entry_points):
                     __all__.append(name)
                 else:
                     warnings.warn(AstropyUserWarning(
-                        'Modeling entry point {0} expected to extend '
+                        'Modeling entry point {} expected to extend '
                         'astropy.modeling.Fitter' .format(name)))
 
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1090,7 +1090,7 @@ class Voigt1D(Fittable1DModel):
         Y = fwhm_L * sqrt_ln2 / fwhm_G
         Y = np.atleast_1d(Y)[..., np.newaxis]
 
-        V = np.sum((C * (Y - A) + D * (X - B))/(((Y - A) ** 2 + (X - B) ** 2)), axis=-1)
+        V = np.sum((C * (Y - A) + D * (X - B))/((Y - A) ** 2 + (X - B) ** 2), axis=-1)
 
         return (fwhm_L * amplitude_L * np.sqrt(np.pi) * sqrt_ln2 / fwhm_G) * V
 

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -81,15 +81,15 @@ class Mapping(FittableModel):
 
     def __repr__(self):
         if self.name is None:
-            return '<Mapping({0})>'.format(self.mapping)
+            return f'<Mapping({self.mapping})>'
         else:
-            return '<Mapping({0}, name={1})>'.format(self.mapping, self.name)
+            return f'<Mapping({self.mapping}, name={self.name})>'
 
     def evaluate(self, *args):
         if len(args) != self.n_inputs:
             name = self.name if self.name is not None else "Mapping"
 
-            raise TypeError('{0} expects {1} inputs; got {2}'.format(
+            raise TypeError('{} expects {} inputs; got {}'.format(
                 name, self.n_inputs, len(args)))
 
         result = tuple(args[idx] for idx in self._mapping)
@@ -116,7 +116,7 @@ class Mapping(FittableModel):
                             for idx in range(self.n_inputs))
         except ValueError:
             raise NotImplementedError(
-                "Mappings such as {0} that drop one or more of their inputs "
+                "Mappings such as {} that drop one or more of their inputs "
                 "are not invertible at this time.".format(self.mapping))
 
         inv = self.__class__(mapping)
@@ -164,9 +164,9 @@ class Identity(Mapping):
 
     def __repr__(self):
         if self.name is None:
-            return '<Identity({0})>'.format(self.n_inputs)
+            return f'<Identity({self.n_inputs})>'
         else:
-            return '<Identity({0}, name={1})>'.format(self.n_inputs, self.name)
+            return f'<Identity({self.n_inputs}, name={self.name})>'
 
     @property
     def inverse(self):

--- a/astropy/modeling/optimizers.py
+++ b/astropy/modeling/optimizers.py
@@ -79,7 +79,7 @@ class Optimization(metaclass=abc.ABCMeta):
         self._acc = val
 
     def __repr__(self):
-        fmt = "{0}()".format(self.__class__.__name__)
+        fmt = f"{self.__class__.__name__}()"
         return fmt
 
     @property

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -47,7 +47,7 @@ def _tofloat(value):
             # catch arrays with strings or user errors like different
             # types of parameters in a parameter set
             raise InputParameterError(
-                "Parameter of {0} could not be converted to "
+                "Parameter of {} could not be converted to "
                 "float".format(type(value)))
     elif isinstance(value, Quantity):
         # Quantities are fine as is
@@ -62,7 +62,7 @@ def _tofloat(value):
             "Expected parameter to be of numerical type, not boolean")
     else:
         raise InputParameterError(
-            "Don't know how to convert parameter of {0} to "
+            "Don't know how to convert parameter of {} to "
             "float".format(type(value)))
     return value
 
@@ -223,8 +223,8 @@ class Parameter(OrderedDescriptor):
         if model is None and isinstance(default, Quantity):
             if unit is not None and not unit.is_equivalent(default.unit):
                 raise ParameterDefinitionError(
-                    "parameter default {0} does not have units equivalent to "
-                    "the required unit {1}".format(default, unit))
+                    "parameter default {} does not have units equivalent to "
+                    "the required unit {}".format(default, unit))
 
             unit = default.unit
             default = default.value
@@ -239,7 +239,7 @@ class Parameter(OrderedDescriptor):
             if min is not None or max is not None:
                 raise ValueError(
                     'bounds may not be specified simultaneously with min or '
-                    'or max when instantiating Parameter {0}'.format(name))
+                    'or max when instantiating Parameter {}'.format(name))
         else:
             bounds = (min, max)
 
@@ -289,7 +289,7 @@ class Parameter(OrderedDescriptor):
                 obj._param_metrics[self.name]['orig_unit'] = value.unit
         else:
             if not isinstance(value, Quantity):
-                raise UnitsError("The '{0}' parameter should be given as a "
+                raise UnitsError("The '{}' parameter should be given as a "
                                  "Quantity because it was originally initialized "
                                  "as a Quantity".format(self._name))
             else:
@@ -337,7 +337,7 @@ class Parameter(OrderedDescriptor):
             if len(oldvalue[key]) == 0:
                 raise InputParameterError(
                     "Slice assignment outside the parameter dimensions for "
-                    "'{0}'".format(self.name))
+                    "'{}'".format(self.name))
             for idx, val in zip(range(*key.indices(len(self))), value):
                 self.__setitem__(idx, val)
         else:
@@ -345,28 +345,28 @@ class Parameter(OrderedDescriptor):
                 oldvalue[key] = value
             except IndexError:
                 raise InputParameterError(
-                    "Input dimension {0} invalid for {1!r} parameter with "
-                    "dimension {2}".format(key, self.name, n_models))
+                    "Input dimension {} invalid for {!r} parameter with "
+                    "dimension {}".format(key, self.name, n_models))
 
     def __repr__(self):
-        args = "'{0}'".format(self._name)
+        args = f"'{self._name}'"
         if self._model is None:
             if self._default is not None:
-                args += ', default={0}'.format(self._default)
+                args += f', default={self._default}'
         else:
-            args += ', value={0}'.format(self.value)
+            args += f', value={self.value}'
 
         if self.unit is not None:
-            args += ', unit={0}'.format(self.unit)
+            args += f', unit={self.unit}'
 
         for cons in self.constraints:
             val = getattr(self, cons)
             if val not in (None, False, (None, None)):
                 # Maybe non-obvious, but False is the default for the fixed and
                 # tied constraints
-                args += ', {0}={1}'.format(cons, val)
+                args += f', {cons}={val}'
 
-        return "{0}({1})".format(self.__class__.__name__, args)
+        return f"{self.__class__.__name__}({args})"
 
     @property
     def name(self):
@@ -859,7 +859,7 @@ class Parameter(OrderedDescriptor):
 
             if np.size(value) != param_size:
                 raise InputParameterError(
-                    "Input value for parameter {0!r} does not have {1} elements "
+                    "Input value for parameter {!r} does not have {} elements "
                     "as the current value does".format(name, param_size))
 
             model._parameters[param_slice] = np.array(value).ravel()
@@ -950,5 +950,5 @@ def param_repr_oneline(param):
 
     out = array_repr_oneline(param.value)
     if param.unit is not None:
-        out = '{0} {1!s}'.format(out, param.unit)
+        out = f'{out} {param.unit!s}'
     return out

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -138,16 +138,16 @@ class PolynomialModel(PolynomialBase):
         names = []
         if ndim == 1:
             for n in range(self._order):
-                names.append('c{0}'.format(n))
+                names.append(f'c{n}')
         else:
             for i in range(self.degree + 1):
-                names.append('c{0}_{1}'.format(i, 0))
+                names.append('c{}_{}'.format(i, 0))
             for i in range(1, self.degree + 1):
-                names.append('c{0}_{1}'.format(0, i))
+                names.append('c{}_{}'.format(0, i))
             for i in range(1, self.degree):
                 for j in range(1, self.degree):
                     if i + j < self.degree + 1:
-                        names.append('c{0}_{1}'.format(i, j))
+                        names.append(f'c{i}_{j}')
         return tuple(names)
 
 
@@ -236,7 +236,7 @@ class OrthoPolynomialBase(PolynomialBase):
         yvar = np.arange(self.y_degree + 1)
         for j in yvar:
             for i in xvar:
-                name = 'c{0}_{1}'.format(i, j)
+                name = f'c{i}_{j}'
                 coeff = coeffs[self.param_names.index(name)]
                 invlex_coeffs.append(coeff)
         return np.array(invlex_coeffs[::-1])
@@ -287,7 +287,7 @@ class OrthoPolynomialBase(PolynomialBase):
         names = []
         for j in range(self.y_degree + 1):
             for i in range(self.x_degree + 1):
-                names.append('c{0}_{1}'.format(i, j))
+                names.append(f'c{i}_{j}')
         return tuple(names)
 
     def _fcache(self, x, y):
@@ -847,7 +847,7 @@ class Polynomial1D(PolynomialModel):
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         mapping = []
         for i in range(self.degree + 1):
-            par = getattr(self, 'c{0}'.format(i))
+            par = getattr(self, f'c{i}')
             mapping.append((par.name, outputs_unit['y'] / inputs_unit['x'] ** i))
         return OrderedDict(mapping)
 
@@ -971,7 +971,7 @@ class Polynomial2D(PolynomialModel):
         for i in lencoeff:
             for j in lencoeff:
                 if i + j <= self.degree:
-                    name = 'c{0}_{1}'.format(j, i)
+                    name = f'c{j}_{i}'
                     coeff = coeffs[self.param_names.index(name)]
                     invlex_coeffs.append(coeff)
         return invlex_coeffs[::-1]
@@ -1015,7 +1015,7 @@ class Polynomial2D(PolynomialModel):
             for j in range(self.degree + 1):
                 if i + j > 2:
                     continue
-                par = getattr(self, 'c{0}_{1}'.format(i, j))
+                par = getattr(self, f'c{i}_{j}')
                 mapping.append((par.name, outputs_unit['z'] / inputs_unit['x'] ** i / inputs_unit['y'] ** j))
         return OrderedDict(mapping)
 
@@ -1321,27 +1321,27 @@ class _SIP1D(PolynomialBase):
     def _generate_coeff_names(self, coeff_prefix):
         names = []
         for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, i, 0))
+            names.append('{}_{}_{}'.format(coeff_prefix, i, 0))
         for i in range(2, self.order + 1):
-            names.append('{0}_{1}_{2}'.format(coeff_prefix, 0, i))
+            names.append('{}_{}_{}'.format(coeff_prefix, 0, i))
         for i in range(1, self.order):
             for j in range(1, self.order):
                 if i + j < self.order + 1:
-                    names.append('{0}_{1}_{2}'.format(coeff_prefix, i, j))
+                    names.append(f'{coeff_prefix}_{i}_{j}')
         return names
 
     def _coeff_matrix(self, coeff_prefix, coeffs):
         mat = np.zeros((self.order + 1, self.order + 1))
         for i in range(2, self.order + 1):
-            attr = '{0}_{1}_{2}'.format(coeff_prefix, i, 0)
+            attr = '{}_{}_{}'.format(coeff_prefix, i, 0)
             mat[i, 0] = coeffs[self.param_names.index(attr)]
         for i in range(2, self.order + 1):
-            attr = '{0}_{1}_{2}'.format(coeff_prefix, 0, i)
+            attr = '{}_{}_{}'.format(coeff_prefix, 0, i)
             mat[0, i] = coeffs[self.param_names.index(attr)]
         for i in range(1, self.order):
             for j in range(1, self.order):
                 if i + j < self.order + 1:
-                    attr = '{0}_{1}_{2}'.format(coeff_prefix, i, j)
+                    attr = f'{coeff_prefix}_{i}_{j}'
                     mat[i, j] = coeffs[self.param_names.index(attr)]
         return mat
 
@@ -1419,11 +1419,11 @@ class SIP(Model):
                          name=name, meta=meta)
 
     def __repr__(self):
-        return '<{0}({1!r})>'.format(self.__class__.__name__,
+        return '<{}({!r})>'.format(self.__class__.__name__,
             [self.shift_a, self.shift_b, self.sip1d_a, self.sip1d_b])
 
     def __str__(self):
-        parts = ['Model: {0}'.format(self.__class__.__name__)]
+        parts = [f'Model: {self.__class__.__name__}']
         for model in [self.shift_a, self.shift_b, self.sip1d_a, self.sip1d_b]:
             parts.append(indent(str(model), width=4))
             parts.append('')
@@ -1493,11 +1493,11 @@ class InverseSIP(Model):
                          name=name, meta=meta)
 
     def __repr__(self):
-        return '<{0}({1!r})>'.format(self.__class__.__name__,
+        return '<{}({!r})>'.format(self.__class__.__name__,
             [self.sip1d_ap, self.sip1d_bp])
 
     def __str__(self):
-        parts = ['Model: {0}'.format(self.__class__.__name__)]
+        parts = [f'Model: {self.__class__.__name__}']
         for model in [self.sip1d_ap, self.sip1d_bp]:
             parts.append(indent(str(model), width=4))
             parts.append('')

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1992,7 +1992,7 @@ class AffineTransformation2D(Model):
 
         if det == 0:
             raise InputParameterError(
-                "Transformation matrix is singular; {0} model does not "
+                "Transformation matrix is singular; {} model does not "
                 "have an inverse".format(self.__class__.__name__))
 
         matrix = np.linalg.inv(self.matrix.value)

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -141,11 +141,11 @@ class EulerAngleRotation(_EulerRotation, Model):
         if len(axes_order) != 3:
             raise TypeError(
                 "Expected axes_order to be a character sequence of length 3,"
-                "got {0}".format(axes_order))
+                "got {}".format(axes_order))
         unrecognized = set(axes_order).difference(self.axes)
         if unrecognized:
-            raise ValueError("Unrecognized axis label {0}; "
-                             "should be one of {1} ".format(unrecognized, self.axes))
+            raise ValueError("Unrecognized axis label {}; "
+                             "should be one of {} ".format(unrecognized, self.axes))
         self.axes_order = axes_order
         qs = [isinstance(par, u.Quantity) for par in [phi, theta, psi]]
         if any(qs) and not all(qs):

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -158,8 +158,8 @@ def _arith_oper(left, right):
 
     if left_inputs != right_inputs or left_outputs != right_outputs:
         raise ModelDefinitionError(
-            "Unsupported operands for arithmetic operator: left (n_inputs={0}, "
-            "n_outputs={1}) and right (n_inputs={2}, n_outputs={3}); "
+            "Unsupported operands for arithmetic operator: left (n_inputs={}, "
+            "n_outputs={}) and right (n_inputs={}, n_outputs={}); "
             "models must have the same n_inputs and the same "
             "n_outputs for this operator.".format(
                 left_inputs, left_outputs, right_inputs, right_outputs))
@@ -282,7 +282,7 @@ def _cdot(left, right):
     except ValueError:
         raise ModelDefinitionError(
             'Models cannot be combined with the "|" operator; '
-            'left coord_matrix is {0}, right coord_matrix is {1}'.format(
+            'left coord_matrix is {}, right coord_matrix is {}'.format(
                 cright, cleft))
     return result
 

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -111,7 +111,7 @@ class _Tabular(Model):
 
         if self.lookup_table.ndim != lookup_table.ndim:
             raise ValueError("lookup_table should be an array with "
-                             "{0} dimensions.".format(self.lookup_table.ndim))
+                             "{} dimensions.".format(self.lookup_table.ndim))
 
         if points is None:
             points = tuple(np.arange(x, dtype=float)
@@ -123,14 +123,14 @@ class _Tabular(Model):
             if npts != lookup_table.ndim:
                 raise ValueError(
                     "Expected grid points in "
-                    "{0} directions, got {1}.".format(lookup_table.ndim, npts))
+                    "{} directions, got {}.".format(lookup_table.ndim, npts))
             if (npts > 1 and isinstance(points[0], u.Quantity) and
                     len(set([getattr(p, 'unit', None) for p in points])) > 1):
                 raise ValueError('points must all have the same unit.')
 
         if isinstance(fill_value, u.Quantity):
             if not isinstance(lookup_table, u.Quantity):
-                raise ValueError('fill value is in {0} but expected to be '
+                raise ValueError('fill value is in {} but expected to be '
                                  'unitless.'.format(fill_value.unit))
             fill_value = fill_value.to(lookup_table.unit).value
 
@@ -141,7 +141,7 @@ class _Tabular(Model):
         self.fill_value = fill_value
 
     def __repr__(self):
-        fmt = "<{0}(points={1}, lookup_table={2})>".format(
+        fmt = "<{}(points={}, lookup_table={})>".format(
             self.__class__.__name__, self.points, self.lookup_table)
         return fmt
 
@@ -159,7 +159,7 @@ class _Tabular(Model):
             ('  bounds_error', self.bounds_error)
         ]
 
-        parts = ['{0}: {1}'.format(keyword, value)
+        parts = [f'{keyword}: {value}'
                  for keyword, value in default_keywords
                  if value is not None]
 
@@ -279,7 +279,7 @@ def tabular_model(dim, name=None):
         raise ValueError('Lookup table must have at least one dimension.')
 
     table = np.zeros([2] * dim)
-    inputs = tuple('x{0}'.format(idx) for idx in range(table.ndim))
+    inputs = tuple(f'x{idx}' for idx in range(table.ndim))
     members = {'lookup_table': table, 'inputs': inputs}
 
     if dim == 1:
@@ -290,7 +290,7 @@ def tabular_model(dim, name=None):
     if name is None:
         model_id = _Tabular._id
         _Tabular._id += 1
-        name = 'Tabular{0}'.format(model_id)
+        name = f'Tabular{model_id}'
 
     return type(str(name), (_Tabular,), members)
 

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -162,7 +162,7 @@ class Fittable2DModelTester:
         x = test_parameters['x_values']
         y = test_parameters['y_values']
         z = test_parameters['z_values']
-        assert np.all((np.abs(model(x, y) - z) < self.eval_error))
+        assert np.all(np.abs(model(x, y) - z) < self.eval_error)
 
     def test_bounding_box2D(self, model_class, test_parameters):
         """Test bounding box evaluation"""

--- a/astropy/modeling/tests/test_projections.py
+++ b/astropy/modeling/tests/test_projections.py
@@ -38,13 +38,13 @@ pars.remove(('XPH',))
 def test_Sky2Pix(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(code))
+    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
     params = []
     for i in range(3):
-        key = 'PV2_{0}'.format(i + 1)
+        key = 'PV2_{}'.format(i + 1)
         if key in header:
             params.append(header[key])
 
@@ -65,13 +65,13 @@ def test_Sky2Pix(code):
 def test_Pix2Sky(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(code))
+    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
     params = []
     for i in range(3):
-        key = 'PV2_{0}'.format(i + 1)
+        key = 'PV2_{}'.format(i + 1)
         if key in header:
             params.append(header[key])
 
@@ -93,13 +93,13 @@ def test_Pix2Sky(code):
 def test_Sky2Pix_unit(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(code))
+    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
     params = []
     for i in range(3):
-        key = 'PV2_{0}'.format(i + 1)
+        key = 'PV2_{}'.format(i + 1)
         if key in header:
             params.append(header[key])
 
@@ -120,13 +120,13 @@ def test_Sky2Pix_unit(code):
 def test_Pix2Sky_unit(code):
     """Check astropy model eval against wcslib eval"""
 
-    wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(code))
+    wcs_map = os.path.join(MAPS_DIR, f"1904-66_{code}.hdr")
     test_file = get_pkg_data_filename(wcs_map)
     header = fits.Header.fromfile(test_file, endcard=False, padding=False)
 
     params = []
     for i in range(3):
-        key = 'PV2_{0}'.format(i + 1)
+        key = 'PV2_{}'.format(i + 1)
         if key in header:
             params.append(header[key])
 
@@ -170,7 +170,7 @@ class TestZenithalPerspective:
 
     def setup_class(self):
         ID = 'AZP'
-        wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(ID))
+        wcs_map = os.path.join(MAPS_DIR, f"1904-66_{ID}.hdr")
         test_file = get_pkg_data_filename(wcs_map)
         header = fits.Header.fromfile(test_file, endcard=False, padding=False)
         self.wazp = wcs.WCS(header)
@@ -201,7 +201,7 @@ class TestCylindricalPerspective:
 
     def setup_class(self):
         ID = "CYP"
-        wcs_map = os.path.join(MAPS_DIR, "1904-66_{0}.hdr".format(ID))
+        wcs_map = os.path.join(MAPS_DIR, f"1904-66_{ID}.hdr")
         test_file = get_pkg_data_filename(wcs_map)
         header = fits.Header.fromfile(test_file, endcard=False, padding=False)
         self.wazp = wcs.WCS(header)

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -275,7 +275,7 @@ class ExpressionTree:
         operands = deque()
 
         if format_leaf is None:
-            format_leaf = lambda i, l: '[{0}]'.format(i)
+            format_leaf = lambda i, l: f'[{i}]'
 
         for node in self.traverse_postorder():
             if node.isleaf:
@@ -289,10 +289,10 @@ class ExpressionTree:
 
             if (node.left is not None and not node.left.isleaf and
                     operator_precedence[node.left.value] < oper_order):
-                left = '({0})'.format(left)
+                left = f'({left})'
             if (node.right is not None and not node.right.isleaf and
                     operator_precedence[node.right.value] < oper_order):
-                right = '({0})'.format(right)
+                right = f'({right})'
 
             operands.append(' '.join((left, node.value, right)))
 
@@ -483,7 +483,7 @@ class _BoundingBox(tuple):
         if nd == 1:
             MESSAGE = "Bounding box for {0} model must be a sequence of length "
             "2 consisting of a lower and upper bound, or a 1-tuple "
-            "containing such a sequence as its sole element.".format(model.name)
+            f"containing such a sequence as its sole element."
 
             try:
                 valid_shape = np.shape(bounding_box) in ((2,), (1, 2))
@@ -504,7 +504,7 @@ class _BoundingBox(tuple):
             MESSAGE = "Bounding box for {0} model must be a sequence of length "
             "{1} (the number of model inputs) consisting of pairs of "
             "lower and upper bounds for those inputs on which to "
-            "evaluate the model.".format(model.name, nd)
+            f"evaluate the model."
 
             try:
                 valid_shape = all([len(i) == 2 for i in bounding_box])

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -403,8 +403,8 @@ class CCDData(NDDataArray):
 
         if len(key) > 8 and len(value) > 72:
             short_name = key[:8]
-            self.meta['HIERARCH {0}'.format(key.upper())] = (
-                short_name, "Shortened name for {}".format(key))
+            self.meta['HIERARCH {}'.format(key.upper())] = (
+                short_name, f"Shortened name for {key}")
             self.meta[short_name] = value
         else:
             self.meta[key] = value
@@ -552,7 +552,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
     }
     for key, msg in unsupport_open_keywords.items():
         if key in kwd:
-            prefix = 'unsupported keyword: {0}.'.format(key)
+            prefix = f'unsupported keyword: {key}.'
             raise TypeError(' '.join([prefix, msg]))
     with fits.open(filename, **kwd) as hdus:
         hdr = hdus[hdu].header
@@ -591,7 +591,7 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                     comb_hdr.extend(hdr, unique=True)
                     hdr = comb_hdr
                     log.info("first HDU with data is extension "
-                             "{0}.".format(hdu))
+                             "{}.".format(hdu))
                     break
 
         if 'bunit' in hdr:
@@ -618,8 +618,8 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                         'file before reading it.'
                         .format(fits_unit_string))
             else:
-                log.info("using the unit {0} passed to the FITS reader instead "
-                         "of the unit {1} in the FITS file."
+                log.info("using the unit {} passed to the FITS reader instead "
+                         "of the unit {} in the FITS file."
                          .format(unit, fits_unit_string))
 
         use_unit = unit or fits_unit_string

--- a/astropy/nddata/compat.py
+++ b/astropy/nddata/compat.py
@@ -118,7 +118,7 @@ class NDDataArray(NDArithmeticMixin, NDSlicingMixin, NDIOMixin, NDData):
                 if not self.unit and value._unit:
                     # Raise an error if uncertainty has unit and data does not
                     raise ValueError("Cannot assign an uncertainty with unit "
-                                     "to {0} without "
+                                     "to {} without "
                                      "a unit".format(class_name))
                 self._uncertainty = value
                 self._uncertainty.parent_nddata = self

--- a/astropy/nddata/decorators.py
+++ b/astropy/nddata/decorators.py
@@ -168,7 +168,7 @@ def support_nddata(_func=None, accepts=NDData,
         # First argument should be data
         if not func_args or func_args[0] != attr_arg_map.get('data', 'data'):
             raise ValueError("Can only wrap functions whose first positional "
-                             "argument is `{0}`"
+                             "argument is `{}`"
                              "".format(attr_arg_map.get('data', 'data')))
 
         @wraps(func)
@@ -178,7 +178,7 @@ def support_nddata(_func=None, accepts=NDData,
             input_data = data
             ignored = []
             if not unpack and isinstance(data, NDData):
-                raise TypeError("Only NDData sub-classes that inherit from {0}"
+                raise TypeError("Only NDData sub-classes that inherit from {}"
                                 " can be used by this function"
                                 "".format(accepts.__name__))
 
@@ -225,8 +225,8 @@ def support_nddata(_func=None, accepts=NDData,
                                  (bound_args.arguments[propmatch] is not
                                   sig[propmatch].default))):
                             warnings.warn(
-                                "Property {0} has been passed explicitly and "
-                                "as an NDData property{1}, using explicitly "
+                                "Property {} has been passed explicitly and "
+                                "as an NDData property{}, using explicitly "
                                 "specified value"
                                 "".format(propmatch, '' if prop == propmatch
                                           else ' ' + prop),

--- a/astropy/nddata/flag_collection.py
+++ b/astropy/nddata/flag_collection.py
@@ -42,7 +42,7 @@ class FlagCollection(OrderedDict):
             if value.shape == self.shape:
                 OrderedDict.__setitem__(self, item, value, **kwargs)
             else:
-                raise ValueError("flags array shape {0} does not match data "
-                                 "shape {1}".format(value.shape, self.shape))
+                raise ValueError("flags array shape {} does not match data "
+                                 "shape {}".format(value.shape, self.shape))
         else:
             raise TypeError("flags should be given as a Numpy array")

--- a/astropy/nddata/mixins/ndarithmetic.py
+++ b/astropy/nddata/mixins/ndarithmetic.py
@@ -224,7 +224,7 @@ class NDArithmeticMixin:
             try:
                 kwds2[splitted[0]][splitted[1]] = kwds[i]
             except KeyError:
-                raise KeyError('Unknown prefix {0} for parameter {1}'
+                raise KeyError('Unknown prefix {} for parameter {}'
                                ''.format(splitted[0], i))
 
         kwargs = {}

--- a/astropy/nddata/nduncertainty.py
+++ b/astropy/nddata/nduncertainty.py
@@ -326,7 +326,7 @@ class NDUncertainty(metaclass=ABCMeta):
         # Check if the subclass supports correlation
         if not self.supports_correlated:
             if isinstance(correlation, np.ndarray) or correlation != 0:
-                raise ValueError("{0} does not support uncertainty propagation"
+                raise ValueError("{} does not support uncertainty propagation"
                                  " with correlation."
                                  "".format(self.__class__.__name__))
 
@@ -591,7 +591,7 @@ class _VariancePropagationMixin:
             if (other_uncert.unit and
                 to_variance(1 * other_uncert.unit) !=
                     ((1 * other_uncert.parent_nddata.unit)**2).unit):
-                d_b = to_variance((other_uncert.array * other_uncert.unit)).to(
+                d_b = to_variance(other_uncert.array * other_uncert.unit).to(
                     (1 * other_uncert.parent_nddata.unit)**2).value
             else:
                 d_b = to_variance(other_uncert.array)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -961,7 +961,7 @@ def test_recognized_fits_formats_for_read_write(tmpdir):
     supported_extensions = ['fit', 'fits', 'fts']
 
     for ext in supported_extensions:
-        path = tmpdir.join("test.{}".format(ext))
+        path = tmpdir.join(f"test.{ext}")
         ccd_data.write(path.strpath)
         from_disk = CCDData.read(path.strpath)
         assert (ccd_data.data == from_disk.data).all()

--- a/astropy/samp/client.py
+++ b/astropy/samp/client.py
@@ -121,7 +121,7 @@ class SAMPClient:
             protocol = 'http'
 
             self._xmlrpcAddr = urlunparse((protocol,
-                                           '{0}:{1}'.format(self._addr or self._host_name,
+                                           '{}:{}'.format(self._addr or self._host_name,
                                                             self._port),
                                            '', '', '', ''))
 
@@ -154,7 +154,7 @@ class SAMPClient:
             self._thread.join(timeout)
         if self._thread.is_alive():
             raise SAMPClientError("Client was not shut down successfully "
-                                  "(timeout={0}s)".format(timeout))
+                                  "(timeout={}s)".format(timeout))
 
     @property
     def is_running(self):
@@ -179,7 +179,7 @@ class SAMPClient:
             try:
                 read_ready = select.select([self.client.socket], [], [], 0.1)[0]
             except OSError as exc:
-                warnings.warn("Call to select in SAMPClient failed: {0}".format(exc),
+                warnings.warn(f"Call to select in SAMPClient failed: {exc}",
                               SAMPWarning)
             else:
                 if read_ready:

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -241,7 +241,7 @@ class SAMPHubServer:
         prot = 'http'
 
         self._port = self._server.socket.getsockname()[1]
-        addr = "{0}:{1}".format(self._addr or self._host_name, self._port)
+        addr = "{}:{}".format(self._addr or self._host_name, self._port)
         self._url = urlunparse((prot, addr, '', '', '', ''))
         self._server.register_introspection_functions()
         self._register_standard_api(self._server)
@@ -267,7 +267,7 @@ class SAMPHubServer:
             self._register_web_profile_api(self._web_profile_server)
             log.info("Hub set to run with Web Profile support enabled.")
         except socket.error:
-            log.warning("Port {0} already in use. Impossible to run the "
+            log.warning("Port {} already in use. Impossible to run the "
                         "Hub with Web Profile support.".format(self._web_port),
                         SAMPWarning)
             self._web_profile = False
@@ -330,7 +330,7 @@ class SAMPHubServer:
                     if (now - self._client_activity_time[private_key] > self._client_timeout
                         and private_key != self._hub_private_key):
                         warnings.warn(
-                            "Client {} timeout expired!".format(private_key),
+                            f"Client {private_key} timeout expired!",
                             SAMPWarning)
                         self._notify_disconnection(private_key)
                         self._unregister(private_key)
@@ -422,7 +422,7 @@ class SAMPHubServer:
         # Custom keys
 
         params['hub.id'] = self.id
-        params['hub.label'] = self._label or "Hub {0}".format(self.id)
+        params['hub.label'] = self._label or f"Hub {self.id}"
 
         return params
 
@@ -534,7 +534,7 @@ class SAMPHubServer:
             try:
                 read_ready = select.select([self._server.socket], [], [], 0.01)[0]
             except OSError as exc:
-                warnings.warn("Call to select() in SAMPHubServer failed: {0}".format(exc),
+                warnings.warn(f"Call to select() in SAMPHubServer failed: {exc}",
                               SAMPWarning)
             else:
                 if read_ready:
@@ -557,7 +557,7 @@ class SAMPHubServer:
                 try:
                     read_ready = select.select([self._web_profile_server.socket], [], [], 0.01)[0]
                 except OSError as exc:
-                    warnings.warn("Call to select() in SAMPHubServer failed: {0}".format(exc),
+                    warnings.warn(f"Call to select() in SAMPHubServer failed: {exc}",
                                   SAMPWarning)
                 else:
                     if read_ready:
@@ -639,7 +639,7 @@ class SAMPHubServer:
 
         for mtype in msubs:
             if mtype in self._mtype2ids and private_key in self._mtype2ids[mtype]:
-                log.debug("notify disconnection to {}".format(public_id))
+                log.debug(f"notify disconnection to {public_id}")
                 self._launch_thread(target=_xmlrpc_call_disconnect,
                                    args=(endpoint, private_key,
                                          self._hub_public_id,
@@ -715,7 +715,7 @@ class SAMPHubServer:
         self._client_id_counter += 1
         public_id = 'cli#hub'
         if self._client_id_counter > 0:
-            public_id = "cli#{}".format(self._client_id_counter)
+            public_id = f"cli#{self._client_id_counter}"
 
         return private_key, public_id
 
@@ -756,7 +756,7 @@ class SAMPHubServer:
                     del self._web_profile_callbacks[private_key]
                 self._web_profile_server.remove_client(private_key)
 
-        log.debug("unregister {} ({})".format(public_key, private_key))
+        log.debug(f"unregister {public_key} ({private_key})")
 
         return ""
 

--- a/astropy/samp/hub_script.py
+++ b/astropy/samp/hub_script.py
@@ -136,7 +136,7 @@ def hub_script(timeout=0):
         except NameError:
             pass
     except OSError as e:
-        print("[SAMP] Error: I/O error({0}): {1}".format(e.errno, e.strerror))
+        print(f"[SAMP] Error: I/O error({e.errno}): {e.strerror}")
         sys.exit(1)
     except SystemExit:
         pass

--- a/astropy/samp/lockfile_helpers.py
+++ b/astropy/samp/lockfile_helpers.py
@@ -46,10 +46,10 @@ def write_lockfile(lockfilename, lockfiledict):
 
     lockfile = open(lockfilename, "w")
     now_iso = datetime.datetime.now().isoformat()
-    lockfile.write("# SAMP lockfile written on {}\n".format(now_iso))
+    lockfile.write(f"# SAMP lockfile written on {now_iso}\n")
     lockfile.write("# Standard Profile required keys\n")
     for key, value in lockfiledict.items():
-        lockfile.write("{0}={1}\n".format(key, value))
+        lockfile.write(f"{key}={value}\n")
     lockfile.close()
 
 
@@ -99,7 +99,7 @@ def create_lock_file(lockfilename=None, mode=None, hub_id=None,
                              stat.S_IREAD + stat.S_IWRITE + stat.S_IEXEC)
 
                 lockfilename = os.path.join(lockfiledir,
-                                            "samp-hub-{}".format(hub_id))
+                                            f"samp-hub-{hub_id}")
 
         else:
             log.debug("Running mode: multiple")

--- a/astropy/samp/tests/test_helpers.py
+++ b/astropy/samp/tests/test_helpers.py
@@ -33,7 +33,7 @@ def assert_output(mtype, private_key, sender_id, params, timeout=None):
             break
         except (OSError, EOFError):
             if timeout is not None and time.time() - start > timeout:
-                raise Exception("Timeout while waiting for file: {0}".format(filename))
+                raise Exception(f"Timeout while waiting for file: {filename}")
 
     assert rec_mtype == mtype
     assert rec_private_key == private_key

--- a/astropy/samp/tests/test_web_profile.py
+++ b/astropy/samp/tests/test_web_profile.py
@@ -69,15 +69,15 @@ class TestWebProfile(BaseTestStandardProfile):
 
         # Check some additional queries to the server
 
-        with get_readable_fileobj('http://localhost:{0}/crossdomain.xml'.format(self.hub._web_port)) as f:
+        with get_readable_fileobj(f'http://localhost:{self.hub._web_port}/crossdomain.xml') as f:
             assert f.read() == CROSS_DOMAIN
 
-        with get_readable_fileobj('http://localhost:{0}/clientaccesspolicy.xml'.format(self.hub._web_port)) as f:
+        with get_readable_fileobj(f'http://localhost:{self.hub._web_port}/clientaccesspolicy.xml') as f:
             assert f.read() == CLIENT_ACCESS_POLICY
 
         # Check headers
 
-        req = Request('http://localhost:{0}/crossdomain.xml'.format(self.hub._web_port))
+        req = Request(f'http://localhost:{self.hub._web_port}/crossdomain.xml')
         req.add_header('Origin', 'test_web_profile')
         resp = urlopen(req)
 

--- a/astropy/samp/tests/web_profile_test_helpers.py
+++ b/astropy/samp/tests/web_profile_test_helpers.py
@@ -52,12 +52,12 @@ class SAMPWebHubProxy(SAMPHubProxy):
 
         try:
             self.proxy = ServerProxyPool(pool_size, xmlrpc.ServerProxy,
-                                         'http://127.0.0.1:{0}'.format(web_port),
+                                         f'http://127.0.0.1:{web_port}',
                                          allow_none=1)
             self.ping()
             self._connected = True
         except xmlrpc.ProtocolError as p:
-            raise SAMPHubError("Protocol Error {}: {}".format(p.errcode, p.errmsg))
+            raise SAMPHubError(f"Protocol Error {p.errcode}: {p.errmsg}")
 
     @property
     def _samp_hub(self):

--- a/astropy/samp/utils.py
+++ b/astropy/samp/utils.py
@@ -53,7 +53,7 @@ class _ServerProxyPoolMethod:
         self.__name = name
 
     def __getattr__(self, name):
-        return _ServerProxyPoolMethod(self.__proxies, "{}.{}".format(self.__name, name))
+        return _ServerProxyPoolMethod(self.__proxies, f"{self.__name}.{name}")
 
     def __call__(self, *args, **kwrds):
         proxy = self.__proxies.get()
@@ -142,7 +142,7 @@ class _HubAsClientMethod:
         self.__name = name
 
     def __getattr__(self, name):
-        return _HubAsClientMethod(self.__send, "{}.{}".format(self.__name, name))
+        return _HubAsClientMethod(self.__send, f"{self.__name}.{name}")
 
     def __call__(self, *args):
         return self.__send(self.__name, args)

--- a/astropy/samp/web_profile.py
+++ b/astropy/samp/web_profile.py
@@ -55,7 +55,7 @@ class WebProfileRequestHandler(SAMPSimpleXMLRPCRequestHandler):
 
             self.send_response(200, 'OK')
             self.send_header('Content-Type', 'text/x-cross-domain-policy')
-            self.send_header("Content-Length", "{0}".format(len(response)))
+            self.send_header("Content-Length", "{}".format(len(response)))
             self.end_headers()
             self.wfile.write(response.encode('utf-8'))
             self.wfile.flush()
@@ -68,7 +68,7 @@ class WebProfileRequestHandler(SAMPSimpleXMLRPCRequestHandler):
 
             self.send_response(200, 'OK')
             self.send_header('Content-Type', 'text/xml')
-            self.send_header("Content-Length", "{0}".format(len(response)))
+            self.send_header("Content-Length", "{}".format(len(response)))
             self.end_headers()
             self.wfile.write(response.encode('utf-8'))
             self.wfile.flush()
@@ -104,7 +104,7 @@ class WebProfileRequestHandler(SAMPSimpleXMLRPCRequestHandler):
 
         split_path = self.path.split('?')
 
-        if split_path[0] in ['/translator/{}'.format(clid) for clid in self.server.clients]:
+        if split_path[0] in [f'/translator/{clid}' for clid in self.server.clients]:
             # Request of a file proxying
             urlpath = parse_qs(split_path[1])
             try:
@@ -123,7 +123,7 @@ class WebProfileRequestHandler(SAMPSimpleXMLRPCRequestHandler):
     def is_http_path_valid(self):
 
         valid_paths = (["/clientaccesspolicy.xml", "/crossdomain.xml"] +
-                       ['/translator/{}'.format(clid) for clid in self.server.clients])
+                       [f'/translator/{clid}' for clid in self.server.clients])
         return self.path.split('?')[0] in valid_paths
 
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -266,7 +266,7 @@ def binom_conf_interval(k, n, conf=0.68269, interval='wilson'):
 
         conf_interval = np.array([lowerbound, upperbound])
     else:
-        raise ValueError('Unrecognized interval: {0:s}'.format(interval))
+        raise ValueError(f'Unrecognized interval: {interval:s}')
 
     return conf_interval
 
@@ -451,13 +451,13 @@ def binned_binom_proportion(x, success, bins=10, range=None, conf=0.68269,
 
 def _check_poisson_conf_inputs(sigma, background, conflevel, name):
     if sigma != 1:
-        raise ValueError("Only sigma=1 supported for interval {0}"
+        raise ValueError("Only sigma=1 supported for interval {}"
                          .format(name))
     if background != 0:
-        raise ValueError("background not supported for interval {0}"
+        raise ValueError("background not supported for interval {}"
                          .format(name))
     if conflevel is not None:
-        raise ValueError("conflevel not supported for interval {0}"
+        raise ValueError("conflevel not supported for interval {}"
                          .format(name))
 
 
@@ -702,7 +702,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
             conf_interval[0, n == 0] = 0
     elif interval == 'kraft-burrows-nousek':
         if conflevel is None:
-            raise ValueError('Set conflevel for method {0}. (sigma is '
+            raise ValueError('Set conflevel for method {}. (sigma is '
                              'ignored.)'.format(interval))
         conflevel = np.asanyarray(conflevel)
         if np.any(conflevel <= 0) or np.any(conflevel >= 1):

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -64,7 +64,7 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
         elif bins == 'freedman':
             da, bins = freedman_bin_width(a, True)
         else:
-            raise ValueError("unrecognized bin code: '{}'".format(bins))
+            raise ValueError(f"unrecognized bin code: '{bins}'")
 
         if range:
             # Check that the upper and lower edges are what was requested.

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -217,8 +217,8 @@ class SigmaClip:
         self.stdfunc = self._parse_stdfunc(stdfunc)
 
     def __repr__(self):
-        return ('SigmaClip(sigma={0}, sigma_lower={1}, sigma_upper={2}, '
-                'maxiters={3}, cenfunc={4}, stdfunc={5})'
+        return ('SigmaClip(sigma={}, sigma_lower={}, sigma_upper={}, '
+                'maxiters={}, cenfunc={}, stdfunc={})'
                 .format(self.sigma, self.sigma_lower, self.sigma_upper,
                         self.maxiters, self.cenfunc, self.stdfunc))
 
@@ -227,7 +227,7 @@ class SigmaClip:
         attrs = ['sigma', 'sigma_lower', 'sigma_upper', 'maxiters', 'cenfunc',
                  'stdfunc']
         for attr in attrs:
-            lines.append('    {0}: {1}'.format(attr, getattr(self, attr)))
+            lines.append('    {}: {}'.format(attr, getattr(self, attr)))
         return '\n'.join(lines)
 
     def _parse_cenfunc(self, cenfunc):
@@ -245,14 +245,14 @@ class SigmaClip:
                     cenfunc = np.nanmean  # pragma: no cover
 
             else:
-                raise ValueError('{} is an invalid cenfunc.'.format(cenfunc))
+                raise ValueError(f'{cenfunc} is an invalid cenfunc.')
 
         return cenfunc
 
     def _parse_stdfunc(self, stdfunc):
         if isinstance(stdfunc, str):
             if stdfunc != 'std':
-                raise ValueError('{} is an invalid stdfunc.'.format(stdfunc))
+                raise ValueError(f'{stdfunc} is an invalid stdfunc.')
 
             if HAS_BOTTLENECK:
                 stdfunc = _nanstd

--- a/astropy/stats/spatial.py
+++ b/astropy/stats/spatial.py
@@ -325,6 +325,6 @@ class RipleysKEstimator:
 
             ripley = self.area * 2. * ripley / (npts * (npts - 1))
         else:
-            raise ValueError('mode {} is not implemented.'.format(mode))
+            raise ValueError(f'mode {mode} is not implemented.')
 
         return ripley

--- a/astropy/table/bst.py
+++ b/astropy/table/bst.py
@@ -275,7 +275,7 @@ class BST:
             return self._inorder(self.root, [])
         elif order == 'postorder':
             return self._postorder(self.root, [])
-        raise ValueError("Invalid traversal method: \"{0}\"".format(order))
+        raise ValueError(f"Invalid traversal method: \"{order}\"")
 
     def items(self):
         '''
@@ -518,7 +518,7 @@ class FastBase:
         if self.unique:
             if key in self.data:
                 # already exists
-                raise ValueError('Cannot add duplicate value "{0}" in a '
+                raise ValueError('Cannot add duplicate value "{}" in a '
                                  'unique index'.format(key))
             self.data[key] = val
         else:

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -130,7 +130,7 @@ class FalseArray(np.ndarray):
     def __setitem__(self, item, val):
         val = np.asarray(val)
         if np.any(val):
-            raise ValueError('Cannot set any element of {0} class to True'
+            raise ValueError('Cannot set any element of {} class to True'
                              .format(self.__class__.__name__))
 
 
@@ -432,8 +432,8 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
             # revert to restore previous format if there was one
             self._format = prev_format
             raise ValueError(
-                "Invalid format for column '{0}': could not display "
-                "values in this column using this format ({1})".format(
+                "Invalid format for column '{}': could not display "
+                "values in this column using this format ({})".format(
                     self.name, err.args[0]))
 
     @property
@@ -877,7 +877,7 @@ class Column(BaseColumn):
                           ('length', len(self))):
 
             if val is not None:
-                descr_vals.append('{0}={1!r}'.format(attr, val))
+                descr_vals.append(f'{attr}={val!r}')
 
         descr = '<' + ' '.join(descr_vals) + '>\n'
 

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -60,7 +60,7 @@ class TableRead(registry.UnifiedReadWrite):
             try:
                 out = cls(out, copy=False)
             except Exception:
-                raise TypeError('could not convert reader output to {0} '
+                raise TypeError('could not convert reader output to {} '
                                 'class.'.format(cls.__name__))
         return out
 

--- a/astropy/table/groups.py
+++ b/astropy/table/groups.py
@@ -43,9 +43,9 @@ def _table_group_by(table, keys):
     if isinstance(keys, (list, tuple)):
         for name in keys:
             if name not in table.colnames:
-                raise ValueError('Table does not have key column {0!r}'.format(name))
+                raise ValueError(f'Table does not have key column {name!r}')
             if table.masked and np.any(table[name].mask):
-                raise ValueError('Missing values in key column {0!r} are not allowed'.format(name))
+                raise ValueError(f'Missing values in key column {name!r} are not allowed')
 
         # Make a column slice of the table without copying
         table_keys = table.__class__([table[key] for key in keys], copy=False)
@@ -57,13 +57,13 @@ def _table_group_by(table, keys):
     elif isinstance(keys, (np.ndarray, Table)):
         table_keys = keys
         if len(table_keys) != len(table):
-            raise ValueError('Input keys array length {0} does not match table length {1}'
+            raise ValueError('Input keys array length {} does not match table length {}'
                              .format(len(table_keys), len(table)))
         table_index = None
         grouped_by_table_cols = False
 
     else:
-        raise TypeError('Keys input must be string, list, tuple, Table or numpy array, but got {0}'
+        raise TypeError('Keys input must be string, list, tuple, Table or numpy array, but got {}'
                         .format(type(keys)))
 
     # If there is not already an available index and table_keys is a Table then ensure
@@ -133,11 +133,11 @@ def column_group_by(column, keys):
         keys = keys.as_array()
 
     if not isinstance(keys, np.ndarray):
-        raise TypeError('Keys input must be numpy array, but got {0}'
+        raise TypeError('Keys input must be numpy array, but got {}'
                         .format(type(keys)))
 
     if len(keys) != len(column):
-        raise ValueError('Input keys array length {0} does not match column length {1}'
+        raise ValueError('Input keys array length {} does not match column length {}'
                          .format(len(keys), len(column)))
 
     idx_sort = keys.argsort()
@@ -206,7 +206,7 @@ class BaseGroups:
         return out
 
     def __repr__(self):
-        return '<{0} indices={1}>'.format(self.__class__.__name__, self.indices)
+        return f'<{self.__class__.__name__} indices={self.indices}>'
 
     def __len__(self):
         return len(self.indices) - 1
@@ -258,7 +258,7 @@ class ColumnGroups(BaseGroups):
             else:
                 vals = np.array([func(par_col[i0: i1]) for i0, i1 in zip(i0s, i1s)])
         except Exception:
-            raise TypeError("Cannot aggregate column '{0}' with type '{1}'"
+            raise TypeError("Cannot aggregate column '{}' with type '{}'"
                             .format(par_col.info.name,
                                     par_col.info.dtype))
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -163,7 +163,7 @@ class Index:
         for i, c in enumerate(self.columns):
             if c.info.name == col_name:
                 return i
-        raise ValueError("Column does not belong to index: {0}".format(col_name))
+        raise ValueError(f"Column does not belong to index: {col_name}")
 
     def insert_row(self, pos, vals, columns):
         '''
@@ -208,7 +208,7 @@ class Index:
             col_len = len(self.columns[0])
             return range(*row_specifier.indices(col_len))
         raise ValueError("Expected int, array of ints, or slice but "
-                         "got {0} in remove_rows".format(row_specifier))
+                         "got {} in remove_rows".format(row_specifier))
 
     def remove_rows(self, row_specifier):
         '''
@@ -244,7 +244,7 @@ class Index:
         '''
         # for removal, form a key consisting of column values in this row
         if not self.data.remove(tuple([col[row] for col in self.columns]), row):
-            raise ValueError("Could not remove row {0} from index".format(row))
+            raise ValueError(f"Could not remove row {row} from index")
         # decrement the row number of all later rows
         if reorder:
             self.data.shift_left(row)
@@ -563,7 +563,7 @@ class SlicedIndex:
     def __repr__(self):
         if self.original:
             return repr(self.index)
-        return 'Index slice {0} of\n{1}'.format(
+        return 'Index slice {} of\n{}'.format(
             (self.start, self.stop, self.step), self.index)
 
     def __str__(self):
@@ -640,7 +640,7 @@ def get_index(table, table_copy=None, names=None):
         names = set(table_copy.colnames)
 
     if not names <= set(table.colnames):
-        raise ValueError('{} is not a subset of table columns'.format(names))
+        raise ValueError(f'{names} is not a subset of table columns')
 
     for name in names:
         for index in table[name].info.indices:
@@ -709,7 +709,7 @@ class _IndexModeContext:
         if mode not in ('freeze', 'discard_on_copy', 'copy_on_getitem'):
             raise ValueError("Expected a mode of either 'freeze', "
                              "'discard_on_copy', or 'copy_on_getitem', got "
-                             "'{0}'".format(mode))
+                             "'{}'".format(mode))
 
     def __enter__(self):
         if self.mode == 'discard_on_copy':
@@ -757,7 +757,7 @@ class _IndexModeContext:
 
             return value
 
-        clsname = '_{0}WithIndexCopy'.format(cls.__name__)
+        clsname = f'_{cls.__name__}WithIndexCopy'
 
         new_cls = type(str(clsname), (cls,), {'__getitem__': __getitem__})
 
@@ -802,7 +802,7 @@ class TableIndices(list):
                 except ValueError:
                     pass
             # index search failed
-            raise IndexError("No index found for {0}".format(item))
+            raise IndexError(f"No index found for {item}")
 
         return super().__getitem__(item)
 
@@ -851,7 +851,7 @@ class TableLoc:
             for key in item:
                 p = index.find((key,))
                 if len(p) == 0:
-                    raise KeyError('No matches found for key {0}'.format(key))
+                    raise KeyError(f'No matches found for key {key}')
                 else:
                     rows.extend(p)
         return rows
@@ -872,7 +872,7 @@ class TableLoc:
         rows = self._get_rows(item)
 
         if len(rows) == 0:  # no matches found
-            raise KeyError('No matches found for key {0}'.format(item))
+            raise KeyError(f'No matches found for key {item}')
         elif len(rows) == 1:  # single row
             return self.table[rows[0]]
         return self.table[rows]
@@ -895,7 +895,7 @@ class TableLoc:
         """
         rows = self._get_rows(key)
         if len(rows) == 0:  # no matches found
-            raise KeyError('No matches found for key {0}'.format(key))
+            raise KeyError(f'No matches found for key {key}')
         elif len(rows) == 1:  # single row
             self.table[rows[0]] = value
         else:  # multiple rows
@@ -903,7 +903,7 @@ class TableLoc:
                 for row, val in zip(rows, value):
                     self.table[row] = val
             else:
-                raise ValueError('Right side should contain {0} values'.format(len(rows)))
+                raise ValueError('Right side should contain {} values'.format(len(rows)))
 
 
 class TableLocIndices(TableLoc):
@@ -923,7 +923,7 @@ class TableLocIndices(TableLoc):
         """
         rows = self._get_rows(item)
         if len(rows) == 0:  # no matches found
-            raise KeyError('No matches found for key {0}'.format(item))
+            raise KeyError(f'No matches found for key {item}')
         elif len(rows) == 1:  # single row
             return rows[0]
         return rows
@@ -953,6 +953,6 @@ class TableILoc(TableLoc):
         table_slice = self.table[rows]
 
         if len(table_slice) == 0:  # no matches found
-            raise IndexError('Invalid index for iloc: {0}'.format(item))
+            raise IndexError(f'Invalid index for iloc: {item}')
 
         return table_slice

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -71,7 +71,7 @@ def table_info(tbl, option='attributes', out=''):
     descr_vals = [tbl.__class__.__name__]
     if tbl.masked:
         descr_vals.append('masked=True')
-    descr_vals.append('length={0}'.format(len(tbl)))
+    descr_vals.append('length={}'.format(len(tbl)))
 
     outlines = ['<' + ' '.join(descr_vals) + '>']
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -154,7 +154,7 @@ class JSViewer:
             return conf.datatables_url[:-3]
 
     def ipynb(self, table_id, css=None, sort_columns='[]'):
-        html = '<style>{0}</style>'.format(css if css is not None
+        html = '<style>{}</style>'.format(css if css is not None
                                            else DEFAULT_CSS_NB)
         html += IPYNB_JS_SCRIPT.format(
             display_length=self.display_length,

--- a/astropy/table/meta.py
+++ b/astropy/table/meta.py
@@ -80,13 +80,13 @@ def _construct_odict(load, node):
     if not isinstance(node, yaml.SequenceNode):
         raise yaml.constructor.ConstructorError(
             "while constructing an ordered map", node.start_mark,
-            "expected a sequence, but found {}".format(node.id), node.start_mark)
+            f"expected a sequence, but found {node.id}", node.start_mark)
 
     for subnode in node.value:
         if not isinstance(subnode, yaml.MappingNode):
             raise yaml.constructor.ConstructorError(
                 "while constructing an ordered map", node.start_mark,
-                "expected a mapping of length 1, but found {}".format(subnode.id),
+                f"expected a mapping of length 1, but found {subnode.id}",
                 subnode.start_mark)
 
         if len(subnode.value) != 1:
@@ -143,7 +143,7 @@ def _repr_odict(dumper, data):
     >>> yaml.dump(data, default_flow_style=True)  # doctest: +SKIP
     '!!omap [foo: bar, mumble: quux, baz: gorp]\\n'
     """
-    return _repr_pairs(dumper, u'tag:yaml.org,2002:omap', data.items())
+    return _repr_pairs(dumper, 'tag:yaml.org,2002:omap', data.items())
 
 
 def _repr_column_dict(dumper, data):
@@ -154,7 +154,7 @@ def _repr_column_dict(dumper, data):
     are written in a fixed order that makes sense for astropy table
     columns.
     """
-    return dumper.represent_mapping(u'tag:yaml.org,2002:map', data)
+    return dumper.represent_mapping('tag:yaml.org,2002:map', data)
 
 
 def _get_col_attributes(col):
@@ -333,7 +333,7 @@ def get_header_from_yaml(lines):
         custom odict constructor.
         """
 
-    TableLoader.add_constructor(u'tag:yaml.org,2002:omap', _construct_odict)
+    TableLoader.add_constructor('tag:yaml.org,2002:omap', _construct_odict)
     # Now actually load the YAML data structure into `meta`
     header_yaml = textwrap.dedent('\n'.join(lines))
     try:

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -68,7 +68,7 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
     col_name_count = Counter(col_name_list)
     repeated_names = [name for name, count in col_name_count.items() if count > 1]
     if repeated_names:
-        raise TableMergeError('Merging column names resulted in duplicates: {0}.  '
+        raise TableMergeError('Merging column names resulted in duplicates: {}.  '
                               'Change uniq_col_name or table_names args to fix this.'
                               .format(repeated_names))
 
@@ -101,13 +101,13 @@ def get_descrs(arrays, col_name_map):
         except TableMergeError as tme:
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
-            raise TableMergeError("The '{0}' columns have incompatible types: {1}"
+            raise TableMergeError("The '{}' columns have incompatible types: {}"
                                   .format(names[0], tme._incompat_types))
 
         # Make sure all input shapes are the same
         uniq_shapes = set(col.shape[1:] for col in in_cols)
         if len(uniq_shapes) != 1:
-            raise TableMergeError('Key columns {0!r} have different shape'.format(name))
+            raise TableMergeError(f'Key columns {name!r} have different shape')
         shape = uniq_shapes.pop()
 
         out_descrs.append((fix_column_name(out_name), dtype, shape))
@@ -128,7 +128,7 @@ def common_dtype(cols):
     if len(uniq_types) > 1:
         # Embed into the exception the actual list of incompatible types.
         incompat_types = [col.dtype.name for col in cols]
-        tme = TableMergeError('Columns have incompatible types {0}'
+        tme = TableMergeError('Columns have incompatible types {}'
                               .format(incompat_types))
         tme._incompat_types = incompat_types
         raise tme

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -480,7 +480,7 @@ def unique(input_table, keys=None, silent=False, keep='first'):
             if not silent:
                 raise ValueError(
                     "cannot use columns with masked values as keys; "
-                    "remove column '{0}' from keys and rerun "
+                    "remove column '{}' from keys and rerun "
                     "unique()".format(key))
             del keys[keys.index(key)]
     if len(keys) == 0:
@@ -546,7 +546,7 @@ def get_col_name_map(arrays, common_names, uniq_col_name='{col_name}_{table_name
     col_name_count = Counter(col_name_list)
     repeated_names = [name for name, count in col_name_count.items() if count > 1]
     if repeated_names:
-        raise TableMergeError('Merging column names resulted in duplicates: {0}.  '
+        raise TableMergeError('Merging column names resulted in duplicates: {}.  '
                               'Change uniq_col_name or table_names args to fix this.'
                               .format(repeated_names))
 
@@ -579,13 +579,13 @@ def get_descrs(arrays, col_name_map):
         except TableMergeError as tme:
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
-            raise TableMergeError("The '{0}' columns have incompatible types: {1}"
+            raise TableMergeError("The '{}' columns have incompatible types: {}"
                                   .format(names[0], tme._incompat_types))
 
         # Make sure all input shapes are the same
         uniq_shapes = set(col.shape[1:] for col in in_cols)
         if len(uniq_shapes) != 1:
-            raise TableMergeError('Key columns {0!r} have different shape'.format(names))
+            raise TableMergeError(f'Key columns {names!r} have different shape')
         shape = uniq_shapes.pop()
 
         out_descrs.append((fix_column_name(out_name), dtype, shape))
@@ -603,7 +603,7 @@ def common_dtype(cols):
     try:
         return metadata.common_dtype(cols)
     except metadata.MergeConflictError as err:
-        tme = TableMergeError('Columns have incompatible types {0}'
+        tme = TableMergeError('Columns have incompatible types {}'
                               .format(err._incompat_types))
         tme._incompat_types = err._incompat_types
         raise tme
@@ -647,7 +647,7 @@ def _join(left, right, keys=None, join_type='inner',
 
     if join_type not in ('inner', 'outer', 'left', 'right'):
         raise ValueError("The 'join_type' argument should be in 'inner', "
-                         "'outer', 'left' or 'right' (got '{0}' instead)".
+                         "'outer', 'left' or 'right' (got '{}' instead)".
                          format(join_type))
 
     # If we have a single key, put it in a tuple
@@ -662,10 +662,10 @@ def _join(left, right, keys=None, join_type='inner',
     for arr, arr_label in ((left, 'Left'), (right, 'Right')):
         for name in keys:
             if name not in arr.colnames:
-                raise TableMergeError('{0} table does not have key column {1!r}'
+                raise TableMergeError('{} table does not have key column {!r}'
                                       .format(arr_label, name))
             if hasattr(arr[name], 'mask') and np.any(arr[name].mask):
-                raise TableMergeError('{0} key column {1!r} has missing values'
+                raise TableMergeError('{} key column {!r} has missing values'
                                       .format(arr_label, name))
             if not isinstance(arr[name], np.ndarray):
                 raise ValueError("non-ndarray column '{}' not allowed as a key column"
@@ -847,7 +847,7 @@ def _vstack(arrays, join_type='outer', col_name_map=None, metadata_conflicts='wa
         except metadata.MergeConflictError as err:
             # Beautify the error message when we are trying to merge columns with incompatible
             # types by including the name of the columns that originated the error.
-            raise TableMergeError("The '{0}' columns have incompatible types: {1}"
+            raise TableMergeError("The '{}' columns have incompatible types: {}"
                                   .format(out_name, err._incompat_types))
 
         idx0 = 0
@@ -917,7 +917,7 @@ def _hstack(arrays, join_type='outer', uniq_col_name='{col_name}_{table_name}',
         raise ValueError("join_type arg must be either 'inner', 'exact' or 'outer'")
 
     if table_names is None:
-        table_names = ['{0}'.format(ii + 1) for ii in range(len(arrays))]
+        table_names = ['{}'.format(ii + 1) for ii in range(len(arrays))]
     if len(arrays) != len(table_names):
         raise ValueError('Number of arrays must match number of table_names')
 

--- a/astropy/table/pprint.py
+++ b/astropy/table/pprint.py
@@ -85,7 +85,7 @@ def get_auto_format_func(
             try:
                 out = format_func(format_, val)
                 if not isinstance(out, str):
-                    raise ValueError('Format function for value {0} returned {1} '
+                    raise ValueError('Format function for value {} returned {} '
                                      'instead of string type'
                                      .format(val, type(val)))
             except Exception as err:
@@ -95,7 +95,7 @@ def get_auto_format_func(
                 if val is np.ma.masked:
                     return str(val)
 
-                raise ValueError('Format function for value {0} failed: {1}'
+                raise ValueError('Format function for value {} failed: {}'
                                  .format(val, err))
             # If the user-supplied function handles formatting masked elements, use
             # it directly.  Otherwise, wrap it in a function that traps them.
@@ -123,7 +123,7 @@ def get_auto_format_func(
                     break
             else:
                 # None of the possible string functions passed muster.
-                raise ValueError('unable to parse format string {0} for its '
+                raise ValueError('unable to parse format string {} for its '
                                  'column.'.format(format_))
 
             # String-based format functions will fail on masked elements;
@@ -254,7 +254,7 @@ class TableFormatter:
                 if i == n_header - 1:
                     continue
                 td = 'th' if i < n_header else 'td'
-                val = '<{0}>{1}</{2}>'.format(td, xml_escape(col_str.strip()), td)
+                val = '<{}>{}</{}>'.format(td, xml_escape(col_str.strip()), td)
                 row = ('<tr>' + val + '</tr>')
                 if i < n_header:
                     row = ('<thead>' + row + '</thead>')
@@ -309,7 +309,7 @@ class TableFormatter:
                 col_strs[i] = getattr(col_str, justify_method)(*justify_args)
 
         if outs['show_length']:
-            col_strs.append('Length = {0} rows'.format(len(col)))
+            col_strs.append('Length = {} rows'.format(len(col)))
 
         return col_strs, outs
 
@@ -357,7 +357,7 @@ class TableFormatter:
             # Get column name (or 'None' if not set)
             col_name = str(col.info.name)
             if multidims:
-                col_name += ' [{0}]'.format(
+                col_name += ' [{}]'.format(
                     ','.join(str(n) for n in multidims))
             n_header += 1
             yield col_name
@@ -438,7 +438,7 @@ class TableFormatter:
                 else:
                     left = format_func(col_format, col[(idx,) + multidim0])
                     right = format_func(col_format, col[(idx,) + multidim1])
-                    return '{0} .. {1}'.format(left, right)
+                    return f'{left} .. {right}'
             else:
                 return format_func(col_format, col[idx])
 
@@ -451,8 +451,8 @@ class TableFormatter:
                     yield format_col_str(idx)
                 except ValueError:
                     raise ValueError(
-                        'Unable to parse format string "{0}" for entry "{1}" '
-                        'in column "{2}"'.format(col_format, col[idx],
+                        'Unable to parse format string "{}" for entry "{}" '
+                        'in column "{}"'.format(col_format, col[idx],
                                                  col.info.name))
 
         outs['show_length'] = show_length
@@ -528,11 +528,11 @@ class TableFormatter:
 
         elif isinstance(align, (list, tuple)):
             if len(align) != n_cols:
-                raise ValueError('got {0} alignment values instead of '
-                                 'the number of columns ({1})'
+                raise ValueError('got {} alignment values instead of '
+                                 'the number of columns ({})'
                                  .format(len(align), n_cols))
         else:
-            raise TypeError('align keyword must be str or list or tuple (got {0})'
+            raise TypeError('align keyword must be str or list or tuple (got {})'
                             .format(type(align)))
 
         for align_, col in zip(align, table.columns.values()):
@@ -579,14 +579,14 @@ class TableFormatter:
                 rows.append('<table id="{tid}" class="{tcls}">'.format(
                     tid=tableid, tcls=tableclass))
             else:
-                rows.append('<table id="{tid}">'.format(tid=tableid))
+                rows.append(f'<table id="{tableid}">')
 
             for i in range(n_rows):
                 # _pformat_col output has a header line '----' which is not needed here
                 if i == n_header - 1:
                     continue
                 td = 'th' if i < n_header else 'td'
-                vals = ('<{0}>{1}</{2}>'.format(td, xml_escape(col[i].strip()), td)
+                vals = ('<{}>{}</{}>'.format(td, xml_escape(col[i].strip()), td)
                         for col in cols)
                 row = ('<tr>' + ''.join(vals) + '</tr>')
                 if i < n_header:

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -36,7 +36,7 @@ class Row:
         n = len(table)
 
         if index < -n or index >= n:
-            raise IndexError('index {0} out of range for table with length {1}'
+            raise IndexError('index {} out of range for table with length {}'
                              .format(index, len(table)))
 
         # Finally, ensure the index is positive [#8422] and set Row attributes
@@ -168,12 +168,12 @@ class Row:
         index = self.index if (self.index >= 0) else self.index + len(self._table)
         table = self._table[index:index + 1]
         descr_vals = [self.__class__.__name__,
-                      'index={0}'.format(self.index)]
+                      f'index={self.index}']
         if table.masked:
             descr_vals.append('masked=True')
 
         return table._base_repr_(html, descr_vals, max_width=-1,
-                                 tableid='table{0}'.format(id(self._table)))
+                                 tableid='table{}'.format(id(self._table)))
 
     def _repr_html_(self):
         return self._base_repr_(html=True)

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -207,7 +207,7 @@ def _construct_mixin_from_obj_attrs_and_info(obj_attrs, info):
     # the _construct_from_col method.  Prevent accidentally running
     # untrusted code by only importing known astropy classes.
     if cls_full_name not in __construct_mixin_classes:
-        raise ValueError('unsupported class for construct {}'.format(cls_full_name))
+        raise ValueError(f'unsupported class for construct {cls_full_name}')
 
     mod_name, cls_name = re.match(r'(.+)\.(\w+)', cls_full_name).groups()
     module = import_module(mod_name)

--- a/astropy/table/soco.py
+++ b/astropy/table/soco.py
@@ -55,7 +55,7 @@ class Node(object):
     __hash__ = None
 
     def __repr__(self):
-        return 'Node({0!r}, {1!r})'.format(self.key, self.value)
+        return f'Node({self.key!r}, {self.value!r})'
 
 
 class SCEngine:
@@ -82,7 +82,7 @@ class SCEngine:
         Add a key, value pair.
         '''
         if self._unique and (key in self._nodes):
-            message = 'duplicate {0:!r} in unique index'.format(key)
+            message = f'duplicate {key:!r} in unique index'
             raise ValueError(message)
         self._nodes.add(Node(key, value))
 
@@ -167,4 +167,4 @@ class SCEngine:
         self._nodes.update(nodes)
 
     def __repr__(self):
-        return '{0!r}'.format(list(self._nodes))
+        return '{!r}'.format(list(self._nodes))

--- a/astropy/table/sorted_array.py
+++ b/astropy/table/sorted_array.py
@@ -66,7 +66,7 @@ class SortedArray:
         if self.unique and 0 <= pos < len(self.row_index) and \
            all(self.data[pos][i] == key[i] for i in range(len(key))):
             # already exists
-            raise ValueError('Cannot add duplicate value "{0}" in a '
+            raise ValueError('Cannot add duplicate value "{}" in a '
                              'unique index'.format(key))
         self.data.insert_row(pos, key)
         self.row_index = self.row_index.insert(pos, row)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -243,12 +243,12 @@ class TableColumns(OrderedDict):
 
         """
         if item in self and not validated:
-            raise ValueError("Cannot replace column '{0}'.  Use Table.replace_column() instead."
+            raise ValueError("Cannot replace column '{}'.  Use Table.replace_column() instead."
                              .format(item))
         super().__setitem__(item, value)
 
     def __repr__(self):
-        names = ("'{0}'".format(x) for x in self.keys())
+        names = (f"'{x}'" for x in self.keys())
         return "<{1} names=({0})>".format(",".join(names), self.__class__.__name__)
 
     def _rename_column(self, name, new_name):
@@ -256,7 +256,7 @@ class TableColumns(OrderedDict):
             return
 
         if new_name in self:
-            raise KeyError("Column {0} already exists".format(new_name))
+            raise KeyError(f"Column {new_name} already exists")
 
         mapper = {name: new_name}
         new_names = [mapper.get(name, name) for name in self]
@@ -558,7 +558,7 @@ class Table:
             data = [[]] * n_cols
 
         else:
-            raise ValueError('Data type {0} not allowed to init Table'
+            raise ValueError('Data type {} not allowed to init Table'
                              .format(type(data)))
 
         # Set up defaults if names and/or dtype are not specified.
@@ -716,8 +716,8 @@ class Table:
         # make sure all columns support indexing
         for col in columns:
             if not getattr(col.info, '_supports_indexing', False):
-                raise ValueError('Cannot create an index on column "{0}", of '
-                                 'type "{1}"'.format(col.info.name, type(col)))
+                raise ValueError('Cannot create an index on column "{}", of '
+                                 'type "{}"'.format(col.info.name, type(col)))
 
         index = Index(columns, engine=engine, unique=unique)
         if not self.indices:
@@ -794,7 +794,7 @@ class Table:
         """
         for inp_list, inp_str in ((dtype, 'dtype'), (names, 'names')):
             if not isiterable(inp_list):
-                raise ValueError('{0} must be a list or None'.format(inp_str))
+                raise ValueError(f'{inp_str} must be a list or None')
 
         if len(names) != n_cols or len(dtype) != n_cols:
             raise ValueError(
@@ -822,7 +822,7 @@ class Table:
                 try:
                     cols[name].append(row[name])
                 except KeyError:
-                    raise ValueError('Row {0} has no value for column {1}'.format(i, name))
+                    raise ValueError(f'Row {i} has no value for column {name}')
 
         if all(name is None for name in names):
             names = names_from_data
@@ -1000,7 +1000,7 @@ class Table:
 
         lengths = set(len(col) for col in cols)
         if len(lengths) > 1:
-            raise ValueError('Inconsistent data column lengths: {0}'
+            raise ValueError('Inconsistent data column lengths: {}'
                              .format(lengths))
 
         # Make sure that all Column-based objects have correct class.  For
@@ -1124,14 +1124,14 @@ class Table:
             descr_vals = [self.__class__.__name__]
             if self.masked:
                 descr_vals.append('masked=True')
-            descr_vals.append('length={0}'.format(len(self)))
+            descr_vals.append('length={}'.format(len(self)))
 
         descr = ' '.join(descr_vals)
         if html:
             from astropy.utils.xml.writer import xml_escape
-            descr = '<i>{0}</i>\n'.format(xml_escape(descr))
+            descr = '<i>{}</i>\n'.format(xml_escape(descr))
         else:
-            descr = '<{0}>\n'.format(descr)
+            descr = f'<{descr}>\n'
 
         if tableid is None:
             tableid = 'table{id}'.format(id=id(self))
@@ -1221,7 +1221,7 @@ class Table:
                                                     show_name=show_name, show_unit=show_unit,
                                                     show_dtype=show_dtype, align=align)
         if outs['show_length']:
-            lines.append('Length = {0} rows'.format(len(self)))
+            lines.append('Length = {} rows'.format(len(self)))
 
         n_header = outs['n_header']
 
@@ -1298,7 +1298,7 @@ class Table:
         from IPython.display import HTML
 
         if tableid is None:
-            tableid = 'table{0}-{1}'.format(id(self),
+            tableid = 'table{}-{}'.format(id(self),
                                             np.random.randint(1, 1e6))
 
         jsv = JSViewer(display_length=display_length)
@@ -1393,7 +1393,7 @@ class Table:
         try:
             br = webbrowser.get(None if browser == 'default' else browser)
         except webbrowser.Error:
-            log.error("Browser '{}' not found.".format(browser))
+            log.error(f"Browser '{browser}' not found.")
         else:
             br.open(urljoin('file:', pathname2url(path)))
 
@@ -1422,7 +1422,7 @@ class Table:
             tableid=tableid, tableclass=tableclass, align=align)
 
         if outs['show_length']:
-            lines.append('Length = {0} rows'.format(len(self)))
+            lines.append('Length = {} rows'.format(len(self)))
 
         return lines
 
@@ -1515,7 +1515,7 @@ class Table:
             # For all, a new table is constructed with slice of all columns
             return self._new_from_slice(item)
         else:
-            raise ValueError('Illegal type {0} for table item access'
+            raise ValueError('Illegal type {} for table item access'
                              .format(type(item)))
 
     def __setitem__(self, item, value):
@@ -1561,7 +1561,7 @@ class Table:
 
                 else:  # Assume this is an iterable that will work
                     if len(value) != n_cols:
-                        raise ValueError('Right side value needs {0} elements (one for each column)'
+                        raise ValueError('Right side value needs {} elements (one for each column)'
                                          .format(n_cols))
                     vals = value
 
@@ -1569,7 +1569,7 @@ class Table:
                     col[item] = val
 
             else:
-                raise ValueError('Illegal type {0} for table item access'
+                raise ValueError('Illegal type {} for table item access'
                                  .format(type(item)))
 
     def __delitem__(self, item):
@@ -1694,7 +1694,7 @@ class Table:
         try:
             return self.colnames.index(name)
         except ValueError:
-            raise ValueError("Column {0} does not exist".format(name))
+            raise ValueError(f"Column {name} does not exist")
 
     def add_column(self, col, index=None, name=None, rename_duplicate=False, copy=True,
                    default_name=None):
@@ -1948,7 +1948,7 @@ class Table:
         self.replace_column(name, col)
 
         if 'always' in warns:
-            warnings.warn("replaced column '{}'".format(name),
+            warnings.warn(f"replaced column '{name}'",
                           TableReplaceWarning, stacklevel=3)
 
         if 'slice' in warns:
@@ -2016,7 +2016,7 @@ class Table:
             >>> t.replace_column('a', float_a)
         """
         if name not in self.colnames:
-            raise ValueError('column name {0} is not in the table'.format(name))
+            raise ValueError(f'column name {name} is not in the table')
 
         if self[name].info.indices:
             raise ValueError('cannot replace a table index column')
@@ -2224,7 +2224,7 @@ class Table:
 
         for name in names:
             if name not in self.columns:
-                raise KeyError("Column {0} does not exist".format(name))
+                raise KeyError(f"Column {name} does not exist")
 
         for name in names:
             self.columns.pop(name)
@@ -2334,7 +2334,7 @@ class Table:
 
         for name in names:
             if name not in self.columns:
-                raise KeyError("Column {0} does not exist".format(name))
+                raise KeyError(f"Column {name} does not exist")
 
         remove = list(set(self.keys()) - set(names))
 
@@ -2380,7 +2380,7 @@ class Table:
         '''
 
         if name not in self.keys():
-            raise KeyError("Column {0} does not exist".format(name))
+            raise KeyError(f"Column {name} does not exist")
 
         self.columns[name].info.name = new_name
 
@@ -2534,7 +2534,7 @@ class Table:
 
         N = len(self)
         if index < -N or index > N:
-            raise IndexError("Index {0} is out of bounds for table with length {1}"
+            raise IndexError("Index {} is out of bounds for table with length {}"
                              .format(index, N))
         if index < 0:
             index += N
@@ -2576,7 +2576,7 @@ class Table:
                         # For masked table any unsupplied values are masked by default.
                         mask_list.append(self.masked and vals is not None)
                     else:
-                        raise ValueError("Value must be supplied for column '{0}'".format(name))
+                        raise ValueError(f"Value must be supplied for column '{name}'")
 
             vals = vals_list
             mask = mask_list
@@ -2613,8 +2613,8 @@ class Table:
                 newcol = col.insert(index, val, axis=0)
 
                 if len(newcol) != N + 1:
-                    raise ValueError('Incorrect length for column {0} after inserting {1}'
-                                     ' (expected {2}, got {3})'
+                    raise ValueError('Incorrect length for column {} after inserting {}'
+                                     ' (expected {}, got {})'
                                      .format(name, val, len(newcol), N + 1))
                 newcol.info.parent_table = self
 
@@ -2633,7 +2633,7 @@ class Table:
                 table_index.insert_row(index, vals, self.columns.values())
 
         except Exception as err:
-            raise ValueError("Unable to insert row because of exception in column '{0}':\n{1}"
+            raise ValueError("Unable to insert row because of exception in column '{}':\n{}"
                              .format(name, err))
         else:
             self._replace_cols(columns)

--- a/astropy/table/table_helpers.py
+++ b/astropy/table/table_helpers.py
@@ -179,5 +179,5 @@ class ArrayWrapper:
         return self.data.shape
 
     def __repr__(self):
-        return ("<{0} name='{1}' data={2}>"
+        return ("<{} name='{}' data={}>"
                 .format(self.__class__.__name__, self.info.name, self.data))

--- a/astropy/table/tests/test_array.py
+++ b/astropy/table/tests/test_array.py
@@ -26,7 +26,7 @@ def wide_array():
 
 def test_array_find(array):
     for i in range(1, 11):
-        print("Searching for {0}".format(i))
+        print(f"Searching for {i}")
         assert array.find((i % 2, i)) == [i]
     assert array.find((1, 4)) == []
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -69,7 +69,7 @@ class TestColumn():
 
     def test_view(self, Column):
         c = np.array([1, 2, 3], dtype=np.int64).view(Column)
-        assert repr(c) == "<{0} dtype='int64' length=3>\n1\n2\n3".format(Column.__name__)
+        assert repr(c) == f"<{Column.__name__} dtype='int64' length=3>\n1\n2\n3"
 
     def test_format(self, Column):
         """Show that the formatted output from str() works"""
@@ -669,7 +669,7 @@ def test_col_unicode_sandwich_create_from_str(Column):
     """
     # a-umlaut is a 2-byte character in utf-8, test fails with ascii encoding.
     # Stress the system by injecting non-ASCII characters.
-    uba = u'bä'
+    uba = 'bä'
     c = Column([uba, 'def'], dtype='S')
     assert c.dtype.char == 'S'
     assert c[0] == uba
@@ -686,7 +686,7 @@ def test_col_unicode_sandwich_bytes(Column):
     """
     # a-umlaut is a 2-byte character in utf-8, test fails with ascii encoding.
     # Stress the system by injecting non-ASCII characters.
-    uba = u'bä'
+    uba = 'bä'
     uba8 = uba.encode('utf-8')
     c = Column([uba8, b'def'])
     assert c.dtype.char == 'S'
@@ -706,7 +706,7 @@ def test_col_unicode_sandwich_bytes(Column):
     assert ok.dtype.char == '?'
     assert np.all(ok)
 
-    assert np.all(c == np.array([uba, u'def']))
+    assert np.all(c == np.array([uba, 'def']))
     assert np.all(c == np.array([uba8, b'def']))
 
     # Scalar compare
@@ -722,7 +722,7 @@ def test_col_unicode_sandwich_unicode():
     Sanity check that Unicode Column behaves normally.
     """
     # On Py2 the unicode must be ASCII-compatible, else the final test fails.
-    uba = u'bä'
+    uba = 'bä'
     uba8 = uba.encode('utf-8')
 
     c = table.Column([uba, 'def'], dtype='U')
@@ -762,10 +762,10 @@ def test_masked_col_unicode_sandwich():
     assert ok[0] == True
     assert ok[1] is np.ma.masked
     assert np.all(c == [b'abc', b'def'])
-    assert np.all(c == np.array([u'abc', u'def']))
+    assert np.all(c == np.array(['abc', 'def']))
     assert np.all(c == np.array([b'abc', b'def']))
 
-    for cmp in (u'abc', b'abc'):
+    for cmp in ('abc', b'abc'):
         ok = c == cmp
         assert type(ok) is np.ma.MaskedArray
         assert ok[0] == True
@@ -777,19 +777,19 @@ def test_unicode_sandwich_set(Column):
     """
     Test setting
     """
-    uba = u'bä'
+    uba = 'bä'
 
     c = Column([b'abc', b'def'])
 
     c[0] = b'aa'
-    assert np.all(c == [u'aa', u'def'])
+    assert np.all(c == ['aa', 'def'])
 
     c[0] = uba  # a-umlaut is a 2-byte character in utf-8, test fails with ascii encoding
-    assert np.all(c == [uba, u'def'])
-    assert c.pformat() == [u'None', u'----', '  ' + uba, u' def']
+    assert np.all(c == [uba, 'def'])
+    assert c.pformat() == ['None', '----', '  ' + uba, ' def']
 
     c[:] = b'cc'
-    assert np.all(c == [u'cc', u'cc'])
+    assert np.all(c == ['cc', 'cc'])
 
     c[:] = uba
     assert np.all(c == [uba, uba])

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -77,7 +77,7 @@ def test_table_info_stats(table_types):
     masked = 'masked=True ' if t.masked else ''
     out = StringIO()
     t.info('stats', out=out)
-    table_header_line = '<{0} {1}length=4>'.format(t.__class__.__name__, masked)
+    table_header_line = f'<{t.__class__.__name__} {masked}length=4>'
     exp = [table_header_line,
            'name mean std min max',
            '---- ---- --- --- ---',
@@ -149,7 +149,7 @@ def test_data_info():
                'dtype = float64',
                'unit = m / s',
                'description = description',
-               'class = {0}'.format(type(c).__name__),
+               'class = {}'.format(type(c).__name__),
                'n_bad = 1',
                'length = 3']
         assert out.getvalue().splitlines() == exp

--- a/astropy/table/tests/test_np_utils.py
+++ b/astropy/table/tests/test_np_utils.py
@@ -22,9 +22,9 @@ def test_common_dtype():
         for name2, type2 in dtype:
             try:
                 np_utils.common_dtype([arr[name1], arr[name2]])
-                succeed.add('{0} {1}'.format(name1, name2))
+                succeed.add(f'{name1} {name2}')
             except np_utils.TableMergeError:
-                fail.add('{0} {1}'.format(name1, name2))
+                fail.add(f'{name1} {name2}')
 
     # known bad combinations
     bad = set(['str int', 'str bool', 'uint8 bool', 'uint8 str', 'object float32',

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -798,7 +798,7 @@ class TestVStack():
         self._setup(operation_table_type)
         with pytest.raises(TableMergeError) as excinfo:
             table.vstack([self.t1, self.t3], join_type='inner')
-        assert ("The 'b' columns have incompatible types: {0}"
+        assert ("The 'b' columns have incompatible types: {}"
                 .format([self.t1['b'].dtype.name, self.t3['b'].dtype.name])
                 in str(excinfo.value))
 
@@ -1393,7 +1393,7 @@ def test_vstack_unicode():
     Test for problem related to issue #5617 when vstack'ing *unicode*
     columns.  In this case the character size gets multiplied by 4.
     """
-    t = table.Table([[u'a']], names=['a'])
+    t = table.Table([['a']], names=['a'])
     assert t['a'].itemsize == 4  # 4-byte / char for U dtype
 
     t2 = table.vstack([t, t])

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -41,7 +41,7 @@ class TestMultiD():
                          '</table>']
         nbclass = table.conf.default_notebook_table_class
         assert t._repr_html_().splitlines() == [
-            '<i>{0} masked={1} length=2</i>'.format(table_type.__name__, t.masked),
+            f'<i>{table_type.__name__} masked={t.masked} length=2</i>',
             '<table id="table{id}" class="{nbclass}">'.format(id=id(t), nbclass=nbclass),
             '<thead><tr><th>col0 [2]</th><th>col1 [2]</th><th>col2 [2]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
@@ -80,11 +80,11 @@ class TestMultiD():
                          '</table>']
         nbclass = table.conf.default_notebook_table_class
         assert t._repr_html_().splitlines() == [
-            '<i>{0} masked={1} length=2</i>'.format(table_type.__name__, t.masked),
+            f'<i>{table_type.__name__} masked={t.masked} length=2</i>',
             '<table id="table{id}" class="{nbclass}">'.format(id=id(t), nbclass=nbclass),
             '<thead><tr><th>col0 [1,1]</th><th>col1 [1,1]</th><th>col2 [1,1]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
-            '<tr><td>1</td><td>3</td><td>5</td></tr>', u'<tr><td>10</td><td>30</td><td>50</td></tr>',
+            '<tr><td>1</td><td>3</td><td>5</td></tr>', '<tr><td>10</td><td>30</td><td>50</td></tr>',
             '</table>']
 
         t = table_type([arr])
@@ -127,7 +127,7 @@ class TestPprint():
         lines = t.pformat()
         assert lines == ['<No columns>']
         c = repr(t)
-        assert c.splitlines() == ['<{0} masked={1} length=0>'.format(table_type.__name__, t.masked),
+        assert c.splitlines() == [f'<{table_type.__name__} masked={t.masked} length=0>',
                                   '<No columns>']
 
     def test_format0(self, table_type):
@@ -544,10 +544,10 @@ def test_pprint_py3_bytes():
     is printed correctly (without the "b" prefix like b'string').
     """
     val = bytes('val', encoding='utf-8')
-    blah = u'bläh'.encode('utf-8')
+    blah = 'bläh'.encode('utf-8')
     dat = np.array([val, blah], dtype=[('col', 'S10')])
     t = table.Table(dat)
-    assert t['col'].pformat() == ['col ', '----', ' val', u'bläh']
+    assert t['col'].pformat() == ['col ', '----', ' val', 'bläh']
 
 
 def test_pprint_nameless_col():
@@ -565,26 +565,26 @@ def test_html():
 
     lines = t.pformat(html=True)
     assert lines == ['<table id="table{id}">'.format(id=id(t)),
-                     u'<thead><tr><th>a</th></tr></thead>',
-                     u'<tr><td>1.0</td></tr>',
-                     u'<tr><td>2.0</td></tr>',
-                     u'</table>']
+                     '<thead><tr><th>a</th></tr></thead>',
+                     '<tr><td>1.0</td></tr>',
+                     '<tr><td>2.0</td></tr>',
+                     '</table>']
 
     lines = t.pformat(html=True, tableclass='table-striped')
     assert lines == [
         '<table id="table{id}" class="table-striped">'.format(id=id(t)),
-        u'<thead><tr><th>a</th></tr></thead>',
-        u'<tr><td>1.0</td></tr>',
-        u'<tr><td>2.0</td></tr>',
-        u'</table>']
+        '<thead><tr><th>a</th></tr></thead>',
+        '<tr><td>1.0</td></tr>',
+        '<tr><td>2.0</td></tr>',
+        '</table>']
 
     lines = t.pformat(html=True, tableclass=['table', 'table-striped'])
     assert lines == [
         '<table id="table{id}" class="table table-striped">'.format(id=id(t)),
-        u'<thead><tr><th>a</th></tr></thead>',
-        u'<tr><td>1.0</td></tr>',
-        u'<tr><td>2.0</td></tr>',
-        u'</table>']
+        '<thead><tr><th>a</th></tr></thead>',
+        '<tr><td>1.0</td></tr>',
+        '<tr><td>2.0</td></tr>',
+        '</table>']
 
 
 def test_align():
@@ -703,4 +703,4 @@ def test_decode_replace():
     https://docs.python.org/3/library/codecs.html#codecs.replace_errors
     """
     t = Table([[b'Z\xf0']])
-    assert t.pformat() == [u'col0', u'----', u'  Z\ufffd']
+    assert t.pformat() == ['col0', '----', '  Z\ufffd']

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -135,7 +135,7 @@ class TestRow():
         self._setup(table_types)
         table = self.t
         row = table[0]
-        assert repr(row).splitlines() == ['<{0} {1}{2}>'
+        assert repr(row).splitlines() == ['<{} {}{}>'
                                           .format(row.__class__.__name__,
                                                   'index=0',
                                                   ' masked=True' if table.masked else ''),
@@ -147,11 +147,11 @@ class TestRow():
                                          '--- ---',
                                          '  1   4']
 
-        assert row._repr_html_().splitlines() == ['<i>{0} {1}{2}</i>'
+        assert row._repr_html_().splitlines() == ['<i>{} {}{}</i>'
                                                   .format(row.__class__.__name__,
                                                           'index=0',
                                                           ' masked=True' if table.masked else ''),
-                                                  '<table id="table{0}">'.format(id(table)),
+                                                  '<table id="table{}">'.format(id(table)),
                                                   '<thead><tr><th>a</th><th>b</th></tr></thead>',
                                                   '<thead><tr><th>int64</th><th>int64</th></tr></thead>',
                                                   '<tr><td>1</td><td>4</td></tr>',

--- a/astropy/tests/command.py
+++ b/astropy/tests/command.py
@@ -269,7 +269,7 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
                                    dir=self.temp_root)
         self.tmp_dir = os.path.realpath(tmp_dir)
 
-        log.info('installing to temporary directory: {0}'.format(self.tmp_dir))
+        log.info(f'installing to temporary directory: {self.tmp_dir}')
 
         # We now install the package to the temporary directory. We do this
         # rather than build and copy because this will ensure that e.g. entry
@@ -344,13 +344,13 @@ class AstropyTest(Command, metaclass=FixRemoteDataOption):
 
         cmd_pre = (
             'import coverage; '
-            'cov = coverage.coverage(data_file=r"{0}", config_file=r"{1}"); '
+            'cov = coverage.coverage(data_file=r"{}", config_file=r"{}"); '
             'cov.start();'.format(
                 os.path.abspath(".coverage"), os.path.abspath(tmp_coveragerc)))
         cmd_post = (
             'cov.stop(); '
             'from astropy.tests.helper import _save_coverage; '
-            '_save_coverage(cov, result, r"{0}", r"{1}");'.format(
+            '_save_coverage(cov, result, r"{}", r"{}");'.format(
                 os.path.abspath('.'), os.path.abspath(self.testing_path)))
 
         return cmd_pre, cmd_post

--- a/astropy/tests/helper.py
+++ b/astropy/tests/helper.py
@@ -433,12 +433,12 @@ def generic_recursive_equality_test(a, b, class_history):
     dict_b = b.__dict__
     for key in dict_a:
         assert key in dict_b,\
-          "Did not pickle {0}".format(key)
+          f"Did not pickle {key}"
         if hasattr(dict_a[key], '__eq__'):
             eq = (dict_a[key] == dict_b[key])
             if '__iter__' in dir(eq):
                 eq = (False not in eq)
-            assert eq, "Value of {0} changed by pickling".format(key)
+            assert eq, f"Value of {key} changed by pickling"
 
         if hasattr(dict_a[key], '__dict__'):
             if dict_a[key].__class__ in class_history:

--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -39,10 +39,10 @@ def pytest_report_header(config):
     if len(TESTED_VERSIONS) > 1:
         for pkg, version in TESTED_VERSIONS.items():
             if pkg not in ['Astropy', 'astropy_helpers']:
-                s = "\nRunning tests with {0} version {1}.\n".format(
+                s = "\nRunning tests with {} version {}.\n".format(
                     pkg, version)
     else:
-        s = "\nRunning tests with Astropy version {0}.\n".format(
+        s = "\nRunning tests with Astropy version {}.\n".format(
             TESTED_VERSIONS['Astropy'])
 
     # Per https://github.com/astropy/astropy/pull/4204, strip the rootdir from
@@ -57,25 +57,25 @@ def pytest_report_header(config):
     else:
         dirs = args
 
-    s += "Running tests in {0}.\n\n".format(" ".join(dirs))
+    s += "Running tests in {}.\n\n".format(" ".join(dirs))
 
-    s += "Date: {0}\n\n".format(datetime.datetime.now().isoformat()[:19])
+    s += "Date: {}\n\n".format(datetime.datetime.now().isoformat()[:19])
 
     from platform import platform
     plat = platform()
     if isinstance(plat, bytes):
         plat = plat.decode(stdoutencoding, 'replace')
-    s += "Platform: {0}\n\n".format(plat)
-    s += "Executable: {0}\n\n".format(sys.executable)
-    s += "Full Python Version: \n{0}\n\n".format(sys.version)
+    s += f"Platform: {plat}\n\n"
+    s += f"Executable: {sys.executable}\n\n"
+    s += f"Full Python Version: \n{sys.version}\n\n"
 
-    s += "encodings: sys: {0}, locale: {1}, filesystem: {2}".format(
+    s += "encodings: sys: {}, locale: {}, filesystem: {}".format(
         sys.getdefaultencoding(),
         locale.getpreferredencoding(),
         sys.getfilesystemencoding())
     s += '\n'
 
-    s += "byteorder: {0}\n".format(sys.byteorder)
+    s += f"byteorder: {sys.byteorder}\n"
     s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
         sys.float_info)
 
@@ -84,13 +84,13 @@ def pytest_report_header(config):
             with ignore_warnings(DeprecationWarning):
                 module = resolve_name(module_name)
         except ImportError:
-            s += "{0}: not available\n".format(module_display)
+            s += f"{module_display}: not available\n"
         else:
             try:
                 version = module.__version__
             except AttributeError:
                 version = 'unknown (no __version__ attribute)'
-            s += "{0}: {1}\n".format(module_display, version)
+            s += f"{module_display}: {version}\n"
 
     # Helpers version
     if 'astropy_helpers' in TESTED_VERSIONS:
@@ -102,7 +102,7 @@ def pytest_report_header(config):
             astropy_helpers_version = None
 
     if astropy_helpers_version:
-        s += "astropy_helpers: {0}\n".format(astropy_helpers_version)
+        s += f"astropy_helpers: {astropy_helpers_version}\n"
 
     special_opts = ["remote_data", "pep8"]
     opts = []
@@ -113,7 +113,7 @@ def pytest_report_header(config):
                 op = ': '.join((op, op_value))
             opts.append(op)
     if opts:
-        s += "Using Astropy options: {0}.\n".format(", ".join(opts))
+        s += "Using Astropy options: {}.\n".format(", ".join(opts))
 
     return s
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -147,11 +147,11 @@ class TestRunnerBase:
 
             # Allow disabling of options in a subclass
             if result is NotImplemented:
-                raise TypeError("run_tests() got an unexpected keyword argument {}".format(keyword))
+                raise TypeError(f"run_tests() got an unexpected keyword argument {keyword}")
 
             # keyword methods must return a list
             if not isinstance(result, list):
-                raise TypeError("{} keyword method must return a list".format(keyword))
+                raise TypeError(f"{keyword} keyword method must return a list")
 
             args += result
 
@@ -446,7 +446,7 @@ class TestRunner(TestRunnerBase):
         """
         if pastebin is not None:
             if pastebin in ['failed', 'all']:
-                return ['--pastebin={0}'.format(pastebin)]
+                return [f'--pastebin={pastebin}']
             else:
                 raise ValueError("pastebin should be 'failed' or 'all'")
 
@@ -468,14 +468,14 @@ class TestRunner(TestRunnerBase):
             remote_data = 'none'
         elif remote_data not in ('none', 'astropy', 'any'):
             warnings.warn("The remote_data option should be one of "
-                          "none/astropy/any (found {0}). For backward-compatibility, "
+                          "none/astropy/any (found {}). For backward-compatibility, "
                           "assuming 'any', but you should change the option to be "
                           "one of the supported ones to avoid issues in "
                           "future.".format(remote_data),
                           AstropyDeprecationWarning)
             remote_data = 'any'
 
-        return ['--remote-data={0}'.format(remote_data)]
+        return [f'--remote-data={remote_data}']
 
     @keyword()
     def pep8(self, pep8, kwargs):
@@ -591,7 +591,7 @@ class TestRunner(TestRunnerBase):
             useful for diagnosing sporadic failures.
         """
         if repeat:
-            return ['--repeat={0}'.format(repeat)]
+            return [f'--repeat={repeat}']
 
         return []
 

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -143,8 +143,8 @@ def test_warning_logging_with_io_votable_warning():
     assert len(log_list) == 1
     assert len(warn_list) == 0
     assert log_list[0].levelname == 'WARNING'
-    x = log_list[0].message.startswith(("W02: ?:?:?: W02: a attribute 'b' is "
-                                        "invalid.  Must be a standard XML id"))
+    x = log_list[0].message.startswith("W02: ?:?:?: W02: a attribute 'b' is "
+                                        "invalid.  Must be a standard XML id")
     assert x
     assert log_list[0].origin == 'astropy.tests.test_logger'
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -406,8 +406,8 @@ class Time(ShapedLikeNDArray):
                 self.location = np.broadcast_to(self.location, self.shape,
                                                 subok=True)
             except Exception:
-                raise ValueError('The location with shape {0} cannot be '
-                                 'broadcast against time with shape {1}. '
+                raise ValueError('The location with shape {} cannot be '
+                                 'broadcast against time with shape {}. '
                                  'Typically, either give a single location or '
                                  'one for each time.'
                                  .format(self.location.shape, self.shape))
@@ -441,8 +441,8 @@ class Time(ShapedLikeNDArray):
         if scale is not None:
             if not (isinstance(scale, str) and
                     scale.lower() in self.SCALES):
-                raise ScaleValueError("Scale {0!r} is not in the allowed scales "
-                                      "{1}".format(scale,
+                raise ScaleValueError("Scale {!r} is not in the allowed scales "
+                                      "{}".format(scale,
                                                    sorted(self.SCALES)))
 
         # If either of the input val, val2 are masked arrays then
@@ -476,7 +476,7 @@ class Time(ShapedLikeNDArray):
             formats = [(name, cls) for name, cls in self.FORMATS.items()
                        if issubclass(cls, TimeUnique)]
             err_msg = ('any of the formats where the format keyword is '
-                       'optional {0}'.format([name for name, cls in formats]))
+                       'optional {}'.format([name for name, cls in formats]))
             # AstropyTime is a pseudo-format that isn't in the TIME_FORMATS registry,
             # but try to guess it at the end.
             formats.append(('astropy_time', TimeAstropyTime))
@@ -487,12 +487,12 @@ class Time(ShapedLikeNDArray):
                 raise ValueError("No time format was given, and the input is "
                                  "not unique")
             else:
-                raise ValueError("Format {0!r} is not one of the allowed "
-                                 "formats {1}".format(format,
+                raise ValueError("Format {!r} is not one of the allowed "
+                                 "formats {}".format(format,
                                                       sorted(self.FORMATS)))
         else:
             formats = [(format, self.FORMATS[format])]
-            err_msg = 'the format class {0}'.format(format)
+            err_msg = f'the format class {format}'
 
         for format, FormatClass in formats:
             try:
@@ -502,7 +502,7 @@ class Time(ShapedLikeNDArray):
             except (ValueError, TypeError):
                 pass
         else:
-            raise ValueError('Input values did not match {0}'.format(err_msg))
+            raise ValueError(f'Input values did not match {err_msg}')
 
     @classmethod
     def now(cls):
@@ -609,7 +609,7 @@ class Time(ShapedLikeNDArray):
     def format(self, format):
         """Set time format"""
         if format not in self.FORMATS:
-            raise ValueError('format must be one of {0}'
+            raise ValueError('format must be one of {}'
                              .format(list(self.FORMATS)))
         format_cls = self.FORMATS[format]
 
@@ -628,7 +628,7 @@ class Time(ShapedLikeNDArray):
         self._format = format
 
     def __repr__(self):
-        return ("<{0} object: scale='{1}' format='{2}' value={3}>"
+        return ("<{} object: scale='{}' format='{}' value={}>"
                 .format(self.__class__.__name__, self.scale, self.format,
                         getattr(self, self.format)))
 
@@ -704,7 +704,7 @@ class Time(ShapedLikeNDArray):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+            raise ValueError("Scale {!r} is not in the allowed scales {}"
                              .format(scale, sorted(self.SCALES)))
 
         # Determine the chain of scale transformations to get from the current
@@ -729,7 +729,7 @@ class Time(ShapedLikeNDArray):
             # sys1, sys2 though the property applies for both xform directions.
             args = [jd1, jd2]
             for sys12 in ((sys1, sys2), (sys2, sys1)):
-                dt_method = '_get_delta_{0}_{1}'.format(*sys12)
+                dt_method = '_get_delta_{}_{}'.format(*sys12)
                 try:
                     get_dt = getattr(self, dt_method)
                 except AttributeError:
@@ -1140,7 +1140,7 @@ class Time(ShapedLikeNDArray):
         from astropy.coordinates import Longitude
 
         if kind.lower() not in SIDEREAL_TIME_MODELS.keys():
-            raise ValueError('The kind of sidereal time has to be {0}'.format(
+            raise ValueError('The kind of sidereal time has to be {}'.format(
                 ' or '.join(sorted(SIDEREAL_TIME_MODELS.keys()))))
 
         available_models = SIDEREAL_TIME_MODELS[kind.lower()]
@@ -1150,8 +1150,8 @@ class Time(ShapedLikeNDArray):
         else:
             if model.upper() not in available_models:
                 raise ValueError(
-                    'Model {0} not implemented for {1} sidereal time; '
-                    'available models are {2}'
+                    'Model {} not implemented for {} sidereal time; '
+                    'available models are {}'
                     .format(model, kind, sorted(available_models.keys())))
 
         if longitude is None:
@@ -1331,7 +1331,7 @@ class Time(ShapedLikeNDArray):
         # in the copy.  If the format is unchanged this process is lightweight
         # and does not create any new arrays.
         if new_format not in tm.FORMATS:
-            raise ValueError('format must be one of {0}'
+            raise ValueError('format must be one of {}'
                              .format(list(tm.FORMATS)))
 
         NewFormat = tm.FORMATS[new_format]
@@ -1568,8 +1568,8 @@ class Time(ShapedLikeNDArray):
                 raise ScaleValueError("Cannot convert TimeDelta with "
                                       "undefined scale to any defined scale.")
             else:
-                raise ScaleValueError("Cannot convert {0} with scale "
-                                      "'{1}' to scale '{2}'"
+                raise ScaleValueError("Cannot convert {} with scale "
+                                      "'{}' to scale '{}'"
                                       .format(self.__class__.__name__,
                                               self.scale, attr))
 
@@ -1772,7 +1772,7 @@ class Time(ShapedLikeNDArray):
                 else:
                     if self.scale not in TIME_TYPES[other.scale]:
                         raise TypeError("Cannot subtract Time and TimeDelta instances "
-                                        "with scales '{0}' and '{1}'"
+                                        "with scales '{}' and '{}'"
                                         .format(self.scale, other.scale))
                     out._set_scale(other.scale)
             # remove attributes that are invalidated by changing time
@@ -1784,7 +1784,7 @@ class Time(ShapedLikeNDArray):
             # the scales should be compatible (e.g., cannot convert TDB to LOCAL)
             if other.scale not in self.SCALES:
                 raise TypeError("Cannot subtract Time instances "
-                                "with scales '{0}' and '{1}'"
+                                "with scales '{}' and '{}'"
                                 .format(self.scale, other.scale))
             self_time = (self._time if self.scale in TIME_DELTA_SCALES
                          else self.tai._time)
@@ -1833,7 +1833,7 @@ class Time(ShapedLikeNDArray):
             else:
                 if self.scale not in TIME_TYPES[other.scale]:
                     raise TypeError("Cannot add Time and TimeDelta instances "
-                                    "with scales '{0}' and '{1}'"
+                                    "with scales '{}' and '{}'"
                                     .format(self.scale, other.scale))
                 out._set_scale(other.scale)
         # remove attributes that are invalidated by changing time
@@ -1873,8 +1873,8 @@ class Time(ShapedLikeNDArray):
            other.scale is not None and other.scale not in self.SCALES):
             # Other will also not be able to do it, so raise a TypeError
             # immediately, allowing us to explain why it doesn't work.
-            raise TypeError("Cannot compare {0} instances with scales "
-                            "'{1}' and '{2}'".format(self.__class__.__name__,
+            raise TypeError("Cannot compare {} instances with scales "
+                            "'{}' and '{}'".format(self.__class__.__name__,
                                                      self.scale, other.scale))
 
         if self.scale is not None and other.scale is not None:
@@ -2006,7 +2006,7 @@ class TimeDelta(Time):
         if scale == self.scale:
             return
         if scale not in self.SCALES:
-            raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+            raise ValueError("Scale {!r} is not in the allowed scales {}"
                              .format(scale, sorted(self.SCALES)))
 
         # For TimeDelta, there can only be a change in scale factor,
@@ -2037,7 +2037,7 @@ class TimeDelta(Time):
         if(self.scale is not None and self.scale not in other.SCALES or
            other.scale is not None and other.scale not in self.SCALES):
             raise TypeError("Cannot add TimeDelta instances with scales "
-                            "'{0}' and '{1}'".format(self.scale, other.scale))
+                            "'{}' and '{}'".format(self.scale, other.scale))
 
         # adjust the scale of other if the scale of self is set (or no scales)
         if self.scale is not None or other.scale is None:
@@ -2069,7 +2069,7 @@ class TimeDelta(Time):
         if(self.scale is not None and self.scale not in other.SCALES or
            other.scale is not None and other.scale not in self.SCALES):
             raise TypeError("Cannot subtract TimeDelta instances with scales "
-                            "'{0}' and '{1}'".format(self.scale, other.scale))
+                            "'{}' and '{}'".format(self.scale, other.scale))
 
         # adjust the scale of other if the scale of self is set (or no scales)
         if self.scale is not None or other.scale is None:
@@ -2325,9 +2325,9 @@ def _check_for_masked_and_fill(val, val2):
 
 class OperandTypeError(TypeError):
     def __init__(self, left, right, op=None):
-        op_string = '' if op is None else ' for {0}'.format(op)
+        op_string = '' if op is None else f' for {op}'
         super().__init__(
-            "Unsupported operand type(s){0}: "
-            "'{1}' and '{2}'".format(op_string,
+            "Unsupported operand type(s){}: "
+            "'{}' and '{}'".format(op_string,
                                      left.__class__.__name__,
                                      right.__class__.__name__))

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -182,7 +182,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
         ok1 = val1.dtype == np.double and np.all(np.isfinite(val1))
         ok2 = val2 is None or (val2.dtype == np.double and not np.any(np.isinf(val2)))
         if not (ok1 and ok2):
-            raise TypeError('Input values for {0} class must be finite doubles'
+            raise TypeError('Input values for {} class must be finite doubles'
                             .format(self.name))
 
         if getattr(val1, 'unit', None) is not None:
@@ -243,8 +243,8 @@ class TimeFormat(metaclass=TimeFormatMeta):
             scale = self._default_scale
 
         if scale not in TIME_SCALES:
-            raise ScaleValueError("Scale value '{0}' not in "
-                                  "allowed values {1}"
+            raise ScaleValueError("Scale value '{}' not in "
+                                  "allowed values {}"
                                   .format(scale, TIME_SCALES))
 
         return scale
@@ -428,8 +428,8 @@ class TimeFromEpoch(TimeFormat):
             tm = getattr(Time(jd1, jd2, scale=self.epoch_scale,
                               format='jd'), self.scale)
         except Exception as err:
-            raise ScaleValueError("Cannot convert from '{0}' epoch scale '{1}'"
-                                  "to specified scale '{2}', got error:\n{3}"
+            raise ScaleValueError("Cannot convert from '{}' epoch scale '{}'"
+                                  "to specified scale '{}', got error:\n{}"
                                   .format(self.name, self.epoch_scale,
                                           self.scale, err))
 
@@ -444,8 +444,8 @@ class TimeFromEpoch(TimeFormat):
             try:
                 tm = getattr(parent, self.epoch_scale)
             except Exception as err:
-                raise ScaleValueError("Cannot convert from '{0}' epoch scale '{1}'"
-                                      "to specified scale '{2}', got error:\n{3}"
+                raise ScaleValueError("Cannot convert from '{}' epoch scale '{}'"
+                                      "to specified scale '{}', got error:\n{}"
                                       .format(self.name, self.epoch_scale,
                                               self.scale, err))
 
@@ -572,7 +572,7 @@ class TimeAstropyTime(TimeUnique):
         val1_0 = val1.flat[0]
         if not (isinstance(val1_0, Time) and all(type(val) is type(val1_0)
                                                  for val in val1.flat)):
-            raise TypeError('Input values for {0} class must all be same '
+            raise TypeError('Input values for {} class must all be same '
                             'astropy Time type.'.format(cls.name))
 
         if scale is None:
@@ -611,7 +611,7 @@ class TimeDatetime(TimeUnique):
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class
         if not all(isinstance(val, datetime.datetime) for val in val1.flat):
-            raise TypeError('Input values for {0} class must be '
+            raise TypeError('Input values for {} class must be '
                             'datetime objects'.format(self.name))
         return val1, None
 
@@ -753,7 +753,7 @@ class TimeString(TimeUnique):
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for these classes
         if val1.dtype.kind not in ('S', 'U'):
-            raise TypeError('Input values for {0} class must be strings'
+            raise TypeError('Input values for {} class must be strings'
                             .format(self.name))
         return val1, None
 
@@ -795,7 +795,7 @@ class TimeString(TimeUnique):
             vals[-1] = vals[-1] + fracsec
             return vals
         else:
-            raise ValueError('Time {0} does not match {1} format'
+            raise ValueError('Time {} does not match {} format'
                              .format(timestr, self.name))
 
     def set_jds(self, val1, val2):
@@ -885,7 +885,7 @@ class TimeString(TimeUnique):
         fnmatchcase = fnmatch.fnmatchcase
         subfmts = [x for x in self.subfmts if fnmatchcase(x[0], pattern)]
         if len(subfmts) == 0:
-            raise ValueError('No subformats match {0}'.format(pattern))
+            raise ValueError(f'No subformats match {pattern}')
         return subfmts
 
 
@@ -980,7 +980,7 @@ class TimeDatetime64(TimeISOT):
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class`
         if not val1.dtype.kind == 'M':
-            raise TypeError('Input values for {0} class must be '
+            raise TypeError('Input values for {} class must be '
                             'datetime64 objects'.format(self.name))
         return val1, None
 
@@ -1063,7 +1063,7 @@ class TimeFITS(TimeString):
             if tm:
                 break
         else:
-            raise ValueError('Time {0} does not match {1} format'
+            raise ValueError('Time {} does not match {} format'
                              .format(timestr, self.name))
         tm = tm.groupdict()
         # Scale and realization are deprecated and strings in this form
@@ -1076,7 +1076,7 @@ class TimeFITS(TimeString):
             fits_scale = tm['scale'].upper()
             scale = FITS_DEPRECATED_SCALES.get(fits_scale, fits_scale.lower())
             if scale not in TIME_SCALES:
-                raise ValueError("Scale {0!r} is not in the allowed scales {1}"
+                raise ValueError("Scale {!r} is not in the allowed scales {}"
                                  .format(scale, sorted(TIME_SCALES)))
             # If no scale was given in the initialiser, set the scale to
             # that given in the string.  Realization is ignored
@@ -1085,7 +1085,7 @@ class TimeFITS(TimeString):
             if self._scale is None:
                 self._scale = scale
             if scale != self.scale:
-                raise ValueError("Input strings for {0} class must all "
+                raise ValueError("Input strings for {} class must all "
                                  "have consistent time scales."
                                  .format(self.name))
         return [int(tm['year']), int(tm['mon']), int(tm['mday']),
@@ -1167,7 +1167,7 @@ class TimeEpochDateString(TimeString):
                 if epoch_type.upper() != epoch_prefix:
                     raise ValueError
             except (IndexError, ValueError, UnicodeEncodeError):
-                raise ValueError('Time {0} does not match {1} format'
+                raise ValueError('Time {} does not match {} format'
                                  .format(time_str, self.name))
             else:
                 years[...] = year
@@ -1215,8 +1215,8 @@ class TimeDeltaFormat(TimeFormat, metaclass=TimeDeltaFormatMeta):
         Check that the scale is in the allowed list of scales, or is `None`
         """
         if scale is not None and scale not in TIME_DELTA_SCALES:
-            raise ScaleValueError("Scale value '{0}' not in "
-                                  "allowed values {1}"
+            raise ScaleValueError("Scale value '{}' not in "
+                                  "allowed values {}"
                                   .format(scale, TIME_DELTA_SCALES))
 
         return scale
@@ -1249,7 +1249,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     def _check_val_type(self, val1, val2):
         # Note: don't care about val2 for this class
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
-            raise TypeError('Input values for {0} class must be '
+            raise TypeError('Input values for {} class must be '
                             'datetime.timedelta objects'.format(self.name))
         return val1, None
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -500,8 +500,8 @@ class TestBasic:
         uses the 2012-06-30 leap second for testing."""
         for year, month, day in ((2012, 6, 30), (2016, 12, 31)):
             # Start with a day without a leap second and note rollover
-            yyyy_mm = '{:04d}-{:02d}'.format(year, month)
-            yyyy_mm_dd = '{:04d}-{:02d}-{:02d}'.format(year, month, day)
+            yyyy_mm = f'{year:04d}-{month:02d}'
+            yyyy_mm_dd = f'{year:04d}-{month:02d}-{day:02d}'
             with pytest.warns(ErfaWarning):
                 t1 = Time(yyyy_mm + '-01 23:59:60.0', scale='utc')
             assert t1.iso == yyyy_mm + '-02 00:00:00.000'
@@ -517,7 +517,7 @@ class TestBasic:
             assert t1.iso == yyyy_mm_dd + ' 23:59:60.999'
 
             if month == 6:
-                yyyy_mm_dd_plus1 = '{:04d}-07-01'.format(year)
+                yyyy_mm_dd_plus1 = f'{year:04d}-07-01'
             else:
                 yyyy_mm_dd_plus1 = '{:04d}-01-01'.format(year+1)
 
@@ -1235,7 +1235,7 @@ def test_sum_is_equivalent():
 def test_string_valued_columns():
     # Columns have a nice shim that translates bytes to string as needed.
     # Ensure Time can handle these.  Use multi-d array just to be sure.
-    times = [[['{:04d}-{:02d}-{:02d}'.format(y, m, d) for d in range(1, 3)]
+    times = [[[f'{y:04d}-{m:02d}-{d:02d}' for d in range(1, 3)]
               for m in range(5, 7)] for y in range(2012, 2014)]
     cutf32 = Column(times)
     cbytes = cutf32.astype('S')

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -46,11 +46,11 @@ class TestERFATestCases:
         result, precision, name = erfa_test_input
         if name[4] == 'm':
             kind = 'mean'
-            model_name = 'IAU{0:2d}{1:s}'.format(20 if name[7] == '0' else 19,
+            model_name = 'IAU{:2d}{:s}'.format(20 if name[7] == '0' else 19,
                                                  name[7:])
         else:
             kind = 'apparent'
-            model_name = 'IAU{0:2d}{1:s}'.format(20 if name[6] == '0' else 19,
+            model_name = 'IAU{:2d}{:s}'.format(20 if name[6] == '0' else 19,
                                                  name[6:].upper())
 
         assert kind in SIDEREAL_TIME_MODELS.keys()

--- a/astropy/timeseries/binned.py
+++ b/astropy/timeseries/binned.py
@@ -153,8 +153,8 @@ class BinnedTimeSeries(BaseTimeSeries, metaclass=InheritDocstrings):
         else:
 
             if len(self.colnames) > 0 and len(time_bin_start) != len(self):
-                raise ValueError("Length of 'time_bin_start' ({0}) should match "
-                                 "table length ({1})".format(len(time_bin_start), len(self)))
+                raise ValueError("Length of 'time_bin_start' ({}) should match "
+                                 "table length ({})".format(len(time_bin_start), len(self)))
 
             if time_bin_end is not None:
                 if time_bin_end.isscalar:
@@ -297,7 +297,7 @@ class BinnedTimeSeries(BaseTimeSeries, metaclass=InheritDocstrings):
                                       scale=time_scale, format=time_format)
                 table.remove_column(time_bin_start_column)
             else:
-                raise ValueError("Bin start time column '{}' not found in the input data.".format(time_bin_start_column))
+                raise ValueError(f"Bin start time column '{time_bin_start_column}' not found in the input data.")
 
             if time_bin_end_column is not None:
 
@@ -306,7 +306,7 @@ class BinnedTimeSeries(BaseTimeSeries, metaclass=InheritDocstrings):
                                         scale=time_scale, format=time_format)
                     table.remove_column(time_bin_end_column)
                 else:
-                    raise ValueError("Bin end time column '{}' not found in the input data.".format(time_bin_end_column))
+                    raise ValueError(f"Bin end time column '{time_bin_end_column}' not found in the input data.")
 
                 time_bin_size = None
 
@@ -316,7 +316,7 @@ class BinnedTimeSeries(BaseTimeSeries, metaclass=InheritDocstrings):
                     time_bin_size = table.columns[time_bin_size_column]
                     table.remove_column(time_bin_size_column)
                 else:
-                    raise ValueError("Bin size column '{}' not found in the input data.".format(time_bin_size_column))
+                    raise ValueError(f"Bin size column '{time_bin_size_column}' not found in the input data.")
 
                 if time_bin_size.unit is None:
                     if time_bin_size_unit is None or not isinstance(time_bin_size_unit, u.UnitBase):

--- a/astropy/timeseries/core.py
+++ b/astropy/timeseries/core.py
@@ -37,7 +37,7 @@ def autocheck_required_columns(cls):
     for name in COLUMN_RELATED_METHODS:
         if (not hasattr(cls, name) or
                 not isinstance(getattr(cls, name), FunctionType)):
-            raise ValueError("{0} is not a valid method".format(name))
+            raise ValueError(f"{name} is not a valid method")
         setattr(cls, name, decorator_method(getattr(cls, name)))
 
     return cls
@@ -70,14 +70,14 @@ class BaseTimeSeries(QTable):
 
             if not self._required_columns_relax and len(self.colnames) == 0:
 
-                raise ValueError("{0} object is invalid - expected '{1}' "
-                                 "as the first column{2} but time series has no columns"
+                raise ValueError("{} object is invalid - expected '{}' "
+                                 "as the first column{} but time series has no columns"
                                  .format(self.__class__.__name__, required_columns[0], plural))
 
             elif self.colnames[:len(required_columns)] != required_columns:
 
-                raise ValueError("{0} object is invalid - expected '{1}' "
-                                 "as the first column{2} but found '{3}'"
+                raise ValueError("{} object is invalid - expected '{}' "
+                                 "as the first column{} but found '{}'"
                                  .format(self.__class__.__name__, required_columns[0], plural, self.colnames[0]))
 
             if (self._required_columns_relax

--- a/astropy/timeseries/io/kepler.py
+++ b/astropy/timeseries/io/kepler.py
@@ -47,13 +47,13 @@ def kepler_fits_reader(filename):
                                   "supported through this reader".format(hdulist[0].header['telescop']))
 
     if hdu.header['EXTVER'] > 1:
-        raise NotImplementedError("Support for {0} v{1} files not yet "
+        raise NotImplementedError("Support for {} v{} files not yet "
                                   "implemented".format(hdu.header['TELESCOP'], hdu.header['EXTVER']))
 
     # Check time scale
     if hdu.header['TIMESYS'] != 'TDB':
-        raise NotImplementedError("Support for {0} time scale not yet "
-                                  "implemented in {1} reader".format(hdu.header['TIMESYS'], hdu.header['TELESCOP']))
+        raise NotImplementedError("Support for {} time scale not yet "
+                                  "implemented in {} reader".format(hdu.header['TIMESYS'], hdu.header['TELESCOP']))
 
     tab = Table.read(hdu, format='fits')
 
@@ -74,7 +74,7 @@ def kepler_fits_reader(filename):
     # Filter out NaN rows
     nans = np.isnan(tab['time'].data)
     if np.any(nans):
-        warnings.warn('Ignoring {0} rows with NaN times'.format(np.sum(nans)))
+        warnings.warn('Ignoring {} rows with NaN times'.format(np.sum(nans)))
     tab = tab[~nans]
 
     # Time column is dependent on source and we correct it here

--- a/astropy/timeseries/io/tests/test_kepler.py
+++ b/astropy/timeseries/io/tests/test_kepler.py
@@ -16,8 +16,8 @@ def fake_header(extver, version, timesys, telescop):
                    "NAXIS": 0,
                    "EXTVER": extver,
                    "VERSION": version,
-                   'TIMESYS': "{}".format(timesys),
-                   "TELESCOP": "{}".format(telescop)})
+                   'TIMESYS': f"{timesys}",
+                   "TELESCOP": f"{telescop}"})
 
 
 def fake_hdulist(extver=1, version=2, timesys="TDB", telescop="KEPLER"):

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -171,7 +171,7 @@ class BoxLeastSquares(BasePeriodogram):
         """
 
         duration = self._validate_duration(duration)
-        baseline = strip_units((self._trel.max() - self._trel.min()))
+        baseline = strip_units(self._trel.max() - self._trel.min())
         min_duration = strip_units(np.min(duration))
 
         # Estimate the required frequency spacing
@@ -277,7 +277,7 @@ class BoxLeastSquares(BasePeriodogram):
         try:
             oversample = int(oversample)
         except TypeError:
-            raise ValueError("oversample must be an int, got {0}"
+            raise ValueError("oversample must be an int, got {}"
                              .format(oversample))
         if oversample < 1:
             raise ValueError("oversample must be greater than or equal to 1")
@@ -341,14 +341,14 @@ class BoxLeastSquares(BasePeriodogram):
 
         if self._tstart is None:
             if isinstance(times, Time):
-                raise TypeError('{0} was provided as an absolute time but '
+                raise TypeError('{} was provided as an absolute time but '
                                 'the BoxLeastSquares class was initialized '
                                 'with relative times.'.format(name))
         else:
             if isinstance(times, Time):
                 times = (times - self._tstart).to(u.day)
             else:
-                raise TypeError('{0} was provided as a relative time but '
+                raise TypeError('{} was provided as a relative time but '
                                 'the BoxLeastSquares class was initialized '
                                 'with absolute times.'.format(name))
 

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -26,10 +26,10 @@ def assert_allclose_blsresults(blsresult, other, **kwargs):
     """
     for k, v in blsresult.items():
         if k not in other:
-            raise AssertionError("missing key '{0}'".format(k))
+            raise AssertionError(f"missing key '{k}'")
         if k == "objective":
             assert v == other[k], (
-                "Mismatched objectives. Expected '{0}', got '{1}'"
+                "Mismatched objectives. Expected '{}', got '{}'"
                 .format(v, other[k])
             )
             continue

--- a/astropy/timeseries/periodograms/lombscargle/_statistics.py
+++ b/astropy/timeseries/periodograms/lombscargle/_statistics.py
@@ -95,7 +95,7 @@ def pdf_single(z, N, normalization, dH=1, dK=3):
     elif normalization == 'log':
         return 0.5 * Nk * np.exp(-0.5 * Nk * z)
     else:
-        raise ValueError("normalization='{0}' is not recognized"
+        raise ValueError("normalization='{}' is not recognized"
                          "".format(normalization))
 
 
@@ -146,7 +146,7 @@ def fap_single(z, N, normalization, dH=1, dK=3):
     elif normalization == 'log':
         return np.exp(-0.5 * Nk * z)
     else:
-        raise ValueError("normalization='{0}' is not recognized"
+        raise ValueError("normalization='{}' is not recognized"
                          "".format(normalization))
 
 
@@ -200,7 +200,7 @@ def inv_fap_single(fap, N, normalization, dH=1, dK=3):
         elif normalization == 'log':
             return -2 / Nk * np.log(fap)
         else:
-            raise ValueError("normalization='{0}' is not recognized"
+            raise ValueError("normalization='{}' is not recognized"
                              "".format(normalization))
 
 
@@ -264,7 +264,7 @@ def tau_davies(Z, fmax, t, y, dy, normalization='standard', dH=1, dK=3):
         return (_gamma(NK) * W * np.exp(-0.5 * Z * (NK - 0.5))
                 * np.sqrt(NK * np.sinh(0.5 * Z)))
     else:
-        raise NotImplementedError("normalization={0}".format(normalization))
+        raise NotImplementedError(f"normalization={normalization}")
 
 
 def fap_naive(Z, fmax, t, y, dy, normalization='standard'):
@@ -313,7 +313,7 @@ def inv_fap_davies(p, fmax, t, y, dy, normalization='standard'):
     func = lambda z, *args: fap_davies(z, *args) - p
     res = optimize.root(func, z0, args=args, method='lm')
     if not res.success:
-        raise ValueError('inv_fap_baluev did not converge for p={0}'.format(p))
+        raise ValueError(f'inv_fap_baluev did not converge for p={p}')
     return res.x
 
 
@@ -338,7 +338,7 @@ def inv_fap_baluev(p, fmax, t, y, dy, normalization='standard'):
     func = lambda z, *args: fap_baluev(z, *args) - p
     res = optimize.root(func, z0, args=args, method='lm')
     if not res.success:
-        raise ValueError('inv_fap_baluev did not converge for p={0}'.format(p))
+        raise ValueError(f'inv_fap_baluev did not converge for p={p}')
     return res.x
 
 
@@ -428,7 +428,7 @@ def false_alarm_probability(Z, fmax, t, y, dy, normalization='standard',
     if method == 'single':
         return fap_single(Z, len(t), normalization)
     elif method not in METHODS:
-        raise ValueError("Unrecognized method: {0}".format(method))
+        raise ValueError(f"Unrecognized method: {method}")
     method = METHODS[method]
     method_kwds = method_kwds or {}
 
@@ -488,7 +488,7 @@ def false_alarm_level(p, fmax, t, y, dy, normalization,
     if method == 'single':
         return inv_fap_single(p, len(t), normalization)
     elif method not in INV_METHODS:
-        raise ValueError("Unrecognized method: {0}".format(method))
+        raise ValueError(f"Unrecognized method: {method}")
     method = INV_METHODS[method]
     method_kwds = method_kwds or {}
 

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -376,14 +376,14 @@ class LombScargle(BasePeriodogram):
 
         if self._tstart is None:
             if isinstance(times, Time):
-                raise TypeError('{0} was provided as an absolute time but '
+                raise TypeError('{} was provided as an absolute time but '
                                 'the LombScargle class was initialized '
                                 'with relative times.'.format(name))
         else:
             if isinstance(times, Time):
                 times = (times - self._tstart).to(u.day)
             else:
-                raise TypeError('{0} was provided as a relative time but '
+                raise TypeError('{} was provided as a relative time but '
                                 'the LombScargle class was initialized '
                                 'with absolute times.'.format(name))
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
@@ -82,6 +82,6 @@ def lombscargle_chi2(t, y, dy, frequency, normalization='standard',
     elif normalization == 'standard':
         p /= chi2_ref
     else:
-        raise ValueError("normalization='{0}' "
+        raise ValueError("normalization='{}' "
                          "not recognized".format(normalization))
     return p

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -130,7 +130,7 @@ def lombscargle_fast(t, y, dy, f0, df, Nf,
     elif normalization == 'psd':
         power *= 0.5 * (dy ** -2.0).sum()
     else:
-        raise ValueError("normalization='{0}' "
+        raise ValueError("normalization='{}' "
                          "not recognized".format(normalization))
 
     return power

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -130,6 +130,6 @@ def lombscargle_fastchi2(t, y, dy, f0, df, Nf, normalization='standard',
     elif normalization == 'model':
         p /= chi2_ref - p
     else:
-        raise ValueError("normalization='{0}' "
+        raise ValueError("normalization='{}' "
                          "not recognized".format(normalization))
     return p

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -103,7 +103,7 @@ def validate_method(method, dy, fit_mean, nterms,
             method = 'cython'
 
     if method not in METHODS:
-        raise ValueError("invalid method: {0}".format(method))
+        raise ValueError(f"invalid method: {method}")
 
     return method
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -68,6 +68,6 @@ def lombscargle_scipy(t, y, frequency, normalization='standard',
     elif normalization == 'model':
         p /= 0.5 * t.size * np.mean(y ** 2) - p
     else:
-        raise ValueError("normalization='{0}' "
+        raise ValueError("normalization='{}' "
                          "not recognized".format(normalization))
     return p

--- a/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
@@ -115,6 +115,6 @@ def lombscargle_slow(t, y, dy, frequency, normalization='standard',
     elif normalization == 'psd':
         p *= 0.5 * (dy ** -2.0).sum()
     else:
-        raise ValueError("normalization='{0}' "
+        raise ValueError("normalization='{}' "
                          "not recognized".format(normalization))
     return p.ravel()

--- a/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_lombscargle.py
@@ -85,7 +85,7 @@ def test_all_methods(data, method, center_data, fit_mean,
     elif errors == 'full':
         pass
     else:
-        raise ValueError("Unrecognized error type: '{0}'".format(errors))
+        raise ValueError(f"Unrecognized error type: '{errors}'")
 
     kwds = {}
 
@@ -163,7 +163,7 @@ def test_nterms_methods(method, center_data, fit_mean, errors,
     elif errors == 'full':
         pass
     else:
-        raise ValueError("Unrecognized error type: '{0}'".format(errors))
+        raise ValueError(f"Unrecognized error type: '{errors}'")
 
     ls = LombScargle(t, y, dy, center_data=center_data,
                      fit_mean=fit_mean, nterms=nterms,
@@ -202,7 +202,7 @@ def test_fast_approximations(method, center_data, fit_mean,
     elif errors == 'full':
         pass
     else:
-        raise ValueError("Unrecognized error type: '{0}'".format(errors))
+        raise ValueError(f"Unrecognized error type: '{errors}'")
 
     ls = LombScargle(t, y, dy, center_data=center_data,
                      fit_mean=fit_mean, nterms=nterms,
@@ -402,7 +402,7 @@ def test_model_parameters(data, nterms, fit_mean, center_data,
     elif errors == 'full':
         pass
     else:
-        raise ValueError("Unrecognized error type: '{0}'".format(errors))
+        raise ValueError(f"Unrecognized error type: '{errors}'")
 
     ls = LombScargle(t, y, dy,
                      nterms=nterms,

--- a/astropy/timeseries/periodograms/lombscargle/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/utils.py
@@ -66,7 +66,7 @@ def convert_normalization(Z, N, from_normalization, to_normalization,
 
     for norm in from_to:
         if norm not in NORMALIZATIONS:
-            raise ValueError("{0} is not a valid normalization"
+            raise ValueError("{} is not a valid normalization"
                              "".format(from_normalization))
 
     if from_normalization == to_normalization:
@@ -98,6 +98,6 @@ def convert_normalization(Z, N, from_normalization, to_normalization,
                                            to_normalization='standard')
         return 0.5 * chi2_ref * Z_standard
     else:
-        raise NotImplementedError("conversion from '{0}' to '{1}'"
+        raise NotImplementedError("conversion from '{}' to '{}'"
                                   "".format(from_normalization,
                                             to_normalization))

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -122,8 +122,8 @@ class TimeSeries(BaseTimeSeries):
             time = time_start + time_delta
 
         elif len(self.colnames) > 0 and len(time) != len(self):
-            raise ValueError("Length of 'time' ({0}) should match "
-                             "data length ({1})".format(len(time), n_samples))
+            raise ValueError("Length of 'time' ({}) should match "
+                             "data length ({})".format(len(time), n_samples))
 
         elif time_delta is not None:
             raise TypeError("'time_delta' should not be specified since "
@@ -308,6 +308,6 @@ class TimeSeries(BaseTimeSeries):
                 time = Time(table.columns[time_column], scale=time_scale, format=time_format)
                 table.remove_column(time_column)
             else:
-                raise ValueError("Time column '{}' not found in the input data.".format(time_column))
+                raise ValueError(f"Time column '{time_column}' not found in the input data.")
 
             return TimeSeries(time=time, data=table)

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -145,13 +145,13 @@ class Distribution:
 
     def __str__(self):
         distrstr = str(self.distribution)
-        toadd = ' with n_samples={}'.format(self.n_samples)
+        toadd = f' with n_samples={self.n_samples}'
         return distrstr + toadd
 
     def _repr_latex_(self):
         if hasattr(self.distribution, '_repr_latex_'):
             superlatex = self.distribution._repr_latex_()
-            toadd = r', \; n_{{\rm samp}}={}'.format(self.n_samples)
+            toadd = fr', \; n_{{\rm samp}}={self.n_samples}'
             return superlatex[:-1] + toadd + superlatex[-1]
         else:
             return None

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -91,13 +91,13 @@ def _normalize_equivalencies(equivalencies):
             funit, tunit, a, b = equiv
         else:
             raise ValueError(
-                "Invalid equivalence entry {0}: {1!r}".format(i, equiv))
+                f"Invalid equivalence entry {i}: {equiv!r}")
         if not (funit is Unit(funit) and
                 (tunit is None or tunit is Unit(tunit)) and
                 callable(a) and
                 callable(b)):
             raise ValueError(
-                "Invalid equivalence entry {0}: {1!r}".format(i, equiv))
+                f"Invalid equivalence entry {i}: {equiv!r}")
         normalized.append((funit, tunit, a, b))
 
     return normalized
@@ -194,7 +194,7 @@ class _UnitRegistry:
             for st in unit._names:
                 if (st in self._registry and unit != self._registry[st]):
                     raise ValueError(
-                        "Object with name {0!r} already exists in namespace. "
+                        "Object with name {!r} already exists in namespace. "
                         "Filter the set of units to avoid name clashes before "
                         "enabling them.".format(st))
 
@@ -528,7 +528,7 @@ class UnitBase(metaclass=InheritDocstrings):
     def __repr__(self):
         string = unit_format.Generic.to_string(self)
 
-        return 'Unit("{0}")'.format(string)
+        return f'Unit("{string}")'
 
     def _get_physical_type_id(self):
         """
@@ -876,17 +876,17 @@ class UnitBase(metaclass=InheritDocstrings):
             unit_str = unit.to_string('unscaled')
             physical_type = unit.physical_type
             if physical_type != 'unknown':
-                unit_str = "'{0}' ({1})".format(
+                unit_str = "'{}' ({})".format(
                     unit_str, physical_type)
             else:
-                unit_str = "'{0}'".format(unit_str)
+                unit_str = f"'{unit_str}'"
             return unit_str
 
         unit_str = get_err_str(unit)
         other_str = get_err_str(other)
 
         raise UnitConversionError(
-            "{0} and {1} are not convertible".format(
+            "{} and {} are not convertible".format(
                 unit_str, other_str))
 
     def _get_converter(self, other, equivalencies=[]):
@@ -950,7 +950,7 @@ class UnitBase(metaclass=InheritDocstrings):
                 return self_decomposed.scale / other_decomposed.scale
 
         raise UnitConversionError(
-            "'{0!r}' is not a scaled version of '{1!r}'".format(self, other))
+            f"'{self!r}' is not a scaled version of '{other!r}'")
 
     def to(self, other, value=UNITY, equivalencies=[]):
         """
@@ -1130,7 +1130,7 @@ class UnitBase(metaclass=InheritDocstrings):
 
         if not is_final_result(self):
             result = UnitsError(
-                "Cannot represent unit {0} in terms of the given "
+                "Cannot represent unit {} in terms of the given "
                 "units".format(self))
             cached_results[key] = result
             raise result
@@ -1407,7 +1407,7 @@ class UnitBase(metaclass=InheritDocstrings):
                 lines = [f.format(*line) for line in lines]
                 lines = (lines[0:1] +
                          ['['] +
-                         ['{0} ,'.format(x) for x in lines[1:]] +
+                         [f'{x} ,' for x in lines[1:]] +
                          [']'])
                 return '\n'.join(lines)
 
@@ -1612,8 +1612,8 @@ class NamedUnit(UnitBase):
         for name in self._names:
             if name in namespace and self != namespace[name]:
                 raise ValueError(
-                    "Object with name {0!r} already exists in "
-                    "given namespace ({1!r}).".format(
+                    "Object with name {!r} already exists in "
+                    "given namespace ({!r}).".format(
                         name, namespace[name]))
 
         for name in self._names:
@@ -1684,7 +1684,7 @@ class IrreducibleUnit(NamedUnit):
                                              _error_check=False)
 
             raise UnitConversionError(
-                "Unit {0} can not be decomposed into the requested "
+                "Unit {} can not be decomposed into the requested "
                 "bases".format(self))
 
         return self
@@ -1707,7 +1707,7 @@ class UnrecognizedUnit(IrreducibleUnit):
     __reduce__ = object.__reduce__
 
     def __repr__(self):
-        return "UnrecognizedUnit({0})".format(str(self))
+        return "UnrecognizedUnit({})".format(str(self))
 
     def __bytes__(self):
         return self.name.encode('ascii', 'replace')
@@ -1720,7 +1720,7 @@ class UnrecognizedUnit(IrreducibleUnit):
 
     def _unrecognized_operator(self, *args, **kwargs):
         raise ValueError(
-            "The unit {0!r} is unrecognized, so all arithmetic operations "
+            "The unit {!r} is unrecognized, so all arithmetic operations "
             "with it are invalid.".format(self.name))
 
     __pow__ = __div__ = __rdiv__ = __truediv__ = __rtruediv__ = __mul__ = \
@@ -1745,7 +1745,7 @@ class UnrecognizedUnit(IrreducibleUnit):
     def _get_converter(self, other, equivalencies=None):
         self._normalize_equivalencies(equivalencies)
         raise ValueError(
-            "The unit {0!r} is unrecognized.  It can not be converted "
+            "The unit {!r} is unrecognized.  It can not be converted "
             "to other units.".format(self.name))
 
     def get_format_name(self, format):
@@ -1827,7 +1827,7 @@ class _UnitMetaClass(InheritDocstrings):
                         format_clause = f.name + ' '
                     else:
                         format_clause = ''
-                    msg = ("'{0}' did not parse as {1}unit: {2}"
+                    msg = ("'{}' did not parse as {}unit: {}"
                            .format(s, format_clause, str(e)))
                     if parse_strict == 'raise':
                         raise ValueError(msg)
@@ -1845,7 +1845,7 @@ class _UnitMetaClass(InheritDocstrings):
             raise TypeError("None is not a valid Unit")
 
         else:
-            raise TypeError("{0} can not be converted to a Unit".format(s))
+            raise TypeError(f"{s} can not be converted to a Unit")
 
 
 class Unit(NamedUnit, metaclass=_UnitMetaClass):
@@ -2056,7 +2056,7 @@ class CompositeUnit(UnitBase):
             return super().__repr__()
         else:
             if self._scale != 1.0:
-                return 'Unit(dimensionless with a scale of {0})'.format(
+                return 'Unit(dimensionless with a scale of {})'.format(
                     self._scale)
             else:
                 return 'Unit(dimensionless)'

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -29,7 +29,7 @@ def _get_allowed_units(targets):
                 physical_type_id = _unit_physical_mapping[target]
 
             except KeyError:  # Function argument target is invalid
-                raise ValueError("Invalid unit or physical type '{0}'."
+                raise ValueError("Invalid unit or physical type '{}'."
                                  .format(target))
 
             # get unit directly from physical type id
@@ -62,19 +62,19 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
             else:
                 error_msg = "no 'unit' attribute"
 
-            raise TypeError("Argument '{0}' to function '{1}' has {2}. "
+            raise TypeError("Argument '{}' to function '{}' has {}. "
                   "You may want to pass in an astropy Quantity instead."
                      .format(param_name, func_name, error_msg))
 
     else:
         if len(targets) > 1:
-            raise UnitsError("Argument '{0}' to function '{1}' must be in units"
-                             " convertible to one of: {2}."
+            raise UnitsError("Argument '{}' to function '{}' must be in units"
+                             " convertible to one of: {}."
                              .format(param_name, func_name,
                                      [str(targ) for targ in targets]))
         else:
-            raise UnitsError("Argument '{0}' to function '{1}' must be in units"
-                             " convertible to '{2}'."
+            raise UnitsError("Argument '{}' to function '{}' must be in units"
+                             " convertible to '{}'."
                              .format(param_name, func_name,
                                      str(targets[0])))
 

--- a/astropy/units/format/__init__.py
+++ b/astropy/units/format/__init__.py
@@ -46,9 +46,9 @@ def get_format(format=None):
         return format
     elif not (isinstance(format, str) or format is None):
         raise TypeError(
-            "Formatter must a subclass or instance of a subclass of {0!r} "
+            "Formatter must a subclass or instance of a subclass of {!r} "
             "or a string giving the name of the formatter.  Valid formatter "
-            "names are: [{1}]".format(Base, ', '.join(Base.registry)))
+            "names are: [{}]".format(Base, ', '.join(Base.registry)))
 
     if format is None:
         format = 'generic'
@@ -58,5 +58,5 @@ def get_format(format=None):
     if format_lower in Base.registry:
         return Base.registry[format_lower]
 
-    raise ValueError("Unknown format {0!r}.  Valid formatter names are: "
-                     "[{1}]".format(format, ', '.join(Base.registry)))
+    raise ValueError("Unknown format {!r}.  Valid formatter names are: "
+                     "[{}]".format(format, ', '.join(Base.registry)))

--- a/astropy/units/format/base.py
+++ b/astropy/units/format/base.py
@@ -53,7 +53,7 @@ class Base(metaclass=_FormatterMeta):
         """
 
         raise NotImplementedError(
-            "Can not parse {0}".format(cls.__name__))
+            f"Can not parse {cls.__name__}")
 
     @classmethod
     def to_string(cls, u):
@@ -62,7 +62,7 @@ class Base(metaclass=_FormatterMeta):
         """
 
         raise NotImplementedError(
-            "Can not output in {0} format".format(cls.__name__))
+            f"Can not output in {cls.__name__} format")
 
     @classmethod
     def _add_tab_header(cls, name):

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -124,7 +124,7 @@ class CDS(Base):
         # Error handling rule
         def t_error(t):
             raise ValueError(
-                "Invalid character at col {0}".format(t.lexpos))
+                f"Invalid character at col {t.lexpos}")
 
         lexer_exists = os.path.exists(os.path.join(os.path.dirname(__file__),
                                       'cds_lextab.py'))
@@ -283,7 +283,7 @@ class CDS(Base):
             return cls._parse_unit(t.value)
         except ValueError as e:
             raise ValueError(
-                "At col {0}, {1}".format(
+                "At col {}, {}".format(
                     t.lexpos, str(e)))
 
     @classmethod
@@ -291,8 +291,8 @@ class CDS(Base):
         if unit not in cls._units:
             if detailed_exception:
                 raise ValueError(
-                    "Unit '{0}' not supported by the CDS SAC "
-                    "standard. {1}".format(
+                    "Unit '{}' not supported by the CDS SAC "
+                    "standard. {}".format(
                         unit, did_you_mean(
                             unit, cls._units)))
             else:
@@ -332,7 +332,7 @@ class CDS(Base):
             if power == 1:
                 out.append(cls._get_unit_name(base))
             else:
-                out.append('{0}{1}'.format(
+                out.append('{}{}'.format(
                     cls._get_unit_name(base), int(power)))
         return '.'.join(out)
 
@@ -356,7 +356,7 @@ class CDS(Base):
                 if e:
                     if not e.startswith('-'):
                         e = "+" + e
-                    parts.append('10{0}'.format(e))
+                    parts.append(f'10{e}')
                 s = 'x'.join(parts)
 
             pairs = list(zip(unit.bases, unit.powers))

--- a/astropy/units/format/console.py
+++ b/astropy/units/format/console.py
@@ -32,7 +32,7 @@ class Console(base.Base):
 
     @classmethod
     def _format_superscript(cls, number):
-        return '^{0}'.format(number)
+        return f'^{number}'
 
     @classmethod
     def _format_unit_list(cls, units):
@@ -41,7 +41,7 @@ class Console(base.Base):
             if power == 1:
                 out.append(cls._get_unit_name(base))
             else:
-                out.append('{0}{1}'.format(
+                out.append('{}{}'.format(
                     cls._get_unit_name(base),
                     cls._format_superscript(
                             utils.format_power(power))))
@@ -56,7 +56,7 @@ class Console(base.Base):
             parts.append(m)
 
         if ex:
-            parts.append("10{0}".format(
+            parts.append("10{}".format(
                 cls._format_superscript(ex)))
 
         return cls._times.join(parts)
@@ -80,7 +80,7 @@ class Console(base.Base):
                     negatives = cls._format_unit_list(negatives)
                     l = len(s)
                     r = max(len(positives), len(negatives))
-                    f = "{{0:^{0}s}} {{1:^{1}s}}".format(l, r)
+                    f = f"{{0:^{l}s}} {{1:^{r}s}}"
 
                     lines = [
                         f.format('', positives),

--- a/astropy/units/format/fits.py
+++ b/astropy/units/format/fits.py
@@ -84,7 +84,7 @@ class Fits(generic.Generic):
         if unit not in cls._units:
             if detailed_exception:
                 raise ValueError(
-                    "Unit '{0}' not supported by the FITS standard. {1}".format(
+                    "Unit '{}' not supported by the FITS standard. {}".format(
                         unit, utils.did_you_mean_units(
                             unit, cls._units, cls._deprecated_units,
                             cls._to_decomposed_alternative)))
@@ -121,9 +121,9 @@ class Fits(generic.Generic):
                 raise core.UnitScaleError(
                     "The FITS unit format is not able to represent scales "
                     "that are not powers of 10.  Multiply your data by "
-                    "{0:e}.".format(unit.scale))
+                    "{:e}.".format(unit.scale))
             elif unit.scale != 1.0:
-                parts.append('10**{0}'.format(int(base)))
+                parts.append('10**{}'.format(int(base)))
 
             pairs = list(zip(unit.bases, unit.powers))
             if len(pairs):
@@ -144,7 +144,7 @@ class Fits(generic.Generic):
             scale = unit.scale
             unit = copy.copy(unit)
             unit._scale = 1.0
-            return '{0} (with data multiplied by {1})'.format(
+            return '{} (with data multiplied by {})'.format(
                 cls.to_string(unit), scale)
         return s
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -29,7 +29,7 @@ def _to_string(cls, unit):
         parts = []
 
         if cls._show_scale and unit.scale != 1:
-            parts.append('{0:g}'.format(unit.scale))
+            parts.append(f'{unit.scale:g}')
 
         if len(unit.bases):
             positives, negatives = utils.get_grouped_by_powers(
@@ -43,9 +43,9 @@ def _to_string(cls, unit):
                 parts.append('/')
                 unit_list = cls._format_unit_list(negatives)
                 if len(negatives) == 1:
-                    parts.append('{0}'.format(unit_list))
+                    parts.append(f'{unit_list}')
                 else:
-                    parts.append('({0})'.format(unit_list))
+                    parts.append(f'({unit_list})')
 
         return ' '.join(parts)
     elif isinstance(unit, core.NamedUnit):
@@ -156,7 +156,7 @@ class Generic(Base):
         # Error handling rule
         def t_error(t):
             raise ValueError(
-                "Invalid character at col {0}".format(t.lexpos))
+                f"Invalid character at col {t.lexpos}")
 
         lexer_exists = os.path.exists(os.path.join(os.path.dirname(__file__),
                                       'generic_lextab.py'))
@@ -423,7 +423,7 @@ class Generic(Base):
                     p[0] = function_unit(p[3])
                     return
 
-            raise ValueError("'{0}' is not a recognized function".format(p[1]))
+            raise ValueError("'{}' is not a recognized function".format(p[1]))
 
         def p_error(p):
             raise ValueError()
@@ -445,7 +445,7 @@ class Generic(Base):
             return cls._parse_unit(t.value)
         except ValueError as e:
             raise ValueError(
-                "At col {0}, {1}".format(
+                "At col {}, {}".format(
                     t.lexpos, str(e)))
 
     @classmethod
@@ -458,7 +458,7 @@ class Generic(Base):
 
         if detailed_exception:
             raise ValueError(
-                '{0} is not a valid unit. {1}'.format(
+                '{} is not a valid unit. {}'.format(
                     s, did_you_mean(s, registry)))
         else:
             raise ValueError()
@@ -471,7 +471,7 @@ class Generic(Base):
         result = cls._do_parse(s, debug=debug)
         if s.count('/') > 1:
             warnings.warn(
-                "'{0}' contains multiple slashes, which is "
+                "'{}' contains multiple slashes, which is "
                 "discouraged by the FITS standard".format(s),
                 core.UnitsWarning)
         return result
@@ -490,7 +490,7 @@ class Generic(Base):
                     raise
                 else:
                     raise ValueError(
-                        "Syntax error parsing unit '{0}'".format(s))
+                        f"Syntax error parsing unit '{s}'")
 
     @classmethod
     def _get_unit_name(cls, unit):
@@ -507,10 +507,10 @@ class Generic(Base):
             else:
                 power = utils.format_power(power)
                 if '/' in power:
-                    out.append('{0}({1})'.format(
+                    out.append('{}({})'.format(
                         cls._get_unit_name(base), power))
                 else:
-                    out.append('{0}{1}'.format(
+                    out.append('{}{}'.format(
                         cls._get_unit_name(base), power))
         return ' '.join(out)
 

--- a/astropy/units/format/latex.py
+++ b/astropy/units/format/latex.py
@@ -55,7 +55,7 @@ class Latex(base.Base):
             else:
                 positives = '1'
             negatives = cls._format_unit_list(negatives)
-            s = r'\frac{{{0}}}{{{1}}}'.format(positives, negatives)
+            s = fr'\frac{{{positives}}}{{{negatives}}}'
         else:
             positives = cls._format_unit_list(positives)
             s = positives
@@ -82,7 +82,7 @@ class Latex(base.Base):
         elif isinstance(unit, core.NamedUnit):
             s = cls._latex_escape(unit.name)
 
-        return r'$\mathrm{{{0}}}$'.format(s)
+        return fr'$\mathrm{{{s}}}$'
 
     @classmethod
     def format_exponential_notation(cls, val, format_spec=".8g"):
@@ -109,7 +109,7 @@ class Latex(base.Base):
             if m:
                 parts.append(m)
             if ex:
-                parts.append("10^{{{0}}}".format(ex))
+                parts.append(f"10^{{{ex}}}")
 
             return r" \times ".join(parts)
         else:

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -162,7 +162,7 @@ class OGIP(generic.Generic):
         # Error handling rule
         def t_error(t):
             raise ValueError(
-                "Invalid character at col {0}".format(t.lexpos))
+                f"Invalid character at col {t.lexpos}")
 
         lexer_exists = os.path.exists(os.path.join(os.path.dirname(__file__),
                                                    'ogip_lextab.py'))
@@ -244,7 +244,7 @@ class OGIP(generic.Generic):
 
             if p1_str in cls._functions and p1_str != 'sqrt':
                 raise ValueError(
-                    "The function '{0}' is valid in OGIP, but not understood "
+                    "The function '{}' is valid in OGIP, but not understood "
                     "by astropy.units.".format(
                         p[1]))
 
@@ -281,7 +281,7 @@ class OGIP(generic.Generic):
             if math.log10(p[0]) % 1.0 != 0.0:
                 from astropy.units.core import UnitsWarning
                 warnings.warn(
-                    "'{0}' scale should be a power of 10 in "
+                    "'{}' scale should be a power of 10 in "
                     "OGIP format".format(p[0]), UnitsWarning)
 
         def p_division(p):
@@ -378,7 +378,7 @@ class OGIP(generic.Generic):
             return cls._parse_unit(t.value)
         except ValueError as e:
             raise ValueError(
-                "At col {0}, '{1}': {2}".format(
+                "At col {}, '{}': {}".format(
                     t.lexpos, t.value, str(e)))
 
     @classmethod
@@ -386,8 +386,8 @@ class OGIP(generic.Generic):
         if unit not in cls._units:
             if detailed_exception:
                 raise ValueError(
-                    "Unit '{0}' not supported by the OGIP "
-                    "standard. {1}".format(
+                    "Unit '{}' not supported by the OGIP "
+                    "standard. {}".format(
                         unit, utils.did_you_mean_units(
                             unit, cls._units, cls._deprecated_units,
                             cls._to_decomposed_alternative)))
@@ -420,7 +420,7 @@ class OGIP(generic.Generic):
                     raise
                 else:
                     raise ValueError(
-                        "Syntax error parsing unit '{0}'".format(s))
+                        f"Syntax error parsing unit '{s}'")
 
     @classmethod
     def _get_unit_name(cls, unit):
@@ -439,10 +439,10 @@ class OGIP(generic.Generic):
             else:
                 power = utils.format_power(power)
                 if '/' in power:
-                    out.append('{0}**({1})'.format(
+                    out.append('{}**({})'.format(
                         cls._get_unit_name(base), power))
                 else:
-                    out.append('{0}**{1}'.format(
+                    out.append('{}**{}'.format(
                         cls._get_unit_name(base), power))
         return ' '.join(out)
 
@@ -455,7 +455,7 @@ class OGIP(generic.Generic):
             # Can't use np.log10 here, because p[0] may be a Python long.
             if math.log10(unit.scale) % 1.0 != 0.0:
                 warnings.warn(
-                    "'{0}' scale should be a power of 10 in "
+                    "'{}' scale should be a power of 10 in "
                     "OGIP format".format(
                         unit.scale),
                     core.UnitsWarning)
@@ -473,7 +473,7 @@ class OGIP(generic.Generic):
                 scale = unit.scale
                 unit = copy.copy(unit)
                 unit._scale = 1.0
-                return '{0} (with data multiplied by {1})'.format(
+                return '{} (with data multiplied by {})'.format(
                     generic._to_string(cls, unit), scale)
 
         return generic._to_string(unit)

--- a/astropy/units/format/unicode_format.py
+++ b/astropy/units/format/unicode_format.py
@@ -39,7 +39,7 @@ class Unicode(console.Console):
             parts.append(m.replace('-', '−'))
 
         if ex:
-            parts.append("10{0}".format(
+            parts.append("10{}".format(
                 cls._format_superscript(ex)))
 
         return cls._times.join(parts)

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -210,9 +210,9 @@ def unit_deprecation_warning(s, unit, standard_name, format_decomposed):
     """
     from astropy.units.core import UnitsWarning
 
-    message = "The unit '{0}' has been deprecated in the {1} standard.".format(
+    message = "The unit '{}' has been deprecated in the {} standard.".format(
         s, standard_name)
     decomposed = _try_decomposed(unit, format_decomposed)
     if decomposed is not None:
-        message += " Suggested: {0}.".format(decomposed)
+        message += f" Suggested: {decomposed}."
     warnings.warn(message, UnitsWarning)

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -87,7 +87,7 @@ class VOUnit(generic.Generic):
             return core.dimensionless_unscaled
         if s.count('/') > 1:
             raise core.UnitsError(
-                "'{0}' contains multiple slashes, which is "
+                "'{}' contains multiple slashes, which is "
                 "disallowed by the VOUnit standard".format(s))
         result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
@@ -105,8 +105,8 @@ class VOUnit(generic.Generic):
                 raise ValueError()
 
             warnings.warn(
-                "Unit {0!r} not supported by the VOUnit "
-                "standard. {1}".format(
+                "Unit {!r} not supported by the VOUnit "
+                "standard. {}".format(
                     unit, utils.did_you_mean_units(
                         unit, cls._units, cls._deprecated_units,
                         cls._to_decomposed_alternative)),
@@ -128,11 +128,11 @@ class VOUnit(generic.Generic):
         if isinstance(unit, core.PrefixUnit):
             if unit._represents.scale == 10.0:
                 raise ValueError(
-                    "In '{0}': VOUnit can not represent units with the 'da' "
+                    "In '{}': VOUnit can not represent units with the 'da' "
                     "(deka) prefix".format(unit))
             elif unit._represents.scale == 0.1:
                 raise ValueError(
-                    "In '{0}': VOUnit can not represent units with the 'd' "
+                    "In '{}': VOUnit can not represent units with the 'd' "
                     "(deci) prefix".format(unit))
 
         name = unit.get_format_name('vounit')
@@ -142,7 +142,7 @@ class VOUnit(generic.Generic):
 
         if name not in cls._units:
             raise ValueError(
-                "Unit {0!r} is not part of the VOUnit standard".format(name))
+                f"Unit {name!r} is not part of the VOUnit standard")
 
         if name in cls._deprecated_units:
             utils.unit_deprecation_warning(
@@ -195,7 +195,7 @@ class VOUnit(generic.Generic):
                 raise core.UnitScaleError(
                     "The VOUnit format is not able to "
                     "represent scale for dimensionless units. "
-                    "Multiply your data by {0:e}."
+                    "Multiply your data by {:e}."
                     .format(unit.scale))
             s = ''
             if unit.scale != 1:
@@ -230,6 +230,6 @@ class VOUnit(generic.Generic):
             scale = unit.scale
             unit = copy.copy(unit)
             unit._scale = 1.0
-            return '{0} (with data multiplied by {1})'.format(
+            return '{} (with data multiplied by {})'.format(
                 cls.to_string(unit), scale)
         return s

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -98,7 +98,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
             if (not isinstance(self._physical_unit, UnitBase) or
                 self._physical_unit.is_equivalent(
                     self._default_function_unit)):
-                raise UnitConversionError("Unit {0} is not a physical unit."
+                raise UnitConversionError("Unit {} is not a physical unit."
                                           .format(self._physical_unit))
 
         if function_unit is None:
@@ -111,8 +111,8 @@ class FunctionUnitBase(metaclass=ABCMeta):
                 self._function_unit = function_unit
             else:
                 raise UnitConversionError(
-                    "Cannot initialize '{0}' instance with function unit '{1}'"
-                    ", as it is not equivalent to default function unit '{2}'."
+                    "Cannot initialize '{}' instance with function unit '{}'"
+                    ", as it is not equivalent to default function unit '{}'."
                     .format(self.__class__.__name__, function_unit,
                             self._default_function_unit))
 
@@ -361,7 +361,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
             provided, defaults to the generic format.
         """
         if format not in ('generic', 'unscaled', 'latex'):
-            raise ValueError("Function units cannot be written in {0} format. "
+            raise ValueError("Function units cannot be written in {} format. "
                              "Only 'generic', 'unscaled' and 'latex' are "
                              "supported.".format(format))
         self_str = self.function_unit.to_string(format)
@@ -372,7 +372,7 @@ class FunctionUnitBase(metaclass=ABCMeta):
             self_str += r'$\mathrm{{\left( {0} \right)}}$'.format(
                 pu_str[1:-1])   # need to strip leading and trailing "$"
         else:
-            self_str += '({0})'.format(pu_str)
+            self_str += f'({pu_str})'
         return self_str
 
     def __str__(self):
@@ -380,20 +380,20 @@ class FunctionUnitBase(metaclass=ABCMeta):
         self_str = str(self.function_unit)
         pu_str = str(self.physical_unit)
         if pu_str:
-            self_str += '({0})'.format(pu_str)
+            self_str += f'({pu_str})'
         return self_str
 
     def __repr__(self):
         # By default, try to give a representation using `Unit(<string>)`,
         # with string such that parsing it would give the correct FunctionUnit.
         if callable(self.function_unit):
-            return 'Unit("{0}")'.format(self.to_string())
+            return 'Unit("{}")'.format(self.to_string())
 
         else:
-            return '{0}("{1}"{2})'.format(
+            return '{}("{}"{})'.format(
                 self.__class__.__name__, self.physical_unit,
                 "" if self.function_unit is self._default_function_unit
-                else ', unit="{0}"'.format(self.function_unit))
+                else f', unit="{self.function_unit}"')
 
     def _repr_latex_(self):
         """
@@ -557,9 +557,9 @@ class FunctionQuantity(Quantity):
                 unit = self._unit_class(function_unit=unit or 'nonsense')
             except Exception:
                 raise UnitTypeError(
-                    "{0} instances require {1} function units"
+                    "{} instances require {} function units"
                     .format(type(self).__name__, self._unit_class.__name__) +
-                    ", so cannot set it to '{0}'.".format(unit))
+                    f", so cannot set it to '{unit}'.")
 
         self._unit = unit
 
@@ -570,7 +570,7 @@ class FunctionQuantity(Quantity):
         # another argument might know what to do.
         if function not in self._supported_ufuncs:
             raise UnitTypeError(
-                "Cannot use ufunc '{0}' with function quantities"
+                "Cannot use ufunc '{}' with function quantities"
                 .format(function.__name__))
 
         return super().__array_ufunc__(function, method, *inputs, **kwargs)
@@ -665,7 +665,7 @@ class FunctionQuantity(Quantity):
             args = tuple(getattr(arg, '_function_view', arg) for arg in args)
             return self._function_view._wrap_function(function, *args, **kwargs)
 
-        raise TypeError("Cannot use method that uses function '{0}' with "
+        raise TypeError("Cannot use method that uses function '{}' with "
                         "function quantities that are not dimensionless."
                         .format(function.__name__))
 

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -359,8 +359,8 @@ ABmag.__doc__ = "AB magnitude: ABmag=-48.6 corresponds to 1 erg/s/cm2/Hz"
 
 M_bol = MagUnit(photometric.Bol)
 M_bol.__doc__ = ("Absolute bolometric magnitude: M_bol=0 corresponds to "
-                 "L_bol0={0}".format(photometric.Bol.si))
+                 "L_bol0={}".format(photometric.Bol.si))
 
 m_bol = MagUnit(photometric.bol)
 m_bol.__doc__ = ("Apparent bolometric magnitude: m_bol=0 corresponds to "
-                 "f_bol0={0}".format(photometric.bol.si))
+                 "f_bol0={}".format(photometric.bol.si))

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -39,7 +39,7 @@ def def_physical_type(unit, name):
     r = unit._get_physical_type_id()
     if r in _physical_unit_mapping:
         raise ValueError(
-            "{0!r} ({1!r}) already defined as {2!r}".format(
+            "{!r} ({!r}) already defined as {!r}".format(
                 r, name, _physical_unit_mapping[r]))
     _physical_unit_mapping[r] = name
     _unit_physical_mapping[name] = r

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -121,7 +121,7 @@ class QuantityInfoBase(ParentDtypeInfo):
 
     @staticmethod
     def default_format(val):
-        return '{0.value:}'.format(val)
+        return f'{val.value}'
 
     @staticmethod
     def possible_string_format_functions(format_):
@@ -327,7 +327,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                     value = float(v.group())
 
                 except Exception:
-                    raise TypeError('Cannot parse "{0}" as a {1}. It does not '
+                    raise TypeError('Cannot parse "{}" as a {}. It does not '
                                     'start with a number.'
                                     .format(value, cls.__name__))
 
@@ -358,9 +358,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                 try:
                     value_unit = Unit(value_unit)
                 except Exception as exc:
-                    raise TypeError("The unit attribute {0!r} of the input could "
+                    raise TypeError("The unit attribute {!r} of the input could "
                                     "not be parsed as an astropy Unit, raising "
-                                    "the following exception:\n{1}"
+                                    "the following exception:\n{}"
                                     .format(value.unit, exc))
 
                 if unit is None:
@@ -615,7 +615,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             unit = Unit(str(unit), parse_strict='silent')
             if not isinstance(unit, UnitBase):
                 raise UnitTypeError(
-                    "{0} instances require {1} units, not {2} instances."
+                    "{} instances require {} units, not {} instances."
                     .format(type(self).__name__, UnitBase, type(unit)))
 
         self._unit = unit
@@ -816,7 +816,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         """
         if not self._include_easy_conversion_members:
             raise AttributeError(
-                "'{0}' object has no '{1}' member".format(
+                "'{}' object has no '{}' member".format(
                     self.__class__.__name__,
                     attr))
 
@@ -836,7 +836,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
 
         if value is None:
             raise AttributeError(
-                "{0} instance has no attribute '{1}'".format(
+                "{} instance has no attribute '{}'".format(
                     self.__class__.__name__, attr))
         else:
             return value
@@ -1173,9 +1173,9 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         }
 
         if format not in formats:
-            raise ValueError("Unknown format '{0}'".format(format))
+            raise ValueError(f"Unknown format '{format}'")
         elif format is None:
-            return '{0}{1:s}'.format(self.value, self._unitstr)
+            return f'{self.value}{self._unitstr:s}'
 
         # else, for the moment we assume format="latex"
 
@@ -1191,7 +1191,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
                                                      format_spec=format_spec)
 
         def complex_formatter(value):
-            return '({0}{1}i)'.format(
+            return '({}{}i)'.format(
                 Latex.format_exponential_notation(value.real,
                                                   format_spec=format_spec),
                 Latex.format_exponential_notation(value.imag,
@@ -1241,7 +1241,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
         sep = ',' if NUMPY_LT_1_14 else ', '
         arrstr = np.array2string(self.view(np.ndarray), separator=sep,
                                  prefix=prefixstr)
-        return '{0}{1}{2:s}>'.format(prefixstr, arrstr, self._unitstr)
+        return f'{prefixstr}{arrstr}{self._unitstr:s}>'
 
     def _repr_latex_(self):
         """
@@ -1272,7 +1272,7 @@ class Quantity(np.ndarray, metaclass=InheritDocstrings):
             value = self.value
             full_format_spec = format_spec
 
-        return format("{0}{1:s}".format(value, self._unitstr),
+        return format(f"{value}{self._unitstr:s}",
                       full_format_spec)
 
     def decompose(self, bases=[]):
@@ -1737,10 +1737,10 @@ class SpecificTypeQuantity(Quantity):
     def _set_unit(self, unit):
         if unit is None or not unit.is_equivalent(self._equivalent_unit):
             raise UnitTypeError(
-                "{0} instances require units equivalent to '{1}'"
+                "{} instances require units equivalent to '{}'"
                 .format(type(self).__name__, self._equivalent_unit) +
                 (", but no unit was given." if unit is None else
-                 ", so cannot set it to '{0}'.".format(unit)))
+                 f", so cannot set it to '{unit}'."))
 
         super()._set_unit(unit)
 
@@ -1778,7 +1778,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     try:
         desired = desired.to(actual.unit)
     except UnitsError:
-        raise UnitsError("Units for 'desired' ({0}) and 'actual' ({1}) "
+        raise UnitsError("Units for 'desired' ({}) and 'actual' ({}) "
                          "are not convertible"
                          .format(desired.unit, actual.unit))
 
@@ -1790,7 +1790,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         try:
             atol = atol.to(actual.unit)
         except UnitsError:
-            raise UnitsError("Units for 'atol' ({0}) and 'actual' ({1}) "
+            raise UnitsError("Units for 'atol' ({}) and 'actual' ({}) "
                              "are not convertible"
                              .format(atol.unit, actual.unit))
 

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -63,7 +63,7 @@ class UfuncHelpers(dict):
         import the helpers for that module.
         """
         if ufunc in self.UNSUPPORTED:
-            raise TypeError("Cannot use ufunc '{0}' with quantities"
+            raise TypeError("Cannot use ufunc '{}' with quantities"
                             .format(ufunc.__name__))
 
         for module, module_info in list(self.modules.items()):
@@ -83,7 +83,7 @@ class UfuncHelpers(dict):
                 else:
                     return self[ufunc]
 
-        raise TypeError("unknown ufunc {0}.  If you believe this ufunc "
+        raise TypeError("unknown ufunc {}.  If you believe this ufunc "
                         "should be supported, please raise an issue on "
                         "https://github.com/astropy/astropy"
                         .format(ufunc.__name__))
@@ -182,7 +182,7 @@ def converters_and_unit(function, method, *args):
                         converters[i] = None
                     else:
                         raise UnitConversionError(
-                            "Can only apply '{0}' function to "
+                            "Can only apply '{}' function to "
                             "dimensionless quantities when other "
                             "argument is not a quantity (unless the "
                             "latter is all zero/infinity/nan)"
@@ -190,8 +190,8 @@ def converters_and_unit(function, method, *args):
             except TypeError:
                 # _can_have_arbitrary_unit failed: arg could not be compared
                 # with zero or checked to be finite. Then, ufunc will fail too.
-                raise TypeError("Unsupported operand type(s) for ufunc {0}: "
-                                "'{1}'".format(function.__name__,
+                raise TypeError("Unsupported operand type(s) for ufunc {}: "
+                                "'{}'".format(function.__name__,
                                                ','.join([arg.__class__.__name__
                                                          for arg in args])))
 
@@ -245,10 +245,10 @@ def converters_and_unit(function, method, *args):
         else:
             if method in {'reduce', 'accumulate',
                           'reduceat', 'outer'} and nin != 2:
-                raise ValueError("{0} only supported for binary functions"
+                raise ValueError("{} only supported for binary functions"
                                  .format(method))
 
-            raise TypeError("Unexpected ufunc method {0}.  If this should "
+            raise TypeError("Unexpected ufunc method {}.  If this should "
                             "work, please raise an issue on"
                             "https://github.com/astropy/astropy"
                             .format(method))
@@ -312,17 +312,17 @@ def check_output(output, unit, inputs, function=None):
         # Check that we're not trying to store a plain Numpy array or a
         # Quantity with an inconsistent unit (e.g., not angular for Angle).
         if unit is None:
-            raise TypeError("Cannot store non-quantity output{0} in {1} "
+            raise TypeError("Cannot store non-quantity output{} in {} "
                             "instance".format(
-                                (" from {0} function".format(function.__name__)
+                                (f" from {function.__name__} function"
                                  if function is not None else ""),
                                 type(output)))
 
         if output.__quantity_subclass__(unit)[0] is not type(output):
             raise UnitTypeError(
-                "Cannot store output with unit '{0}'{1} "
-                "in {2} instance.  Use {3} instance instead."
-                .format(unit, (" from {0} function".format(function.__name__)
+                "Cannot store output with unit '{}'{} "
+                "in {} instance.  Use {} instance instead."
+                .format(unit, (f" from {function.__name__} function"
                                if function is not None else ""), type(output),
                         output.__quantity_subclass__(unit)[0]))
 
@@ -333,9 +333,9 @@ def check_output(output, unit, inputs, function=None):
         # output is not a Quantity, so cannot obtain a unit.
         if not (unit is None or unit is dimensionless_unscaled):
             raise UnitTypeError("Cannot store quantity with dimension "
-                                "{0}in a non-Quantity instance."
+                                "{}in a non-Quantity instance."
                                 .format("" if function is None else
-                                        "resulting from {0} function "
+                                        "resulting from {} function "
                                         .format(function.__name__)))
 
     # check we can handle the dtype (e.g., that we are not int
@@ -343,5 +343,5 @@ def check_output(output, unit, inputs, function=None):
     if not np.can_cast(np.result_type(*inputs), output.dtype,
                        casting='same_kind'):
         raise TypeError("Arguments cannot be cast safely to inplace "
-                        "output with dtype={0}".format(output.dtype))
+                        "output with dtype={}".format(output.dtype))
     return output

--- a/astropy/units/quantity_helper/erfa.py
+++ b/astropy/units/quantity_helper/erfa.py
@@ -17,7 +17,7 @@ def helper_s2c(f, unit1, unit2):
         return [get_converter(unit1, radian),
                 get_converter(unit2, radian)], dimensionless_unscaled
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 
@@ -28,7 +28,7 @@ def helper_s2p(f, unit1, unit2, unit3):
         return [get_converter(unit1, radian),
                 get_converter(unit2, radian), None], unit3
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 

--- a/astropy/units/quantity_helper/helpers.py
+++ b/astropy/units/quantity_helper/helpers.py
@@ -34,7 +34,7 @@ def get_converter(from_unit, to_unit):
         return from_unit._apply_equivalencies(
                 from_unit, to_unit, get_current_unit_registry().equivalencies)
     except AttributeError:
-        raise UnitTypeError("Unit '{0}' cannot be converted to '{1}'"
+        raise UnitTypeError("Unit '{}' cannot be converted to '{}'"
                             .format(from_unit, to_unit))
     if scale == 1.:
         return None
@@ -77,7 +77,7 @@ def get_converters_and_unit(f, unit1, unit2):
             converters[changeable] = get_converter(unit2, unit1)
         except UnitsError:
             raise UnitConversionError(
-                "Can only apply '{0}' function to quantities "
+                "Can only apply '{}' function to quantities "
                 "with compatible dimensions"
                 .format(f.__name__))
 
@@ -130,7 +130,7 @@ def helper_modf(f, unit):
         return ([get_converter(unit, dimensionless_unscaled)],
                 (dimensionless_unscaled, dimensionless_unscaled))
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "dimensionless quantities"
                             .format(f.__name__))
 
@@ -147,7 +147,7 @@ def helper_dimensionless_to_dimensionless(f, unit):
         return ([get_converter(unit, dimensionless_unscaled)],
                 dimensionless_unscaled)
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "dimensionless quantities"
                             .format(f.__name__))
 
@@ -160,7 +160,7 @@ def helper_dimensionless_to_radian(f, unit):
     try:
         return [get_converter(unit, dimensionless_unscaled)], radian
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "dimensionless quantities"
                             .format(f.__name__))
 
@@ -170,7 +170,7 @@ def helper_degree_to_radian(f, unit):
     try:
         return [get_converter(unit, degree)], radian
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 
@@ -180,7 +180,7 @@ def helper_radian_to_degree(f, unit):
     try:
         return [get_converter(unit, radian)], degree
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 
@@ -190,14 +190,14 @@ def helper_radian_to_dimensionless(f, unit):
     try:
         return [get_converter(unit, radian)], dimensionless_unscaled
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 
 
 def helper_frexp(f, unit):
     if not unit.is_unity():
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "unscaled dimensionless quantities"
                             .format(f.__name__))
     return [None], (None, None)
@@ -264,7 +264,7 @@ def helper_two_arg_dimensionless(f, unit1, unit2):
         converter2 = (get_converter(unit2, dimensionless_unscaled)
                       if unit2 is not None else None)
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "dimensionless quantities"
                             .format(f.__name__))
     return ([converter1, converter2], dimensionless_unscaled)
@@ -307,7 +307,7 @@ def helper_clip(f, unit1, unit2, unit3):
                            for unit in (unit2, unit3)]
         except UnitsError:
             raise UnitConversionError(
-                "Can only apply '{0}' function to quantities with "
+                "Can only apply '{}' function to quantities with "
                 "compatible dimensions".format(f.__name__))
 
     else:
@@ -321,7 +321,7 @@ def helper_clip(f, unit1, unit2, unit3):
                     converters.append(False)
                 else:
                     raise UnitConversionError(
-                        "Can only apply '{0}' function to quantities with "
+                        "Can only apply '{}' function to quantities with "
                         "compatible dimensions".format(f.__name__))
             else:
                 converters.append(converter)

--- a/astropy/units/quantity_helper/scipy_special.py
+++ b/astropy/units/quantity_helper/scipy_special.py
@@ -42,7 +42,7 @@ def helper_degree_to_dimensionless(f, unit):
     try:
         return [get_converter(unit, degree)], dimensionless_unscaled
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 
@@ -54,7 +54,7 @@ def helper_degree_minute_second_to_radian(f, unit1, unit2, unit3):
                 get_converter(unit2, arcmin),
                 get_converter(unit3, arcsec)], radian
     except UnitsError:
-        raise UnitTypeError("Can only apply '{0}' function to "
+        raise UnitTypeError("Can only apply '{}' function to "
                             "quantities with angle units"
                             .format(f.__name__))
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -245,7 +245,7 @@ def test_latex():
 
 def test_new_style_latex():
     fluxunit = u.erg / (u.cm ** 2 * u.s)
-    assert "{0:latex}".format(fluxunit) == r'$\mathrm{\frac{erg}{s\,cm^{2}}}$'
+    assert f"{fluxunit:latex}" == r'$\mathrm{\frac{erg}{s\,cm^{2}}}$'
 
 
 def test_latex_scale():

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -945,7 +945,7 @@ class TestQuantityDisplay:
         assert str(qscalar) == qscalar.to_string()
 
         res = 'Quantity as KMS: 150000000000.0 km / s'
-        assert "Quantity as KMS: {0}".format(qscalar.to_string(unit=u.km / u.s)) == res
+        assert "Quantity as KMS: {}".format(qscalar.to_string(unit=u.km / u.s)) == res
 
         res = r'$1.5 \times 10^{14} \; \mathrm{\frac{m}{s}}$'
         assert qscalar.to_string(format="latex") == res

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -84,7 +84,7 @@ def test_wrong_unit3(solarx_unit, solary_unit):
         solarx, solary = myfunc_args(1*u.arcsec, 100*u.km)
 
     str_to = str(solary_unit)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
+    assert str(e.value) == f"Argument 'solary' to function 'myfunc_args' must be in units convertible to '{str_to}'."
 
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [
@@ -179,7 +179,7 @@ def test_kwarg_wrong_unit3(solarx_unit, solary_unit):
         solarx, solary = myfunc_args(1*u.arcsec, solary=100*u.km)
 
     str_to = str(solary_unit)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
+    assert str(e.value) == f"Argument 'solary' to function 'myfunc_args' must be in units convertible to '{str_to}'."
 
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -73,7 +73,7 @@ def test_wrong_unit(x_input, y_input):
         x, y = myfunc_args(1*x_unit, 100*u.Joule)  # has to be an unspecified unit
 
     str_to = str(y_target)
-    assert str(e.value) == "Argument 'y' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
+    assert str(e.value) == f"Argument 'y' to function 'myfunc_args' must be in units convertible to '{str_to}'."
 
 
 def test_not_quantity(x_input, y_input):
@@ -138,7 +138,7 @@ def test_kwarg_wrong_unit(x_input, y_input):
         x, y = myfunc_args(1*x_unit, y=100*u.Joule)
 
     str_to = str(y_target)
-    assert str(e.value) == "Argument 'y' to function 'myfunc_args' must be in units convertible to '{0}'.".format(str_to)
+    assert str(e.value) == f"Argument 'y' to function 'myfunc_args' must be in units convertible to '{str_to}'."
 
 
 def test_kwarg_not_quantity(x_input, y_input):

--- a/astropy/units/tests/test_quantity_ufuncs.py
+++ b/astropy/units/tests/test_quantity_ufuncs.py
@@ -537,7 +537,7 @@ class TestQuantityMathFuncs:
         # Can't use exp() with non-dimensionless quantities
         with pytest.raises(TypeError) as exc:
             function(3. * u.m / u.s)
-        assert exc.value.args[0] == ("Can only apply '{0}' function to "
+        assert exc.value.args[0] == ("Can only apply '{}' function to "
                                      "dimensionless quantities"
                                      .format(function.__name__))
 
@@ -589,7 +589,7 @@ class TestQuantityMathFuncs:
 
         with pytest.raises(TypeError) as exc:
             function(1. * u.km / u.s, 3. * u.m / u.s)
-        assert exc.value.args[0] == ("Can only apply '{0}' function to "
+        assert exc.value.args[0] == ("Can only apply '{}' function to "
                                      "dimensionless quantities"
                                      .format(function.__name__))
 
@@ -1248,6 +1248,6 @@ if HAS_SCIPY:
             # Can't use jv() with non-dimensionless quantities
             with pytest.raises(TypeError) as exc:
                 function(1. * u.kg, 3. * u.m / u.s)
-            assert exc.value.args[0] == ("Can only apply '{0}' function to "
+            assert exc.value.args[0] == ("Can only apply '{}' function to "
                                          "dimensionless quantities"
                                          .format(function.__name__))

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -657,7 +657,7 @@ def test_suggestions():
         try:
             u.Unit(search)
         except ValueError as e:
-            assert 'Did you mean {0}?'.format(matches) in str(e)
+            assert f'Did you mean {matches}?' in str(e)
         else:
             assert False, 'Expected ValueError'
 

--- a/astropy/units/utils.py
+++ b/astropy/units/utils.py
@@ -71,9 +71,9 @@ def _iter_unit_summary(namespace):
         doc = _get_first_sentence(unit.__doc__).strip()
         represents = ''
         if isinstance(unit, core.Unit):
-            represents = ":math:`{0}`".format(
+            represents = ":math:`{}`".format(
                 unit._represents.to_string('latex')[1:-1])
-        aliases = ', '.join('``{0}``'.format(x) for x in unit.aliases)
+        aliases = ', '.join(f'``{x}``' for x in unit.aliases)
 
         yield (unit, doc, represents, aliases, 'Yes' if unit.name in has_prefixes else 'No')
 
@@ -111,11 +111,11 @@ def generate_unit_summary(namespace):
 
     for unit_summary in _iter_unit_summary(namespace):
         docstring.write("""
-   * - ``{0}``
-     - {1}
-     - {2}
-     - {3}
-     - {4}
+   * - ``{}``
+     - {}
+     - {}
+     - {}
+     - {}
 """.format(*unit_summary))
 
     return docstring.getvalue()
@@ -150,10 +150,10 @@ def generate_prefixonly_unit_summary(namespace):
 
     for unit_summary in _iter_unit_summary(faux_namespace):
         docstring.write("""
-   * - Prefixes for ``{0}``
-     - {1} prefixes
-     - {2}
-     - {3}
+   * - Prefixes for ``{}``
+     - {} prefixes
+     - {}
+     - {}
      - Only
 """.format(*unit_summary))
 

--- a/astropy/utils/argparse.py
+++ b/astropy/utils/argparse.py
@@ -15,7 +15,7 @@ def directory(arg):
 
     if not isinstance(arg, str) and os.path.isdir(arg):
         raise argparse.ArgumentTypeError(
-            "{0} is not a directory or does not exist (the directory must "
+            "{} is not a directory or does not exist (the directory must "
             "be created first)".format(arg))
 
     return os.path.abspath(arg)
@@ -32,7 +32,7 @@ def readable_directory(arg):
 
     if not os.access(arg, os.R_OK):
         raise argparse.ArgumentTypeError(
-            "{0} exists but is not readable with its current "
+            "{} exists but is not readable with its current "
             "permissions".format(arg))
 
     return arg
@@ -49,7 +49,7 @@ def writeable_directory(arg):
 
     if not os.access(arg, os.W_OK):
         raise argparse.ArgumentTypeError(
-            "{0} exists but is not writeable with its current "
+            "{} exists but is not writeable with its current "
             "permissions".format(arg))
 
     return arg

--- a/astropy/utils/codegen.py
+++ b/astropy/utils/codegen.py
@@ -67,36 +67,36 @@ def make_function_with_signature(func, args=(), kwargs={}, varargs=None,
             pos_args.append(item)
 
         if keyword.iskeyword(argname) or not _ARGNAME_RE.match(argname):
-            raise SyntaxError('invalid argument name: {0}'.format(argname))
+            raise SyntaxError(f'invalid argument name: {argname}')
 
     for item in (varargs, varkwargs):
         if item is not None:
             if keyword.iskeyword(item) or not _ARGNAME_RE.match(item):
-                raise SyntaxError('invalid argument name: {0}'.format(item))
+                raise SyntaxError(f'invalid argument name: {item}')
 
     def_signature = [', '.join(pos_args)]
 
     if varargs:
-        def_signature.append(', *{0}'.format(varargs))
+        def_signature.append(f', *{varargs}')
 
     call_signature = def_signature[:]
 
     if name is None:
         name = func.__name__
 
-    global_vars = {'__{0}__func'.format(name): func}
+    global_vars = {f'__{name}__func': func}
     local_vars = {}
     # Make local variables to handle setting the default args
     for idx, item in enumerate(key_args):
         key, value = item
-        default_var = '_kwargs{0}'.format(idx)
+        default_var = f'_kwargs{idx}'
         local_vars[default_var] = value
-        def_signature.append(', {0}={1}'.format(key, default_var))
+        def_signature.append(f', {key}={default_var}')
         call_signature.append(', {0}={0}'.format(key))
 
     if varkwargs:
-        def_signature.append(', **{0}'.format(varkwargs))
-        call_signature.append(', **{0}'.format(varkwargs))
+        def_signature.append(f', **{varkwargs}')
+        call_signature.append(f', **{varkwargs}')
 
     def_signature = ''.join(def_signature).lstrip(', ')
     call_signature = ''.join(call_signature).lstrip(', ')

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -256,7 +256,7 @@ def _color_text(text, color):
         return text
 
     color_code = color_mapping.get(color, '0;39')
-    return '\033[{0}m{1}\033[0m'.format(color_code, text)
+    return f'\033[{color_code}m{text}\033[0m'
 
 
 def _decode_preferred_encoding(s):
@@ -425,12 +425,12 @@ def human_time(seconds):
     seconds = int(seconds)
 
     if seconds < 60:
-        return '   {0:2d}s'.format(seconds)
+        return f'   {seconds:2d}s'
     for i in range(len(units) - 1):
         unit1, limit1 = units[i]
         unit2, limit2 = units[i + 1]
         if seconds >= limit1:
-            return '{0:2d}{1}{2:2d}{3}'.format(
+            return '{:2d}{}{:2d}{}'.format(
                 seconds // limit1, unit1,
                 (seconds % limit1) // limit2, unit2)
     return '  ~inf'
@@ -482,7 +482,7 @@ def human_file_size(size):
         str_value = str_value[:2]
     else:
         str_value = str_value[:3]
-    return "{0:>3s}{1}".format(str_value, suffix)
+    return f"{str_value:>3s}{suffix}"
 
 
 class _mapfunc(object):
@@ -648,10 +648,10 @@ class ProgressBar:
         else:
             t = ((time.time() - self._start_time) * (1.0 - frac)) / frac
             prefix = ' ETA '
-        write(' {0:>4s}/{1:>4s}'.format(
+        write(' {:>4s}/{:>4s}'.format(
             human_file_size(value),
             self._human_total))
-        write(' ({:>6.2%})'.format(frac))
+        write(f' ({frac:>6.2%})')
         write(prefix)
         if t is not None:
             write(human_time(t))
@@ -685,7 +685,7 @@ class ProgressBar:
         # Calculate percent completion, and update progress bar
         frac = (value/self._total)
         self._widget.value = frac * 100
-        self._widget.description = ' ({:>6.2%})'.format(frac)
+        self._widget.description = f' ({frac:>6.2%})'
 
     def _silent_update(self, value=None):
         pass

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -458,9 +458,9 @@ def get_pkg_data_fileobj(data_name, package=None, encoding=None, cache=True):
             except urllib.error.URLError:
                 pass
         else:
-            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
-            raise urllib.error.URLError("Failed to download {0} from the following "
-                                        "repositories:\n\n{1}".format(data_name, urls))
+            urls = '\n'.join(f'  - {url}' for url in all_urls)
+            raise urllib.error.URLError("Failed to download {} from the following "
+                                        "repositories:\n\n{}".format(data_name, urls))
 
 
 def get_pkg_data_filename(data_name, package=None, show_progress=True,
@@ -565,9 +565,9 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
                                          timeout=remote_timeout)
                 except urllib.error.URLError:
                     pass
-            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
-            raise urllib.error.URLError("Failed to download {0} from the following "
-                                        "repositories:\n\n{1}\n\n".format(data_name, urls))
+            urls = '\n'.join(f'  - {url}' for url in all_urls)
+            raise urllib.error.URLError("Failed to download {} from the following "
+                                        "repositories:\n\n{}\n\n".format(data_name, urls))
 
         else:
             return hashfn
@@ -588,9 +588,9 @@ def get_pkg_data_filename(data_name, package=None, show_progress=True,
                                          timeout=remote_timeout)
                 except urllib.error.URLError:
                     pass
-            urls = '\n'.join('  - {0}'.format(url) for url in all_urls)
-            raise urllib.error.URLError("Failed to download {0} from the following "
-                                        "repositories:\n\n{1}".format(data_name, urls))
+            urls = '\n'.join(f'  - {url}' for url in all_urls)
+            raise urllib.error.URLError("Failed to download {} from the following "
+                                        "repositories:\n\n{}".format(data_name, urls))
 
 
 def get_pkg_data_contents(data_name, package=None, encoding=None, cache=True):
@@ -939,8 +939,8 @@ def check_free_space_in_dir(path, size):
     space = get_free_space_in_dir(path)
     if space < size:
         raise OSError(
-            "Not enough free space in '{0}' "
-            "to download a {1} file".format(
+            "Not enough free space in '{}' "
+            "to download a {} file".format(
                 path, human_file_size(size)))
 
 
@@ -1044,7 +1044,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
             else:
                 progress_stream = io.StringIO()
 
-            dlmsg = "Downloading {0}".format(remote_url)
+            dlmsg = f"Downloading {remote_url}"
             with ProgressBarOrSpinner(size, dlmsg, file=progress_stream) as p:
                 with NamedTemporaryFile(delete=False) as f:
                     try:

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -338,7 +338,7 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
 
         # Finally this must be an actual data attribute that this class is handling.
         if attr not in self.attr_names:
-            raise AttributeError("attribute must be one of {0}".format(self.attr_names))
+            raise AttributeError(f"attribute must be one of {self.attr_names}")
 
         if attr == 'parent_table':
             value = None if value is None else weakref.ref(value)
@@ -433,7 +433,7 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
                 if hasattr(self, 'info_summary_' + option):
                     option = getattr(self, 'info_summary_' + option)
                 else:
-                    raise ValueError('option={0} is not an allowed information type'
+                    raise ValueError('option={} is not an allowed information type'
                                      .format(option))
 
             with warnings.catch_warnings():
@@ -460,7 +460,7 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
 
         for key, val in info.items():
             if val != '':
-                out.write('{0} = {1}'.format(key, val) + os.linesep)
+                out.write(f'{key} = {val}' + os.linesep)
 
     def __repr__(self):
         if self._parent is None:

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -185,7 +185,7 @@ def deprecated(since, message='', name='', alternative='', pending=False,
                 message = ('The {func} {obj_type} is deprecated and may '
                            'be removed in a future version.')
             if alternative:
-                altmessage = '\n        Use {} instead.'.format(alternative)
+                altmessage = f'\n        Use {alternative} instead.'
 
         message = ((message.format(**{
             'func': name,
@@ -468,8 +468,8 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # 3.) positional-only argument, varargs, varkwargs or some
                 #     unknown type:
                 else:
-                    raise TypeError('cannot replace argument "{0}" of kind '
-                                    '{1!r}.'.format(new_name[i], param.kind))
+                    raise TypeError('cannot replace argument "{}" of kind '
+                                    '{!r}.'.format(new_name[i], param.kind))
 
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
@@ -482,7 +482,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                     # Display the deprecation warning only when it's not
                     # pending.
                     if not pending[i]:
-                        message = ('"{0}" was deprecated in version {1} '
+                        message = ('"{}" was deprecated in version {} '
                                    'and will be removed in a future version. '
                                    .format(old_name[i], since[i]))
                         if new_name[i] is not None:

--- a/astropy/utils/diff.py
+++ b/astropy/utils/diff.py
@@ -81,7 +81,7 @@ def report_diff_values(a, b, fileobj=sys.stdout, indent_width=0):
         for idx in diff_indices[:3]:
             lidx = idx.tolist()
             fileobj.write(
-                fixed_width_indent('  at {!r}:\n'.format(lidx), indent_width))
+                fixed_width_indent(f'  at {lidx!r}:\n', indent_width))
             report_diff_values(a[tuple(idx)], b[tuple(idx)], fileobj=fileobj,
                                indent_width=indent_width + 1)
 

--- a/astropy/utils/introspection.py
+++ b/astropy/utils/introspection.py
@@ -134,7 +134,7 @@ def minversion(module, version, inclusive=True, version_path='__version__'):
     else:
         raise ValueError('module argument must be an actual imported '
                          'module, or the import name of the module; '
-                         'got {0!r}'.format(module))
+                         'got {!r}'.format(module))
 
     if '.' not in version_path:
         have_version = getattr(module, version_path)

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -58,7 +58,7 @@ def common_dtype(arrs):
     if len(uniq_types) > 1:
         # Embed into the exception the actual list of incompatible types.
         incompat_types = [dtype(arr).name for arr in arrs]
-        tme = MergeConflictError('Arrays have incompatible types {0}'
+        tme = MergeConflictError('Arrays have incompatible types {}'
                                  .format(incompat_types))
         tme._incompat_types = incompat_types
         raise tme
@@ -69,7 +69,7 @@ def common_dtype(arrs):
     # values or the final arr_common = .. step is unpredictable.
     for i, arr in enumerate(arrs):
         if arr.dtype.kind in ('S', 'U'):
-            arrs[i] = [(u'0' if arr.dtype.kind == 'U' else b'0') *
+            arrs[i] = [('0' if arr.dtype.kind == 'U' else b'0') *
                        dtype_bytes_or_chars(arr.dtype)]
 
     arr_common = np.array([arr[0] for arr in arrs])
@@ -296,8 +296,8 @@ def _warn_str_func(key, left, right):
 
 
 def _error_str_func(key, left, right):
-    out = ('Cannot merge meta key {0!r} '
-           'types {1!r} and {2!r}'
+    out = ('Cannot merge meta key {!r} '
+           'types {!r} and {!r}'
            .format(key, type(left), type(right)))
     return out
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -222,7 +222,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
     elif version == 'dev' or version == 'latest':
         baseurl = 'http://devdocs.astropy.org/'
     else:
-        baseurl = 'http://docs.astropy.org/en/{vers}/'.format(vers=version)
+        baseurl = f'http://docs.astropy.org/en/{version}/'
 
     if timeout is None:
         uf = urllib.request.urlopen(baseurl + 'objects.inv')
@@ -244,7 +244,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
         # intersphinx version line, project name, and project version
         ivers, proj, vers, compr = headerlines
         if 'The remainder of this file is compressed using zlib' not in compr:
-            raise ValueError('The file downloaded from {0} does not seem to be'
+            raise ValueError('The file downloaded from {} does not seem to be'
                              'the usual Sphinx objects.inv format.  Maybe it '
                              'has changed?'.format(baseurl + 'objects.inv'))
 
@@ -268,7 +268,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
             break
 
     if resurl is None:
-        raise ValueError('Could not find the docs for the object {obj}'.format(obj=obj))
+        raise ValueError(f'Could not find the docs for the object {obj}')
     elif openinbrowser:
         webbrowser.open(resurl)
 
@@ -484,7 +484,7 @@ def did_you_mean(s, candidates, n=3, cutoff=0.8, fix=None):
         else:
             matches = (', '.join(matches[:-1]) + ' or ' +
                        matches[-1])
-        return 'Did you mean {0}?'.format(matches)
+        return f'Did you mean {matches}?'
 
     return ''
 
@@ -612,7 +612,7 @@ class OrderedDescriptor(metaclass=abc.ABCMeta):
                 return self.__order < other.__order
             except AttributeError:
                 raise RuntimeError(
-                    'Could not determine ordering for {0} and {1}; at least '
+                    'Could not determine ordering for {} and {}; at least '
                     'one of them is not calling super().__init__ in its '
                     '__init__.'.format(self, other))
         else:
@@ -927,7 +927,7 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
 
     def __len__(self):
         if self.isscalar:
-            raise TypeError("Scalar {0!r} object has no len()"
+            raise TypeError("Scalar {!r} object has no len()"
                             .format(self.__class__.__name__))
         return self.shape[0]
 
@@ -940,14 +940,14 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
             return self._apply('__getitem__', item)
         except IndexError:
             if self.isscalar:
-                raise TypeError('scalar {0!r} object is not subscriptable.'
+                raise TypeError('scalar {!r} object is not subscriptable.'
                                 .format(self.__class__.__name__))
             else:
                 raise
 
     def __iter__(self):
         if self.isscalar:
-            raise TypeError('scalar {0!r} object is not iterable.'
+            raise TypeError('scalar {!r} object is not iterable.'
                             .format(self.__class__.__name__))
 
         # We cannot just write a generator here, since then the above error

--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -56,7 +56,7 @@ class ScienceState:
                 self._parent._value = self._value
 
             def __repr__(self):
-                return ('<ScienceState {0}: {1!r}>'
+                return ('<ScienceState {}: {!r}>'
                         .format(self._parent.__name__, self._parent._value))
 
         ctx = _Context(cls, cls._value)

--- a/astropy/utils/tests/test_data_info.py
+++ b/astropy/utils/tests/test_data_info.py
@@ -12,7 +12,7 @@ STRING_TYPE_NAMES = {(True, 'S'): 'bytes',
                      (True, 'U'): 'str'}
 
 DTYPE_TESTS = ((np.array(b'abcd').dtype, STRING_TYPE_NAMES[(True, 'S')] + '4'),
-               (np.array(u'abcd').dtype, STRING_TYPE_NAMES[(True, 'U')] + '4'),
+               (np.array('abcd').dtype, STRING_TYPE_NAMES[(True, 'U')] + '4'),
                ('S4', STRING_TYPE_NAMES[(True, 'S')] + '4'),
                ('U4', STRING_TYPE_NAMES[(True, 'U')] + '4'),
                (np.void, 'void'),

--- a/astropy/utils/tests/test_metadata.py
+++ b/astropy/utils/tests/test_metadata.py
@@ -191,8 +191,8 @@ def test_metadata_merging_new_strategy():
 
 
 def test_common_dtype_string():
-    u3 = np.array([u'123'])
-    u4 = np.array([u'1234'])
+    u3 = np.array(['123'])
+    u4 = np.array(['1234'])
     b3 = np.array([b'123'])
     b5 = np.array([b'12345'])
     assert common_dtype([u3, u4]).endswith('U4')
@@ -203,7 +203,7 @@ def test_common_dtype_string():
 def test_common_dtype_basic():
     i8 = np.array(1, dtype=np.int64)
     f8 = np.array(1, dtype=np.float64)
-    u3 = np.array(u'123')
+    u3 = np.array('123')
 
     with pytest.raises(MergeConflictError):
         common_dtype([i8, u3])

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -108,7 +108,7 @@ def test_set_locale():
         locale.setlocale(locale.LC_ALL, 'en_US')
         locale.setlocale(locale.LC_ALL, 'de_DE')
     except locale.Error as e:
-        pytest.skip('Locale error: {}'.format(e))
+        pytest.skip(f'Locale error: {e}')
     finally:
         locale.setlocale(locale.LC_ALL, current)
 
@@ -143,4 +143,4 @@ def test_dtype_bytes_or_chars():
     assert misc.dtype_bytes_or_chars(np.dtype(object)) is None
     assert misc.dtype_bytes_or_chars(np.dtype(np.int32)) == 4
     assert misc.dtype_bytes_or_chars(np.array(b'12345').dtype) == 5
-    assert misc.dtype_bytes_or_chars(np.array(u'12345').dtype) == 5
+    assert misc.dtype_bytes_or_chars(np.array('12345').dtype) == 5

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -72,7 +72,7 @@ def timefunc(num_tries=1, verbose=True):
             te = time.time()
             tt = (te - ts) / num_tries
             if verbose:  # pragma: no cover
-                log.info('{0} took {1} s on AVERAGE for {2} call(s).'.format(
+                log.info('{} took {} s on AVERAGE for {} call(s).'.format(
                     function.__name__, tt, num_tries))
             return tt, result
         return wrapper
@@ -254,20 +254,20 @@ class RunTimePredictor:
 
         x_arr = np.array(list(self._cache_good.keys()))
         if x_arr.size < min_datapoints:
-            raise ValueError('requires {0} points but has {1}'.format(
+            raise ValueError('requires {} points but has {}'.format(
                 min_datapoints, x_arr.size))
 
         if model is None:
             model = modeling.models.Polynomial1D(1)
         elif not isinstance(model, modeling.core.Model):
             raise modeling.fitting.ModelsError(
-                '{0} is not a model.'.format(model))
+                f'{model} is not a model.')
 
         if fitter is None:
             fitter = modeling.fitting.LinearLSQFitter()
         elif not isinstance(fitter, modeling.fitting.Fitter):
             raise modeling.fitting.ModelsError(
-                '{0} is not a fitter.'.format(fitter))
+                f'{fitter} is not a fitter.')
 
         self._fit_func = fitter(
             model, x_arr**power, list(self._cache_good.values()))

--- a/astropy/utils/xml/check.py
+++ b/astropy/utils/xml/check.py
@@ -54,9 +54,9 @@ def check_mime_content_type(content_type):
     (syntactically at least), as defined by RFC 2045.
     """
     ctrls = ''.join(chr(x) for x in range(0, 0x20))
-    token_regex = '[^()<>@,;:\\\"/[\\]?= {}\x7f]+'.format(ctrls)
+    token_regex = f'[^()<>@,;:\\\"/[\\]?= {ctrls}\x7f]+'
     return re.match(
-        r'(?P<type>{})/(?P<subtype>{})$'.format(token_regex, token_regex),
+        fr'(?P<type>{token_regex})/(?P<subtype>{token_regex})$',
         content_type) is not None
 
 

--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -32,7 +32,7 @@ def get_extensions(build_type='release'):
             # symbols and the linker won't try to use the system expat in
             # place of ours.
             cfg['extra_link_args'].extend([
-                '-Wl,--version-script={0}'.format(
+                '-Wl,--version-script={}'.format(
                     join(XML_DIR, 'iterparse.map'))
                 ])
         cfg['define_macros'].append(("HAVE_EXPAT_CONFIG_H", 1))

--- a/astropy/utils/xml/validate.py
+++ b/astropy/utils/xml/validate.py
@@ -40,7 +40,7 @@ def validate_schema(filename, schema_file):
         raise TypeError("schema_file must be a path to an XML Schema or DTD")
 
     p = subprocess.Popen(
-        "xmllint --noout --nonet {} {}".format(schema_part, filename),
+        f"xmllint --noout --nonet {schema_part} {filename}",
         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
 
@@ -50,7 +50,7 @@ def validate_schema(filename, schema_file):
     elif p.returncode < 0:
         from astropy.utils.misc import signal_number_to_name
         raise OSError(
-            "xmllint was terminated by signal '{0}'".format(
+            "xmllint was terminated by signal '{}'".format(
                 signal_number_to_name(-p.returncode)))
 
     return p.returncode, stdout, stderr

--- a/astropy/utils/xml/writer.py
+++ b/astropy/utils/xml/writer.py
@@ -126,7 +126,7 @@ class XMLWriter:
         self._data = []
         self._tags.append(tag)
         self.write(self.get_indentation_spaces(-1))
-        self.write("<{}".format(tag))
+        self.write(f"<{tag}")
         if attrib or extra:
             attrib = attrib.copy()
             attrib.update(extra)
@@ -137,7 +137,7 @@ class XMLWriter:
                     # This is just busy work -- we know our keys are clean
                     # k = xml_escape_cdata(k)
                     v = self.xml_escape(v)
-                    self.write(" {}=\"{}\"".format(k, v))
+                    self.write(f" {k}=\"{v}\"")
         self._open = 1
 
         return len(self._tags)
@@ -259,7 +259,7 @@ class XMLWriter:
         """
         if tag:
             if not self._tags:
-                raise ValueError("unbalanced end({})".format(tag))
+                raise ValueError(f"unbalanced end({tag})")
             if tag != self._tags[-1]:
                 raise ValueError("expected end({}), got {}".format(
                         self._tags[-1], tag))
@@ -275,7 +275,7 @@ class XMLWriter:
             return
         if indent:
             self.write(self.get_indentation_spaces())
-        self.write("</{}>\n".format(tag))
+        self.write(f"</{tag}>\n")
 
     def close(self, id):
         """

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -226,7 +226,7 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
     elif stretch == 'asinh':
         stretch = AsinhStretch(asinh_a)
     else:
-        raise ValueError('Unknown stretch: {0}.'.format(stretch))
+        raise ValueError(f'Unknown stretch: {stretch}.')
 
     vmin, vmax = interval.get_limits(data)
 

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -84,7 +84,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
         return 1
 
     if image.ndim != 2:
-        log.critical('data in FITS extension {0} is not a 2D array'
+        log.critical('data in FITS extension {} is not a 2D array'
                      .format(ext))
 
     if out_fn is None:
@@ -106,7 +106,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
     try:
         cm.get_cmap(cmap)
     except ValueError:
-        log.critical('{0} is not a valid matplotlib colormap name.'
+        log.critical('{} is not a valid matplotlib colormap name.'
                      .format(cmap))
         return 1
 
@@ -117,7 +117,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
 
     mimg.imsave(out_fn, norm(image), cmap=cmap, origin='lower',
                 format=out_format)
-    log.info('Saved file to {0}.'.format(out_fn))
+    log.info(f'Saved file to {out_fn}.')
 
 
 def main(args=None):

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -126,7 +126,7 @@ def test_formats(format, expected):
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
         assert get_ticklabels(ax.xaxis) == expected
-        ax.get_xlabel() == 'Time ({0})'.format(format)
+        ax.get_xlabel() == f'Time ({format})'
 
 
 @pytest.mark.parametrize(('format', 'expected'), FORMAT_CASES)
@@ -138,7 +138,7 @@ def test_auto_formats(format, expected):
         ax.set_xlim(Time(Time('2014-03-22T12:30:30.9'), format=format),
                     Time('2077-03-22T12:30:32.1'))
         assert get_ticklabels(ax.xaxis) == expected
-        ax.get_xlabel() == 'Time ({0})'.format(format)
+        ax.get_xlabel() == f'Time ({format})'
 
 
 FORMAT_CASES_SIMPLIFY = [

--- a/astropy/visualization/time.py
+++ b/astropy/visualization/time.py
@@ -206,7 +206,7 @@ def time_support(*, scale=None, format=None, simplify=True):
         @format.setter
         def format(self, value):
             if value in UNSUPPORTED_FORMATS:
-                raise ValueError('time_support does not support format={0}'.format(value))
+                raise ValueError(f'time_support does not support format={value}')
             self._format = value
 
         def __enter__(self):
@@ -254,6 +254,6 @@ def time_support(*, scale=None, format=None, simplify=True):
             majfmt = AstropyTimeFormatter(self)
             return units.AxisInfo(majfmt=majfmt,
                                   majloc=majloc,
-                                  label='Time ({0})'.format(self.scale))
+                                  label=f'Time ({self.scale})')
 
     return MplTimeConverter(scale=scale, format=format, simplify=simplify)

--- a/astropy/visualization/units.py
+++ b/astropy/visualization/units.py
@@ -58,9 +58,9 @@ def quantity_support(format='latex_inline'):
         elif n == 2:
             return 'π'
         elif n % 2 == 0:
-            return '{0}π'.format(n / 2)
+            return '{}π'.format(n / 2)
         else:
-            return '{0}π/2'.format(n)
+            return f'{n}π/2'
 
     class MplQuantityConverter(units.ConversionInterface):
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -122,7 +122,7 @@ class WCSAxes(Axes):
             return ""
 
         if self._display_coords_index == -1:
-            return "%s %s (pixel)" % (x, y)
+            return f"{x} {y} (pixel)"
 
         pixel = np.array([x, y])
 
@@ -136,9 +136,9 @@ class WCSAxes(Axes):
         if self._display_coords_index == 0:
             system = "world"
         else:
-            system = "world, overlay {0}".format(self._display_coords_index)
+            system = f"world, overlay {self._display_coords_index}"
 
-        coord_string = "%s %s (%s)" % (xw, yw, system)
+        coord_string = f"{xw} {yw} ({system})"
 
         return coord_string
 
@@ -706,9 +706,9 @@ class WCSAxes(Axes):
 
             for pos in ('bottom', 'left', 'top', 'right'):
                 if pos in kwargs:
-                    raise ValueError("Cannot specify {0}= when axis='both'".format(pos))
+                    raise ValueError(f"Cannot specify {pos}= when axis='both'")
                 if 'label' + pos in kwargs:
-                    raise ValueError("Cannot specify label{0}= when axis='both'".format(pos))
+                    raise ValueError(f"Cannot specify label{pos}= when axis='both'")
 
             for coord in self.coords:
                 coord.tick_params(**kwargs)

--- a/astropy/visualization/wcsaxes/fitswcs.py
+++ b/astropy/visualization/wcsaxes/fitswcs.py
@@ -79,7 +79,7 @@ class WCSWorld2PixelTransform(World2PixelTransform):
                 raise ValueError("WCS has more than 2 dimensions, so ``slice`` should be set")
             elif len(slice) != self.wcs.wcs.naxis:
                 raise ValueError("slice should have as many elements as WCS "
-                                 "has dimensions (should be {0})".format(self.wcs.wcs.naxis))
+                                 "has dimensions (should be {})".format(self.wcs.wcs.naxis))
             else:
                 self.slice = slice
                 self.x_index = slice.index('x')

--- a/astropy/visualization/wcsaxes/formatter_locator.py
+++ b/astropy/visualization/wcsaxes/formatter_locator.py
@@ -80,7 +80,7 @@ class BaseFormatterLocator:
             raise TypeError("values should be an astropy.units.Quantity array")
         if not values.unit.is_equivalent(self._unit):
             raise UnitsError("value should be in units compatible with "
-                             "coordinate units ({0}) but found {1}".format(self._unit, values.unit))
+                             "coordinate units ({}) but found {}".format(self._unit, values.unit))
         self._number = None
         self._spacing = None
         self._values = values
@@ -251,7 +251,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
             else:
                 self._precision = 0
         else:
-            raise ValueError("Invalid format: {0}".format(value))
+            raise ValueError(f"Invalid format: {value}")
 
         if self.spacing is not None and self.spacing < self.base_spacing:
             warnings.warn("Spacing is too small - resetting spacing to match format")
@@ -368,7 +368,7 @@ class AngleFormatterLocator(BaseFormatterLocator):
                     # which should be sufficient.
                     spacing = spacing.to_value(unit)
                     fields = 0
-                    precision = len("{0:.10f}".format(spacing).replace('0', ' ').strip().split('.', 1)[1])
+                    precision = len(f"{spacing:.10f}".replace('0', ' ').strip().split('.', 1)[1])
                 else:
                     spacing = spacing.to_value(unit / 3600)
                     if spacing >= 3600:
@@ -509,7 +509,7 @@ class ScalarFormatterLocator(BaseFormatterLocator):
                     self.spacing = self.base_spacing * max(1, round(ratio))
 
         elif not value.startswith('%'):
-            raise ValueError("Invalid format: {0}".format(value))
+            raise ValueError(f"Invalid format: {value}")
 
     @property
     def base_spacing(self):

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -68,7 +68,7 @@ class CoordinateTransform(CurvedTransform):
         if isinstance(self._input_system_name, str):
             self.input_system = frame_transform_graph.lookup_name(self._input_system_name)
             if self.input_system is None:
-                raise ValueError("Frame {0} not found".format(self._input_system_name))
+                raise ValueError(f"Frame {self._input_system_name} not found")
         elif isinstance(self._input_system_name, BaseCoordinateFrame):
             self.input_system = self._input_system_name
         else:
@@ -77,7 +77,7 @@ class CoordinateTransform(CurvedTransform):
         if isinstance(self._output_system_name, str):
             self.output_system = frame_transform_graph.lookup_name(self._output_system_name)
             if self.output_system is None:
-                raise ValueError("Frame {0} not found".format(self._output_system_name))
+                raise ValueError(f"Frame {self._output_system_name} not found")
         elif isinstance(self._output_system_name, BaseCoordinateFrame):
             self.output_system = self._output_system_name
         else:

--- a/astropy/visualization/wcsaxes/utils.py
+++ b/astropy/visualization/wcsaxes/utils.py
@@ -109,7 +109,7 @@ def get_coord_meta(frame):
         initial_frame = frame
         frame = frame_transform_graph.lookup_name(frame)
         if frame is None:
-            raise ValueError("Unknown frame: {0}".format(initial_frame))
+            raise ValueError(f"Unknown frame: {initial_frame}")
 
     if not isinstance(frame, BaseCoordinateFrame):
         frame = frame()

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -20,7 +20,7 @@ def TWO_OR_MORE_ARGS(naxis, indent=0):
 """args : flexible
     There are two accepted forms for the positional arguments:
 
-        - 2 arguments: An *N* x *{0}* array of coordinates, and an
+        - 2 arguments: An *N* x *{}* array of coordinates, and an
           *origin*.
 
         - more than 2 arguments: An array for each axis, followed by
@@ -35,7 +35,7 @@ def TWO_OR_MORE_ARGS(naxis, indent=0):
 
 def RETURNS(out_type, indent=0):
     return _fix("""result : array
-    Returns the {0}.  If the input was a single array and
+    Returns the {}.  If the input was a single array and
     origin, a single array is returned, otherwise a tuple of arrays is
     returned.""".format(out_type), indent)
 
@@ -98,7 +98,7 @@ Parameters
 pixcrd : double array[ncoord][nelem]
     Array of pixel coordinates.
 
-{0}
+{}
 
 Returns
 -------
@@ -1117,7 +1117,7 @@ pixcrd : double array[naxis].
     Pixel coordinates.  The element indicated by *mixpix* is given and
     the remaining elements will be written in-place.
 
-{0}
+{}
 
 Returns
 -------
@@ -1301,7 +1301,7 @@ Parameters
 pixcrd : double array[ncoord][nelem]
     Array of pixel coordinates.
 
-{0}
+{}
 
 Returns
 -------
@@ -1377,7 +1377,7 @@ Parameters
 pixcrd : double array[ncoord][nelem].
     Array of pixel coordinates.
 
-{0}
+{}
 
 Returns
 -------
@@ -1445,7 +1445,7 @@ Parameters
 pixcrd : double array[ncoord][nelem]
     Array of pixel coordinates.
 
-{0}
+{}
 
 Returns
 -------
@@ -1519,7 +1519,7 @@ Parameters
 world : double array[ncoord][nelem]
     Array of world coordinates, in decimal degrees.
 
-{0}
+{}
 
 Returns
 -------
@@ -1746,7 +1746,7 @@ Parameters
 foccrd : double array[ncoord][nelem]
     Array of focal plane coordinates.
 
-{0}
+{}
 
 Returns
 -------
@@ -1773,7 +1773,7 @@ Parameters
 pixcrd : double array[ncoord][nelem]
     Array of pixel coordinates.
 
-{0}
+{}
 
 Returns
 -------

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -68,10 +68,10 @@ def write_wcsconfig_h(paths):
     #define HAVE_WCSLIB_VERSION 1
 
     /* WCSLIB library version number. */
-    #define WCSLIB_VERSION {0}
+    #define WCSLIB_VERSION {}
 
     /* 64-bit integer data type. */
-    #define WCSLIB_INT64 {1}
+    #define WCSLIB_INT64 {}
 
     /* Windows needs some other defines to prevent inclusion of wcsset()
        which conflicts with wcslib's wcsset().  These need to be set
@@ -135,7 +135,7 @@ its contents, edit astropy/wcs/docstrings.py
 """)
     for key in keys:
         val = docs[key]
-        h_file.write('extern char doc_{0}[{1}];\n'.format(key, len(val)))
+        h_file.write('extern char doc_{}[{}];\n'.format(key, len(val)))
     h_file.write("\n#endif\n\n")
 
     setup_helpers.write_if_different(
@@ -163,7 +163,7 @@ MSVC, do not support string literals greater than 256 characters.
         for i in range(0, len(val), 12):
             section = val[i:i+12]
             c_file.write('    ')
-            c_file.write(''.join('0x{0:02x}, '.format(x) for x in section))
+            c_file.write(''.join(f'0x{x:02x}, ' for x in section))
             c_file.write('\n')
 
         c_file.write("    };\n\n")

--- a/astropy/wcs/tests/extension/test_extension.py
+++ b/astropy/wcs/tests/extension/test_extension.py
@@ -31,8 +31,8 @@ def test_wcsapi_extension(tmpdir):
     # interactive session, so it likely had something to do with pytest's
     # output capture
     p = subprocess.Popen([sys.executable, 'setup.py', 'build',
-                          '--build-base={0}'.format(build_dir), 'install',
-                          '--install-lib={0}'.format(install_dir),
+                          f'--build-base={build_dir}', 'install',
+                          f'--install-lib={install_dir}',
                           astropy_path], cwd=setup_path, env=env,
                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -62,8 +62,8 @@ def test_wcsapi_extension(tmpdir):
         return
 
     assert p.returncode == 0, (
-        "setup.py exited with non-zero return code {0}\n"
-        "stdout:\n\n{1}\n\nstderr:\n\n{2}\n".format(
+        "setup.py exited with non-zero return code {}\n"
+        "stdout:\n\n{}\n\nstderr:\n\n{}\n".format(
             p.returncode, stdout, stderr))
 
     code = """

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -511,7 +511,7 @@ def test_all_world2pix(fname=None, ext=0,
         ndiv = 0
         if e.divergent is not None:
             ndiv = e.divergent.shape[0]
-            print("There are {} diverging solutions.".format(ndiv))
+            print(f"There are {ndiv} diverging solutions.")
             print("Indices of diverging solutions:\n{}"
                   .format(e.divergent))
             print("Diverging solutions:\n{}\n"
@@ -541,7 +541,7 @@ def test_all_world2pix(fname=None, ext=0,
               .format(e.best_solution.shape[0] - ndiv - nslow))
         print("Best solutions (all points):\n{}"
               .format(e.best_solution))
-        print("Accuracy:\n{}\n".format(e.accuracy))
+        print(f"Accuracy:\n{e.accuracy}\n")
         print("\nFinished running 'test_all_world2pix' with errors.\n"
               "ERROR: {}\nRun time: {}\n"
               .format(e.args[0], runtime_end - runtime_begin))
@@ -554,8 +554,8 @@ def test_all_world2pix(fname=None, ext=0,
     meanerr = np.mean(errors)
     maxerr = np.amax(errors)
     print("\nFinished running 'test_all_world2pix'.\n"
-          "Mean error = {0:e}  (Max error = {1:e})\n"
-          "Run time: {2}\n"
+          "Mean error = {:e}  (Max error = {:e})\n"
+          "Run time: {}\n"
           .format(meanerr, maxerr, runtime_end - runtime_begin))
 
     assert(maxerr < 2.0 * tolerance)
@@ -919,8 +919,8 @@ def test_no_truncate_crval():
 
     header = w.to_header()
     for ii in range(3):
-        assert header['CRVAL{0}'.format(ii + 1)] == w.wcs.crval[ii]
-        assert header['CDELT{0}'.format(ii + 1)] == w.wcs.cdelt[ii]
+        assert header['CRVAL{}'.format(ii + 1)] == w.wcs.crval[ii]
+        assert header['CDELT{}'.format(ii + 1)] == w.wcs.cdelt[ii]
 
 
 def test_no_truncate_crval_try2():
@@ -938,8 +938,8 @@ def test_no_truncate_crval_try2():
 
     header = w.to_header()
     for ii in range(3):
-        assert header['CRVAL{0}'.format(ii + 1)] == w.wcs.crval[ii]
-        assert header['CDELT{0}'.format(ii + 1)] == w.wcs.cdelt[ii]
+        assert header['CRVAL{}'.format(ii + 1)] == w.wcs.crval[ii]
+        assert header['CDELT{}'.format(ii + 1)] == w.wcs.cdelt[ii]
 
 
 def test_no_truncate_crval_p17():
@@ -1241,9 +1241,9 @@ class TestWcsWithTime:
         for i in range(1, 5):
             for j in range(1, 5):
                 if i == j:
-                    pc[i-1, j-1] = self.header.get('PC{}_{}A'.format(i, j), 1)
+                    pc[i-1, j-1] = self.header.get(f'PC{i}_{j}A', 1)
                 else:
-                    pc[i-1, j-1] = self.header.get('PC{}_{}A'.format(i, j), 0)
+                    pc[i-1, j-1] = self.header.get(f'PC{i}_{j}A', 0)
         assert_allclose(self.w.wcs.pc, pc)
 
         char_keys = ['timesys', 'trefpos', 'trefdir', 'plephem', 'timeunit',

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -487,7 +487,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                 raise ValueError(
                     """
 FITS WCS distortion paper lookup tables and SIP distortions only work
-in 2 dimensions.  However, WCSLIB has detected {0} dimensions in the
+in 2 dimensions.  However, WCSLIB has detected {} dimensions in the
 core WCS keywords.  To use core WCS in conjunction with FITS WCS
 distortion paper lookup tables or SIP distortion, you must select or
 reduce these to 2 dimensions using the naxis kwarg.
@@ -496,8 +496,8 @@ reduce these to 2 dimensions using the naxis kwarg.
             header_naxis = header.get('NAXIS', None)
             if header_naxis is not None and header_naxis < wcsprm.naxis:
                 warnings.warn(
-                    "The WCS transformation has more axes ({0:d}) than the "
-                    "image it is associated with ({1:d})".format(
+                    "The WCS transformation has more axes ({:d}) than the "
+                    "image it is associated with ({:d})".format(
                         wcsprm.naxis, header_naxis), FITSFixedWarning)
 
         self._get_naxis(header)
@@ -768,7 +768,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                         del header[dp_extver_key]
                     else:
                         d_extver = 1
-                    dp_axis_key = dp + '.AXIS.{0:d}'.format(i)
+                    dp_axis_key = dp + f'.AXIS.{i:d}'
                     if i == header[dp_axis_key]:
                         d_data = fobj['D2IMARR', d_extver].data
                     else:
@@ -843,15 +843,15 @@ reduce these to 2 dimensions using the naxis kwarg.
         def write_d2i(num, det2im):
             if det2im is None:
                 return
-            '{0}{1:d}'.format(dist, num),
-            hdulist[0].header['{0}{1:d}'.format(dist, num)] = (
+            f'{dist}{num:d}',
+            hdulist[0].header[f'{dist}{num:d}'] = (
                 'LOOKUP', 'Detector to image correction type')
-            hdulist[0].header['{0}{1:d}.EXTVER'.format(d_kw, num)] = (
+            hdulist[0].header[f'{d_kw}{num:d}.EXTVER'] = (
                 num, 'Version number of WCSDVARR extension')
-            hdulist[0].header['{0}{1:d}.NAXES'.format(d_kw, num)] = (
+            hdulist[0].header[f'{d_kw}{num:d}.NAXES'] = (
                 len(det2im.data.shape), 'Number of independent variables in d2im function')
             for i in range(det2im.data.ndim):
-                hdulist[0].header['{0}{1:d}.AXIS.{2:d}'.format(d_kw, num, i + 1)] = (
+                hdulist[0].header['{}{:d}.AXIS.{:d}'.format(d_kw, num, i + 1)] = (
                     i + 1, 'Axis number of the jth independent variable in a d2im function')
 
             image = fits.ImageHDU(det2im.data, name='D2IMARR')
@@ -869,7 +869,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                                      'Coordinate increment along axis')
             header['CDELT2'] = (det2im.cdelt[1],
                                      'Coordinate increment along axis')
-            image.ver = int(hdulist[0].header['{0}{1:d}.EXTVER'.format(d_kw, num)])
+            image.ver = int(hdulist[0].header[f'{d_kw}{num:d}.EXTVER'])
             hdulist.append(image)
         write_d2i(1, self.det2im1)
         write_d2i(2, self.det2im2)
@@ -919,7 +919,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                         del header[dp_extver_key]
                     else:
                         d_extver = 1
-                    dp_axis_key = dp + '.AXIS.{0:d}'.format(i)
+                    dp_axis_key = dp + f'.AXIS.{i:d}'
                     if i == header[dp_axis_key]:
                         d_data = fobj['WCSDVARR', d_extver].data
                     else:
@@ -967,15 +967,15 @@ reduce these to 2 dimensions using the naxis kwarg.
             if cpdis is None:
                 return
 
-            hdulist[0].header['{0}{1:d}'.format(dist, num)] = (
+            hdulist[0].header[f'{dist}{num:d}'] = (
                 'LOOKUP', 'Prior distortion function type')
-            hdulist[0].header['{0}{1:d}.EXTVER'.format(d_kw, num)] = (
+            hdulist[0].header[f'{d_kw}{num:d}.EXTVER'] = (
                 num, 'Version number of WCSDVARR extension')
-            hdulist[0].header['{0}{1:d}.NAXES'.format(d_kw, num)] = (
+            hdulist[0].header[f'{d_kw}{num:d}.NAXES'] = (
                 len(cpdis.data.shape), 'Number of independent variables in distortion function')
 
             for i in range(cpdis.data.ndim):
-                hdulist[0].header['{0}{1:d}.AXIS.{2:d}'.format(d_kw, num, i + 1)] = (
+                hdulist[0].header['{}{:d}.AXIS.{:d}'.format(d_kw, num, i + 1)] = (
                     i + 1,
                     'Axis number of the jth independent variable in a distortion function')
 
@@ -988,7 +988,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             header['CRVAL2'] = (cpdis.crval[1], 'Coordinate system value at reference pixel')
             header['CDELT1'] = (cpdis.cdelt[0], 'Coordinate increment along axis')
             header['CDELT2'] = (cpdis.cdelt[1], 'Coordinate increment along axis')
-            image.ver = int(hdulist[0].header['{0}{1:d}.EXTVER'.format(d_kw, num)])
+            image.ver = int(hdulist[0].header[f'{d_kw}{num:d}.EXTVER'])
             hdulist.append(image)
 
         write_dist(1, self.cpdis1)
@@ -1025,7 +1025,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             a = np.zeros((m + 1, m + 1), np.double)
             for i in range(m + 1):
                 for j in range(m - i + 1):
-                    key = "A_{0}_{1}".format(i, j)
+                    key = f"A_{i}_{j}"
                     if key in header:
                         a[i, j] = header[key]
                         del header[key]
@@ -1035,7 +1035,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 b = np.zeros((m + 1, m + 1), np.double)
                 for i in range(m + 1):
                     for j in range(m - i + 1):
-                        key = "B_{0}_{1}".format(i, j)
+                        key = f"B_{i}_{j}"
                         if key in header:
                             b[i, j] = header[key]
                             del header[key]
@@ -1046,7 +1046,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             del header['A_ORDER']
             del header['B_ORDER']
 
-            ctype = [header['CTYPE{0}{1}'.format(nax, wcskey)] for nax in range(1, self.naxis + 1)]
+            ctype = [header[f'CTYPE{nax}{wcskey}'] for nax in range(1, self.naxis + 1)]
             if any(not ctyp.endswith('-SIP') for ctyp in ctype):
                 message = """
                 Inconsistent SIP distortion information is present in the FITS header and the WCS object:
@@ -1083,7 +1083,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             ap = np.zeros((m + 1, m + 1), np.double)
             for i in range(m + 1):
                 for j in range(m - i + 1):
-                    key = "AP_{0}_{1}".format(i, j)
+                    key = f"AP_{i}_{j}"
                     if key in header:
                         ap[i, j] = header[key]
                         del header[key]
@@ -1093,7 +1093,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 bp = np.zeros((m + 1, m + 1), np.double)
                 for i in range(m + 1):
                     for j in range(m - i + 1):
-                        key = "BP_{0}_{1}".format(i, j)
+                        key = f"BP_{i}_{j}"
                         if key in header:
                             bp[i, j] = header[key]
                             del header[key]
@@ -1114,12 +1114,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         if a is None and b is None and ap is None and bp is None:
             return None
 
-        if "CRPIX1{0}".format(wcskey) not in header or "CRPIX2{0}".format(wcskey) not in header:
+        if f"CRPIX1{wcskey}" not in header or f"CRPIX2{wcskey}" not in header:
             raise ValueError(
                 "Header has SIP keywords without CRPIX keywords")
 
-        crpix1 = header.get("CRPIX1{0}".format(wcskey))
-        crpix2 = header.get("CRPIX2{0}".format(wcskey))
+        crpix1 = header.get(f"CRPIX1{wcskey}")
+        crpix2 = header.get(f"CRPIX2{wcskey}")
 
         return Sip(a, b, ap, bp, (crpix1, crpix2))
 
@@ -1137,12 +1137,12 @@ reduce these to 2 dimensions using the naxis kwarg.
             if a is None:
                 return
             size = a.shape[0]
-            keywords['{0}_ORDER'.format(name)] = size - 1
+            keywords[f'{name}_ORDER'] = size - 1
             for i in range(size):
                 for j in range(size - i):
                     if a[i, j] != 0.0:
                         keywords[
-                            '{0}_{1:d}_{2:d}'.format(name, i, j)] = a[i, j]
+                            f'{name}_{i:d}_{j:d}'] = a[i, j]
 
         write_array('A', self.sip.a)
         write_array('B', self.sip.b)
@@ -1242,7 +1242,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             if xy.shape[-1] != self.naxis:
                 raise ValueError(
                     "When providing two arguments, the array must be "
-                    "of shape (N, {0})".format(self.naxis))
+                    "of shape (N, {})".format(self.naxis))
             if 0 in xy.shape:
                 return xy
             if ra_dec_order and sky == 'input':
@@ -1260,7 +1260,7 @@ reduce these to 2 dimensions using the naxis kwarg.
             except Exception:
                 raise TypeError(
                     "When providing two arguments, they must be "
-                    "(coords[N][{0}], origin)".format(self.naxis))
+                    "(coords[N][{}], origin)".format(self.naxis))
             if xy.shape == () or len(xy.shape) == 1:
                 return _return_list_of_arrays([xy], origin)
             return _return_single_array(xy, origin)
@@ -1306,17 +1306,17 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {0}
+        {}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
 
-        {1}
+        {}
 
         Returns
         -------
 
-        {2}
+        {}
 
         Notes
         -----
@@ -1374,17 +1374,17 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {0}
+        {}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
 
-        {1}
+        {}
 
         Returns
         -------
 
-        {2}
+        {}
 
         Raises
         ------
@@ -1813,7 +1813,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 raise NoConvergence(
                     "'WCS.all_world2pix' failed to "
                     "converge to the requested accuracy.\n"
-                    "After {0:d} iterations, the solution is diverging "
+                    "After {:d} iterations, the solution is diverging "
                     "at least for one input point."
                     .format(k), best_solution=pix,
                     accuracy=np.abs(dpix), niter=k,
@@ -2174,17 +2174,17 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         Parameters
         ----------
-        {0}
+        {}
 
             For a transformation that is not two-dimensional, the
             two-argument form must be used.
 
-        {1}
+        {}
 
         Returns
         -------
 
-        {2}
+        {}
 
         Notes
         -----
@@ -2237,12 +2237,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {0}
+        {}
 
         Returns
         -------
 
-        {1}
+        {}
 
         Raises
         ------
@@ -2266,12 +2266,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {0}
+        {}
 
         Returns
         -------
 
-        {1}
+        {}
 
         Raises
         ------
@@ -2295,12 +2295,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {0}
+        {}
 
         Returns
         -------
 
-        {1}
+        {}
 
         Raises
         ------
@@ -2336,12 +2336,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {0}
+        {}
 
         Returns
         -------
 
-        {1}
+        {}
 
         Raises
         ------
@@ -2373,12 +2373,12 @@ reduce these to 2 dimensions using the naxis kwarg.
         Parameters
         ----------
 
-        {0}
+        {}
 
         Returns
         -------
 
-        {1}
+        {}
 
         Raises
         ------
@@ -2557,7 +2557,7 @@ reduce these to 2 dimensions using the naxis kwarg.
 
             if len(missing_keys):
                 warnings.warn(
-                    "Some non-standard WCS keywords were excluded: {0} "
+                    "Some non-standard WCS keywords were excluded: {} "
                     "Use the ``relax`` kwarg to control this.".format(
                         ', '.join(missing_keys)),
                     AstropyWarning)
@@ -2610,7 +2610,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 log.info(_add_sip_to_ctype)
         for i in range(1, self.naxis+1):
             # strip() must be called here to cover the case of alt key= " "
-            kw = 'CTYPE{0}{1}'.format(i, self.wcs.alt).strip()
+            kw = f'CTYPE{i}{self.wcs.alt}'.strip()
             if kw in header:
                 if add_sip:
                     val = header[kw].strip("-SIP") + "-SIP"
@@ -2667,12 +2667,12 @@ reduce these to 2 dimensions using the naxis kwarg.
 
         with open(filename, mode='w') as f:
             f.write(comments)
-            f.write('{}\n'.format(coordsys))
+            f.write(f'{coordsys}\n')
             f.write('polygon(')
             ftpr = self.calc_footprint()
             if ftpr is not None:
                 ftpr.tofile(f, sep=',')
-                f.write(') # color={0}, width={1:d} \n'.format(color, width))
+                f.write(f') # color={color}, width={width:d} \n')
 
     @property
     def _naxis1(self):
@@ -2700,7 +2700,7 @@ reduce these to 2 dimensions using the naxis kwarg.
                 not isinstance(header, (str, bytes))):
             for naxis in itertools.count(1):
                 try:
-                    _naxis.append(header['NAXIS{}'.format(naxis)])
+                    _naxis.append(header[f'NAXIS{naxis}'])
                 except KeyError:
                     break
         if len(_naxis) == 0:
@@ -2718,8 +2718,8 @@ reduce these to 2 dimensions using the naxis kwarg.
         the `printwcs()` method.
         '''
         description = ["WCS Keywords\n",
-                       "Number of WCS axes: {0!r}".format(self.naxis)]
-        sfmt = ' : ' + "".join(["{"+"{0}".format(i)+"!r}  " for i in range(self.naxis)])
+                       f"Number of WCS axes: {self.naxis!r}"]
+        sfmt = ' : ' + "".join(["{"+f"{i}"+"!r}  " for i in range(self.naxis)])
 
         keywords = ['CTYPE', 'CRVAL', 'CRPIX']
         values = [self.wcs.ctype, self.wcs.crval, self.wcs.crpix]
@@ -2996,8 +2996,8 @@ reduce these to 2 dimensions using the naxis kwarg.
             except TypeError as exc:
                 if 'indices must be integers' not in str(exc):
                     raise
-                warnings.warn("NAXIS{0} attribute is not updated because at "
-                              "least one index ('{1}') is no integer."
+                warnings.warn("NAXIS{} attribute is not updated because at "
+                              "least one index ('{}') is no integer."
                               "".format(wcs_index, iview), AstropyUserWarning)
             else:
                 wcs_new._naxis[wcs_index] = nitems
@@ -3019,7 +3019,7 @@ reduce these to 2 dimensions using the naxis kwarg.
         # Having __getitem__ makes Python think WCS is iterable. However,
         # Python first checks whether __iter__ is present, so we can raise an
         # exception here.
-        raise TypeError("'{0}' object is not iterable".format(self.__class__.__name__))
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
 
     @property
     def axis_type_names(self):
@@ -3258,7 +3258,7 @@ def validate(source):
             self._key = key
 
         def __repr__(self):
-            result = ["  WCS key '{0}':".format(self._key or ' ')]
+            result = ["  WCS key '{}':".format(self._key or ' ')]
             if len(self):
                 for entry in self:
                     for i, line in enumerate(entry.splitlines()):
@@ -3284,10 +3284,10 @@ def validate(source):
         def __repr__(self):
             if len(self):
                 if self._hdu_name:
-                    hdu_name = ' ({0})'.format(self._hdu_name)
+                    hdu_name = f' ({self._hdu_name})'
                 else:
                     hdu_name = ''
-                result = ['HDU {0}{1}:'.format(self._hdu_index, hdu_name)]
+                result = [f'HDU {self._hdu_index}{hdu_name}:']
                 for wcs in self:
                     result.append(repr(wcs))
                 return '\n'.join(result)

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -121,8 +121,8 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
         # Check that the number of classes matches the number of inputs
         if len(world_objects) != len(classes):
-            raise ValueError("Number of world inputs ({0}) does not match "
-                             "expected ({1})".format(len(world_objects), len(classes)))
+            raise ValueError("Number of world inputs ({}) does not match "
+                             "expected ({})".format(len(world_objects), len(classes)))
 
         # Determine whether the classes are uniquely matched, that is we check
         # whether there is only one of each class.
@@ -167,7 +167,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
                 w = world_objects[ikey]
                 if not isinstance(w, klass):
                     raise ValueError("Expected the following order of world "
-                                     "arguments: {0}".format(', '.join([k.__name__ for (k, _, _) in classes.values()])))
+                                     "arguments: {}".format(', '.join([k.__name__ for (k, _, _) in classes.values()])))
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -282,10 +282,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         # Overall header
 
-        s = '{0} Transformation\n\n'.format(self.__class__.__name__)
-        s += ('This transformation has {0} pixel and {1} world dimensions\n\n'
+        s = f'{self.__class__.__name__} Transformation\n\n'
+        s += ('This transformation has {} pixel and {} world dimensions\n\n'
               .format(self.pixel_n_dim, self.world_n_dim))
-        s += 'Array shape (Numpy order): {0}\n\n'.format(self.array_shape)
+        s += f'Array shape (Numpy order): {self.array_shape}\n\n'
 
         # Pixel dimensions table
 
@@ -304,7 +304,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
             s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
                   (" "*5 + str(None) if pixel_shape[ipix] is None else
                    ('{0:' + str(pixel_siz_width) + 'd}').format(pixel_shape[ipix])) + '  ' +
-                  '{0:s}'.format(str(None if self.pixel_bounds is None else self.pixel_bounds[ipix]) + '\n'))
+                  '{:s}'.format(str(None if self.pixel_bounds is None else self.pixel_bounds[ipix]) + '\n'))
 
         s += '\n'
 
@@ -323,11 +323,11 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
             if self.world_axis_physical_types[iwrl] is not None:
                 s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
                       ('{0:' + str(world_typ_width) + 's}').format(self.world_axis_physical_types[iwrl]) + '  ' +
-                      '{0:s}'.format(self.world_axis_units[iwrl] + '\n'))
+                      '{:s}'.format(self.world_axis_units[iwrl] + '\n'))
             else:
                 s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
                       ('{0:' + str(world_typ_width) + 's}').format('None') + '  ' +
-                      '{0:s}'.format('unknown' + '\n'))
+                      '{:s}'.format('unknown' + '\n'))
         s += '\n'
 
         # Axis correlation matrix
@@ -375,4 +375,4 @@ def validate_physical_types(physical_types):
         if (physical_type is not None and
             physical_type not in VALID_UCDS and
                 not physical_type.startswith('custom:')):
-            raise ValueError("Invalid physical type: {0}".format(physical_type))
+            raise ValueError(f"Invalid physical type: {physical_type}")


### PR DESCRIPTION
This used a hacked version of `pyupgrade` at `e477316` to convert format and % strings to modern formatting, including f-strings where possible.  The hack bit was to essentially de-select all upgrades except for string formatting ones.

Not included are multiline statements for reasons discussed below.