### PR TITLE
Add example in narrative docs for the ``fixed`` parameter in models

### DIFF
--- a/docs/modeling/fitting.rst
+++ b/docs/modeling/fitting.rst
@@ -182,6 +182,13 @@ Fitters support constrained fitting.
           1.0 2.0 3.0
           1.0 2.0 3.0
 
+  The syntax to fix the same parameter ``c0`` using an argument to the model
+  instead of ``p1.c0.fixed = True`` would be::
+
+      >>> p1 = models.Polynomial1D(2, c0=[1, 1], c1=[2, 2], c2=[3, 3],
+      ...                          n_models=2, fixed={'c0': True})
+
+
 - A parameter can be `~astropy.modeling.Parameter.tied` (linked to
   another parameter). This can be done in two ways::
 


### PR DESCRIPTION
I expeced an example in the docs for how to dfine a fixed parameter.
I understand why the current implementation is the way it is, but
it's not obvious that you need to pass in a dictionary where all
the fixed parameters are set to ``True``. I had expected a list with
parameter names or a tuple.
At the end of the day, all paraemtes that I pass are True, so a dict
where all values are True is not obvious.
I added a single line of code in the docs at the position where I expected
to find it.