### PR TITLE
find_api_page to use custom headers and also HTTPS when version is given

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -442,8 +442,8 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- Fixed ``find_api_page`` access by using HTTPS when version is specified.
-  [#9032]
+- Fixed ``find_api_page`` access by using custom request headers and HTTPS
+  when version is specified. [#9032]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -442,6 +442,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fixed ``find_api_page`` access by using HTTPS when version is specified.
+  [#9032]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -224,7 +224,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
     elif version == 'dev' or version == 'latest':
         baseurl = 'http://devdocs.astropy.org/'
     else:
-        baseurl = f'http://docs.astropy.org/en/{version}/'
+        baseurl = f'https://docs.astropy.org/en/{version}/'
 
     if timeout is None:
         uf = urllib.request.urlopen(baseurl + 'objects.inv')
@@ -298,7 +298,7 @@ if sys.platform == 'win32':
         """
         Returns True if the given filepath has the hidden attribute on
         MS-Windows.  Based on a post here:
-        http://stackoverflow.com/questions/284115/cross-platform-hidden-file-detection
+        https://stackoverflow.com/questions/284115/cross-platform-hidden-file-detection
         """
         if isinstance(filepath, bytes):
             filepath = filepath.decode(sys.getfilesystemencoding())

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -229,7 +229,7 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
     # Custom request headers; see
     # https://github.com/astropy/astropy/issues/8990
     req = urllib.request.Request(
-        baseurl + 'objects.inv', headers={'User-Agent': 'Astropy/{version}'})
+        baseurl + 'objects.inv', headers={'User-Agent': f'Astropy/{version}'})
 
     if timeout is None:
         uf = urllib.request.urlopen(req)

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -226,10 +226,15 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
     else:
         baseurl = f'https://docs.astropy.org/en/{version}/'
 
+    # Custom request headers; see
+    # https://github.com/astropy/astropy/issues/8990
+    req = urllib.request.Request(
+        baseurl + 'objects.inv', headers={'User-Agent': 'Astropy/{version}'})
+
     if timeout is None:
-        uf = urllib.request.urlopen(baseurl + 'objects.inv')
+        uf = urllib.request.urlopen(req)
     else:
-        uf = urllib.request.urlopen(baseurl + 'objects.inv', timeout=timeout)
+        uf = urllib.request.urlopen(req, timeout=timeout)
 
     try:
         oiread = uf.read()

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -32,7 +32,11 @@ def test_api_lookup():
     objurl = misc.find_api_page(misc, 'dev', False, timeout=3)
 
     assert strurl == objurl
-    assert strurl == 'http://devdocs.astropy.org/utils/index.html#module-astropy.utils.misc'
+    assert strurl == 'http://devdocs.astropy.org/utils/index.html#module-astropy.utils.misc'  # noqa
+
+    # Try a non-dev version
+    objurl = misc.find_api_page(misc, 'v3.2.1', False, timeout=3)
+    assert objurl == 'https://docs.astropy.org/en/v3.2.1/utils/index.html#module-astropy.utils.misc'  # noqa
 
 
 def test_skip_hidden():


### PR DESCRIPTION
Attempt to fix #8990, as suggested by @mhvk and @saimn .