### PR TITLE
Adding flake8 testing to the docs build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,14 @@ jobs:
             pip install "numpydoc<0.9" "matplotlib<3.1" "sphinx<2.2"
             pip install .[docs,all]
       - run:
+          name: Make sure flake8 passes
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install flake8
+            # select options should be the same as in the travis config
+            flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
+      - run:
           name: Build Docs
           command: venv/bin/python setup.py build_docs -w
           environment:


### PR DESCRIPTION
This is to close #9215. We keep the travis job as well so it makes sure the full suite is not running when the job is failing. See discussion in the issue. 

Longer term ideally we can run the flake8 as an action that is required to pass before any CI kicks in, but we're not there yet atm (it's not yet clear to me whether conditional actions can control apps, hopefully if will work that way at least in the long run).
