### PR TITLE
DOC: Add modeling ref tags back

### DIFF
--- a/docs/modeling/basic-fitting.rst
+++ b/docs/modeling/basic-fitting.rst
@@ -3,6 +3,8 @@
 Basic Fitting
 =============
 
+.. _modeling-getting-started-1d-fitting:
+
 Simple 1-D model fitting
 ------------------------
 

--- a/docs/modeling/changes_for_4.rst
+++ b/docs/modeling/changes_for_4.rst
@@ -1,14 +1,15 @@
 .. include:: links.inc
 
+.. _modeling-major-changes-for-4.0:
+
 Changes to Modeling in v4.0
 ***************************
-
 
 In order to make the internal code less complex, improve performance, and
 make the behavior of parameters in compound models more intuitive,
 many changes have been made internally to the modeling code,
 particularly to compound models and parameters. This page
-summarizes the important changes. More technical details are 
+summarizes the important changes. More technical details are
 given at the end, but it is generally not necessary to read those
 unless you want to understand why some changes were necessary.
 
@@ -26,10 +27,10 @@ unless you want to understand why some changes were necessary.
         newmodel = Gaussian1D(3.2, 7.1, 2.1) + Const1D(3.)
 
 - Previous to v4.0, parameters were class descriptors, which meant
-  that they could not hold values for the models. Instead, the 
+  that they could not hold values for the models. Instead, the
   values were held inside the models. This resulted in confusion
   when compound models were used since this necessitated that
-  the compound models make copies of the values. As a result, 
+  the compound models make copies of the values. As a result,
   changing the value in the compound model did not change the
   constituent model's parameter value and vice versa. Now
   parameters are distinct instances for each use and they
@@ -37,7 +38,7 @@ unless you want to understand why some changes were necessary.
   now share the same values as the constituent models.
 
 - Previously when model sets were used, the parameter shape
-  did not show the corresponding dimension for the number 
+  did not show the corresponding dimension for the number
   of models. Now it does. For example:
 
   Old::
@@ -64,14 +65,14 @@ unless you want to understand why some changes were necessary.
   or assign directly to the parameter value.
 
 - The use of 'imputed' units, i.e., supplying input/output units
-  to a compound model without them but where the component models 
+  to a compound model without them but where the component models
   support the _parameter_units_for_data_units() method is much more
   restricted in its applicability, which will only work when the
   compound expression uses the '+' or '-' operators. Past behavior
   led to sometimes arbitrary assignments of units, and sometimes
   incorrect units to the parameters.
 
-- Slicing is more restrictive now. Previously a model defined as 
+- Slicing is more restrictive now. Previously a model defined as
   such::
 
         m = m1 * m2 + m3
@@ -81,9 +82,9 @@ unless you want to understand why some changes were necessary.
         m[1:] # results in m2 + m3
 
   Now, only submodels in the expression tree (think of it as
-  the sequence of operations as performed) are permitted as 
+  the sequence of operations as performed) are permitted as
   slices. This means some slices that make sense do not work
-  now. The following code illustrates what is permitted 
+  now. The following code illustrates what is permitted
   and what isn't::
 
         m = m1 + m2 + m3 + m4
@@ -113,17 +114,17 @@ they are defined in share the same parameter descriptor instance.
 This means the parameter cannot hold different values for different
 model instances. The way that this was worked around was to have
 the model hold the actual parameter value (and any other information
-relevant to that particular instance of the model). The actual 
+relevant to that particular instance of the model). The actual
 values of the parameters were held in an array that the model
 held, and that array held all values for all parameters in one
 array. The drawback of this approach was that compound models
 had to create their own array holding values for all the parameters
-of the compound model. As a result, the parameter values in a 
+of the compound model. As a result, the parameter values in a
 compound model were completely disassociated with those in
-the constituent model that made up the compound model. Changes 
+the constituent model that made up the compound model. Changes
 to one were not reflected in the other, often leadin to confusion.
 
-The new implementation still uses attributes defined at the 
+The new implementation still uses attributes defined at the
 class level for the parameters, but only
 as an intermediate solution. In creating an instance of the model
 the class instance is used to create a local instance of a
@@ -134,7 +135,7 @@ shared between compound and constituent models.
 One consequence is that the interface to fitting engines still
 use the model parameter array, but this array is constructed
 from the parameters on the fly. One may set a completely new
-array; the model is defined to detect such assignments and 
+array; the model is defined to detect such assignments and
 back propagate the values to the parameters. For example, when
 doing a fit, the fit results are propagated to the parameters
 in such a way. But if one assigns a slice to the model parameter
@@ -144,7 +145,7 @@ works unless an explicit method call is made to back propagate
 the values. It is not recommended to use this kind of interface
 now.
 
-Likewise, parameter-specific attributes also are kept by the 
+Likewise, parameter-specific attributes also are kept by the
 parameter, such as the constraints on the parameter minimum or
 maximum, and whether it is fixed as far as fitting is concerned.
 
@@ -155,22 +156,22 @@ size; when it previously did not.
 Compound Model Implementation Changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Compound models previously were implemented using a metaclass 
+Compound models previously were implemented using a metaclass
 for the compound model while also inheriting from the Model
 class (which itself has a metaclass). The primary reason for
-this approach was to support expressions of Model classes. 
+this approach was to support expressions of Model classes.
 However, this leads to a confusing implementation,
 some decrease in performance, and some odd results when
 expressions of model classes also include model instances.
 
 The new implementation does away with the metaclass for
 compound models and correspondingly no longer supports
-expressions of model classes, but only expressions of 
-model instances. Previously the expression tree was a private 
+expressions of model classes, but only expressions of
+model instances. Previously the expression tree was a private
 attribute. Now the compound class is itself an expression
 tree. The mapping of constituent parameters to the
-compound is not automatically done except when certain 
-method or attribute calls are made, which are not normally 
+compound is not automatically done except when certain
+method or attribute calls are made, which are not normally
 done on subexpressions. There may be some special cases
 where it is necessary to force this by calling the `.map_parameters`
 method.

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -16,6 +16,8 @@ Different fitting algorithms can be used with any model.  For those fitters
 with the capabilities fitting can be done using uncertainties, parameters with
 bounds, and priors.
 
+.. _modeling-getting-started:
+
 Getting started
 ===============
 
@@ -55,6 +57,8 @@ the code and plot below for a 1-dimensional Gaussian.
       resulted in compound models parameters not sharing the same value as the
       constituent models, if one of them changed, the other didn't. Now they
       see exactly the same value.
+
+.. _modeling-using:
 
 Concepts
 ========

--- a/docs/modeling/model-sets.rst
+++ b/docs/modeling/model-sets.rst
@@ -1,5 +1,7 @@
 .. include:: links.inc
 
+.. _modeling-getting-started-model-sets:
+
 Model sets
 ==========
 


### PR DESCRIPTION
This is a direct follow-up #9078 . I think I found where all the old tags should go, **except** this one (which seems to be listed under TODO, so hopefully you can add this remaining one back in when you get to it):

```rst
.. _modeling-getting-started-masked-data:

Fitting masked data
-------------------
```

cc @karllark 