### PR TITLE
Fix unresolved link

### DIFF
--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -229,7 +229,7 @@ image were already in memory.  This works the same way for tables.  For most
 cases this is your best bet for working with large files.
 
 To ensure use of memory mapping, just add the ``memmap=True`` argument to
-`fits.open <astropy.io.fits.open>`_.  Likewise, using ``memmap=False`` will
+`astropy.io.fits.open`.  Likewise, using ``memmap=False`` will
 force data to be read entirely into memory.
 
 


### PR DESCRIPTION
Sphinx does not resolve the link as given in the docs currently.
The easiest solution is spell out te entire path of the function
in question because I think `~astrop.io.fits.open` which will display just
"open" in the rendered document is too confusing.

[skip CI]