### PR TITLE
Update minimum python version in installation docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,9 +135,9 @@ package.
 
 **Code Quality**
   * Are the [coding guidelines](http://docs.astropy.org/en/latest/development/codeguide.html) followed?
-  * Is the code compatible with Python >=3.5?
+  * Is the code compatible with Python >=3.6?
   * Are there dependencies other than the `astropy` core, the Python Standard
-    Library, and NumPy 1.10.0 or later?
+    Library, and NumPy 1.13.0 or later?
     * Is the package importable even if the C-extensions are not built?
     * Are additional dependencies handled appropriately?
     * Do functions that require additional dependencies raise an `ImportError`

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -26,7 +26,7 @@ import sys
 import os
 from warnings import warn
 
-__minimum_python_version__ = '3.5'
+__minimum_python_version__ = '3.6'
 __minimum_numpy_version__ = '1.13.0'
 # ASDF is an optional dependency, but this is the minimum version that is
 # compatible with Astropy when it is installed.


### PR DESCRIPTION
The minimum python version was moved to 3.6 in https://github.com/astropy/astropy/pull/8955.  This PR updates the installation docs, which still stay `>= 3.5`.

This PR also updates the minimum python and numpy versions in `CONTRIBUTING.md`.  Perhaps we should consider removing the minimum version numbers in that file.