### PR TITLE
More usage of Py_CLEAR in WCS C-extension

### DIFF
--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -52,31 +52,12 @@ static int
 Wcs_clear(
     Wcs* self) {
 
-  PyObject* tmp;
-
-  tmp = self->py_det2im[0];
-  self->py_det2im[0] = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->py_det2im[1];
-  self->py_det2im[1] = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->py_sip;
-  self->py_sip = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->py_distortion_lookup[0];
-  self->py_distortion_lookup[0] = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->py_distortion_lookup[1];
-  self->py_distortion_lookup[1] = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->py_wcsprm;
-  self->py_wcsprm = NULL;
-  Py_XDECREF(tmp);
+  Py_CLEAR(self->py_det2im[0]);
+  Py_CLEAR(self->py_det2im[1]);
+  Py_CLEAR(self->py_sip);
+  Py_CLEAR(self->py_distortion_lookup[0]);
+  Py_CLEAR(self->py_distortion_lookup[1]);
+  Py_CLEAR(self->py_wcsprm);
 
   return 0;
 }
@@ -497,8 +478,7 @@ Wcs_set_wcs(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_wcsprm);
-  self->py_wcsprm = NULL;
+  Py_CLEAR(self->py_wcsprm);
   self->x.wcs = NULL;
 
   if (value != NULL && value != Py_None) {
@@ -536,8 +516,7 @@ Wcs_set_cpdis1(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_distortion_lookup[0]);
-  self->py_distortion_lookup[0] = NULL;
+  Py_CLEAR(self->py_distortion_lookup[0]);
   self->x.cpdis[0] = NULL;
 
   if (value != NULL && value != Py_None) {
@@ -575,8 +554,7 @@ Wcs_set_cpdis2(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_distortion_lookup[1]);
-  self->py_distortion_lookup[1] = NULL;
+  Py_CLEAR(self->py_distortion_lookup[1]);
   self->x.cpdis[1] = NULL;
 
   if (value != NULL && value != Py_None) {
@@ -614,8 +592,7 @@ Wcs_set_det2im1(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_det2im[0]);
-  self->py_det2im[0] = NULL;
+  Py_CLEAR(self->py_det2im[0]);
   self->x.det2im[0] = NULL;
 
   if (value != NULL && value != Py_None) {
@@ -653,8 +630,7 @@ Wcs_set_det2im2(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_det2im[1]);
-  self->py_det2im[1] = NULL;
+  Py_CLEAR(self->py_det2im[1]);
   self->x.det2im[1] = NULL;
 
   if (value != NULL && value != Py_None) {
@@ -692,8 +668,7 @@ Wcs_set_sip(
     /*@shared@*/ PyObject* value,
     /*@unused@*/ void* closure) {
 
-  Py_XDECREF(self->py_sip);
-  self->py_sip = NULL;
+  Py_CLEAR(self->py_sip);
   self->x.sip = NULL;
 
   if (value != NULL && value != Py_None) {

--- a/astropy/wcs/src/distortion_wrap.c
+++ b/astropy/wcs/src/distortion_wrap.c
@@ -25,11 +25,7 @@ static int
 PyDistLookup_clear(
     PyDistLookup* self) {
 
-  PyObject* tmp;
-
-  tmp = (PyObject*)self->py_data;
-  self->py_data = NULL;
-  Py_XDECREF(tmp);
+  Py_CLEAR(self->py_data);
 
   return 0;
 }
@@ -177,8 +173,7 @@ PyDistLookup_set_data(
   PyArrayObject* value_array = NULL;
 
   if (value == NULL) {
-    Py_XDECREF(self->py_data);
-    self->py_data = NULL;
+    Py_CLEAR(self->py_data);
     self->x.data = NULL;
     return 0;
   }

--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -66,11 +66,7 @@ static int
 PyStrListProxy_clear(
     PyStrListProxy *self) {
 
-  PyObject *tmp;
-
-  tmp = self->pyobject;
-  self->pyobject = NULL;
-  Py_XDECREF(tmp);
+  Py_CLEAR(self->pyobject);
 
   return 0;
 }

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -78,15 +78,8 @@ static int
 PyUnitListProxy_clear(
     PyUnitListProxy *self) {
 
-  PyObject *tmp;
-
-  tmp = self->pyobject;
-  self->pyobject = NULL;
-  Py_XDECREF(tmp);
-
-  tmp = self->unit_class;
-  self->unit_class = NULL;
-  Py_XDECREF(tmp);
+  Py_CLEAR(self->pyobject);
+  Py_CLEAR(self->unit_class);
 
   return 0;
 }

--- a/astropy/wcs/src/wcslib_tabprm_wrap.c
+++ b/astropy/wcs/src/wcslib_tabprm_wrap.c
@@ -82,11 +82,8 @@ PyTabprm_traverse(
 static int
 PyTabprm_clear(
     PyTabprm* self) {
-  PyObject* tmp;
 
-  tmp = self->owner;
-  self->owner = NULL;
-  Py_XDECREF(tmp);
+  Py_CLEAR(self->owner);
 
   return 0;
 }

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -1773,8 +1773,7 @@ PyWcsprm_sub(
 
       axes[i] = element_val;
 
-      Py_DECREF(element);
-      element = NULL;
+      Py_CLEAR(element);
     }
   } else if (PyLong_Check(py_axes)) {
     tmp = (Py_ssize_t)PyLong_AsSsize_t(py_axes);


### PR DESCRIPTION
1.) Correct code like this:

```
PyObject *tmp;
tmp = instance->attribute;
instance->attribute = NULL;
Py_XDECREF(tmp);
```

Can be replaced by a shorter `Py_CLEAR(instance->attribute)`.

2.) Incorrect code that used

```
Py_XDECREF(instance->attribute);
instance->attribute = NULL;
```

Can lead to a segmentation fault because the deleted attribute could try to access the deleted attribute "instance->attribute" during the `__del__` invocation.

In this case the `Py_CLEAR(instance->attribute)` is not only shorter but also corrects for the rare case that there are such `__del__` implementations.