### PR TITLE
Address issue #8995 by ignoring BINARY2 mask bits for string values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -291,10 +291,6 @@ astropy.io.votable
   being a boolean. In addition, changed default to ``ignore``, which means
   that warnings will not be shown by default when loading VO tables. [#8715]
 
-- Address issue #8995 by ignoring BINARY2 null mask bits for string values
-  on parsing a VOTable.  In this way, the reader should never create masked
-  values for string types. [#9057]
-
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
@@ -472,6 +468,10 @@ astropy.io.registry
 
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
+
+- Address issue #8995 by ignoring BINARY2 null mask bits for string values
+  on parsing a VOTable.  In this way, the reader should never create masked
+  values for string types. [#9057]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -291,6 +291,10 @@ astropy.io.votable
   being a boolean. In addition, changed default to ``ignore``, which means
   that warnings will not be shown by default when loading VO tables. [#8715]
 
+- Address issue #8995 by ignoring BINARY2 null mask bits for string values
+  on parsing a VOTable.  In this way, the reader should never create masked
+  values for string types. [#9057]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/tests/data/binary2_masked_strings.xml
+++ b/astropy/io/votable/tests/data/binary2_masked_strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<VOTABLE version="1.3" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3">
+<RESOURCE type="results">
+<INFO name="QUERY_STATUS" value="OK"/>
+<INFO name="QUERY" value=""><![CDATA[
+    select top 3 source_id, ra, dec, a_g_val, datalink_url, epoch_photometry_url
+    from gaiadr2.gaia_source;
+    ]]></INFO>
+<INFO name="CAPTION" value=""><![CDATA[How to cite and acknowledge Gaia: http://gea.esac.esa.int/archive/documentation/credits.html]]></INFO>
+<INFO name="PAGE" value=""></INFO>
+<INFO name="PAGE_SIZE" value=""></INFO>
+<INFO name="JOBID" value="1564151313219O"><![CDATA[1564151313219O]]></INFO>
+<INFO name="JOBNAME" value=""></INFO>
+<COOSYS ID="GAIADR2" epoch="J2015.5" system="ICRS" />
+
+<TABLE>
+<FIELD datatype="long" name="source_id" ucd="meta.id">
+<DESCRIPTION>Unique source identifier (unique within a particular Data Release)</DESCRIPTION>
+</FIELD>
+<FIELD datatype="double" name="ra" ref="GAIADR2" ucd="pos.eq.ra;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C1">
+<DESCRIPTION>Right ascension</DESCRIPTION>
+</FIELD>
+<FIELD datatype="double" name="dec" ref="GAIADR2" ucd="pos.eq.dec;meta.main" unit="deg" utype="Char.SpatialAxis.Coverage.Location.Coord.Position2D.Value2.C2">
+<DESCRIPTION>Declination</DESCRIPTION>
+</FIELD>
+<FIELD datatype="float" name="a_g_val" ucd="phys.absorption.gal" unit="mag">
+<DESCRIPTION>line-of-sight extinction in the G band, A_G)</DESCRIPTION>
+</FIELD>
+<FIELD arraysize="*" datatype="char" name="datalink_url" ucd="meta.ref.url" utype="Acess.reference">
+<DESCRIPTION>datalink url</DESCRIPTION>
+</FIELD>
+<FIELD arraysize="*" datatype="char" name="epoch_photometry_url" ucd="meta.ref.url" utype="Acess.reference">
+<DESCRIPTION>epoch photometry url</DESCRIPTION>
+</FIELD>
+<DATA>
+<BINARY2>
+<STREAM encoding='base64'>
+FFLLmBAAGRWAQHAVRQ+m94jARLCaKTcsmH/AAAAAAABNaHR0cDovL2dlYWRhdGEu
+ZXNhYy5lc2EuaW50L2RhdGEtc2VydmVyL2RhdGFsaW5rL2xpbmtzP0lEPTU5NjYw
+MjkzMjU4NzA4OTY1MTIAAAAAFFLLkKkAGZWAQHAT1HglkUvARMFn9Z1IbH/AAAAA
+AABNaHR0cDovL2dlYWRhdGEuZXNhYy5lc2EuaW50L2RhdGEtc2VydmVyL2RhdGFs
+aW5rL2xpbmtzP0lEPTU5NjYwMjExODY5MDc5MDMzNjAAAAAAFFLLjfkAPRcAQHAW
+5p3URUPARKpfojAl2n/AAAAAAABNaHR0cDovL2dlYWRhdGEuZXNhYy5lc2EuaW50
+L2RhdGEtc2VydmVyL2RhdGFsaW5rL2xpbmtzP0lEPTU5NjYwMTgyMzE5NzI3MzA2
+MjQAAAAA
+</STREAM>
+</BINARY2>
+</DATA>
+</TABLE>
+</RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -200,9 +200,6 @@ def test_binary2_masked_strings():
     output = io.BytesIO()
     astropy_table.write(output, format='votable')
 
-    # TODO - Construct test cases for unicodeChar strings and fixed length
-    # strings of both types.
-
 
 class TestVerifyOptions:
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -8,6 +8,8 @@ import os
 import pathlib
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
+from numpy.ma import allequal
 
 from astropy.config import set_temp_config, reload_config
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
@@ -184,6 +186,23 @@ def test_empty_table():
     votable = parse(get_pkg_data_filename('data/empty_table.xml'))
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa
+
+def test_binary2_masked_strings():
+    """
+    Issue #8995
+    """
+    # Read a VOTable which sets the null mask bit for each empty string value.
+    votable = parse(get_pkg_data_filename('data/binary2_masked_strings.xml'))
+    table = votable.get_first_table()
+    astropy_table = table.to_table()
+
+    # Ensure string columns have no masked values and can be written out
+    assert not np.any(table.array.mask['epoch_photometry_url'])
+    output = io.BytesIO()
+    astropy_table.write(output, format='votable')
+
+    # TODO - Construct test cases for unicodeChar strings and fixed length
+    # strings of both types.
 
 
 class TestVerifyOptions:

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -8,8 +8,6 @@ import os
 import pathlib
 import pytest
 import numpy as np
-from numpy.testing import assert_array_equal
-from numpy.ma import allequal
 
 from astropy.config import set_temp_config, reload_config
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
@@ -186,6 +184,7 @@ def test_empty_table():
     votable = parse(get_pkg_data_filename('data/empty_table.xml'))
     table = votable.get_first_table()
     astropy_table = table.to_table()  # noqa
+
 
 def test_binary2_masked_strings():
     """

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2626,6 +2626,12 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
                     mask_bits = careful_read(int((len(fields) + 7) / 8))
                     row_mask_data = list(converters.bitarray_to_bool(
                         mask_bits, len(fields)))
+
+                    # Ignore the mask for string columns (see issue 8995)
+                    for i, f in enumerate(fields):
+                        if f.datatype == 'char' or f.datatype == 'unicodeChar':
+                            row_mask_data[i] = False
+
                 for i, binparse in enumerate(binparsers):
                     try:
                         value, value_mask = binparse(careful_read)

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2629,7 +2629,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
 
                     # Ignore the mask for string columns (see issue 8995)
                     for i, f in enumerate(fields):
-                        if f.datatype == 'char' or f.datatype == 'unicodeChar':
+                        if row_mask_data[i] and (f.datatype == 'char' or f.datatype == 'unicodeChar'):
                             row_mask_data[i] = False
 
                 for i, binparse in enumerate(binparsers):


### PR DESCRIPTION
VOTables with BINARY2 serialization can mark values as null with a bit at the beginning of the data row.  On read, each of these marked values was being stored as a numpy.ma.core.MaskedConstant.  That makes sense for numerical values, but much less so for string values.  Those MaskedConstants for strings then caused problems on writing the table back out.

This fix changes the reader behavior to ignore the BINARY2 null bits for string values.