### PR TITLE
Check NaN before making and querying kdtree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -352,6 +352,9 @@ astropy.coordinates
 - Fix concatenation of representations for cases where the units were different.
   [#8877]
 
+- Check any NaN before building and querying KDTree for matching coordinates.
+  [#9007]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -352,7 +352,8 @@ astropy.coordinates
 - Fix concatenation of representations for cases where the units were different.
   [#8877]
 
-- Check any NaN before building and querying KDTree for matching coordinates.
+- Check for NaN values in catalog and match coordinates before building and 
+  querying the ``KDTree`` for coordinate matching. [#9007]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -353,7 +353,6 @@ astropy.coordinates
   [#8877]
 
 - Check any NaN before building and querying KDTree for matching coordinates.
-  [#9007]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/matching.py
+++ b/astropy/coordinates/matching.py
@@ -74,6 +74,9 @@ def match_coordinates_3d(matchcoord, catalogcoord, nthneighbor=1, storekdtree='k
     matchxyz = matchcoord.cartesian.xyz.to(catunit)
 
     matchflatxyz = matchxyz.reshape((3, np.prod(matchxyz.shape) // 3))
+    # Querying NaN returns garbage
+    if np.isnan(matchflatxyz.value).any():
+        raise ValueError("Matching coordinates cannot contain NaN entries.")
     dist, idx = kdt.query(matchflatxyz.T, nthneighbor)
 
     if nthneighbor > 1:  # query gives 1D arrays if k=1, 2D arrays otherwise
@@ -457,6 +460,9 @@ def _get_cartesian_kdtree(coord, attrname_or_kdt='kdtree', forceunit=None):
         else:
             cartxyz = coord.cartesian.xyz.to(forceunit)
         flatxyz = cartxyz.reshape((3, np.prod(cartxyz.shape) // 3))
+        # There should be no NaNs in the kdtree data.
+        if np.isnan(flatxyz.value).any():
+            raise ValueError("Catalog coordinates cannot contain NaN entries.")
         try:
             # Set compact_nodes=False, balanced_tree=False to use
             # "sliding midpoint" rule, which is much faster than standard for

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -297,3 +297,37 @@ def test_match_catalog_empty():
     with pytest.raises(ValueError) as excinfo:
         sc1.match_to_catalog_3d(cat0)
     assert 'catalog' in str(excinfo.value)
+
+
+@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif('OLDER_SCIPY')
+def test_match_catalog_nan():
+    from astropy.coordinates import SkyCoord, Galactic
+
+    sc1 = SkyCoord(1, 2, unit="deg")
+    sc_with_nans = SkyCoord(1, np.nan, unit="deg")
+
+    cat = SkyCoord([1.1, 3], [2.1, 5], unit="deg")
+    cat_with_nans = SkyCoord([1.1, np.nan], [2.1, 5], unit="deg")
+    galcat_with_nans = Galactic([1.2, np.nan]*u.deg, [5.6, 7.8]*u.deg)
+
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_sky(cat_with_nans)
+    assert 'Catalog coordinates cannot contain' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_3d(cat_with_nans)
+    assert 'Catalog coordinates cannot contain' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_sky(galcat_with_nans)
+    assert 'Catalog coordinates cannot contain' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        sc1.match_to_catalog_3d(galcat_with_nans)
+    assert 'Catalog coordinates cannot contain' in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        sc_with_nans.match_to_catalog_sky(cat)
+    assert 'Matching coordinates cannot contain' in str(excinfo.value)
+    with pytest.raises(ValueError) as excinfo:
+        sc_with_nans.match_to_catalog_3d(cat)
+    assert 'Matching coordinates cannot contain' in str(excinfo.value)


### PR DESCRIPTION
Scipy's kdtree outputs garbage values (dist=inf, idx=`<length of array>`) when built with or queried with any NaNs in the data array but the error is only raised when trying to use the idx `arr[idx]` which results in IndexError. This does not help the user identify the problem. In order to fix it, I check any NaNs before building and querying a kdtree.

I think the best place to check is after all conversions between frames and representations are done.

Fixes #8985  