### PR TITLE
MNT: Flip primary and mirror locations for data

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -45,10 +45,10 @@ class Conf(_config.ConfigNamespace):
     """
 
     dataurl = _config.ConfigItem(
-        'http://data.astropy.org/',
+        'http://www.astropy.org/astropy-data/',
         'Primary URL for astropy remote data site.')
     dataurl_mirror = _config.ConfigItem(
-        'http://www.astropy.org/astropy-data/',
+        'http://data.astropy.org/',
         'Mirror URL for astropy remote data site.')
     remote_timeout = _config.ConfigItem(
         10.,


### PR DESCRIPTION
This flips the primary and mirror locations for Astropy data. cc @jhunkeler and @rendinam

I don't think change log is required?