### PR TITLE
Change to static inline wrap_into in bls.c

### DIFF
--- a/astropy/timeseries/periodograms/bls/bls.c
+++ b/astropy/timeseries/periodograms/bls/bls.c
@@ -36,7 +36,7 @@ void compute_objective(
     }
 }
 
-inline double wrap_into (double x, double period)
+static inline double wrap_into (double x, double period)
 {
     return x - period * floor(x / period);
 }


### PR DESCRIPTION
This PR changes the `wrap_into` function in `bls.c` from `inline` to `static inline`.


This fixes the following test fail on the latest Python master built from source on macOS:
```
/usr/local/lib/python3.9/site-packages/astropy/timeseries/periodograms/bls/core.py:12: in <module>
    from . import methods
/usr/local/lib/python3.9/site-packages/astropy/timeseries/periodograms/bls/methods.py:9: in <module>
    from ._impl import bls_impl
E   ImportError: dlopen(/usr/local/lib/python3.9/site-packages/astropy/timeseries/periodograms/bls/_impl.cpython-39d-darwin.so, 2): Symbol not found: _wrap_into
E     Referenced from: /usr/local/lib/python3.9/site-packages/astropy/timeseries/periodograms/bls/_impl.cpython-39d-darwin.so
E     Expected in: flat namespace
E    in /usr/local/lib/python3.9/site-packages/astropy/timeseries/periodograms/bls/_impl.cpython-39d-darwin.so
```
Full log: https://gist.github.com/cdeil/9586f0c3666d1afe3132a290ce92fc5f

I'm at the EuroPython sprints and wanted to see how far I can get building everything from source with CPython master, just for fun. I don't think this needs to be added to CI, but it is an issue that would show up in the future for Astropy, not sure if it would be in Python 3.8 or 3.9. This change fixes the linker error locally for me.

As far as I know `static inline` is the standard solution for such cases to avoid to expose it (see [here](https://en.wikipedia.org/wiki/Inline_function), the `_wrap_into` function is only used once in the same C file `bls.c`. There's many other cases of `static inline` in the Astropy repo: see [here](https://github.com/astropy/astropy/search?q=static+inline&unscoped_q=static+inline).
