### PR TITLE
Updated CircleCI configuration to upload test images as artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl --mpl-results-path=$PWD/results"
+      - store_artifacts:
+          path: results
 
   image-tests-mpl222:
     docker:
@@ -47,7 +49,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl --mpl-results-path=$PWD/results"
+      - store_artifacts:
+          path: results
 
   image-tests-mpl302:
     docker:
@@ -56,7 +60,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl --mpl-results-path=$PWD/results"
+      - store_artifacts:
+          path: results
 
   image-tests-mpl310:
     docker:
@@ -65,7 +71,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl --mpl-results-path=$PWD/results"
+      - store_artifacts:
+          path: results
 
   image-tests-mpldev:
     docker:
@@ -80,7 +88,9 @@ jobs:
           command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl --mpl-results-path=$PWD/results"
+      - store_artifacts:
+          path: results
 
   html-docs:
     docker:

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -5,6 +5,11 @@ from astropy.utils.decorators import wraps
 
 MPL_VERSION = matplotlib.__version__
 
+# The developer versions of the form 3.1.x+... contain changes that will only
+# be included in the 3.2.x release, so we update this here.
+if MPL_VERSION[:3] == '3.1' and '+' in MPL_VERSION:
+    MPL_VERSION = '3.2'
+
 ROOT = "http://{server}/testing/astropy/2018-10-24T12:38:34.134556/{mpl_version}/"
 IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x') + ',' +
                        ROOT.format(server='www.astropy.org/astropy-data', mpl_version=MPL_VERSION[:3] + '.x'))


### PR DESCRIPTION
This is to make it easier to see what the plots look like in case of failures