### PR TITLE
Remove default warning when replacing a column that is a slice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -265,6 +265,10 @@ astropy.table
   to a valid column for the table.  ``Table.__setitem__`` now just calls
   ``add_column``.
 
+- Changed default table configuration setting ``replace_warnings`` from
+  ``['slice']`` to ``[]``.  This removes the default warning when replacing
+  a table column that is a slice of another column. [#9144]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -19,7 +19,7 @@ class Conf(_config.ConfigNamespace):
         'tables (and not overridden). See <http://getbootstrap.com/css/#tables '
         'for a list of useful bootstrap classes.')
     replace_warnings = _config.ConfigItem(
-        ['slice'],
+        [],
         'List of conditions for issuing a warning when replacing a table '
         "column using setitem, e.g. t['a'] = value.  Allowed options are "
         "'always', 'slice', 'refcount', 'attributes'.",

--- a/docs/table/modify_table.rst
+++ b/docs/table/modify_table.rst
@@ -307,4 +307,4 @@ following string values:
   Print a warning if any of the standard column attributes changed.
 
 The default value for the ``table.conf.replace_warnings`` option is
-``['slice']``.
+``[]`` (no warnings).


### PR DESCRIPTION
This is a bit obscure, but was put in place in version 1.3.  See: https://docs.astropy.org/en/v3.2.1/table/modify_table.html#api-change-in-replacing-columns

I think it has been long enough that this is no longer something that requires warning a user by default.

BTW (@bsipocz ?) is there a programmatic way to deprecate use of a `ConfigItem`?  I'd like to consider deprecating `replace_warnings` and `replace_inplace`.