### PR TITLE
Fix indentation error in astropy.test.__doc__

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -165,7 +165,7 @@ class TestRunnerBase:
 
         Parameters
         ----------
-        {keywords}
+{keywords}
 
         """
 


### PR DESCRIPTION
The first parameter `package` in the  `astropy.test` docstring is currently misindented:
```
Help on function test in module astropy:

test(**kwargs)
    Run the tests for the package.
    
    This method builds arguments for and then calls ``pytest.main``.
    
    Parameters
    ----------
            package : str, optional
        The name of a specific package to test, e.g. 'io.fits' or
        'utils'. Accepts comma separated string to specify multiple
        packages. If nothing is specified all default tests are run.
    
    args : str, optional
        Additional arguments to be passed to ``pytest.main`` in the ``args``
        keyword argument.
```

This PR fixes the issue by reverting the change in https://github.com/astropy/astropy/commit/aec506544f6686ad7edf3001d20e0e018ae00b85#diff-836e0185b50212c030b8d95210ff52e8R128

This line is also related: https://github.com/astropy/astropy/commit/250b625d99dff99bf184a7e5b048a88d1790a721#diff-836e0185b50212c030b8d95210ff52e8R87

I don't understand why the `test` function still shows up OK in Sphinx HTML output (see e.g. https://photutils.readthedocs.io/en/stable/api/photutils.test.html), probably Sphinx somehow manages to handle this misindentation issue.

@Cadair - please review.