### PR TITLE
DOC: Promote developer-docs header to chapter and TOC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -122,9 +122,9 @@ Nuts and bolts
 
 .. _developer-docs:
 
-=======================
+***********************
 Developer Documentation
-=======================
+***********************
 
 The developer documentation contains instructions for how to contribute to
 Astropy or affiliated packages, as well as coding, documentation, and


### PR DESCRIPTION
Fixes #9112 by putting the "Developer Documentation" in `index.rst` to the same level as "User Documentation", "Project details" etc.

Note: the original markup was probably intended to put this at an intermediate level (`section`) between "User Documentation" (`chapter`) and its subdivisions; however as Sphinx assigns the levels in the order they are encountered, there is no way I could make out to have it recognise a structure like
```
Astropy Documentation 
                      \ -> User Documentation
                                              \
                                               \ -> Data structures ...
                                              \
                                               \ -> Files, I/O ...
                      \
                       \ -> Developer Documentation
```
