### PR TITLE
Remove duplicate Astropy definition in doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,6 @@ rst_epilog += """
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 
 .. Astropy
-.. _Astropy: http://astropy.org
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy
 .. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
 """.format(astropy)


### PR DESCRIPTION
This is a result of astropy/sphinx-astropy#25 , which is causing `html-docs` CI failure across the other PRs here, although I have no idea why our CI is picking up an unreleased version of `sphinx-astropy` somehow. 🤷‍♀ 

This was originally a subset of #9175 but I decided to turn it into its own PR in case this needs a different milestone, which I'll let someone else set because I don't know how far back to backport CircleCI stuff, than the other one. Here is the workflow:

* If both PRs turn out to have same milestone and the other one can get merged soon: **close this without merge**
* If the other PR takes too long to get reviewed: **merge this one first**
* If the other PR has a different milestone: **merge this one first**

If this gets merged first, I will drop this change from the other PR and rebase it.