### PR TITLE
Ensure that nutation columns are also copied from IERS B to IERS_Auto

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -414,6 +414,12 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- For the default ``IERS_Auto`` table, which combines IERS A and B values, the
+  IERS nutation parameters "dX_2000A" and "dY_2000A" are now also taken from
+  the actual IERS B file rather than from the B values stored in the IERS A
+  file.  Any differences should be negligible for any practical application,
+  but this may help exactly reproducing results. [#9237]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -798,5 +798,7 @@ class IERS_Auto(IERS_A):
             table['UT1_UTC_B'][:n_iers_b] = iers_b['UT1_UTC']
             table['PM_X_B'][:n_iers_b] = iers_b['PM_x']
             table['PM_Y_B'][:n_iers_b] = iers_b['PM_y']
+            table['dX_2000A_B'][:n_iers_b] = iers_b['dX_2000A']
+            table['dY_2000A_B'][:n_iers_b] = iers_b['dY_2000A']
 
         return table


### PR DESCRIPTION
This takes an uncontroversial piece from #9204 by @aarchiba - which is that `dX_2000A` and `dY_2000A` should also be copied from IERS B to `IERS_Auto` - and rebased it on top of the refactoring in #9226.

@aarchiba - I slightly rewrote your test (and moved it), so that it now tests that the `IERS_Auto` values that one would use are actually the same as those in the `IERS_B` file. I think this is the most important test, as it is what is actually used in astropy.