### PR TITLE
Fix possible buffer overflow with cunit or ctype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -506,6 +506,9 @@ astropy.wcs
 
 - Fixed a crash while loading a WCS from headers containing duplicate SIP keywords. [#8893]
 
+- Fixed a possible buffer overflow when using too large negative indices for
+  ``cunit`` or ``ctype`` [#9151]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -113,7 +113,7 @@ PyStrListProxy_getitem(
     PyStrListProxy* self,
     Py_ssize_t index) {
 
-  if (index >= self->size) {
+  if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;
   }
@@ -127,7 +127,7 @@ PyStrListProxy_setitem(
     Py_ssize_t index,
     PyObject* arg) {
 
-  if (index >= self->size) {
+  if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return -1;
   }

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -174,7 +174,7 @@ PyUnitListProxy_getitem(
   PyObject *value;
   PyObject *result;
 
-  if (index >= self->size) {
+  if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return NULL;
   }
@@ -227,7 +227,7 @@ PyUnitListProxy_setitem(
   PyObject* unicode_value;
   PyObject* bytes_value;
 
-  if (index >= self->size) {
+  if (index >= self->size || index < 0) {
     PyErr_SetString(PyExc_IndexError, "index out of range");
     return -1;
   }

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -267,6 +267,8 @@ def test_ctype_index_error():
     assert list(w.ctype) == ['', '']
     with pytest.raises(IndexError):
         w.ctype[2] = 'FOO'
+    with pytest.raises(IndexError):
+        w.ctype[-3] = 'FOO'
 
 
 def test_ctype_invalid_error():
@@ -337,6 +339,8 @@ def test_unit3():
     w = wcs.WCS()
     with pytest.raises(IndexError):
         w.wcs.cunit[2] = u.m
+    with pytest.raises(IndexError):
+        w.wcs.cunit[-3] = u.m
     with pytest.raises(ValueError):
         w.wcs.cunit = [u.m, u.m, u.m]
 

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -265,10 +265,11 @@ def test_ctype_repr():
 def test_ctype_index_error():
     w = _wcs.Wcsprm()
     assert list(w.ctype) == ['', '']
-    with pytest.raises(IndexError):
-        w.ctype[2] = 'FOO'
-    with pytest.raises(IndexError):
-        w.ctype[-3] = 'FOO'
+    for idx in (2, -3):
+        with pytest.raises(IndexError):
+            w.ctype[idx]
+        with pytest.raises(IndexError):
+            w.ctype[idx] = 'FOO'
 
 
 def test_ctype_invalid_error():
@@ -337,10 +338,11 @@ def test_unit2():
 
 def test_unit3():
     w = wcs.WCS()
-    with pytest.raises(IndexError):
-        w.wcs.cunit[2] = u.m
-    with pytest.raises(IndexError):
-        w.wcs.cunit[-3] = u.m
+    for idx in (2, -3):
+        with pytest.raises(IndexError):
+            w.wcs.cunit[idx]
+        with pytest.raises(IndexError):
+            w.wcs.cunit[idx] = u.m
     with pytest.raises(ValueError):
         w.wcs.cunit = [u.m, u.m, u.m]
 


### PR DESCRIPTION
If the negative index is too large to wrap around then the `index` can be negative and thus the `array` is accessed out-of-bounds, leading to a buffer overflow.