### PR TITLE
Fixed breaking of master by #8857

### DIFF
--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -637,7 +637,7 @@ def test_representation():
     for attr in ('ra', 'dec', 'distance'):
         with pytest.raises(AttributeError) as err:
             getattr(icrs, attr)
-        assert 'object has no attribute' in str(err)
+        assert 'object has no attribute' in str(err.value)
 
     with pytest.raises(ValueError) as err:
         icrs.representation_type = 'WRONG'


### PR DESCRIPTION
The merging of #8857 broke master because it hadn't been updated to handle the changes in pytest 5 (see #8949).  This PR fixes the issue.