### PR TITLE
Cache preload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -295,7 +295,7 @@ astropy.utils
 
 - All operations that act on the astropy download cache now take an argument
   ``pkgname`` that allows one to specify which package's cache to use.
-  [#8327]
+  [#8237]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,12 @@ astropy.utils
 - The specific IERS Earth rotation parameter table used for time and
   coordinate transformations can now be set, either in a context or per
   session, using ``astropy.utils.iers.earth_rotation_table``. [#9244]
+- Added ``export_cache`` and ``import_cache`` to permit transporting
+  downloaded data to machines with no Internet connection. Also
+  ``check_download_cache`` to confirm that the persistent cache has not become
+  damaged. ``download_file`` and related functions now accept a list of fallback
+  sources, and they are able to update the cache at the user's request. Several new
+  functions are available to investigate the cache contents. [#9182]
 
 - A new ``astropy.utils.iers.LeapSeconds`` class has been added to track
   leap seconds. [#9365]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -274,6 +274,7 @@ astropy.utils
 - The specific IERS Earth rotation parameter table used for time and
   coordinate transformations can now be set, either in a context or per
   session, using ``astropy.utils.iers.earth_rotation_table``. [#9244]
+
 - Added ``export_cache`` and ``import_cache`` to permit transporting
   downloaded data to machines with no Internet connection. Also
   ``check_download_cache`` to confirm that the persistent cache has not become
@@ -283,13 +284,18 @@ astropy.utils
 
 - A new ``astropy.utils.iers.LeapSeconds`` class has been added to track
   leap seconds. [#9365]
+
 - Allow ``astropy.utils.console.ProgressBarOrSpinner.map`` and
   ``.map_unordered`` to take an argument ``multiprocessing_start_method`` to
   control how subprocesses are started; the different methods (``fork``,
   ``spawn``, and ``forkserver``) have different implications in terms of
   security, efficiency, and behavioural anomalies. The option is useful in
   particular for cross-platform testing because Windows supports only ``spawn``
-  while Linux defaults to ``fork``. [#9812]
+  while Linux defaults to ``fork``. [#9182]
+
+- All operations that act on the astropy download cache now take an argument
+  ``pkgname`` that allows one to specify which package's cache to use.
+  [#8327]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
@@ -656,7 +662,7 @@ astropy.io.votable
 - Address issue #8995 by ignoring BINARY2 null mask bits for string values
   on parsing a VOTable.  In this way, the reader should never create masked
   values for string types. [#9057]
-  
+
 - Corrected a spurious warning issued for the ``value`` attribute of the
   ``<OPTION>`` element in VOTable, as well as a test that erroneously
   treated the warning as acceptable.  [#9470]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -283,6 +283,13 @@ astropy.utils
 
 - A new ``astropy.utils.iers.LeapSeconds`` class has been added to track
   leap seconds. [#9365]
+- Allow ``astropy.utils.console.ProgressBarOrSpinner.map`` and
+  ``.map_unordered`` to take an argument ``multiprocessing_start_method`` to
+  control how subprocesses are started; the different methods (``fork``,
+  ``spawn``, and ``forkserver``) have different implications in terms of
+  security, efficiency, and behavioural anomalies. The option is useful in
+  particular for cross-platform testing because Windows supports only ``spawn``
+  while Linux defaults to ``fork``. [#9812]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -741,8 +741,8 @@ class ProgressBar:
             Useful primarily for testing; if in doubt leave it as the default.
             When using multiprocessing, certain anomalies occur when starting
             processes with the "spawn" method (the only option on Windows);
-            other anomalies occur with the "fork" method (the default on Unix).
-
+            other anomalies occur with the "fork" method (the default on
+            Linux).
         """
 
         if multiprocess:
@@ -813,8 +813,8 @@ class ProgressBar:
             Useful primarily for testing; if in doubt leave it as the default.
             When using multiprocessing, certain anomalies occur when starting
             processes with the "spawn" method (the only option on Windows);
-            other anomalies occur with the "fork" method (the default on Unix).
-
+            other anomalies occur with the "fork" method (the default on
+            Linux).
         """
 
         results = []

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -834,16 +834,14 @@ class ProgressBar:
                         bar.update(i)
             else:
                 ctx = multiprocessing.get_context(multiprocessing_start_method)
-                p = ctx.Pool(processes=(int(multiprocess)
-                                        if multiprocess is not True
-                                        else None))
-                for i, result in enumerate(
-                    p.imap_unordered(function, items, chunksize=chunksize)
-                ):
-                    bar.update(i)
-                    results.append(result)
-                p.close()
-                p.join()
+                with ctx.Pool(processes=(int(multiprocess)
+                                         if multiprocess is not True
+                                         else None)) as p:
+                    for i, result in enumerate(
+                        p.imap_unordered(function, items, chunksize=chunksize)
+                    ):
+                        bar.update(i)
+                        results.append(result)
 
         return results
 

--- a/astropy/utils/console.py
+++ b/astropy/utils/console.py
@@ -692,11 +692,11 @@ class ProgressBar:
 
     @classmethod
     def map(cls, function, items, multiprocess=False, file=None, step=100,
-            ipython_widget=False):
-        """
-        Does a `map` operation while displaying a progress bar with
-        percentage complete. The map operation may run on arbitrary order
-        on the items, but the results are returned in sequential order.
+            ipython_widget=False, multiprocessing_start_method=None):
+        """Map function over items while displaying a progress bar with percentage complete.
+
+        The map operation may run in arbitrary order on the items, but the results are
+        returned in sequential order.
 
         ::
 
@@ -735,15 +735,24 @@ class ProgressBar:
             of the chunks of ``items`` that are submitted as separate tasks
             to the process pool.  A large step size may make the job
             complete faster if ``items`` is very long.
+
+        multiprocessing_start_method : str, optional
+            Useful primarily for testing; if in doubt leave it as the default.
+            When using multiprocessing, certain anomalies occur when starting
+            processes with the "spawn" method (the only option on Windows);
+            other anomalies occur with the "fork" method (the default on Unix).
+
         """
 
         if multiprocess:
             function = _mapfunc(function)
             items = list(enumerate(items))
 
-        results = cls.map_unordered(function, items, multiprocess=multiprocess,
-                                    file=file, step=step,
-                                    ipython_widget=ipython_widget)
+        results = cls.map_unordered(
+            function, items, multiprocess=multiprocess,
+            file=file, step=step,
+            ipython_widget=ipython_widget,
+            multiprocessing_start_method=multiprocessing_start_method)
 
         if multiprocess:
             _, results = zip(*sorted(results))
@@ -753,8 +762,10 @@ class ProgressBar:
 
     @classmethod
     def map_unordered(cls, function, items, multiprocess=False, file=None,
-                      step=100, ipython_widget=False):
-        """
+                      step=100, ipython_widget=False,
+                      multiprocessing_start_method=None):
+        """Map function over items, reporting the progress.
+
         Does a `map` operation while displaying a progress bar with
         percentage complete. The map operation may run on arbitrary order
         on the items, and the results may be returned in arbitrary order.
@@ -796,6 +807,13 @@ class ProgressBar:
             of the chunks of ``items`` that are submitted as separate tasks
             to the process pool.  A large step size may make the job
             complete faster if ``items`` is very long.
+
+        multiprocessing_start_method : str, optional
+            Useful primarily for testing; if in doubt leave it as the default.
+            When using multiprocessing, certain anomalies occur when starting
+            processes with the "spawn" method (the only option on Windows);
+            other anomalies occur with the "fork" method (the default on Unix).
+
         """
 
         results = []
@@ -815,10 +833,13 @@ class ProgressBar:
                     if (i % chunksize) == 0:
                         bar.update(i)
             else:
-                p = multiprocessing.Pool(
-                    processes=(int(multiprocess) if multiprocess is not True else None))
+                ctx = multiprocessing.get_context(multiprocessing_start_method)
+                p = ctx.Pool(processes=(int(multiprocess)
+                                        if multiprocess is not True
+                                        else None))
                 for i, result in enumerate(
-                    p.imap_unordered(function, items, chunksize=chunksize)):
+                    p.imap_unordered(function, items, chunksize=chunksize)
+                ):
                     bar.update(i)
                     results.append(result)
                 p.close()

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1225,8 +1225,8 @@ def download_files_in_parallel(urls,
     Blocks until all files have downloaded.  The result is a list of
     local file paths corresponding to the given urls.
 
-    The results will be stored in the cache under the values in `urls` even if
-    they are obtained from some other location via ``sources``. See
+    The results will be stored in the cache under the values in ``urls`` even
+    if they are obtained from some other location via ``sources``. See
     `~download_file` for details.
 
     Parameters
@@ -1489,7 +1489,7 @@ def _keep_trying(timeout):
 # be open for reading if someone has it open for writing. So we need to lock
 # access to the shelve even for reading.
 @contextlib.contextmanager
-def _cache_lock(need_write=False):
+def _cache_lock(pkgname, need_write=False):
     lockdir = os.path.join(_get_download_cache_locs(pkgname)[0], 'lock')
     pidfn = os.path.join(lockdir, 'pid')
     assume_cache_readonly = False

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-""" This module contains helper functions for accessing, downloading, and caching data files.
-"""
+"""Functions for accessing, downloading, and caching data files."""
 
 import atexit
 import contextlib
@@ -41,7 +40,7 @@ __all__ = [
     'get_pkg_data_filenames',
     'is_url_in_cache', 'get_cached_urls',
     'cache_total_size', 'cache_contents',
-    'export_download_cache', 'import_download_cache',
+    'export_download_cache', 'import_download_cache', 'import_to_cache',
     'check_download_cache',
     'clear_download_cache',
     'compute_hash',
@@ -1269,9 +1268,9 @@ def download_files_in_parallel(urls,
         # cache was set to True because multiprocessing cannot insert the items
         # in the list of to-be-removed files. This could be fixed, but really,
         # just use the cache, with update_cache if appropriate.
-        warn("Disabling the cache does not work because of multiprocessing, "
-             "it will be set to ``True``. You may need to manually remove the "
-             "cached files with clear_download_cache() afterwards.",
+        warn('Disabling the cache does not work because of multiprocessing, '
+             'it will be set to ``"update"``. You may need to manually remove '
+             'the cached files with clear_download_cache() afterwards.',
              AstropyWarning)
         cache = "update"
 
@@ -1491,8 +1490,11 @@ def _cache_lock(pkgname):
                     os.remove(pidfn)
                 os.rmdir(lockdir)
             else:
-                msg = 'Error releasing lock. "{}" exists but is not a directory.'
-                raise RuntimeError(msg.format(lockdir))
+                msg = (
+                    'Error releasing lock. "{}" exists but is not a directory.'
+                    .format(lockdir)
+                )
+                raise RuntimeError(msg)
         else:
             # Just in case we were called from _clear_download_cache
             # or something went wrong before creating the directory
@@ -1794,6 +1796,7 @@ def export_download_cache(filename_or_obj, urls=None, pkgname='astropy'):
     See Also
     --------
     import_download_cache : import the contents of such a ZIP file
+    import_to_cache : import a single file directly
     """
     if urls is None:
         urls = get_cached_urls(pkgname)
@@ -1838,6 +1841,7 @@ def import_download_cache(filename_or_obj, urls=None, update_cache=False, pkgnam
     See Also
     --------
     export_download_cache : export the contents the cache to of such a ZIP file
+    import_to_cache : import a single file directly
     """
     block_size = 65536
     with zipfile.ZipFile(filename_or_obj, 'r') as z, TemporaryDirectory() as d:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1,26 +1,57 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import hashlib
 import io
 import os
-import pathlib
 import sys
+import base64
+import shutil
+import hashlib
+import pathlib
 import tempfile
-import urllib.request
+import warnings
+import itertools
 import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
+import py.path
 import pytest
 
-from astropy.utils.data import (_get_download_cache_locs, CacheMissingWarning,
-                                get_pkg_data_filename, get_readable_fileobj, conf)
-
+from astropy.utils import data
+from astropy.config import paths
+from astropy.utils.data import (
+    CacheMissingWarning,
+    conf,
+    _cache,
+    compute_hash,
+    download_file,
+    cache_contents,
+    _tempfilestodel,
+    get_cached_urls,
+    is_url_in_cache,
+    cache_total_size,
+    get_file_contents,
+    check_download_cache,
+    clear_download_cache,
+    get_pkg_data_fileobj,
+    get_readable_fileobj,
+    export_download_cache,
+    get_pkg_data_contents,
+    get_pkg_data_filename,
+    import_download_cache,
+    get_free_space_in_dir,
+    check_free_space_in_dir,
+    _get_download_cache_locs,
+    download_files_in_parallel,
+)
 from astropy.tests.helper import raises, catch_warnings
 
-TESTURL = 'http://www.astropy.org'
-TESTLOCAL = get_pkg_data_filename(os.path.join('data', 'local.dat'))
-
-# General file object function
+TESTURL = "http://www.astropy.org"
+TESTURL2 = "http://www.astropy.org/about.html"
+TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))
 
 try:
     import bz2  # noqa
@@ -36,86 +67,260 @@ except ImportError:
 else:
     HAS_XZ = True
 
+n_parallel_hammer = 10
+n_thread_hammer = 20
 
-@pytest.mark.remote_data(source='astropy')
-def test_download_nocache():
-    from astropy.utils.data import download_file
 
-    fnout = download_file(TESTURL)
+def url_to(path):
+    return pathlib.Path(path).resolve().as_uri()
+
+
+@pytest.fixture
+def valid_urls(tmpdir):
+    def _valid_urls(tmpdir):
+        for i in itertools.count():
+            c = os.urandom(16).hex()
+            fn = os.path.join(tmpdir, "valid_"+str(i))
+            with open(fn, "w") as f:
+                f.write(c)
+            u = url_to(fn)
+            yield u, c
+    return _valid_urls(tmpdir)
+
+
+@pytest.fixture
+def invalid_urls(tmpdir):
+    def _invalid_urls(tmpdir):
+        for i in itertools.count():
+            fn = os.path.join(tmpdir, "invalid_"+str(i))
+            assert not os.path.exists(fn)
+            yield url_to(fn)
+    return _invalid_urls(tmpdir)
+
+
+@pytest.fixture
+def temp_cache(tmpdir):
+    with paths.set_temp_cache(tmpdir):
+        yield None
+        check_download_cache(check_hashes=True)
+
+
+@pytest.mark.remote_data(source="astropy")
+def test_download_nocache_from_internet():
+    fnout = download_file(TESTURL, cache=False)
     assert os.path.isfile(fnout)
 
 
-@pytest.mark.remote_data(source='astropy')
-def test_download_parallel():
-    from astropy.utils.data import download_files_in_parallel
-
-    main_url = conf.dataurl
-    mirror_url = conf.dataurl_mirror
-    fileloc = 'intersphinx/README'
-    try:
-        fnout = download_files_in_parallel([main_url, main_url + fileloc])
-    except urllib.error.URLError:  # Use mirror if timed out
-        fnout = download_files_in_parallel([mirror_url, mirror_url + fileloc])
-    assert all([os.path.isfile(f) for f in fnout]), fnout
+@pytest.fixture
+def a_binary_file(tmp_path):
+    fn = tmp_path / "file"
+    b_contents = b"\xde\xad\xbe\xef"
+    with open(fn, "wb") as f:
+        f.write(b_contents)
+    yield fn, b_contents
 
 
-# NOTE: Does not need remote data.
-def test_download_mirror_cache():
-    import pathlib
-    import shelve
-    from astropy.utils.data import _find_pkg_data_path, download_file, get_cached_urls
-
-    main_url = pathlib.Path(
-        _find_pkg_data_path(os.path.join('data', 'dataurl'))).as_uri() + '/'
-    mirror_url = pathlib.Path(
-        _find_pkg_data_path(os.path.join('data', 'dataurl_mirror'))).as_uri() + '/'  # noqa
-
-    main_file = main_url + 'index.html'
-    mirror_file = mirror_url + 'index.html'
-
-    # Temporarily change data.conf.
-    # This also test https://github.com/astropy/astropy/pull/8163 because
-    # urlopen() on a local dir URI also gives URLError.
-    with conf.set_temp('dataurl', main_url):
-        with conf.set_temp('dataurl_mirror', mirror_url):
-
-            # "Download" files by rerouting URLs to local URIs.
-            download_file(main_file, cache=True)
-            download_file(mirror_file, cache=True)
-
-            # Now test that download_file looks in mirror's cache before
-            # download.
-            # https://github.com/astropy/astropy/issues/6982
-            dldir, urlmapfn = _get_download_cache_locs()
-            with shelve.open(urlmapfn) as url2hash:
-                del url2hash[main_file]
-
-            # Comparing hash makes sure they download the same file
-            # but does not guarantee they were downloaded from the same URL.
-            assert (download_file(main_file, cache=True) ==
-                    download_file(mirror_file, cache=True))
-
-            # This has to be called after the last download to obtain
-            # an accurate view of cached URLs.
-            # This is to ensure that main_file was not re-downloaded
-            # unnecessarily.
-            # This test also tests for "assert TESTURL in get_cached_urls()".
-            c_urls = get_cached_urls()
-            assert (mirror_file in c_urls) and (main_file not in c_urls)
+@pytest.fixture
+def a_file(tmp_path):
+    fn = tmp_path / "file.txt"
+    contents = "contents\n"
+    with open(fn, "w") as f:
+        f.write(contents)
+    yield fn, contents
 
 
-@pytest.mark.remote_data(source='astropy')
+def test_download_with_sources_and_bogus_original(valid_urls,
+                                                  invalid_urls,
+                                                  temp_cache):
+    u, c = next(valid_urls)
+    urls = [(u, c, None)]
+    sources = {}
+    for i in range(5):
+        um, c_bad = next(valid_urls)
+        assert not is_url_in_cache(um)
+        sources[um] = []
+        for j in range(i):
+            sources[um].append(next(invalid_urls))
+        u, c = next(valid_urls)
+        sources[um].append(u)
+        urls.append((um, c, c_bad))
+    rs = [download_file(u, cache=True, sources=sources.get(u, None))
+          for (u, c, c_bad) in urls]
+    assert len(rs) == len(urls)
+    for r, (u, c, c_bad) in zip(rs, urls):
+        assert get_file_contents(r) == c
+        assert get_file_contents(r) != c_bad
+        assert is_url_in_cache(u)
+
+
+def test_download_file_threaded_many(temp_cache, valid_urls):
+    """Hammer download_file with multiple threaded requests.
+
+    The goal is to stress-test the locking system. Normal parallel downloading
+    also does this but coverage tools lose track of which paths are explored.
+    The hope is that if the parallelism happens in threads, and from here, the
+    code coverage tools should be able to cope, maybe?
+
+    """
+    urls = [next(valid_urls) for i in range(n_thread_hammer)]
+    with ThreadPoolExecutor(max_workers=len(urls)) as P:
+        r = list(P.map(lambda u: download_file(u, cache=True),
+                       [u for (u, c) in urls]))
+    check_download_cache()
+    assert len(r) == len(urls)
+    for r, (u, c) in zip(r, urls):
+        assert get_file_contents(r) == c
+
+
+def test_clear_download_multiple_references_doesnt_corrupt_storage(
+        temp_cache,
+        tmpdir
+):
+    """Check that files with the same hash don't confuse the storage."""
+    content = "Test data; doesn't matter much.\n"
+
+    def make_url():
+        with NamedTemporaryFile("w", dir=str(tmpdir), delete=False) as f:
+            f.write(content)
+        url = url_to(f.name)
+        clear_download_cache(url)
+        hash = download_file(url, cache=True)
+        return url, hash
+
+    a_url, a_hash = make_url()
+    clear_download_cache(a_hash)
+    assert not is_url_in_cache(a_url)
+
+    f_url, f_hash = make_url()
+    g_url, g_hash = make_url()
+
+    assert f_url != g_url
+    assert f_hash == g_hash
+    assert is_url_in_cache(f_url)
+    assert is_url_in_cache(g_url)
+
+    clear_download_cache(f_url)
+    assert not is_url_in_cache(f_url)
+    assert is_url_in_cache(g_url)
+    assert os.path.exists(g_hash), \
+        "Contents should not be deleted while a reference exists"
+
+    clear_download_cache(g_url)
+    assert not os.path.exists(g_hash), \
+        "No reference exists any more, file should be deleted"
+
+
+def test_download_file_basic(valid_urls):
+    primary, contents = next(valid_urls)
+    f = download_file(primary, cache=False)
+    assert get_file_contents(f) == contents
+
+
+def test_download_file_local_survives(tmpdir):
+    fn = tmpdir / "file"
+    contents = "some text"
+    with open(fn, "w") as f:
+        f.write(contents)
+    u = url_to(fn)
+    f = download_file(u, cache=False)
+    assert fn not in _tempfilestodel
+    assert os.path.isfile(fn)
+    assert get_file_contents(f) == contents
+
+
+def test_download_file_local_cache_survives(tmpdir, temp_cache):
+    fn = tmpdir / "file"
+    contents = "some other text"
+    with open(fn, "w") as f:
+        f.write(contents)
+    u = url_to(fn)
+    f = download_file(u, cache=True)
+    assert fn not in _tempfilestodel
+    assert os.path.isfile(fn)
+    assert get_file_contents(f) == contents
+
+
+def test_sources_normal(temp_cache, valid_urls, invalid_urls):
+    primary, contents = next(valid_urls)
+    fallback1 = next(invalid_urls)
+    f = download_file(primary, cache=True, sources=[primary, fallback1])
+    assert get_file_contents(f) == contents
+    assert is_url_in_cache(primary)
+    assert not is_url_in_cache(fallback1)
+
+
+def test_sources_fallback(temp_cache, valid_urls, invalid_urls):
+    primary = next(invalid_urls)
+    fallback1, contents = next(valid_urls)
+    f = download_file(primary, cache=True, sources=[primary, fallback1])
+    assert get_file_contents(f) == contents
+    assert is_url_in_cache(primary)
+    assert not is_url_in_cache(fallback1)
+
+
+def test_sources_ignore_primary(temp_cache, valid_urls, invalid_urls):
+    primary, bogus = next(valid_urls)
+    fallback1, contents = next(valid_urls)
+    f = download_file(primary, cache=True, sources=[fallback1])
+    assert get_file_contents(f) == contents
+    assert is_url_in_cache(primary)
+    assert not is_url_in_cache(fallback1)
+
+
+def test_sources_multiple(temp_cache, valid_urls, invalid_urls):
+    primary = next(invalid_urls)
+    fallback1 = next(invalid_urls)
+    fallback2, contents = next(valid_urls)
+    f = download_file(primary,
+                      cache=True,
+                      sources=[primary, fallback1, fallback2])
+    assert get_file_contents(f) == contents
+    assert is_url_in_cache(primary)
+    assert not is_url_in_cache(fallback1)
+    assert not is_url_in_cache(fallback2)
+
+
+def test_sources_multiple_missing(temp_cache, valid_urls, invalid_urls):
+    primary = next(invalid_urls)
+    fallback1 = next(invalid_urls)
+    fallback2 = next(invalid_urls)
+    with pytest.raises(urllib.error.URLError):
+        download_file(primary,
+                      cache=True,
+                      sources=[primary, fallback1, fallback2])
+    assert not is_url_in_cache(primary)
+    assert not is_url_in_cache(fallback1)
+    assert not is_url_in_cache(fallback2)
+
+
+def test_update_url(tmpdir, temp_cache):
+    with TemporaryDirectory(dir=tmpdir) as d:
+        f_name = os.path.join(d, "f")
+        with open(f_name, "w") as f:
+            f.write("old")
+        f_url = url_to(f.name)
+        assert get_file_contents(download_file(f_url, cache=True)) == "old"
+        with open(f_name, "w") as f:
+            f.write("new")
+        assert get_file_contents(download_file(f_url, cache=True)) == "old"
+        assert get_file_contents(download_file(f_url,
+                                               cache=True,
+                                               update_cache=True)) == "new"
+    assert not os.path.exists(f_name)
+    assert get_file_contents(download_file(f_url, cache=True)) == "new"
+    with pytest.raises(urllib.error.URLError):
+        download_file(f_url, cache=True, update_cache=True)
+    assert get_file_contents(download_file(f_url, cache=True)) == "new"
+
+
+@pytest.mark.remote_data(source="astropy")
 def test_download_noprogress():
-    from astropy.utils.data import download_file
-
-    fnout = download_file(TESTURL, show_progress=False)
+    fnout = download_file(TESTURL, cache=False, show_progress=False)
     assert os.path.isfile(fnout)
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data(source="astropy")
 def test_download_cache():
-
-    from astropy.utils.data import download_file, clear_download_cache
 
     download_dir = _get_download_cache_locs()[0]
 
@@ -127,102 +332,251 @@ def test_download_cache():
     clear_download_cache(TESTURL)
     assert not os.path.exists(fnout)
 
+    # Clearing download cache succeeds even if the URL does not exist.
+    clear_download_cache("http://this_was_never_downloaded_before.com")
+
+    # Make sure lockdir was released
+    lockdir = os.path.join(download_dir, "lock")
+    assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
+
+
+def test_download_cache_after_clear(tmpdir, temp_cache, valid_urls):
+    testurl, contents = next(valid_urls)
     # Test issues raised in #4427 with clear_download_cache() without a URL,
     # followed by subsequent download.
-    fnout = download_file(TESTURL, cache=True)
+    download_dir = _get_download_cache_locs()[0]
+
+    fnout = download_file(testurl, cache=True)
     assert os.path.isfile(fnout)
+
     clear_download_cache()
     assert not os.path.exists(fnout)
     assert not os.path.exists(download_dir)
-    fnout = download_file(TESTURL, cache=True)
+
+    fnout = download_file(testurl, cache=True)
     assert os.path.isfile(fnout)
 
-    # Clearing download cache succeeds even if the URL does not exist.
-    clear_download_cache('http://this_was_never_downloaded_before.com')
 
-    # Make sure lockdir was released
-    lockdir = os.path.join(download_dir, 'lock')
-    assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
+@pytest.mark.remote_data(source="astropy")
+def test_download_parallel_from_internet_works():
+    main_url = conf.dataurl
+    mirror_url = conf.dataurl_mirror
+    fileloc = "intersphinx/README"
+    try:
+        fnout = download_files_in_parallel([main_url, main_url + fileloc])
+    except urllib.error.URLError:  # Use mirror if timed out
+        fnout = download_files_in_parallel([mirror_url, mirror_url + fileloc])
+    assert all([os.path.isfile(f) for f in fnout]), fnout
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.parametrize("method", [None, "spawn"])
+def test_download_parallel_fills_cache(tmpdir, valid_urls, method):
+    urls = []
+    # tmpdir is shared between many tests, and that can cause weird
+    # interactions if we set the temporary cache too directly
+    with paths.set_temp_cache(tmpdir):
+        for i in range(5):
+            um, c = next(valid_urls)
+            assert not is_url_in_cache(um)
+            urls.append((um, c))
+        rs = download_files_in_parallel([u for (u, c) in urls],
+                                        multiprocessing_start_method=method)
+        assert len(rs) == len(urls)
+        url_set = set(u for (u, c) in urls)
+        assert url_set <= set(get_cached_urls())
+        for r, (u, c) in zip(rs, urls):
+            assert get_file_contents(r) == c
+        check_download_cache()
+    assert not url_set.intersection(get_cached_urls())
+    check_download_cache()
+
+
+def test_download_parallel_with_empty_sources(valid_urls, temp_cache):
+    urls = []
+    sources = {}
+    for i in range(5):
+        um, c = next(valid_urls)
+        assert not is_url_in_cache(um)
+        urls.append((um, c))
+    rs = download_files_in_parallel([u for (u, c) in urls], sources=sources)
+    assert len(rs) == len(urls)
+    # u = set(u for (u, c) in urls)
+    # assert u <= set(get_cached_urls())
+    check_download_cache()
+    for r, (u, c) in zip(rs, urls):
+        assert get_file_contents(r) == c
+
+
+def test_download_parallel_with_sources_and_bogus_original(valid_urls,
+                                                           invalid_urls,
+                                                           temp_cache):
+    u, c = next(valid_urls)
+    urls = [(u, c, None)]
+    sources = {}
+    for i in range(5):
+        um, c_bad = next(valid_urls)
+        assert not is_url_in_cache(um)
+        sources[um] = []
+        for j in range(i):
+            sources[um].append(next(invalid_urls))
+        u, c = next(valid_urls)
+        sources[um].append(u)
+        urls.append((um, c, c_bad))
+    rs = download_files_in_parallel([u for (u, c, c_bad) in urls],
+                                    sources=sources)
+    assert len(rs) == len(urls)
+    # u = set(u for (u, c, c_bad) in urls)
+    # assert u <= set(get_cached_urls())
+    for r, (u, c, c_bad) in zip(rs, urls):
+        assert get_file_contents(r) == c
+        assert get_file_contents(r) != c_bad
+
+
+def test_download_parallel_many(temp_cache, valid_urls):
+    td = []
+    for i in range(n_parallel_hammer):
+        u, c = next(valid_urls)
+        clear_download_cache(u)
+        td.append((u, c))
+
+    r = download_files_in_parallel([u for (u, c) in td])
+    assert len(r) == len(td)
+    for r, (u, c) in zip(r, td):
+        assert get_file_contents(r) == c
+
+
+def test_download_parallel_partial_success(temp_cache,
+                                           valid_urls,
+                                           invalid_urls):
+    td = []
+    for i in range(n_parallel_hammer):
+        u, c = next(valid_urls)
+        clear_download_cache(u)
+        td.append((u, c))
+
+    u_bad = next(invalid_urls)
+
+    with pytest.raises(urllib.request.URLError):
+        download_files_in_parallel([u_bad] + [u for (u, c) in td])
+    # Actually some files may get downloaded, others not.
+    # Is this good? Should we stubbornly keep trying?
+    # assert not any([is_url_in_cache(u) for (u, c) in td])
+
+
+def test_download_parallel_update(temp_cache, tmpdir):
+    td = []
+    for i in range(n_parallel_hammer):
+        c = "%04d" % i
+        fn = os.path.join(tmpdir, c)
+        with open(fn, "w") as f:
+            f.write(c)
+        u = url_to(fn)
+        clear_download_cache(u)
+        td.append((fn, u, c))
+
+    r1 = download_files_in_parallel([u for (fn, u, c) in td])
+    assert len(r1) == len(td)
+    for r_1, (fn, u, c) in zip(r1, td):
+        assert get_file_contents(r_1) == c
+
+    td2 = []
+    for (fn, u, c) in td:
+        c_plus = c + " updated"
+        fn = os.path.join(tmpdir, c)
+        with open(fn, "w") as f:
+            f.write(c_plus)
+        td2.append((fn, u, c, c_plus))
+
+    r2 = download_files_in_parallel([u for (fn, u, c) in td],
+                                    update_cache=False)
+    assert len(r2) == len(td)
+    for r_2, (fn, u, c, c_plus) in zip(r2, td2):
+        assert get_file_contents(r_2) == c
+        assert c != c_plus
+    r3 = download_files_in_parallel([u for (fn, u, c) in td],
+                                    update_cache=True)
+
+    assert len(r3) == len(td)
+    for r_3, (fn, u, c, c_plus) in zip(r3, td2):
+        assert get_file_contents(r_3) != c
+        assert get_file_contents(r_3) == c_plus
+
+
+@pytest.mark.remote_data(source="astropy")
 def test_url_nocache():
-    with get_readable_fileobj(TESTURL, cache=False, encoding='utf-8') as page:
-        assert page.read().find('Astropy') > -1
+    with get_readable_fileobj(TESTURL, cache=False, encoding="utf-8") as page:
+        assert page.read().find("Astropy") > -1
 
 
-@pytest.mark.remote_data(source='astropy')
-def test_find_by_hash():
+@pytest.mark.remote_data(source="astropy")
+def test_find_by_hash(valid_urls, temp_cache):
+    testurl, contents = next(valid_urls)
+    p = download_file(testurl, cache=True)
+    hash = compute_hash(p)
 
-    from astropy.utils.data import clear_download_cache
-
-    with get_readable_fileobj(TESTURL, encoding="binary", cache=True) as page:
-        hash = hashlib.md5(page.read())
-
-    hashstr = 'hash/' + hash.hexdigest()
+    hashstr = "hash/" + hash
 
     fnout = get_pkg_data_filename(hashstr)
     assert os.path.isfile(fnout)
     clear_download_cache(hashstr[5:])
     assert not os.path.isfile(fnout)
 
-    lockdir = os.path.join(_get_download_cache_locs()[0], 'lock')
-    assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
+    lockdir = os.path.join(_get_download_cache_locs()[0], "lock")
+    assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data(source="astropy")
 def test_find_invalid():
     # this is of course not a real data file and not on any remote server, but
     # it should *try* to go to the remote server
     with pytest.raises(urllib.error.URLError):
-        get_pkg_data_filename('kjfrhgjklahgiulrhgiuraehgiurhgiuhreglhurieghruelighiuerahiulruli')
+        get_pkg_data_filename(
+            "kjfrhgjklahgiulrhgiuraehgiurhgiuhreglhurieghruelighiuerahiulruli"
+        )
 
 
 # Package data functions
-@pytest.mark.parametrize(('filename'), ['local.dat', 'local.dat.gz',
-                                        'local.dat.bz2', 'local.dat.xz'])
+@pytest.mark.parametrize(
+    ("filename"), ["local.dat", "local.dat.gz", "local.dat.bz2", "local.dat.xz"]
+)
 def test_local_data_obj(filename):
-    from astropy.utils.data import get_pkg_data_fileobj
-
-    if (not HAS_BZ2 and 'bz2' in filename) or (not HAS_XZ and 'xz' in filename):
+    if (not HAS_BZ2 and "bz2" in filename) or (not HAS_XZ and "xz" in filename):
         with pytest.raises(ValueError) as e:
-            with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
+            with get_pkg_data_fileobj(os.path.join("data", filename), encoding="binary") as f:
                 f.readline()
                 # assert f.read().rstrip() == b'CONTENT'
-        assert ' format files are not supported' in str(e.value)
+        assert " format files are not supported" in str(e.value)
     else:
-        with get_pkg_data_fileobj(os.path.join('data', filename), encoding='binary') as f:
+        with get_pkg_data_fileobj(os.path.join("data", filename), encoding="binary") as f:
             f.readline()
-            assert f.read().rstrip() == b'CONTENT'
+            assert f.read().rstrip() == b"CONTENT"
 
 
-@pytest.fixture(params=['invalid.dat.bz2', 'invalid.dat.gz'])
+@pytest.fixture(params=["invalid.dat.bz2", "invalid.dat.gz"])
 def bad_compressed(request, tmpdir):
-
     # These contents have valid headers for their respective file formats, but
     # are otherwise malformed and invalid.
-    bz_content = b'BZhinvalid'
-    gz_content = b'\x1f\x8b\x08invalid'
+    bz_content = b"BZhinvalid"
+    gz_content = b"\x1f\x8b\x08invalid"
 
     datafile = tmpdir.join(request.param)
     filename = datafile.strpath
 
-    if filename.endswith('.bz2'):
+    if filename.endswith(".bz2"):
         contents = bz_content
-    elif filename.endswith('.gz'):
+    elif filename.endswith(".gz"):
         contents = gz_content
     else:
-        contents = 'invalid'
+        contents = "invalid"
 
-    datafile.write(contents, mode='wb')
+    datafile.write(contents, mode="wb")
 
     return filename
 
 
 def test_local_data_obj_invalid(bad_compressed):
-
-    is_bz2 = bad_compressed.endswith('.bz2')
-    is_xz = bad_compressed.endswith('.xz')
+    is_bz2 = bad_compressed.endswith(".bz2")
+    is_xz = bad_compressed.endswith(".xz")
 
     # Note, since these invalid files are created on the fly in order to avoid
     # problems with detection by antivirus software
@@ -233,16 +587,16 @@ def test_local_data_obj_invalid(bad_compressed):
     # test.
     if (not HAS_BZ2 and is_bz2) or (not HAS_XZ and is_xz):
         with pytest.raises(ValueError) as e:
-            with get_readable_fileobj(bad_compressed, encoding='binary') as f:
+            with get_readable_fileobj(bad_compressed, encoding="binary") as f:
                 f.read()
-        assert ' format files are not supported' in str(e.value)
+        assert " format files are not supported" in str(e.value)
     else:
-        with get_readable_fileobj(bad_compressed, encoding='binary') as f:
-            assert f.read().rstrip().endswith(b'invalid')
+        with get_readable_fileobj(bad_compressed, encoding="binary") as f:
+            assert f.read().rstrip().endswith(b"invalid")
 
 
 def test_local_data_name():
-    assert os.path.isfile(TESTLOCAL) and TESTLOCAL.endswith('local.dat')
+    assert os.path.isfile(TESTLOCAL) and TESTLOCAL.endswith("local.dat")
 
     # TODO: if in the future, the root data/ directory is added in, the below
     # test should be uncommented and the README.rst should be replaced with
@@ -263,14 +617,14 @@ def test_data_name_third_party_package():
     """
 
     # Get the actual data dir:
-    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
 
     sys.path.insert(0, data_dir)
     try:
         import test_package
+
         filename = test_package.get_data_filename()
-        assert filename == os.path.join(data_dir, 'test_package', 'data',
-                                        'foo.txt')
+        assert filename == os.path.join(data_dir, "test_package", "data", "foo.txt")
     finally:
         sys.path.pop(0)
 
@@ -278,17 +632,16 @@ def test_data_name_third_party_package():
 @raises(RuntimeError)
 def test_local_data_nonlocalfail():
     # this would go *outside* the astropy tree
-    get_pkg_data_filename('../../../data/README.rst')
+    get_pkg_data_filename("../../../data/README.rst")
 
 
 def test_compute_hash(tmpdir):
-    from astropy.utils.data import compute_hash
 
-    rands = b'1234567890abcdefghijklmnopqrstuvwxyz'
+    rands = b"1234567890abcdefghijklmnopqrstuvwxyz"
 
-    filename = tmpdir.join('tmp.dat').strpath
+    filename = tmpdir.join("tmp.dat").strpath
 
-    with open(filename, 'wb') as ntf:
+    with open(filename, "wb") as ntf:
         ntf.write(rands)
         ntf.flush()
 
@@ -299,25 +652,21 @@ def test_compute_hash(tmpdir):
 
 
 def test_get_pkg_data_contents():
-    from astropy.utils.data import get_pkg_data_fileobj, get_pkg_data_contents
 
-    with get_pkg_data_fileobj('data/local.dat') as f:
+    with get_pkg_data_fileobj("data/local.dat") as f:
         contents1 = f.read()
 
-    contents2 = get_pkg_data_contents('data/local.dat')
+    contents2 = get_pkg_data_contents("data/local.dat")
 
     assert contents1 == contents2
 
 
-@pytest.mark.remote_data(source='astropy')
+@pytest.mark.remote_data(source="astropy")
 def test_data_noastropy_fallback(monkeypatch):
     """
     Tests to make sure the default behavior when the cache directory can't
     be located is correct
     """
-
-    from astropy.utils import data
-    from astropy.config import paths
 
     # needed for testing the *real* lock at the end
     lockdir = os.path.join(_get_download_cache_locs('astropy')[0], 'lock')
@@ -326,13 +675,13 @@ def test_data_noastropy_fallback(monkeypatch):
     conf.delete_temporary_downloads_at_exit = True
 
     # make sure the config and cache directories are not searched
-    monkeypatch.setenv('XDG_CONFIG_HOME', 'foo')
-    monkeypatch.delenv('XDG_CONFIG_HOME')
-    monkeypatch.setenv('XDG_CACHE_HOME', 'bar')
-    monkeypatch.delenv('XDG_CACHE_HOME')
+    monkeypatch.setenv("XDG_CONFIG_HOME", "foo")
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    monkeypatch.setenv("XDG_CACHE_HOME", "bar")
+    monkeypatch.delenv("XDG_CACHE_HOME")
 
-    monkeypatch.setattr(paths.set_temp_config, '_temp_path', None)
-    monkeypatch.setattr(paths.set_temp_cache, '_temp_path', None)
+    monkeypatch.setattr(paths.set_temp_config, "_temp_path", None)
+    monkeypatch.setattr(paths.set_temp_cache, "_temp_path", None)
 
     # make sure the _find_or_create_astropy_dir function fails as though the
     # astropy dir could not be accessed
@@ -346,6 +695,7 @@ def test_data_noastropy_fallback(monkeypatch):
 
     # first try with cache
     with catch_warnings(CacheMissingWarning) as w:
+        warnings.simplefilter("ignore", ResourceWarning)
         fnout = data.download_file(TESTURL, cache=True)
 
     assert os.path.isfile(fnout)
@@ -356,9 +706,9 @@ def test_data_noastropy_fallback(monkeypatch):
     w2 = w.pop(0)
 
     assert w1.category == CacheMissingWarning
-    assert 'Remote data cache could not be accessed' in w1.message.args[0]
+    assert "Remote data cache could not be accessed" in w1.message.args[0]
     assert w2.category == CacheMissingWarning
-    assert 'File downloaded to temporary location' in w2.message.args[0]
+    assert "File downloaded to temporary location" in w2.message.args[0]
     assert fnout == w2.message.args[1]
 
     # clearing the cache should be a no-up that doesn't affect fnout
@@ -376,46 +726,58 @@ def test_data_noastropy_fallback(monkeypatch):
     w3 = w.pop()
 
     assert w3.category == data.CacheMissingWarning
-    assert 'Not clearing data cache - cache inacessable' in str(w3.message)
+    assert "Not clearing data cache - cache inacessible" in str(w3.message)
 
     # now try with no cache
     with catch_warnings(CacheMissingWarning) as w:
         fnnocache = data.download_file(TESTURL, cache=False)
-    with open(fnnocache, 'rb') as page:
-        assert page.read().decode('utf-8').find('Astropy') > -1
+    with open(fnnocache, "rb") as page:
+        assert page.read().decode("utf-8").find("Astropy") > -1
 
     # no warnings should be raise in fileobj because cache is unnecessary
     assert len(w) == 0
 
     # lockdir determined above as the *real* lockdir, not the temp one
-    assert not os.path.isdir(lockdir), 'Cache dir lock was not released!'
+    assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
 
 
-@pytest.mark.parametrize(('filename'), [
-    'unicode.txt',
-    'unicode.txt.gz',
-    pytest.param('unicode.txt.bz2', marks=pytest.mark.xfail(not HAS_BZ2, reason='no bz2 support')),
-    pytest.param('unicode.txt.xz', marks=pytest.mark.xfail(not HAS_XZ, reason='no lzma support'))])
+@pytest.mark.parametrize(
+    ("filename"),
+    [
+        "unicode.txt",
+        "unicode.txt.gz",
+        pytest.param(
+            "unicode.txt.bz2",
+            marks=pytest.mark.xfail(not HAS_BZ2, reason="no bz2 support"),
+        ),
+        pytest.param(
+            "unicode.txt.xz",
+            marks=pytest.mark.xfail(not HAS_XZ, reason="no lzma support"),
+        ),
+    ],
+)
 def test_read_unicode(filename):
-    from astropy.utils.data import get_pkg_data_contents
 
-    contents = get_pkg_data_contents(os.path.join('data', filename), encoding='utf-8')
+    contents = get_pkg_data_contents(os.path.join("data", filename), encoding="utf-8")
     assert isinstance(contents, str)
     contents = contents.splitlines()[1]
     assert contents == "האסטרונומי פייתון"
 
-    contents = get_pkg_data_contents(os.path.join('data', filename), encoding='binary')
+    contents = get_pkg_data_contents(os.path.join("data", filename), encoding="binary")
     assert isinstance(contents, bytes)
     x = contents.splitlines()[1]
-    assert x == (b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0"
-                 b"\xd7\x95\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:])
+    assert x == (
+        b"\xff\xd7\x94\xd7\x90\xd7\xa1\xd7\x98\xd7\xa8\xd7\x95\xd7\xa0"
+        b"\xd7\x95\xd7\x9e\xd7\x99 \xd7\xa4\xd7\x99\xd7\x99\xd7\xaa\xd7\x95\xd7\x9f"[1:]
+    )
 
 
 def test_compressed_stream():
-    import base64
 
-    gzipped_data = (b"H4sICIxwG1AAA2xvY2FsLmRhdAALycgsVkjLzElVANKlxakpCpl5CiUZqQ"
-                    b"olqcUl8Tn5yYk58SmJJYnxWmCRzLx0hbTSvOSSzPy8Yi5nf78QV78QLgAlLytnRQAAAA==")
+    gzipped_data = (
+        b"H4sICIxwG1AAA2xvY2FsLmRhdAALycgsVkjLzElVANKlxakpCpl5CiUZqQ"
+        b"olqcUl8Tn5yYk58SmJJYnxWmCRzLx0hbTSvOSSzPy8Yi5nf78QV78QLgAlLytnRQAAAA=="
+    )
     gzipped_data = base64.b64decode(gzipped_data)
     assert isinstance(gzipped_data, bytes)
 
@@ -430,62 +792,457 @@ def test_compressed_stream():
         def read(self, nbytes=None):
             if nbytes is None:
                 result = self.data
-                self.data = b''
+                self.data = b""
             else:
                 result = self.data[:nbytes]
                 self.data = self.data[nbytes:]
             return result
 
     stream = FakeStream(gzipped_data)
-    with get_readable_fileobj(stream, encoding='binary') as f:
+    with get_readable_fileobj(stream, encoding="binary") as f:
         f.readline()
-        assert f.read().rstrip() == b'CONTENT'
+        assert f.read().rstrip() == b"CONTENT"
 
 
-@pytest.mark.remote_data(source='astropy')
-def test_invalid_location_download():
+@pytest.mark.remote_data(source="astropy")
+def test_invalid_location_download_raises_urlerror():
     """
     checks that download_file gives a URLError and not an AttributeError,
     as its code pathway involves some fiddling with the exception.
     """
-    from astropy.utils.data import download_file
 
     with pytest.raises(urllib.error.URLError):
-        download_file('http://www.astropy.org/nonexistentfile')
+        download_file("http://www.astropy.org/nonexistentfile")
 
 
 def test_invalid_location_download_noconnect():
     """
     checks that download_file gives an OSError if the socket is blocked
     """
-    from astropy.utils.data import download_file
 
     # This should invoke socket's monkeypatched failure
     with pytest.raises(OSError):
-        download_file('http://astropy.org/nonexistentfile')
+        download_file("http://astropy.org/nonexistentfile")
 
 
-@pytest.mark.remote_data(source='astropy')
-def test_is_url_in_cache():
-    from astropy.utils.data import download_file, is_url_in_cache
+@pytest.mark.remote_data(source="astropy")
+def test_is_url_in_cache_remote():
 
-    assert not is_url_in_cache('http://astropy.org/nonexistentfile')
+    assert not is_url_in_cache("http://astropy.org/nonexistentfile")
 
     download_file(TESTURL, cache=True, show_progress=False)
     assert is_url_in_cache(TESTURL)
 
 
+def test_is_url_in_cache_local(temp_cache, valid_urls, invalid_urls):
+
+    testurl, contents = next(valid_urls)
+    nonexistent = next(invalid_urls)
+
+    assert not is_url_in_cache(testurl)
+    assert not is_url_in_cache(nonexistent)
+
+    download_file(testurl, cache=True, show_progress=False)
+    assert is_url_in_cache(testurl)
+    assert not is_url_in_cache(nonexistent)
+
+
+def test_check_download_cache(tmpdir, temp_cache, valid_urls, invalid_urls):
+    testurl, testurl_contents = next(valid_urls)
+    testurl2, testurl2_contents = next(valid_urls)
+
+    zip_file_name = os.path.join(tmpdir, "the.zip")
+    clear_download_cache()
+    check_download_cache()
+
+    download_file(testurl, cache=True)
+    # normal files probably corresponding to the urlmap
+    normal = check_download_cache()
+    download_file(testurl2, cache=True)
+    assert check_download_cache() == normal
+
+    export_download_cache(zip_file_name, [testurl, testurl2])
+    assert check_download_cache(check_hashes=True) == normal
+
+    clear_download_cache(testurl2)
+    assert check_download_cache() == normal
+
+    import_download_cache(zip_file_name, [testurl])
+    assert check_download_cache(check_hashes=True) == normal
+
+
+def test_export_import_roundtrip_one(tmpdir, temp_cache, valid_urls):
+    testurl, contents = next(valid_urls)
+    f = download_file(testurl, cache=True, show_progress=False)
+    assert get_file_contents(f) == contents
+    normal = check_download_cache()
+    initial_urls_in_cache = set(get_cached_urls())
+    zip_file_name = os.path.join(tmpdir, "the.zip")
+
+    export_download_cache(zip_file_name, [testurl])
+    clear_download_cache(testurl)
+    import_download_cache(zip_file_name)
+    assert is_url_in_cache(testurl)
+    assert set(get_cached_urls()) == initial_urls_in_cache
+    assert get_file_contents(download_file(testurl,
+                                           cache=True,
+                                           show_progress=False)) == contents
+    assert check_download_cache(check_hashes=True) == normal
+
+
+def test_export_with_download(temp_cache, valid_urls):
+    testurl, contents = next(valid_urls)
+    with NamedTemporaryFile("wb") as zip_file:
+        clear_download_cache(testurl)
+        export_download_cache(zip_file, [testurl])
+        assert is_url_in_cache(testurl)
+
+
+def test_import_one(tmpdir, temp_cache, valid_urls):
+    testurl, testurl_contents = next(valid_urls)
+    testurl2, testurl2_contents = next(valid_urls)
+    zip_file_name = os.path.join(tmpdir, "the.zip")
+
+    download_file(testurl, cache=True)
+    download_file(testurl2, cache=True)
+    assert is_url_in_cache(testurl2)
+    export_download_cache(zip_file_name, [testurl, testurl2])
+    clear_download_cache(testurl)
+    clear_download_cache(testurl2)
+    import_download_cache(zip_file_name, [testurl])
+    assert is_url_in_cache(testurl)
+    assert not is_url_in_cache(testurl2)
+
+
+def test_export_import_roundtrip(tmpdir, temp_cache, valid_urls):
+    zip_file_name = os.path.join(tmpdir, "the.zip")
+    for u, c in itertools.islice(valid_urls, 7):
+        download_file(u, cache=True)
+    normal = check_download_cache()
+    initial_urls_in_cache = set(get_cached_urls())
+
+    export_download_cache(zip_file_name)
+    clear_download_cache()
+    import_download_cache(zip_file_name)
+
+    assert set(get_cached_urls()) == initial_urls_in_cache
+    assert check_download_cache(check_hashes=True) == normal
+
+
+def test_export_import_roundtrip_different_location(tmpdir, valid_urls):
+    original_cache = tmpdir / "original"
+    os.mkdir(original_cache)
+    zip_file_name = tmpdir / "the.zip"
+
+    urls = list(itertools.islice(valid_urls, 7))
+    initial_urls_in_cache = set(u for (u, c) in urls)
+    with paths.set_temp_cache(original_cache):
+        for u, c in urls:
+            download_file(u, cache=True)
+        assert set(get_cached_urls()) == initial_urls_in_cache
+        export_download_cache(zip_file_name)
+
+    new_cache = tmpdir / "new"
+    os.mkdir(new_cache)
+    with paths.set_temp_cache(new_cache):
+        import_download_cache(zip_file_name)
+        check_download_cache(check_hashes=True)
+        assert set(get_cached_urls()) == initial_urls_in_cache
+        for (u, c) in urls:
+            assert get_file_contents(download_file(u, cache=True)) == c
+
+
+def test_cache_size_is_zero_when_empty(temp_cache):
+    assert not get_cached_urls()
+    assert cache_total_size() == 0
+
+
+def test_cache_size_changes_correctly_when_files_are_added_and_removed(
+        temp_cache,
+        valid_urls):
+    u, c = next(valid_urls)
+    clear_download_cache(u)
+    s_i = cache_total_size()
+    download_file(u, cache=True)
+    assert cache_total_size() == s_i + len(c)
+    clear_download_cache(u)
+    assert cache_total_size() == s_i
+
+
+def test_cache_contents_agrees_with_get_urls(temp_cache, valid_urls):
+    r = []
+    for i in range(7):
+        a, a_c = next(valid_urls)
+        a_f = download_file(a, cache=True)
+        r.append((a, a_c, a_f))
+    assert set(cache_contents().keys()) == set(get_cached_urls())
+    for (u, c, h) in r:
+        assert cache_contents()[u] == h
+
+
+def test_free_space_checker_huge(tmpdir):
+    with pytest.raises(OSError):
+        check_free_space_in_dir(tmpdir, 1_000_000_000_000_000_000)
+
+
+def test_get_free_space_file_directory(tmpdir):
+    fn = tmpdir / "file"
+    with open(fn, "w"):
+        pass
+    with pytest.raises(OSError):
+        get_free_space_in_dir(fn)
+    assert get_free_space_in_dir(tmpdir) > 0
+
+
+def test_download_file_bogus_settings(invalid_urls, temp_cache):
+    u = next(invalid_urls)
+    with pytest.raises(ValueError):
+        download_file(u, cache=False, update_cache=True)
+    with pytest.raises(ValueError):
+        download_file(u, sources=[])
+
+
+def test_download_file_local_directory(tmpdir):
+    with pytest.raises(urllib.request.URLError):
+        download_file(url_to(tmpdir))
+
+
+def test_download_file_schedules_deletion(valid_urls):
+    u, c = next(valid_urls)
+    f = download_file(u)
+    assert f in _tempfilestodel
+    # how to test deletion actually occurs?
+
+
+def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmpdir):
+    fn = os.path.abspath(os.path.join(tmpdir, "file"))
+    with open(fn, "w") as f:
+        f.write("content")
+    assert os.path.exists(fn)
+    with pytest.raises(RuntimeError):
+        clear_download_cache(fn)
+    assert os.path.exists(fn)
+
+
+def test_check_download_cache_finds_unreferenced_files(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    download_file(u, cache=True)
+    with _cache(write=True) as (dldir, urlmap):
+        del urlmap[u]
+    with pytest.raises(ValueError):
+        check_download_cache()
+    clear_download_cache()
+
+
+def test_check_download_cache_finds_missing_files(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    os.remove(download_file(u, cache=True))
+    with pytest.raises(ValueError):
+        check_download_cache()
+    clear_download_cache()
+
+
+def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    download_file(u, cache=True)
+    with _cache(write=True) as (dldir, urlmap):
+        bd = os.path.join(dldir, "bogus")
+        os.mkdir(bd)
+        bf = os.path.join(bd, "file")
+        with open(bf, "wt") as f:
+            f.write("bogus file that exists")
+        urlmap[u] = bf
+    with pytest.raises(ValueError):
+        check_download_cache()
+    clear_download_cache()
+
+
+def test_check_download_cache_finds_bogus_hashes(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    fn = download_file(u, cache=True)
+    with open(fn, "w") as f:
+        f.write("bogus contents")
+    with pytest.raises(ValueError):
+        check_download_cache(check_hashes=True)
+    clear_download_cache()
+
+
+def test_download_cache_update_doesnt_damage_cache(temp_cache, valid_urls):
+    u, _ = next(valid_urls)
+    download_file(u, cache=True)
+    download_file(u, cache=True, update_cache=True)
+
+
+def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
+    def check_quietly_ignores_bogus_cache():
+        with catch_warnings(CacheMissingWarning) as w:
+            assert not get_cached_urls()
+        assert any(wi.category == CacheMissingWarning for wi in w)
+        with catch_warnings(CacheMissingWarning) as w:
+            assert not is_url_in_cache("http://www.example.com/")
+        assert any(wi.category == CacheMissingWarning for wi in w)
+        with catch_warnings(CacheMissingWarning) as w:
+            assert not cache_contents()
+        assert any(wi.category == CacheMissingWarning for wi in w)
+        with catch_warnings(CacheMissingWarning) as w:
+            u, c = next(valid_urls)
+            r = download_file(u, cache=True)
+            assert get_file_contents(r) == c
+        assert any(wi.category == CacheMissingWarning for wi in w)
+        with catch_warnings(CacheMissingWarning) as w:
+            assert not is_url_in_cache(u)
+        assert any(wi.category == CacheMissingWarning for wi in w)
+        with pytest.raises(OSError):
+            check_download_cache()
+
+    fn = str(tmpdir / "file")
+    ct = "contents\n"
+    os.mkdir(fn)
+    with paths.set_temp_cache(fn):
+        shutil.rmtree(fn)
+        with open(fn, "w") as f:
+            f.write(ct)
+        with pytest.raises(OSError):
+            paths.get_cache_dir()
+        check_quietly_ignores_bogus_cache()
+    assert get_file_contents(fn) == ct
+
+    with pytest.raises(OSError):
+        with paths.set_temp_cache(fn):
+            pass
+    assert get_file_contents(str(fn)) == ct
+
+    cd = str(tmpdir / "astropy")
+    with open(cd, "w") as f:
+        f.write(ct)
+    with paths.set_temp_cache(tmpdir):
+        check_quietly_ignores_bogus_cache()
+    assert get_file_contents(cd) == ct
+    os.remove(cd)
+
+    os.makedirs(cd)
+    cd = str(tmpdir / "astropy" / "download")
+    with open(cd, "w") as f:
+        f.write(ct)
+    with paths.set_temp_cache(tmpdir):
+        check_quietly_ignores_bogus_cache()
+    assert get_file_contents(cd) == ct
+    os.remove(cd)
+
+    os.makedirs(cd)
+    py_version = 'py' + str(sys.version_info.major)
+    cd = str(tmpdir / "astropy" / "download" / py_version)
+    with open(cd, "w") as f:
+        f.write(ct)
+    with paths.set_temp_cache(tmpdir):
+        check_quietly_ignores_bogus_cache()
+    assert get_file_contents(cd) == ct
+    os.remove(cd)
+
+    cd = str(tmpdir / "astropy" / "download" / py_version / "urlmap")
+    os.makedirs(cd)
+    with paths.set_temp_cache(tmpdir):
+        check_quietly_ignores_bogus_cache()
+
+
+def test_get_fileobj_str(a_file):
+    fn, c = a_file
+    with get_readable_fileobj(str(fn)) as rf:
+        assert rf.read() == c
+
+
+def test_get_fileobj_localpath(a_file):
+    fn, c = a_file
+    with get_readable_fileobj(py.path.local(fn)) as rf:
+        assert rf.read() == c
+
+
+def test_get_fileobj_pathlib(a_file):
+    fn, c = a_file
+    with get_readable_fileobj(pathlib.Path(fn)) as rf:
+        assert rf.read() == c
+
+
+def test_get_fileobj_binary(a_binary_file):
+    fn, c = a_binary_file
+    with get_readable_fileobj(fn, encoding="binary") as rf:
+        assert rf.read() == c
+
+
+def test_get_fileobj_already_open_text(a_file):
+    fn, c = a_file
+    with open(fn, "r") as f:
+        with get_readable_fileobj(f) as rf:
+            with pytest.raises(TypeError):
+                rf.read()
+
+
+def test_get_fileobj_already_open_binary(a_file):
+    fn, c = a_file
+    with open(fn, "rb") as f:
+        with get_readable_fileobj(f) as rf:
+            assert rf.read() == c
+
+
+def test_get_fileobj_binary_already_open_binary(a_binary_file):
+    fn, c = a_binary_file
+    with open(fn, "rb") as f:
+        with get_readable_fileobj(f, encoding="binary") as rf:
+            assert rf.read() == c
+
+
+def test_cache_contents_not_writable(temp_cache, valid_urls):
+    c = cache_contents()
+    with pytest.raises(TypeError):
+        c["foo"] = 7
+    u, _ = next(valid_urls)
+    download_file(u, cache=True)
+    c = cache_contents()
+    assert u in c
+    with pytest.raises(TypeError):
+        c["foo"] = 7
+
+
+def test_cache_read_not_writable(temp_cache, valid_urls):
+    with _cache() as (dldir, urlmap):
+        with pytest.raises(TypeError):
+            urlmap["foo"] = 7
+    u, _ = next(valid_urls)
+    download_file(u, cache=True)
+    with _cache() as (dldir, urlmap):
+        assert u in urlmap
+        with pytest.raises(TypeError):
+            urlmap["foo"] = 7
+
+
+def test_cache_not_relocatable(tmpdir, valid_urls):
+    u, c = next(valid_urls)
+    d1 = tmpdir / "1"
+    os.mkdir(d1)
+    with paths.set_temp_cache(d1):
+        p1 = download_file(u, cache=True)
+        assert is_url_in_cache(u)
+        assert get_file_contents(p1) == c
+    d2 = tmpdir / "2"
+    # this will not work!
+    shutil.copytree(d1, d2)
+    with paths.set_temp_cache(d2):
+        assert is_url_in_cache(u)
+        p2 = download_file(u, cache=True)
+        assert p1 == p2
+
+
 def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
     """checks that get_readable_fileobj leaves no temporary files behind"""
     # Create a 'file://' URL pointing to a path on the local filesystem
-    url = 'file://' + urllib.request.pathname2url(TESTLOCAL)
+    url = url_to(TESTLOCAL)
 
     # Save temporary files to a known location
-    monkeypatch.setattr(tempfile, 'tempdir', str(tmpdir))
+    monkeypatch.setattr(tempfile, "tempdir", str(tmpdir))
 
     # Call get_readable_fileobj() as a context manager
-    with get_readable_fileobj(url):
-        pass
+    with get_readable_fileobj(url) as f:
+        f.read()
 
     # Get listing of files in temporary directory
     tempdir_listing = tmpdir.listdir()
@@ -498,23 +1255,25 @@ def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
 def test_path_objects_get_readable_fileobj():
     fpath = pathlib.Path(TESTLOCAL)
     with get_readable_fileobj(fpath) as f:
-        assert f.read().rstrip() == ('This file is used in the test_local_data_* '
-                                     'testing functions\nCONTENT')
+        assert f.read().rstrip() == (
+            "This file is used in the test_local_data_* "
+            "testing functions\nCONTENT"
+        )
 
 
 def test_nested_get_readable_fileobj():
     """Ensure fileobj state is as expected when get_readable_fileobj()
     is called inside another get_readable_fileobj().
     """
-    with get_readable_fileobj(TESTLOCAL, encoding='binary') as fileobj:
-        with get_readable_fileobj(fileobj, encoding='UTF-8') as fileobj2:
+    with get_readable_fileobj(TESTLOCAL, encoding="binary") as fileobj:
+        with get_readable_fileobj(fileobj, encoding="UTF-8") as fileobj2:
             fileobj2.seek(1)
         fileobj.seek(1)
 
         # Theoretically, fileobj2 should be closed already here but it is not.
         # See https://github.com/astropy/astropy/pull/8675.
         # UNCOMMENT THIS WHEN PYTHON FINALLY LETS IT HAPPEN.
-        #assert fileobj2.closed
+        # assert fileobj2.closed
 
     assert fileobj.closed and fileobj2.closed
 
@@ -539,7 +1298,7 @@ def test_download_file_wrong_size(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", mockurl)
 
-    with pytest.raises(urllib.error.ContentTooShortError):
+    with pytest.raises(urllib.error.URLError):
         report_length = 1024
         real_length = 1023
         download_file(TESTURL, cache=False)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -304,12 +304,11 @@ def test_update_url(tmpdir, temp_cache):
             f.write("new")
         assert get_file_contents(download_file(f_url, cache=True)) == "old"
         assert get_file_contents(download_file(f_url,
-                                               cache=True,
-                                               update_cache=True)) == "new"
+                                               cache="update")) == "new"
     assert not os.path.exists(f_name)
     assert get_file_contents(download_file(f_url, cache=True)) == "new"
     with pytest.raises(urllib.error.URLError):
-        download_file(f_url, cache=True, update_cache=True)
+        download_file(f_url, cache="update")
     assert get_file_contents(download_file(f_url, cache=True)) == "new"
 
 
@@ -488,13 +487,13 @@ def test_download_parallel_update(temp_cache, tmpdir):
         td2.append((fn, u, c, c_plus))
 
     r2 = download_files_in_parallel([u for (fn, u, c) in td],
-                                    update_cache=False)
+                                    cache=True)
     assert len(r2) == len(td)
     for r_2, (fn, u, c, c_plus) in zip(r2, td2):
         assert get_file_contents(r_2) == c
         assert c != c_plus
     r3 = download_files_in_parallel([u for (fn, u, c) in td],
-                                    update_cache=True)
+                                    cache="update")
 
     assert len(r3) == len(td)
     for r_3, (fn, u, c, c_plus) in zip(r3, td2):
@@ -997,8 +996,6 @@ def test_get_free_space_file_directory(tmpdir):
 def test_download_file_bogus_settings(invalid_urls, temp_cache):
     u = next(invalid_urls)
     with pytest.raises(ValueError):
-        download_file(u, cache=False, update_cache=True)
-    with pytest.raises(ValueError):
         download_file(u, sources=[])
 
 
@@ -1070,7 +1067,7 @@ def test_check_download_cache_finds_bogus_hashes(temp_cache, valid_urls):
 def test_download_cache_update_doesnt_damage_cache(temp_cache, valid_urls):
     u, _ = next(valid_urls)
     download_file(u, cache=True)
-    download_file(u, cache=True, update_cache=True)
+    download_file(u, cache="update")
 
 
 def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -212,4 +212,4 @@ to locations you know do work.
 
 If you have a particular URL that is giving you trouble, you can download it
 using some other tool (for example ``wget``), possibly on another machine, and
-then use `import_to_cache`.
+then use `~astropy.utils.data.import_to_cache`.

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -1,0 +1,215 @@
+.. _utils-data:
+
+***************************************************
+Downloadable data management (`astropy.utils.data`)
+***************************************************
+
+Introduction
+============
+
+A number of Astropy's tools work with data sets that are either awkwardly
+large (for example `~astropy.coordinates.solar_system_ephemeris`) or
+regularly updated (for example `~astropy.utils.iers.IERS_B`) or both
+(for example `~astropy.utils.iers.IERS_A`). What's more, this kind of
+data - authoritative data made available on the Web, and possibly updated
+from time to time - is reasonably common in astronomy. Astropy therefore
+provides some tools for working with such data.
+
+The primary tool for this is the Astropy *cache*. This is a repository
+of downloaded data, indexed by the URL where it was obtained. The tool
+`~astropy.utils.data.download_file` and various other things built upon
+it can use this cache to request the contents of a URL, and (if they
+choose to use the cache) the data will only be downloaded if it isn't
+already present in the cache. Of course they can be instructed to obtain
+a new copy of data that has been updated.
+
+The astropy cache is stored in a centralized place (on
+UNIX machines it is ``$HOME/.astropy/cache``, or if the
+environment variable ``XDG_CACHE_HOME`` is set, the cache is in
+``$XDG_CACHE_HOME/astropy``). This centralization means that the cache
+is persistent and shared between all Astropy runs in any virtualenv
+by your user on one machine (possibly more if your home directory is
+shared between multiple machines). This can dramatically accelerate
+Astropy operations and reduce load on servers, like those of the IERS,
+that were not designed for heavy Web traffic. If you find the cache has
+corrupted or out-of-date data in it, you can remove an entry or clear
+the whole thing with `~astropy.utils.data.clear_download_cache`.
+
+The files in the download cache directory are named according to a
+cryptographic hash of their contents (currently MD5, so malevolent entities can
+cause collisions). Thus files with the same content share storage. The
+modification times on these files normally indicate when they were last
+downloaded from the Internet.
+
+Usage Within Astropy
+====================
+
+For the most part, you can ignore the caching mechanism and rely on
+Astropy to have the correct data when you need it. For example, precise
+time conversions and sky locations need meaasured tables of the Earth's
+rotation from the IERS. The table `~astropy.utils.iers.IERS_Auto` provides
+the infrastructure for many of these calculations. It makes available
+Earth rotation parameters, and if you request them for a time more recent
+than its tables cover, it will download updated tables from the IERS. So
+for example asking what time it is in UT1 (a timescale that reflects the
+irregularity of the Earth's rotation) probably triggers a download of the
+IERS data::
+
+   >>> from astropy.time import Time
+   >>> Time.now().ut1  # doctest: +SKIP
+   Downloading https://maia.usno.navy.mil/ser7/finals2000A.all
+   |============================================| 3.2M/3.2M (100.00%)         1s
+   <Time object: scale='ut1' format='datetime' value=2019-09-22 08:39:03.812731>
+
+But running it a second time doesn't require any new download::
+
+   >>> Time.now().ut1  # doctest: +SKIP
+   <Time object: scale='ut1' format='datetime' value=2019-09-22 08:41:21.588836>
+
+Some data is also made available from the `Astropy data server`_ either
+for use within astropy or for your convenience. These are available more
+conveniently with the ``get_pkg_data_*`` functions::
+
+   >>> from astropy.utils.data import get_pkg_data_contents
+   >>> print(get_pkg_data_contents("coordinates/sites-un-ascii"))  # doctest: +SKIP
+   # these are all mappings from the name in sites.json (which is ASCII-only) to the "true" unicode names
+   TUBITAK->TÜBİTAK
+
+Usage From Outside Astropy
+==========================
+
+Users of Astropy can also make use of Astropy's caching
+and downloading mechanism. Most simply, this amounts to using
+`~astropy.utils.data.download_file` with the ``cache=True``
+argument to obtain their data, from the cache if the data is
+there::
+
+   >>> from astropy.utils.iers import IERS_B_URL, IERS_B
+   >>> from astropy.utils.data import download_file
+   >>> IERS_B.open(download_file(IERS_B_URL, cache=True))["year","month","day"][-3:]  # doctest: +SKIP
+    <IERS_B length=3>
+    year month  day
+   int64 int64 int64
+   ----- ----- -----
+    2019     8     4
+    2019     8     5
+    2019     8     6
+
+If users want to update the cache to a newer version of the
+data (note that here the data was already up to date; users
+will have to decide for themselves when to obtain new versions),
+they can use the ``update_cache`` argument::
+
+   >>> IERS_B.open(download_file(IERS_B_URL,
+   ...                           cache=True,
+   ...                           update_cache=True)
+   ... )["year","month","day"][-3:]  # doctest: +SKIP
+   Downloading http://hpiers.obspm.fr/iers/eop/eopc04/eopc04_IAU2000.62-now
+   |=========================================| 3.2M/3.2M (100.00%)         0s
+   <IERS_B length=3>
+    year month  day
+   int64 int64 int64
+   ----- ----- -----
+    2019     8    18
+    2019     8    19
+    2019     8    20
+
+If they are concerned that the primary source of the data may be
+overloaded or unavailable, they can use the ``sources`` argument
+to provide a list of sources to attempt downloading from, in order.
+This need not include the original source. Regardless, the data
+will be stored in the cache under the original URL requested::
+
+   >>> f = download_file("ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de405.bsp",
+   ...     cache=False,
+   ...     sources=['https://data.nanograv.org/static/data/ephem/de405.bsp',
+   ...              'ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de405.bsp'])  # doctest: +SKIP
+   Downloading ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de405.bsp from https://data.nanograv.org/static/data/ephem/de405.bsp
+   |========================================|  65M/ 65M (100.00%)        19s
+
+.. _Astropy data server: http://www.astropy.org/astropy-data/
+
+Cache Management
+================
+
+Because the cache is persistent, it is possible for it to become
+inconveniently large, or become filled with no-longer-relevant data. While
+it is simply a directory on disk, each file is supposed to represent
+the contents of a URL, and many URLs do not make acceptable on-disk
+filenames. There is reason to worry that multiple astropy processes accessing
+the cache simultaneously might lead to cache corruption. The cache is
+therefore protected by a lock and indexed by a persistent dictionary
+mapping URLs to hashes of the file contents, while the file contents are
+stored in files named by their hashes. So access to the cache is easier
+with a few helpers provided by `~astropy.utils.data`.
+
+If a single file is undesired or damaged, it can be removed by calling
+`~astropy.utils.data.clear_download_cache` with an argument that is the URL it
+was obtained from, the filename of the downloaded file, or the hash of its
+contents. Should the cache ever become badly corrupted,
+`~astropy.utils.data.clear_download_cache` with no arguments will simply delete
+the whole directory, freeing the space and removing any inconsistent data. Of
+course, if you remove data using either of these tools, any processes currently
+using that data may be disrupted (or, under Windows, deleting the cache may not
+be possible until those processes terminate). So use
+`~astropy.utils.data.clear_download_cache` with care.
+
+To check the total space occupied by the cache, use
+`~astropy.utils.data.cache_total_size()`. The contents of the cache can be
+listed with `~astropy.utils.data.get_cached_urls`, and the presence of a
+particular URL in the cache can be tested with
+`~astropy.utils.data.is_url_in_cache`. More general manipulations can be
+carried out using `~astropy.utils.data.cache_contents`, which returns a
+dict mapping URLs to on-disk filenames of their contents.
+
+If you want to transfer the cache to another computer, or preserve its contents
+for later use, you can use the functions `~astropy.utils.data.export_download_cache` to
+produce a zipfile listing some or all of the cache contents, and
+`~astropy.utils.data.import_download_cache` to load the astropy cache from such a
+zipfile.
+
+Using Astropy With Limited or No Internet Access
+================================================
+
+You might want to use astropy on a telescope control machine behind a strict
+firewall. Or you might be running contionuous integration on your Astropy
+server and want to avoid hammering astronomy servers on every pull request for
+every architecture. Or you might not have access to US government or military
+web servers. Whichever is the case, you may need to avoid Astropy needing data
+from the Internet. There is no simple and complete solution to this problem at
+the moment, but there are tools that can help.
+
+Exactly which external data your project depends on will depend on what parts
+of Astropy you use and how. The most general solution is to use a computer that
+can access the Internet to run a version of your calculation that pulls in all
+the data files you will require, including sufficiently up-to-date versions of
+files like the IERS data that update regularly. Then once the cache on this
+connected machine is loaded with everything necessary, transport the cache
+contents to your target machine by whatever means you have available, whether
+by copying via an intermediate machine, sneakernet, or carrier pigeon. The
+cache directory itself is somewhat portable between machines of the same UNIX
+flavour; this may be sufficient if you can persuade your CI system to cache the
+directory between runs. For greater portability, though, you can simply use
+`~astropy.utils.data.export_download_cache` and
+`~astropy.utils.data.import_download_cache`, which are portable and will allow
+adding files to an existing cache directory.
+
+If your application needs IERS data specifically, you can download the
+appropriate IERS table, covering the appropriate time span, by any means you
+find convenient. You can then load this file into your application and use the
+resulting table rather than `~astropy.utils.iers.IERS_Auto`. In fact, the IERS
+B table is small enough that a version (not necessarily recent) is bundled with
+Astropy as ``astropy.utils.iers.IERS_B_FILE``. Using a specific non-automatic
+table also has the advantage of giving you control over exactly which version
+of the IERS data your application is using. See also :ref:`iers-working-offline`.
+
+If your issue is with certain specific servers, even if they are the ones
+Astropy normally uses, if you can anticipate exactly which files will be needed
+(or just pick up after Astropy fails to obtain them) and make those files
+available somewhere else, you can request they be downloaded to the cache
+using `~astropy.utils.data.download_file` with the ``sources`` argument set
+to locations you know do work.
+
+If you have a particular URL that is giving you trouble, you can download it
+using some other tool (for example ``wget``), possibly on another machine, and
+then use `import_to_cache`.

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -8,51 +8,49 @@ Introduction
 ============
 
 A number of Astropy's tools work with data sets that are either awkwardly
-large (e.g. `~astropy.coordinates.solar_system_ephemeris`) or
-regularly updated (e.g. `~astropy.utils.iers.IERS_B`) or both
-(e.g. `~astropy.utils.iers.IERS_A`). What's more, this kind of
+large (e.g., `~astropy.coordinates.solar_system_ephemeris`) or
+regularly updated (e.g., `~astropy.utils.iers.IERS_B`) or both
+(e.g., `~astropy.utils.iers.IERS_A`). This kind of
 data - authoritative data made available on the Web, and possibly updated
-from time to time - is reasonably common in astronomy. Astropy therefore
+from time to time - is reasonably common in astronomy. The Astropy Project therefore
 provides some tools for working with such data.
 
-The primary tool for this is the Astropy *cache*. This is a repository of
+The primary tool for this is the ``astropy`` *cache*. This is a repository of
 downloaded data, indexed by the URL where it was obtained. The tool
 `~astropy.utils.data.download_file` and various other things built upon it can
 use this cache to request the contents of a URL, and (if they choose to use the
-cache) the data will only be downloaded if it isn't already present in the
-cache. The tools can, naturally, be instructed to obtain a new copy of data
+cache) the data will only be downloaded if it is not already present in the
+cache. The tools can be instructed to obtain a new copy of data
 that is in the cache but has been updated online.
 
-The astropy cache is stored in a centralized place (on UNIX machines it is
-``$HOME/.astropy/cache``, or if the environment variable ``XDG_CACHE_HOME`` is
-set, the cache is in ``$XDG_CACHE_HOME/astropy``; see :ref:`astropy_config` for
+The ``astropy`` cache is stored in a centralized place (on Linux machines by
+default it is ``$HOME/.astropy/cache``; see :ref:`astropy_config` for
 more details).  You can check its location on your machine::
 
    >>> import astropy.config.paths
    >>> astropy.config.paths.get_cache_dir()  # doctest: +SKIP
    '/home/burnell/.astropy/cache'
 
-This centralization means that the cache is persistent and
-shared between all Astropy runs in any virtualenv by one user on one machine
-(possibly more if your home directory is shared between multiple machines).
-This can dramatically accelerate Astropy operations and reduce load on servers,
+This centralization means that the cache is persistent and shared between all
+``astropy`` runs in any virtualenv by one user on one machine (possibly more if
+your home directory is shared between multiple machines).  This can
+dramatically accelerate ``astropy`` operations and reduce the load on servers,
 like those of the IERS, that were not designed for heavy Web traffic. If you
 find the cache has corrupted or outdated data in it, you can remove an entry or
 clear the whole thing with `~astropy.utils.data.clear_download_cache`.
 
-The files in the download cache directory are named according to a
-cryptographic hash of their contents (currently MD5, so in principle malevolent
-entities can cause collisions, though the security risks this poses are
-marginal at most). Thus files with the same content share storage. The
-modification times on these files normally indicate when they were last
-downloaded from the Internet.
+The files in the cache directory are named according to a cryptographic hash of
+their contents (currently MD5, so in principle malevolent entities can cause
+collisions, though the security risks this poses are marginal at most). Thus
+files with the same content share storage. The modification times on these
+files normally indicate when they were last downloaded from the Internet.
 
 Usage Within Astropy
 ====================
 
 For the most part, you can ignore the caching mechanism and rely on
-Astropy to have the correct data when you need it. For example, precise
-time conversions and sky locations need meaasured tables of the Earth's
+``astropy`` to have the correct data when you need it. For example, precise
+time conversions and sky locations need measured tables of the Earth's
 rotation from the IERS. The table `~astropy.utils.iers.IERS_Auto` provides
 the infrastructure for many of these calculations. It makes available
 Earth rotation parameters, and if you request them for a time more recent
@@ -73,7 +71,7 @@ But running it a second time does not require any new download::
    <Time object: scale='ut1' format='datetime' value=2019-09-22 08:41:21.588836>
 
 Some data is also made available from the `Astropy data server`_ either
-for use within astropy or for your convenience. These are available more
+for use within ``astropy`` or for your convenience. These are available more
 conveniently with the ``get_pkg_data_*`` functions::
 
    >>> from astropy.utils.data import get_pkg_data_contents
@@ -84,7 +82,7 @@ conveniently with the ``get_pkg_data_*`` functions::
 Usage From Outside Astropy
 ==========================
 
-Users of Astropy can also make use of Astropy's caching and downloading
+Users of ``astropy`` can also make use of ``astropy``'s caching and downloading
 mechanism. In its simplest form, this amounts to using
 `~astropy.utils.data.download_file` with the ``cache=True`` argument to obtain
 their data, from the cache if the data is there::
@@ -140,13 +138,13 @@ Cache Management
 Because the cache is persistent, it is possible for it to become inconveniently
 large, or become filled with irrelevant data. While it is simply a
 directory on disk, each file is supposed to represent the contents of a URL,
-and many URLs do not make acceptable on-disk filenames (for example containing
+and many URLs do not make acceptable on-disk filenames (for example, containing
 troublesome characters like ":" and "~"). There is reason to worry that
-multiple astropy processes accessing the cache simultaneously might lead to
+multiple ``astropy`` processes accessing the cache simultaneously might lead to
 cache corruption. The cache is therefore protected by a lock and indexed by a
 persistent dictionary mapping URLs to hashes of the file contents, while the
 file contents are stored in files named by their hashes. So access to the cache
-is easier with a few helpers provided by `~astropy.utils.data`.
+is more convenient with a few helpers provided by `~astropy.utils.data`.
 
 If your cache starts behaving oddly you can use
 `~astropy.utils.data.check_download_cache` to examine your cache contents and
@@ -168,28 +166,28 @@ listed with `~astropy.utils.data.get_cached_urls`, and the presence of a
 particular URL in the cache can be tested with
 `~astropy.utils.data.is_url_in_cache`. More general manipulations can be
 carried out using `~astropy.utils.data.cache_contents`, which returns a
-dict mapping URLs to on-disk filenames of their contents.
+`~dict` mapping URLs to on-disk filenames of their contents.
 
 If you want to transfer the cache to another computer, or preserve its contents
 for later use, you can use the functions `~astropy.utils.data.export_download_cache` to
 produce a ZIP file listing some or all of the cache contents, and
-`~astropy.utils.data.import_download_cache` to load the astropy cache from such a
+`~astropy.utils.data.import_download_cache` to load the ``astropy`` cache from such a
 ZIP file.
 
 Using Astropy With Limited or No Internet Access
 ================================================
 
-You might want to use astropy on a telescope control machine behind a strict
-firewall. Or you might be running continuous integration (CI) on your Astropy
+You might want to use ``astropy`` on a telescope control machine behind a strict
+firewall. Or you might be running continuous integration (CI) on your ``astropy``
 server and want to avoid hammering astronomy servers on every pull request for
 every architecture. Or you might not have access to US government or military
-web servers. Whichever is the case, you may need to avoid Astropy needing data
+web servers. Whichever is the case, you may need to avoid ``astropy`` needing data
 from the Internet. There is no simple and complete solution to this problem at
 the moment, but there are tools that can help.
 
 Exactly which external data your project depends on will depend on what parts
-of Astropy you use and how. The most general solution is to use a computer that
-can access the Internet to run a version of your calculation that pulls in all
+of ``astropy`` you use and how. The most general solution is to use a computer that
+can access the Internet to run a version of your calculation that pulls in all of
 the data files you will require, including sufficiently up-to-date versions of
 files like the IERS data that update regularly. Then once the cache on this
 connected machine is loaded with everything necessary, transport the cache
@@ -207,13 +205,13 @@ appropriate IERS table, covering the appropriate time span, by any means you
 find convenient. You can then load this file into your application and use the
 resulting table rather than `~astropy.utils.iers.IERS_Auto`. In fact, the IERS
 B table is small enough that a version (not necessarily recent) is bundled with
-Astropy as ``astropy.utils.iers.IERS_B_FILE``. Using a specific non-automatic
+``astropy`` as ``astropy.utils.iers.IERS_B_FILE``. Using a specific non-automatic
 table also has the advantage of giving you control over exactly which version
 of the IERS data your application is using. See also :ref:`iers-working-offline`.
 
 If your issue is with certain specific servers, even if they are the ones
-Astropy normally uses, if you can anticipate exactly which files will be needed
-(or just pick up after Astropy fails to obtain them) and make those files
+``astropy`` normally uses, if you can anticipate exactly which files will be needed
+(or just pick up after ``astropy`` fails to obtain them) and make those files
 available somewhere else, you can request they be downloaded to the cache
 using `~astropy.utils.data.download_file` with the ``sources`` argument set
 to locations you know do work. You can also set ``sources`` to an empty list
@@ -221,5 +219,5 @@ to ensure that `~astropy.utils.data.download_file` does not attempt to use
 the Internet at all.
 
 If you have a particular URL that is giving you trouble, you can download it
-using some other tool (e.g. ``wget``), possibly on another machine, and
+using some other tool (e.g., ``wget``), possibly on another machine, and
 then use `~astropy.utils.data.import_file_to_cache`.

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -118,6 +118,8 @@ The IERS Service provides the default online table
 once each 7 days.  The default value of ``auto_max_age`` is 30 days to avoid
 unnecessary network access, but one can reduce this to as low as 10 days.
 
+.. _iers-working-offline:
+
 Working offline
 ---------------
 

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -19,12 +19,13 @@ Astropy.
 Because of the mostly standalone and grab-bag nature of these utilities, they
 are generally best understood through their docstrings, and hence this
 documentation generally does not have detailed sections like the other packages.
-The exception is below:
+The exceptions are below:
 
 .. toctree::
    :maxdepth: 1
 
    iers
+   data
 
 .. note:: The ``astropy.utils.compat`` subpackage is not included in this
     documentation. It contains utility modules for compatibility with


### PR DESCRIPTION
Various tools for managing the astropy download cache. Perhaps most useful for people wanting disconnected operation.

It is possible to export part or all of the contents of the download cache in the form of a ZIP file, which can then be loaded into astropy on another machine to populate its cache without requiring internet access. May be of interest for machines running CI, so they don't re-download everything they need every time a CI run happens - if the ZIP file can be provided to them somehow.

Also there's a new function to consistency check the contents of a cache in case there are unused items or it has become damaged somehow. Recall that the cache is user-wide, across multiple virtualenvs possibly including a development one,  and it is accessed concurrently by multiple processes. 

Finally, the ZIP file mechanism is used to make sure that tests that require purging the cache don't leave the user with an empty cache needing to download all their downloadable files again. Probably only a minor inconvenience for most users with Net connections.