### PR TITLE
Deprecate set_enabled_constants

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,7 +132,8 @@ astropy.config
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 
-- Deprecated ``set_enabled_constants`` context manager. Use ScienceState.
+- Deprecated ``set_enabled_constants`` context manager. Use
+  ``astropy.physical_constants`` and ``astropy.astronomical_constants``.
   [#9025]
 
 astropy.convolution

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,9 @@ astropy.config
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 
+- Deprecated ``set_enabled_constants`` context manager. Use ScienceState.
+  [#9025]
+
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
@@ -362,7 +365,7 @@ astropy.coordinates
 - Fix concatenation of representations for cases where the units were different.
   [#8877]
 
-- Check for NaN values in catalog and match coordinates before building and 
+- Check for NaN values in catalog and match coordinates before building and
   querying the ``KDTree`` for coordinate matching. [#9007]
 
 astropy.cosmology

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -17,6 +17,7 @@ import warnings
 from contextlib import contextmanager
 
 from astropy.utils import find_current_module
+from astropy.utils.decorators import deprecated
 
 # Hack to make circular imports with units work
 from astropy import units
@@ -50,8 +51,7 @@ if __doc__ is not None:
     __doc__ += '\n'.join(_lines)
 
 
-# TODO: Re-implement in a way that is more consistent with astropy.units.
-#       See https://github.com/astropy/astropy/pull/7008 discussions.
+@deprecated('4.0', alternative='Use ScienceState for constants')
 @contextmanager
 def set_enabled_constants(modname):
     """
@@ -102,6 +102,7 @@ def set_enabled_constants(modname):
 
 # Clean up namespace
 del find_current_module
+del deprecated
 del warnings
 del contextmanager
 del _utils

--- a/astropy/constants/__init__.py
+++ b/astropy/constants/__init__.py
@@ -51,7 +51,7 @@ if __doc__ is not None:
     __doc__ += '\n'.join(_lines)
 
 
-@deprecated('4.0', alternative='Use ScienceState for constants')
+@deprecated('4.0', alternative="Use 'astropy.physical_constants' and 'astropy.astronomical_constants'")  # noqa
 @contextmanager
 def set_enabled_constants(modname):
     """

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -159,12 +159,12 @@ def test_context_manager():
     from astropy import constants as const
 
     with pytest.warns(AstropyDeprecationWarning,
-                      match='Use ScienceState for constants'):
+                      match="Use 'astropy.physical_constants'"):
         with const.set_enabled_constants('astropyconst13'):
             assert const.h.value == 6.62606957e-34  # CODATA2010
 
     with pytest.warns(AstropyDeprecationWarning,
-                      match='Use ScienceState for constants'):
+                      match="Use 'astropy.physical_constants'"):
         with const.set_enabled_constants('astropyconst20'):
             assert const.h.value == 6.626070040e-34  # CODATA2014
 
@@ -172,6 +172,6 @@ def test_context_manager():
 
     with pytest.raises(ImportError):
         with pytest.warns(AstropyDeprecationWarning,
-                          match='Use ScienceState for constants'):
+                          match="Use 'astropy.physical_constants'"):
             with const.set_enabled_constants('notreal'):
                 const.h

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -5,8 +5,8 @@ import copy
 import pytest
 
 from astropy.constants import Constant
-from astropy.tests.helper import assert_quantity_allclose
 from astropy.units import Quantity as Q
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_c():
@@ -158,14 +158,20 @@ def test_view():
 def test_context_manager():
     from astropy import constants as const
 
-    with const.set_enabled_constants('astropyconst13'):
-        assert const.h.value == 6.62606957e-34  # CODATA2010
+    with pytest.warns(AstropyDeprecationWarning,
+                      match='Use ScienceState for constants'):
+        with const.set_enabled_constants('astropyconst13'):
+            assert const.h.value == 6.62606957e-34  # CODATA2010
 
-    with const.set_enabled_constants('astropyconst20'):
-        assert const.h.value == 6.626070040e-34  # CODATA2014
+    with pytest.warns(AstropyDeprecationWarning,
+                      match='Use ScienceState for constants'):
+        with const.set_enabled_constants('astropyconst20'):
+            assert const.h.value == 6.626070040e-34  # CODATA2014
 
     assert const.h.value == 6.62607015e-34  # CODATA2018
 
     with pytest.raises(ImportError):
-        with const.set_enabled_constants('notreal'):
-            const.h
+        with pytest.warns(AstropyDeprecationWarning,
+                          match='Use ScienceState for constants'):
+            with const.set_enabled_constants('notreal'):
+                const.h

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -173,9 +173,12 @@ If either `astropy.constants` or `astropy.units` have already been imported, a
 To temporarily set constants to an older version (e.g.,
 for regression testing), a context manager is available, as follows:
 
+    >>> import warnings
     >>> from astropy import constants as const
-    >>> with const.set_enabled_constants('astropyconst13'):
-    ...     print(const.h)
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')  # Ignore deprecation warning
+    ...     with const.set_enabled_constants('astropyconst13'):
+    ...         print(const.h)
       Name   = Planck constant
       Value  = 6.62606957e-34
       Uncertainty  = 2.9e-41

--- a/docs/constants/index.rst
+++ b/docs/constants/index.rst
@@ -170,32 +170,6 @@ If either `astropy.constants` or `astropy.units` have already been imported, a
         ...
     RuntimeError: astropy.units is already imported
 
-To temporarily set constants to an older version (e.g.,
-for regression testing), a context manager is available, as follows:
-
-    >>> import warnings
-    >>> from astropy import constants as const
-    >>> with warnings.catch_warnings():
-    ...     warnings.simplefilter('ignore')  # Ignore deprecation warning
-    ...     with const.set_enabled_constants('astropyconst13'):
-    ...         print(const.h)
-      Name   = Planck constant
-      Value  = 6.62606957e-34
-      Uncertainty  = 2.9e-41
-      Unit  = J s
-      Reference = CODATA 2010
-    >>> print(const.h)
-      Name   = Planck constant
-      Value  = 6.62607015e-34
-      Uncertainty  = 0.0
-      Unit  = J s
-      Reference = CODATA 2018
-
-The context manager may be used at any time in a Python session, but it
-uses the prior version only for `astropy.constants`, and not for any
-other subpackage such as `astropy.units`.
-
-
 .. note that if this section gets too long, it should be moved to a separate
    doc page - see the top of performance.inc.rst for the instructions on how to
    do that


### PR DESCRIPTION
`set_enabled_constants` context manager was added in #7008 (3.0 release). With `ScienceState` implemented in #8517 , this is no longer needed. Fix #8866 

Note to self: Open a new issue as a reminder to completely remove this deprecated feature in a future release after this PR is merged.