### PR TITLE
Add roundtrip test for user-defined unit in ecsv.

### DIFF
--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -497,3 +497,45 @@ def test_round_trip_masked_table_serialize_mask(tmpdir):
         t[name].mask = False
         t2[name].mask = False
         assert np.all(t2[name] == t[name])
+
+
+@pytest.mark.skipif('not HAS_YAML')
+@pytest.mark.parametrize('table_cls', (Table, QTable))
+def test_round_trip_user_defined_unit(table_cls, tmpdir):
+    """Ensure that we can read-back enabled user-defined units."""
+    # Test adapted from #8897, where it was noted that this works
+    # but was not tested.
+    filename = str(tmpdir.join('test.ecsv'))
+    unit = u.def_unit('bandpass_sol_lum')
+    t = table_cls()
+    t['l'] = np.arange(5) * unit
+    t.write(filename)
+    # without the unit enabled, get UnrecognizedUnit
+    with catch_warnings(u.UnitsWarning) as w:
+        t2 = table_cls.read(filename)
+    assert isinstance(t2['l'].unit, u.UnrecognizedUnit)
+    assert str(t2['l'].unit) == 'bandpass_sol_lum'
+    if table_cls is QTable:
+        assert len(w) == 1
+        assert f"'{unit!s}' did not parse" in str(w[0].message)
+        assert np.all(t2['l'].value == t['l'].value)
+    else:
+        assert len(w) == 0
+        assert np.all(t2['l'] == t['l'])
+
+    # But with it enabled, it works.
+    with u.add_enabled_units(unit):
+        with catch_warnings(u.UnitsWarning) as w:
+            t3 = table_cls.read(filename)
+        assert len(w) == 0
+        assert t3['l'].unit is unit
+        assert np.all(t3['l'] == t['l'])
+
+        # Just to be sure, aloso try writing with unit enabled.
+        filename2 = str(tmpdir.join('test2.ecsv'))
+        t3.write(filename2)
+        with catch_warnings(u.UnitsWarning) as w:
+            t4 = table_cls.read(filename)
+        assert len(w) == 0
+        assert t4['l'].unit is unit
+        assert np.all(t4['l'] == t['l'])

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -96,7 +96,7 @@ def _unit_representer(dumper, obj):
 
 def _unit_constructor(loader, node):
     map = loader.construct_mapping(node)
-    return u.Unit(map['unit'])
+    return u.Unit(map['unit'], parse_strict='warn')
 
 
 def _serialized_column_representer(dumper, obj):

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1827,7 +1827,13 @@ class _UnitMetaClass(InheritDocstrings):
                         format_clause = f.name + ' '
                     else:
                         format_clause = ''
-                    msg = ("'{}' did not parse as {}unit: {}"
+                    msg = ("'{}' did not parse as {}unit: {} "
+                           "If this is meant to be a custom unit, "
+                           "define it with 'u.def_unit'. To have it "
+                           "recognized inside a file reader or other code, "
+                           "enable it with 'u.add_enabled_units'. "
+                           "For details, see "
+                           "http://docs.astropy.org/en/latest/units/combining_and_defining.html"
                            .format(s, format_clause, str(e)))
                     if parse_strict == 'raise':
                         raise ValueError(msg)

--- a/docs/units/format.rst
+++ b/docs/units/format.rst
@@ -197,8 +197,11 @@ Normally, passing an unrecognized unit string raises an exception::
   Traceback (most recent call last):
     ...
   ValueError: 'Angstroem' did not parse as fits unit: At col 0, Unit
-  'Angstroem' not supported by the FITS standard. Did you mean
-  Angstrom or angstrom?
+  'Angstroem' not supported by the FITS standard. Did you mean Angstrom
+  or angstrom? If this is meant to be a custom unit, define it with
+  'u.def_unit'. To have it recognized inside a file reader or other
+  code, enable it with 'u.add_enabled_units'. For details, see
+  http://docs.astropy.org/en/latest/units/combining_and_defining.html
 
 However, the `~astropy.units.Unit` constructor has the keyword
 argument ``parse_strict`` that can take one of three values to control


### PR DESCRIPTION
This already worked but was not tested. Based on the example in #8897.

@taldcroft - as you can see from the test, if a unit is not recognized, the whole parsing fails. I wonder if instead we should just let it be an `UnrecognizedUnit`? With the logic that one should be generous on input, strict on output.

If you agree, I can change it, either as part of this PR, or in a separate one.