### PR TITLE
Converting remainder of multi-line test match expressions to raw strings

### DIFF
--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -945,9 +945,9 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
                    constant_values=1)
     with pytest.warns(AstropyUserWarning,
                       match=r"nan_treatment='interpolate', however, NaN values detected "
-                      "post convolution. A contiguous region of NaN values, larger "
-                      "than the kernel size, are present in the input array. "
-                      "Increase the kernel size to avoid this."):
+                      r"post convolution. A contiguous region of NaN values, larger "
+                      r"than the kernel size, are present in the input array. "
+                      r"Increase the kernel size to avoid this."):
         result = convolve(image, kernel, boundary=boundary, nan_treatment='interpolate',
                           normalize_kernel=normalize_kernel)
         assert(np.any(np.isnan(result)))

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -69,8 +69,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -94,8 +94,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -119,8 +119,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -166,8 +166,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -215,8 +215,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel,
@@ -260,8 +260,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel,
@@ -294,8 +294,8 @@ class TestConvolve1D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel,
@@ -444,8 +444,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -473,8 +473,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel)
@@ -502,8 +502,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  fill_value=np.nan if normalize_kernel else 0,
@@ -562,8 +562,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  normalize_kernel=normalize_kernel,
@@ -612,8 +612,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary,
                                  nan_treatment=nan_treatment,
                                  fill_value=np.nan if normalize_kernel else 0,
@@ -701,8 +701,8 @@ class TestConvolve2D:
 
         if boundary is None:
             with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              "version of boundary=None is equivalent to the "
-                              "convolve boundary='fill'"):
+                              r"version of boundary=None is equivalent to the "
+                              r"convolve boundary='fill'"):
                 z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
                                  normalize_kernel=False)
         else:
@@ -734,8 +734,8 @@ def test_asymmetric_kernel(boundary):
 
     if boundary is None:
         with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                          "version of boundary=None is equivalent to the "
-                          "convolve boundary='fill'"):
+                          r"version of boundary=None is equivalent to the "
+                          r"convolve boundary='fill'"):
             z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
     else:
         z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)

--- a/astropy/convolution/tests/test_kernel_class.py
+++ b/astropy/convolution/tests/test_kernel_class.py
@@ -179,7 +179,7 @@ class TestKernels:
         test_gauss_3 = Gaussian1DKernel(5)
 
         with pytest.warns(AstropyUserWarning, match=r'Both array and kernel '
-                          'are Kernel instances'):
+                          r'are Kernel instances'):
             gauss_3 = convolve(gauss_1, gauss_2)
 
         assert np.all(np.abs((gauss_3 - test_gauss_3).array) < 0.01)
@@ -193,7 +193,7 @@ class TestKernels:
         test_gauss_3 = Gaussian2DKernel(5)
 
         with pytest.warns(AstropyUserWarning, match=r'Both array and kernel '
-                          'are Kernel instances'):
+                          r'are Kernel instances'):
             gauss_3 = convolve(gauss_1, gauss_2)
 
         assert np.all(np.abs((gauss_3 - test_gauss_3).array) < 0.01)
@@ -326,7 +326,7 @@ class TestKernels:
         custom = CustomKernel(array)
 
         with pytest.warns(AstropyUserWarning, match=r'kernel cannot be '
-                          'normalized because it sums to zero'):
+                          r'normalized because it sums to zero'):
             custom.normalize()
 
         assert custom.truncation == 0.
@@ -342,7 +342,7 @@ class TestKernels:
         custom = CustomKernel(array)
 
         with pytest.warns(AstropyUserWarning, match=r'kernel cannot be '
-                          'normalized because it sums to zero'):
+                          r'normalized because it sums to zero'):
             custom.normalize()
 
         assert custom.truncation == 0.

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -423,7 +423,7 @@ def test_convert_comment_convention(tmpdir):
     """
     filename = os.path.join(DATA, 'stddata.fits')
     with pytest.warns(AstropyUserWarning, match=r'hdu= was not specified but '
-                      'multiple tables are present'):
+                      r'multiple tables are present'):
         t = Table.read(filename)
 
     assert t.meta['comments'] == [

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1050,7 +1050,7 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.data('test0.fits'), memmap=True) as hdulist:
             with patch.object(mmap, 'mmap', side_effect=mmap_patched) as p:
                 with pytest.warns(AstropyUserWarning, match=r"Could not memory "
-                                  "map array with mode='readonly'"):
+                                  r"map array with mode='readonly'"):
                     data = hdulist[1].data
                 p.reset_mock()
             assert not data.flags.writeable

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -249,7 +249,7 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
         assert fitsdiff.main(["-q", self.data_dir, tmp_d]) == 1
         assert fitsdiff.main(["-q", tmp_d, self.data_dir]) == 1
         with pytest.warns(UserWarning, match=r"Field 'ORBPARM' has a repeat "
-                          "count of 0 in its format code"):
+                          r"count of 0 in its format code"):
             assert fitsdiff.main(["-q", self.data_dir, self.data_dir]) == 0
 
         # no match
@@ -260,7 +260,7 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
 
         # globbing
         with pytest.warns(UserWarning, match=r"Field 'ORBPARM' has a repeat "
-                          "count of 0 in its format code"):
+                          r"count of 0 in its format code"):
             assert fitsdiff.main(["-q", self.data_dir+'/*.fits',
                                   self.data_dir]) == 0
         assert fitsdiff.main(["-q", self.data_dir+'/g*.fits', tmp_d]) == 0

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -47,14 +47,14 @@ class TestFitsTime(FitsTestCase):
                                         unit='Mm')
 
         with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
-                          'specified location, but global Time Position is present'):
+                          r'specified location, but global Time Position is present'):
             table, hdr = time_to_fits(t)
         assert (table['OBSGEO-X'] == t['a'].location.x.to_value(unit='m')).all()
         assert (table['OBSGEO-Y'] == t['a'].location.y.to_value(unit='m')).all()
         assert (table['OBSGEO-Z'] == t['a'].location.z.to_value(unit='m')).all()
 
         with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
-                          'specified location, but global Time Position is present'):
+                          r'specified location, but global Time Position is present'):
             t.write(self.temp('time.fits'), format='fits', overwrite=True)
 
         # Check that a blank value for the "TRPOSn" keyword is not generated
@@ -62,8 +62,8 @@ class TestFitsTime(FitsTestCase):
         assert hdr.get('TRPOS2', None) is None
 
         with pytest.warns(AstropyUserWarning, match=r'Time column reference position '
-                          '"TRPOSn" is not specified. The default value for it is '
-                          '"TOPOCENTER", and the observatory position has been specified.'):
+                          r'"TRPOSn" is not specified. The default value for it is '
+                          r'"TOPOCENTER", and the observatory position has been specified.'):
             tm = table_types.read(self.temp('time.fits'), format='fits',
                                   astropy_native=True)
 
@@ -155,7 +155,7 @@ class TestFitsTime(FitsTestCase):
                          'OBSGEO-Z' : t['a'].location.z.value}
 
         with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
-                          'specified location, but global Time Position is present'):
+                          r'specified location, but global Time Position is present'):
             table, hdr = time_to_fits(t)
 
         # Check the global time keywords in hdr
@@ -287,7 +287,7 @@ class TestFitsTime(FitsTestCase):
         """
         filename = self.data('chandra_time.fits')
         with pytest.warns(AstropyUserWarning, match=r'Time column "time" reference '
-                          'position will be ignored'):
+                          r'position will be ignored'):
             tm = table_types.read(filename, astropy_native=True)
 
         # Test case 1

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -957,7 +957,7 @@ class TestHDUListFunctions(FitsTestCase):
         # This should raise an OSError because there is no end card.
         with pytest.raises(OSError):
             with pytest.warns(AstropyUserWarning, match=r'non-ASCII characters '
-                              'are present in the FITS file header'):
+                              r'are present in the FITS file header'):
                 fits.open(filename)
 
     def test_no_resource_warning_raised_on_non_fits_file(self):

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1107,7 +1107,7 @@ class TestImageFunctions(FitsTestCase):
         hdu = fits.PrimaryHDU(data)
         hdu.header['BLANK'] = 'nan'
         with pytest.warns(fits.verify.VerifyWarning, match=r"Invalid value for "
-                          "'BLANK' keyword in header: 'nan'"):
+                          r"'BLANK' keyword in header: 'nan'"):
             hdu.writeto(self.temp('test.fits'))
 
         with catch_warnings() as w:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -2974,7 +2974,7 @@ class TestColumnFunctions(FitsTestCase):
             zwc_pd = pickle.dumps(zwc[2].data)
             zwc_pl = pickle.loads(zwc_pd)
             with pytest.warns(UserWarning, match=r'Field 2 has a repeat count '
-                              'of 0 in its format code'):
+                              r'of 0 in its format code'):
                 assert comparerecords(zwc_pl, zwc[2].data)
 
     def test_column_lookup_by_name(self):


### PR DESCRIPTION
Follow-up to #8997 completing the change of `pytest.raise` and `pytest.warns` `match` arguments to raw in multi-line strings. Should cover every instance of `match=` found in tests.