### PR TITLE
TableReplaceWarning message

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1869,7 +1869,7 @@ class Table:
                 if isinstance(old_col.base, old_col.__class__):
                     msg = ("replaced column '{}' which looks like an array slice. "
                            "The new column no longer shares memory with the "
-                           "original array.".format(name))
+                           "original array. Try using t[colname][:] = value instead".format(name))
                     warnings.warn(msg, TableReplaceWarning, stacklevel=3)
             except AttributeError:
                 pass

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -233,7 +233,7 @@ object with float values by internally calling
 ``t.replace_column('a', [10.5, 20.5, 30.5])``.  In general this behavior
 is more consistent with Python and Pandas behavior, but there is potential
 for somewhat subtle bugs in code that was written that expects the pre-1.3
-in-place behavior.
+in-place behavior. Therefore, a ``TableReplaceWarning`` will appear.
 
 **Examples**
 ::


### PR DESCRIPTION
Added a sentence in documentation to mention the warning that appears with the new
  ``Table.replace_column()`` implementation and added a sentence how to replace columns
  properly in the ``TableReplaceWarning`` message. (This is with reference to https://github.com/astropy/astropy/issues/9103)