### PR TITLE
Allow for equal sized arrays to be added in nddata.utils.add_array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -460,6 +460,10 @@ bounding box. [#8799]
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Fix to ``add_array``, which now accepts ``array_small`` having dimensions
+  equal to ``array_large``, instead of only allowing smaller sizes of
+  arrays. [#9118]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -314,6 +314,21 @@ def test_add_array_even_shape():
     assert np.all(added_array == large_test_array_ref)
 
 
+def test_add_array_equal_shape():
+    """
+    Test add_array_2D utility function.
+
+    Test by adding an array of ones out of an array of zeros.
+    """
+    large_test_array = np.zeros((11, 11))
+    small_test_array = np.ones((11, 11))
+    large_test_array_ref = large_test_array.copy()
+    large_test_array_ref += small_test_array
+
+    added_array = add_array(large_test_array, small_test_array, (5, 5))
+    assert np.all(added_array == large_test_array_ref)
+
+
 @pytest.mark.parametrize(('position', 'subpixel_index'),
                          zip(test_positions, test_position_indices))
 def test_subpixel_indices(position, subpixel_index):

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -236,7 +236,8 @@ def add_array(array_large, array_small, position):
     array_large : `~numpy.ndarray`
         Large array.
     array_small : `~numpy.ndarray`
-        Small array to add.
+        Small array to add. Can be equal to ``array_large`` in size in a given
+        dimension, but not larger.
     position : tuple
         Position of the small array's center, with respect to the large array.
         Coordinates should be in the same order as the array shape.

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -267,8 +267,8 @@ def add_array(array_large, array_small, position):
            [0., 0., 0., 0., 0.],
            [0., 0., 0., 0., 0.]])
     """
-    # Check if large array is really larger
-    if all(large_shape > small_shape for (large_shape, small_shape)
+    # Check if large array is not smaller
+    if all(large_shape >= small_shape for (large_shape, small_shape)
            in zip(array_large.shape, array_small.shape)):
         large_slices, small_slices = overlap_slices(array_large.shape,
                                                     array_small.shape,


### PR DESCRIPTION
This pull request makes a very minor change to `add_array` in `nddata.utils`, allowing for the possibility of `array_small` and `array_large` to be the same size. Instead of explicitly needing the larger array to be larger, now the smaller array cannot be smaller.

I am unsure of the reasoning behind `>` versus `>=` previously, but cannot see any reason why this logical flip is not allowed; please let me know if there is some reason `array_large` must always be larger than `array_small`.

This PR fixes astropy/photutils#818.

I don't think I am able to add labels, but I thought this change might be minor enough to get away with a `no-changelog-entry-needed` flag -- again, please let me know if it needs a changelog entry (and if I should add another commit to add one myself).