### PR TITLE
TST: rank removed in Numpy 1.18

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -42,7 +42,7 @@ import numpy as np
 
 from astropy.units.core import (
     UnitsError, UnitTypeError, dimensionless_unscaled)
-from astropy.utils.compat import NUMPY_LT_1_17, NUMPY_LT_1_15
+from astropy.utils.compat import NUMPY_LT_1_17, NUMPY_LT_1_15, NUMPY_LT_1_18
 from astropy.utils import isiterable
 
 
@@ -129,7 +129,7 @@ UNSUPPORTED_FUNCTIONS |= {
 # test_quantity_non_ufuncs.py)
 IGNORED_FUNCTIONS = {
     # Deprecated
-    np.rank, np.asscalar,
+    np.asscalar,
     # I/O - useless for Quantity, since no way to store the unit.
     np.save, np.savez, np.savetxt, np.savez_compressed,
     # Polynomials
@@ -138,6 +138,8 @@ IGNORED_FUNCTIONS = {
     # financial
     np.fv, np.ipmt, np.irr, np.mirr, np.nper, np.npv, np.pmt, np.ppmt,
     np.pv, np.rate}
+if NUMPY_LT_1_18:
+    IGNORED_FUNCTIONS |= {np.rank}
 UNSUPPORTED_FUNCTIONS |= IGNORED_FUNCTIONS
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -11,7 +11,8 @@ from astropy import units as u
 from astropy.units.quantity_helper.function_helpers import (
     ARRAY_FUNCTION_ENABLED, SUBCLASS_SAFE_FUNCTIONS, UNSUPPORTED_FUNCTIONS,
     FUNCTION_HELPERS, DISPATCHED_FUNCTIONS, IGNORED_FUNCTIONS)
-from astropy.utils.compat import NUMPY_LT_1_14, NUMPY_LT_1_15, NUMPY_LT_1_16
+from astropy.utils.compat import (
+    NUMPY_LT_1_14, NUMPY_LT_1_15, NUMPY_LT_1_16, NUMPY_LT_1_18)
 
 
 NO_ARRAY_FUNCTION = not ARRAY_FUNCTION_ENABLED
@@ -1756,8 +1757,10 @@ financial_functions = {f for f in all_wrapped_functions.values()
 untested_functions |= financial_functions
 
 deprecated_functions = {
-    np.asscalar, np.rank
+    np.asscalar
     }
+if NUMPY_LT_1_18:
+    deprecated_functions |= {np.rank}
 untested_functions |= deprecated_functions
 
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,7 +7,7 @@ from astropy.utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
-           'NUMPY_LT_1_15', 'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
+           'NUMPY_LT_1_15', 'NUMPY_LT_1_16', 'NUMPY_LT_1_17', 'NUMPY_LT_1_18']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -18,3 +18,4 @@ NUMPY_LT_1_14_2 = not minversion('numpy', '1.14.2')
 NUMPY_LT_1_15 = not minversion('numpy', '1.15')
 NUMPY_LT_1_16 = not minversion('numpy', '1.16')
 NUMPY_LT_1_17 = not minversion('numpy', '1.17')
+NUMPY_LT_1_18 = not minversion('numpy', '1.18')


### PR DESCRIPTION
Attempt to fix this failure in numpy dev job caused by numpy/numpy#14039
```
AttributeError: module 'numpy' has no attribute 'rank'
```

Example log: https://travis-ci.org/astropy/astropy/jobs/566097785

Note for reviewer: Numpy dev job will still fail due to #8976. I am also not sure what to milestone for Numpy 1.18 support.