### PR TITLE
Fixed compatibility of fits2bitmap with latest developer version of Matplotlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2429,6 +2429,8 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed compatibility issues with latest versions of Matplotlib. [#8961]
+
 astropy.vo
 ^^^^^^^^^^
 

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -103,7 +103,9 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
             LooseVersion(matplotlib.__version__) == LooseVersion('2.0.0')):
         image = image[::-1]
 
-    if cmap not in cm.datad:
+    try:
+        cm.get_cmap(cmap)
+    except ValueError:
         log.critical('{0} is not a valid matplotlib colormap name.'
                      .format(cmap))
         return 1


### PR DESCRIPTION
The issue was due to https://github.com/matplotlib/matplotlib/pull/14679 - ``cm.datad`` no longer contains reversed colormaps.