### PR TITLE
Coordinate matching fails for unit-less distances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -364,6 +364,7 @@ astropy.coordinates
 
 - Check for NaN values in catalog and match coordinates before building and 
   querying the ``KDTree`` for coordinate matching. [#9007]
+- Fix sky coordinate matching when a dimensionless distance is provided. [#9008]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1649,7 +1649,11 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         # subtraction
         self_car = self.data.without_differentials().represent_as(r.CartesianRepresentation)
         other_car = other_in_self_system.data.without_differentials().represent_as(r.CartesianRepresentation)
-        return Distance((self_car - other_car).norm())
+        dist = (self_car - other_car).norm()
+        if dist.unit == u.one:
+            return dist
+        else:
+            return Distance(dist)
 
     @property
     def cartesian(self):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -509,7 +509,7 @@ def test_sep():
     i7 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.one)
     i8 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=4*u.one)
     sep3d = i7.separation_3d(i8)
-    assert_allclose(sep3d.to(u.one).value, [1])
+    assert_allclose(sep3d, 1*u.one)
 
     # but should fail with non-dimensionless
     with pytest.raises(ValueError):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -505,6 +505,16 @@ def test_sep():
     sep3d = i5.separation_3d(i6)
     assert_allclose(sep3d.to(u.kpc), np.array([2, 2])*u.kpc)
 
+    # 3d separations of dimensionless distances should still work
+    i7 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.one)
+    i8 = ICRS(ra=1*u.deg, dec=2*u.deg, distance=4*u.one)
+    sep3d = i7.separation_3d(i8)
+    assert_allclose(sep3d.to(u.one).value, [1])
+
+    # but should fail with non-dimensionless
+    with pytest.raises(ValueError):
+        i7.separation_3d(i3)
+
 
 def test_time_inputs():
     """

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -30,7 +30,7 @@ else:
     OLDER_SCIPY = True
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_matching_function():
     from astropy.coordinates import ICRS
     from astropy.coordinates.matching import match_coordinates_3d
@@ -50,7 +50,7 @@ def test_matching_function():
     npt.assert_array_less(d3d.value, 0.02)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_matching_function_3d_and_sky():
     from astropy.coordinates import ICRS
     from astropy.coordinates.matching import match_coordinates_3d, match_coordinates_sky
@@ -78,7 +78,7 @@ def test_matching_function_3d_and_sky():
                           (matching.search_around_3d, [1*u.kpc], 'kdtree_3d', True),
                           (matching.search_around_sky, [1*u.deg], 'kdtree_sky', False)
                          ])
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
     from astropy.coordinates import ICRS
 
@@ -123,7 +123,7 @@ def test_kdtree_storage(functocheck, args, defaultkdtname, bothsaved):
     assert 'KD' in e.value.args[0]
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_python_kdtree(monkeypatch):
     from astropy.coordinates import ICRS
 
@@ -135,7 +135,7 @@ def test_python_kdtree(monkeypatch):
         matching.match_coordinates_sky(cmatch, ccatalog)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
 def test_matching_method():
     from astropy.coordinates import ICRS, SkyCoord
     from astropy.utils import NumpyRNGContext
@@ -165,8 +165,8 @@ def test_matching_method():
     assert len(idx1) == len(d2d1) == len(d3d1) == 20
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('OLDER_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
+                    reason="Requires scipy > 0.12.0 ")
 def test_search_around():
     from astropy.coordinates import ICRS, SkyCoord
     from astropy.coordinates.matching import search_around_sky, search_around_3d
@@ -248,8 +248,8 @@ def test_search_around():
     assert d3d.unit == u.dimensionless_unscaled
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('OLDER_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
+                    reason="Requires scipy > 0.12.0 ")
 def test_search_around_scalar():
     from astropy.coordinates import SkyCoord, Angle
 
@@ -268,8 +268,8 @@ def test_search_around_scalar():
     assert 'search_around_3d' in str(excinfo.value)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('OLDER_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
+                    reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_empty():
     from astropy.coordinates import SkyCoord
 
@@ -299,8 +299,8 @@ def test_match_catalog_empty():
     assert 'catalog' in str(excinfo.value)
 
 
-@pytest.mark.skipif('not HAS_SCIPY')
-@pytest.mark.skipif('OLDER_SCIPY')
+@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
+                    reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_nan():
     from astropy.coordinates import SkyCoord, Galactic
 
@@ -333,8 +333,8 @@ def test_match_catalog_nan():
     assert 'Matching coordinates cannot contain' in str(excinfo.value)
 
 
-@pytest.mark.skipif(str('not HAS_SCIPY'))
-@pytest.mark.skipif(str('OLDER_SCIPY'))
+@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
+                    reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_nounit():
     from .. import ICRS, CartesianRepresentation
     from ..matching import match_coordinates_sky

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -331,3 +331,15 @@ def test_match_catalog_nan():
     with pytest.raises(ValueError) as excinfo:
         sc_with_nans.match_to_catalog_3d(cat)
     assert 'Matching coordinates cannot contain' in str(excinfo.value)
+
+
+@pytest.mark.skipif(str('not HAS_SCIPY'))
+@pytest.mark.skipif(str('OLDER_SCIPY'))
+def test_match_catalog_nounit():
+    from .. import ICRS, CartesianRepresentation
+    from ..matching import match_coordinates_sky
+
+    i1 = ICRS([[1], [2], [3]], representation_type=CartesianRepresentation)
+    i2 = ICRS([[1], [2], [4, 5]], representation_type=CartesianRepresentation)
+    i, sep, sep3d = match_coordinates_sky(i1, i2)
+    assert_allclose(sep3d, [1]*u.dimensionless_unscaled)


### PR DESCRIPTION
This is a revival of #8029, now with a rebase and changelog entry.

The text from @eteq:

> 
> The Problem this PR is trying to solve is most easily shown in this snippet:
> ```python
> from astropy.coordinates import ICRS, CartesianRepresentation, match_coordinates_sky
> i1 = ICRS([[1], [2], [3]], representation_type=CartesianRepresentation)
> i2 = ICRS([[1], [2], [4, 5]], representation_type=CartesianRepresentation)
> i, sep, sep3d = match_coordinates_sky(i1, i2)
> ```
> yields ``astropy.units.core.UnitTypeError: Distance instances require units equivalent to 'm', so cannot set it to ''.``.  
> 
> The problem is: it seems counter-intuitive in that it fails only in `match_coordinates_sky` and not in the `ICRS` constructor or similar. The root cause is really `separation_3d`, which fails if the inputs are dimensionless because the "3d" part of coordinates matching uses `Distance`, which is supposed to be, well, a distance (and have appropriate units).  Given we are now allowing dimensionless distances in the frame classes, arguably we should allow it in `separation_3d`... But that's sort of an API change (albiet a "relaxing" one) - should we allow this "3d distance" to sometimes be dimensionless?
> 
> One could argue this is a bug... but I'm not sure it is, so I'm not sure if this is a bugfix, or new feature, or "shouldn't do", so have not yet flagged it bug, milestoned it, or changelogged it.
> 
> Also marking as a WIP because there's question above whether we really want to do this or not. The code itself I think is done, but the "discussion" part is not.

cc @mhvk @eteq 