### PR TITLE
Use QTable for IERS throughout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -288,6 +288,9 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- ``Time.get_ut1_utc`` now uses the auto-updated ``IERS_Auto`` by default,
+  instead of the bundled ``IERS_B`` file. [#9226]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
@@ -321,6 +324,9 @@ astropy.utils
   performance boost). Generally, this should not affect simple subclasses, but
   because the class now uses ``__slots__`` any attributes on the class have to
   be explicitly given a slot. [#8998]
+
+- ``IERS`` tables now use ``nan`` to mark missing values (rather than ``1e20``).
+  [#9226]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1605,10 +1605,10 @@ class Time(ShapedLikeNDArray):
 
         Parameters
         ----------
-        iers_table : ``astropy.utils.iers.IERS`` table, optional
+        iers_table : `~astropy.utils.iers.IERS` table, optional
             Table containing UT1-UTC differences from IERS Bulletins A
-            and/or B.  If `None`, use default version (see
-            ``astropy.utils.iers``)
+            and/or B.  If `None`, use default combined version (see
+            `astropy.utils.iers.IERS_Auto`)
         return_status : bool
             Whether to return status values.  If `False` (default), iers
             raises `IndexError` if any time is out of the range
@@ -1642,8 +1642,8 @@ class Time(ShapedLikeNDArray):
             array([ True, False]...)
         """
         if iers_table is None:
-            from astropy.utils.iers import IERS
-            iers_table = IERS.open()
+            from astropy.utils.iers import IERS_Auto
+            iers_table = IERS_Auto.open()
 
         return iers_table.ut1_utc(self.utc, return_status=return_status)
 

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -28,12 +28,19 @@ IERS_A_EXCERPT = os.path.join(os.path.dirname(__file__), 'data', 'iers_a_excerpt
 class TestBasic():
     """Basic tests that IERS_B returns correct values"""
 
-    def test_simple(self):
-        iers.IERS.close()
-        assert iers.IERS.iers_table is None
-        iers_tab = iers.IERS.open()
-        assert iers.IERS.iers_table is not None
-        assert isinstance(iers.IERS.iers_table, QTable)
+    @pytest.mark.parametrize('iers_cls', (iers.IERS_B, iers.IERS))
+    def test_simple(self, iers_cls):
+        """Test the default behaviour for IERS_B and IERS."""
+        # Arguably, IERS itself should not be used at all, but it used to
+        # provide IERS_B by default so we check that it continues to do so.
+        # Eventually, IERS should probably be deprecated.
+        iers_cls.close()
+        assert iers_cls.iers_table is None
+        iers_tab = iers_cls.open()
+        assert iers_cls.iers_table is not None
+        assert iers_cls.iers_table is iers_tab
+        assert isinstance(iers_tab, QTable)
+        assert isinstance(iers_tab, iers.IERS_B)
         assert (iers_tab['UT1_UTC'].unit / u.second).is_unity()
         assert (iers_tab['PM_x'].unit / u.arcsecond).is_unity()
         assert (iers_tab['PM_y'].unit / u.arcsecond).is_unity()
@@ -66,13 +73,13 @@ class TestBasic():
         assert len(iers_tab[:2]) == 2
 
     def test_open_filename(self):
-        iers.IERS.close()
-        iers.IERS.open(iers.IERS_B_FILE)
-        assert iers.IERS.iers_table is not None
-        assert isinstance(iers.IERS.iers_table, QTable)
-        iers.IERS.close()
+        iers.IERS_B.close()
+        iers.IERS_B.open(iers.IERS_B_FILE)
+        assert iers.IERS_B.iers_table is not None
+        assert isinstance(iers.IERS_B.iers_table, QTable)
+        iers.IERS_B.close()
         with pytest.raises(FILE_NOT_FOUND_ERROR):
-            iers.IERS.open('surely this does not exist')
+            iers.IERS_B.open('surely this does not exist')
 
     def test_open_network_url(self):
         iers.IERS_A.close()


### PR DESCRIPTION
#9204 made me look at the IERS code again and I realized it could use some cleanup. The first commit ensures we just use `QTable` rather than go through `Table` and then fill the masked columns. This makes merging/selecting between A and B quite a bit cleaner. The second commit removes the `IERS.read` method (which was just assigned to `IERS_B.read`) so that `super` class work; it also prevents warnings about dropped masks.

A small additional change is to ensure that in `Time` the default IERS table is always that from `IERS_Auto`.

cc @aarchiba 