### PR TITLE
Fix test_wcs_sub with Python debug build

### DIFF
--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1757,6 +1757,7 @@ PyWcsprm_sub(
             "string values for axis sequence must be one of 'latitude', 'longitude', 'cubeface', 'spectral', 'stokes', or 'celestial'");
           goto exit;
         }
+        Py_CLEAR(element_utf8);
       } else if (PyLong_Check(element)) {
         tmp = (Py_ssize_t)PyLong_AsSsize_t(element);
         if (tmp == -1 && PyErr_Occurred()) {

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1735,7 +1735,6 @@ PyWcsprm_sub(
           }
 
           element_str = PyBytes_AsString(element_utf8);
-          Py_DECREF(element_utf8); element_utf8 = NULL;
         } else if (PyBytes_Check(element)) {
           element_str = PyBytes_AsString(element);
         }


### PR DESCRIPTION
This PR fixes the following error:
```
(base) hfm-1804a:tmp deil$ ~/work/code/cpython/python.exe 
Python 3.9.0a0 (heads/master:b9a0376b0d, Jul 13 2019, 12:17:36) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from astropy.wcs import _wcs
>>> w = _wcs.Wcsprm()
>>> w.sub(["latitude"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: string values for axis sequence must be one of 'latitude', 'longitude', 'cubeface', 'spectral', 'stokes', or 'celestial'
```
which showed up as a `test_wcs_sub` test fail:
https://gist.github.com/cdeil/0412f4013560942dca14af1f19218826

The reason I'm seeing this error is that I build Python from source with `./configure --with-pydebug` which changes the memory allocator.

This code was introduced in #3357, and as far as I can tell this mostly works by accident. The `PyBytes_AsString` does not make a copy:
https://docs.python.org/3/c-api/bytes.html#c.PyBytes_AsString
```
          element_str = PyBytes_AsString(element_utf8);
          Py_DECREF(element_utf8); element_utf8 = NULL;
```
Note that there is a `Py_XDECREF(element_utf8);` here:
https://github.com/astropy/astropy/compare/master...cdeil:wcs-sub?expand=1#diff-8002e59dfe2d5843dd106b6f5329afffR1822

This PR should be reviewed by someone that understands the Python C API and this code, since I don't really know what I'm doing here.