### PR TITLE
Improve frame docstring and data validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -513,7 +513,11 @@ astropy.coordinates
 
 - Check for NaN values in catalog and match coordinates before building and
   querying the ``KDTree`` for coordinate matching. [#9007]
+
 - Fix sky coordinate matching when a dimensionless distance is provided. [#9008]
+
+- Raise a faster and more meaningful error message when differential data units
+  are not compatible with a containing representation's units. [#9064]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -343,8 +343,8 @@ base_doc = """{__doc__}
         expected keyword arguments for the data passed in. For example, passing
         ``representation_type='cartesian'`` will make the classes expect
         position data with cartesian names, i.e. ``x, y, z`` in most cases
-        unless overriden via ``frame_specific_representation_info``.
-        Check out ``<this frame>().representation_info``.
+        unless overriden via ``frame_specific_representation_info``. To see this
+        frame's names, check out ``<this frame>().representation_info``.
     differential_type : `~astropy.coordinates.BaseDifferential` subclass, str, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets the
@@ -352,8 +352,8 @@ base_doc = """{__doc__}
         arguments of the data passed in. For example, passing
         ``differential_type='cartesian'`` will make the classes expect velocity
         data with the argument names ``v_x, v_y, v_z`` unless overriden via
-        ``frame_specific_representation_info``.
-        Check out ``<this frame>().representation_info``.
+        ``frame_specific_representation_info``. To see this frame's names,
+        check out ``<this frame>().representation_info``.
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -343,8 +343,8 @@ base_doc = """{__doc__}
         expected keyword arguments for the data passed in. For example, passing
         ``representation_type='cartesian'`` will make the classes expect
         position data with cartesian names, i.e. ``x, y, z`` in most cases
-        unless overriden via `frame_specific_representation_info`.
-        Check out `<this frame>().representation_info`.
+        unless overriden via ``frame_specific_representation_info``.
+        Check out ``<this frame>().representation_info``.
     differential_type : `~astropy.coordinates.BaseDifferential` subclass, str, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets the
@@ -352,8 +352,8 @@ base_doc = """{__doc__}
         arguments of the data passed in. For example, passing
         ``differential_type='cartesian'`` will make the classes expect velocity
         data with the argument names ``v_x, v_y, v_z`` unless overriden via
-        `frame_specific_representation_info`.
-        Check out `<this frame>().representation_info`.
+        ``frame_specific_representation_info``.
+        Check out ``<this frame>().representation_info``.
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -572,6 +572,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                              "without positional (representation) data.")
 
         if differential_data:
+            # Check that differential data provided has units compatible
+            # with time-derivative of representation data.
+            # NOTE: there is no dimensionless time while lengths can be
+            # dimensionless (u.dimensionless_unscaled).
+            for comp in representation_data.components:
+                if f'd_{comp}' in differential_data.components:
+                    current_repr_unit = representation_data._units[comp]
+                    current_diff_unit = differential_data._units[f'd_{comp}']
+                    if not current_diff_unit.is_equivalent(current_repr_unit / u.s):
+                        raise ValueError(
+                            "Differential data units are not compatible with"
+                            "time-derivative of representation data units")
             self._data = representation_data.with_differentials(
                 {'s': differential_data})
         else:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -342,14 +342,18 @@ base_doc = """{__doc__}
         sets the expected input representation class, thereby changing the
         expected keyword arguments for the data passed in. For example, passing
         ``representation_type='cartesian'`` will make the classes expect
-        position data with cartesian names, i.e. ``x, y, z`` in most cases.
+        position data with cartesian names, i.e. ``x, y, z`` in most cases
+        unless overriden via `frame_specific_representation_info`.
+        Check out `<this frame>().representation_info`.
     differential_type : `~astropy.coordinates.BaseDifferential` subclass, str, dict, optional
         A differential class or dictionary of differential classes (currently
         only a velocity differential with key 's' is supported). This sets the
         expected input differential class, thereby changing the expected keyword
         arguments of the data passed in. For example, passing
         ``differential_type='cartesian'`` will make the classes expect velocity
-        data with the argument names ``v_x, v_y, v_z``.
+        data with the argument names ``v_x, v_y, v_z`` unless overriden via
+        `frame_specific_representation_info`.
+        Check out `<this frame>().representation_info`.
     copy : bool, optional
         If `True` (default), make copies of the input coordinate arrays.
         Can only be passed in as a keyword argument.

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -307,3 +307,16 @@ def test_negative_distance():
              distance=(-10*u.mas).to(u.pc, u.parallax()))
     assert quantity_allclose(c.ra, RA)
     assert quantity_allclose(c.dec, DEC)
+
+
+def test_velocity_units():
+    """Check that the differential data given has compatible units
+    with the time-derivative of representation data"""
+    with pytest.raises(ValueError) as excinfo:
+        c = ICRS(
+            x=1, y=2, z=3,
+            v_x=1, v_y=2, v_z=3,
+            representation_type=r.CartesianRepresentation,
+            differential_type=r.CartesianDifferential)
+    assert "data units are not compatible with" in str(excinfo.value)
+

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -319,4 +319,3 @@ def test_velocity_units():
             representation_type=r.CartesianRepresentation,
             differential_type=r.CartesianDifferential)
     assert "data units are not compatible with" in str(excinfo.value)
-


### PR DESCRIPTION
This is my attempt to address #7911.

> 1. That the differentials must be at least 1/time and there is no unitless time (although there is unitless length) should be noted somewhere, and the error message printed when they are not can be improved?

The components of differential data is validated to be time-derivative of corresponding component of representation data.

> 2. Current docstring templating gives wrong information about initializing Galactic frame with the cartesian representation.

I think the ideal would be to do a sort of self-reference for the class's empty instance (because you have to do e.g., `Galactic().representation_info` to access the property), but I'm not sure if that is a good idea, so I insert a caveat and next possible course of action.