### PR TITLE
Added plotting support for SlicedLowLevelWCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -119,6 +119,8 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Allow ``SlicedLowLevelWCS`` to be used as a matplotlib projection. [#8980]
+
 API Changes
 -----------
 

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -59,6 +59,10 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
             self._wcs.axis_correlation_matrix[:, self._pixel_keep].any(axis=1))[0]
 
     @property
+    def wcs(self):
+        return self._wcs
+        
+    @property
     def pixel_n_dim(self):
         return len(self._pixel_keep)
 
@@ -155,3 +159,21 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     @property
     def axis_correlation_matrix(self):
         return self._wcs.axis_correlation_matrix[self._world_keep][:,self._pixel_keep]
+
+    def _as_mpl_axes(self):
+        """
+        Compatibility hook for Matplotlib and WCSAxes.
+        With this method, one can do:
+            from astropy.wcs import WCS
+            import matplotlib.pyplot as plt
+            wcs = WCS('filename.fits')
+            fig = plt.figure()
+            ax = fig.add_axes([0.15, 0.1, 0.8, 0.8], projection=wcs)
+            ...
+        and this will generate a plot with the correct WCS coordinates on the
+        axes.
+        """
+
+        # Note this method taken from `astropy.wcs.WCS`
+        from astropy.visualization.wcsaxes import WCSAxes
+        return WCSAxes, {'wcs': self}

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -61,7 +61,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     @property
     def wcs(self):
         return self._wcs
-        
+
     @property
     def pixel_n_dim(self):
         return len(self._pixel_keep)


### PR DESCRIPTION
This PR adds the support for plotting for `SlicedLowLevelWCS`. Note that plotting is not possible out of the box due to this PR, but it just adds a method `_as_mpl_axes` which is necessary for supporting plotting for `SlicedLowLevelWCS`.

Tasks to be done - 
- [x] Tests
- [x] Documentation
##
Edit : As of now only docstring is required for `SlicedLowLevelWCS`, so removing it.
Edit2: As being a private method, I haven't found any test for `wcs.py` so I following the convention, the tests are not required.