### PR TITLE
WCS: Use set_locale context manager for a WCS test case

### DIFF
--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -16,6 +16,7 @@ from astropy.io import fits
 from astropy.wcs import wcs
 from astropy.wcs import _wcs
 from astropy.utils.data import get_pkg_data_contents, get_pkg_data_fileobj, get_pkg_data_filename
+from astropy.utils.misc import set_locale
 from astropy import units as u
 
 
@@ -843,26 +844,15 @@ def test_header_parse():
 
 
 def test_locale():
-    orig_locale = locale.getlocale(locale.LC_NUMERIC)[0]
-
     try:
-        locale.setlocale(locale.LC_NUMERIC, 'fr_FR')
+        with set_locale('fr_FR'):
+            header = get_pkg_data_contents('data/locale.hdr', encoding='binary')
+            w = _wcs.Wcsprm(header)
+            assert re.search("[0-9]+,[0-9]*", w.to_header()) is None
     except locale.Error:
         pytest.xfail(
             "Can't set to 'fr_FR' locale, perhaps because it is not installed "
             "on this system")
-    try:
-        header = get_pkg_data_contents('data/locale.hdr', encoding='binary')
-        w = _wcs.Wcsprm(header)
-        assert re.search("[0-9]+,[0-9]*", w.to_header()) is None
-    finally:
-        if orig_locale is None:
-            # reset to the default setting
-            locale.resetlocale(locale.LC_NUMERIC)
-        else:
-            # restore to whatever the previous value had been set to for
-            # whatever reason
-            locale.setlocale(locale.LC_NUMERIC, orig_locale)
 
 
 @raises(UnicodeEncodeError)


### PR DESCRIPTION
I noticed that I always run into a test failure that's not occurring in the CI. Maybe it's because it's a cmd on Windows, maybe because I have some non-standard locale setting - I really don't know.

```
_____________________________________________________ test_locale _____________________________________________________

    def test_locale():
        orig_locale = locale.getlocale(locale.LC_NUMERIC)[0]

        try:
            locale.setlocale(locale.LC_NUMERIC, 'fr_FR')
        except locale.Error:
            pytest.xfail(
                "Can't set to 'fr_FR' locale, perhaps because it is not installed "
                "on this system")
        try:
            header = get_pkg_data_contents('data/locale.hdr', encoding='binary')
            w = _wcs.Wcsprm(header)
            assert re.search("[0-9]+,[0-9]*", w.to_header()) is None
        finally:
            if orig_locale is None:
                # reset to the default setting
>               locale.resetlocale(locale.LC_NUMERIC)

astropy\wcs\tests\test_wcsprm.py:861:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

category = 4

    def resetlocale(category=LC_ALL):

        """ Sets the locale for category to the default setting.

            The default setting is determined by calling
            getdefaultlocale(). category defaults to LC_ALL.

        """
>       _setlocale(category, _build_localename(getdefaultlocale()))
E       locale.Error: unsupported locale setting

lib\locale.py:614: Error
======================================== 1 failed, 326 passed in 10.41 seconds ========================================
```

Since we do have a context manager for this kind of locale-setting (although only setting the LC_ALL), I tested it out and I don't get any local failures anymore.