### PR TITLE
Turn InheritDocstrings into an empty class

### DIFF
--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -498,48 +498,9 @@ class InheritDocstrings(type):
     docstrings filled in from the methods they override in the base
     class.
 
-    If the class uses multiple inheritance, the docstring will be
-    chosen from the first class in the bases list, in the same way as
-    methods are normally resolved in Python.  If this results in
-    selecting the wrong docstring, the docstring will need to be
-    explicitly included on the method.
+    .. warning:: This class is now a no-op; please use Sphinx>=1.7.
 
-    For example::
-
-        >>> import warnings
-        >>> from astropy.utils.misc import InheritDocstrings
-        >>> with warnings.catch_warnings():
-        ...     # Ignore deprecation warning
-        ...     warnings.simplefilter('ignore')
-        ...     class A(metaclass=InheritDocstrings):
-        ...         def wiggle(self):
-        ...             "Wiggle the thingamajig"
-        ...             pass
-        ...     class B(A):
-        ...         def wiggle(self):
-        ...             pass
-        >>> B.wiggle.__doc__
-        u'Wiggle the thingamajig'
     """
-
-    def __init__(cls, name, bases, dct):
-        def is_public_member(key):
-            return (
-                (key.startswith('__') and key.endswith('__')
-                 and len(key) > 4) or
-                not key.startswith('_'))
-
-        for key, val in dct.items():
-            if ((inspect.isfunction(val) or inspect.isdatadescriptor(val)) and
-                    is_public_member(key) and
-                    val.__doc__ is None):
-                for base in cls.__mro__[1:]:
-                    super_method = getattr(base, key, None)
-                    if super_method is not None:
-                        val.__doc__ = super_method.__doc__
-                        break
-
-        super().__init__(name, bases, dct)
 
 
 class OrderedDescriptor(metaclass=abc.ABCMeta):

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -75,34 +75,6 @@ def test_JsonCustomEncoder():
     assert newd == tmpd
 
 
-def test_inherit_docstrings():
-    with pytest.warns(AstropyDeprecationWarning, match="inherits docstring"):
-        class Base(metaclass=misc.InheritDocstrings):
-            def __call__(self, *args):
-                "FOO"
-                pass
-
-            @property
-            def bar(self):
-                "BAR"
-                pass
-
-    class Subclass(Base):
-        def __call__(self, *args):
-            pass
-
-        @property
-        def bar(self):
-            return 42
-
-    if Base.__call__.__doc__ is not None:
-        # TODO: Maybe if __doc__ is None this test should be skipped instead?
-        assert Subclass.__call__.__doc__ == "FOO"
-
-    if Base.bar.__doc__ is not None:
-        assert Subclass.bar.__doc__ == "BAR"
-
-
 def test_set_locale():
     # First, test if the required locales are available
     current = locale.setlocale(locale.LC_ALL)


### PR DESCRIPTION
As suggested by @astrofrog in https://github.com/astropy/astropy/pull/8881#issuecomment-513838778 .