### PR TITLE
Replace (deprecated) optparse with argparse in fits scripts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Changed the ``fitscheck`` and ``fitsdiff`` script to use the ``argparse``
+  module instead of ``optparse``. [#9148]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -40,10 +40,9 @@ Example uses of fitscheck:
 """
 
 
+import argparse
 import logging
-import optparse
 import sys
-import textwrap
 
 from astropy.tests.helper import catch_warnings
 from astropy.io import fits
@@ -51,53 +50,59 @@ from astropy.io import fits
 
 log = logging.getLogger('fitscheck')
 
+_DESCRIPTION = """
+.e.g. fitscheck example.fits
+
+Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
+for a .fits file.
+Optionally detects and fixes FITS standard compliance problems.
+"""
+
 
 def handle_options(args):
     if not len(args):
         args = ['-h']
 
-    parser = optparse.OptionParser(usage=textwrap.dedent("""
-        fitscheck [options] <.fits files...>
+    parser = argparse.ArgumentParser(
+        description=_DESCRIPTION,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
 
-        .e.g. fitscheck example.fits
+    parser.add_argument(
+        'fits_files', metavar='file', nargs='+',
+        help='.fits files to process.')
 
-        Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
-        for a .fits file.
-        Optionally detects and fixes FITS standard compliance problems.
-        """.strip()))
-
-    parser.add_option(
+    parser.add_argument(
         '-k', '--checksum', dest='checksum_kind',
-        type='choice', choices=['standard', 'remove', 'none'],
+        choices=['standard', 'remove', 'none'],
         help='Choose FITS checksum mode or none.  Defaults standard.',
-        default='standard', metavar='[standard | remove | none]')
+        default='standard')
 
-    parser.add_option(
+    parser.add_argument(
         '-w', '--write', dest='write_file',
         help='Write out file checksums and/or FITS compliance fixes.',
         default=False, action='store_true')
 
-    parser.add_option(
+    parser.add_argument(
         '-f', '--force', dest='force',
         help='Do file update even if original checksum was bad.',
         default=False, action='store_true')
 
-    parser.add_option(
+    parser.add_argument(
         '-c', '--compliance', dest='compliance',
         help='Do FITS compliance checking; fix if possible.',
         default=False, action='store_true')
 
-    parser.add_option(
+    parser.add_argument(
         '-i', '--ignore-missing', dest='ignore_missing',
         help='Ignore missing checksums.',
         default=False, action='store_true')
 
-    parser.add_option(
+    parser.add_argument(
         '-v', '--verbose', dest='verbose', help='Generate extra output.',
         default=False, action='store_true')
 
     global OPTIONS
-    OPTIONS, fits_files = parser.parse_args(args)
+    OPTIONS = parser.parse_args(args)
 
     if OPTIONS.checksum_kind == 'none':
         OPTIONS.checksum_kind = False
@@ -105,7 +110,7 @@ def handle_options(args):
         OPTIONS.write_file = True
         OPTIONS.force = True
 
-    return fits_files
+    return OPTIONS.fits_files
 
 
 def setup_logging():

--- a/astropy/io/fits/scripts/fitscheck.py
+++ b/astropy/io/fits/scripts/fitscheck.py
@@ -51,7 +51,7 @@ from astropy.io import fits
 log = logging.getLogger('fitscheck')
 
 _DESCRIPTION = """
-.e.g. fitscheck example.fits
+e.g. fitscheck example.fits
 
 Verifies and optionally re-writes the CHECKSUM and DATASUM keywords
 for a .fits file.

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -15,6 +15,10 @@ from astropy.version import version
 
 
 class TestFITSDiff_script(FitsTestCase):
+    def test_help(self):
+        with pytest.raises(SystemExit) as e:
+            fitsdiff.main(['-h'])
+        assert e.value.code == 0
 
     def test_noargs(self):
         with pytest.raises(SystemExit) as e:


### PR DESCRIPTION
The [`optparse` module](https://docs.python.org/library/optparse.html) has been deprecated for a while, so I thought it might be useful to transition these scripts to use the `argparse` module.

The functionality of the scripts should not differ (the automated tests are probably not exhaustive...), however the help text for the `fitsdiff` will now look slightly different. Not sure how relevant that is.

Also I'm not sure if that needs a changelog.