### PR TITLE
Development guide update on testing warnings

### DIFF
--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -644,8 +644,8 @@ situations, you can use the `astropy.tests.helper.catch_warnings`
 context manager.  Unlike the `warnings.catch_warnings` context manager
 in the standard library, this one will reset all warning state before
 hand so one is assured to get the warnings reported, regardless of
-what errors may have been emitted by other tests previously.  Here is
-a real-world example::
+what errors or warnings may have been emitted by other tests previously.
+Here is a real-world example::
 
   from astropy.tests.helper import catch_warnings
 
@@ -657,14 +657,27 @@ a real-world example::
       assert ("In merged column 'a' the 'units' attribute does not match (cm != m)"
               in str(warning_lines[0].message))
 
+`pytest`_ provides its own context manager
+:ref:`pytest.warns <pytest:warns>` that, completely
+analogously to ``pytest.raises`` (see below) allows to probe explicitly
+for specific warning classes and, through the optional ``match`` argument,
+messages. Note that when no warning of the specified type is
+triggered, this will make the test fail. When checking for optional,
+but not mandatory warnings, Astropy's ``catch_warnings`` is therefore the
+better option, as it will collect any number of warning lines (including
+zero). 
+
 .. note::
 
-   Within `pytest`_ there is also the option of using the ``recwarn``
-   function argument to test that warnings are triggered.  This method has
-   been found to be problematic in at least one case (`pull request 1174
-   <https://github.com/astropy/astropy/pull/1174#issuecomment-20249309>`_)
-   so the `astropy.tests.helper.catch_warnings` context manager is
-   preferred.
+   With `pytest`_ there is also the option of using the
+   :ref:`recwarn <pytest:recwarn>` function argument to test that
+   warnings are triggered within the entire embedding function.
+   This method has been found to be problematic in at least one case
+   (`pull request 1174 <https://github.com/astropy/astropy/pull/1174#issuecomment-20249309>`_)
+   and the alternative of calling ``pytest.warns`` with a warning type
+   argument of ``None`` requires further processing of the recorded
+   warning(s), so the `astropy.tests.helper.catch_warnings` context
+   manager is preferred in such cases.
 
 Testing exceptions
 ==================


### PR DESCRIPTION
This is an attempt to improve the documentation/recommendations on using `catch_warnings` and `pytest.warns` in `testguide.rst` extracted from a largely unrelated other PR.

From the initial [discussion](https://github.com/astropy/astropy/pull/9082#discussion_r310582476):

@taldcroft:
> Personally I would reduce the first paragraph to an additional sentence in the note saying roughly "Do not use pytest.warns, always use the astropy version". Unless there is a really good reason to use the pytest one, it is better to recommend one and only one way that we test warnings.

@dhomeier:
> This emerged indeed as a side product of adding warning checks to the tests here, and reviewing a load of `pytest.warns` tests for #9087 at the same time.
I only at that point noticed that the existing section practically did not cover `pytest.raises` at all, but just compared `astropy.tests.helper.catch_warnings` to the builtin `warnings.catch_warnings`. The case to prefer the former over `pytest.warns` does not seem nearly as clear cut. Anyway

1. There are plenty of existing `pytest.warns` in the tests right now, and generally with a legitimate use case, I'd say.

2. The actual warning about problems with `pytest` only seems to apply to the `recwarn` fixture (and that appears rather anecdotal and dated; from what I could still extract from #1174 the culprit might as well be [pytest.deprecated_call](https://docs.pytest.org/en/latest/warnings.html#ensuring-code-triggers-a-deprecation-warning), or perhaps the combination of both).

> So the best recommendations I could extract from this situation were

1. Use `pytest.warns` wherever you expect one mandatory warning of known type (and possibly message).

2. Use `astropy.tests.helper.catch_warnings` to collect any number of warnings, not necessary exactly known ahead. Always use this over `warnings.catch_warnings`, `pytest.recwarn` or `with pytest.warns(None) as w`.

> I guess this can use a bit more discussion on how to best phrase it, and of course ultimately it's a policy decision what to recommend...