### PR TITLE
fixed typo: "source" -> "conda"

### DIFF
--- a/docs/development/workflow/virtual_pythons.rst
+++ b/docs/development/workflow/virtual_pythons.rst
@@ -160,7 +160,7 @@ addition to activating new ones.
 
 * ` conda`: Activate the environment ``ENV`` with::
 
-      source activate ENV
+      conda activate ENV
 
 
 .. _deactivate_env:


### PR DESCRIPTION
"source" would not work in this case, I guess it is a typo.