### PR TITLE
Fix reading of unsigned 8 bit integer with compressed fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2497,6 +2497,8 @@ astropy.io.fits
 
 - Fix uint conversion in ``FITS_rec`` when slicing a table. [#8982]
 
+- Fix reading of unsigned 8-bit integer with compressed fits. [#9219]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/src/compressionmodule.c
+++ b/astropy/io/fits/src/compressionmodule.c
@@ -178,7 +178,7 @@ void bitpix_to_datatypes(int bitpix, int* datatype, int* npdatatype) {
     switch (bitpix) {
         case BYTE_IMG:
             *datatype = TBYTE;
-            *npdatatype = NPY_INT8;
+            *npdatatype = NPY_UINT8;
             break;
         case SHORT_IMG:
             *datatype = TSHORT;

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1865,6 +1865,22 @@ class TestCompressedImage(FitsTestCase):
             assert hdu[1].header[keyword] == value
             assert hdu[1].data.dtype == expected
 
+    @pytest.mark.parametrize('dtype', (np.uint8, np.int16, np.uint16, np.int32,
+                                       np.uint32))
+    def test_compressed_integers(self, dtype):
+        """Test that the various integer dtypes are correctly written and read.
+
+        Regression test for https://github.com/astropy/astropy/issues/9072
+
+        """
+        mid = np.iinfo(dtype).max // 2
+        data = np.arange(mid-50, mid+50, dtype=dtype)
+        testfile = self.temp('test.fits')
+        hdu = fits.CompImageHDU(data=data)
+        hdu.writeto(testfile, overwrite=True)
+        new = fits.getdata(testfile)
+        np.testing.assert_array_equal(data, new)
+
 
 def test_comphdu_bscale(tmpdir):
     """


### PR DESCRIPTION
Related to #9072 (cc @cmccully): there is an issue when reading a file with uint8 data and then writing it (with the BPM extension):
```
Filename: fpacked.fits.fz
No.    Name      Ver    Type      Cards   Dimensions   Format
  0  PRIMARY       1 PrimaryHDU       8   ()      
  1  SCI           1 CompImageHDU    280   (4096, 4096)   float32   
  2  CAT           1 BinTableHDU    157   306R x 37C   [D, D, D, D, K, K, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, D, K, D, D]   
  3  BPM           1 CompImageHDU     10   (4096, 4096)   uint8   
```

I'm not completely sure, but I think that the issue comes from the C extension that reads the bytes as signed integer instead of unsigned integer. This is because 8 bit integer are stored as unsigned int whereas the other integers are stored as signed int.

With this change I get something consistent with fitsio:
```
In [2]: fits.getdata('fpacked.fits.fz', extname='BPM')                                         
Out[2]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ...,
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=uint8)

In [3]: import fitsio                                                                          

In [4]: fitsio.FITS('fpacked.fits.fz')['BPM'].read()                                           
Out[4]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ...,
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=uint8)
```
And I can write the data after loading it (with the example from #9072):
```
In [2]: fpacked_hdulist = fits.open('fpacked.fits.fz')                                         

In [3]: fpacked_hdulist['BPM'].data                                                            
Out[3]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ...,
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=uint8)

In [4]: fpacked_hdulist.writeto('fpack_straight_out.fits.fz', overwrite=True)                  
```

Without the change (i.e. with master) it crashes:
```
In [2]: fpacked_hdulist = fits.open('fpacked.fits.fz')                                         

In [8]: fpacked_hdulist['BPM'].data                                                            
Out[8]: 
array([[1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       ...,
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1],
       [1, 1, 1, ..., 1, 1, 1]], dtype=int8)

In [9]: fpacked_hdulist.writeto('fpack_straight_out.fits.fz', overwrite=True)                  
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-9-27c63dcf59d5> in <module>
----> 1 fpacked_hdulist.writeto('fpack_straight_out.fits.fz', overwrite=True)

~/dev/astropy/astropy/utils/decorators.py in wrapper(*args, **kwargs)
    519                             kwargs[new_name[i]] = value
    520 
--> 521             return function(*args, **kwargs)
    522 
    523         return wrapper

~/dev/astropy/astropy/io/fits/hdu/hdulist.py in writeto(self, fileobj, output_verify, overwrite, checksum)
    926         with _free_space_check(self, dirname=dirname):
    927             for hdu in self:
--> 928                 hdu._prewriteto(checksum=checksum)
    929                 hdu._writeto(hdulist._file)
    930                 hdu._postwriteto()

~/dev/astropy/astropy/io/fits/hdu/compressed.py in _prewriteto(self, checksum, inplace)
   1796 
   1797         if self._has_data:
-> 1798             self._update_compressed_data()
   1799 
   1800             # Use methods in the superclass to update the header with

~/dev/astropy/astropy/io/fits/hdu/compressed.py in _update_compressed_data(self)
   1620 
   1621         # Check to see that the image_header matches the image data
-> 1622         image_bitpix = DTYPE2BITPIX[self.data.dtype.name]
   1623 
   1624         if image_bitpix != self._orig_bitpix or self.data.shape != self.shape:

KeyError: 'int8'
```

It's a bit surprising because this code has been there since a long time ago, but ... 

I will add a test later, but before that other opinions are welcome (ping @MSeifert04).