### PR TITLE
Add list of frame classes to main coordinates docs page

### DIFF
--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -26,5 +26,3 @@ from .solar_system import *
 # deprecation warnings are removed
 from .attributes import (TimeFrameAttribute, QuantityFrameAttribute,
                          CartesianRepresentationFrameAttribute)
-
-__doc__ += builtin_frames._transform_graph_docs

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -675,7 +675,7 @@ def angular_separation(lon1, lat1, lon2, lat2):
 
     Parameters
     ----------
-    lon1, lat1, lon2, lat2 : `Angle`, `~astropy.units.Quantity` or float
+    lon1, lat1, lon2, lat2 : `~astropy.coordinates.Angle`, `~astropy.units.Quantity` or float
         Longitude and latitude of the two points. Quantities should be in
         angular units; floats in radians.
 
@@ -715,7 +715,7 @@ def position_angle(lon1, lat1, lon2, lat2):
 
     Parameters
     ----------
-    lon1, lat1, lon2, lat2 : `Angle`, `~astropy.units.Quantity` or float
+    lon1, lat1, lon2, lat2 : `~astropy.coordinates.Angle`, `~astropy.units.Quantity` or float
         Longitude and latitude of the two points. Quantities should be in
         angular units; floats in radians.
 
@@ -744,7 +744,7 @@ def offset_by(lon, lat, posang, distance):
 
     Parameters
     ----------
-    lon, lat, posang, distance : `Angle`, `~astropy.units.Quantity` or float
+    lon, lat, posang, distance : `~astropy.coordinates.Angle`, `~astropy.units.Quantity` or float
         Longitude and latitude of the starting point,
         position angle and distance to the final point.
         Quantities should be in angular units; floats in radians.

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -339,12 +339,12 @@ class Angle(u.SpecificTypeQuantity):
 
     def wrap_at(self, wrap_angle, inplace=False):
         """
-        Wrap the `Angle` object at the given ``wrap_angle``.
+        Wrap the `~astropy.coordinates.Angle` object at the given ``wrap_angle``.
 
         This method forces all the angle values to be within a contiguous
         360 degree range so that ``wrap_angle - 360d <= angle <
         wrap_angle``. By default a new Angle object is returned, but if the
-        ``inplace`` argument is `True` then the `Angle` object is wrapped in
+        ``inplace`` argument is `True` then the `~astropy.coordinates.Angle` object is wrapped in
         place and nothing is returned.
 
         For instance::
@@ -362,19 +362,19 @@ class Angle(u.SpecificTypeQuantity):
 
         Parameters
         ----------
-        wrap_angle : str, `Angle`, angular `~astropy.units.Quantity`
+        wrap_angle : str, `~astropy.coordinates.Angle`, angular `~astropy.units.Quantity`
             Specifies a single value for the wrap angle.  This can be any
-            object that can initialize an `Angle` object, e.g. ``'180d'``,
+            object that can initialize an `~astropy.coordinates.Angle` object, e.g. ``'180d'``,
             ``180 * u.deg``, or ``Angle(180, unit=u.deg)``.
 
         inplace : bool
             If `True` then wrap the object in place instead of returning
-            a new `Angle`
+            a new `~astropy.coordinates.Angle`
 
         Returns
         -------
         out : Angle or `None`
-            If ``inplace is False`` (default), return new `Angle` object
+            If ``inplace is False`` (default), return new `~astropy.coordinates.Angle` object
             with angles wrapped accordingly.  Otherwise wrap in place and
             return `None`.
         """
@@ -405,13 +405,13 @@ class Angle(u.SpecificTypeQuantity):
 
         Parameters
         ----------
-        lower : str, `Angle`, angular `~astropy.units.Quantity`, `None`
+        lower : str, `~astropy.coordinates.Angle`, angular `~astropy.units.Quantity`, `None`
             Specifies lower bound for checking.  This can be any object
-            that can initialize an `Angle` object, e.g. ``'180d'``,
+            that can initialize an `~astropy.coordinates.Angle` object, e.g. ``'180d'``,
             ``180 * u.deg``, or ``Angle(180, unit=u.deg)``.
-        upper : str, `Angle`, angular `~astropy.units.Quantity`, `None`
+        upper : str, `~astropy.coordinates.Angle`, angular `~astropy.units.Quantity`, `None`
             Specifies upper bound for checking.  This can be any object
-            that can initialize an `Angle` object, e.g. ``'180d'``,
+            that can initialize an `~astropy.coordinates.Angle` object, e.g. ``'180d'``,
             ``180 * u.deg``, or ``Angle(180, unit=u.deg)``.
 
         Returns
@@ -483,7 +483,7 @@ class Latitude(Angle):
 
     Parameters
     ----------
-    angle : array, list, scalar, `~astropy.units.Quantity`, `Angle`. The
+    angle : array, list, scalar, `~astropy.units.Quantity`, `~astropy.coordinates.Angle`. The
         angle value(s). If a tuple, will be interpreted as ``(h, m, s)`` or
         ``(d, m, s)`` depending on ``unit``. If a string, it will be
         interpreted following the rules described for

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -332,17 +332,17 @@ class RepresentationMapping(_RepresentationMappingBase):
 base_doc = """{__doc__}
     Parameters
     ----------
-    data : `BaseRepresentation` subclass instance
+    data : `~astropy.coordinates.BaseRepresentation` subclass instance
         A representation object or ``None`` to have no data (or use the
         coordinate component arguments, see below).
     {components}
-    representation_type : `BaseRepresentation` subclass, str, optional
+    representation_type : `~astropy.coordinates.BaseRepresentation` subclass, str, optional
         A representation class or string name of a representation class. This
         sets the expected input representation class, thereby changing the
         expected keyword arguments for the data passed in. For example, passing
         ``representation_type='cartesian'`` will make the classes expect
         position data with cartesian names, i.e. ``x, y, z`` in most cases.
-    differential_type : `BaseDifferential` subclass, str, dict, optional
+    differential_type : `~astropy.coordinates.BaseDifferential` subclass, str, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets the
         expected input differential class, thereby changing the expected keyword
@@ -970,7 +970,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         Parameters
         ----------
-        data : `BaseRepresentation`
+        data : `~astropy.coordinates.BaseRepresentation`
             The representation to use as the data for the new frame.
 
         Returns

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-This package contains the coordinate frames actually implemented by astropy.
+This package contains the coordinate frames implemented by astropy.
 
 Users shouldn't use this module directly, but rather import from the
 `astropy.coordinates` module.  While it is likely to exist for the long-term,
@@ -137,3 +137,7 @@ def make_transform_graph_docs(transform_graph):
 
 
 _transform_graph_docs = make_transform_graph_docs(frame_transform_graph)
+
+# Here, we override the module docstring so that sphinx renders the transform
+# graph without the developer documentation in the main docstring above.
+__doc__ = _transform_graph_docs

--- a/astropy/coordinates/builtin_frames/altaz.py
+++ b/astropy/coordinates/builtin_frames/altaz.py
@@ -16,10 +16,10 @@ __all__ = ['AltAz']
 _90DEG = 90*u.deg
 
 doc_components = """
-    az : `Angle`, optional, must be keyword
+    az : `~astropy.coordinates.Angle`, optional, must be keyword
         The Azimuth for this object (``alt`` must also be given and
         ``representation`` must be None).
-    alt : `Angle`, optional, must be keyword
+    alt : `~astropy.coordinates.Angle`, optional, must be keyword
         The Altitude for this object (``az`` must also be given and
         ``representation`` must be None).
     distance : :class:`~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/baseradec.py
+++ b/astropy/coordinates/builtin_frames/baseradec.py
@@ -9,10 +9,10 @@ __all__ = ['BaseRADecFrame']
 
 
 doc_components = """
-    ra : `Angle`, optional, must be keyword
+    ra : `~astropy.coordinates.Angle`, optional, must be keyword
         The RA for this object (``dec`` must also be given and ``representation``
         must be None).
-    dec : `Angle`, optional, must be keyword
+    dec : `~astropy.coordinates.Angle`, optional, must be keyword
         The Declination for this object (``ra`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/ecliptic.py
+++ b/astropy/coordinates/builtin_frames/ecliptic.py
@@ -16,20 +16,20 @@ __all__ = ['GeocentricMeanEcliptic', 'BarycentricMeanEcliptic',
 
 
 doc_components_ecl = """
-    lon : `Angle`, optional, must be keyword
+    lon : `~astropy.coordinates.Angle`, optional, must be keyword
         The ecliptic longitude for this object (``lat`` must also be given and
         ``representation`` must be None).
-    lat : `Angle`, optional, must be keyword
+    lat : `~astropy.coordinates.Angle`, optional, must be keyword
         The ecliptic latitude for this object (``lon`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword
         The distance for this object from the {0}.
         (``representation`` must be None).
 
-    pm_lon_coslat : `Angle`, optional, must be keyword
+    pm_lon_coslat : `~astropy.coordinates.Angle`, optional, must be keyword
         The proper motion in the ecliptic longitude (including the ``cos(lat)``
         factor) for this object (``pm_lat`` must also be given).
-    pm_lat : `Angle`, optional, must be keyword
+    pm_lat : `~astropy.coordinates.Angle`, optional, must be keyword
         The proper motion in the ecliptic latitude for this object
         (``pm_lon_coslat`` must also be given).
     radial_velocity : :class:`~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -15,10 +15,10 @@ __all__ = ['Galactic']
 
 
 doc_components = """
-    l : `Angle`, optional, must be keyword
+    l : `~astropy.coordinates.Angle`, optional, must be keyword
         The Galactic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
-    b : `Angle`, optional, must be keyword
+    b : `~astropy.coordinates.Angle`, optional, must be keyword
         The Galactic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -58,7 +58,7 @@ doc_footer = """
         velocity components.
     z_sun : `~astropy.units.Quantity`, optional, must be keyword
         The distance from the sun to the Galactic midplane.
-    roll : `Angle`, optional, must be keyword
+    roll : `~astropy.coordinates.Angle`, optional, must be keyword
         The angle to rotate about the final x-axis, relative to the
         orientation for Galactic. For example, if this roll angle is 0,
         the final x-z plane will align with the Galactic coordinates x-z

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -82,10 +82,10 @@ def lsr_to_icrs(lsr_coord, icrs_frame):
 
 
 doc_components_gal = """
-    l : `Angle`, optional, must be keyword
+    l : `~astropy.coordinates.Angle`, optional, must be keyword
         The Galactic longitude for this object (``b`` must also be given and
         ``representation`` must be None).
-    b : `Angle`, optional, must be keyword
+    b : `~astropy.coordinates.Angle`, optional, must be keyword
         The Galactic latitude for this object (``l`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -128,9 +128,9 @@ class SkyOffsetFrame(BaseCoordinateFrame):
 
     Parameters
     ----------
-    representation : `BaseRepresentation` or None
+    representation : `~astropy.coordinates.BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
-    origin : `SkyCoord` or low-level coordinate object.
+    origin : `~astropy.coordinates.SkyCoord` or low-level coordinate object.
         The coordinate which specifies the origin of this frame. Note that this
         origin is used purely for on-sky location/rotation.  It can have a
         ``distance`` but it will not be used by this ``SkyOffsetFrame``.

--- a/astropy/coordinates/builtin_frames/supergalactic.py
+++ b/astropy/coordinates/builtin_frames/supergalactic.py
@@ -11,10 +11,10 @@ __all__ = ['Supergalactic']
 
 
 doc_components = """
-    sgl : `Angle`, optional, must be keyword
+    sgl : `~astropy.coordinates.Angle`, optional, must be keyword
         The supergalactic longitude for this object (``sgb`` must also be given and
         ``representation`` must be None).
-    sgb : `Angle`, optional, must be keyword
+    sgb : `~astropy.coordinates.Angle`, optional, must be keyword
         The supergalactic latitude for this object (``sgl`` must also be given and
         ``representation`` must be None).
     distance : `~astropy.units.Quantity`, optional, must be keyword

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -44,7 +44,7 @@ def rotation_matrix(angle, axis='z', unit=None):
 
     Parameters
     ----------
-    angle : convertible to `Angle`
+    angle : convertible to `~astropy.coordinates.Angle`
         The amount of rotation the matrices should represent.  Can be an array.
     axis : str, or array-like
         Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
@@ -109,7 +109,7 @@ def angle_axis(matrix):
 
     Returns
     -------
-    angle : `Angle`
+    angle : `~astropy.coordinates.Angle`
         The angle of rotation.
     axis : array
         The (normalized) axis of rotation (with last dimension 3).

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -439,9 +439,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     comp1, comp2, comp3 : `~astropy.units.Quantity` or subclass
         The components of the 3D points.  The names are the keys and the
         subclasses the values of the ``attr_classes`` attribute.
-    differentials : dict, `BaseDifferential`, optional
+    differentials : dict, `~astropy.coordinates.BaseDifferential`, optional
         Any differential classes that should be associated with this
-        representation. The input must either be a single `BaseDifferential`
+        representation. The input must either be a single `~astropy.coordinates.BaseDifferential`
         subclass instance, or a dictionary with keys set to a string
         representation of the SI unit with which the differential (derivative)
         is taken. For example, for a velocity differential on a positional
@@ -1235,9 +1235,9 @@ class UnitSphericalRepresentation(BaseRepresentation):
         instances of `~astropy.coordinates.Angle`,
         `~astropy.coordinates.Longitude`, or `~astropy.coordinates.Latitude`.
 
-    differentials : dict, `BaseDifferential`, optional
+    differentials : dict, `~astropy.coordinates.BaseDifferential`, optional
         Any differential classes that should be associated with this
-        representation. The input must either be a single `BaseDifferential`
+        representation. The input must either be a single `~astropy.coordinates.BaseDifferential`
         instance (see `._compatible_differentials` for valid types), or a
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)
@@ -1434,9 +1434,9 @@ class RadialRepresentation(BaseRepresentation):
     distance : `~astropy.units.Quantity`
         The distance of the point(s) from the origin.
 
-    differentials : dict, `BaseDifferential`, optional
+    differentials : dict, `~astropy.coordinates.BaseDifferential`, optional
         Any differential classes that should be associated with this
-        representation. The input must either be a single `BaseDifferential`
+        representation. The input must either be a single `~astropy.coordinates.BaseDifferential`
         instance (see `._compatible_differentials` for valid types), or a
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)
@@ -1519,9 +1519,9 @@ class SphericalRepresentation(BaseRepresentation):
         passed to the :class:`~astropy.coordinates.Distance` class, otherwise
         it is passed to the :class:`~astropy.units.Quantity` class.
 
-    differentials : dict, `BaseDifferential`, optional
+    differentials : dict, `~astropy.coordinates.BaseDifferential`, optional
         Any differential classes that should be associated with this
-        representation. The input must either be a single `BaseDifferential`
+        representation. The input must either be a single `~astropy.coordinates.BaseDifferential`
         instance (see `._compatible_differentials` for valid types), or a
         dictionary of of differential instances with keys set to a string
         representation of the SI unit with which the differential (derivative)

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -97,7 +97,7 @@ def test_representations_api():
 
     # regardless of how input, the `lat` and `lon` come out as angle/distance
     assert isinstance(c1.lat, Angle)
-    assert isinstance(c1.lat, Latitude)  # `Latitude` is an `Angle` subclass
+    assert isinstance(c1.lat, Latitude)  # `Latitude` is an `~astropy.coordinates.Angle` subclass
     assert isinstance(c1.distance, Distance)
 
     # but they are read-only, as representations are immutable once created

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -436,7 +436,6 @@ Built-in Frame Classes
 .. automodapi:: astropy.coordinates.builtin_frames
     :skip: make_transform_graph_docs
     :no-heading:
-    :no-main-docstr:
     :no-inheritance-diagram:
 
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -430,6 +430,15 @@ coordinate systems implemented here include:
     problems and concepts.
 
 
+Built-in frame classes
+======================
+
+.. automodapi:: astropy.coordinates.builtin_frames
+    :skip: make_transform_graph_docs
+    :no-heading:
+    :no-main-docstr:
+
+
 .. _astropy-coordinates-api:
 
 Reference/API

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -437,6 +437,7 @@ Built-in frame classes
     :skip: make_transform_graph_docs
     :no-heading:
     :no-main-docstr:
+    :no-inheritance-diagram:
 
 
 .. _astropy-coordinates-api:

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -435,7 +435,6 @@ Built-in Frame Classes
 
 .. automodapi:: astropy.coordinates.builtin_frames
     :skip: make_transform_graph_docs
-    :no-heading:
     :no-inheritance-diagram:
 
 

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -430,7 +430,7 @@ coordinate systems implemented here include:
     problems and concepts.
 
 
-Built-in frame classes
+Built-in Frame Classes
 ======================
 
 .. automodapi:: astropy.coordinates.builtin_frames

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -75,11 +75,11 @@ class Sagittarius(coord.BaseCoordinateFrame):
 
     Parameters
     ----------
-    representation : `BaseRepresentation` or None
+    representation : `~astropy.coordinates.BaseRepresentation` or None
         A representation object or None to have no data (or use the other keywords)
-    Lambda : `Angle`, optional, must be keyword
+    Lambda : `~astropy.coordinates.Angle`, optional, must be keyword
         The longitude-like angle corresponding to Sagittarius' orbit.
-    Beta : `Angle`, optional, must be keyword
+    Beta : `~astropy.coordinates.Angle`, optional, must be keyword
         The latitude-like angle corresponding to Sagittarius' orbit.
     distance : `Quantity`, optional, must be keyword
         The Distance for this object along the line-of-sight.


### PR DESCRIPTION
This adds an auto-generated list of the built-in frame classes just before the full reference/API. I often want to see a text list of the frames, or need to click on the docs page for a frame class and scrolling through the full API is cumbersome.