### PR TITLE
Add two new optional attributes to the APE 14 WCS: pixel_axis_names and world_axis_names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -166,6 +166,8 @@ astropy.wcs
 - Added a ``wcs_as_str`` function to ``astropy.wcs.wcsapi`` to show a summary
 - Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
   of an APE-14-compliant WCS as a string. [#8546, #9207]
+- Added two new optional attributes to the APE 14 low-level WCS: ``pixel_axis_names``
+  and ``world_axis_names``. [#9156]
 
 API Changes
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,7 @@ astropy.wcs
 
 - Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
 - Added a ``wcs_as_str`` function to ``astropy.wcs.wcsapi`` to show a summary
+- Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
   of an APE-14-compliant WCS as a string. [#8546, #9207]
 
 API Changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ astropy.modeling
 - Significant reorganization of the documentation. [#9078, #9171]
 
 - Add ``Tabular1D.inverse`` [#9083]
+- Significant reorganization of the documentation. [#9078, #9171]
 
 - ``Model.rename`` was changed to add the ability to rename ``Model.inputs`` and ``Model.outputs``. [#9220]
 
@@ -162,6 +163,7 @@ astropy.wcs
   slicing operations in turn. [#9210]
 
 - Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
+- Added a ``wcs_as_str`` function to ``astropy.wcs.wcsapi`` to show a summary
   of an APE-14-compliant WCS as a string. [#8546, #9207]
 
 API Changes

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -180,16 +180,17 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
     @property
     def world_axis_physical_types(self):
         types = []
-        for axis_type in self.axis_type_names:
-            if axis_type.startswith('UT('):
+        for ctype in self.wcs.ctype:
+            if ctype.startswith('UT('):
                 types.append('time')
             else:
+                ctype_name = ctype.split('-')[0]
                 for custom_mapping in CTYPE_TO_UCD1_CUSTOM:
-                    if axis_type in custom_mapping:
-                        types.append(custom_mapping[axis_type])
+                    if ctype_name in custom_mapping:
+                        types.append(custom_mapping[ctype_name])
                         break
                 else:
-                    types.append(CTYPE_TO_UCD1.get(axis_type, None))
+                    types.append(CTYPE_TO_UCD1.get(ctype_name, None))
         return types
 
     @property
@@ -207,6 +208,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     unit = ''
             units.append(unit)
         return units
+
+    @property
+    def world_axis_names(self):
+        return list(self.wcs.cname)
 
     @property
     def axis_correlation_matrix(self):
@@ -330,7 +335,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
         for i in range(self.naxis):
             if components[i] is None:
-                name = self.axis_type_names[i].lower()
+                name = self.wcs.ctype[i].split('-')[0].lower()
                 if name == '':
                     name = 'world'
                 while name in classes:

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -263,21 +263,21 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         An iterable of strings describing the name for each pixel axis.
 
-        If an axis does not have a name, `None` can be returned.
+        If an axis does not have a name, an empty string should be returned.
         """
-        return [None] * self.pixel_n_dim
+        return [''] * self.pixel_n_dim
 
     @property
     def world_axis_names(self):
         """
         An iterable of strings describing the name for each world axis.
 
-        If an axis does not have a name, `None` can be returned. Note that
+        If an axis does not have a name, an empty string be returned. Note that
         these names are just for display purposes and are not standardized.
         For standardized axis types, see
         `~BaseLowLevelWCS.world_axis_physical_types`.
         """
-        return [None] * self.world_n_dim
+        return [''] * self.world_n_dim
 
     @property
     def axis_correlation_matrix(self):

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -263,8 +263,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         An iterable of strings describing the name for each pixel axis.
 
-        If an axis does not have a name (the default if a subclass does not
-        override), an empty string should be returned.
+        If an axis does not have a name, an empty string should be returned
+        (this is the default behavior for all axes if a subclass does not
+        override this property). Note that these names are just for display
+        purposes and are not standardized.
         """
         return [''] * self.pixel_n_dim
 
@@ -273,10 +275,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         An iterable of strings describing the name for each world axis.
 
-        If an axis does not have a name (the default if a subclass does not
-        override), an empty string should be returned. Note that
-        these names are just for display purposes and are not standardized.
-        For standardized axis types, see
+        If an axis does not have a name, an empty string should be returned
+        (this is the default behavior for all axes if a subclass does not
+        override this property). Note that these names are just for display
+        purposes and are not standardized. For standardized axis types, see
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_physical_types`.
         """
         return [''] * self.world_n_dim

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -275,7 +275,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         If an axis does not have a name, an empty string be returned. Note that
         these names are just for display purposes and are not standardized.
         For standardized axis types, see
-        `~BaseLowLevelWCS.world_axis_physical_types`.
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_physical_types`.
         """
         return [''] * self.world_n_dim
 

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -247,7 +247,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
     def pixel_bounds(self):
         """
         The bounds (in pixel coordinates) inside which the WCS is defined,
-        as a list with `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` ``(min, max)`` tuples.
+        as a list with `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`
+        ``(min, max)`` tuples.
 
         The bounds should be given in ``[(xmin, xmax), (ymin, ymax)]``
         order. WCS solutions are sometimes only guaranteed to be accurate
@@ -258,15 +259,37 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return None
 
     @property
+    def pixel_axis_names(self):
+        """
+        An iterable of strings describing the name for each pixel axis.
+
+        If an axis does not have a name, `None` can be returned.
+        """
+        return [None] * self.pixel_n_dim
+
+    @property
+    def world_axis_names(self):
+        """
+        An iterable of strings describing the name for each world axis.
+
+        If an axis does not have a name, `None` can be returned. Note that
+        these names are just for display purposes and are not standardized.
+        For standardized axis types, see
+        `~BaseLowLevelWCS.world_axis_physical_types`.
+        """
+        return [None] * self.world_n_dim
+
+    @property
     def axis_correlation_matrix(self):
         """
         Returns an (`~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim`,
-        `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`) matrix that indicates using booleans
-        whether a given world coordinate depends on a given pixel coordinate.
+        `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`) matrix that
+        indicates using booleans whether a given world coordinate depends on a
+        given pixel coordinate.
 
-        This defaults to a matrix where all elements are `True` in the absence of
-        any further information. For completely independent axes, the diagonal
-        would be `True` and all other entries `False`.
+        This defaults to a matrix where all elements are `True` in the absence
+        of any further information. For completely independent axes, the
+        diagonal would be `True` and all other entries `False`.
         """
         return np.ones((self.world_n_dim, self.pixel_n_dim), dtype=bool)
 

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -263,7 +263,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         An iterable of strings describing the name for each pixel axis.
 
-        If an axis does not have a name, an empty string should be returned.
+        If an axis does not have a name (the default if a subclass does not
+        override), an empty string should be returned.
         """
         return [''] * self.pixel_n_dim
 
@@ -272,7 +273,8 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
         An iterable of strings describing the name for each world axis.
 
-        If an axis does not have a name, an empty string be returned. Note that
+        If an axis does not have a name (the default if a subclass does not
+        override), an empty string should be returned. Note that
         these names are just for display purposes and are not standardized.
         For standardized axis types, see
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_physical_types`.

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -133,6 +133,14 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     def world_axis_units(self):
         return [self._wcs.world_axis_units[i] for i in self._world_keep]
 
+    @property
+    def pixel_axis_names(self):
+        return [self._wcs.pixel_axis_names[i] for i in self._pixel_keep]
+
+    @property
+    def world_axis_names(self):
+        return [self._wcs.world_axis_names[i] for i in self._world_keep]
+
     def pixel_to_world_values(self, *pixel_arrays):
         pixel_arrays_new = []
         ipix_curr = -1

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -38,9 +38,8 @@ def test_empty():
     assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == [None]
     assert wcs.world_axis_units == ['']
-
-    assert wcs.pixel_axis_names == [None]
-    assert wcs.world_axis_names == [None]
+    assert wcs.pixel_axis_names == ['']
+    assert wcs.world_axis_names == ['']
 
     assert_equal(wcs.axis_correlation_matrix, True)
 
@@ -117,9 +116,8 @@ def test_simple_celestial():
     assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
     assert wcs.world_axis_units == ['deg', 'deg']
-
-    assert wcs.pixel_axis_names == [None, None]
-    assert wcs.world_axis_names == [None, None]
+    assert wcs.pixel_axis_names == ['', '']
+    assert wcs.world_axis_names == ['', '']
 
     assert_equal(wcs.axis_correlation_matrix, True)
 
@@ -196,6 +194,9 @@ WCSAXES = 3
 CTYPE1  = GLAT-CAR
 CTYPE2  = FREQ
 CTYPE3  = GLON-CAR
+CNAME1  = Longitude
+CNAME2  = Frequency
+CNAME3  = Latitude
 CRVAL1  = 10
 CRVAL2  = 20
 CRVAL3  = 25
@@ -227,9 +228,8 @@ def test_spectral_cube():
     assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-
-    assert wcs.pixel_axis_names == [None, None, None]
-    assert wcs.world_axis_names == [None, None, None]
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Longitude', 'Frequency', 'Latitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
                                                [False, True, False],
@@ -315,9 +315,8 @@ def test_spectral_cube_nonaligned():
 
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-
-    assert wcs.pixel_axis_names == [None, None, None]
-    assert wcs.world_axis_names == [None, None, None]
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Longitude', 'Frequency', 'Latitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, True],
                                                [False, True, True],
@@ -411,9 +410,8 @@ def test_time_cube():
     assert wcs.pixel_shape == (2048, 2048, 11)
     assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
     assert wcs.world_axis_units == ['deg', 'deg', 's']
-
-    assert wcs.pixel_axis_names == [None, None, None]
-    assert wcs.world_axis_names == [None, None, None]
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['', '', '']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, False],
                                                [True, True, False],
@@ -568,3 +566,4 @@ def test_caching_components_and_classes():
     frame = wcs.world_axis_object_classes['celestial'][2]['frame']
     assert isinstance(frame, FK5)
     assert frame.equinox.jyear == 2010.
+

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -566,4 +566,3 @@ def test_caching_components_and_classes():
     frame = wcs.world_axis_object_classes['celestial'][2]['frame']
     assert isinstance(frame, FK5)
     assert frame.equinox.jyear == 2010.
-

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -39,6 +39,9 @@ def test_empty():
     assert wcs.world_axis_physical_types == [None]
     assert wcs.world_axis_units == ['']
 
+    assert wcs.pixel_axis_names == [None]
+    assert wcs.world_axis_names == [None]
+
     assert_equal(wcs.axis_correlation_matrix, True)
 
     assert wcs.world_axis_object_components == [('world', 0, 'value')]
@@ -114,6 +117,9 @@ def test_simple_celestial():
     assert wcs.pixel_shape is None
     assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
     assert wcs.world_axis_units == ['deg', 'deg']
+
+    assert wcs.pixel_axis_names == [None, None]
+    assert wcs.world_axis_names == [None, None]
 
     assert_equal(wcs.axis_correlation_matrix, True)
 
@@ -222,7 +228,12 @@ def test_spectral_cube():
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
 
-    assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
+    assert wcs.pixel_axis_names == [None, None, None]
+    assert wcs.world_axis_names == [None, None, None]
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
+                                               [False, True, False],
+                                               [True, False, True]])
 
     assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
                                                   ('freq', 0, 'value'),
@@ -305,7 +316,12 @@ def test_spectral_cube_nonaligned():
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
 
-    assert_equal(wcs.axis_correlation_matrix, [[True, True, True], [False, True, True], [True, True, True]])
+    assert wcs.pixel_axis_names == [None, None, None]
+    assert wcs.world_axis_names == [None, None, None]
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, True, True],
+                                               [False, True, True],
+                                               [True, True, True]])
 
     # NOTE: we check world_axis_object_components and world_axis_object_classes
     # again here because in the past this failed when non-aligned axes were
@@ -396,7 +412,12 @@ def test_time_cube():
     assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
     assert wcs.world_axis_units == ['deg', 'deg', 's']
 
-    assert_equal(wcs.axis_correlation_matrix, [[True, True, False], [True, True, False], [False, False, True]])
+    assert wcs.pixel_axis_names == [None, None, None]
+    assert wcs.world_axis_names == [None, None, None]
+
+    assert_equal(wcs.axis_correlation_matrix, [[True, True, False],
+                                               [True, True, False],
+                                               [False, False, True]])
 
     with pytest.warns(FutureWarning):
         assert wcs.world_axis_object_components == [

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -22,6 +22,9 @@ NAXIS3  = 30
 CTYPE1  = GLAT-CAR
 CTYPE2  = FREQ
 CTYPE3  = GLON-CAR
+CNAME1  = Latitude
+CNAME2  = Frequency
+CNAME3  = Longitude
 CRVAL1  = 10
 CRVAL2  = 20
 CRVAL3  = 25
@@ -67,9 +70,9 @@ Pixel Dim  Axis Name  Data size  Bounds
         2  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       em.freq           Hz
-        2  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Frequency  em.freq           Hz
+        2  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -91,6 +94,8 @@ def test_ellipsis():
     assert wcs.pixel_shape == (10, 20, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -130,8 +135,8 @@ Pixel Dim  Axis Name  Data size  Bounds
         1  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -152,6 +157,8 @@ def test_spectral_slice():
     assert wcs.pixel_shape == (10, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'deg']
+    assert wcs.pixel_axis_names == ['', '']
+    assert wcs.world_axis_names == ['Latitude', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True], [True, True]])
 
@@ -187,9 +194,9 @@ Pixel Dim  Axis Name  Data size  Bounds
         2  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       em.freq           Hz
-        2  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Frequency  em.freq           Hz
+        2  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -211,6 +218,8 @@ def test_spectral_range():
     assert wcs.pixel_shape == (10, 6, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -250,9 +259,9 @@ Pixel Dim  Axis Name  Data size  Bounds
         1  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       em.freq           Hz
-        2  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Frequency  em.freq           Hz
+        2  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -274,6 +283,8 @@ def test_celestial_slice():
     assert wcs.pixel_shape == (20, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.pixel_axis_names == ['', '']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[False, True], [True, False], [False, True]])
 
@@ -314,9 +325,9 @@ Pixel Dim  Axis Name  Data size  Bounds
         2  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       em.freq           Hz
-        2  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Frequency  em.freq           Hz
+        2  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -338,6 +349,8 @@ def test_celestial_range():
     assert wcs.pixel_shape == (5, 20, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -385,9 +398,9 @@ Pixel Dim  Axis Name  Data size  Bounds
         2  None              30  (5, 15)
 
 World Dim  Axis Name  Physical Type     Units
-        0  None       pos.galactic.lat  deg
-        1  None       em.freq           Hz
-        2  None       pos.galactic.lon  deg
+        0  Latitude   pos.galactic.lat  deg
+        1  Frequency  em.freq           Hz
+        2  Longitude  pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -409,6 +422,8 @@ def test_celestial_range_rot():
     assert wcs.pixel_shape == (5, 20, 30)
     assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
     assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.pixel_axis_names == ['', '', '']
+    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -61,15 +61,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 20, 10)
 
-Pixel Dim  Data size  Bounds
-        0         10  (-1, 11)
-        1         20  (-2, 18)
-        2         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              10  (-1, 11)
+        1  None              20  (-2, 18)
+        2  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -125,13 +125,13 @@ This transformation has 2 pixel and 2 world dimensions
 
 Array shape (Numpy order): (30, 10)
 
-Pixel Dim  Data size  Bounds
-        0         10  (-1, 11)
-        1         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              10  (-1, 11)
+        1  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -181,15 +181,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 6, 10)
 
-Pixel Dim  Data size  Bounds
-        0         10  (-1, 11)
-        1          6  (-6, 14)
-        2         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              10  (-1, 11)
+        1  None               6  (-6, 14)
+        2  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -245,14 +245,14 @@ This transformation has 2 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 20)
 
-Pixel Dim  Data size  Bounds
-        0         20  (-2, 18)
-        1         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              20  (-2, 18)
+        1  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -308,15 +308,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 20, 5)
 
-Pixel Dim  Data size  Bounds
-        0          5  (-6, 6)
-        1         20  (-2, 18)
-        2         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None               5  (-6, 6)
+        1  None              20  (-2, 18)
+        2  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -379,15 +379,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 20, 5)
 
-Pixel Dim  Data size  Bounds
-        0          5  (-6, 6)
-        1         20  (-2, 18)
-        2         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None               5  (-6, 6)
+        1  None              20  (-2, 18)
+        2  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -464,15 +464,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): None
 
-Pixel Dim  Data size  Bounds
-        0       None  None
-        1       None  None
-        2       None  None
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None            None  None
+        1  None            None  None
+        2  None            None  None
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  em.freq           Hz
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       em.freq           Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 
@@ -552,15 +552,15 @@ This transformation has 3 pixel and 3 world dimensions
 
 Array shape (Numpy order): (30, 20, 10)
 
-Pixel Dim  Data size  Bounds
-        0         10  (-1, 11)
-        1         20  (-2, 18)
-        2         30  (5, 15)
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              10  (-1, 11)
+        1  None              20  (-2, 18)
+        2  None              30  (5, 15)
 
-World Dim  Physical Type     Units
-        0  pos.galactic.lat  deg
-        1  None              unknown
-        2  pos.galactic.lon  deg
+World Dim  Axis Name  Physical Type     Units
+        0  None       pos.galactic.lat  deg
+        1  None       None              Hz
+        2  None       pos.galactic.lon  deg
 
 Correlation between pixel and world axes:
 

--- a/astropy/wcs/wcsapi/tests/test_utils.py
+++ b/astropy/wcs/wcsapi/tests/test_utils.py
@@ -33,11 +33,11 @@ This transformation has 1 pixel and 1 world dimensions
 
 Array shape (Numpy order): None
 
-Pixel Dim  Data size  Bounds
-        0       None  None
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None            None  None
 
-World Dim  Physical Type  Units
-        0  None           unknown
+World Dim  Axis Name  Physical Type  Units
+        0  None       None           unknown
 
 Correlation between pixel and world axes:
 

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -43,8 +43,10 @@ def wcs_info_str(wcs):
 
     # Find largest between header size and value length
     pixel_dim_width = max(9, len(str(wcs.pixel_n_dim)))
-    pixel_nam_width = max(9, max(len(x) if x is not None else 0 for x in wcs.pixel_axis_names))
+    pixel_nam_width = max(9, max(len(x) for x in wcs.pixel_axis_names))
     pixel_siz_width = max(9, len(str(max(array_shape))))
+
+    print(pixel_nam_width)
 
     s += (('{0:' + str(pixel_dim_width) + 's}').format('Pixel Dim') + '  ' +
             ('{0:' + str(pixel_nam_width) + 's}').format('Axis Name') + '  ' +
@@ -74,20 +76,9 @@ def wcs_info_str(wcs):
 
     for iwrl in range(wcs.world_n_dim):
 
-        if wcs.world_axis_names[iwrl] is None:
-            name = 'None'
-        else:
-            name = wcs.world_axis_names[iwrl]
-
-        if wcs.world_axis_physical_types[iwrl] is None:
-            typ = 'None'
-        else:
-            typ = wcs.world_axis_physical_types[iwrl]
-
-        if wcs.world_axis_units[iwrl] is None:
-            unit = 'unknown'
-        else:
-            unit = wcs.world_axis_units[iwrl]
+        name = wcs.world_axis_names[iwrl] or 'None'
+        typ = wcs.world_axis_physical_types[iwrl] or 'None'
+        unit = wcs.world_axis_units[iwrl] or 'unknown'
 
         s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
                 ('{0:' + str(world_nam_width) + 's}').format(name) + '  ' +

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -43,15 +43,18 @@ def wcs_info_str(wcs):
 
     # Find largest between header size and value length
     pixel_dim_width = max(9, len(str(wcs.pixel_n_dim)))
+    pixel_nam_width = max(9, max(len(x) if x is not None else 0 for x in wcs.pixel_axis_names))
     pixel_siz_width = max(9, len(str(max(array_shape))))
 
     s += (('{0:' + str(pixel_dim_width) + 's}').format('Pixel Dim') + '  ' +
+            ('{0:' + str(pixel_nam_width) + 's}').format('Axis Name') + '  ' +
             ('{0:' + str(pixel_siz_width) + 's}').format('Data size') + '  ' +
             'Bounds\n')
 
     for ipix in range(wcs.pixel_n_dim):
         s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
-                (" "*5 + str(None) if pixel_shape[ipix] is None else
+                ('{0:' + str(pixel_nam_width) + 's}').format(wcs.pixel_axis_names[ipix] or 'None') + '  ' +
+                (" " * 5 + str(None) if pixel_shape[ipix] is None else
                 ('{0:' + str(pixel_siz_width) + 'd}').format(pixel_shape[ipix])) + '  ' +
                 '{:s}'.format(str(None if wcs.pixel_bounds is None else wcs.pixel_bounds[ipix]) + '\n'))
 
@@ -61,22 +64,35 @@ def wcs_info_str(wcs):
 
     # Find largest between header size and value length
     world_dim_width = max(9, len(str(wcs.world_n_dim)))
+    world_nam_width = max(9, max(len(x) if x is not None else 0 for x in wcs.world_axis_names))
     world_typ_width = max(13, max(len(x) if x is not None else 0 for x in wcs.world_axis_physical_types))
 
     s += (('{0:' + str(world_dim_width) + 's}').format('World Dim') + '  ' +
+            ('{0:' + str(world_nam_width) + 's}').format('Axis Name') + '  ' +
             ('{0:' + str(world_typ_width) + 's}').format('Physical Type') + '  ' +
             'Units\n')
 
     for iwrl in range(wcs.world_n_dim):
 
-        if wcs.world_axis_physical_types[iwrl] is not None:
-            s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
-                    ('{0:' + str(world_typ_width) + 's}').format(wcs.world_axis_physical_types[iwrl]) + '  ' +
-                    '{:s}'.format(wcs.world_axis_units[iwrl] + '\n'))
+        if wcs.world_axis_names[iwrl] is None:
+            name = 'None'
         else:
-            s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
-                    ('{0:' + str(world_typ_width) + 's}').format('None') + '  ' +
-                    '{:s}'.format('unknown' + '\n'))
+            name = wcs.world_axis_names[iwrl]
+
+        if wcs.world_axis_physical_types[iwrl] is None:
+            typ = 'None'
+        else:
+            typ = wcs.world_axis_physical_types[iwrl]
+
+        if wcs.world_axis_units[iwrl] is None:
+            unit = 'unknown'
+        else:
+            unit = wcs.world_axis_units[iwrl]
+
+        s += (('{0:' + str(world_dim_width) + 'd}').format(iwrl) + '  ' +
+                ('{0:' + str(world_nam_width) + 's}').format(name) + '  ' +
+                ('{0:' + str(world_typ_width) + 's}').format(typ) + '  ' +
+                '{:s}'.format(unit + '\n'))
     s += '\n'
 
     # Axis correlation matrix


### PR DESCRIPTION
Following discussions with @Cadair, this adds two new optional attributes to the APE 14 WCS specification. This is a proposal, and should be approved by the original authors (and interested parties) for the APE 14 document, since the base classes here are now the authoritative reference APIs. So this should not be merged until approved by everyone tagged for review here.