### PR TITLE
 Allow adding a table column as a list of mixin-type objects (+ row improvement)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -285,6 +285,9 @@ astropy.table
   ``['slice']`` to ``[]``.  This removes the default warning when replacing
   a table column that is a slice of another column. [#9144]
 
+- Removed the non-public method ``astropy.table.np_utils.recarray_fromrecords``.
+  [#9165]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,9 @@ astropy.table
 - Adding depth-wise stacking ``cstack()`` in higher level table operation.
   It help will in stacking table column depth-wise. [#8939]
 
+- Allow adding a table column as a list of mixin-type objects, for instance
+  ``t['q'] = [1 * u.m, 2 * u.m]``. [#9165]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/np_utils.py
+++ b/astropy/table/np_utils.py
@@ -171,26 +171,3 @@ def fix_column_name(val):
             raise
 
     return val
-
-
-def recarray_fromrecords(rec_list):
-    """
-    Partial replacement for `~numpy.core.records.fromrecords` which includes
-    a workaround for the bug with unicode arrays described at:
-    https://github.com/astropy/astropy/issues/3052
-
-    This should not serve as a full replacement for the original function;
-    this only does enough to fulfill the needs of the table module.
-    """
-
-    # Note: This is just copying what Numpy does for converting arbitrary rows
-    # to column arrays in the recarray module; it could be there is a better
-    # way
-    nfields = len(rec_list[0])
-    obj = np.array(rec_list, dtype=object)
-    array_list = [np.array(obj[..., i].tolist()) for i in range(nfields)]
-    formats = []
-    for obj in array_list:
-        formats.append(obj.dtype.str)
-    formats = ','.join(formats)
-    return np.rec.fromarrays(array_list, formats=formats)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -26,7 +26,7 @@ from .pprint import TableFormatter
 from .column import (BaseColumn, Column, MaskedColumn, _auto_names, FalseArray,
                      col_copy)
 from .row import Row
-from .np_utils import fix_column_name, recarray_fromrecords
+from .np_utils import fix_column_name
 from .info import TableInfo
 from .index import Index, _IndexModeContext, get_index
 from .connect import TableRead, TableWrite

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -462,8 +462,7 @@ class Table:
             elif isinstance(rows, self.Row):
                 data = rows
             else:
-                rec_data = recarray_fromrecords(rows)
-                data = [rec_data[name] for name in rec_data.dtype.names]
+                data = list(zip(*rows))
 
         # Infer the type of the input data and set up the initialization
         # function, number of columns, and potentially the default col names

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2427,3 +2427,17 @@ def test_data_to_col_convert_strategy():
     t['b'] = np.int64(2)  # Failed previously
     assert np.all(t['a'] == [1, 1])
     assert np.all(t['b'] == [2, 2])
+
+
+def test_rows_with_mixins():
+    tm = Time([1, 2], format='cxcsec')
+    q = [1, 2] * u.m
+    rows = [(1, q[0], tm[0]),
+            (2, q[1], tm[1])]
+    t = table.QTable(rows=rows)
+    t['a'] = [q[0], q[1]]
+    t['b'] = [tm[0], tm[1]]
+    assert np.all(t['col1'] == q)
+    assert np.all(t['col2'] == tm)
+    assert np.all(t['a'] == q)
+    assert np.all(t['b'] == tm)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2430,14 +2430,26 @@ def test_data_to_col_convert_strategy():
 
 
 def test_rows_with_mixins():
+    """Test for #9165 to allow adding a list of mixin objects"""
     tm = Time([1, 2], format='cxcsec')
     q = [1, 2] * u.m
+    mixed1 = [1 * u.m, 2]  # Mixed input, fails to convert to Quantity
+    mixed2 = [2, 1 * u.m]  # Mixed input, not detected as potential mixin
     rows = [(1, q[0], tm[0]),
             (2, q[1], tm[1])]
     t = table.QTable(rows=rows)
     t['a'] = [q[0], q[1]]
     t['b'] = [tm[0], tm[1]]
+    t['m1'] = mixed1
+    t['m2'] = mixed2
+
     assert np.all(t['col1'] == q)
     assert np.all(t['col2'] == tm)
     assert np.all(t['a'] == q)
     assert np.all(t['b'] == tm)
+    assert np.all(t['m1'][ii] == mixed1[ii] for ii in range(2))
+    assert np.all(t['m2'][ii] == mixed2[ii] for ii in range(2))
+    assert type(t['m1']) is table.Column
+    assert t['m1'].dtype is np.dtype(object)
+    assert type(t['m2']) is table.Column
+    assert t['m2'].dtype is np.dtype(object)


### PR DESCRIPTION
This PR started with a desire to allow initializing a table with row data that has Quantity values.  But along the way I noticed that the existing legacy way of handling rows is slow and unnecessarily complex:
```
In [1]: rows = [list(range(100))] * 100
In [2]: from astropy.table.np_utils import recarray_fromrecords
In [3]: timeit recarray_fromrecords(rows)
1.88 ms ± 22.9 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
In [4]: timeit list(zip(*rows))
72.9 µs ± 483 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```

EDIT (MHvK): the change for rows is nice in that it
fixes #8976