### PR TITLE
Change Table data-to-col convert strategy from white-list to "try"

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -925,15 +925,17 @@ class Table:
                        if issubclass(self.ColumnClass, self.MaskedColumn)
                        else self.MaskedColumn)
 
-        elif isinstance(data, np.ndarray) or isiterable(data):
+        else:
+            # `data` is none of the above, so just go for it and try init'ing Column
             col_cls = self.ColumnClass
 
-        else:
-            raise ValueError('Elements in list initialization must be '
-                             'either Column or list-like')
+        try:
+            col = col_cls(name=name, data=data, dtype=dtype,
+                          copy=copy, copy_indices=self._init_indices)
+        except Exception:
+            # Broad exception class since we don't know what might go wrong
+            raise ValueError('unable to convert data to Column for Table')
 
-        col = col_cls(name=name, data=data, dtype=dtype,
-                      copy=copy, copy_indices=self._init_indices)
         col = self._convert_col_for_table(col)
 
         return col

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2392,3 +2392,14 @@ def test_custom_masked_column_in_nonmasked_table():
         assert type(t['c']) is MyMaskedColumn
         assert type(t['d']) is MySubColumn
         assert type(t['e']) is MySubMaskedColumn  # sub-class not downgraded
+
+
+def test_data_to_col_convert_strategy():
+    """Test the update to how data_to_col works (#8972), using the regression
+    example from #8971.
+    """
+    t = table.Table([[0, 1]])
+    t['a'] = 1
+    t['b'] = np.int64(2)  # Failed previously
+    assert np.all(t['a'] == [1, 1])
+    assert np.all(t['b'] == [2, 2])


### PR DESCRIPTION
The regression in #8971 is addressed by this change, but the change is actually a bit broader and needs some consideration.  Previously the `_convert_data_to_col` method was basically white-listing all possible valid data types (and of course missing a numpy scalar). 

 Instead this approach checks a few cases that need special handling and at the end just tries to initialize a Column (or whatever subclass) with the data.  I think this is a better approach but I wonder if there are things that can now slip through and make trouble.

Will add a test for the #8971 regression but wanted to see if @mhvk has any thoughts.  I can't quite think of any obvious way to generate the exception at this point.

Fixes #8971 