### PR TITLE
TST: Get rid of wcs test warnings

### DIFF
--- a/astropy/wcs/tests/test_pickle.py
+++ b/astropy/wcs/tests/test_pickle.py
@@ -1,32 +1,40 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import os
 import pickle
 
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_fileobj
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.misc import NumpyRNGContext
 from astropy.io import fits
+from astropy.io.fits.verify import VerifyWarning
 from astropy import wcs
+from astropy.wcs.wcs import FITSFixedWarning
 
 
 def test_basic():
     wcs1 = wcs.WCS()
     s = pickle.dumps(wcs1)
-    wcs2 = pickle.loads(s)
+    with pytest.warns(FITSFixedWarning):
+        pickle.loads(s)
 
 
 def test_dist():
     with get_pkg_data_fileobj(
             os.path.join("data", "dist.fits"), encoding='binary') as test_file:
         hdulist = fits.open(test_file)
-        wcs1 = wcs.WCS(hdulist[0].header, hdulist)
+        # The use of ``AXISCORR`` for D2IM correction has been deprecated
+        with pytest.warns(AstropyDeprecationWarning):
+            wcs1 = wcs.WCS(hdulist[0].header, hdulist)
         assert wcs1.det2im2 is not None
-        s = pickle.dumps(wcs1)
-        wcs2 = pickle.loads(s)
+        with pytest.warns(VerifyWarning):
+            s = pickle.dumps(wcs1)
+        with pytest.warns(FITSFixedWarning):
+            wcs2 = pickle.loads(s)
 
         with NumpyRNGContext(123456789):
             x = np.random.rand(2 ** 16, wcs1.wcs.naxis)
@@ -40,10 +48,12 @@ def test_sip():
     with get_pkg_data_fileobj(
             os.path.join("data", "sip.fits"), encoding='binary') as test_file:
         hdulist = fits.open(test_file, ignore_missing_end=True)
-        wcs1 = wcs.WCS(hdulist[0].header)
+        with pytest.warns(FITSFixedWarning):
+            wcs1 = wcs.WCS(hdulist[0].header)
         assert wcs1.sip is not None
         s = pickle.dumps(wcs1)
-        wcs2 = pickle.loads(s)
+        with pytest.warns(FITSFixedWarning):
+            wcs2 = pickle.loads(s)
 
         with NumpyRNGContext(123456789):
             x = np.random.rand(2 ** 16, wcs1.wcs.naxis)
@@ -57,10 +67,12 @@ def test_sip2():
     with get_pkg_data_fileobj(
             os.path.join("data", "sip2.fits"), encoding='binary') as test_file:
         hdulist = fits.open(test_file, ignore_missing_end=True)
-        wcs1 = wcs.WCS(hdulist[0].header)
+        with pytest.warns(FITSFixedWarning):
+            wcs1 = wcs.WCS(hdulist[0].header)
         assert wcs1.sip is not None
         s = pickle.dumps(wcs1)
-        wcs2 = pickle.loads(s)
+        with pytest.warns(FITSFixedWarning):
+            wcs2 = pickle.loads(s)
 
         with NumpyRNGContext(123456789):
             x = np.random.rand(2 ** 16, wcs1.wcs.naxis)
@@ -76,7 +88,8 @@ def test_wcs():
 
     wcs1 = wcs.WCS(header)
     s = pickle.dumps(wcs1)
-    wcs2 = pickle.loads(s)
+    with pytest.warns(FITSFixedWarning):
+        wcs2 = pickle.loads(s)
 
     with NumpyRNGContext(123456789):
         x = np.random.rand(2 ** 16, wcs1.wcs.naxis)
@@ -94,7 +107,8 @@ class Sub(wcs.WCS):
 def test_subclass():
     wcs = Sub()
     s = pickle.dumps(wcs)
-    wcs2 = pickle.loads(s)
+    with pytest.warns(FITSFixedWarning):
+        wcs2 = pickle.loads(s)
 
     assert isinstance(wcs2, Sub)
     assert wcs.foo == 42

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -569,16 +569,15 @@ def test_noncelestial_scale(cdelt, pc, cd):
     if pc is not None:
         mywcs.wcs.pc = pc
 
-    # Some inputs emit RuntimeWarning
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', RuntimeWarning)
-        mywcs.wcs.cdelt = cdelt
+    # TODO: Some inputs emit RuntimeWarning from here onwards.
+    #       Fix the test data. See @nden's comment in PR 9010.
+    mywcs.wcs.cdelt = cdelt
 
-        mywcs.wcs.ctype = ['RA---TAN', 'FREQ']
+    mywcs.wcs.ctype = ['RA---TAN', 'FREQ']
 
-        ps = non_celestial_pixel_scales(mywcs)
+    ps = non_celestial_pixel_scales(mywcs)
 
-        assert_almost_equal(ps.to_value(u.deg), np.array([0.1, 0.2]))
+    assert_almost_equal(ps.to_value(u.deg), np.array([0.1, 0.2]))
 
 
 @pytest.mark.parametrize('mode', ['all', 'wcs'])

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 import pytest
 
 import numpy as np
@@ -7,10 +9,12 @@ from numpy.testing import assert_almost_equal
 from numpy.testing import assert_allclose
 
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_filename
+from astropy.utils.exceptions import AstropyUserWarning
 from astropy.time import Time
 from astropy import units as u
 
-from astropy.wcs.wcs import WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE
+from astropy.wcs.wcs import (WCS, Sip, WCSSUB_LONGITUDE, WCSSUB_LATITUDE,
+                             FITSFixedWarning)
 from astropy.wcs.wcsapi.fitswcs import SlicedFITSWCS
 from astropy.wcs.utils import (proj_plane_pixel_scales,
                                is_proj_plane_distorted,
@@ -91,7 +95,7 @@ def test_slice():
     mywcs.wcs.cdelt = [0.1, 0.1]
     mywcs.wcs.crpix = [1, 1]
     mywcs._naxis = [1000, 500]
-    pscale = 0.1 # from cdelt
+    pscale = 0.1  # from cdelt
 
     slice_wcs = mywcs.slice([slice(1, None), slice(0, None)])
     assert np.all(slice_wcs.wcs.crpix == np.array([1, 0]))
@@ -113,11 +117,14 @@ def test_slice():
     assert slice_wcs._naxis == [500, 250]
 
     # Non-integral values do not alter the naxis attribute
-    slice_wcs = mywcs.slice([slice(50.), slice(20.)])
+    with pytest.warns(AstropyUserWarning):
+        slice_wcs = mywcs.slice([slice(50.), slice(20.)])
     assert slice_wcs._naxis == [1000, 500]
-    slice_wcs = mywcs.slice([slice(50.), slice(20)])
+    with pytest.warns(AstropyUserWarning):
+        slice_wcs = mywcs.slice([slice(50.), slice(20)])
     assert slice_wcs._naxis == [20, 500]
-    slice_wcs = mywcs.slice([slice(50), slice(20.5)])
+    with pytest.warns(AstropyUserWarning):
+        slice_wcs = mywcs.slice([slice(50), slice(20.5)])
     assert slice_wcs._naxis == [1000, 50]
 
 
@@ -133,7 +140,7 @@ def test_slice_with_sip():
          [0, 2.44084308e-05, 2.81394789e-11, 5.17856895e-13, 0.0],
          [-2.41334657e-07, 1.29289255e-10, 2.35753629e-14, 0.0, 0.0],
          [-2.37162007e-10, 5.43714947e-13, 0.0, 0.0, 0.0],
-         [ -2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
+         [-2.81029767e-13, 0.0, 0.0, 0.0, 0.0]]
     )
     b = np.array(
         [[0, 0, 2.99270374e-05, -2.38136074e-10, 7.23205168e-13],
@@ -144,7 +151,7 @@ def test_slice_with_sip():
     )
     mywcs.sip = Sip(a, b, None, None, mywcs.wcs.crpix)
     mywcs.wcs.set()
-    pscale = 0.1 # from cdelt
+    pscale = 0.1  # from cdelt
 
     slice_wcs = mywcs.slice([slice(1, None), slice(0, None)])
     # test that CRPIX maps to CRVAL:
@@ -561,13 +568,17 @@ def test_noncelestial_scale(cdelt, pc, cd):
         mywcs.wcs.cd = cd
     if pc is not None:
         mywcs.wcs.pc = pc
-    mywcs.wcs.cdelt = cdelt
 
-    mywcs.wcs.ctype = ['RA---TAN', 'FREQ']
+    # Some inputs emit RuntimeWarning
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', RuntimeWarning)
+        mywcs.wcs.cdelt = cdelt
 
-    ps = non_celestial_pixel_scales(mywcs)
+        mywcs.wcs.ctype = ['RA---TAN', 'FREQ']
 
-    assert_almost_equal(ps.to_value(u.deg), np.array([0.1, 0.2]))
+        ps = non_celestial_pixel_scales(mywcs)
+
+        assert_almost_equal(ps.to_value(u.deg), np.array([0.1, 0.2]))
 
 
 @pytest.mark.parametrize('mode', ['all', 'wcs'])
@@ -644,7 +655,8 @@ def test_is_proj_plane_distorted():
 
     # real case:
     header = get_pkg_data_filename('data/sip.fits')
-    wcs = WCS(header)
+    with pytest.warns(FITSFixedWarning):
+        wcs = WCS(header)
     assert(is_proj_plane_distorted(wcs))
 
 
@@ -655,7 +667,8 @@ def test_skycoord_to_pixel_distortions(mode):
     from astropy.coordinates import SkyCoord
 
     header = get_pkg_data_filename('data/sip.fits')
-    wcs = WCS(header)
+    with pytest.warns(FITSFixedWarning):
+        wcs = WCS(header)
 
     ref = SkyCoord(202.50 * u.deg, 47.19 * u.deg, frame='icrs')
 

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -1,8 +1,11 @@
+import warnings
+
 import pytest
 
 from numpy.testing import assert_equal, assert_allclose
 from astropy.wcs import WCS
 from astropy.io.fits import Header
+from astropy.io.fits.verify import VerifyWarning
 from astropy.coordinates import SkyCoord, Galactic
 from astropy.units import Quantity
 from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
@@ -39,7 +42,9 @@ CUNIT2  = Hz
 CUNIT3  = deg
 """
 
-WCS_SPECTRAL_CUBE = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', VerifyWarning)
+    WCS_SPECTRAL_CUBE = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
 WCS_SPECTRAL_CUBE.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 
 
@@ -392,7 +397,10 @@ def test_celestial_range():
 
 # Now try with a 90 degree rotation
 
-WCS_SPECTRAL_CUBE_ROT = WCS(Header.fromstring(HEADER_SPECTRAL_CUBE, sep='\n'))
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', VerifyWarning)
+    WCS_SPECTRAL_CUBE_ROT = WCS(Header.fromstring(
+        HEADER_SPECTRAL_CUBE, sep='\n'))
 WCS_SPECTRAL_CUBE_ROT.wcs.pc = [[0, 0, 1], [0, 1, 0], [1, 0, 0]]
 WCS_SPECTRAL_CUBE_ROT.wcs.crval[0] = 0
 WCS_SPECTRAL_CUBE_ROT.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
@@ -482,7 +490,9 @@ CUNIT2  = Hz
 CUNIT3  = deg
 """
 
-WCS_NO_SHAPE_CUBE = WCS(Header.fromstring(HEADER_NO_SHAPE_CUBE, sep='\n'))
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', VerifyWarning)
+    WCS_NO_SHAPE_CUBE = WCS(Header.fromstring(HEADER_NO_SHAPE_CUBE, sep='\n'))
 
 EXPECTED_NO_SHAPE_REPR = """
 SlicedLowLevelWCS Transformation

--- a/docs/wcs/index.rst
+++ b/docs/wcs/index.rst
@@ -91,8 +91,11 @@ The basic workflow is as follows:
 
 For example, to convert pixel coordinates from a two dimensional image to world coordinates::
 
+    >>> import warnings
     >>> from astropy.wcs import WCS
-    >>> w = WCS('image.fits')
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')
+    ...     w = WCS('image.fits')
     >>> lon, lat = w.all_pix2world(30, 40, 0)
     >>> print(lon, lat)
     31.0 41.0


### PR DESCRIPTION
This should get rid of most of the `wcs` test warnings. This is part of work for #7928 . The warnings were captured by removing the line in `setup.cfg` to suppress pytest warnings and then add this in the same section:

```
[pytest]
filterwarnings =
    error
```

And then run tests with `python setup.py -P wcs`.