### PR TITLE
DOC: Pin matplotlib version in intersphinx

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -51,15 +51,19 @@ class WCSAxes(Axes):
     ----------
     fig : `~matplotlib.figure.Figure`
         The figure to add the axes to
+
     rect : list
         The position of the axes in the figure in relative units. Should be
         given as ``[left, bottom, width, height]``.
+
     wcs : :class:`~astropy.wcs.WCS`, optional
         The WCS for the data. If this is specified, ``transform`` cannot be
         specified.
+
     transform : `~matplotlib.transforms.Transform`, optional
         The transform for the data. If this is specified, ``wcs`` cannot be
         specified.
+
     coord_meta : dict, optional
         A dictionary providing additional metadata when ``transform`` is
         specified. This should include the keys ``type``, ``wrap``, and
@@ -71,8 +75,10 @@ class WCSAxes(Axes):
         coordinates as :class:`~astropy.units.Unit` instances. This can
         optionally also include a ``format_unit`` entry giving the units to use
         for the tick labels (if not specified, this defaults to ``unit``).
+
     transData : `~matplotlib.transforms.Transform`, optional
         Can be used to override the default data -> pixel mapping.
+
     slices : tuple, optional
         For WCS transformations with more than two dimensions, we need to
         choose which dimensions are being shown in the 2D image. The slice
@@ -86,12 +92,13 @@ class WCSAxes(Axes):
         x axis, and the final WCS dimension (first Numpy dimension) will be
         shown on the y-axis (and therefore the data will be plotted using
         ``data[:, :, 50].transpose()``)
+
     frame_class : type, optional
         The class for the frame, which should be a subclass of
         :class:`~astropy.visualization.wcsaxes.frame.BaseFrame`. The default is to use a
         :class:`~astropy.visualization.wcsaxes.frame.RectangularFrame`
-    """
 
+    """
     def __init__(self, fig, rect, wcs=None, transform=None, coord_meta=None,
                  transData=None, slices=None, frame_class=RectangularFrame,
                  **kwargs):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,9 +73,6 @@ intersphinx_mapping['sphinx_automodapi'] = ('https://sphinx-automodapi.readthedo
 intersphinx_mapping['packagetemplate'] = ('http://docs.astropy.org/projects/package-template/en/latest/', None)
 intersphinx_mapping['h5py'] = ('http://docs.h5py.org/en/stable/', None)
 
-# Pin matplotlib version: https://github.com/astropy/astropy/pull/9145
-intersphinx_mapping['matplotlib'] = ('https://matplotlib.org/3.0.3/', None)
-
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,9 +74,7 @@ intersphinx_mapping['packagetemplate'] = ('http://docs.astropy.org/projects/pack
 intersphinx_mapping['h5py'] = ('http://docs.h5py.org/en/stable/', None)
 
 # Pin matplotlib version: https://github.com/astropy/astropy/pull/9145
-intersphinx_mapping['matplotlib'] = (
-    'https://matplotlib.org/3.0.3/',
-    (None, 'http://data.astropy.org/intersphinx/matplotlib.inv'))
+intersphinx_mapping['matplotlib'] = ('https://matplotlib.org/3.0.3/', None)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,11 @@ intersphinx_mapping['sphinx_automodapi'] = ('https://sphinx-automodapi.readthedo
 intersphinx_mapping['packagetemplate'] = ('http://docs.astropy.org/projects/package-template/en/latest/', None)
 intersphinx_mapping['h5py'] = ('http://docs.h5py.org/en/stable/', None)
 
+# Pin matplotlib version: https://github.com/astropy/astropy/pull/9145
+intersphinx_mapping['matplotlib'] = (
+    'https://matplotlib.org/3.0.3/',
+    (None, 'http://data.astropy.org/intersphinx/matplotlib.inv'))
+
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns.append('_templates')


### PR DESCRIPTION
This is to fix the failing HTML doc job on CircleCI, which is disrupting reviews of other PRs.

```
Warning, treated as error:
.../astropy/visualization/wcsaxes/core.py:docstring of astropy.visualization.wcsaxes.WCSAxes:93:
Block quote ends without a blank line; unexpected unindent.
```