### PR TITLE
[WIP] Fix the frame conversions involving velocities

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1125,7 +1125,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                             continue
 
                         if new_attr_unit and hasattr(diff, comp):
-                            diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit)
+                            try:
+                                diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit)
+                            except Exception:
+                                diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit / u.m).decompose()
 
                     diff = diff.__class__(copy=False, **diffkwargs)
 

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import ICRS, Galactic, Galactocentric
+from astropy.coordinates.builtin_frames import CIRS, ICRS, Galactic, Galactocentric
 from astropy.coordinates import builtin_frames as bf
 from astropy.coordinates import galactocentric_frame_defaults
 from astropy.units import allclose as quantity_allclose
@@ -320,3 +320,9 @@ def test_velocity_units():
             representation_type=r.CartesianRepresentation,
             differential_type=r.CartesianDifferential)
     assert "data units are not compatible with" in str(excinfo.value)
+
+
+def test_frame_with_velocity_without_distance_can_be_transformed():
+    frame = CIRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
+    rep = frame.transform_to(ICRS)
+    assert "<ICRS Coordinate: (ra, dec, distance) in" in repr(rep)


### PR DESCRIPTION
Partially Fixes #7028 

I open this thread for the discussion a bit earlier because else, I will forget what I have to say xD.

These three lines are the one's creating the issue: 

```
                # If the new differential is known to this frame and has a

                # defined set of names and units, then use that.

                new_attrs = self.representation_info.get(differential_cls)
```
https://github.com/astropy/astropy/blob/master/astropy/coordinates/baseframe.py#L1077-L1079

The predefined units for the radial velocity are `km/s` which turns out to be incorrect when we **don't** pass the distance, as then the differential has the units `1/s` . 

My understanding is that the frame should not have the differential in the radial direction in the first place (When the distance is not passed). 

The `self.data.differentials` for the frame is like this: 

```
{'s': <CartesianDifferential (d_x, d_y, d_z) in 1 / s
     (-4.95270491e-13, 1.85358499e-11, 4.90574248e-12)>}
```

Now that it is that way, we should not at least compare it with hard coded values, which we are doing in: 
https://github.com/astropy/astropy/blob/master/astropy/coordinates/baseframe.py#L1117

For that, after discussion with @Juanlu001 , I have added a try and except block. Open for further discussion