### PR TITLE
numpy.testing.utils raises a ImportWarning saying it should be imported from numpy.testing directly

### DIFF
--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 
 import numpy as np
 
-from numpy.testing.utils import assert_allclose, assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.utils import minversion
 from astropy.modeling.core import Model, ModelDefinitionError


### PR DESCRIPTION
This [warning](https://github.com/numpy/numpy/blob/v1.17.2/numpy/testing/utils.py#L10-L13) has been in place for a while and is easy to fix.