### PR TITLE
Remove display plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
+          command: |
+            pip install pytest-astropy-header --upgrade --no-deps
+            python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
       - store_artifacts:
           path: results
 
@@ -49,7 +51,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
+          command: |
+            pip install pytest-astropy-header --upgrade --no-deps
+            python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
       - store_artifacts:
           path: results
 
@@ -60,7 +64,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
+          command: |
+            pip install pytest-astropy-header --upgrade --no-deps
+            python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
       - store_artifacts:
           path: results
 
@@ -71,7 +77,9 @@ jobs:
       - checkout
       - run:
           name: Run tests
-          command: python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
+          command: |
+            pip install pytest-astropy-header --upgrade --no-deps
+            python3 setup.py test -P visualization --remote-data=astropy --open-files -a "--mpl --mpl-results-path=$PWD/results"
       - store_artifacts:
           path: results
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -180,7 +180,7 @@ astropy.tests
 ^^^^^^^^^^^^^
 
 - The plugin that handles the custom header in the test output has been
-  moved to the pytest-astropy-header plugin package. See the README at
+  moved to the ``pytest-astropy-header plugin`` package. See the README at
   https://github.com/astropy/pytest-astropy-header for information about
   using this new plugin. [#9214]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -179,6 +179,11 @@ astropy.table
 astropy.tests
 ^^^^^^^^^^^^^
 
+- The plugin that handles the custom header in the test output has been
+  moved to the pytest-astropy-header plugin package. See the README at
+  https://github.com/astropy/pytest-astropy-header for information about
+  using this new plugin. [#9214]
+
 astropy.time
 ^^^^^^^^^^^^
 

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -79,3 +79,26 @@ def pytest_unconfigure(config):
 PYTEST_HEADER_MODULES['Cython'] = 'cython'
 PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
 PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Output a warning to IPython users in case any tests failed."""
+
+    try:
+        get_ipython()
+    except NameError:
+        return
+
+    if not terminalreporter.stats.get('failed'):
+        # Only issue the warning when there are actually failures
+        return
+
+    terminalreporter.ensure_newline()
+    terminalreporter.write_line(
+        'Some tests are known to fail when run from the IPython prompt; '
+        'especially, but not limited to tests involving logging and warning '
+        'handling.  Unless you are certain as to the cause of the failure, '
+        'please check that the failure occurs outside IPython as well.  See '
+        'http://docs.astropy.org/en/stable/known_issues.html#failing-logging-'
+        'tests-when-running-the-tests-in-ipython for more information.',
+        yellow=True, bold=True)

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -57,6 +57,12 @@ def pytest_configure(config):
     os.mkdir(os.path.join(os.environ['XDG_CONFIG_HOME'], 'astropy'))
     os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 
+    config.option.astropy_header = True
+
+    PYTEST_HEADER_MODULES['Cython'] = 'cython'
+    PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
+    PYTEST_HEADER_MODULES['asdf'] = 'asdf'
+
 
 def pytest_unconfigure(config):
     builtins._pytest_running = False
@@ -74,11 +80,6 @@ def pytest_unconfigure(config):
         os.environ.pop('XDG_CACHE_HOME')
     else:
         os.environ['XDG_CACHE_HOME'] = builtins._xdg_cache_home_orig
-
-
-PYTEST_HEADER_MODULES['Cython'] = 'cython'
-PYTEST_HEADER_MODULES['Scikit-image'] = 'skimage'
-PYTEST_HEADER_MODULES['asdf'] = 'asdf'
 
 
 def pytest_terminal_summary(terminalreporter):

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -8,7 +8,7 @@ import os
 import builtins
 import tempfile
 
-from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -8,7 +8,7 @@ import os
 import builtins
 import tempfile
 
-from pytest_astropy import PYTEST_HEADER_MODULES
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -8,7 +8,7 @@ import os
 import builtins
 import tempfile
 
-from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+from pytest_astropy import PYTEST_HEADER_MODULES
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:

--- a/astropy/tests/plugins/__init__.py
+++ b/astropy/tests/plugins/__init__.py
@@ -1,4 +1,1 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This package contains pytest plugins that are used by the astropy test suite.
-"""

--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -1,141 +1,18 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This plugin provides customization of the header displayed by pytest for
-reporting purposes.
-"""
 
-import os
-import sys
-import datetime
-import locale
-import math
-from collections import OrderedDict
+# This plugin now lives in pytest-astropy, but we keep the code below during
+# a deprecation phase.
 
-from astropy.tests.helper import ignore_warnings
-from astropy.utils.introspection import resolve_name
+import warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
+try:
+    from pytest_astropy import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+except ImportError:
+    PYTEST_HEADER_MODULES = {}
+    TESTED_VERSIONS = {}
 
-PYTEST_HEADER_MODULES = OrderedDict([('Numpy', 'numpy'),
-                                     ('Scipy', 'scipy'),
-                                     ('Matplotlib', 'matplotlib'),
-                                     ('h5py', 'h5py'),
-                                     ('Pandas', 'pandas')])
-
-# This always returns with Astropy's version
-from astropy import __version__
-TESTED_VERSIONS = OrderedDict([('Astropy', __version__)])
-
-
-def pytest_report_header(config):
-
-    try:
-        stdoutencoding = sys.stdout.encoding or 'ascii'
-    except AttributeError:
-        stdoutencoding = 'ascii'
-
-    args = config.args
-
-    # TESTED_VERSIONS can contain the affiliated package version, too
-    if len(TESTED_VERSIONS) > 1:
-        for pkg, version in TESTED_VERSIONS.items():
-            if pkg not in ['Astropy', 'astropy_helpers']:
-                s = "\nRunning tests with {} version {}.\n".format(
-                    pkg, version)
-    else:
-        s = "\nRunning tests with Astropy version {}.\n".format(
-            TESTED_VERSIONS['Astropy'])
-
-    # Per https://github.com/astropy/astropy/pull/4204, strip the rootdir from
-    # each directory argument
-    if hasattr(config, 'rootdir'):
-        rootdir = str(config.rootdir)
-        if not rootdir.endswith(os.sep):
-            rootdir += os.sep
-
-        dirs = [arg[len(rootdir):] if arg.startswith(rootdir) else arg
-                for arg in args]
-    else:
-        dirs = args
-
-    s += "Running tests in {}.\n\n".format(" ".join(dirs))
-
-    s += "Date: {}\n\n".format(datetime.datetime.now().isoformat()[:19])
-
-    from platform import platform
-    plat = platform()
-    if isinstance(plat, bytes):
-        plat = plat.decode(stdoutencoding, 'replace')
-    s += f"Platform: {plat}\n\n"
-    s += f"Executable: {sys.executable}\n\n"
-    s += f"Full Python Version: \n{sys.version}\n\n"
-
-    s += "encodings: sys: {}, locale: {}, filesystem: {}".format(
-        sys.getdefaultencoding(),
-        locale.getpreferredencoding(),
-        sys.getfilesystemencoding())
-    s += '\n'
-
-    s += f"byteorder: {sys.byteorder}\n"
-    s += "float info: dig: {0.dig}, mant_dig: {0.dig}\n\n".format(
-        sys.float_info)
-
-    for module_display, module_name in PYTEST_HEADER_MODULES.items():
-        try:
-            with ignore_warnings(DeprecationWarning):
-                module = resolve_name(module_name)
-        except ImportError:
-            s += f"{module_display}: not available\n"
-        else:
-            try:
-                version = module.__version__
-            except AttributeError:
-                version = 'unknown (no __version__ attribute)'
-            s += f"{module_display}: {version}\n"
-
-    # Helpers version
-    if 'astropy_helpers' in TESTED_VERSIONS:
-        astropy_helpers_version = TESTED_VERSIONS['astropy_helpers']
-    else:
-        try:
-            from astropy.version import astropy_helpers_version
-        except ImportError:
-            astropy_helpers_version = None
-
-    if astropy_helpers_version:
-        s += f"astropy_helpers: {astropy_helpers_version}\n"
-
-    special_opts = ["remote_data", "pep8"]
-    opts = []
-    for op in special_opts:
-        op_value = getattr(config.option, op, None)
-        if op_value:
-            if isinstance(op_value, str):
-                op = ': '.join((op, op_value))
-            opts.append(op)
-    if opts:
-        s += "Using Astropy options: {}.\n".format(", ".join(opts))
-
-    return s
-
-
-def pytest_terminal_summary(terminalreporter):
-    """Output a warning to IPython users in case any tests failed."""
-
-    try:
-        get_ipython()
-    except NameError:
-        return
-
-    if not terminalreporter.stats.get('failed'):
-        # Only issue the warning when there are actually failures
-        return
-
-    terminalreporter.ensure_newline()
-    terminalreporter.write_line(
-        'Some tests are known to fail when run from the IPython prompt; '
-        'especially, but not limited to tests involving logging and warning '
-        'handling.  Unless you are certain as to the cause of the failure, '
-        'please check that the failure occurs outside IPython as well.  See '
-        'http://docs.astropy.org/en/stable/known_issues.html#failing-logging-'
-        'tests-when-running-the-tests-in-ipython for more information.',
-        yellow=True, bold=True)
+warnings.warn('The astropy.tests.plugins.display plugin has been deprecated. '
+              'See the pytest-astropy documentation for information on '
+              'migrating to using pytest-astropy to customize the pytest '
+              'header.', AstropyDeprecationWarning)

--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -7,7 +7,7 @@ import warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 try:
-    from pytest_astropy import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
 except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ import os
 import pkg_resources
 import tempfile
 
-from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
+from pytest_astropy import PYTEST_HEADER_MODULES
 import astropy
 
 if find_spec('asdf') is not None:

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ import os
 import pkg_resources
 import tempfile
 
-from pytest_astropy import PYTEST_HEADER_MODULES
+from pytest_astropy_header.display import PYTEST_HEADER_MODULES
 import astropy
 
 if find_spec('asdf') is not None:

--- a/conftest.py
+++ b/conftest.py
@@ -11,10 +11,6 @@ import tempfile
 from astropy.tests.plugins.display import PYTEST_HEADER_MODULES
 import astropy
 
-pytest_plugins = [
-    'astropy.tests.plugins.display',
-]
-
 if find_spec('asdf') is not None:
     from asdf import __version__ as asdf_version
     if asdf_version >= astropy.__minimum_asdf_version__:


### PR DESCRIPTION
This moves the last remaining plugin from astropy core to a standalone plugin (https://github.com/astropy/pytest-astropy-header), and fixes https://github.com/astropy/pytest-astropy/issues/15.

Note that ``pytest_terminal_summary`` is actually a core-specific workaround, so I am moving it to the ``conftest.py`` in core (it's only needed because we do funny stuff with IPython in astropy.utils).

This PR won't be mergeable until a release of pytest-astropy-header and pytest-astropy is made. I'm waiting for feedback before doing that though.

### Benefits to migrating

The main motivation for migrating is that this will make it easier in future to make improvements to the plugin without having to rely on the astropy release cycle. It also should simplify configuration for the plugin in third party packages (packages can easily opt-in/out of this with pytest ini options and/or command-line flags). This was the last plugin that still lived in astropy core.

### Migration for packages

As usual, we have to be careful to think of all testing scenarios when moving a plugin, to minimize pain. I've therefore included a section in the README of the plugin package on migrating to this new plugin. Note that the new plugin is essentially opt-in - packages need to take action to switch to the new one, which is necessary to avoid people seeing the astropy header for unrelated packages. See the [README](https://github.com/astropy/pytest-astropy-header) for more details.

If packages don't do anything, things will continue to work except that a deprecation warning will be raised with astropy 4.0 (and until we decide to break things). If Astropy 4.0 is installed, but pytest-astropy is not recent enough (meaning pytest-astropy-header isn't installed), the header might be missing but nothing should error.

### Impact for core package

There should be no impact for the core package, except that a recent version of pytest-astropy will be required for testing for the header to be present.

### Impact for other packages

For third-party packages, there are several cases to consider. I'm assuming packages follow the migration instructions in the [README](https://github.com/astropy/pytest-astropy-header).

When the plugin is used and astropy<4 is installed, the ``PYTEST_HEADER_MODULES`` and
``TESTED_VERSIONS`` variables are actually shared with astropy. The new plugin here is smart enough to detect if the original plugin is enabled, and if so, the one here will do nothing and the astropy one will work as expected since the variables are shared. For astropy 2.0 the display header was not a real plugin so we can disable it as described using ``del pytest_report_header`` as described in the migration guide.

With astropy >4 this should work as expected since there is now only one plugin, the one in the new plugin package.

Here's an example with ccdproc including the changes described in the migration docs here. so with ``conftest.py`` set to:

```python
import os

from .tests.pytest_fixtures import *

from astropy.version import version as astropy_version
if astropy_version < '3.0':
    from astropy.tests.pytest_plugins import *
    del pytest_report_header
else:
    from pytest_astropy.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS


def pytest_configure(config):

    config.option.astropy_header = True

    PYTEST_HEADER_MODULES.pop('h5py', None)
    PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
    PYTEST_HEADER_MODULES['astroscrappy'] = 'astroscrappy'
    PYTEST_HEADER_MODULES['reproject'] = 'reproject'

    from .version import version, astropy_helpers_version
    packagename = os.path.basename(os.path.dirname(__file__))
    TESTED_VERSIONS[packagename] = version
    TESTED_VERSIONS['astropy_helpers'] = astropy_helpers_version
```

**Running the tests with python setup.py test**

_With astropy 2.0.15:_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T16:13:55

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy 3.2.1:_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T15:57:42

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy_helpers: 3.2.1
Using Astropy options: remote_data: none.
```

_With astropy dev (after plugin removal, see https://github.com/astropy/astropy/pull/9214):_

```
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc docs.

Date: 2019-09-09T16:48:17

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```

**Running the tests with pytest**

_With astropy 2.0.15:_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:18:58

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```

_With astropy 3.2.1:_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T15:59:06

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy dev:_

```
$ pytest ccdproc
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:49:22

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

**Running the tests with package.test()**

_With astropy 2.0.14:_

```
In [2]: ccdproc.test()                                                                                                                                     
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:12:57

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 2.0.14
astroscrappy: 1.0.8
reproject: 0.5
astropy-helpers: 3.2.1
```

_With astropy 3.2.1:_

```
In [2]: ccdproc.test()                                                                                                                                     
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-4.6.5, py-1.8.0, pluggy-0.12.0

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:00:41

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 3.2.1
astroscrappy: 1.0.8
reproject: 0.5
astropy_helpers: 3.2.1
Using Astropy options: remote_data: none.
```

_With astropy dev:_

```
In [2]: ccdproc.test()                                                                                                                                     
WARNING: AstropyDeprecationWarning: The astropy.tests.plugins.display plugin has been deprecated. See the pytest-astropy documentation for information on migrating to using pytest-astropy to customize the pytest header. [astropy.tests.plugins.display]
=================================================================== test session starts ===================================================================
platform linux -- Python 3.7.3, pytest-3.6.4, py-1.8.0, pluggy-0.7.1

Running tests with ccdproc version 2.1.dev1561.
Running tests in ccdproc.

Date: 2019-09-09T16:49:49

Platform: Linux-5.0.0-27-generic-x86_64-with-Ubuntu-19.04-disco

Executable: /home/tom/python/dev/bin/python3.7

Full Python Version: 
3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0]

encodings: sys: utf-8, locale: UTF-8, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions: 
Numpy: 1.17.0
Scipy: 1.3.1
Matplotlib: 3.1.1
Pandas: 0.25.0
Astropy: 4.0.dev25644
astroscrappy: 1.0.8
reproject: not available
astropy-helpers: 3.2.1

Using Astropy options: remote_data: none.
```
