### PR TITLE
Fix potential segfault because of incorrect refcounting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -519,6 +519,8 @@ astropy.wcs
 - Fixed a possible buffer overflow when using too large negative indices for
   ``cunit`` or ``ctype`` [#9151]
 
+- Fixed reference counting in ``WCSBase.__init__`` [#9166]
+
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -123,8 +123,9 @@ Wcs_init(
         return -1;
       }
 
-      Py_XDECREF(self->py_det2im[i]);
+      Py_CLEAR(self->py_det2im[i]);
       self->py_det2im[i] = py_det2im[i];
+      Py_INCREF(py_det2im[i]);
       self->x.det2im[i] = &(((PyDistLookup*)py_det2im[i])->x);
     }
   }
@@ -137,8 +138,9 @@ Wcs_init(
       return -1;
     }
 
-    Py_XDECREF(self->py_sip);
+    Py_CLEAR(self->py_sip);
     self->py_sip = py_sip;
+    Py_INCREF(py_sip);
     self->x.sip = &(((PySip*)py_sip)->x);
   }
 
@@ -151,8 +153,9 @@ Wcs_init(
         return -1;
       }
 
-      Py_XDECREF(self->py_distortion_lookup[i]);
+      Py_CLEAR(self->py_distortion_lookup[i]);
       self->py_distortion_lookup[i] = py_distortion_lookup[i];
+      Py_INCREF(py_distortion_lookup[i]);
       self->x.cpdis[i] = &(((PyDistLookup*)py_distortion_lookup[i])->x);
     }
   }
@@ -165,17 +168,11 @@ Wcs_init(
       return -1;
     }
 
-    Py_XDECREF(self->py_wcsprm);
+    Py_CLEAR(self->py_wcsprm);
     self->py_wcsprm = py_wcsprm;
+    Py_INCREF(py_wcsprm);
     self->x.wcs = &(((PyWcsprm*)py_wcsprm)->x);
   }
-
-  Py_XINCREF(self->py_sip);
-  Py_XINCREF(self->py_distortion_lookup[0]);
-  Py_XINCREF(self->py_distortion_lookup[1]);
-  Py_XINCREF(self->py_wcsprm);
-  Py_XINCREF(self->py_det2im[0]);
-  Py_XINCREF(self->py_det2im[1]);
 
   return 0;
 }


### PR DESCRIPTION
This fixes a potential segfault (although a bit improbably because `WCSBase` is "well hidden") from code like this:

```
from astropy import wcs
import numpy as np
sip = wcs.Sip(np.ones((5, 5)), np.ones((5, 5)), np.ones((5, 5)), np.ones((5, 5)), np.array([1, 2]))

w = wcs.WCS()
wcs.WCSBase.__init__(w, sip, (None, None), None, (None, None))
try:
    wcs.WCSBase.__init__(w, sip, (None, None), 1, (None, None))
except:
    pass

try:
    wcs.WCSBase.__init__(w, sip, (None, None), 1, (None, None))
except:
    pass
```

I didn't add that as test-case because it's highly artificial and likely not useful in the future.

The `Py_CLEAR` instead of `Py_XDECREF` is also preventing highly unlikely bugs in case the "decrefed" instance has a `__del__` implementation that makes weird stuff (see [the inline documentation of `Py_CLEAR`](https://github.com/python/cpython/blob/v3.7.4/Include/object.h#L808-L841) for a more detailed explanation.).