### PR TITLE
Generate new model from existing model by fixing the value of some input variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,7 +71,12 @@ astropy.modeling
 - Add ``Tabular1D.inverse`` [#9083]
 - Significant reorganization of the documentation. [#9078, #9171]
 
-- ``Model.rename`` was changed to add the ability to rename ``Model.inputs`` and ``Model.outputs``. [#9220]
+- ``Model.rename`` was changed to add the ability to rename ``Model.inputs``
+  and ``Model.outputs``. [#9220]
+
+- New function ``fix_inputs`` to generate new models from others by fixing
+  specific inputs variable values to constants. [#9135]
+
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -11,6 +11,7 @@ from asdf import util
 from asdf.tests import helpers
 
 import astropy.units as u
+from astropy.modeling.core import fix_inputs
 from astropy.modeling import models as astmodels
 
 test_models = [
@@ -165,3 +166,27 @@ def test_tabular_model_units(tmpdir):
                                  method='nearest')
     tree = {'model': model2}
     helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_fix_inputs(tmpdir):
+    model = astmodels.Pix2Sky_TAN() | astmodels.Rotation2D()
+    tree = {
+        'compound': fix_inputs(model, {'x': 45}),
+        'compound1': fix_inputs(model, {0: 45})
+    }
+
+    helpers.assert_roundtrip_tree(tree, tmpdir)
+
+
+def test_fix_inputs_type():
+    with pytest.raises(TypeError):
+        tree = {
+        'compound': fix_inputs(3, {'x': 45})
+        }
+        helpers.assert_roundtrip_tree(tree, tmpdir)
+
+    with pytest.raises(AttributeError):
+        tree = {
+        'compound': astmodels.Pix2Sky_TAN() & {'x': 45}
+        }
+        helpers.assert_roundtrip_tree(tree, tmpdir)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2309,7 +2309,6 @@ class CompoundModel(Model):
         self._bounding_box = None
         self._user_bounding_box = None
         self._leaflist = None
-        self._fix_input_hook = None
         self._opset = None
         self._tdict = None
         self._parameters = None
@@ -2423,9 +2422,6 @@ class CompoundModel(Model):
                 self._fix_input_bounding_box(input_ind)
             except NotImplementedError:
                 pass
-            # Call the hook if it exists
-            if self._fix_input_hook is not None:
-                self._fix_input_hook(input_ind)
 
         else:
             raise ModelDefinitionError('Illegal operator: ', self.op)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3306,7 +3306,9 @@ class CompoundModel(Model):
         bounding_box = list(self.left.bounding_box)
         for ind in input_ind:
             del bounding_box[ind]
-        self.bounding_box = tuple(bounding_box)
+        if self.n_inputs == 1:
+            bounding_box = bounding_box[0]
+        self.bounding_box = bounding_box
 
     @property
     def has_user_bounding_box(self):

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -5,7 +5,7 @@ Creates a common namespace for all pre-defined models.
 """
 
 
-from .core import custom_model, hide_inverse  # pylint: disable=W0611
+from .core import custom_model, hide_inverse, fix_inputs # pylint: disable=W0611
 from .mappings import *
 from .projections import *
 from .rotations import *

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -349,11 +349,19 @@ def test_fix_inputs_with_bounding_box():
     g1 = Gaussian2D(1, 0, 0, 1, 1)
     g2 = Gaussian2D(1, 0, 0, 1, 1)
     assert g1.bounding_box == ((-5.5,5.5), (-5.5,5.5))
+
     gg1 = g1 & g2
     gg1.bounding_box = ((-5.5,5.5), (-5.4,5.4), (-5.3,5.3), (-5.2,5.2))
     assert gg1.bounding_box == ((-5.5,5.5), (-5.4,5.4), (-5.3,5.3), (-5.2,5.2))
+
     sg = fix_inputs(gg1, {0: 0, 2: 0})
     assert sg.bounding_box == ((-5.4,5.4), (-5.2,5.2))
+
+    g1 = Gaussian1D(10, 3, 1)
+    g = g1 & g1
+    g.bounding_box = ((1, 4), (6, 8))
+    gf = fix_inputs(g, {0: 1})
+    assert gf.bounding_box == (6, 8)
 
 
 def test_indexing_on_instance():

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -244,3 +244,8 @@ def test_model_set_axis_outputs():
     assert_allclose(y0[:, 1], y1[1])
     with pytest.raises(ValueError):
         model_set(x)
+
+
+def test_compound_model_sets():
+    with pytest.raises(ValueError):
+        Polynomial1D(1, n_models=2, model_set_axis=1) | Polynomial1D(1, n_models=2, model_set_axis=0)

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -1369,3 +1369,34 @@ This opens up the possibility of essentially arbitrarily complex transformation
 graphs.  Currently the tools do not exist to make it easy to navigate and
 reason about highly complex compound models that use these mappings, but that
 is a possible enhancement for future versions.
+
+
+Model Reduction
+---------------
+
+In order to save much duplication in the construction of complex models, it is
+possible to define one complex model that covers all cases where the
+variables that distinguish the models are made part of the model's input
+variables. The ``fix_inputs`` function allows defining models derived from
+the more complex one by setting one or more of the inputs to a constant
+value. Examples of this sort of situation arise when working out
+the transformations from detector pixel to RA, Dec, and lambda for
+spectrographs when the slit locations may be moved (e.g., fiber fed or
+commandable slit masks), or different orders may be selected (e.g., Eschelle).
+In the case of order, one may have a function of pixel ``x``, ``y``, ``spectral_order``
+that map into ``RA``, ``Dec`` and ``lambda``. Without specifying ``spectral_order``, it is
+ambiguious what ``RA``, ``Dec`` and ``Lambda`` corresponds to a pixel location. It
+is usually possible to define a function of all three inputs. Presuming
+this model is ``general_transform`` then ``fix_inputs`` may be used to define
+the transform for a specific order as follows:
+
+::
+     >>> order1_transform = fix_inputs(general_transform, {'order': 1})  # doctest: +SKIP
+
+creates a new compound model that takes only pixel position and generates
+``RA``, ``Dec``, and ``lambda``. The ``fix_inputs`` function can be used to set input
+values by position (0 is the first) or by input variable name, and more
+than one can be set in the dictionary supplied.
+
+If the input model has a bounding_box, the generated model will have the
+bounding for the input coordinate removed.


### PR DESCRIPTION
This PR provides a special operator for compound models that takes an existing model (presumably with at least 2 inputs and assigns supplied constant values for the specified inputs and generates a compound model that provides those values to the wrapped model (in this respect it behaves like functools.partial. The specification of the input values is done by a dict where the input is specified by order (i.e., an int) or by a the name of the input (string). The following illustrates its use:

```
>>> from astropy.modeling.models import fix_inputs, Gaussian2D
>>> g2d = Gaussian2D(1,2,3,4,5)
>>> g1d = fix_inputs(g2d, {'y': 0.75}

```
In this case `g1d(0)` gives the same value as `g2d(0, 0.75)`

This functionality defining a more general model where effectively some of the inputs are parameters, and from which more specific models may be defined by supplying specific value for the parameter used as an input. If the underlying model has a bounding box, then the corresponding input is removed from the bounding box in the new model. Provision is given for supplying a function that generates a bounding box as a function of the fixed value. 

EDIT: The asdf schema is implemented in spacetelescope/asdf-standard#207