### PR TITLE
Updated minimum required version of Cython

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2563,7 +2563,9 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-
+- Updated required version of Cython to v0.29.13 to make sure that
+  generated C files are compatible with the upcoming Python 3.8 release
+  as well as earlier supported versions of Python. [#9198]
 
 2.0.14 (2019-06-14)
 ===================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -192,7 +192,7 @@ You will need a compiler suite and the development headers for Python and
 NumPy in order to build ``astropy``.
 
 If you are building the latest developer version rather than using a stable
-release, you will also need `Cython <http://cython.org/>`_ (v0.21 or later) and
+release, you will also need `Cython <http://cython.org/>`_ (v0.29.13 or later) and
 `jinja2 <http://jinja.pocoo.org/docs/dev/>`_ (v2.7 or later) installed. The
 released packages have the necessary C files packaged with them, and hence do
 not require Cython.

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,6 @@ else:
     # Make sure we have the packages needed for building astropy, but do not
     # require them when installing from an sdist as the c files are included.
     if not os.path.exists(os.path.join(os.path.dirname(__file__), 'PKG-INFO')):
-        setup_requires.extend(['cython>=0.21', 'jinja2>=2.7'])
+        setup_requires.extend(['cython>=0.29.13', 'jinja2>=2.7'])
 
 setup(setup_requires=setup_requires)


### PR DESCRIPTION
As illustrated in https://github.com/numpy/numpy/issues/14403, we need to make sure we use the latest version of Cython to generate C code that is compatible with Python 3.8 while still being compatible with 3.6 and 3.7, so I've updated the minimum required Cython version in ``setup.py``.

@bsipocz - how far we backport this depends on whether we are planning on supporting Python 3.8 from the 2.0.x LTS branch. I guess it's an easy enough backport?

@dhomeier @Juanlu001 - does this seem reasonable to you?