### PR TITLE
MNT: Deprecate np.alen in quantity helper

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -67,7 +67,7 @@ UNSUPPORTED_FUNCTIONS = set()
 """Functions that cannot sensibly be used with quantities."""
 
 SUBCLASS_SAFE_FUNCTIONS |= {
-    np.alen, np.shape, np.size, np.ndim,
+    np.shape, np.size, np.ndim,
     np.reshape, np.ravel, np.moveaxis, np.rollaxis, np.swapaxes,
     np.transpose, np.atleast_1d, np.atleast_2d, np.atleast_3d,
     np.expand_dims, np.squeeze, np.broadcast_to, np.broadcast_arrays,
@@ -99,7 +99,8 @@ SUBCLASS_SAFE_FUNCTIONS |= {
 
 if not NUMPY_LT_1_15:
     SUBCLASS_SAFE_FUNCTIONS |= {np.take_along_axis, np.put_along_axis}
-
+if NUMPY_LT_1_18:
+    SUBCLASS_SAFE_FUNCTIONS |= {np.alen}
 
 # Implemented as methods on Quantity:
 # np.ediff1d is from setops, but we support it anyway; the others

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -140,6 +140,8 @@ IGNORED_FUNCTIONS = {
     np.pv, np.rate}
 if NUMPY_LT_1_18:
     IGNORED_FUNCTIONS |= {np.rank}
+else:
+    IGNORED_FUNCTIONS |= {np.alen}
 UNSUPPORTED_FUNCTIONS |= IGNORED_FUNCTIONS
 
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -72,6 +72,7 @@ class NoUnitTestSetup(BasicTestSetup):
 
 
 class TestShapeInformation(BasicTestSetup):
+    @pytest.mark.skipif(not NUMPY_LT_1_18, reason='alen is deprecated')
     def test_alen(self):
         assert np.alen(self.q) == 3
 

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -72,9 +72,10 @@ class NoUnitTestSetup(BasicTestSetup):
 
 
 class TestShapeInformation(BasicTestSetup):
-    @pytest.mark.skipif(not NUMPY_LT_1_18, reason='alen is deprecated')
-    def test_alen(self):
-        assert np.alen(self.q) == 3
+    # alen is deprecated in Numpy 1.8
+    if NUMPY_LT_1_18:
+        def test_alen(self):
+            assert np.alen(self.q) == 3
 
     def test_shape(self):
         assert np.shape(self.q) == (3, 3)

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1763,8 +1763,10 @@ deprecated_functions = {
     }
 if NUMPY_LT_1_18:
     deprecated_functions |= {np.rank}
-untested_functions |= deprecated_functions
+else:
+    deprecated_functions |= {np.alen}
 
+untested_functions |= deprecated_functions
 io_functions = {np.save, np.savez, np.savetxt, np.savez_compressed}
 untested_functions |= io_functions
 


### PR DESCRIPTION
Thanks for the suggestion, @mhvk! Fix #9106 

I think Numpy dropped PY2 support, so no need to backport all the way back to 2.x? Please remilestone if I am mistaken.

**Note to reviewer:** Inspect the numpy-dev job carefully. It is allowed to fail.