### PR TITLE
Raise NotImplementedError in inverse

### DIFF
--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -251,7 +251,7 @@ class _Tabular(Model):
                 lookup_table = self.points[0][::-1]
             else:
                 # equal-valued or double-valued lookup_table
-                raise ValueError("The points in lookup_table must be strictly ascending")
+                raise NotImplementedError
             return Tabular1D(points=points, lookup_table=lookup_table)
         else:
             raise NotImplementedError("An analytical inverse transform "

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -724,7 +724,7 @@ def test_tabular1d_inverse():
     points = np.arange(5)
     values = np.array([1.5, 3.4, 3.4, 32, 25])
     t = models.Tabular1D(points, values)
-    with pytest.raises(ValueError):
+    with pytest.raises(NotImplementedError):
         t.inverse((3.4, 7.))
 
     # Check that Tabular2D.inverse raises an error


### PR DESCRIPTION
Modeling expects a `NotImplementedError` to be raised when an analytical inverse is not available. This tells the `CompoundModel` constructor not to attempt to create an analytical inverse for a compound model. The recently added `Tabular1D.inverse` raises a `ValueError` which breaks the model composition in some cases. Fixed here.