### PR TITLE
Fixes SyntaxWarnings from Python 3.8

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1108,7 +1108,7 @@ class MaskedColumnInfo(ColumnInfo):
                 out['mask'] = col.mask
                 self._represent_as_dict_attrs += ('mask',)
 
-        elif method is 'null_value':
+        elif method == 'null_value':
             pass
 
         else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2258,7 +2258,7 @@ def test_primary_key_is_inherited():
     original_key = t.primary_key
 
     # can't test if tuples are equal, so just check content
-    assert original_key[0] is 'a'
+    assert original_key[0] == 'a'
 
     t2 = t[:]
     t3 = t.copy()

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -184,7 +184,7 @@ class LowLevelWCS5D(BaseLowLevelWCS):
     def world_axis_object_components(self):
         return [('freq', 0, 'value'),
                 ('time', 0, 'mjd'),
-                ('celestial', 0, 'spherical.lon.degree')
+                ('celestial', 0, 'spherical.lon.degree'),
                 ('celestial', 1, 'spherical.lat.degree'),
                 ('stokes', 0, 'value')]
 


### PR DESCRIPTION
The two comparisons usings "is" trigger the warning and because these are strings they can be replaced by "==".

The one test in wcsaxes looks like a real bug where the missing "," was interpreted as function call on a tuple.

Not sure about the milestone.