### PR TITLE
Fix backward-compatibility for ax.coords in WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,7 +125,11 @@ astropy.visualization
   plot and format ``Time`` objects in Matplotlib. [#8782]
 
 - Added support for plotting any WCS compliant with the generalized (APE 14)
-  WCS API with WCSAxes. [#8885]
+  WCS API with WCSAxes. [#8885, #9098]
+
+- Improved display of information when inspecting ``WCSAxes.coords``. [#9098]
+
+- Improved error checking for the ``slices=`` argument to ``WCSAxes``. [#9098]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -571,6 +571,9 @@ class CoordinateHelper:
 
     def _update_ticks(self):
 
+        if self.coord_index is None:
+            return
+
         # TODO: this method should be optimized for speed
 
         # Here we determine the location and rotation of all the ticks. For
@@ -809,6 +812,9 @@ class CoordinateHelper:
         # the value in the slice). Here we basically assume that if the WCS
         # had a third axis, it has been abstracted away in the transformation.
 
+        if self.coord_index is None:
+            return
+
         coord_range = self.parent_map.get_coord_range()
 
         tick_world_coordinates, spacing = self.locator(*coord_range[self.coord_index])
@@ -852,6 +858,9 @@ class CoordinateHelper:
             return get_lon_lat_path(xy_world, pixel, xy_world_round)
 
     def _update_grid_contour(self):
+
+        if self.coord_index is None:
+            return
 
         if hasattr(self, '_grid') and self._grid:
             for line in self._grid.collections:

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -52,17 +52,31 @@ class CoordinatesMap:
         self._coords = []
         self._aliases = {}
 
-        for coord_index in range(len(coord_meta['type'])):
+        visible_count = 0
+
+        for index in range(len(coord_meta['type'])):
 
             # Extract coordinate metadata
-            coord_type = coord_meta['type'][coord_index]
-            coord_wrap = coord_meta['wrap'][coord_index]
-            coord_unit = coord_meta['unit'][coord_index]
-            name = coord_meta['name'][coord_index]
+            coord_type = coord_meta['type'][index]
+            coord_wrap = coord_meta['wrap'][index]
+            coord_unit = coord_meta['unit'][index]
+            name = coord_meta['name'][index]
+
+            if 'visible' in coord_meta:
+                visible = coord_meta['visible'][index]
+            else:
+                visible = True
+
             if 'format_unit' in coord_meta:
-                format_unit = coord_meta['format_unit'][coord_index]
+                format_unit = coord_meta['format_unit'][index]
             else:
                 format_unit = None
+
+            if visible:
+                visible_count += 1
+                coord_index = visible_count - 1
+            else:
+                coord_index = None
 
             self._coords.append(CoordinateHelper(parent_axes=axes,
                                                  parent_map=self,
@@ -129,5 +143,5 @@ class CoordinatesMap:
         ymin, ymax = self._axes.get_ylim()
         return find_coordinate_range(self._transform,
                                      [xmin, xmax, ymin, ymax],
-                                     [coord.coord_type for coord in self],
-                                     [coord.coord_unit for coord in self])
+                                     [coord.coord_type for coord in self if coord.coord_index is not None],
+                                     [coord.coord_unit for coord in self if coord.coord_index is not None])

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -169,4 +169,3 @@ class CoordinatesMap:
         s = f'<CoordinatesMap with {len(self._coords)} world coordinates:\n\n'
         table = indent(str(self._as_table()), '  ')
         return s + table + '\n\n>'
-

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -347,7 +347,7 @@ class WCSAxes(Axes):
 
         if self.wcs is not None:
 
-            transform, coord_meta = transform_coord_meta_from_wcs(self.wcs, self.frame_class, slices)
+            transform, coord_meta = transform_coord_meta_from_wcs(self.wcs, self.frame_class, slices=slices)
 
         self.coords = CoordinatesMap(self,
                                      transform=transform,

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -473,10 +473,14 @@ class WCSAxes(Axes):
                 break
 
     def get_xlabel(self):
-        return self.coords[self._x_index].get_axislabel()
+        for coord in self.coords:
+            if 'b' in coord.axislabels.get_visible_axes():
+                return coord.get_axislabel()
 
     def get_ylabel(self):
-        return self.coords[self._y_index].get_axislabel()
+        for coord in self.coords:
+            if 'l' in coord.axislabels.get_visible_axes():
+                return coord.get_axislabel()
 
     def get_coords_overlay(self, frame, coord_meta=None):
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -140,6 +140,9 @@ def test_set_label_properties():
     assert ax.coords[1].axislabels.get_minpad('l') == 3
     assert ax.coords[1].axislabels.get_color() == 'green'
 
+    assert ax.get_xlabel() == 'Test x label'
+    assert ax.get_ylabel() == 'Test y label'
+
 
 GAL_HEADER = fits.Header.fromstring("""
 SIMPLE  =                    T / conforms to FITS standard

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -312,3 +312,20 @@ def test_contour_empty():
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
     ax.contour(np.zeros((4, 4)), transform=ax.get_transform('world'))
+
+
+@ignore_matplotlibrc
+def test_iterate_coords(tmpdir):
+
+    # Regression test for a bug that caused ax.coords to return too few axes
+
+    wcs3d = WCS(naxis=3)
+    wcs3d.wcs.ctype = ['x', 'y', 'z']
+    wcs3d.wcs.cunit = ['deg', 'deg', 'km/s']
+    wcs3d.wcs.crpix = [614.5, 856.5, 333]
+    wcs3d.wcs.cdelt = [6.25, 6.25, 23]
+    wcs3d.wcs.crval = [0., 0., 1.]
+
+    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+
+    x, y, z = ax.coords

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -362,6 +362,7 @@ def test_invalid_slices_errors():
     plt.subplot(1, 1, 1, projection=wcs2d)
     plt.subplot(1, 1, 1, projection=wcs2d, slices=('x', 'y'))
     plt.subplot(1, 1, 1, projection=wcs2d, slices=('y', 'x'))
+    plt.subplot(1, 1, 1, projection=wcs2d, slices=['x', 'y'])
 
     with pytest.raises(ValueError) as exc:
         plt.subplot(1, 1, 1, projection=wcs2d, slices=(1, 'x'))

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -332,3 +332,24 @@ def test_iterate_coords(tmpdir):
     ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
 
     x, y, z = ax.coords
+
+
+@ignore_matplotlibrc
+def test_invalid_slices_errors(tmpdir):
+
+    # Make sure that users get a clear message when specifying a WCS with
+    # >2 dimensions without giving the 'slices' argument, or if the 'slices'
+    # argument has too many/few elements.
+
+    wcs3d = WCS(naxis=3)
+    wcs3d.wcs.ctype = ['x', 'y', 'z']
+
+    with pytest.raises(ValueError) as exc:
+        plt.subplot(1, 1, 1, projection=wcs3d)
+    assert exc.value.args[0] == "WCS has more than 2 pixel dimensions, so 'slices' should be set"
+
+    with pytest.raises(ValueError) as exc:
+        plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1, 2))
+    assert exc.value.args[0] == "'slices' should have as many elements as WCS has pixel dimensions (should be 3)"
+
+    plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -335,7 +335,7 @@ def test_iterate_coords(tmpdir):
 
 
 @ignore_matplotlibrc
-def test_invalid_slices_errors(tmpdir):
+def test_invalid_slices_errors():
 
     # Make sure that users get a clear message when specifying a WCS with
     # >2 dimensions without giving the 'slices' argument, or if the 'slices'
@@ -353,3 +353,47 @@ def test_invalid_slices_errors(tmpdir):
     assert exc.value.args[0] == "'slices' should have as many elements as WCS has pixel dimensions (should be 3)"
 
     plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+
+
+EXPECTED_REPR_1 = """
+<CoordinatesMap with 3 world coordinates:
+
+  index        aliases           type   unit wrap format_unit visible
+  ----- --------------------- --------- ---- ---- ----------- -------
+      0                  dist    scalar      None                  no
+      1 pos.galactic.lon glon longitude  deg  360         deg     yes
+      2 pos.galactic.lat glat  latitude  deg None         deg     yes
+
+>
+ """.strip()
+
+EXPECTED_REPR_2 = """
+<CoordinatesMap with 3 world coordinates:
+
+  index        aliases           type   unit wrap format_unit visible
+  ----- --------------------- --------- ---- ---- ----------- -------
+      0                  dist    scalar      None                 yes
+      1 pos.galactic.lon glon longitude  deg  360         deg     yes
+      2 pos.galactic.lat glat  latitude  deg None         deg     yes
+
+>
+ """.strip()
+
+@ignore_matplotlibrc
+def test_repr():
+
+    # Unit test to make sure __repr__ looks as expected
+
+    wcs3d = WCS(GAL_HEADER)
+
+    # Cube header has world coordinates as distance, lon, lat, so start off
+    # by slicing in a way that we select just lon,lat:
+
+    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=(1, 'x', 'y'))
+    assert repr(ax.coords) == EXPECTED_REPR_1
+
+    # Now slice in a way that all world coordinates are still present:
+
+    ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+    assert repr(ax.coords) == EXPECTED_REPR_2
+

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -344,15 +344,36 @@ def test_invalid_slices_errors():
     wcs3d = WCS(naxis=3)
     wcs3d.wcs.ctype = ['x', 'y', 'z']
 
+    plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+
     with pytest.raises(ValueError) as exc:
         plt.subplot(1, 1, 1, projection=wcs3d)
-    assert exc.value.args[0] == "WCS has more than 2 pixel dimensions, so 'slices' should be set"
+    assert exc.value.args[0] == ("WCS has more than 2 pixel dimensions, so "
+                                 "'slices' should be set")
 
     with pytest.raises(ValueError) as exc:
         plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1, 2))
-    assert exc.value.args[0] == "'slices' should have as many elements as WCS has pixel dimensions (should be 3)"
+    assert exc.value.args[0] == ("'slices' should have as many elements as "
+                                 "WCS has pixel dimensions (should be 3)")
 
-    plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
+    wcs2d = WCS(naxis=2)
+    wcs2d.wcs.ctype = ['x', 'y']
+
+    plt.subplot(1, 1, 1, projection=wcs2d)
+    plt.subplot(1, 1, 1, projection=wcs2d, slices=('x', 'y'))
+    plt.subplot(1, 1, 1, projection=wcs2d, slices=('y', 'x'))
+
+    with pytest.raises(ValueError) as exc:
+        plt.subplot(1, 1, 1, projection=wcs2d, slices=(1, 'x'))
+    assert exc.value.args[0] == ("WCS only has 2 pixel dimensions and cannot "
+                                 "be sliced")
+
+    wcs1d = WCS(naxis=1)
+    wcs1d.wcs.ctype = ['x']
+
+    with pytest.raises(ValueError) as exc:
+        plt.subplot(1, 1, 1, projection=wcs1d)
+    assert exc.value.args[0] == "WCS should have at least 2 pixel dimensions"
 
 
 EXPECTED_REPR_1 = """

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -401,6 +401,7 @@ EXPECTED_REPR_2 = """
 >
  """.strip()
 
+
 @ignore_matplotlibrc
 def test_repr():
 
@@ -418,4 +419,3 @@ def test_repr():
 
     ax = plt.subplot(1, 1, 1, projection=wcs3d, slices=('x', 'y', 1))
     assert repr(ax.coords) == EXPECTED_REPR_2
-

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -100,6 +100,7 @@ def test_coord_type_from_ctype():
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
+    wcs.wcs.set()
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
@@ -112,6 +113,7 @@ def test_coord_type_from_ctype():
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
+    wcs.wcs.set()
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
@@ -124,6 +126,7 @@ def test_coord_type_from_ctype():
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
+    wcs.wcs.set()
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 
@@ -136,6 +139,7 @@ def test_coord_type_from_ctype():
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
+    wcs.wcs.set()
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
 

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -20,7 +20,16 @@ IDENTITY.wcs.crpix = [1., 1.]
 IDENTITY.wcs.cdelt = [1., 1.]
 
 
-def transform_coord_meta_from_wcs(wcs, frame_class, aslice=None):
+def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
+
+    if wcs.pixel_n_dim > 2:
+        if slices is None:
+            raise ValueError("WCS has more than 2 pixel dimensions, so "
+                             "'slices' should be set")
+        elif len(slices) != wcs.pixel_n_dim:
+            raise ValueError("'slices' should have as many elements as WCS "
+                             "has pixel dimensions (should be {})"
+                             .format(wcs.pixel_n_dim))
 
     is_fits_wcs = isinstance(wcs, WCS)
 
@@ -92,12 +101,12 @@ def transform_coord_meta_from_wcs(wcs, frame_class, aslice=None):
     coord_meta['default_ticks_position'] = [''] * wcs.world_n_dim
 
     invert_xy = False
-    if aslice is not None:
-        wcs_slice = list(aslice)
+    if slices is not None:
+        wcs_slice = list(slices)
         wcs_slice[wcs_slice.index("x")] = slice(None)
         wcs_slice[wcs_slice.index("y")] = slice(None)
         wcs = SlicedLowLevelWCS(wcs, wcs_slice[::-1])
-        invert_xy = aslice.index('x') > aslice.index('y')
+        invert_xy = slices.index('x') > slices.index('y')
         world_keep = wcs._world_keep
     else:
         world_keep = list(range(wcs.world_n_dim))

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -22,6 +22,9 @@ IDENTITY.wcs.cdelt = [1., 1.]
 
 def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
 
+    if slices is not None:
+        slices = tuple(slices)
+
     if wcs.pixel_n_dim > 2:
         if slices is None:
             raise ValueError("WCS has more than 2 pixel dimensions, so "

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -30,6 +30,10 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
             raise ValueError("'slices' should have as many elements as WCS "
                              "has pixel dimensions (should be {})"
                              .format(wcs.pixel_n_dim))
+    elif wcs.pixel_n_dim < 2:
+        raise ValueError("WCS should have at least 2 pixel dimensions")
+    elif slices is not None and slices != ('x', 'y') and slices != ('y', 'x'):
+        raise ValueError("WCS only has 2 pixel dimensions and cannot be sliced")
 
     is_fits_wcs = isinstance(wcs, WCS)
 
@@ -136,8 +140,7 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
         # backward-compatibility.
         if len(coord_meta['type']) == 2:
             for i in range(2):
-                if i in world_keep:
-                    coord_meta['default_ticks_position'][world_keep[i]] = 'bltr'
+                coord_meta['default_ticks_position'][world_keep[i]] = 'bltr'
 
     elif frame_class is EllipticalFrame:
 

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -139,11 +139,11 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
                 m[pos[0], :] = 0
 
         # In the special and common case where the frame is rectangular and
-        # we are dealing with 2-d WCS, we show all ticks on all axes for
-        # backward-compatibility.
-        if len(coord_meta['type']) == 2:
-            for i in range(2):
-                coord_meta['default_ticks_position'][world_keep[i]] = 'bltr'
+        # we are dealing with 2-d WCS (after slicing), we show all ticks on
+        # all axes for backward-compatibility.
+        if len(world_keep) == 2:
+            for index in world_keep:
+                coord_meta['default_ticks_position'][index] = 'bltr'
 
     elif frame_class is EllipticalFrame:
 


### PR DESCRIPTION
In https://github.com/astropy/astropy/pull/8885, the behavior of ``ax.coords`` changed from returning all coordinates in the specified WCS to just the coordinates that were remaining after slicing the WCS, so this restores the original behavior.

Coordinates that will never be visible now have ``CoordinateHelper.coord_index`` set to ``None``, and I think I'm ok with breaking that backward-compatibility since I don't think anyone will likely be using that attribute. One open question is whether coordinates that will never be shown (because they are sliced out and uncorrelated) should be distinguishable in some other way from ones that are visible, e.g. by a different class from ``CoordinateHelper``? Maybe it's fine as-is (in the PR)?

This also:

* Fixes a bug introduced in #8885 that caused ``get_xlabel``/``get_ylabel`` to not work
* Implements a nice ``__repr__`` for ``ax.coords``
* Improves the error checking related to the ``slices`` argument and the dimensionality of the WCS

Note that I can't label this **Affects-dev** otherwise the bot complains about the presence of the changelog entries for the things that are new here and not just fixing #8885.

@Cadair - can you check whether this fixes SunPy? This fixes the tests for glue-core.