### PR TITLE
Collate module index by module name ignoring `astropy.` suffix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,11 @@ version = astropy.__version__.split('-', 1)[0]
 release = astropy.__version__
 
 
+# -- Options for the module index ---------------------------------------------
+
+modindex_common_prefix = ['astropy.']
+
+
 # -- Options for HTML output ---------------------------------------------------
 
 # A NOTE ON HTML THEMES


### PR DESCRIPTION
For example, `astropy.visualization` will go in the "V" section, not "A".