### PR TITLE
Decorator `quantity_input` was not working as intended in annotation style

### DIFF
--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -7,7 +7,7 @@ import inspect
 from astropy.utils.decorators import wraps
 from astropy.utils.misc import isiterable
 
-from .core import Unit, UnitsError, add_enabled_equivalencies
+from .core import Unit, UnitBase, UnitsError, add_enabled_equivalencies
 from .physical import _unit_physical_mapping
 
 
@@ -222,7 +222,7 @@ class QuantityInput:
                 #    are not strings or subclasses of Unit. This is to allow
                 #    non unit related annotations to pass through
                 if is_annotation:
-                    valid_targets = [t for t in valid_targets if isinstance(t, (str, Unit))]
+                    valid_targets = [t for t in valid_targets if isinstance(t, (str, UnitBase))]
 
                 # Now we loop over the allowed units/physical types and validate
                 #   the value of the argument:


### PR DESCRIPTION
PR #8984 introduced a bug where the annotation style for the decorator `quantity_input` was not working as intended.  The PR intended to retain all targets that were units or strings, but it used `is_instance(Unit)` instead of `is_instance(UnitBase)`, so it threw out valid units that don't derive from `Unit` (e.g., `IrreducibleUnit` and `CompositeUnit`).  The result was that `quantity_input` stopped doing its job for a whole bunch of target units.

We found this in SunPy testing, but it was missed in Astropy testing because there were tests for mismatched units only for decorator kwarg style, and not for annotation style.

Ping @Cadair 