### PR TITLE
Limit numpy version in 32bit test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ jobs:
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
       - run:
           name: Install dependencies for Python 3.6
-          command: /opt/python/cp36-cp36m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.17" scipy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.6
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/pip install numpy scipy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp37-cp37m/bin/pip install "numpy<1.17" scipy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"


### PR DESCRIPTION
Temporary workaround for #9059 to remove false positive CI failures for unrelated PRs. 