### PR TITLE
Settable inputs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,7 +66,9 @@ astropy.modeling
 
 - Significant reorganization of the documentation. [#9078, #9171]
 
-- Add Tabular1D.inverse [#9083]
+- Add ``Tabular1D.inverse`` [#9083]
+
+- ``Model.rename`` was changed to add the ability to rename ``Model.inputs`` and ``Model.outputs``. [#9219]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,7 +68,7 @@ astropy.modeling
 
 - Add ``Tabular1D.inverse`` [#9083]
 
-- ``Model.rename`` was changed to add the ability to rename ``Model.inputs`` and ``Model.outputs``. [#9219]
+- ``Model.rename`` was changed to add the ability to rename ``Model.inputs`` and ``Model.outputs``. [#9220]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -243,11 +243,15 @@ class _ModelMeta(abc.ABCMeta):
         else:
             if not isinstance(inputs, tuple):
                 raise TypeError("Expected 'inputs' to be a tuple of strings.")
+            elif len(inputs) != len(cls.inputs):
+                raise ValueError(f'{cls.name} expects {len(cls.inputs)} inputs')
         if outputs is None:
             outputs = cls.outputs
         else:
             if not isinstance(outputs, tuple):
                 raise TypeError("Expected 'outputs' to be a tuple of strings.")
+            elif len(outputs) != len(cls.outputs):
+                raise ValueError(f'{cls.name} expects {len(cls.outputs)} outputs')
         new_cls = type(name, (cls,), {"inputs": inputs, "outputs": outputs})
         new_cls.__module__ = modname
         new_cls.__qualname__ = name

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -208,9 +208,9 @@ class _ModelMeta(abc.ABCMeta):
         """
         return not (cls.__name__.startswith('_') or inspect.isabstract(cls))
 
-    def rename(cls, name):
+    def rename(cls, name=None, inputs=None, outputs=None):
         """
-        Creates a copy of this model class with a new name.
+        Creates a copy of this model class with a new name, inputs or outputs.
 
         The new class is technically a subclass of the original class, so that
         instance and type checks will still work.  For example::
@@ -236,7 +236,19 @@ class _ModelMeta(abc.ABCMeta):
         else:
             modname = '__main__'
 
-        new_cls = type(name, (cls,), {})
+        if name is None:
+            name = cls.name
+        if inputs is None:
+            inputs = cls.inputs
+        else:
+            if not isinstance(inputs, tuple):
+                raise TypeError("Expected 'inputs' to be a tuple of strings.")
+        if outputs is None:
+            outputs = cls.outputs
+        else:
+            if not isinstance(outputs, tuple):
+                raise TypeError("Expected 'outputs' to be a tuple of strings.")
+        new_cls = type(name, (cls,), {"inputs": inputs, "outputs": outputs})
         new_cls.__module__ = modname
         new_cls.__qualname__ = name
 

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -450,3 +450,21 @@ def test_rename_path(tmpdir):
 
     output = subprocess.check_output([sys.executable, script], env=env)
     assert output.splitlines() == MODEL_RENAME_EXPECTED.splitlines()
+
+
+@pytest.mark.parametrize('model_class',
+                         [models.Gaussian1D, models.Polynomial1D, models.Shift, models.Tabular1D])
+def test_rename_1d(model_class):
+    new_model = model_class.rename(name='Test1D', inputs=('r',), outputs=('q',))
+    assert new_model.name == 'Test1D'
+    assert new_model.inputs == ('r',)
+    assert new_model.outputs == ('q',)
+
+
+@pytest.mark.parametrize('model_class',
+                         [models.Gaussian2D, models.Polynomial2D, models.Tabular2D])
+def test_rename_2d(model_class):
+    new_model = model_class.rename(name='Test2D', inputs=('r', 't'), outputs=('q',))
+    assert new_model.name == 'Test2D'
+    assert new_model.inputs == ('r', 't')
+    assert new_model.outputs == ('q',)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -485,4 +485,3 @@ def test_rename_invalid():
         models.Gaussian2D.rename(inputs=('w',))
     with pytest.raises(ValueError):
         models.Gaussian2D.rename(outputs=('w', 'e'))
-        

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -469,3 +469,20 @@ def test_rename_2d(model_class):
     assert new_model.name == 'Test2D'
     assert new_model.inputs == ('r', 't')
     assert new_model.outputs == ('q',)
+
+    new_model = model_class.rename(inputs=('r', 't'), outputs=('q',))
+    assert new_model.name == model_class.name
+    assert new_model.inputs == ('r', 't')
+    assert new_model.outputs == ('q',)
+
+
+def test_rename_invalid():
+    with pytest.raises(TypeError):
+        models.Gaussian1D.rename(inputs=('w'))
+    with pytest.raises(TypeError):
+        models.Gaussian1D.rename(outputs=('w'))
+    with pytest.raises(ValueError):
+        models.Gaussian2D.rename(inputs=('w',))
+    with pytest.raises(ValueError):
+        models.Gaussian2D.rename(outputs=('w', 'e'))
+        

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -453,7 +453,8 @@ def test_rename_path(tmpdir):
 
 
 @pytest.mark.parametrize('model_class',
-                         [models.Gaussian1D, models.Polynomial1D, models.Shift, models.Tabular1D])
+                         [models.Gaussian1D, models.Polynomial1D,
+                          models.Shift, models.Tabular1D])
 def test_rename_1d(model_class):
     new_model = model_class.rename(name='Test1D', inputs=('r',), outputs=('q',))
     assert new_model.name == 'Test1D'


### PR DESCRIPTION
Add the ability to rename a model's inputs and outputs. This is useful in defining WCSs when meaningful names of inputs and outputs are more user friendly.
It's a simple addition to the `Model.rename` method which creates a subclass of the original model.