### PR TITLE
Refactor remaining tests for Exceptions to use `pytest.raises` context

### DIFF
--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -944,7 +944,7 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
     image = np.pad(nan_centroid, pad_width=kernel.shape[0]*2, mode='constant',
                    constant_values=1)
     with pytest.warns(AstropyUserWarning,
-                      match="nan_treatment='interpolate', however, NaN values detected "
+                      match=r"nan_treatment='interpolate', however, NaN values detected "
                       "post convolution. A contiguous region of NaN values, larger "
                       "than the kernel size, are present in the input array. "
                       "Increase the kernel size to avoid this."):

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -68,7 +68,7 @@ class TestConvolve1D:
         y = np.array([1.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -93,7 +93,7 @@ class TestConvolve1D:
         y = np.array([0., 1., 0.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -118,7 +118,7 @@ class TestConvolve1D:
         y = np.array([1., 1., 1.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -165,7 +165,7 @@ class TestConvolve1D:
         y = np.array([0.5, 0.5, 0.5], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -214,7 +214,7 @@ class TestConvolve1D:
         y = np.array([0., 1., 0.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -259,7 +259,7 @@ class TestConvolve1D:
         y = np.array([1.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -293,7 +293,7 @@ class TestConvolve1D:
         y = np.array([1., 1., 1.], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -443,7 +443,7 @@ class TestConvolve2D:
         y = np.array([[1.]], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -472,7 +472,7 @@ class TestConvolve2D:
                       [0., 0., 0.]], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -501,7 +501,7 @@ class TestConvolve2D:
                       [1., 1., 1.]], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -561,7 +561,7 @@ class TestConvolve2D:
                       [0., 0., 0.]], dtype='float64')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -611,7 +611,7 @@ class TestConvolve2D:
         #     return
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
@@ -700,7 +700,7 @@ class TestConvolve2D:
                       [1., -1., 1.]], dtype='float')
 
         if boundary is None:
-            with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                               "version of boundary=None is equivalent to the "
                               "convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
@@ -733,7 +733,7 @@ def test_asymmetric_kernel(boundary):
     y = np.array([1, 2, 3], dtype='>f8')
 
     if boundary is None:
-        with pytest.warns(AstropyUserWarning, match="The convolve_fft "
+        with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
                           "version of boundary=None is equivalent to the "
                           "convolve boundary='fill'"):
             z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -178,7 +178,7 @@ class TestKernels:
         gauss_2 = Gaussian1DKernel(4)
         test_gauss_3 = Gaussian1DKernel(5)
 
-        with pytest.warns(AstropyUserWarning, match='Both array and kernel '
+        with pytest.warns(AstropyUserWarning, match=r'Both array and kernel '
                           'are Kernel instances'):
             gauss_3 = convolve(gauss_1, gauss_2)
 
@@ -192,7 +192,7 @@ class TestKernels:
         gauss_2 = Gaussian2DKernel(4)
         test_gauss_3 = Gaussian2DKernel(5)
 
-        with pytest.warns(AstropyUserWarning, match='Both array and kernel '
+        with pytest.warns(AstropyUserWarning, match=r'Both array and kernel '
                           'are Kernel instances'):
             gauss_3 = convolve(gauss_1, gauss_2)
 
@@ -325,7 +325,7 @@ class TestKernels:
 
         custom = CustomKernel(array)
 
-        with pytest.warns(AstropyUserWarning, match='kernel cannot be '
+        with pytest.warns(AstropyUserWarning, match=r'kernel cannot be '
                           'normalized because it sums to zero'):
             custom.normalize()
 
@@ -341,7 +341,7 @@ class TestKernels:
 
         custom = CustomKernel(array)
 
-        with pytest.warns(AstropyUserWarning, match='kernel cannot be '
+        with pytest.warns(AstropyUserWarning, match=r'kernel cannot be '
                           'normalized because it sums to zero'):
             custom.normalize()
 

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -131,7 +131,7 @@ def test_python_kdtree(monkeypatch):
     ccatalog = ICRS([1, 2, 3, 4]*u.degree, [0, 0, 0, 0]*u.degree, distance=[1, 2, 3, 4]*u.kpc)
 
     monkeypatch.delattr("scipy.spatial.cKDTree")
-    with pytest.warns(UserWarning, match='C-based KD tree not found'):
+    with pytest.warns(UserWarning, match=r'C-based KD tree not found'):
         matching.match_coordinates_sky(cmatch, ccatalog)
 
 

--- a/astropy/cosmology/tests/test_cosmology.py
+++ b/astropy/cosmology/tests/test_cosmology.py
@@ -1581,11 +1581,11 @@ def test_z_at_value():
     # test behavior when the solution is outside z limits (should
     # raise a CosmologyError)
     with pytest.raises(core.CosmologyError):
-        with pytest.warns(UserWarning, match='fval is not bracketed'):
+        with pytest.warns(UserWarning, match=r'fval is not bracketed'):
             z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc, zmax=0.5)
 
     with pytest.raises(core.CosmologyError):
-        with pytest.warns(UserWarning, match='fval is not bracketed'):
+        with pytest.warns(UserWarning, match=r'fval is not bracketed'):
             z_at_value(cosmo.angular_diameter_distance, 1500*u.Mpc, zmin=4.)
 
 

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -422,7 +422,7 @@ def test_convert_comment_convention(tmpdir):
     Regression test for https://github.com/astropy/astropy/issues/6079
     """
     filename = os.path.join(DATA, 'stddata.fits')
-    with pytest.warns(AstropyUserWarning, match='hdu= was not specified but '
+    with pytest.warns(AstropyUserWarning, match=r'hdu= was not specified but '
                       'multiple tables are present'):
         t = Table.read(filename)
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -273,13 +273,9 @@ class TestCore(FitsTestCase):
         # silentfix+exception should only mention the unfixable error in the
         # exception
         hdu = make_invalid_hdu()
-        try:
+        with pytest.raises(fits.VerifyError , match='Illegal keyword name') as excinfo:
             hdu.verify('silentfix+exception')
-        except fits.VerifyError as exc:
-            assert 'Illegal keyword name' in str(exc)
-            assert 'not upper case' not in str(exc)
-        else:
-            self.fail('An exception should have been raised.')
+        assert 'not upper case' not in str(excinfo.value)
 
         # fix+ignore is not too useful, but it should warn about the fixed
         # problems while saying nothing about the unfixable problems
@@ -299,13 +295,8 @@ class TestCore(FitsTestCase):
 
         # fix+exception
         hdu = make_invalid_hdu()
-        try:
+        with pytest.raises(fits.VerifyError , match=r'(?s)not upper case..+ Illegal keyword name') as excinfo:
             hdu.verify('fix+exception')
-        except fits.VerifyError as exc:
-            assert 'Illegal keyword name' in str(exc)
-            assert 'not upper case' in str(exc)
-        else:
-            self.fail('An exception should have been raised.')
 
     def test_getext(self):
         """
@@ -596,10 +587,8 @@ class TestFileFunctions(FitsTestCase):
         OSError (and not some other arbitrary exception).
         """
 
-        try:
+        with pytest.raises(OSError , match='No such file or directory') as excinfo:
             fits.open(self.temp('foobar.fits'))
-        except OSError as e:
-            assert 'No such file or directory' in str(e)
 
         # But opening in ostream or append mode should be okay, since they
         # allow writing new files

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -273,7 +273,7 @@ class TestCore(FitsTestCase):
         # silentfix+exception should only mention the unfixable error in the
         # exception
         hdu = make_invalid_hdu()
-        with pytest.raises(fits.VerifyError, match='Illegal keyword name') as excinfo:
+        with pytest.raises(fits.VerifyError, match=r'Illegal keyword name') as excinfo:
             hdu.verify('silentfix+exception')
         assert 'not upper case' not in str(excinfo.value)
 
@@ -295,7 +295,7 @@ class TestCore(FitsTestCase):
 
         # fix+exception
         hdu = make_invalid_hdu()
-        with pytest.raises(fits.VerifyError, match='Illegal keyword name') as excinfo:
+        with pytest.raises(fits.VerifyError, match=r'Illegal keyword name') as excinfo:
             hdu.verify('fix+exception')
         assert 'not upper case' in str(excinfo.value)
 
@@ -588,7 +588,7 @@ class TestFileFunctions(FitsTestCase):
         OSError (and not some other arbitrary exception).
         """
 
-        with pytest.raises(OSError, match='No such file or directory'):
+        with pytest.raises(OSError, match=r'No such file or directory'):
             fits.open(self.temp('foobar.fits'))
 
         # But opening in ostream or append mode should be okay, since they
@@ -1049,7 +1049,7 @@ class TestFileFunctions(FitsTestCase):
 
         with fits.open(self.data('test0.fits'), memmap=True) as hdulist:
             with patch.object(mmap, 'mmap', side_effect=mmap_patched) as p:
-                with pytest.warns(AstropyUserWarning, match="Could not memory "
+                with pytest.warns(AstropyUserWarning, match=r"Could not memory "
                                   "map array with mode='readonly'"):
                     data = hdulist[1].data
                 p.reset_mock()
@@ -1344,7 +1344,7 @@ class TestStreamingFunctions(FitsTestCase):
         pytest.raises(fits.VerifyError, hdul.writeto, filename,
                       output_verify='exception')
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             hdul.writeto(filename, output_verify='fix')
         with fits.open(filename):
             assert hdul[1].name == '12345678'

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -273,7 +273,7 @@ class TestCore(FitsTestCase):
         # silentfix+exception should only mention the unfixable error in the
         # exception
         hdu = make_invalid_hdu()
-        with pytest.raises(fits.VerifyError , match='Illegal keyword name') as excinfo:
+        with pytest.raises(fits.VerifyError, match='Illegal keyword name') as excinfo:
             hdu.verify('silentfix+exception')
         assert 'not upper case' not in str(excinfo.value)
 
@@ -295,8 +295,9 @@ class TestCore(FitsTestCase):
 
         # fix+exception
         hdu = make_invalid_hdu()
-        with pytest.raises(fits.VerifyError , match=r'(?s)not upper case..+ Illegal keyword name') as excinfo:
+        with pytest.raises(fits.VerifyError, match='Illegal keyword name') as excinfo:
             hdu.verify('fix+exception')
+        assert 'not upper case' in str(excinfo.value)
 
     def test_getext(self):
         """
@@ -587,7 +588,7 @@ class TestFileFunctions(FitsTestCase):
         OSError (and not some other arbitrary exception).
         """
 
-        with pytest.raises(OSError , match='No such file or directory') as excinfo:
+        with pytest.raises(OSError, match='No such file or directory'):
             fits.open(self.temp('foobar.fits'))
 
         # But opening in ostream or append mode should be okay, since they

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -248,7 +248,7 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
         tmp_d = self.temp('sub/')
         assert fitsdiff.main(["-q", self.data_dir, tmp_d]) == 1
         assert fitsdiff.main(["-q", tmp_d, self.data_dir]) == 1
-        with pytest.warns(UserWarning, match="Field 'ORBPARM' has a repeat "
+        with pytest.warns(UserWarning, match=r"Field 'ORBPARM' has a repeat "
                           "count of 0 in its format code"):
             assert fitsdiff.main(["-q", self.data_dir, self.data_dir]) == 0
 
@@ -259,7 +259,7 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
         assert "'arange.fits' has no match in" in err
 
         # globbing
-        with pytest.warns(UserWarning, match="Field 'ORBPARM' has a repeat "
+        with pytest.warns(UserWarning, match=r"Field 'ORBPARM' has a repeat "
                           "count of 0 in its format code"):
             assert fitsdiff.main(["-q", self.data_dir+'/*.fits',
                                   self.data_dir]) == 0

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -46,14 +46,14 @@ class TestFitsTime(FitsTestCase):
         t['a'].location = EarthLocation([1., 2.], [2., 3.], [3., 4.],
                                         unit='Mm')
 
-        with pytest.warns(AstropyUserWarning, match='Time Column "b" has no '
+        with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
                           'specified location, but global Time Position is present'):
             table, hdr = time_to_fits(t)
         assert (table['OBSGEO-X'] == t['a'].location.x.to_value(unit='m')).all()
         assert (table['OBSGEO-Y'] == t['a'].location.y.to_value(unit='m')).all()
         assert (table['OBSGEO-Z'] == t['a'].location.z.to_value(unit='m')).all()
 
-        with pytest.warns(AstropyUserWarning, match='Time Column "b" has no '
+        with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
                           'specified location, but global Time Position is present'):
             t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
@@ -61,7 +61,7 @@ class TestFitsTime(FitsTestCase):
         hdr = fits.getheader(self.temp('time.fits'), 1)
         assert hdr.get('TRPOS2', None) is None
 
-        with pytest.warns(AstropyUserWarning, match='Time column reference position '
+        with pytest.warns(AstropyUserWarning, match=r'Time column reference position '
                           '"TRPOSn" is not specified. The default value for it is '
                           '"TOPOCENTER", and the observatory position has been specified.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
@@ -154,7 +154,7 @@ class TestFitsTime(FitsTestCase):
                          'OBSGEO-Y' : t['a'].location.y.value,
                          'OBSGEO-Z' : t['a'].location.z.value}
 
-        with pytest.warns(AstropyUserWarning, match='Time Column "b" has no '
+        with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
                           'specified location, but global Time Position is present'):
             table, hdr = time_to_fits(t)
 
@@ -286,7 +286,7 @@ class TestFitsTime(FitsTestCase):
            to be time.
         """
         filename = self.data('chandra_time.fits')
-        with pytest.warns(AstropyUserWarning, match='Time column "time" reference '
+        with pytest.warns(AstropyUserWarning, match=r'Time column "time" reference '
                           'position will be ignored'):
             tm = table_types.read(filename, astropy_native=True)
 

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -956,7 +956,7 @@ class TestHDUListFunctions(FitsTestCase):
 
         # This should raise an OSError because there is no end card.
         with pytest.raises(OSError):
-            with pytest.warns(AstropyUserWarning, match='non-ASCII characters '
+            with pytest.warns(AstropyUserWarning, match=r'non-ASCII characters '
                               'are present in the FITS file header'):
                 fits.open(filename)
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -309,7 +309,7 @@ class TestHeaderFunctions(FitsTestCase):
         c = fits.Card.fromstring('abc     = +  2.1   e + 12')
         assert c.value == 2100000000000.0
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert str(c) == _pad("ABC     =             +2.1E+12")
 
     def test_fixable_non_fsc(self):
@@ -320,7 +320,7 @@ class TestHeaderFunctions(FitsTestCase):
             "no_quote=  this card's value has no quotes "
             "/ let's also try the comment")
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(c) == "NO_QUOTE= 'this card''s value has no quotes' "
                     "/ let's also try the comment       ")
 
@@ -335,7 +335,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert c.keyword == 'XYZ'
         assert c.value == 100
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert str(c) == _pad("XYZ     =                  100")
 
     def test_equal_only_up_to_column_10(self, capsys):
@@ -347,14 +347,14 @@ class TestHeaderFunctions(FitsTestCase):
         # should be left alone
         c = fits.Card.fromstring("HISTO       =   (1, 2)")
         with pytest.warns(AstropyUserWarning,
-                          match='header keyword is invalid'):
+                          match=r'header keyword is invalid'):
             assert str(c) == _pad("HISTO       =   (1, 2)")
 
         # Likewise this card should just be left in its original form and
         # we shouldn't guess how to parse it or rewrite it.
         c = fits.Card.fromstring("   HISTORY          (1, 2)")
         with pytest.warns(AstropyUserWarning,
-                          match='header keyword is invalid'):
+                          match=r'header keyword is invalid'):
             assert str(c) == _pad("   HISTORY          (1, 2)")
 
     def test_verify_invalid_equal_sign(self):
@@ -488,7 +488,7 @@ class TestHeaderFunctions(FitsTestCase):
             _pad("continue  'continue must have string value (with quotes)' "
                  "/ comments with ''. "))
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(c) ==
                     "ABC     = 'longstring''s testing  continue with long string but without the &'  "
                     "CONTINUE  'ampersand at the endcontinue must have string value (with quotes)&'  "
@@ -621,7 +621,7 @@ class TestHeaderFunctions(FitsTestCase):
         # identically to accessing it in the pytest.raises context below.
         pytest.raises(KeyError, lambda k: header[k], 'NAXIS')
         # Test exception with message
-        with pytest.raises(KeyError, match="Keyword 'NAXIS' not found."):
+        with pytest.raises(KeyError, match=r"Keyword 'NAXIS' not found."):
             header['NAXIS']
 
     def test_hierarch_card_lookup(self):
@@ -642,16 +642,16 @@ class TestHeaderFunctions(FitsTestCase):
     def test_hierarch_card_insert_delete(self):
         header = fits.Header()
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='greater than 8 characters'):
+                          match=r'greater than 8 characters'):
             header['abcdefghi'] = 10
         header['abcdefgh'] = 10
         header['abcdefg'] = 10
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='greater than 8 characters'):
+                          match=r'greater than 8 characters'):
             header.insert(2, ('abcdefghij', 10))
         del header['abcdefghij']
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='greater than 8 characters'):
+                          match=r'greater than 8 characters'):
             header.insert(2, ('abcdefghij', 10))
         del header[2]
         assert list(header.keys())[2] == 'abcdefg'.upper()
@@ -1808,12 +1808,12 @@ class TestHeaderFunctions(FitsTestCase):
         # Now if this were reserialized, would new values for these cards be
         # written with repaired exponent signs?
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(h.cards['FOCALLEN']) ==
                     _pad("FOCALLEN= +1.550000000000E+002"))
         assert h.cards['FOCALLEN']._modified
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(h.cards['APERTURE']) ==
                     _pad("APERTURE= +0.000000000000E+000"))
         assert h.cards['APERTURE']._modified
@@ -1824,12 +1824,12 @@ class TestHeaderFunctions(FitsTestCase):
         # really should be "fixed" before being returned to the user
         h = fits.Header.fromstring(hstr, sep='\n')
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(h.cards['FOCALLEN']) ==
                     _pad("FOCALLEN= +1.550000000000E+002"))
         assert h.cards['FOCALLEN']._modified
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             assert (str(h.cards['APERTURE']) ==
                     _pad("APERTURE= +0.000000000000E+000"))
         assert h.cards['APERTURE']._modified
@@ -2195,7 +2195,7 @@ class TestHeaderFunctions(FitsTestCase):
 
         c = fits.Card.fromstring('HIERARCH ESO DET CHIP PXSPACE = 5e6')
         with pytest.warns(fits.verify.VerifyWarning,
-                          match='Verification reported errors'):
+                          match=r'Verification reported errors'):
             c.verify('fix')
         assert str(c) == _pad('HIERARCH ESO DET CHIP PXSPACE = 5E6')
 
@@ -2531,7 +2531,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
 
         pytest.raises(IndexError, lambda x: self._test_header[x], 8)
         # Test exception with message
-        with pytest.raises(KeyError, match="Keyword 'DP1.AXIS.3' not found."):
+        with pytest.raises(KeyError, match=r"Keyword 'DP1\.AXIS\.3' not found."):
             self._test_header['DP1.AXIS.3']
 
     def test_update_rvkc(self):

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -617,6 +617,9 @@ class TestHeaderFunctions(FitsTestCase):
         """Test that accessing a non-existent keyword raises a KeyError."""
 
         header = fits.Header()
+        # De-referencing header through the inline function should behave
+        # identically to accessing it in the pytest.raises context below.
+        pytest.raises(KeyError, lambda k: header[k], 'NAXIS')
         # Test exception with message
         with pytest.raises(KeyError, match="Keyword 'NAXIS' not found."):
             header['NAXIS']

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -617,12 +617,9 @@ class TestHeaderFunctions(FitsTestCase):
         """Test that accessing a non-existent keyword raises a KeyError."""
 
         header = fits.Header()
-        pytest.raises(KeyError, lambda k: header[k], 'NAXIS')
-        # Test the exception message
-        try:
+        # Test exception with message
+        with pytest.raises(KeyError, match="Keyword 'NAXIS' not found."):
             header['NAXIS']
-        except KeyError as e:
-            assert e.args[0] == "Keyword 'NAXIS' not found."
 
     def test_hierarch_card_lookup(self):
         header = fits.Header()
@@ -2530,12 +2527,9 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         """
 
         pytest.raises(IndexError, lambda x: self._test_header[x], 8)
-        pytest.raises(KeyError, lambda k: self._test_header[k], 'DP1.AXIS.3')
-        # Test the exception message
-        try:
+        # Test exception with message
+        with pytest.raises(KeyError, match="Keyword 'DP1.AXIS.3' not found."):
             self._test_header['DP1.AXIS.3']
-        except KeyError as e:
-            assert e.args[0] == "Keyword 'DP1.AXIS.3' not found."
 
     def test_update_rvkc(self):
         """A RVKC can be updated either via index or keyword access."""

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -902,7 +902,7 @@ class TestImageFunctions(FitsTestCase):
             data = hdul[0].data
             assert np.isnan(data[0])
             with pytest.warns(fits.verify.VerifyWarning,
-                              match="Invalid 'BLANK' keyword in header"):
+                              match=r"Invalid 'BLANK' keyword in header"):
                 hdul.writeto(self.temp('test2.fits'))
 
         # Now reopen the newly written file.  It should not have a 'BLANK'
@@ -1106,7 +1106,7 @@ class TestImageFunctions(FitsTestCase):
         data = np.arange(100, dtype=np.float64)
         hdu = fits.PrimaryHDU(data)
         hdu.header['BLANK'] = 'nan'
-        with pytest.warns(fits.verify.VerifyWarning, match="Invalid value for "
+        with pytest.warns(fits.verify.VerifyWarning, match=r"Invalid value for "
                           "'BLANK' keyword in header: 'nan'"):
             hdu.writeto(self.temp('test.fits'))
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2973,7 +2973,7 @@ class TestColumnFunctions(FitsTestCase):
             # Doesn't pickle zero-width (_phanotm) column 'ORBPARM'
             zwc_pd = pickle.dumps(zwc[2].data)
             zwc_pl = pickle.loads(zwc_pd)
-            with pytest.warns(UserWarning, match='Field 2 has a repeat count '
+            with pytest.warns(UserWarning, match=r'Field 2 has a repeat count '
                               'of 0 in its format code'):
                 assert comparerecords(zwc_pl, zwc[2].data)
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -115,7 +115,7 @@ def test_read_nopath_multi_tables(tmpdir):
     t1.write(test_file, path="the_table_but_different", append=True,
              overwrite=True)
     with pytest.warns(AstropyUserWarning,
-                      match="path= was not specified but multiple tables"):
+                      match=r"path= was not specified but multiple tables"):
         t2 = Table.read(test_file)
 
     assert np.all(t1['a'] == t2['a'])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1881,15 +1881,14 @@ class TestReplaceColumn(SetupData):
         self._setup(table_types)
         t = table_types.Table([self.a, self.b])
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Cannot replace column 'a'.  Use Table.replace_column.. instead."):
             t.columns['a'] = [1, 2, 3]
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="column name not there is not in the table"):
             t.replace_column('not there', [1, 2, 3])
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError, match="length of new column must match table length"):
             t.replace_column('a', [1, 2])
-        assert "length of new column must match table length" in str(exc.value)
 
     def test_replace_column(self, table_types):
         """Replace existing column with a new column"""

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1881,13 +1881,13 @@ class TestReplaceColumn(SetupData):
         self._setup(table_types)
         t = table_types.Table([self.a, self.b])
 
-        with pytest.raises(ValueError, match="Cannot replace column 'a'.  Use Table.replace_column.. instead."):
+        with pytest.raises(ValueError, match=r"Cannot replace column 'a'.  Use Table.replace_column.. instead."):
             t.columns['a'] = [1, 2, 3]
 
-        with pytest.raises(ValueError, match="column name not there is not in the table"):
+        with pytest.raises(ValueError, match=r"column name not there is not in the table"):
             t.replace_column('not there', [1, 2, 3])
 
-        with pytest.raises(ValueError, match="length of new column must match table length"):
+        with pytest.raises(ValueError, match=r"length of new column must match table length"):
             t.replace_column('a', [1, 2])
 
     def test_replace_column(self, table_types):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1174,7 +1174,7 @@ def test_to_datetime():
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
 
-    with pytest.raises(ValueError, match='does not support leap seconds') as e:
+    with pytest.raises(ValueError, match='does not support leap seconds'):
         Time('2015-06-30 23:59:60.000').to_datetime()
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1174,9 +1174,8 @@ def test_to_datetime():
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError, match='does not support leap seconds') as e:
         Time('2015-06-30 23:59:60.000').to_datetime()
-        assert 'does not support leap seconds' in str(e.message)
 
 
 @pytest.mark.skipif('not HAS_PYTZ')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1174,7 +1174,7 @@ def test_to_datetime():
         assert tz.tzname(dt) == tz_dt.tzname()
     assert np.all(time == forced_to_astropy_time)
 
-    with pytest.raises(ValueError, match='does not support leap seconds'):
+    with pytest.raises(ValueError, match=r'does not support leap seconds'):
         Time('2015-06-30 23:59:60.000').to_datetime()
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -652,7 +652,7 @@ def test_suggestions():
             ('milimeter', 'millimeter'),
             ('ångström', 'Angstrom or angstrom'),
             ('kev', 'EV, eV, kV or keV')]:
-        with pytest.raises(ValueError, match=f'Did you mean {matches}\?'):
+        with pytest.raises(ValueError, match=f'Did you mean {matches}'):
             u.Unit(search)
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -245,17 +245,13 @@ def test_unit_noarg():
 
 
 def test_convertible_exception():
-    try:
+    with pytest.raises(u.UnitsError , match='length'):
         u.AA.to(u.h * u.s ** 2)
-    except u.UnitsError as e:
-        assert "length" in str(e)
 
 
 def test_convertible_exception2():
-    try:
+    with pytest.raises(u.UnitsError , match='length'):
         u.m.to(u.s)
-    except u.UnitsError as e:
-        assert "length" in str(e)
 
 
 @raises(TypeError)
@@ -656,12 +652,8 @@ def test_suggestions():
             ('milimeter', 'millimeter'),
             ('ångström', 'Angstrom or angstrom'),
             ('kev', 'EV, eV, kV or keV')]:
-        try:
+        with pytest.raises(ValueError, match=f'Did you mean {matches}?'):
             u.Unit(search)
-        except ValueError as e:
-            assert f'Did you mean {matches}?' in str(e)
-        else:
-            assert False, 'Expected ValueError'
 
 
 def test_fits_hst_unit():

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -652,7 +652,7 @@ def test_suggestions():
             ('milimeter', 'millimeter'),
             ('ångström', 'Angstrom or angstrom'),
             ('kev', 'EV, eV, kV or keV')]:
-        with pytest.raises(ValueError, match=f'Did you mean {matches}?'):
+        with pytest.raises(ValueError, match=f'Did you mean {matches}\?'):
             u.Unit(search)
 
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -245,12 +245,12 @@ def test_unit_noarg():
 
 
 def test_convertible_exception():
-    with pytest.raises(u.UnitsError , match='length'):
+    with pytest.raises(u.UnitsError, match=r'length.+ are not convertible'):
         u.AA.to(u.h * u.s ** 2)
 
 
 def test_convertible_exception2():
-    with pytest.raises(u.UnitsError , match='length'):
+    with pytest.raises(u.UnitsError, match=r'length. and .+time.+ are not convertible'):
         u.m.to(u.s)
 
 

--- a/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
+++ b/astropy/visualization/wcsaxes/tests/test_formatter_locator.py
@@ -84,7 +84,7 @@ class TestAngleFormatterLocator:
         values, spacing = fl.locator(34.3, 36.1)
         assert_almost_equal(values.to_value(u.degree), [34.5, 35., 35.5, 36.])
 
-        with pytest.warns(UserWarning, match='Spacing is too small'):
+        with pytest.warns(UserWarning, match=r'Spacing is too small'):
             fl.format = 'dd'
         values, spacing = fl.locator(34.3, 36.1)
         assert_almost_equal(values.to_value(u.degree), [35., 36.])
@@ -192,7 +192,7 @@ class TestAngleFormatterLocator:
     def test_incorrect_spacing(self):
         fl = AngleFormatterLocator()
         fl.spacing = 0.032 * u.deg
-        with pytest.warns(UserWarning, match='Spacing is not a multiple of base spacing'):
+        with pytest.warns(UserWarning, match=r'Spacing is not a multiple of base spacing'):
             fl.format = 'dd:mm:ss'
         assert_almost_equal(fl.spacing.to_value(u.arcsec), 115.)
 
@@ -355,7 +355,7 @@ class TestScalarFormatterLocator:
         values, spacing = fl.locator(34.3, 36.1)
         assert_almost_equal(values.value, [34.5, 35., 35.5, 36.])
 
-        with pytest.warns(UserWarning, match='Spacing is too small'):
+        with pytest.warns(UserWarning, match=r'Spacing is too small'):
             fl.format = 'x'
         values, spacing = fl.locator(34.3, 36.1)
         assert_almost_equal(values.value, [35., 36.])
@@ -421,7 +421,7 @@ class TestScalarFormatterLocator:
     def test_incorrect_spacing(self):
         fl = ScalarFormatterLocator(unit=u.m)
         fl.spacing = 0.032 * u.m
-        with pytest.warns(UserWarning, match='Spacing is not a multiple of base spacing'):
+        with pytest.warns(UserWarning, match=r'Spacing is not a multiple of base spacing'):
             fl.format = 'x.xx'
         assert_almost_equal(fl.spacing.to_value(u.m), 0.03)
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -259,6 +259,8 @@ location.  This mode can be triggered by running the tests like so::
 
 
 
+.. _writing-tests:
+
 Writing tests
 *************
 
@@ -687,7 +689,7 @@ to the underlying ``re.search``, as in the example below::
   with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:
       hdu.verify('fix+exception')
   assert str(excinfo.value).count('Card') == 2
-  
+
 This invocation also illustrates how to get an ``ExceptionInfo`` object
 returned to perform additional diagnostics on the info.
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -624,8 +624,8 @@ present.
 Using pytest helper functions
 =============================
 
-If your tests need to use `pytest helper functions
-<https://pytest.org/en/latest/builtin.html#pytest-helpers>`_, such as
+If your tests need to use `pytest
+:ref:`pytest helper functions <pytest:pytest helpers>`_, such as
 ``pytest.raises``, import ``pytest`` into your test module like so::
 
     import pytest
@@ -674,7 +674,7 @@ Just like the handling of warnings described above, tests that are
 designed to trigger certain errors should verify that an exception of
 the expected type is raised in the expeced place.  This is efficiently
 done by running the tested code inside the
-`pytest.raises <pytest:assertraises>`_
+:ref:`pytest.raises <pytest:assertraises>`_
 context manager.  Its optional ``match`` argument allows to check the
 error message for any patterns using ``regex`` syntax.  For example the
 matches ``pytest.raises(OSError, match=r'^No such file')`` and
@@ -683,7 +683,7 @@ to ``assert str(err).startswith(No such file)`` and ``assert
 str(err).endswith(or directory)``, respectively, on the raised error
 message ``err``.
 For matching multi-line messages you need to pass the ``(?s)``
-`flag <python:re-syntax>`_
+:ref:`flag <python:re-syntax>`_
 to the underlying ``re.search``, as in the example below::
 
   with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -665,6 +665,32 @@ a real-world example::
    so the `astropy.tests.helper.catch_warnings` context manager is
    preferred.
 
+Testing exceptions
+==================
+
+Just like the handling of warnings described above, tests that are
+designed to trigger certain errors should verify that an exception of
+the expected type is raised in the expeced place.  This is efficiently
+done by running the tested code inside the
+`pytests.raises<https://docs.pytest.org/en/latest/assert.html#assertraises>`_
+context manager.  Its optional ``matches`` argument allows to check the
+error message for any patterns using ``regex`` syntax.  For example the
+matches ``pytest.raises(OSError, match=r'^No such file')`` and
+``pytest.raises(OSError, match=r'or directory$')`` would be equivalent
+to ``assert str(err).startswith(No such file)`` and ``assert
+str(err).endswith(or directory)``, respectively, on the raised error
+message ``err``.
+For matching multi-line messages you need to pass the ``(?s)``
+`flag<https://docs.python.org/3/library/re.html#re.S>`_
+to the underlying ``re.search``, as in the example below::
+
+  with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:
+      hdu.verify('fix+exception')
+  assert str(excinfo.value).count('Card') == 2
+  
+This invocation also illustrates how to get an ``ExceptionInfo`` object
+returned to perform additional diagnostics on the info.
+
 Testing configuration parameters
 ================================
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -440,7 +440,7 @@ Tests that create files
 Tests may often be run from directories where users do not have write
 permissions so tests which create files should always do so in
 temporary directories. This can be done with the
-:ref:`pytest 'tmpdir' fixture <pytest:tmpdir>` or with
+:ref:`pytest 'tmpdir' fixture <pytest:tmpdir handling>` or with
 Python's built-in :ref:`tempfile module <python:tempfile-examples>`.
 
 
@@ -671,7 +671,7 @@ Testing exceptions
 
 Just like the handling of warnings described above, tests that are
 designed to trigger certain errors should verify that an exception of
-the expected type is raised in the expeced place.  This is efficiently
+the expected type is raised in the expected place.  This is efficiently
 done by running the tested code inside the
 :ref:`pytest.raises <pytest:assertraises>`
 context manager.  Its optional ``match`` argument allows to check the
@@ -685,7 +685,7 @@ For matching multi-line messages you need to pass the ``(?s)``
 :ref:`flag <python:re-syntax>`
 to the underlying ``re.search``, as in the example below::
 
-  with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:
+  with pytest.raises(fits.VerifyError, match=r'(?s)not upper.+ Illegal key') as excinfo:
       hdu.verify('fix+exception')
   assert str(excinfo.value).count('Card') == 2
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -674,8 +674,8 @@ Just like the handling of warnings described above, tests that are
 designed to trigger certain errors should verify that an exception of
 the expected type is raised in the expeced place.  This is efficiently
 done by running the tested code inside the
-`pytests.raises <https://docs.pytest.org/en/latest/assert.html#assertraises>`_
-context manager.  Its optional ``matches`` argument allows to check the
+`pytest.raises <pytest:assertraises>`_
+context manager.  Its optional ``match`` argument allows to check the
 error message for any patterns using ``regex`` syntax.  For example the
 matches ``pytest.raises(OSError, match=r'^No such file')`` and
 ``pytest.raises(OSError, match=r'or directory$')`` would be equivalent
@@ -683,7 +683,7 @@ to ``assert str(err).startswith(No such file)`` and ``assert
 str(err).endswith(or directory)``, respectively, on the raised error
 message ``err``.
 For matching multi-line messages you need to pass the ``(?s)``
-`flag <https://docs.python.org/3/library/re.html#re.S>`_
+`flag <python:re-syntax>`_
 to the underlying ``re.search``, as in the example below::
 
   with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -82,12 +82,12 @@ through with the ``--args`` argument::
 
     > python setup.py test --args "-x"
 
-`pytest`_ will look for files that `look like tests
-<https://pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery>`_
-in the current directory and all recursive directories then run all the code that
-`looks like tests
-<https://pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery>`_
-within those files.
+`pytest`_ will look for files that 
+:ref:`look like tests <pytest:python test discovery>`, per default
+in the current directory and all recursive directories, then run all
+the code that looks like tests (essentially all functions or methods
+with ``test_`` prefixes or inside ``Test`` prefixed classes) within
+those files.
 
 Turn on PEP8 checking by passing ``--pep8`` to the ``test`` command. This will
 turn off regular testing and enable PEP8 testing.
@@ -132,7 +132,7 @@ internet. To turn these tests on use the ``remote_data`` flag::
     astropy.test(package='io.fits', remote_data=True)
 
 In addition, the ``test`` function supports any of the options that can be
-passed to `pytest.main() <https://pytest.org/en/latest/builtin.html#pytest.main>`_,
+passed to :ref:`pytest.main() <pytest:pytest.main-usage>`
 and convenience options ``verbose=`` and ``pastebin=``.
 
 Enable PEP8 compliance testing with ``pep8=True`` in the call to
@@ -270,8 +270,7 @@ Writing tests
  * ``Test`` prefixed classes (without an ``__init__`` method)
  * ``test_`` prefixed functions and methods
 
-Consult the `test discovery rules
-<https://pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery>`_
+Consult the :ref:`test discovery rules <pytest:python test discovery>`
 for detailed information on how to name files and tests so that they are
 automatically discovered by `pytest`_.
 
@@ -440,10 +439,10 @@ Tests that create files
 
 Tests may often be run from directories where users do not have write
 permissions so tests which create files should always do so in
-temporary directories. This can be done with the `pytest tmpdir
-function argument <https://pytest.org/en/latest/tmpdir.html>`_ or with
-Python's built-in `tempfile module
-<https://docs.python.org/3/library/tempfile.html#module-tempfile>`_.
+temporary directories. This can be done with the
+:ref:`pytest tmpdir function argument <pytest:tmpdir >`
+or with Python's built-in :ref:`tempfile module <python:tempfile>`.
+
 
 Setting up/Tearing down tests
 =============================
@@ -624,8 +623,8 @@ present.
 Using pytest helper functions
 =============================
 
-If your tests need to use `pytest
-:ref:`pytest helper functions <pytest:assert>`, such as
+If your tests need to use
+:ref:`pytest helper functions <pytest:pytest.raises>`, such as
 ``pytest.raises``, import ``pytest`` into your test module like so::
 
     import pytest

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -625,7 +625,7 @@ Using pytest helper functions
 =============================
 
 If your tests need to use `pytest
-:ref:`pytest helper functions <pytest:pytest helpers>`_, such as
+:ref:`pytest helper functions <pytest:pytest helpers>`, such as
 ``pytest.raises``, import ``pytest`` into your test module like so::
 
     import pytest
@@ -674,7 +674,7 @@ Just like the handling of warnings described above, tests that are
 designed to trigger certain errors should verify that an exception of
 the expected type is raised in the expeced place.  This is efficiently
 done by running the tested code inside the
-:ref:`pytest.raises <pytest:assertraises>`_
+:ref:`pytest.raises <pytest:assertraises>`
 context manager.  Its optional ``match`` argument allows to check the
 error message for any patterns using ``regex`` syntax.  For example the
 matches ``pytest.raises(OSError, match=r'^No such file')`` and
@@ -683,7 +683,7 @@ to ``assert str(err).startswith(No such file)`` and ``assert
 str(err).endswith(or directory)``, respectively, on the raised error
 message ``err``.
 For matching multi-line messages you need to pass the ``(?s)``
-:ref:`flag <python:re-syntax>`_
+:ref:`flag <python:re-syntax>`
 to the underlying ``re.search``, as in the example below::
 
   with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -625,7 +625,7 @@ Using pytest helper functions
 =============================
 
 If your tests need to use `pytest
-:ref:`pytest helper functions <pytest:pytest helpers>`, such as
+:ref:`pytest helper functions <pytest:assert>`, such as
 ``pytest.raises``, import ``pytest`` into your test module like so::
 
     import pytest

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -623,8 +623,8 @@ present.
 Using pytest helper functions
 =============================
 
-If your tests need to use
-:ref:`pytest helper functions <pytest:pytest.raises>`, such as
+If your tests need to use `pytest helper functions
+<https://docs.pytest.org/en/latest/reference.html#functions>`_, such as
 ``pytest.raises``, import ``pytest`` into your test module like so::
 
     import pytest

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -440,7 +440,7 @@ Tests that create files
 Tests may often be run from directories where users do not have write
 permissions so tests which create files should always do so in
 temporary directories. This can be done with the
-:ref:`pytest tmpdir function argument <pytest:tmpdir >`
+:ref:`pytest 'tmpdir' fixture <pytest:tmpdir>`
 or with Python's built-in :ref:`tempfile module <python:tempfile>`.
 
 

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -440,8 +440,8 @@ Tests that create files
 Tests may often be run from directories where users do not have write
 permissions so tests which create files should always do so in
 temporary directories. This can be done with the
-:ref:`pytest 'tmpdir' fixture <pytest:tmpdir>`
-or with Python's built-in :ref:`tempfile module <python:tempfile>`.
+:ref:`pytest 'tmpdir' fixture <pytest:tmpdir>` or with
+Python's built-in :ref:`tempfile module <python:tempfile-examples>`.
 
 
 Setting up/Tearing down tests

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -672,7 +672,7 @@ Just like the handling of warnings described above, tests that are
 designed to trigger certain errors should verify that an exception of
 the expected type is raised in the expeced place.  This is efficiently
 done by running the tested code inside the
-`pytests.raises<https://docs.pytest.org/en/latest/assert.html#assertraises>`_
+`pytests.raises <https://docs.pytest.org/en/latest/assert.html#assertraises>`_
 context manager.  Its optional ``matches`` argument allows to check the
 error message for any patterns using ``regex`` syntax.  For example the
 matches ``pytest.raises(OSError, match=r'^No such file')`` and
@@ -681,7 +681,7 @@ to ``assert str(err).startswith(No such file)`` and ``assert
 str(err).endswith(or directory)``, respectively, on the raised error
 message ``err``.
 For matching multi-line messages you need to pass the ``(?s)``
-`flag<https://docs.python.org/3/library/re.html#re.S>`_
+`flag <https://docs.python.org/3/library/re.html#re.S>`_
 to the underlying ``re.search``, as in the example below::
 
   with pytest.raises(fits.VerifyError, match=r'(?s)not upper..+ Illegal key') as excinfo:

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -332,10 +332,11 @@ In more detail
 
 #. Add tests of your new code, if appropriate. Some changes (e.g. to
    documentation) do not need tests. Detailed instructions are at
-   :ref:`testing-guidelines`, but if you have no experience writing tests or
+   :ref:`writing-tests`, but if you have no experience writing tests or
    with the `py.test`_ testing framework submit your changes without adding
-   tests, but mention in the pull request that you have not written tests. An
-   example of writing a test is in :ref:`astropy-fix-example`.
+   tests, but mention in the pull request that you have not written tests.
+   An example of writing a test is in
+   :ref:`stop-and-think-any-more-tests-or-other-changes`.
 
 #. Stage your changes using ``git add`` and commit them using ``git commit``.
    An example of doing that, based on the fix for an actual Astropy issue, is

--- a/docs/development/workflow/development_workflow.rst
+++ b/docs/development/workflow/development_workflow.rst
@@ -336,7 +336,7 @@ In more detail
    with the `py.test`_ testing framework submit your changes without adding
    tests, but mention in the pull request that you have not written tests.
    An example of writing a test is in
-   :ref:`stop-and-think-any-more-tests-or-other-changes`.
+   :ref:`astropy-fix-add-tests`.
 
 #. Stage your changes using ``git add`` and commit them using ``git commit``.
    An example of doing that, based on the fix for an actual Astropy issue, is

--- a/docs/development/workflow/git_edit_workflow_examples.rst
+++ b/docs/development/workflow/git_edit_workflow_examples.rst
@@ -386,6 +386,8 @@ your change.
 
 We'll take care of that in a moment with a "pull request", but first...
 
+.. _astropy-fix-add-tests:
+
 Stop and think: any more tests or other changes?
 ================================================
 


### PR DESCRIPTION
Resolves #8959 - converting remaining 8 `try: ... except:` blocks of tests for exceptions to `pytest`'s context manager (the rest is covered in #8979).
Added documentation on using `pytest.raises` to `testguide.rst` and changed links in `development_workflow.rst` to directly point to the sections on writing tests.