### PR TITLE
Hypothesis tests for `astropy.units`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,13 @@ jobs:
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
       - run:
           name: Install dependencies for Python 3.6
-          command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.17" scipy pytest pytest-astropy pytest-xdist Cython jinja2
+          command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.17" scipy pytest hypothesis pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.6
           command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.7
-          command: /opt/python/cp37-cp37m/bin/pip install "numpy<1.17" scipy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp37-cp37m/bin/pip install "numpy<1.17" scipy pytest hypothesis pytest-astropy pytest-xdist Cython jinja2 pandas
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ venv
 # Other
 .cache
 .tox
+.hypothesis
 .*.swp
 .*.swo
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ compiler: gcc
 # https://docs.travis-ci.com/user/caching#Clearing-Caches
 cache:
   - ccache
+  - .hypothesis
 
 os:
     - linux
@@ -33,8 +34,8 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
-        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck hypothesis'
+        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck hypothesis'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'

--- a/astropy/units/tests/test_decompse.py
+++ b/astropy/units/tests/test_decompse.py
@@ -1,0 +1,23 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Property-based tests for unit decomposition.
+"""
+
+from hypothesis import given, strategies as st
+
+import astropy.units as u
+
+UNITS = sorted(u.get_current_unit_registry().all_units, key=repr)
+
+
+@given(st.lists(st.sampled_from(UNITS), min_size=2))
+def test_intermediate_decomposition_is_no_op(lst):
+    # This test checks that when multiplying togther any sequence of units,
+    # it makes no difference whether we decompose between every step or only
+    # at the end.  This is true for rational numbers, but not for floats!
+    decomp = compound = u.dimensionless_unscaled
+    for unit in lst:
+        decomp = (decomp * unit).decompose()
+        compound *= unit
+        assert decomp == compound.decompose(), (decomp, compound)

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,8 @@ import os
 import pkg_resources
 import tempfile
 
+import hypothesis
+
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 import astropy
 
@@ -24,6 +26,16 @@ if find_spec('asdf') is not None:
         if "asdf_schema_tester" not in entry_points:
             pytest_plugins += ['asdf.tests.schema_tester']
         PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
+
+# Tell Hypothesis that we might be running slow tests, to print the seed blob
+# so we can easily reproduce failures from CI, and derive a fuzzing profile
+# to try many more inputs.  Select profiles with the environment variable.
+
+hypothesis.settings.register_profile("ci", deadline=None, print_blob=True)
+hypothesis.settings.register_profile(
+    "fuzzing", parent=hypothesis.settings.get_profile("ci"), max_examples=10**4
+)
+hypothesis.settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "ci"))
 
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     ipython
     coverage
     skyfield
+    hypothesis
 all =
     scipy
     h5py
@@ -71,6 +72,7 @@ all =
     bottleneck
     ipython
     pytest
+    hypothesis
 docs =
     sphinx-astropy
     pytest


### PR DESCRIPTION
This PR adds [Hypothesis tests](https://hypothesis.readthedocs.io/) for `astropy.units`, as proposed in #9017. 

The test will reliably find floating-point imprecision in the scale factors of various units, which can build up over the course of round-trip conversions.  I would propose that all units should be defined with the scale factor from fundamental SI units stored as a `Fraction`, so that conversions can be lossless - the overhead is very small as it is a single number in the metadata for an array of any size.

I've done my best to list the test-time dependency on `hypothesis` in the right place, but would be very happy if anyone had suggestions or feedback on this :smile: 