### PR TITLE
Fix issue with data path that caused crash on Windows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -456,6 +456,10 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
+- Fixed a bug that caused files outside of the astropy module directory to be
+  included as package data, resulting in some cases in errors when doing
+  repeated builds. [#9039]
+
 
 3.2.1 (2019-06-14)
 ==================

--- a/astropy/setup_package.py
+++ b/astropy/setup_package.py
@@ -3,14 +3,16 @@
 import os
 import glob
 
+ROOT = os.path.dirname(__file__)
+
 
 def get_package_data():
 
     # Find all files in data/ sub-directories since this is a standard location
     # for data files. We then need to adjust the paths to be relative to here
     # (otherwise glob will be evaluated relative to setup.py)
-    data_files = glob.glob('**/data/**/*', recursive=True)
-    data_files = [os.path.relpath(x, os.path.dirname(__file__)) for x in data_files]
+    data_files = glob.glob(os.path.join(ROOT, '**', 'data', '**', '*'), recursive=True)
+    data_files = [os.path.relpath(x, ROOT) for x in data_files]
 
     # Glob doesn't recognize hidden files
     data_files.append('utils/tests/data/.hidden_file.txt')


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/8903

Not sure how I missed this before but I think this would happen on all platforms (It's just that on Windows long paths cause errors). I think these changes aren't in v2.0.x so no need to backport to LTS though. To reproduce the issue, just run ``python setup.py build`` several times repeatedly and noticed the nested build folders.

@MSeifert04 - feel free to try this out!