### PR TITLE
Remove bintrees from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,6 @@ all =
     bleach
     PyYAML
     pandas
-    bintrees
     sortedcontainers
     pytz
     jplephem


### PR DESCRIPTION
The package fails to install on Python 3.7 (with a compilation issue),
and is deprecated in favor of sortedcontainers (https://github.com/mozman/bintrees).

xref #6539

Follow up of #7574 and #8042