### PR TITLE
Remove pytest runtime dependency from asdf tags for SkyCoord and TimeDelta

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1694,18 +1694,3 @@ class SkyCoord(ShapedLikeNDArray):
             return icrs_sky_coord
         else:
             return icrs_sky_coord.transform_to(frame)
-
-
-def _skycoord_equal(sc1, sc2):
-    """SkyCoord equality useful for testing and ASDF serialization
-    """
-    if not sc1.is_equivalent_frame(sc2):
-        return False
-    if sc1.representation_type is not sc2.representation_type:
-        return False
-    if sc1.shape != sc2.shape:
-        return False  # Maybe raise ValueError corresponding to future numpy behavior
-    eq = np.ones(shape=sc1.shape, dtype=bool)
-    for comp in sc1.data.components:
-        eq &= getattr(sc1.data, comp) == getattr(sc2.data, comp)
-    return np.all(eq)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,7 +23,7 @@ from .representation import (SphericalRepresentation,
 from .sky_coordinate_parsers import (_get_frame_class, _get_frame_without_data,
                                      _parse_coordinate_data)
 
-__all__ = ['SkyCoord', 'SkyCoordInfo']
+__all__ = ['SkyCoord', 'SkyCoordInfo', 'skycoord_equal']
 
 
 class SkyCoordInfo(MixinInfo):
@@ -1694,3 +1694,16 @@ class SkyCoord(ShapedLikeNDArray):
             return icrs_sky_coord
         else:
             return icrs_sky_coord.transform_to(frame)
+
+
+def skycoord_equal(sc1, sc2):
+    if not sc1.is_equivalent_frame(sc2):
+        return False
+    if sc1.representation_type is not sc2.representation_type:
+        return False
+    if sc1.shape != sc2.shape:
+        return False  # Maybe raise ValueError corresponding to future numpy behavior
+    eq = np.ones(shape=sc1.shape, dtype=bool)
+    for comp in sc1.data.components:
+        eq &= getattr(sc1.data, comp) == getattr(sc2.data, comp)
+    return np.all(eq)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -23,7 +23,7 @@ from .representation import (SphericalRepresentation,
 from .sky_coordinate_parsers import (_get_frame_class, _get_frame_without_data,
                                      _parse_coordinate_data)
 
-__all__ = ['SkyCoord', 'SkyCoordInfo', 'skycoord_equal']
+__all__ = ['SkyCoord', 'SkyCoordInfo']
 
 
 class SkyCoordInfo(MixinInfo):
@@ -1696,7 +1696,9 @@ class SkyCoord(ShapedLikeNDArray):
             return icrs_sky_coord.transform_to(frame)
 
 
-def skycoord_equal(sc1, sc2):
+def _skycoord_equal(sc1, sc2):
+    """SkyCoord equality useful for testing and ASDF serialization
+    """
     if not sc1.is_equivalent_frame(sc2):
         return False
     if sc1.representation_type is not sc2.representation_type:

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -3,7 +3,8 @@
 
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
-from astropy.coordinates import SkyCoord, skycoord_equal
+from astropy.coordinates import SkyCoord
+from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
 
 from ...types import AstropyType
 

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -4,7 +4,7 @@
 from asdf.yamlutil import custom_tree_to_tagged_tree
 
 from astropy.coordinates import SkyCoord
-from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
+from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
 from ...types import AstropyType
 

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -1,12 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-import numpy as np
+from asdf.yamlutil import custom_tree_to_tagged_tree
 
-from asdf.yamlutil import custom_tree_to_tagged_tree, tagged_tree_to_custom_tree
-
-from astropy.coordinates import SkyCoord
-from astropy.table.tests.test_operations import skycoord_equal
+from astropy.coordinates import SkyCoord, skycoord_equal
 
 from ...types import AstropyType
 

--- a/astropy/io/misc/asdf/tags/helpers.py
+++ b/astropy/io/misc/asdf/tags/helpers.py
@@ -1,0 +1,22 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+import numpy as np
+
+
+__all__ = []
+
+
+def skycoord_equal(sc1, sc2):
+    """SkyCoord equality useful for testing and ASDF serialization
+    """
+    if not sc1.is_equivalent_frame(sc2):
+        return False
+    if sc1.representation_type is not sc2.representation_type:
+        return False
+    if sc1.shape != sc2.shape:
+        return False  # Maybe raise ValueError corresponding to future numpy behavior
+    eq = np.ones(shape=sc1.shape, dtype=bool)
+    for comp in sc1.data.components:
+        eq &= getattr(sc1.data, comp) == getattr(sc2.data, comp)
+    return np.all(eq)

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -7,7 +7,8 @@ import numpy as np
 import astropy.units as u
 from astropy import table
 from astropy.time import Time, TimeDelta
-from astropy.coordinates import SkyCoord, EarthLocation, skycoord_equal
+from astropy.coordinates import SkyCoord, EarthLocation
+from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
 
 from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -8,7 +8,7 @@ import astropy.units as u
 from astropy import table
 from astropy.time import Time, TimeDelta
 from astropy.coordinates import SkyCoord, EarthLocation
-from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
+from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
 from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)

--- a/astropy/io/misc/asdf/tags/table/tests/test_table.py
+++ b/astropy/io/misc/asdf/tags/table/tests/test_table.py
@@ -7,8 +7,7 @@ import numpy as np
 import astropy.units as u
 from astropy import table
 from astropy.time import Time, TimeDelta
-from astropy.coordinates import SkyCoord, EarthLocation
-from astropy.table.tests.test_operations import skycoord_equal
+from astropy.coordinates import SkyCoord, EarthLocation, skycoord_equal
 
 from astropy import __minimum_asdf_version__
 asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)

--- a/astropy/io/misc/asdf/tags/time/timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/timedelta.py
@@ -1,17 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
+import functools
 
 from asdf.yamlutil import custom_tree_to_tagged_tree
+import numpy as np
 
 from astropy.time import TimeDelta
-from astropy.time.tests.test_delta import (allclose_jd, allclose_jd2,
-                                           allclose_sec)
 
 from ...types import AstropyType
 
-
 __all__ = ['TimeDeltaType']
+
+allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
+allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52)  # 20 ps atol
+allclose_sec = functools.partial(np.allclose, rtol=2. ** -52,
+                                 atol=2. ** -52 * 24 * 3600)  # 20 ps atol
 
 
 class TimeDeltaType(AstropyType):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -14,7 +14,8 @@ from astropy.utils import metadata
 from astropy.utils.metadata import MergeConflictError
 from astropy import table
 from astropy.time import Time
-from astropy.coordinates import SkyCoord, skycoord_equal
+from astropy.coordinates import SkyCoord
+from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
 
 
 def sort_eq(list1, list2):

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -14,24 +14,11 @@ from astropy.utils import metadata
 from astropy.utils.metadata import MergeConflictError
 from astropy import table
 from astropy.time import Time
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import SkyCoord, skycoord_equal
 
 
 def sort_eq(list1, list2):
     return sorted(list1) == sorted(list2)
-
-
-def skycoord_equal(sc1, sc2):
-    if not sc1.is_equivalent_frame(sc2):
-        return False
-    if sc1.representation_type is not sc2.representation_type:
-        return False
-    if sc1.shape != sc2.shape:
-        return False  # Maybe raise ValueError corresponding to future numpy behavior
-    eq = np.ones(shape=sc1.shape, dtype=bool)
-    for comp in sc1.data.components:
-        eq &= getattr(sc1.data, comp) == getattr(sc2.data, comp)
-    return np.all(eq)
 
 
 class TestJoin():

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 from collections import OrderedDict
 
 import pytest
@@ -15,7 +14,7 @@ from astropy.utils.metadata import MergeConflictError
 from astropy import table
 from astropy.time import Time
 from astropy.coordinates import SkyCoord
-from astropy.coordinates.sky_coordinate import _skycoord_equal as skycoord_equal
+from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
 
 def sort_eq(list1, list2):


### PR DESCRIPTION
- Move `skycoord_equal()` function from

   `astropy.table.tests.test_operations` to `astropy.coordinates.sky_coordinate`

   Update imports.
- Define the set of functions `allclose_jd()`, `allclose_jd2()`, `allclose_sec()` for the `TimeDeltaType` that are defined several times elsewhere in test modules with subtle variations depending on use.

   These convenience functions should probably be centralized at some future point, but someone will have to look at the different `atol` and `rtol` settings and make some decisions. Not for this PR.

Resolves #9099.

Close #9100 