### PR TITLE
Refactoring: Use Py_VISIT macro in the traverse methods of WCS C-extension types

### DIFF
--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -50,15 +50,7 @@ PyStrListProxy_traverse(
     visitproc visit,
     void *arg) {
 
-  int vret;
-
-  if (self->pyobject) {
-    vret = visit(self->pyobject, arg);
-    if (vret != 0) {
-      return vret;
-    }
-  }
-
+  Py_VISIT(self->pyobject);
   return 0;
 }
 

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -55,22 +55,8 @@ PyUnitListProxy_traverse(
     visitproc visit,
     void *arg) {
 
-  int vret;
-
-  if (self->pyobject) {
-    vret = visit(self->pyobject, arg);
-    if (vret != 0) {
-      return vret;
-    }
-  }
-
-  if (self->unit_class) {
-    vret = visit(self->unit_class, arg);
-    if (vret != 0) {
-      return vret;
-    }
-  }
-
+  Py_VISIT(self->pyobject);
+  Py_VISIT(self->unit_class);
   return 0;
 }
 

--- a/astropy/wcs/src/wcslib_tabprm_wrap.c
+++ b/astropy/wcs/src/wcslib_tabprm_wrap.c
@@ -69,13 +69,7 @@ wcslib_tab_to_python_exc(int status) {
 static int
 PyTabprm_traverse(
     PyTabprm* self, visitproc visit, void *arg) {
-  int vret;
-
-  vret = visit(self->owner, arg);
-  if (vret != 0) {
-    return vret;
-  }
-
+  Py_VISIT(self->owner);
   return 0;
 }
 


### PR DESCRIPTION
The `Py_VISIT` macro is identical to the code before. It just makes the code more succinct.