### PR TITLE
Do not count fractional exponents against excess solidus instances in units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2435,6 +2435,10 @@ astropy.units
 - ``Quantity`` now preserves the ``dtype`` for anything that is floating
   point, including ``float16``. [#8872]
 
+- ``Unit()`` now accepts units with fractional exponents such as ``m(3/2)``
+  in the default/``fits`` and ``vounit`` formats that would previously
+  have been rejected for containing multiple solidi (``/``). [#9000]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -469,11 +469,14 @@ class Generic(Base):
             s = s.decode('ascii')
 
         result = cls._do_parse(s, debug=debug)
-        if s.count('/') > 1:
-            warnings.warn(
-                "'{}' contains multiple slashes, which is "
-                "discouraged by the FITS standard".format(s),
-                core.UnitsWarning)
+        nsolidus = s.count('/')
+        if nsolidus > 1:
+            # Check for fractional exponents (accepted)
+            if nsolidus - len(re.findall(r'\(\d+/\d+\)', s)) > 1:
+                warnings.warn(
+                    "'{}' contains multiple slashes, which is "
+                    "discouraged by the FITS standard".format(s),
+                    core.UnitsWarning)
         return result
 
     @classmethod

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -469,14 +469,13 @@ class Generic(Base):
             s = s.decode('ascii')
 
         result = cls._do_parse(s, debug=debug)
-        nsolidus = s.count('/')
-        if nsolidus > 1:
-            # Check for fractional exponents (accepted)
-            if nsolidus - len(re.findall(r'\(\d+/\d+\)', s)) > 1:
-                warnings.warn(
-                    "'{}' contains multiple slashes, which is "
-                    "discouraged by the FITS standard".format(s),
-                    core.UnitsWarning)
+        # Check for excess solidi, but exclude fractional exponents (accepted)
+        if (s.count('/') > 1 and
+                s.count('/') - len(re.findall(r'\(\d+/\d+\)', s)) > 1):
+            warnings.warn(
+                "'{}' contains multiple slashes, which is "
+                "discouraged by the FITS standard".format(s),
+                core.UnitsWarning)
         return result
 
     @classmethod

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -85,13 +85,12 @@ class VOUnit(generic.Generic):
             return None
         if s == '':
             return core.dimensionless_unscaled
-        nsolidus = s.count('/')
-        if nsolidus > 1:
-            # Check for fractional exponents (allowed)
-            if nsolidus - len(re.findall(r'\(\d+/\d+\)', s)) > 1:
-                raise core.UnitsError(
-                    "'{}' contains multiple slashes, which is "
-                    "disallowed by the VOUnit standard".format(s))
+        # Check for excess solidi, but exclude fractional exponents (allowed)
+        if (s.count('/') > 1 and
+                s.count('/') - len(re.findall(r'\(\d+/\d+\)', s)) > 1):
+            raise core.UnitsError(
+                "'{}' contains multiple slashes, which is "
+                "disallowed by the VOUnit standard".format(s))
         result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported in "

--- a/astropy/units/format/vounit.py
+++ b/astropy/units/format/vounit.py
@@ -85,10 +85,13 @@ class VOUnit(generic.Generic):
             return None
         if s == '':
             return core.dimensionless_unscaled
-        if s.count('/') > 1:
-            raise core.UnitsError(
-                "'{}' contains multiple slashes, which is "
-                "disallowed by the VOUnit standard".format(s))
+        nsolidus = s.count('/')
+        if nsolidus > 1:
+            # Check for fractional exponents (allowed)
+            if nsolidus - len(re.findall(r'\(\d+/\d+\)', s)) > 1:
+                raise core.UnitsError(
+                    "'{}' contains multiple slashes, which is "
+                    "disallowed by the VOUnit standard".format(s))
         result = cls._do_parse(s, debug=debug)
         if hasattr(result, 'function_unit'):
             raise ValueError("Function units are not yet supported in "

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -171,6 +171,7 @@ def test_multiple_solidus():
     with pytest.raises(ValueError):
         u.Unit("m/s/kg", format="vounit")
 
+    # Regression test for #9000: solidi in exponents do not count towards this.
     x = u.Unit("kg(3/10) * m(5/2) / s", format="vounit")
     assert x.to_string() == 'kg(3/10) m(5/2) / s'
 

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -171,6 +171,9 @@ def test_multiple_solidus():
     with pytest.raises(ValueError):
         u.Unit("m/s/kg", format="vounit")
 
+    x = u.Unit("kg(3/10) * m(5/2) / s", format="vounit")
+    assert x.to_string() == 'kg(3/10) m(5/2) / s'
+
 
 def test_unknown_unit3():
     unit = u.Unit("FOO", parse_strict='silent')


### PR DESCRIPTION
When checking for (discouraged/disallowed) multiple solidus instances in unit strings, the `fits` and `vounit` parsers are simply counting every `/` character in the unit name, including those in fractional exponents, which are permitted by both standards. This leads to a bunch of warnings like
```
UnitsWarning: '3.16228e-05 kg(1/2) m(3/2) / s' contains multiple slashes, which is discouraged by the FITS standard
    core.UnitsWarning)
```
and potential incorrectly raised exceptions with the `vounit` format.

Additional check for numerical fractions inside `()` added to catch these cases. I have not added a test for `u.Unit("kg(1/2) * m(3/2) / s", format="fits")`, since I did not find an easy solution for checking that _no_ warning is raised (i.e. other than setting and resetting `warnings.filters` to turn it into an exception etc....). 