### PR TITLE
Configuration option for the encoding of log files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,12 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+astropy.logger
+^^^^^^^^^^^^^^
+
+- Added a configuration option to specify the text encoding of the log file,
+  with the default behavior being the platform-preferred encoding. [#9203]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/astropy.cfg
+++ b/astropy/astropy.cfg
@@ -108,8 +108,8 @@
 ## Whether to always log messages to a log file
 # log_to_file = False
 
-## The file to log messages to. When '', it defaults to a file 'astropy.log' in
-## the astropy config directory.
+## The file to log messages to. If empty string is given, it defaults to a
+## file 'astropy.log' in the astropy config directory.
 # log_file_path = ""
 
 ## Threshold for logging messages to log_file_path
@@ -118,8 +118,8 @@
 ## Format for log file entries
 # log_file_format = "%(asctime)r, %(origin)r, %(levelname)r, %(message)r"
 
-## The encoding (e.g., UTF-8) to use for the log file.  If '', it defaults to
-## the platform-preferred encoding.
+## The encoding (e.g., UTF-8) to use for the log file.  If empty string is
+## given, it defaults to the platform-preferred encoding.
 # log_file_encoding = ""
 
 [utils.data]

--- a/astropy/astropy.cfg
+++ b/astropy/astropy.cfg
@@ -118,6 +118,10 @@
 ## Format for log file entries
 # log_file_format = "%(asctime)r, %(origin)r, %(levelname)r, %(message)r"
 
+## The encoding (e.g., UTF-8) to use for the log file.  If '', it defaults to
+## the platform-preferred encoding.
+# log_file_encoding = ""
+
 [utils.data]
 
 ## URL for astropy remote data site.

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -399,7 +399,7 @@ class AstropyLogger(Logger):
                 # your code here
         '''
 
-        fh = logging.FileHandler(filename)
+        fh = logging.FileHandler(filename, encoding="UTF-8")
         if filter_level is not None:
             fh.setLevel(filter_level)
         if filter_origin is not None:
@@ -495,7 +495,7 @@ class AstropyLogger(Logger):
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 
-                fh = logging.FileHandler(log_file_path)
+                fh = logging.FileHandler(log_file_path, encoding="UTF-8")
             except OSError as e:
                 warnings.warn(
                     'log file {!r} could not be opened for writing: '

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -67,7 +67,7 @@ class Conf(_config.ConfigNamespace):
         "file.")
     log_file_path = _config.ConfigItem(
         '',
-        "The file to log messages to. When ``''``, "
+        "The file to log messages to.  If empty string is given, "
         "it defaults to a file ``'astropy.log'`` in "
         "the astropy config directory.")
     log_file_level = _config.ConfigItem(
@@ -80,8 +80,8 @@ class Conf(_config.ConfigNamespace):
         "Format for log file entries.")
     log_file_encoding = _config.ConfigItem(
         '',
-        "The encoding (e.g., UTF-8) to use for the log file.  If ``''``, it "
-        "defaults to the platform-preferred encoding.")
+        "The encoding (e.g., UTF-8) to use for the log file.  If empty string "
+        "is given, it defaults to the platform-preferred encoding.")
 
 
 conf = Conf()
@@ -402,7 +402,7 @@ class AstropyLogger(Logger):
             with logger.log_to_file('myfile.log'):
                 # your code here
         '''
-        encoding = conf.log_file_encoding if conf.log_file_encoding != "" else None
+        encoding = conf.log_file_encoding if conf.log_file_encoding else None
         fh = logging.FileHandler(filename, encoding=encoding)
         if filter_level is not None:
             fh.setLevel(filter_level)
@@ -499,7 +499,7 @@ class AstropyLogger(Logger):
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 
-                encoding = conf.log_file_encoding if conf.log_file_encoding != "" else None
+                encoding = conf.log_file_encoding if conf.log_file_encoding else None
                 fh = logging.FileHandler(log_file_path, encoding=encoding)
             except OSError as e:
                 warnings.warn(

--- a/astropy/logger.py
+++ b/astropy/logger.py
@@ -78,6 +78,10 @@ class Conf(_config.ConfigNamespace):
         "%(asctime)r, "
         "%(origin)r, %(levelname)r, %(message)r",
         "Format for log file entries.")
+    log_file_encoding = _config.ConfigItem(
+        '',
+        "The encoding (e.g., UTF-8) to use for the log file.  If ``''``, it "
+        "defaults to the platform-preferred encoding.")
 
 
 conf = Conf()
@@ -398,8 +402,8 @@ class AstropyLogger(Logger):
             with logger.log_to_file('myfile.log'):
                 # your code here
         '''
-
-        fh = logging.FileHandler(filename, encoding="UTF-8")
+        encoding = conf.log_file_encoding if conf.log_file_encoding != "" else None
+        fh = logging.FileHandler(filename, encoding=encoding)
         if filter_level is not None:
             fh.setLevel(filter_level)
         if filter_origin is not None:
@@ -495,7 +499,8 @@ class AstropyLogger(Logger):
                 else:
                     log_file_path = os.path.expanduser(log_file_path)
 
-                fh = logging.FileHandler(log_file_path, encoding="UTF-8")
+                encoding = conf.log_file_encoding if conf.log_file_encoding != "" else None
+                fh = logging.FileHandler(log_file_path, encoding=encoding)
             except OSError as e:
                 warnings.warn(
                     'log file {!r} could not be opened for writing: '

--- a/astropy/tests/test_logger.py
+++ b/astropy/tests/test_logger.py
@@ -4,6 +4,8 @@
 import importlib
 import sys
 import warnings
+import logging
+import locale
 
 import pytest
 
@@ -482,3 +484,24 @@ def test_log_to_file_origin2(tmpdir):
     log_file.close()
 
     assert len(log_entries) == 0
+
+
+@pytest.mark.parametrize(('encoding'), ['', 'utf-8', 'cp1252'])
+def test_log_to_file_encoding(tmpdir, encoding):
+
+    local_path = tmpdir.join('test.log')
+    log_path = str(local_path.realpath())
+
+    orig_encoding = conf.log_file_encoding
+
+    conf.log_file_encoding = encoding
+
+    with log.log_to_file(log_path):
+        for handler in log.handlers:
+            if isinstance(handler, logging.FileHandler):
+                if encoding:
+                    assert handler.stream.encoding == encoding
+                else:
+                    assert handler.stream.encoding == locale.getpreferredencoding()
+
+    conf.log_file_encoding = orig_encoding

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -115,10 +115,10 @@ emitted in the ``astropy.wcs`` sub-package.
 Using the configuration file
 ============================
 
-Options for the logger can be set in the ``[config.logging_helper]`` section
+Options for the logger can be set in the ``[logger]`` section
 of the Astropy configuration file::
 
-    [config.logging_helper]
+    [logger]
 
     # Threshold for the logging messages. Logging messages that are less severe
     # than this level will be ignored. The levels are 'DEBUG', 'INFO', 'WARNING',
@@ -135,16 +135,21 @@ of the Astropy configuration file::
     log_exceptions = False
 
     # Whether to always log messages to a log file
-    log_to_file = True
+    log_to_file = False
 
-    # The file to log messages to
-    log_file_path = '~/.astropy/astropy.log'
+    # The file to log messages to. When '', it defaults to a file `astropy.log` in
+    # the astropy config directory.
+    log_file_path = ''
 
     # Threshold for logging messages to log_file_path
     log_file_level = 'INFO'
 
     # Format for log file entries
-    log_file_format = '%(asctime)s, %(origin)s, %(levelname)s, %(message)s'
+    log_file_format = '%(asctime)r, %(origin)r, %(levelname)r, %(message)r'
+
+    # The encoding (e.g., UTF-8) to use for the log file.  If '', it
+    # defaults to the platform-preferred encoding.
+    log_file_encoding = ""
 
 
 Reference/API

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -135,20 +135,20 @@ of the Astropy configuration file::
     log_exceptions = False
 
     # Whether to always log messages to a log file
-    log_to_file = False
+    log_to_file = True
 
-    # The file to log messages to. When '', it defaults to a file `astropy.log` in
-    # the astropy config directory.
-    log_file_path = ''
+    # The file to log messages to. If empty string is given, it defaults to a
+    # file `astropy.log` in the astropy config directory.
+    log_file_path = '~/.astropy/astropy.log'
 
     # Threshold for logging messages to log_file_path
     log_file_level = 'INFO'
 
     # Format for log file entries
-    log_file_format = '%(asctime)r, %(origin)r, %(levelname)r, %(message)r'
+    log_file_format = '%(asctime)s, %(origin)s, %(levelname)s, %(message)s'
 
-    # The encoding (e.g., UTF-8) to use for the log file.  If '', it
-    # defaults to the platform-preferred encoding.
+    # The encoding (e.g., UTF-8) to use for the log file.  If empty string is
+    # given, it defaults to the platform-preferred encoding.
     log_file_encoding = ""
 
 


### PR DESCRIPTION
Python's built-in `logging` package – and hence `AstropyLogger` – uses the platform-preferred encoding by default when writing to a file, so on Windows it uses CP-1252 instead of UTF-8.  That means that sending certain Unicode characters to a log file causes errors on Windows.  My ~suggested fix is simple: explicitly set the encoding to UTF-8, irrespective of platform.~

~Questions I have: Are there Windows users out there relying on CP-1252 for logging to a file?  How bad is it to append to an existing log file that had a different encoding?~

Per comments, this PR now implements a configuration option for specifying the encoding of log files, with the default behavior of using the platform-preferred encoding.
