### PR TITLE
Fixed WCS.wcs.cunit equality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -504,6 +504,9 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fixed equality test between ``cunit`` where the first element was equal but
+  the following elements differed. [#9154]
+
 - Fixed a crash while loading a WCS from headers containing duplicate SIP keywords. [#8893]
 
 

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -192,6 +192,8 @@ PyUnitListProxy_richcmp(
 	PyObject *a,
 	PyObject *b,
 	int op){
+  PyUnitListProxy *lhs, *rhs;
+  Py_ssize_t idx;
   assert(a != NULL && b != NULL);
   if (!PyObject_TypeCheck(a, &PyUnitListProxyType) ||
       !PyObject_TypeCheck(b, &PyUnitListProxyType)) {
@@ -201,28 +203,24 @@ PyUnitListProxy_richcmp(
     Py_RETURN_NOTIMPLEMENTED;
   }
 
-  {
-    /* The actual comparison of the two objects. unit_class is ignored because
-     * it's not an essential property of the instances.
-     */
-    PyUnitListProxy *lhs, *rhs;
-    Py_ssize_t idx;
-    lhs = (PyUnitListProxy *)a;
-    rhs = (PyUnitListProxy *)b;
-    if (lhs->size != rhs->size) {
+  /* The actual comparison of the two objects. unit_class is ignored because
+   * it's not an essential property of the instances.
+   */
+  lhs = (PyUnitListProxy *)a;
+  rhs = (PyUnitListProxy *)b;
+  if (lhs->size != rhs->size) {
+    if (op == Py_EQ) {
+      Py_RETURN_FALSE;
+    } else {
+      Py_RETURN_TRUE;
+    }
+  }
+  for (idx = 0; idx < lhs->size; idx++) {
+    if (strncmp(lhs->array[idx], rhs->array[idx], ARRAYSIZE) != 0) {
       if (op == Py_EQ) {
         Py_RETURN_FALSE;
       } else {
         Py_RETURN_TRUE;
-      }
-    }
-    for (idx = 0; idx < lhs->size; idx++) {
-      if (strncmp(lhs->array[idx], rhs->array[idx], ARRAYSIZE) != 0) {
-        if (op == Py_EQ) {
-          Py_RETURN_FALSE;
-        } else {
-          Py_RETURN_TRUE;
-        }
       }
     }
   }

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -206,6 +206,7 @@ PyUnitListProxy_richcmp(
      * it's not an essential property of the instances.
      */
     PyUnitListProxy *lhs, *rhs;
+    Py_ssize_t idx;
     lhs = (PyUnitListProxy *)a;
     rhs = (PyUnitListProxy *)b;
     if (lhs->size != rhs->size) {
@@ -215,7 +216,7 @@ PyUnitListProxy_richcmp(
         Py_RETURN_TRUE;
       }
     }
-    for (Py_ssize_t idx = 0; idx < lhs->size; idx++) {
+    for (idx = 0; idx < lhs->size; idx++) {
       if (strncmp(lhs->array[idx], rhs->array[idx], ARRAYSIZE) != 0) {
         if (op == Py_EQ) {
           Py_RETURN_FALSE;

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -194,6 +194,7 @@ PyUnitListProxy_richcmp(
 	int op){
   PyUnitListProxy *lhs, *rhs;
   Py_ssize_t idx;
+  int equal = 1;
   assert(a != NULL && b != NULL);
   if (!PyObject_TypeCheck(a, &PyUnitListProxyType) ||
       !PyObject_TypeCheck(b, &PyUnitListProxyType)) {
@@ -209,23 +210,15 @@ PyUnitListProxy_richcmp(
   lhs = (PyUnitListProxy *)a;
   rhs = (PyUnitListProxy *)b;
   if (lhs->size != rhs->size) {
-    if (op == Py_EQ) {
-      Py_RETURN_FALSE;
-    } else {
-      Py_RETURN_TRUE;
-    }
+    equal = 0;
   }
-  for (idx = 0; idx < lhs->size; idx++) {
+  for (idx = 0; idx < lhs->size && equal == 1; idx++) {
     if (strncmp(lhs->array[idx], rhs->array[idx], ARRAYSIZE) != 0) {
-      if (op == Py_EQ) {
-        Py_RETURN_FALSE;
-      } else {
-        Py_RETURN_TRUE;
-      }
+      equal = 0;
     }
   }
-  /* If it managed to get here then everything is considered equal. */
-  if (op == Py_EQ) {
+  if ((op == Py_EQ && equal == 1) ||
+      (op == Py_NE && equal == 0)) {
     Py_RETURN_TRUE;
   } else {
     Py_RETURN_FALSE;

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -1193,20 +1193,31 @@ def test_cunit():
     w1 = wcs.WCS(naxis=2)
     w2 = wcs.WCS(naxis=2)
     w3 = wcs.WCS(naxis=2)
+    w4 = wcs.WCS(naxis=2)
     # Initializing the values of cunit
     w1.wcs.cunit = ['deg', 'm/s']
     w2.wcs.cunit = ['km/h', 'km/h']
     w3.wcs.cunit = ['deg', 'm/s']
+    w4.wcs.cunit = ['deg', 'deg']
 
     # Equality checking a cunit with itself
     assert w1.wcs.cunit == w1.wcs.cunit
+    assert not w1.wcs.cunit != w1.wcs.cunit
     # Equality checking of two different cunit object having same values
     assert w1.wcs.cunit == w3.wcs.cunit
+    assert not w1.wcs.cunit != w3.wcs.cunit
+    # Equality checking of two different cunit object having the same first unit
+    # but different second unit (see #9154)
+    assert not w1.wcs.cunit == w4.wcs.cunit
+    assert w1.wcs.cunit != w4.wcs.cunit
     # Inequality checking of two different cunit object having different values
     assert not w1.wcs.cunit == w2.wcs.cunit
+    assert w1.wcs.cunit != w2.wcs.cunit
     # Inequality checking of cunit with a list of literals
     assert not w1.wcs.cunit == [1, 2, 3]
+    assert w1.wcs.cunit != [1, 2, 3]
     # Inequality checking with some characters
+    assert not w1.wcs.cunit == ['a', 'b', 'c']
     assert w1.wcs.cunit != ['a', 'b', 'c']
     # Comparison is not implemented TypeError will raise
     with pytest.raises(TypeError):


### PR DESCRIPTION
When the first item was the same the previous approach considered them equal and didn't check the following items.

Also removed the comparison of `unit_class` since that's just the `astropy.units.Unit` class and shouldn't be relevant for equality. Maybe that reference should not be kept in the instances but rather as static reference but that's something that can be addressed in the future and is not appropriate to change in a bug-fix commit.