### PR TITLE
Suppress divide by zero warnings for log(prob) in statistics.

### DIFF
--- a/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
+++ b/astropy/timeseries/periodograms/lombscargle/tests/test_statistics.py
@@ -71,7 +71,7 @@ def test_distribution(null_data, normalization, with_errors, fmax=40):
 @pytest.mark.parametrize('N', [10, 100, 1000])
 @pytest.mark.parametrize('normalization', NORMALIZATIONS)
 def test_inverse_single(N, normalization):
-    fap = np.linspace(0.00001, 1, 100)
+    fap = np.linspace(0, 1, 11)
 
     z = inv_fap_single(fap, N, normalization)
     fap_out = fap_single(z, N, normalization)
@@ -85,7 +85,7 @@ def test_inverse_bootstrap(null_data, normalization, use_errs, fmax=5):
     if not use_errs:
         dy = None
 
-    fap = np.linspace(0, 1, 10)
+    fap = np.linspace(0, 1, 11)
     method = 'bootstrap'
     method_kwds = METHOD_KWDS['bootstrap']
 
@@ -114,7 +114,7 @@ def test_inverses(method, normalization, use_errs, N, T=5, fmax=5):
         dy = None
     method_kwds = METHOD_KWDS.get(method, None)
 
-    fap = np.logspace(-10, -0.00001, 10)
+    fap = np.logspace(-10, 0, 11)
 
     ls = LombScargle(t, y, dy, normalization=normalization)
     z = ls.false_alarm_level(fap, maximum_frequency=fmax,


### PR DESCRIPTION
@bsipocz - I had meant this as a PR to your #8964, but I was just too late, you had already merged it.

Anyway, the reason for it was that after thinking a bit more about these runtime division-by-zero warnings in the lomb-scargle probability tests, I ended up feeling that we should suppress the warning, rather than try to avoid the relevant cases in the tests. This because one is asking to calculate something for a probability of 0, and it seems appropriate that in that case one gets, e.g., a power of infinity out - no need for a warning.

cc @jakevdp since he may have a more informed opinion (Jake: all this arose because we're trying to actually look at pytest warnings rather than ignoring them. So, we constantly have to wonder whether a warning is something serious or just a mistake in the tests.)
