### PR TITLE
Fix issue in construction of warning message in astropy.samp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2405,6 +2405,12 @@ astropy.nddata
   be incorrectly raised for a 0-shaped small array at the origin.
   [#8901]
 
+astropy.samp
+^^^^^^^^^^^^
+
+- Fixed a bug that caused an incorrectly constructed warning message
+  to raise an error. [#8966]
+
 astropy.stats
 ^^^^^^^^^^^^^
 

--- a/astropy/samp/hub.py
+++ b/astropy/samp/hub.py
@@ -1233,7 +1233,7 @@ class SAMPHubServer:
                 return
 
         # If we are here, then the above attempts failed
-        error_message = samp_method_name + " failed after " + conf.n_retries + " attempts"
+        error_message = samp_method_name + " failed after " + str(conf.n_retries) + " attempts"
         raise SAMPHubError(error_message)
 
     def _public_id_to_private_key(self, public_id):


### PR DESCRIPTION
I'm not sure how no one else ran into this before, but the fix is simple. Testing this is actually a lot more complicated as the warning/error is raised inside a thread and it's not clear how to best capture it. I think the fix is simple enough to merge as-is though.

I'm not using f-string syntax as this needs to be backported.