### PR TITLE
add inverse to GenericModel

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -124,6 +124,10 @@ class GenericModel(mappings.Mapping):
         super().__init__(mapping)
         self._outputs = tuple('x' + str(idx) for idx in range(self.n_outputs + 1))
 
+    @property
+    def inverse(self):
+        raise NotImplementedError()
+
 
 class GenericType(TransformType):
     name = "transform/generic"


### PR DESCRIPTION
This PR fixes an issue in asdf testing of schemas - spacetelescope/asdf#687.

Some of the asdf schemas have examples which use a custom model called [GenericModel](https://github.com/astropy/astropy/blob/master/astropy/io/misc/asdf/tags/transform/basic.py#L121) . It is located within the `Transform` tags in `astropy/io/misc/asdf/tags/transform/basic.py`. 
The examples currently fail with astropy master. The new modeling is a bit more aggressive when creating inverse models (but more correct). Because `GenericModel` inherits from `Mapping` and does not define its inverse it inherits the inverse from `Mapping` which has the wrong inputs for `GenericModel`. The solution here is to implement `GenericModel.inverse`.