### PR TITLE
ASDF support for orthogonal polynomials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,10 +45,8 @@ astropy.io.misc
 
 - Eliminate deprecated compatibility mode when writing ``Table`` metadata to HDF5 format. [#8899]
 
-- Add support for orthogonal polynomial models to ASDF [requires
-  asdf-standard PR #204]
+- Add support for orthogonal polynomial models to ASDF. [#9107]
 
-- Add support for orthogonal polynomial models to ASDF [#9107]
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -380,7 +378,7 @@ astropy.table
 
 - Fix bug where adding a column consisting of a list of masked arrays was
   dropping the masks. [#9048]
-  
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ astropy.io.misc
 
 - Eliminate deprecated compatibility mode when writing ``Table`` metadata to HDF5 format. [#8899]
 
+- Add support for orthogonal polynomial models to ASDF [requires
+  asdf-standard PR #204]
+
+- Add support for orthogonal polynomial models to ASDF [#9107]
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -376,7 +380,7 @@ astropy.table
 
 - Fix bug where adding a column consisting of a list of masked arrays was
   dropping the masks. [#9048]
-
+  
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -15,8 +15,14 @@ from astropy.modeling import models as astmodels
 
 test_models = [
     astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
-    astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
+    astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3),
+    astmodels.Shift(2.),
     astmodels.Hermite1D(2, c0=2, c1=3, c2=0.5),
+    astmodels.Legendre1D(2, c0=2, c1=3, c2=0.5),
+    astmodels.Chebyshev1D(2, c0=2, c1=3, c2=0.5),
+    astmodels.Chebyshev2D(1, 1, c0_0=1, c0_1=2, c1_0=3),
+    astmodels.Legendre2D(1, 1, c0_0=1, c0_1=2, c1_0=3),
+    astmodels.Hermite2D(1, 1, c0_0=1, c0_1=2, c1_0=3),
     astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
     astmodels.Multiply(3), astmodels.Multiply(10*u.m),
     astmodels.RotateCelestial2Native(5.63, -72.5, 180),

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -16,6 +16,7 @@ from astropy.modeling import models as astmodels
 test_models = [
     astmodels.Identity(2), astmodels.Polynomial1D(2, c0=1, c1=2, c2=3),
     astmodels.Polynomial2D(1, c0_0=1, c0_1=2, c1_0=3), astmodels.Shift(2.),
+    astmodels.Hermite1D(2, c0=2, c1=3, c2=0.5),
     astmodels.Scale(3.4), astmodels.RotateNative2Celestial(5.63, -72.5, 180),
     astmodels.Multiply(3), astmodels.Multiply(10*u.m),
     astmodels.RotateCelestial2Native(5.63, -72.5, 180),


### PR DESCRIPTION
This adds support for serializing orthogonal polynomials to ASDF. It requires that asdf-standard be updated to use asdf-standard PR spacetelescope/asdf-standard#204 that adds a schema that supports orthogonal polynomials. Tests cannot pass until that change is part of the dependencies.

EDIT: Fixed PR link