### PR TITLE
Faster info via meta class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -317,6 +317,11 @@ astropy.utils
 - Deprecated ``astropy.utils.timer`` module, which has been moved to
   ``astroquery.utils.timer`` and will be part of ``astroquery`` 0.4.0. [#9038]
 
+- The implementation of ``data_info.DataInfo`` has changed (for a considerable
+  performance boost). Generally, this should not affect simple subclasses, but
+  because the class now uses ``__slots__`` any attributes on the class have to
+  be explicitly given a slot. [#8998]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -72,9 +72,11 @@ class SkyCoordInfo(MixinInfo):
         if 'distance' in attrs and np.all(obj.distance == 1.0):
             attrs.remove('distance')
 
-        self._represent_as_dict_attrs = attrs
-
-        out = super()._represent_as_dict()
+        out = {}
+        for attr in attrs:
+            value = getattr(obj, attr, None)
+            if value is not None:
+                out[attr] = value
 
         out['representation_type'] = obj.representation_type.get_name()
         out['frame'] = obj.frame.name

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -16,7 +16,7 @@ from astropy.time import Time
 from .distances import Distance
 from .angles import Angle
 from .baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                        GenericFrame, _get_repr_cls)
+                        GenericFrame)
 from .builtin_frames import ICRS, SkyOffsetFrame
 from .representation import (SphericalRepresentation,
                              UnitSphericalRepresentation, SphericalDifferential)
@@ -72,11 +72,7 @@ class SkyCoordInfo(MixinInfo):
         if 'distance' in attrs and np.all(obj.distance == 1.0):
             attrs.remove('distance')
 
-        out = {}
-        for attr in attrs:
-            value = getattr(obj, attr, None)
-            if value is not None:
-                out[attr] = value
+        out = super()._represent_as_dict(attrs)
 
         out['representation_type'] = obj.representation_type.get_name()
         out['frame'] = obj.frame.name

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1092,21 +1092,16 @@ class MaskedColumnInfo(ColumnInfo):
         method = self.serialize_method[self._serialize_context]
 
         if method == 'data_mask':
-            # Note that adding to _represent_as_dict_attrs triggers later code which
-            # will add this to the '__serialized_columns__' meta YAML dict.
-
-            # Note also one driver here is a performance issue in #8443 where repr() of a
+            # Note: a driver here is a performance issue in #8443 where repr() of a
             # np.ma.MaskedArray value is up to 10 times slower than repr of a normal array
             # value.  So regardless of whether there are masked elements it is useful to
             # explicitly define this as a serialized column and use col.data.data (ndarray)
             # instead of letting it fall through to the "standard" serialization machinery.
             out['data'] = col.data.data
-            self._represent_as_dict_attrs += ('data',)
 
             if np.any(col.mask):
                 # Only if there are actually masked elements do we add the ``mask`` column
                 out['mask'] = col.mask
-                self._represent_as_dict_attrs += ('mask',)
 
         elif method is 'null_value':
             pass

--- a/astropy/table/info.py
+++ b/astropy/table/info.py
@@ -117,8 +117,6 @@ def table_info(tbl, option='attributes', out=''):
 
 
 class TableInfo(DataInfo):
-    _parent = None
-
     def __call__(self, option='attributes', out=''):
         return table_info(self._parent, option, out)
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -58,7 +58,6 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
     ``MaskedColumn`` can also be serialized.
     """
     obj_attrs = col.info._represent_as_dict()
-    ordered_keys = col.info._represent_as_dict_attrs
 
     # If serialization is not required (see function docstring above)
     # or explicitly specified as excluded, then treat as a normal column.
@@ -83,8 +82,8 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
         if nontrivial(col_attr):
             info[attr] = xform(col_attr) if xform else col_attr
 
-    data_attrs = [key for key in ordered_keys if key in obj_attrs and
-                  getattr(obj_attrs[key], 'shape', ())[:1] == col.shape[:1]]
+    data_attrs = [key for key, value in obj_attrs.items() if
+                  getattr(value, 'shape', ())[:1] == col.shape[:1]]
 
     for data_attr in data_attrs:
         data = obj_attrs[data_attr]

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -248,14 +248,6 @@ def test_no_deprecation_warning():
         assert len(warns) == 0
 
 
-# No problem any more?
-# def test_lost_parent_error():
-#     c = table.Column([1, 2, 3], name='a')
-#     with pytest.raises(AttributeError) as err:
-#         c[:].info.name
-#     assert 'failed access "info" attribute' in str(err.value)
-
-
 def test_info_serialize_method():
     """
     Unit test of context manager to set info.serialize_method.  Normally just

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -248,11 +248,12 @@ def test_no_deprecation_warning():
         assert len(warns) == 0
 
 
-def test_lost_parent_error():
-    c = table.Column([1, 2, 3], name='a')
-    with pytest.raises(AttributeError) as err:
-        c[:].info.name
-    assert 'failed access "info" attribute' in str(err.value)
+# No problem any more?
+# def test_lost_parent_error():
+#     c = table.Column([1, 2, 3], name='a')
+#     with pytest.raises(AttributeError) as err:
+#         c[:].info.name
+#     assert 'failed access "info" attribute' in str(err.value)
 
 
 def test_info_serialize_method():

--- a/astropy/table/tests/test_info.py
+++ b/astropy/table/tests/test_info.py
@@ -248,6 +248,13 @@ def test_no_deprecation_warning():
         assert len(warns) == 0
 
 
+def test_lost_parent_error():
+    c = table.Column([1, 2, 3], name='a')
+    with pytest.raises(AttributeError) as err:
+        c[:].info.name
+    assert 'failed access "info" attribute' in str(err.value)
+
+
 def test_info_serialize_method():
     """
     Unit test of context manager to set info.serialize_method.  Normally just

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -98,7 +98,6 @@ class TimeInfo(MixinInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
-    attrs_from_parent = set(['unit'])  # unit is read-only and None
     attr_names = MixinInfo.attr_names | {'serialize_method'}
     _supports_indexing = True
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -224,16 +224,8 @@ class ParentAttribute:
 class DataInfoMeta(type):
     def __new__(mcls, name, bases, dct):
         # Ensure that we do not gain a __dict__, which would mean
-        # arbitrary attributes could be set (as a by-product, save
-        # some memory).
+        # arbitrary attributes could be set.
         dct.setdefault('__slots__', [])
-        # Set a default __doc__, mostly to avoid InheritDocstrings
-        # from trying to give us a docstring if none is present.
-        dct.setdefault('__doc__', """\
-Container for meta information like name, description, format.
-This is required when the object is used as a mixin column within
-a table, but can be used as a general way to store meta information.
-""")
         return super().__new__(mcls, name, bases, dct)
 
     def __init__(cls, name, bases, dct):
@@ -361,9 +353,14 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""") from None
     def __setstate__(self, state):
         self._attrs = state
 
-    def _represent_as_dict(self):
-        """Get the values for the parent ``attrs`` and return as a dict."""
-        return _get_obj_attrs_map(self._parent, self._represent_as_dict_attrs)
+    def _represent_as_dict(self, attrs=None):
+        """Get the values for the parent ``attrs`` and return as a dict.
+
+        By default, uses '_represent_as_dict_attrs'.
+        """
+        if attrs is None:
+            attrs = self._represent_as_dict_attrs
+        return _get_obj_attrs_map(self._parent, attrs)
 
     def _construct_from_dict(self, map):
         args = [map.pop(attr) for attr in self._construct_from_dict_args]

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -270,7 +270,10 @@ reference with ``c = col[3:5]`` followed by ``c.info``.""")
             info = instance.__dict__.get('info')
             if info is None:
                 info = instance.__dict__['info'] = self.__class__(bound=True)
-            info._parent = instance
+            # Bypass setter and in particular __setattr__
+            # info._parent = instance
+            # info.__class__._parent.fset(info, instance)
+            info.__dict__['_parent_ref'] = weakref.ref(instance)
         return info
 
     def __set__(self, instance, value):

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -306,10 +306,11 @@ class DataInfo(metaclass=DataInfoMeta):
     @property
     def _parent(self):
         try:
-            return self._parent_ref()
+            parent = self._parent_ref()
         except AttributeError:
             return None
-        except TypeError:
+
+        if parent is None:
             raise AttributeError("""\
 failed access "info" attribute on a temporary object.
 
@@ -317,7 +318,9 @@ It looks like you have done something like ``col[3:5].info``, i.e.
 you accessed ``info`` from a temporary slice object ``col[3:5]`` that
 only exists momentarily.  This has failed because the reference to
 that temporary object is now lost.  Instead force a permanent
-reference with ``c = col[3:5]`` followed by ``c.info``.""") from None
+reference with ``c = col[3:5]`` followed by ``c.info``.""")
+
+        return parent
 
     def __get__(self, instance, owner_cls):
         if instance is None:


### PR DESCRIPTION
@taldcroft - I decided to try the metaclass approach to `DataInfo`, where for every attribute one automatically generates a descriptor that either gets/sets in `_attrs` or from the parent. It is a bit of magic in the meta-class, but not really that much more than there was before in `__getattr__` and `__setattr__`. Note that I had to move to `__slots__` in order to continue to disallow setting arbitrary attributes; not completely clear whether that is worth it. I have some other comments in-line.

Comparing this PR to current master:
```
from astropy.table import MaskedColumn
m = MaskedColumn([1, 2])
%timeit m.info
# 1000000 loops, best of 5: 290 ns per loop
# on current master: 1.24 µs
%timeit m.info.name
# 1000000 loops, best of 5: 659 ns per loop
# on current master: 2.12 µs

from astropy import units as u
q = [1, 2] * u.m
%timeit q.info
# 1000000 loops, best of 5: 319 ns per loop
# on current master: 1.82 µs
%timeit q.info.name
# 1000000 loops, best of 5: 463 ns per loop 
# on current master: 2.46 µs
```

The last item is the most relevant for possibly moving everything to `info` - `463 ns` is still about 6 times slower than just `%timeit m.name`. But it is not obvious to me that with the general speed-up here, it would still be a limiting factor.
