### PR TITLE
Avoid getting DeprecationWarnings on broadcasted arrays fed into Cython

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
@@ -100,8 +100,8 @@ def lombscargle_cython(t, y, dy, frequency, normalization='standard',
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef _standard_lomb_scargle(DTYPE_t[::1] t, DTYPE_t[::1] y, DTYPE_t[::1] dy,
-                            DTYPE_t[::1] omega, DTYPE_t[::1] PLS):
+cdef _standard_lomb_scargle(const DTYPE_t[::1] t, const DTYPE_t[::1] y, const DTYPE_t[::1] dy,
+                            const DTYPE_t[::1] omega, DTYPE_t[::1] PLS):
     cdef ITYPE_t N_freq = omega.shape[0]
     cdef ITYPE_t N_obs = t.shape[0]
 
@@ -163,8 +163,8 @@ cdef _standard_lomb_scargle(DTYPE_t[::1] t, DTYPE_t[::1] y, DTYPE_t[::1] dy,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef _generalized_lomb_scargle(DTYPE_t[::1] t, DTYPE_t[::1] y, DTYPE_t[::1] dy,
-                               DTYPE_t[::1] omega, DTYPE_t[::1] PLS):
+cdef _generalized_lomb_scargle(const DTYPE_t[::1] t, const DTYPE_t[::1] y, const DTYPE_t[::1] dy,
+                               const DTYPE_t[::1] omega, DTYPE_t[::1] PLS):
     cdef ITYPE_t N_freq = omega.shape[0]
     cdef ITYPE_t N_obs = t.shape[0]
 


### PR DESCRIPTION
Hopefully will fix (most of?) #8935. Note that this goes the route of explicitly declaring broadcast arrays as `readonly`, which should be futureproof and guarantees a bit more that we're not messing things up inadvertently.

Note: check `numpy-dev` run in particular!

p.s. Can add a change-log entry if people feel it is useful - noting that users will generally not see the `DeprecationWarning`