### PR TITLE
Allowing non unit annotations in quantity_input decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Accept non-unit type annotations in @quantity_input. [#8984]
+
 - For numpy 1.17 and later, the new ``__array_function__`` protocol is used to
   ensure that all top-level numpy functions interact properly with
   ``Quantity``, preserving units also in operations like ``np.concatenate``.

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -283,6 +283,28 @@ def test_default_value_check():
     assert x.unit == x_unit
 
 
+def test_str_unit_typo():
+    @u.quantity_input
+    def myfunc_args(x: "kilograam"):
+        return x
+
+    with pytest.raises(ValueError):
+        result = myfunc_args(u.kg)
+
+
+def test_type_annotations():
+    @u.quantity_input
+    def myfunc_args(x: u.m, y: str):
+        return x, y
+
+    in_quantity = 2 * u.m
+    in_string = "cool string"
+
+    quantity, string = myfunc_args(in_quantity, in_string)
+    assert quantity == in_quantity
+    assert string == in_string
+
+
 def test_args_None():
     x_target = u.deg
     x_unit = u.arcsec

--- a/docs/units/quantity.rst
+++ b/docs/units/quantity.rst
@@ -353,6 +353,14 @@ Alternatively, you can use the annotations syntax to provide the units:
     >>> myfunction(100*u.arcsec)  # doctest: +SKIP
     Unit("arcsec")
 
+You can also annotate for different types in non-unit expecting arguments:
+
+    >>> @u.quantity_input  # doctest: +SKIP
+    ... def myfunction(myarg: u.arcsec, nice_string: str):
+    ...     return myarg.unit, nice_string
+    >>> myfunction(100*u.arcsec, "a nice string")  # doctest: +SKIP
+    (Unit("arcsec"), 'a nice string')
+
 You can define a return decoration, to which the return
 value will be converted, i.e.::
 


### PR DESCRIPTION
(I copied the description from https://github.com/astropy/astropy/pull/7672, since that PR does the same thing but since has gone stale)

Closes https://github.com/astropy/astropy/issues/7661

Instead of raising an error, `@quantity_input` will skip any non-unit type annotations in function parameters. So, code such as below won't result in an error:
```python
>>> import astropy.units as u

>>> @u.quantity_input
... def f(x: u.m, y: str) -> u.m:
...    return x

>>> f(1 * u.m, 'x')
<Quantity 1. m>
# this would otherwise give
# TypeError: <class 'str'> can not be converted to a Unit
```

It will however, raise a ValueError in cases like these:
```python
>>> import astropy.units as u

>>> @u.quantity_input
... # consider the typo "kilogrammm" instead of "kilogram"
... def f(x: u.m, y: "kilogrammm") -> u.m:
...    return x

>>> f(1 * u.m, 2 * u.kg)
ValueError: Invalid unit or physical type 'kilogrammm'.
```

TLDR; @quantity_input now ignores any parameter in function definition which is non-unit type annotated, but will raise a ValueError if a string is passed and Unit(string) is unable to parse it (like above example).

EDIT: Close #7672 