### PR TITLE
Ensure fits Header subclasses are preserved on slicing and copying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -205,6 +205,10 @@ astropy.io.fits
 
 - Masked column handling has changed, see ``astropy.table`` entry below. [#8789]
 
+- ``io.fits.Header`` has been made safe for subclasses for copying and slicing.
+  As a result of this change, the private subclass ``CompImageHeader`` now always
+  should be passed an explicit ``image_header``. [#9229]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -132,10 +132,10 @@ class Header:
 
     def __getitem__(self, key):
         if isinstance(key, slice):
-            return Header([copy.copy(c) for c in self._cards[key]])
+            return self.__class__([copy.copy(c) for c in self._cards[key]])
         elif self._haswildcard(key):
-            return Header([copy.copy(self._cards[idx])
-                           for idx in self._wildcardmatch(key)])
+            return self.__class__([copy.copy(self._cards[idx])
+                                   for idx in self._wildcardmatch(key)])
         elif (isinstance(key, str) and
               key.upper() in Card._commentary_keywords):
             key = key.upper()
@@ -824,7 +824,7 @@ class Header:
             A new :class:`Header` instance.
         """
 
-        tmp = Header(copy.copy(card) for card in self._cards)
+        tmp = self.__class__((copy.copy(card) for card in self._cards))
         if strip:
             tmp._strip()
         return tmp
@@ -1294,7 +1294,7 @@ class Header:
             new cards to the header.
         """
 
-        temp = Header(cards)
+        temp = self.__class__(cards)
         if strip:
             temp._strip()
 


### PR DESCRIPTION
This PR makes `Header` sub-class safe, by ensuring that `__getitem__` and `copy` return a `self.__class__` instance rather than a `Header` instance. It adds a(nother) hack to `CompImageHeader` to ensure that for that case slicing and copying continues to return a `Header` instance.

fixes #7379