### PR TITLE
Introduce double-quote syntax to inline define custom units in VOUnit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -861,6 +861,9 @@ astropy.units
   [#8808]
 
 - Add equivalencies for surface brightness units to spectral_density. [#9282]
+- Changed undocumented "inline" definition of custom units with
+  ``Unit('myunit', format='votable')`` to require additional enclosure
+  in double quotes. [#8979]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,10 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Changed undocumented "inline" definition of custom units with
+  ``Unit('myunit', format='votable')`` to require additional enclosure
+  in double quotes. [#8979]
+
 - Added ``torr`` pressure unit. [#9787]
 
 - Added the ``equal_nan`` keyword argument to ``isclose`` and ``allclose``, and
@@ -861,9 +865,6 @@ astropy.units
   [#8808]
 
 - Add equivalencies for surface brightness units to spectral_density. [#9282]
-- Changed undocumented "inline" definition of custom units with
-  ``Unit('myunit', format='votable')`` to require additional enclosure
-  in double quotes. [#8979]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -536,7 +536,9 @@ class UnitBase:
         useful as a dictionary key.
         """
         unit = self.decompose()
-        r = zip([x.name for x in unit.bases], unit.powers)
+        # custom units are stored under their quoted (alias) name
+        r = zip([x.name if f"'{x.name:}'" not in x.aliases else
+                 f"'{x.name:}'" for x in unit.bases], unit.powers)
         # bases and powers are already sorted in a unique way
         # r.sort()
         r = tuple(r)
@@ -876,6 +878,8 @@ class UnitBase:
             if physical_type != 'unknown':
                 unit_str = "'{}' ({})".format(
                     unit_str, physical_type)
+            elif hasattr(unit, 'long_names') and len(unit.long_names) > 0:
+                unit_str = f"'{unit_str}' (custom unit \"{unit.long_names[0]}\")"
             else:
                 unit_str = f"'{unit_str}'"
             return unit_str

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -121,9 +121,9 @@ class VOUnit(generic.Generic):
                     raise ValueError()
                 raise ValueError("Unit {0!r} not supported by the VOUnit "
                                  "standard. {1}".format(
-                                 unit, utils.did_you_mean_units(
-                                     unit, cls._units, cls._deprecated_units,
-                                     cls._to_decomposed_alternative)))
+                                     unit, utils.did_you_mean_units(
+                                         unit, cls._units, cls._deprecated_units,
+                                         cls._to_decomposed_alternative)))
 
             warnings.warn(
                 "Unit {!r} not supported by the VOUnit "
@@ -198,7 +198,7 @@ class VOUnit(generic.Generic):
                     return core.PrefixUnit(
                         [prefix + x for x in base_unit.names],
                         core.CompositeUnit(factor, [base_unit], [1],
-                                        _error_check=False),
+                                           _error_check=False),
                         format={'vounit': prefix + base_unit.names[-1]},
                         namespace=cls._custom_units)
 

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -96,6 +96,7 @@ class VOUnit(generic.Generic):
             cls._custom_inline = True
             result = cls._do_parse(s.strip('"'), debug=debug)
         else:
+            cls._custom_inline = False
             result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported in "

--- a/astropy/units/physical.py
+++ b/astropy/units/physical.py
@@ -60,7 +60,7 @@ def get_physical_type(unit):
     -------
     physical : str
         The name of the physical quantity, or unknown if not
-        known.
+        known (quoted custom units are always considered unknown).
     """
     r = unit._get_physical_type_id()
     return _physical_unit_mapping.get(r, 'unknown')

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -419,13 +419,6 @@ def test_scaled_dimensionless():
 
 
 def test_deprecated_did_you_mean_units():
-    # First clear custom unit namespace to ensure consistent test outcome.
-    u.format.VOUnit._custom_units.clear()
-    with pytest.raises(ValueError,
-                       match='not supported by the VOUnit standard') as e:
-        u.Unit('ANGSTROM', format='vounit')
-    assert str(e.value).count('nm') == 1
-
     with pytest.raises(ValueError,
                        match=r'Crab .deprecated. or mCrab .deprecated..$'):
         u.Unit('crab', format='ogip')
@@ -437,6 +430,11 @@ def test_deprecated_did_you_mean_units():
                        match='not supported by the CDS SAC standard') as e:
         u.Unit('ANGSTROM', format='cds')
     assert str(e.value).count('Angstrom') == 5
+
+    with pytest.raises(ValueError,
+                       match='not supported by the VOUnit standard') as e:
+        u.Unit('ANGSTROM', format='vounit')
+    assert str(e.value).count('nm') == 1
 
     with catch_warnings() as w:
         u.Unit('angstrom', format='vounit')

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -548,6 +548,7 @@ def test_vounit_implicit_custom():
     assert x.bases[1].name == 'week'
     assert 'urlong' not in u.format.VOUnit._custom_units
 
+
 @pytest.mark.parametrize('scale, number, string',
                          [('10+2', 100, '10**2'),
                           ('10(+2)', 100, '10**2'),

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -419,6 +419,13 @@ def test_scaled_dimensionless():
 
 
 def test_deprecated_did_you_mean_units():
+    # First clear custom unit namespace to ensure consistent test outcome.
+    u.format.VOUnit._custom_units.clear()
+    with pytest.raises(ValueError,
+                       match='not supported by the VOUnit standard') as e:
+        u.Unit('ANGSTROM', format='vounit')
+    assert str(e.value).count('nm') == 1
+
     with pytest.raises(ValueError,
                        match=r'Crab .deprecated. or mCrab .deprecated..$'):
         u.Unit('crab', format='ogip')
@@ -430,11 +437,6 @@ def test_deprecated_did_you_mean_units():
                        match='not supported by the CDS SAC standard') as e:
         u.Unit('ANGSTROM', format='cds')
     assert str(e.value).count('Angstrom') == 5
-
-    with pytest.raises(ValueError,
-                       match='not supported by the VOUnit standard') as e:
-        u.Unit('ANGSTROM', format='vounit')
-    assert str(e.value).count('nm') == 1
 
     with catch_warnings() as w:
         u.Unit('angstrom', format='vounit')

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -474,6 +474,7 @@ def test_deprecated_did_you_mean_units():
     assert '0.1nm' in str(w[0].message)
     assert not isinstance(x, u.UnrecognizedUnit)
 
+
 @pytest.mark.parametrize('string', ['mag(ct/s)', 'dB(mW)', 'dex(cm s**-2)'])
 def test_fits_function(string):
     # Function units cannot be written, so ensure they're not parsed either.

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -420,19 +420,19 @@ def test_scaled_dimensionless():
 
 def test_deprecated_did_you_mean_units():
     with pytest.raises(ValueError,
-                       match=r'Crab .deprecated. or mCrab .deprecated..$'):
+                       match=r'Crab \(deprecated\) or mCrab \(deprecated\)'):
         u.Unit('crab', format='ogip')
 
-    with pytest.raises(ValueError, match='Did you mean Angstrom or angstrom?' ):
+    with pytest.raises(ValueError, match=r'Did you mean Angstrom or angstrom'):
         u.Unit('ANGSTROM', format='fits')
 
     with pytest.raises(ValueError,
-                       match='not supported by the CDS SAC standard') as e:
+                       match=r'not supported by the CDS SAC standard') as e:
         u.Unit('ANGSTROM', format='cds')
     assert str(e.value).count('Angstrom') == 5
 
     with pytest.raises(ValueError,
-                       match='not supported by the VOUnit standard') as e:
+                       match=r'not supported by the VOUnit standard') as e:
         u.Unit('ANGSTROM', format='vounit')
     assert str(e.value).count('nm') == 1
 
@@ -520,7 +520,7 @@ def test_vounit_implicit_custom():
     u.format.VOUnit._custom_units.clear()
     # Implicit as indicated by double-quoted strings shall recognise prefixes.
     # Yikes, this becomes "femto-urlong"...  But at least there's a warning.
-    with catch_warnings() as w:
+    with catch_warnings():
         x = u.Unit('"furlong/week"', format="vounit")
     assert not isinstance(x.bases[0], u.IrreducibleUnit)
     assert isinstance(x.bases[1], u.IrreducibleUnit)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -419,6 +419,7 @@ def test_scaled_dimensionless():
 
 
 def test_deprecated_did_you_mean_units():
+<<<<<<< HEAD
     with pytest.raises(ValueError) as exc_info:
         u.Unit('ANGSTROM', format='fits')
     assert 'Did you mean Angstrom or angstrom?' in str(exc_info.value)
@@ -435,12 +436,43 @@ def test_deprecated_did_you_mean_units():
     assert 'angstrom (deprecated)' in str(w[0].message)
     assert '0.1nm' in str(w[0].message)
     assert str(w[0].message).count('0.1nm') == 1
+=======
+    with pytest.raises(ValueError,
+                       match=r'Crab .deprecated. or mCrab .deprecated..$'):
+        u.Unit('crab', format='ogip')
+
+    with pytest.raises(ValueError, match='Did you mean Angstrom or angstrom?' ):
+        u.Unit('ANGSTROM', format='fits')
+
+    with pytest.raises(ValueError,
+                       match='not supported by the CDS SAC standard') as e:
+        u.Unit('ANGSTROM', format='cds')
+    assert str(e.value).count('Angstrom') == 5
+
+    with pytest.raises(ValueError,
+                       match='not supported by the VOUnit standard') as e:
+        u.Unit('ANGSTROM', format='vounit')
+    assert str(e.value).count('nm') == 1
+>>>>>>> Introduce double-quote syntax to mark custom units in VOUnit
 
     with catch_warnings() as w:
         u.Unit('angstrom', format='vounit')
     assert len(w) == 1
     assert '0.1nm' in str(w[0].message)
 
+    with catch_warnings() as w:
+        x = u.Unit('ANGSTROM', format='vounit', parse_strict='warn')
+    assert len(w) == 1
+    assert 'angstrom (deprecated)' in str(w[0].message)
+    assert '0.1nm' in str(w[0].message)
+    assert isinstance(x, u.UnrecognizedUnit)
+
+    with catch_warnings() as w:
+        x = u.Unit('"ANGSTROM"', format='vounit', parse_strict='raise')
+    assert len(w) == 1
+    assert 'angstrom (deprecated)' in str(w[0].message)
+    assert '0.1nm' in str(w[0].message)
+    assert not isinstance(x, u.UnrecognizedUnit)
 
 @pytest.mark.parametrize('string', ['mag(ct/s)', 'dB(mW)', 'dex(cm s**-2)'])
 def test_fits_function(string):
@@ -464,7 +496,7 @@ def test_vounit_binary_prefix():
     u.Unit('Kibyte', format='vounit') == u.Unit('1024 B')
     u.Unit('Kibit', format='vounit') == u.Unit('1024 B')
     with catch_warnings() as w:
-        u.Unit('kibibyte', format='vounit')
+        u.Unit('"kibibyte"', format='vounit')
     assert len(w) == 1
 
 
@@ -501,14 +533,21 @@ def test_vounit_custom():
 
 
 def test_vounit_implicit_custom():
-    # Yikes, this becomes "femto-urlong"...  But at least there's a warning.
-    with catch_warnings() as w:
-        x = u.Unit("furlong/week", format="vounit")
+    # implicit as indicated by double-quoted strings shall recognise prefixes
+    x = u.Unit('"furlong/week"', format="vounit")
+    assert not isinstance(x.bases[0], u.IrreducibleUnit)
+    assert isinstance(x.bases[1], u.IrreducibleUnit)
     assert x.bases[0]._represents.scale == 1e-15
     assert x.bases[0]._represents.bases[0].name == 'urlong'
-    assert len(w) == 2
-    assert 'furlong' in str(w[0].message)
-    assert 'week' in str(w[1].message)
+    assert x.bases[1].name == 'week'
+
+    # explicit (single-quoted) is not to be further parsed;
+    # but we cannot overwrite already created custom units
+    x = u.Unit("'acre' / 'month'", format="vounit")
+    assert isinstance(x.bases[0], u.IrreducibleUnit)
+    assert isinstance(x.bases[1], u.IrreducibleUnit)
+    assert x.bases[0].name == 'acre'
+    assert x.bases[1].name == 'month'
 
 
 @pytest.mark.parametrize('scale, number, string',


### PR DESCRIPTION
Adressing #8978, this is changing the (undocumented) inline definition of arbitrary custom (unknown) units possible as
```
u.Unit('swallow', format='votable')
```
to be explicitly requested by enclosing the whole unit string in double quotes as
```
u.Unit('"swallow"', format='votable')
```
This is still complementary to the existing support of single-quoted unit names, i.e. _will_ parse SI prefixes according to the VOUnits standard - unlike  `'furlong'`, `"furlong"` will be parsed as `femto-urlong`.

There are some remaining complications because custom units are placed in the dictionary of known `units` and cannot be replaced by a re-definition, i.e. depending on the order in which
```
u.Unit('"furlong/week"', format='vounit')
```
```
u.Unit("'furlong' / 'week'", format='vounit')
```
are called, one has either `'furlong'` or `urlong` and `femto-urlong` already defined, and the second call will fail. The standard describes in 2.2

> A **symbol** within a unit-component _should_ be parsed as follows:
> 1. If it corresponds to a known **base symbol**, then it _must_ be recognised as such (for example the Pa must be parsed as the known Pascal, and never as the peta-year).
> 2. If the symbol starts with a multiplicative prefix, then this is recognised independently of whether  the resulting base symbol is a known or unknown unit (...)

In that sense, if the new unit becomes a "known base symbol" once defined, case 1. should take precedence over identifying any prefixes, as is currently the case.
But one might discuss whether the prefix search in `_def_custom_unit` should rather be moved ahead of the loop over `unit in cls._custom_units`...

It should also be noted that both `u.Unit('"furlong"', format='vounit')` and `u.Unit("'furlong'", format='vounit')` create different units from `u.Unit('furlong', format='vounit', parse_strict='warn')`, which returns a `u.UnrecognizedUnit` instance.