### PR TITLE
Remove continuation slash from FITS test

### DIFF
--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3305,7 +3305,7 @@ def test_a3dtable(tmpdir):
             hdul.verify('fix')
 
         assert str(w[0].message) == 'Verification reported errors:'
-        assert str(w[2].message)\
-            .endswith('Converted the XTENSION keyword to BINTABLE.')
+        assert str(w[2].message).endswith(
+            'Converted the XTENSION keyword to BINTABLE.')
 
         assert hdul[1].header['XTENSION'] == 'BINTABLE'


### PR DESCRIPTION
Direct follow up of #9003 , as suggested by @mhvk . Given that I am touching FITS, I better let the full CI run, just in case... :crossed_fingers: 