### PR TITLE
Trial to speed up mixin column info.

### DIFF
--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -117,8 +117,6 @@ def table_info(tbl, option='attributes', out=''):
 
 
 class TableInfo(DataInfo):
-    _parent = None
-
     def __call__(self, option='attributes', out=''):
         return table_info(self._parent, option, out)
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -270,7 +270,10 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
             info = instance.__dict__.get('info')
             if info is None:
                 info = instance.__dict__['info'] = self.__class__(bound=True)
-            info._parent = instance
+            # Bypass setter and in particular __setattr__
+            # info._parent = instance
+            # info.__class__._parent.fset(info, instance)
+            info.__dict__['_parent_ref'] = weakref.ref(instance)
         return info
 
     def __set__(self, instance, value):


### PR DESCRIPTION
@taldcroft - just a proof of concept, to try to make getting `col.info` itself faster. More generally, we might want to think about replacing getting/setting attributes on the parent not via `__getattr__` and `__setattr__`, but rather via (automatically generated) properties on `info`.

```
from astropy.table import MaskedColumn
m = MaskedColumn([1, 2])
%timeit m.info
# 1000000 loops, best of 5: 336 ns per loop
# on current master: 1.26 µs
m.info._name = 'bla'
%timeit m.info._name
# 1000000 loops, best of 5: 370 ns per loop
# on current master: 1.28 µs
%timeit m.name
# 10000000 loops, best of 5: 82.3 ns per loop
# "only" 4.5 times faster instead of 15!
```