### PR TITLE
Fix loading of IERS data files

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -644,8 +644,9 @@ class IERS_B(IERS):
 
 class IERS_Auto(IERS_A):
     """
-    Provide most-recent IERS data and automatically handle downloading
-    of updated values as necessary.
+    Provide most-recent IERS A data and automatically handle downloading
+    of updated values as necessary. Also merge IERS B values into IERS A
+    table.
     """
     iers_table = None
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -630,7 +630,7 @@ class IERS_Auto(IERS_A):
 
         """
         if not conf.auto_download:
-            cls.iers_table = cls.from_iers_b(IERS.open())
+            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_URL))
             return cls.iers_table
 
         all_urls = (conf.iers_auto_url, conf.iers_auto_url_mirror)
@@ -662,7 +662,7 @@ class IERS_Auto(IERS_A):
             warn(AstropyWarning('failed to download {}, using local IERS-B: {}'
                                 .format(' and '.join(all_urls),
                                         ';'.join(err_list))))  # noqa
-            cls.iers_table = cls.from_iers_b(IERS.open())
+            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_URL))
             return cls.iers_table
 
         cls.iers_table = cls.read(file=filename)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -630,7 +630,7 @@ class IERS_Auto(IERS_A):
 
         """
         if not conf.auto_download:
-            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_URL))
+            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_FILE))
             return cls.iers_table
 
         all_urls = (conf.iers_auto_url, conf.iers_auto_url_mirror)
@@ -662,7 +662,7 @@ class IERS_Auto(IERS_A):
             warn(AstropyWarning('failed to download {}, using local IERS-B: {}'
                                 .format(' and '.join(all_urls),
                                         ';'.join(err_list))))  # noqa
-            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_URL))
+            cls.iers_table = cls.from_iers_b(IERS_B.open(IERS_B_FILE))
             return cls.iers_table
 
         cls.iers_table = cls.read(file=filename)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -824,7 +824,7 @@ class IERS_Auto(IERS_A):
         Here, we use the bundled astropy IERS-B table to overwrite the values
         in the downloaded IERS-A table.
         """
-        iers_b = IERS_B.open()
+        iers_b = IERS_B.open(IERS_B_FILE)
         # Substitute IERS-B values for existing B values in IERS-A table
         mjd_b = table['MJD'][np.isfinite(table['UT1_UTC_B'])]
         i0 = np.searchsorted(iers_b['MJD'], mjd_b[0], side='left')

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -598,49 +598,6 @@ class IERS_B(IERS):
         """Set PM source flag for entries in IERS table"""
         return np.ones_like(i) * FROM_IERS_B
 
-    @classmethod
-    def _create_a_columns(cls, table):
-        """
-        Return a new table with appropriate combination of IERS_A and B columns.
-        """
-        # UT1_UTC present in IERS B already
-        table['UT1_UTC_B'] = table['UT1_UTC'].data
-        table['UT1_UTC_B'].unit = table['UT1_UTC'].unit
-        table['UT1Flag'] = 'B'
-
-        # Repeat for polar motions.
-        table['PM_X'] = table['PM_x'].data
-        table['PM_X'].unit = table['PM_x'].unit
-        table['PM_Y'] = table['PM_y'].data
-        table['PM_Y'].unit = table['PM_y'].unit
-        table['PM_X_B'] = table['PM_x'].data
-        table['PM_X_B'].unit = table['PM_x'].unit
-        table['PM_Y_B'] = table['PM_y'].data
-        table['PM_Y_B'].unit = table['PM_y'].unit
-        table['PolPMFlag'] = 'B'
-
-        # IERS A uses marcsec but IERS B uses arcsec for these
-        # Convert in case someone does a plain .value
-        table['dX_2000A_B'] = table['dX_2000A'].to(u.marcsec).data
-        table['dX_2000A_B'].unit = table['dX_2000A'].to(u.marcsec).unit
-
-        table['dY_2000A_B'] = table['dY_2000A'].to(u.marcsec).data
-        table['dY_2000A_B'].unit = table['dY_2000A'].to(u.marcsec).unit
-
-        table['NutFlag'] = 'B'
-
-        # No predictions in B
-        # Get the table index for the first row that has predictive values
-        # PolPMFlag_A  IERS (I) or Prediction (P) flag for
-        #              Bull. A polar motion values
-        # UT1Flag_A    IERS (I) or Prediction (P) flag for
-        #              Bull. A UT1-UTC values
-        #is_predictive = (table['UT1Flag_A'] == 'P') | (table['PolPMFlag_A'] == 'P')
-        #table.meta['predictive_index'] = np.min(np.flatnonzero(is_predictive))
-        #table.meta['predictive_mjd'] = table['MJD'][table.meta['predictive_index']]
-
-        return table
-
 
 class IERS_Auto(IERS_A):
     """
@@ -673,7 +630,7 @@ class IERS_Auto(IERS_A):
 
         """
         if not conf.auto_download:
-            cls.iers_table = IERS_B._create_a_columns(IERS.open())
+            cls.iers_table = cls.from_iers_b(IERS.open())
             return cls.iers_table
 
         all_urls = (conf.iers_auto_url, conf.iers_auto_url_mirror)
@@ -705,13 +662,39 @@ class IERS_Auto(IERS_A):
             warn(AstropyWarning('failed to download {}, using local IERS-B: {}'
                                 .format(' and '.join(all_urls),
                                         ';'.join(err_list))))  # noqa
-            cls.iers_table = IERS_B._create_a_columns(IERS.open())
+            cls.iers_table = cls.from_iers_b(IERS.open())
             return cls.iers_table
 
         cls.iers_table = cls.read(file=filename)
         cls.iers_table.meta['data_url'] = str(url)
 
         return cls.iers_table
+
+    @classmethod
+    def from_iers_b(cls, table):
+        """
+        Return a new table with appropriate combination of IERS_A and B columns.
+        """
+        table = table.copy()
+
+        # UT1_UTC present in IERS B already
+        table['UT1_UTC_B'] = table['UT1_UTC']
+        table['UT1Flag'] = 'B'
+
+        # Repeat for polar motions.
+        table['PM_X'] = table['PM_x']
+        table['PM_Y'] = table['PM_y']
+        table['PM_X_B'] = table['PM_x']
+        table['PM_Y_B'] = table['PM_y']
+        table['PolPMFlag'] = 'B'
+
+        # IERS A uses marcsec but IERS B uses arcsec for these
+        # Convert in case someone does a plain .value
+        table['dX_2000A_B'] = table['dX_2000A'].to(u.marcsec)
+        table['dY_2000A_B'] = table['dY_2000A'].to(u.marcsec)
+        table['NutFlag'] = 'B'
+
+        return table
 
     def _check_interpolate_indices(self, indices_orig, indices_clipped, max_input_mjd):
         """Check that the indices from interpolation match those after clipping to the

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -86,19 +86,8 @@ copy_columns = [
 
 @pytest.mark.parametrize("b_name,a_name", copy_columns)
 def test_IERS_B_parameters_loaded_into_IERS_Auto(b_name, a_name):
-    B = IERS_B.open(IERS_B_FILE)
-    B[b_name]
     A = IERS_Auto.open()
-    try:
-        A[a_name]
-    except KeyError:
-        if A["MJD"][-1] < 59100 * u.d:
-            pytest.xfail(
-                "Bug #9205 IERS B data is available but not merged into "
-                "IERS_Auto object unless new IERS A data is available."
-            )
-        else:
-            raise
+    A[a_name]
 
 
 copy_columns_atol = [

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -1,0 +1,140 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import os
+import urllib.request
+import warnings
+
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.data import download_file, clear_download_cache
+from astropy.utils.iers import (
+    IERS_A, IERS_Auto, IERS_B, IERS_B_URL, IERS_B_FILE
+)
+from astropy import units as u
+from astropy.table import QTable
+from astropy.time import Time, TimeDelta
+
+try:
+    IERS_A.open("finals2000A.all")  # check if IERS_A is available
+except OSError:
+    HAS_IERS_A = False
+else:
+    HAS_IERS_A = True
+
+
+test_columns = [
+    # These are very stringent thresholds
+    # Can mark individual parameter sets with xfail, see docs
+    ("UT1_UTC", 10 * u.us),
+    ("PM_x", 1e-3 * u.marcsec),
+    ("PM_y", 1e-3 * u.marcsec),
+    ("dX_2000A", 1e-4 * u.marcsec),
+    ("dY_2000A", 1e-4 * u.marcsec),
+    # Maybe repeat tests with more practical thresholds
+    # but not xfail?
+]
+
+
+@pytest.mark.parametrize("keyword,atol", test_columns)
+@pytest.mark.xfail(
+        reason="IERS B has changed old values since the version in astropy")
+@pytest.mark.remote_data
+def test_IERS_B_download_agrees_with_IERS_B_local(keyword, atol):
+    B_local = IERS_B.open(IERS_B_FILE)
+    B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    if B["MJD"][-1] < B_local["MJD"][-1]:
+        clear_download_cache(IERS_B_URL)
+        B = IERS_B.open(download_file(IERS_B_URL, cache=True))
+    assert (
+        B["MJD"][-1] >= B_local["MJD"][-1]
+    ), "Local IERS B data should never be newer than the internet version!"
+    if B["MJD"][-1] == B_local["MJD"][-1]:
+        # Unable to run test because current version is in astropy already
+        return
+
+    mjd = B_local["MJD"][-1]
+
+    ok_B = B["MJD"] <= mjd
+    assert_quantity_allclose(
+        B["MJD"][ok_B],
+        B_local["MJD"],
+        atol=0.01 * u.day,
+        rtol=0,
+        err_msg="MJDs don't match",
+    )
+    assert_quantity_allclose(
+        B[keyword][ok_B],
+        B_local[keyword],
+        atol=atol,
+        rtol=0,
+        err_msg="Built-in IERS B {} values don't match downloaded "
+        "IERS B values".format(keyword),
+    )
+
+
+copy_columns = [
+    ("UT1_UTC", "UT1_UTC_B"),
+    ("PM_x", "PM_X_B"),
+    ("PM_y", "PM_Y_B"),
+    ("dX_2000A", "dX_2000A_B"),
+    ("dY_2000A", "dY_2000A_B"),
+]
+
+
+@pytest.mark.parametrize("b_name,a_name", copy_columns)
+def test_IERS_B_parameters_loaded_into_IERS_Auto(b_name, a_name):
+    B = IERS_B.open(IERS_B_FILE)
+    B[b_name]
+    A = IERS_Auto.open()
+    try:
+        A[a_name]
+    except KeyError:
+        if A["MJD"][-1] < 59100 * u.d:
+            pytest.xfail(
+                "Bug? IERS B data is available but not merged into IERS_Auto "
+                "object unless new IERS A data is available."
+            )
+        else:
+            raise
+
+
+copy_columns_atol = [
+    ("UT1_UTC", "UT1_UTC_B", 10 * u.us),
+    ("PM_x", "PM_X_B", 1e-3 * u.marcsec),
+    ("PM_y", "PM_Y_B", 1e-3 * u.marcsec),
+    pytest.param("dX_2000A", "dX_2000A_B", 1e-4 * u.marcsec,
+                 marks=pytest.mark.xfail),
+    pytest.param("dY_2000A", "dY_2000A_B", 1e-4 * u.marcsec,
+                 marks=pytest.mark.xfail),
+]
+
+
+@pytest.mark.remote_data
+@pytest.mark.parametrize("b_name,a_name,atol", copy_columns_atol)
+def test_IERS_B_parameters_loaded_into_IERS_Auto_correctly(
+        b_name,
+        a_name,
+        atol):
+    A = IERS_Auto.open()
+    A[a_name]
+    B = IERS_B.open(IERS_B_FILE)
+
+    ok_A = A["MJD"] < B["MJD"][-1]
+
+    mjds_A = A["MJD"][ok_A].to(u.day).value
+    i_B = np.searchsorted(B["MJD"].to(u.day).value, mjds_A)
+
+    assert_equal(np.diff(i_B), 1, err_msg="Valid region not contiguous")
+    assert_equal(A["MJD"][ok_A], B["MJD"][i_B],
+                 err_msg="MJDs don't make sense")
+    assert_quantity_allclose(
+        A[a_name][ok_A],
+        B[b_name][i_B],
+        atol=atol,
+        rtol=0,
+        err_msg="Bug? IERS B parameter {} not copied over "
+                "IERS A parameter {}".format(b_name, a_name),
+    )

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -94,8 +94,8 @@ def test_IERS_B_parameters_loaded_into_IERS_Auto(b_name, a_name):
     except KeyError:
         if A["MJD"][-1] < 59100 * u.d:
             pytest.xfail(
-                "Bug? IERS B data is available but not merged into IERS_Auto "
-                "object unless new IERS A data is available."
+                "Bug #9205 IERS B data is available but not merged into "
+                "IERS_Auto object unless new IERS A data is available."
             )
         else:
             raise
@@ -135,6 +135,6 @@ def test_IERS_B_parameters_loaded_into_IERS_Auto_correctly(
         B[b_name][i_B],
         atol=atol,
         rtol=0,
-        err_msg="Bug? IERS B parameter {} not copied over "
+        err_msg="Bug #9206 IERS B parameter {} not copied over "
                 "IERS A parameter {}".format(b_name, a_name),
     )

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -84,6 +84,7 @@ copy_columns = [
 ]
 
 
+@pytest.mark.remote_data
 @pytest.mark.parametrize("b_name,a_name", copy_columns)
 def test_IERS_B_parameters_loaded_into_IERS_Auto(b_name, a_name):
     A = IERS_Auto.open()

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -105,10 +105,8 @@ copy_columns_atol = [
     ("UT1_UTC", "UT1_UTC_B", 10 * u.us),
     ("PM_x", "PM_X_B", 1e-3 * u.marcsec),
     ("PM_y", "PM_Y_B", 1e-3 * u.marcsec),
-    pytest.param("dX_2000A", "dX_2000A_B", 1e-4 * u.marcsec,
-                 marks=pytest.mark.xfail),
-    pytest.param("dY_2000A", "dY_2000A_B", 1e-4 * u.marcsec,
-                 marks=pytest.mark.xfail),
+    ("dX_2000A", "dX_2000A_B", 1e-4 * u.marcsec),
+    ("dY_2000A", "dY_2000A_B", 1e-4 * u.marcsec),
 ]
 
 

--- a/astropy/utils/iers/tests/test_iers_b_into_auto.py
+++ b/astropy/utils/iers/tests/test_iers_b_into_auto.py
@@ -105,6 +105,7 @@ def test_IERS_B_parameters_loaded_into_IERS_Auto_correctly(
         b_name,
         a_name,
         atol):
+    IERS_Auto.iers_table = None
     A = IERS_Auto.open()
     A[a_name]
     B = IERS_B.open(IERS_B_FILE)


### PR DESCRIPTION
This test suite has them marked as xfail, but there are some troubling anomalies in the handling of the IERS B data. Tests demonstrate, and currently xfail:

- The IERS B data is not loaded into the IERS_Auto object if new IERS A data is not available, even though the IERS B file is present. 
- When new IERS A data is available, the columns dX_2000A_B and dY_2000A_B are not loaded in from the (potentially new) IERS B data that is available, unlike UT1_UTC_B, PM_X_B, and PM_Y_B.

Also, not exactly a bug, but it is good to have tests to let us know when this has occurred:

- The IERS will occasionally change existing, old, IERS B entries when releasing a new IERS B file. This can lead to surprising non-reproducibility, and it argues for ensuring that the version of IERS B distributed with astropy is recent (in hopes that they do not often change the old entries). 