### PR TITLE
WCS: Untrack objects before deallocating them.

### DIFF
--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -66,6 +66,7 @@ static void
 Wcs_dealloc(
     Wcs* self) {
 
+  PyObject_GC_UnTrack(self);
   Wcs_clear(self);
   pipeline_free(&self->x);
   Py_TYPE(self)->tp_free((PyObject*)self);

--- a/astropy/wcs/src/distortion_wrap.c
+++ b/astropy/wcs/src/distortion_wrap.c
@@ -34,6 +34,7 @@ static void
 PyDistLookup_dealloc(
     PyDistLookup* self) {
 
+  PyObject_GC_UnTrack(self);
   distortion_lookup_t_free(&self->x);
   Py_XDECREF(self->py_data);
   Py_TYPE(self)->tp_free((PyObject*)self);

--- a/astropy/wcs/src/str_list_proxy.c
+++ b/astropy/wcs/src/str_list_proxy.c
@@ -25,6 +25,7 @@ static void
 PyStrListProxy_dealloc(
     PyStrListProxy* self) {
 
+  PyObject_GC_UnTrack(self);
   Py_XDECREF(self->pyobject);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }

--- a/astropy/wcs/src/unit_list_proxy.c
+++ b/astropy/wcs/src/unit_list_proxy.c
@@ -29,6 +29,7 @@ static void
 PyUnitListProxy_dealloc(
     PyUnitListProxy* self) {
 
+  PyObject_GC_UnTrack(self);
   Py_XDECREF(self->pyobject);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }


### PR DESCRIPTION
It's essential to call this before deallocating any fields in the `tp_dealloc` implementation if the object supports gc.

See also: https://docs.python.org/3.7/c-api/gcsupport.html#c.PyObject_GC_UnTrack

> The deallocator (`tp_dealloc` handler) should call this for the object before any of the fields used by the `tp_traverse` handler become invalid.