### PR TITLE
Fix creation of HDU when XTENSION is A3DTABLE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -377,6 +377,8 @@ astropy.io.fits
 - Fixed a wrong exception when converting a Table with a unit that is not FITS
   compliant and not convertible to a string using ``format='fits'``. [#8906]
 
+- Fixed an issue with A3DTABLE extension that could not be read. [#9012]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3288,3 +3288,24 @@ def test_empty_table(tmpdir):
 
     with fits.open(ofile) as hdul:
         assert hdul['TEST'].data.size == 0
+
+
+def test_a3dtable(tmpdir):
+    testfile = str(tmpdir.join('test.fits'))
+    hdu = fits.BinTableHDU.from_columns([
+        fits.Column(name='FOO', format='J', array=np.arange(10))
+    ])
+    hdu.header['XTENSION'] = 'A3DTABLE'
+    hdu.writeto(testfile, output_verify='ignore')
+
+    with fits.open(testfile) as hdul:
+        assert hdul[1].header['XTENSION'] == 'A3DTABLE'
+
+        with catch_warnings() as w:
+            hdul.verify('fix')
+
+        assert str(w[0].message) == 'Verification reported errors:'
+        assert str(w[2].message)\
+            .endswith('Converted the XTENSION keyword to BINTABLE.')
+
+        assert hdul[1].header['XTENSION'] == 'BINTABLE'


### PR DESCRIPTION
Fix #9003, moving the header modification in `.verify` which makes sense I think.
With this and the file from #9003: 
```
In [4]: hdul.verify('fix')                                                                     
WARNING: VerifyWarning: Verification reported errors: [astropy.io.fits.verify]
WARNING: VerifyWarning: HDU 0: [astropy.io.fits.verify]
WARNING: VerifyWarning:     Card 68: [astropy.io.fits.verify]
WARNING: VerifyWarning:         Card 'RA' is not FITS standard (invalid value string: '07:21:53.448479 / Right ascension in HH:MM:SS.ssssss at J2000.0').  Fixed 'RA' card to meet the FITS standard. [astropy.io.fits.verify]
WARNING: VerifyWarning:     Card 69: [astropy.io.fits.verify]
WARNING: VerifyWarning:         Card 'DEC' is not FITS standard (invalid value string: '+71:20:36.36340  / Declination     in DD:MM:SS.sssss  at J2000.0').  Fixed 'DEC' card to meet the FITS standard. [astropy.io.fits.verify]
WARNING: VerifyWarning: HDU 1: [astropy.io.fits.verify]
WARNING: VerifyWarning:     The XTENSION keyword must match the HDU type.  Converted the XTENSION keyword to BINTABLE. [astropy.io.fits.verify]
WARNING: VerifyWarning: HDU 2: [astropy.io.fits.verify]
WARNING: VerifyWarning: HDU 3: [astropy.io.fits.verify]
WARNING: VerifyWarning: Note: astropy.io.fits uses zero-based indexing.
 [astropy.io.fits.verify]
```

TODO:
- [x] test
- [x] changelog