### PR TITLE
Add a check to make sure PyTuple_New succeeded

### DIFF
--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -156,6 +156,10 @@ _get_unit(
   }
 
   args = PyTuple_New(1);
+  if (args == NULL) {
+      Py_DECREF(kw);
+      return NULL;
+  }
   PyTuple_SetItem(args, 0, unit);
   Py_INCREF(unit);
 


### PR DESCRIPTION
This case will probably never happen because the only reason for this to fail will be a lack of memory but with C extensions it's always good to make sure the function succeeded.