### PR TITLE
Fix rendering of verify method in documentation.

### DIFF
--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -59,7 +59,7 @@ class _Verify:
             Output verification option.  Must be one of ``"fix"``,
             ``"silentfix"``, ``"ignore"``, ``"warn"``, or
             ``"exception"``.  May also be any combination of ``"fix"`` or
-            ``"silentfix"`` with ``"+ignore"``, ``+warn``, or ``+exception"
+            ``"silentfix"`` with ``"+ignore"``, ``"+warn"``, or ``"+exception"``
             (e.g. ``"fix+warn"``).  See :ref:`verify` for more info.
         """
 


### PR DESCRIPTION
It was missing the closing double backslash. Also added some quotes to the options to make it more consistent and clear that these are string-options.

Current rendering, for example in [`astropy.io.fits.ImageHDU.verify`](https://docs.astropy.org/en/stable/io/fits/api/images.html#astropy.io.fits.ImageHDU.verify)

With this PR: [`astropy.io.fits.ImageHDU.verify`](https://42256-2081289-gh.circle-artifacts.com/0/home/circleci/project/docs/_build/html/io/fits/api/images.html#astropy.io.fits.ImageHDU.verify)

Do we backport such documentation changes?