### PR TITLE
Fix array_shape, pixel_shape, and pixel_bounds when using WCS.sub

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -645,6 +645,8 @@ astropy.wcs
   ``pixel_to_world_values`` when inputs need broadcasting to the same shape.
   (i.e. when one input is sliced out) [#9250]
 
+- Fixed a bug that caused ``WCS.array_shape``, ``WCS.pixel_shape`` and
+  ``WCS.pixel_bounds`` to be incorrect after using ``WCS.sub``. [#9095]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -566,3 +566,44 @@ def test_caching_components_and_classes():
     frame = wcs.world_axis_object_classes['celestial'][2]['frame']
     assert isinstance(frame, FK5)
     assert frame.equinox.jyear == 2010.
+
+
+def test_sub():
+
+    # Regression test for a bug that caused some of the WCS attributes to be
+    # incorrect when using WCS.sub or WCS.celestial (which is an alias for sub
+    # with lon/lat types).
+
+    wcs = WCS_SPECTRAL_CUBE
+    wcs.pixel_shape = (30, 40, 50)
+    wcs.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+
+    wcs_sub1 = wcs.celestial
+
+    assert wcs_sub1.pixel_n_dim == 2
+    assert wcs_sub1.world_n_dim == 2
+    assert wcs_sub1.array_shape == (50, 30)
+    assert wcs_sub1.pixel_shape == (30, 50)
+    assert wcs_sub1.pixel_bounds == [(-1, 11), (5, 15)]
+    assert wcs_sub1.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
+    assert wcs_sub1.world_axis_units == ['deg', 'deg']
+
+    wcs_sub2 = wcs.sub([0, 2, 0])
+
+    assert wcs_sub2.pixel_n_dim == 3
+    assert wcs_sub2.world_n_dim == 3
+    assert wcs_sub2.array_shape == (None, 40, None)
+    assert wcs_sub2.pixel_shape == (None, 40, None)
+    assert wcs_sub2.pixel_bounds == [None, (-2, 18), None]
+    assert wcs_sub2.world_axis_physical_types == [None, 'em.freq', None]
+    assert wcs_sub2.world_axis_units == ['', 'Hz', '']
+
+    wcs_sub3 = wcs.sub(['longitude', 'latitude'])
+
+    assert wcs_sub3.pixel_n_dim == 2
+    assert wcs_sub3.world_n_dim == 2
+    assert wcs_sub3.array_shape == (30, 50)
+    assert wcs_sub3.pixel_shape == (50, 30)
+    assert wcs_sub3.pixel_bounds == [(5, 15), (-1, 11)]
+    assert wcs_sub3.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
+    assert wcs_sub3.world_axis_units == ['deg', 'deg']

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -194,9 +194,9 @@ WCSAXES = 3
 CTYPE1  = GLAT-CAR
 CTYPE2  = FREQ
 CTYPE3  = GLON-CAR
-CNAME1  = Longitude
+CNAME1  = Latitude
 CNAME2  = Frequency
-CNAME3  = Latitude
+CNAME3  = Longitude
 CRVAL1  = 10
 CRVAL2  = 20
 CRVAL3  = 25
@@ -229,7 +229,7 @@ def test_spectral_cube():
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
     assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Longitude', 'Frequency', 'Latitude']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
                                                [False, True, False],
@@ -316,7 +316,7 @@ def test_spectral_cube_nonaligned():
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
     assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Longitude', 'Frequency', 'Latitude']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, True],
                                                [False, True, True],
@@ -589,6 +589,7 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub1.pixel_bounds == [(-1, 11), (5, 15)]
     assert wcs_sub1.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
     assert wcs_sub1.world_axis_units == ['deg', 'deg']
+    assert wcs_sub1.world_axis_names == ['Latitude', 'Longitude']
 
     # Try adding axes
 
@@ -601,6 +602,7 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub2.pixel_bounds == [None, (-2, 18), None]
     assert wcs_sub2.world_axis_physical_types == [None, 'em.freq', None]
     assert wcs_sub2.world_axis_units == ['', 'Hz', '']
+    assert wcs_sub2.world_axis_names == ['', 'Frequency', '']
 
     # Use strings
 
@@ -613,13 +615,13 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub3.pixel_bounds == [(5, 15), (-1, 11)]
     assert wcs_sub3.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
     assert wcs_sub3.world_axis_units == ['deg', 'deg']
+    assert wcs_sub3.world_axis_names == ['Longitude', 'Latitude']
 
-    # Now try with CNAME set (since we use this internally for identifying axes)
+    # Now try without CNAME set
 
-    wcs.wcs.cname = 'Latitude', 'Frequency', 'Longitude'
+    wcs.wcs.cname = [''] * wcs.wcs.naxis
     wcs_sub4 = wcs.sub(['longitude', 'latitude'])
 
-    assert wcs_sub4.world_axis_names == ['Longitude', 'Latitude']
     assert wcs_sub4.pixel_n_dim == 2
     assert wcs_sub4.world_n_dim == 2
     assert wcs_sub4.array_shape == (30, 50)
@@ -627,3 +629,4 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub4.pixel_bounds == [(5, 15), (-1, 11)]
     assert wcs_sub4.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
     assert wcs_sub4.world_axis_units == ['deg', 'deg']
+    assert wcs_sub4.world_axis_names == ['', '']

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -568,7 +568,7 @@ def test_caching_components_and_classes():
     assert frame.equinox.jyear == 2010.
 
 
-def test_sub():
+def test_sub_wcsapi_attributes():
 
     # Regression test for a bug that caused some of the WCS attributes to be
     # incorrect when using WCS.sub or WCS.celestial (which is an alias for sub
@@ -577,6 +577,8 @@ def test_sub():
     wcs = WCS_SPECTRAL_CUBE
     wcs.pixel_shape = (30, 40, 50)
     wcs.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
+
+    # Use celestial shortcut
 
     wcs_sub1 = wcs.celestial
 
@@ -588,6 +590,8 @@ def test_sub():
     assert wcs_sub1.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
     assert wcs_sub1.world_axis_units == ['deg', 'deg']
 
+    # Try adding axes
+
     wcs_sub2 = wcs.sub([0, 2, 0])
 
     assert wcs_sub2.pixel_n_dim == 3
@@ -598,6 +602,8 @@ def test_sub():
     assert wcs_sub2.world_axis_physical_types == [None, 'em.freq', None]
     assert wcs_sub2.world_axis_units == ['', 'Hz', '']
 
+    # Use strings
+
     wcs_sub3 = wcs.sub(['longitude', 'latitude'])
 
     assert wcs_sub3.pixel_n_dim == 2
@@ -607,3 +613,17 @@ def test_sub():
     assert wcs_sub3.pixel_bounds == [(5, 15), (-1, 11)]
     assert wcs_sub3.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
     assert wcs_sub3.world_axis_units == ['deg', 'deg']
+
+    # Now try with CNAME set (since we use this internally for identifying axes)
+
+    wcs.wcs.cname = 'Latitude', 'Frequency', 'Longitude'
+    wcs_sub4 = wcs.sub(['longitude', 'latitude'])
+
+    assert wcs_sub4.world_axis_names == ['Longitude', 'Latitude']
+    assert wcs_sub4.pixel_n_dim == 2
+    assert wcs_sub4.world_n_dim == 2
+    assert wcs_sub4.array_shape == (30, 50)
+    assert wcs_sub4.pixel_shape == (50, 30)
+    assert wcs_sub4.pixel_bounds == [(5, 15), (-1, 11)]
+    assert wcs_sub4.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
+    assert wcs_sub4.world_axis_units == ['deg', 'deg']


### PR DESCRIPTION
Fixes https://github.com/astropy/astropy/issues/9092 - however I'm pretty unhappy with the amount of code I had to add to ``WCS.sub`` - @nden, is there a better way to do this that leverages existing infrastructure? Essentially I'm trying to convert the input to ``WCS.sub`` to a list of integers giving the axes to select.

I've also included a question inline below.