### PR TITLE
Add missing docs dependencies in setup.cfg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ matrix:
           env: SETUP_CMD='build_docs -b linkcheck'
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
                INSTALL_WITH_PIP=True
-               EXTRAS_INSTALL="docs,all"
+               EXTRAS_INSTALL="docs"
 
     allow_failures:
       - os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,7 +72,12 @@ all =
     bottleneck
     ipython
     pytest
-docs = sphinx-astropy
+docs =
+    sphinx-astropy
+    pytest
+    pyyaml
+    scipy
+    scikit-image
 
 [build_sphinx]
 source-dir = docs


### PR DESCRIPTION
Building the documents from source in the git checkout in a fresh virtualenv like so
```
pip install -e .[docs]
cd docs
make html
```
fails because not all the documentation dependencies are included in the `[docs]` extras_requires list in `setup.cfg`.  This PR adds them.

- pytest
- pyyaml
- scipy
- scikit-image

Perhaps this was not noticed because the TravisCI job that builds the docs installs `[docs,all]`?  I changed that too.