### PR TITLE
Cache name resolve results in astropy.coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ astropy.coordinates
 - The ``Galactocentric`` frame will now use the "latest" parameter definitions
   by default. This currently corresponds to the values defined in v4.0, but will
   change with future releases. [#10238]
+
 - The ``SkyCoord.from_name()`` and Sesame name resolving functionality now
   optionally caches results locally. [#9162]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -867,6 +867,8 @@ astropy.coordinates
   [#8834]
 
 - Passing a NaN to ``Distance`` no longer raises a warning. [#9598]
+- The ``SkyCoord.from_name()`` and Sesame name resolving functionality now
+  optionally caches results locally. [#9162]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,8 +40,8 @@ astropy.coordinates
   by default. This currently corresponds to the values defined in v4.0, but will
   change with future releases. [#10238]
 
-- The ``SkyCoord.from_name()`` and Sesame name resolving functionality now
-  optionally caches results locally. [#9162]
+- The ``SkyCoord.from_name()`` and Sesame name resolving functionality now is
+  able to cache results locally and will do so by default. [#9162]
 
 - Allow in-place modification of array-valued ``Representation`` and ``Differential``
   objects, including of representations with attached differentials. [#10210]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ astropy.coordinates
 - The ``Galactocentric`` frame will now use the "latest" parameter definitions
   by default. This currently corresponds to the values defined in v4.0, but will
   change with future releases. [#10238]
+- The ``SkyCoord.from_name()`` and Sesame name resolving functionality now
+  optionally caches results locally. [#9162]
 
 - Allow in-place modification of array-valued ``Representation`` and ``Differential``
   objects, including of representations with attached differentials. [#10210]
@@ -867,8 +869,6 @@ astropy.coordinates
   [#8834]
 
 - Passing a NaN to ``Distance`` no longer raises a warning. [#9598]
-- The ``SkyCoord.from_name()`` and Sesame name resolving functionality now
-  optionally caches results locally. [#9162]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -161,8 +161,7 @@ def get_icrs_coordinates(name, parse=False, cache=False):
     for url in urls:
         try:
             resp_data = get_file_contents(
-                download_file(url, cache=cache, show_progress=False,
-                              timeout=data.conf.remote_timeout))
+                download_file(url, cache=cache, show_progress=False))
             break
         except urllib.error.URLError as e:
             exceptions.append(e)

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -20,7 +20,7 @@ import urllib.error
 from astropy import units as u
 from .sky_coordinate import SkyCoord
 from astropy.utils import data
-from astropy.utils.data import download_file
+from astropy.utils.data import download_file, get_file_contents
 from astropy.utils.state import ScienceState
 
 __all__ = ["get_icrs_coordinates"]
@@ -78,7 +78,7 @@ def _parse_response(resp_data):
     """
 
     pattr = re.compile(r"%J\s*([0-9\.]+)\s*([\+\-\.0-9]+)")
-    matched = pattr.search(resp_data.decode('utf-8'))
+    matched = pattr.search(resp_data)
 
     if matched is None:
         return None, None
@@ -167,11 +167,10 @@ def get_icrs_coordinates(name, parse=False, cache=False, overwrite=False):
     exceptions = []
     for url in urls:
         try:
-            local_path = download_file(url, cache=cache, show_progress=False,
-                                       timeout=data.conf.remote_timeout)
-            with open(local_path, 'rb') as f:
-                resp_data = f.read()
-                break
+            resp_data = get_file_contents(
+                download_file(url, cache=cache, show_progress=False,
+                              timeout=data.conf.remote_timeout))
+            break
         except urllib.error.URLError as e:
             exceptions.append(e)
             continue

--- a/astropy/coordinates/name_resolve.py
+++ b/astropy/coordinates/name_resolve.py
@@ -87,7 +87,7 @@ def _parse_response(resp_data):
         return ra, dec
 
 
-def get_icrs_coordinates(name, parse=False, cache=False, overwrite=False):
+def get_icrs_coordinates(name, parse=False, cache=False):
     """
     Retrieve an ICRS object by using an online name resolving service to
     retrieve coordinates for the specified name. By default, this will
@@ -115,10 +115,10 @@ def get_icrs_coordinates(name, parse=False, cache=False, overwrite=False):
         in this way may differ from the database coordinates by a few
         deci-arcseconds, so only use this option if you do not need
         sub-arcsecond accuracy for coordinates.
-    cache : bool, optional
-        Determines whether to cache the results or not.
-    overwrite : bool, optional
-            Determines whether to overwrite a pre-existing cached value.
+    cache : bool, str, optional
+        Determines whether to cache the results or not. Passed through to
+        `~astropy.utils.data.download_file`, so pass "update" to update the
+        cached value.
 
     Returns
     -------
@@ -126,13 +126,6 @@ def get_icrs_coordinates(name, parse=False, cache=False, overwrite=False):
         The object's coordinates in the ICRS frame.
 
     """
-
-    if overwrite and not cache:
-        raise ValueError("`overwrite` should only be set to True if you are "
-                         "using caching, i.e. if `cache=True`.")
-
-    if overwrite:
-        cache = "update"
 
     # if requested, first try extract coordinates embedded in the object name.
     # Do this first since it may be much faster than doing the sesame query

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1902,7 +1902,7 @@ class SkyCoord(ShapedLikeNDArray):
 
     # Name resolve
     @classmethod
-    def from_name(cls, name, frame='icrs', parse=False, cache=False):
+    def from_name(cls, name, frame='icrs', parse=False, cache=True):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1902,7 +1902,8 @@ class SkyCoord(ShapedLikeNDArray):
 
     # Name resolve
     @classmethod
-    def from_name(cls, name, frame='icrs', parse=False):
+    def from_name(cls, name, frame='icrs', parse=False, cache=False,
+                  overwrite=False):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame
@@ -1926,6 +1927,10 @@ class SkyCoord(ShapedLikeNDArray):
             in this way may differ from the database coordinates by a few
             deci-arcseconds, so only use this option if you do not need
             sub-arcsecond accuracy for coordinates.
+        cache : bool, optional
+            Determines whether to cache the results or not.
+        overwrite : bool, optional
+            Determines whether to overwrite a pre-existing cached value.
 
         Returns
         -------
@@ -1935,7 +1940,7 @@ class SkyCoord(ShapedLikeNDArray):
 
         from .name_resolve import get_icrs_coordinates
 
-        icrs_coord = get_icrs_coordinates(name, parse)
+        icrs_coord = get_icrs_coordinates(name, parse, cache=cache)
         icrs_sky_coord = cls(icrs_coord)
         if frame in ('icrs', icrs_coord.__class__):
             return icrs_sky_coord

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1902,8 +1902,7 @@ class SkyCoord(ShapedLikeNDArray):
 
     # Name resolve
     @classmethod
-    def from_name(cls, name, frame='icrs', parse=False, cache=False,
-                  overwrite_cache=False):
+    def from_name(cls, name, frame='icrs', parse=False, cache=False):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame
@@ -1921,16 +1920,15 @@ class SkyCoord(ShapedLikeNDArray):
         parse: bool
             Whether to attempt extracting the coordinates from the name by
             parsing with a regex. For objects catalog names that have
-            J-coordinates embedded in their names eg:
+            J-coordinates embedded in their names, e.g.,
             'CRTS SSS100805 J194428-420209', this may be much faster than a
-            sesame query for the same object name. The coordinates extracted
+            Sesame query for the same object name. The coordinates extracted
             in this way may differ from the database coordinates by a few
             deci-arcseconds, so only use this option if you do not need
             sub-arcsecond accuracy for coordinates.
         cache : bool, optional
-            Determines whether to cache the results or not.
-        overwrite_cache : bool, optional
-            Determines whether to overwrite a pre-existing cached value.
+            Determines whether to cache the results or not. To update or
+            overwrite an existing value, pass `cache='update'`.
 
         Returns
         -------
@@ -1939,13 +1937,6 @@ class SkyCoord(ShapedLikeNDArray):
         """
 
         from .name_resolve import get_icrs_coordinates
-
-        if overwrite_cache and not cache:
-            raise ValueError("`overwrite_cache` should only be set to True if "
-                             "you are using caching, i.e. if `cache=True`.")
-
-        if overwrite_cache and cache:
-            overwrite_cache = "update"
 
         icrs_coord = get_icrs_coordinates(name, parse, cache=cache)
         icrs_sky_coord = cls(icrs_coord)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1903,7 +1903,7 @@ class SkyCoord(ShapedLikeNDArray):
     # Name resolve
     @classmethod
     def from_name(cls, name, frame='icrs', parse=False, cache=False,
-                  overwrite=False):
+                  overwrite_cache=False):
         """
         Given a name, query the CDS name resolver to attempt to retrieve
         coordinate information for that object. The search database, sesame
@@ -1929,7 +1929,7 @@ class SkyCoord(ShapedLikeNDArray):
             sub-arcsecond accuracy for coordinates.
         cache : bool, optional
             Determines whether to cache the results or not.
-        overwrite : bool, optional
+        overwrite_cache : bool, optional
             Determines whether to overwrite a pre-existing cached value.
 
         Returns
@@ -1939,6 +1939,13 @@ class SkyCoord(ShapedLikeNDArray):
         """
 
         from .name_resolve import get_icrs_coordinates
+
+        if overwrite_cache and not cache:
+            raise ValueError("`overwrite_cache` should only be set to True if "
+                             "you are using caching, i.e. if `cache=True`.")
+
+        if overwrite_cache and cache:
+            overwrite_cache = "update"
 
         icrs_coord = get_icrs_coordinates(name, parse, cache=cache)
         icrs_sky_coord = cls(icrs_coord)

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1928,7 +1928,7 @@ class SkyCoord(ShapedLikeNDArray):
             sub-arcsecond accuracy for coordinates.
         cache : bool, optional
             Determines whether to cache the results or not. To update or
-            overwrite an existing value, pass `cache='update'`.
+            overwrite an existing value, pass ``cache='update'``.
 
         Returns
         -------

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -152,36 +152,20 @@ def test_name_resolve_cache(tmpdir):
         with shelve.open(urlmapfn) as url2hash:
             assert len(url2hash) == 0
 
-        icrs = get_icrs_coordinates("castor", cache=True)
+        icrs1 = get_icrs_coordinates("castor", cache=True)
 
+        # This is a weak test: we just check to see that a url is added to the
+        #  cache!
         with shelve.open(urlmapfn) as url2hash:
             assert len(url2hash) == 1
-            for k in url2hash.keys():
-                # check for expected search url in URL hash dict:
-                if 'nph-sesame/A?castor' in k:
-                    filename = url2hash[k]  # used below to check mtime
-                    break
-            else:
-                raise AssertionError('sesame url key not added to cache')
 
         # Try reloading coordinates, now should just reload cached data:
-        icrs = get_icrs_coordinates("castor", cache=True)
+        icrs2 = get_icrs_coordinates("castor", cache=True)
         with shelve.open(urlmapfn) as url2hash:
             assert len(url2hash) == 1
-            print(dict(url2hash).values())
 
-        # Try reloading coordinates again, but overwrite, which now should fire
-        # off an http request:
-        print(url2hash.values())
-        # mtime1 = os.path.getmtime(filename)
-        icrs = get_icrs_coordinates("castor", cache=True, overwrite=True)
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
-            print(dict(url2hash).values())
-        # mtime2 = os.path.getmtime(filename)
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
-        assert mtime2 > mtime1
+        assert u.allclose(icrs1.ra, icrs2.ra)
+        assert u.allclose(icrs1.dec, icrs2.dec)
 
         # This argument combination is not allowed:
         with pytest.raises(ValueError):


### PR DESCRIPTION
This PR adds support for caching results from the name resolve (Sesame) functionality in astropy.coordinates (primarily used via `SkyCoord.from_name`).

The motivator here was that, in astropy-tutorials (and in my own scripts), we use `.from_name()` to retrieve coordinates of some objects every time the build is run, but this unnecessarily hammers the Sesame servers and occasionally fails because of connection issues. 

Before I add a changelog entry, I figured I would open the PR to see if anyone has strong opinions about this.
