### PR TITLE
TST: Downgrade Travis Python 3.7 to 3.7.3 instead of 3.7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,7 +119,7 @@ matrix:
 
         - os: linux
           stage: Initial tests
-          env: PYTHON_VERSION=3.7 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+          env: PYTHON_VERSION=3.7.3 CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES="scikit-image $ASDF_PIP_DEP"
                SETUP_CMD='test -a "--durations=50"'
           compiler: clang
@@ -137,7 +137,7 @@ matrix:
         # Try on Windows
         - os: windows
           stage: Final tests
-          env: PYTHON_VERSION=3.7 SETUP_CMD='test --readonly'
+          env: PYTHON_VERSION=3.7.3 SETUP_CMD='test --readonly'
                CONDA_DEPENDENCIES=""
                PIP_DEPENDENCIES="Cython scipy h5py beautifulsoup4 html5lib jinja2 pyyaml matplotlib scikit-image pytz pandas objgraph asdf"
 
@@ -152,7 +152,7 @@ matrix:
         # mark as an allowed failure below.
         - os: linux
           stage: Final tests
-          env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+          env: PYTHON_VERSION=3.7.3 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=''
                PIP_DEPENDENCIES=$DEV_PIP_DEP
                MATPLOTLIB_VERSION=dev
@@ -181,7 +181,7 @@ matrix:
     allow_failures:
       - os: linux
         stage: Final tests
-        env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
+        env: PYTHON_VERSION=3.7.3 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=''
              PIP_DEPENDENCIES=$DEV_PIP_DEP
              MATPLOTLIB_VERSION=dev


### PR DESCRIPTION
Attempt to fix #9113 .

Looking at the failed test log and comparing it to the last successful one, the failed one had error installing `lz4` (apparently a dependency of `asdf`). The error looks like this:
```
AssertionError: ('cp37', 'cp@pyvernodots@m', 'linux_x86_64') !=
                ('cp37', 'cp@PYVERNODOTS@m', 'linux_x86_64')
```
That message brought me to https://askubuntu.com/questions/1164703/installing-openexr-for-python-causes-setuptools-to-fail-with-an-assertion-error , which suggested that `conda` and Python 3.7.4 do not play well together.

Looking at our logs again, indeed the failing one used Python 3.7.4, while the successful one used 3.7.3. Therefore, I am pinning Python 3.7 to 3.7.3 for now.

If this works and is merged, a follow-up issue needs to be opened to unpin it when Python 3.7.5 is released into `conda`.