### PR TITLE
Update configuration for Matplotlib CircleCI jobs on v2.0.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
     docker:
       - image: astropy/image-tests-py36-base:1.2
     steps:
+      - checkout
       - run:
           name: Install C++ compiler
           command: apt install -y g++

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,9 @@ jobs:
       - image: astropy/image-tests-py36-base:1.2
     steps:
       - run:
+          name: Install C++ compiler
+          command: apt install -y g++
+      - run:
           name: Install Python dependencies, including developer version of Matplotlib
           command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,9 @@ jobs:
       - store_artifacts:
           path: results
 
-  image-tests-mpl300:
+  image-tests-mpl302:
     docker:
-      - image: astropy/image-tests-py35-mpl300:1.3
+      - image: astropy/image-tests-py37-mpl302:1.5
     steps:
       - checkout
       - run:
@@ -110,14 +110,22 @@ jobs:
           path: results
 
 
-  image-tests-mpldev:
+  image-tests-mpl310:
     docker:
-      - image: astropy/image-tests-py36-base:1.1
+      - image: astropy/image-tests-py37-mpl310:1.5
     steps:
       - checkout
       - run:
-          name: Install apt dependencies
-          command: apt-get install -y libfreetype6-dev libpng12-dev pkg-config cm-super
+          name: Temporarily downgrade pytest
+          command: pip3 install "pytest<3.7"
+      - run:
+          name: Run tests
+          command: python3 setup.py test -P visualization --remote-data=astropy -a "--mpl"
+
+  image-tests-mpldev:
+    docker:
+      - image: astropy/image-tests-py36-base:1.2
+    steps:
       - run:
           name: Install Python dependencies, including developer version of Matplotlib
           command: pip3 install "pytest<3.7" pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git
@@ -160,7 +168,8 @@ workflows:
       - image-tests-mpl202
       - image-tests-mpl212
       - image-tests-mpl222
-      - image-tests-mpl300
+      - image-tests-mpl302
+      - image-tests-mpl310
       - image-tests-mpldev
 
 notify:


### PR DESCRIPTION
This adds a job for Matplotlib 3.1.x and updates a few other build settings. The Matplotlib dev build will likely fail until https://github.com/astropy/astropy/pull/9029 is back-ported to v2.0.x.

This should otherwise pass once #9030 is merged and this is rebased.