### PR TITLE
Ensure custom units can round-trip in FITS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -382,6 +382,10 @@ astropy.table
 - Fix bug where adding a column consisting of a list of masked arrays was
   dropping the masks. [#9048]
 
+- ``Quantity`` columns with custom units can now round-trip via FITS tables,
+  as long as the custom unit is enabled during reading (otherwise, the unit
+  will become an ``UnrecognizedUnit``). [#9015]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -101,7 +101,7 @@ def _decode_mixins(tbl):
     # Use the `datatype` attribute info to update column attributes that are
     # NOT already handled via standard FITS column keys (name, dtype, unit).
     for col in info['datatype']:
-        for attr in ['description', 'meta']:
+        for attr in ['description', 'meta', 'unit']:
             if attr in col:
                 setattr(tbl[col['name']].info, attr, col[attr])
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -101,7 +101,7 @@ def _decode_mixins(tbl):
     # Use the `datatype` attribute info to update column attributes that are
     # NOT already handled via standard FITS column keys (name, dtype, unit).
     for col in info['datatype']:
-        for attr in ['description', 'meta', 'unit']:
+        for attr in ['description', 'meta']:
             if attr in col:
                 setattr(tbl[col['name']].info, attr, col[attr])
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -525,7 +525,10 @@ def table_to_hdu(table, character_as_bytes=False):
                     "the data or change the units.".format(col.name, str(scale)))
             except ValueError:
                 warnings.warn(
-                    "The unit '{}' could not be saved to FITS format".format(
+                    "The unit '{}' could not be saved in native FITS format "
+                    "and hence will be lost to non-astropy fits readers. "
+                    "Within astropy, it can roundtrip using QTable, but one "
+                    "has to ensure to enable to unit before reading.".format(
                         unit.to_string()), AstropyUserWarning)
             else:
                 # Try creating a Unit to issue a warning if the unit is not

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -524,12 +524,26 @@ def table_to_hdu(table, character_as_bytes=False):
                     "is not recognized by the FITS standard. Either scale "
                     "the data or change the units.".format(col.name, str(scale)))
             except ValueError:
-                warnings.warn(
+                # Warn that the unit is lost, but let the details depend on
+                # whether the column was serialized (because it was a
+                # quantity), since then the unit can be recovered by astropy.
+                warning = (
                     "The unit '{}' could not be saved in native FITS format "
-                    "and hence will be lost to non-astropy fits readers. "
-                    "Within astropy, it can roundtrip using QTable, but one "
-                    "has to ensure to enable to unit before reading.".format(
-                        unit.to_string()), AstropyUserWarning)
+                    .format(unit.to_string()))
+                if any('SerializedColumn' in item and 'name: '+col.name in item
+                       for item in table.meta.get('comments', [])):
+                    warning += (
+                        "and hence will be lost to non-astropy fits readers. "
+                        "Within astropy, the unit can roundtrip using QTable, "
+                        "though one has to enable the unit before reading.")
+                else:
+                    warning += (
+                        "and cannot be recovered in reading. If pyyaml is "
+                        "installed, it can roundtrip within astropy by "
+                        "using QTable both to write and read back, "
+                        "though one has to enable the unit before reading.")
+                warnings.warn(warning, AstropyUserWarning)
+
             else:
                 # Try creating a Unit to issue a warning if the unit is not
                 # FITS compliant

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -222,6 +222,12 @@ class TestSingleTable:
             t.write(filename)
         assert len(w) == 1
         assert 'spam' in str(w[0].message)
+        if table_type is Table or not HAS_YAML:
+            assert ('cannot be recovered in reading. '
+                    'If pyyaml is installed') in str(w[0].message)
+        else:
+            assert 'lost to non-astropy fits readers' in str(w[0].message)
+
         with fits.open(filename) as ff:
             hdu = ff[1]
             assert 'TUNIT1' not in hdu.header

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -74,7 +74,7 @@ class TestConvenience(FitsTestCase):
         with catch_warnings() as w:
             fits.table_to_hdu(table)
             assert len(w) == 1
-            assert str(w[0].message).startswith("The unit 'test' could not be saved to FITS format")
+            assert str(w[0].message).startswith("The unit 'test' could not be saved")
 
     def test_table_to_hdu_convert_comment_convention(self):
         """

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -74,13 +74,13 @@ def _represent_mixin_as_column(col, name, new_cols, mixin_cols,
     # - description: DO store
     # - meta: DO store
     info = {}
-    for attr, nontrivial, xform in (('unit', lambda x: x is not None and x != '', str),
-                                    ('format', lambda x: x is not None, None),
-                                    ('description', lambda x: x is not None, None),
-                                    ('meta', lambda x: x, None)):
+    for attr, nontrivial in (('unit', lambda x: x is not None and x != ''),
+                             ('format', lambda x: x is not None),
+                             ('description', lambda x: x is not None),
+                             ('meta', lambda x: x)):
         col_attr = getattr(col.info, attr)
         if nontrivial(col_attr):
-            info[attr] = xform(col_attr) if xform else col_attr
+            info[attr] = col_attr
 
     data_attrs = [key for key, value in obj_attrs.items() if
                   getattr(value, 'shape', ())[:1] == col.shape[:1]]


### PR DESCRIPTION
Fixes #8897 

Currently, custom units sort-of round-trip through fits, but they do not compare equal, since the re-read version is an `UnrecognizedUnit`. This PR fixes it for astropy-native reading, by giving the serialized unit precedence over that stored in the FITS column. I'm not at all sure this is the best solution...

Like for `ecsv` in #9013, I'm also uncomfortable with reading failing if the unit is not locally enabled - it would seem better to warn and return an `UnrecognizedUnit`.