### PR TITLE
Temporarily pinning sphinx <2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install "numpydoc<0.9" "matplotlib<3.1"
+            pip install "numpydoc<0.9" "matplotlib<3.1" "sphinx<2.2"
             pip install .[docs,all]
       - run:
           name: Build Docs


### PR DESCRIPTION
This is the most likely source or the recent html build failure.

If it indeed solves it, we can go ahead and merge this workaround, or add more commits to this PR to fix the docs to be sphinx 2.2 compatible. I likely won't have time for the latter today.

EDIT: Close #9145 