### PR TITLE
TST: Fix linkcheck cron directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -173,7 +173,7 @@ matrix:
         # we moved it here instead.
         - os: linux
           stage: Cron tests
-          env: SETUP_CMD='build_docs -b linkcheck'
+          env: SETUP_CMD='build_docs -b linkcheck' EVENT_TYPE='cron'
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
                INSTALL_WITH_PIP=True
                EXTRAS_INSTALL="docs"


### PR DESCRIPTION
Currently, the cron job that runs `linkcheck` reports success without running any real link checking. I think it is because of the missing `EVENT_TYPE` (ops).

@larrybradley reports that a local link check run has some failures. If this works, the next scheduled cron job will smoke them out.

I skipped CI here because there is no point to run the push even jobs for this change. There is also no good reason to backport.