### PR TITLE
Accepting mask when creating new column from a list of masked arrays

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1782,6 +1782,10 @@ class Table:
 
         # If value doesn't have a dtype and won't be added as a mixin then
         # convert to a numpy array.
+        # See #8977 Using Masked array for working.
+        if type(col) == type([]) and any(isinstance(x, np.ma.MaskedArray) for x in col):
+            col = np.ma.asarray(col)
+
         if not hasattr(col, 'dtype') and not self._is_mixin_for_table(col):
             col = np.asarray(col)
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2403,3 +2403,13 @@ def test_data_to_col_convert_strategy():
     t['b'] = np.int64(2)  # Failed previously
     assert np.all(t['a'] == [1, 1])
     assert np.all(t['b'] == [2, 2])
+
+
+def test_mask_column_from_list():
+    """Test for #8977 Initialising masked column from a list
+    """
+    t = table.Table([(0, 1)], names='a', masked=True)
+    data = np.ma.masked_greater(np.arange(3), 1)
+    t['b'] = [data, data]
+    assert np.all(t['b'].mask == np.array([[False, False, True],
+                                          [False, False, True]]))


### PR DESCRIPTION
Try to Solve: #8977 
Now  MaskedColumn can be created using a list of maksed_array.

```
In [3]: t['b'] =[np.ma.masked_all(3) for _ in range(10)]

In [4]: t
Out[4]: 
<Table masked=True length=10>
a [3]   b [3]  
int64  float64 
------ --------
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
0 .. 2 -- .. --
```

EDIT: Fix #8977 