### PR TITLE
Let IERS table used in time/coordinates determined by science state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,6 +236,7 @@ astropy.utils
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial
   array. [#9209]
+
 - The specific IERS Earth rotation parameter table used for time and
   coordinate transformations can now be set, either in a context or per
   session, using ``astropy.utils.iers.earth_rotation_table``. [#9244]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -236,6 +236,9 @@ astropy.utils
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial
   array. [#9209]
+- The specific IERS Earth rotation parameter table used for time and
+  coordinate transformations can now be set, either in a context or per
+  session, using ``astropy.utils.iers.earth_rotation_table``. [#9244]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -38,7 +38,7 @@ def get_polar_motion(time):
     gets the two polar motion components in radians for use with apio13
     """
     # Get the polar motion from the IERS table
-    iers_table = iers.earth_rotation_table.get()
+    iers_table = iers.earth_orientation_table.get()
     xp, yp, status = iers_table.pm_xy(time, return_status=True)
 
     wmsg = None

--- a/astropy/coordinates/builtin_frames/utils.py
+++ b/astropy/coordinates/builtin_frames/utils.py
@@ -38,15 +38,16 @@ def get_polar_motion(time):
     gets the two polar motion components in radians for use with apio13
     """
     # Get the polar motion from the IERS table
-    xp, yp, status = iers.IERS_Auto.open().pm_xy(time, return_status=True)
+    iers_table = iers.earth_rotation_table.get()
+    xp, yp, status = iers_table.pm_xy(time, return_status=True)
 
     wmsg = None
     if np.any(status == iers.TIME_BEFORE_IERS_RANGE):
         wmsg = ('Tried to get polar motions for times before IERS data is '
                 'valid. Defaulting to polar motion from the 50-yr mean for those. '
                 'This may affect precision at the 10s of arcsec level')
-        xp.ravel()[status.ravel() == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[0]
-        yp.ravel()[status.ravel() == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[1]
+        xp[status == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[0]
+        yp[status == iers.TIME_BEFORE_IERS_RANGE] = _DEFAULT_PM[1]
 
         warnings.warn(wmsg, AstropyWarning)
 
@@ -55,8 +56,8 @@ def get_polar_motion(time):
                 'valid. Defaulting to polar motion from the 50-yr mean for those. '
                 'This may affect precision at the 10s of arcsec level')
 
-        xp.ravel()[status.ravel() == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[0]
-        yp.ravel()[status.ravel() == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[1]
+        xp[status == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[0]
+        yp[status == iers.TIME_BEYOND_IERS_RANGE] = _DEFAULT_PM[1]
 
         warnings.warn(wmsg, AstropyWarning)
 

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -117,7 +117,7 @@ def test_iau_fullstack(fullstack_icrs, fullstack_fiducial_altaz,
     assert np.all(addecs < tol), 'largest Dec change is {} mas, > {}'.format(np.max(addecs.arcsec*1000), tol)
 
     # check that we're consistent with the ERFA alt/az result
-    iers_tab = iers.earth_rotation_table.get()
+    iers_tab = iers.earth_orientation_table.get()
     xp, yp = u.Quantity(iers_tab.pm_xy(fullstack_times)).to_value(u.radian)
     lon = fullstack_locations.geodetic[0].to_value(u.radian)
     lat = fullstack_locations.geodetic[1].to_value(u.radian)
@@ -179,7 +179,7 @@ def test_future_altaz():
     # table does not raise an exception.  Only if using IERS_B (which happens without
     # --remote-data, i.e. for all CI testing) do we expect another warning.
     messages_to_find = ["Tried to get polar motions for times after IERS data is valid."]
-    if isinstance(iers.earth_rotation_table.get(), iers.IERS_B):
+    if isinstance(iers.earth_orientation_table.get(), iers.IERS_B):
         messages_to_find.append("(some) times are outside of range covered by IERS table.")
 
     messages_found = [False for _ in messages_to_find]

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -117,7 +117,8 @@ def test_iau_fullstack(fullstack_icrs, fullstack_fiducial_altaz,
     assert np.all(addecs < tol), 'largest Dec change is {} mas, > {}'.format(np.max(addecs.arcsec*1000), tol)
 
     # check that we're consistent with the ERFA alt/az result
-    xp, yp = u.Quantity(iers.IERS_Auto.open().pm_xy(fullstack_times)).to_value(u.radian)
+    iers_tab = iers.earth_rotation_table.get()
+    xp, yp = u.Quantity(iers_tab.pm_xy(fullstack_times)).to_value(u.radian)
     lon = fullstack_locations.geodetic[0].to_value(u.radian)
     lat = fullstack_locations.geodetic[1].to_value(u.radian)
     height = fullstack_locations.geodetic[2].to_value(u.m)
@@ -178,7 +179,7 @@ def test_future_altaz():
     # table does not raise an exception.  Only if using IERS_B (which happens without
     # --remote-data, i.e. for all CI testing) do we expect another warning.
     messages_to_find = ["Tried to get polar motions for times after IERS data is valid."]
-    if isinstance(iers.IERS_Auto.iers_table, iers.IERS_B):
+    if isinstance(iers.earth_rotation_table.get(), iers.IERS_B):
         messages_to_find.append("(some) times are outside of range covered by IERS table.")
 
     messages_found = [False for _ in messages_to_find]

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -493,7 +493,7 @@ def test_gcrs_self_transform_closeby():
 
 
 @pytest.mark.remote_data
-def test_earth_rotation_table():
+def test_earth_orientation_table():
     """Check that we can set the IERS table used as Earth Reference.
 
     Use the here and now to be sure we get a difference.
@@ -508,7 +508,7 @@ def test_earth_rotation_table():
 
     assert len(w) == 0
 
-    with iers.earth_rotation_table.set(iers.IERS_B.open()):
+    with iers.earth_orientation_table.set(iers.IERS_B.open()):
         with catch_warnings() as w:
             altaz_b = sc.transform_to(altaz)
         assert len(w) == 1

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -231,7 +231,7 @@ def test_regression_futuretimes_4302():
     # times outside the range of the table does not raise an exception.  Only
     # if using IERS_B (which happens without --remote-data, i.e. for all CI
     # testing) do we expect another warning.
-    if isinstance(iers.earth_rotation_table.get(), iers.IERS_B):
+    if isinstance(iers.earth_orientation_table.get(), iers.IERS_B):
         saw_iers_warnings = False
         for w in found_warnings:
             if issubclass(w.category, AstropyWarning):

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -225,7 +225,13 @@ def test_regression_futuretimes_4302():
         c = CIRS(1*u.deg, 2*u.deg, obstime=future_time)
         c.transform_to(ITRS(obstime=future_time))
 
-    if not isinstance(iers.IERS_Auto.iers_table, iers.IERS_Auto):
+    # check that out-of-range warning appears among any other warnings.  If
+    # tests are run with --remote-data then the IERS table will be an instance
+    # of IERS_Auto which is assured of being "fresh".  In this case getting
+    # times outside the range of the table does not raise an exception.  Only
+    # if using IERS_B (which happens without --remote-data, i.e. for all CI
+    # testing) do we expect another warning.
+    if isinstance(iers.earth_rotation_table.get(), iers.IERS_B):
         saw_iers_warnings = False
         for w in found_warnings:
             if issubclass(w.category, AstropyWarning):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1654,7 +1654,7 @@ class Time(ShapedLikeNDArray):
         ----------
         iers_table : `~astropy.utils.iers.IERS` table, optional
             Table containing UT1-UTC differences from IERS Bulletins A
-            and/or B.  Default: `~astropy.utils.iers.earth_rotation_table`
+            and/or B.  Default: `~astropy.utils.iers.earth_orientation_table`
             (which in turn defaults to the combined version provided by
             `~astropy.utils.iers.IERS_Auto`).
         return_status : bool
@@ -1690,8 +1690,8 @@ class Time(ShapedLikeNDArray):
             array([ True, False]...)
         """
         if iers_table is None:
-            from astropy.utils.iers import earth_rotation_table
-            iers_table = earth_rotation_table.get()
+            from astropy.utils.iers import earth_orientation_table
+            iers_table = earth_orientation_table.get()
 
         return iers_table.ut1_utc(self.utc, return_status=return_status)
 
@@ -1706,8 +1706,8 @@ class Time(ShapedLikeNDArray):
         # Sec. 4.3.1: the arg DUT is the quantity delta_UT1 = UT1 - UTC in
         # seconds. It is obtained from tables published by the IERS.
         if not hasattr(self, '_delta_ut1_utc'):
-            from astropy.utils.iers import earth_rotation_table
-            iers_table = earth_rotation_table.get()
+            from astropy.utils.iers import earth_orientation_table
+            iers_table = earth_orientation_table.get()
             # jd1, jd2 are normally set (see above), except if delta_ut1_utc
             # is access directly; ensure we behave as expected for that case
             if jd1 is None:

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1654,8 +1654,9 @@ class Time(ShapedLikeNDArray):
         ----------
         iers_table : `~astropy.utils.iers.IERS` table, optional
             Table containing UT1-UTC differences from IERS Bulletins A
-            and/or B.  If `None`, use default combined version (see
-            `astropy.utils.iers.IERS_Auto`)
+            and/or B.  Default: `~astropy.utils.iers.earth_rotation_table`
+            (which in turn defaults to the combined version provided by
+            `~astropy.utils.iers.IERS_Auto`).
         return_status : bool
             Whether to return status values.  If `False` (default), iers
             raises `IndexError` if any time is out of the range
@@ -1689,8 +1690,8 @@ class Time(ShapedLikeNDArray):
             array([ True, False]...)
         """
         if iers_table is None:
-            from astropy.utils.iers import IERS_Auto
-            iers_table = IERS_Auto.open()
+            from astropy.utils.iers import earth_rotation_table
+            iers_table = earth_rotation_table.get()
 
         return iers_table.ut1_utc(self.utc, return_status=return_status)
 
@@ -1705,8 +1706,8 @@ class Time(ShapedLikeNDArray):
         # Sec. 4.3.1: the arg DUT is the quantity delta_UT1 = UT1 - UTC in
         # seconds. It is obtained from tables published by the IERS.
         if not hasattr(self, '_delta_ut1_utc'):
-            from astropy.utils.iers import IERS_Auto
-            iers_table = IERS_Auto.open()
+            from astropy.utils.iers import earth_rotation_table
+            iers_table = earth_rotation_table.get()
             # jd1, jd2 are normally set (see above), except if delta_ut1_utc
             # is access directly; ensure we behave as expected for that case
             if jd1 is None:

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -82,7 +82,7 @@ class TestTimeUT1SpecificIERSTable:
         assert tnow_ut1_jd != tnow.jd
 
         delta_ut1_utc = tnow.delta_ut1_utc
-        with iers.earth_rotation_table.set(iers_type.open()):
+        with iers.earth_orientation_table.set(iers_type.open()):
             delta2, status2 = tnow.get_delta_ut1_utc(return_status=True)
             assert status2 == status
             assert delta2.to_value('s') == delta_ut1_utc
@@ -105,7 +105,7 @@ class TestTimeUT1SpecificIERSTable:
         delta1, status1 = tnow.get_delta_ut1_utc(iers_b, return_status=True)
         assert status1 == iers.TIME_BEYOND_IERS_RANGE
 
-        with iers.earth_rotation_table.set(iers.IERS_B.open()):
+        with iers.earth_orientation_table.set(iers.IERS_B.open()):
             delta2, status2 = tnow.get_delta_ut1_utc(return_status=True)
             assert status2 == status1
 

--- a/astropy/time/tests/test_ut1.py
+++ b/astropy/time/tests/test_ut1.py
@@ -72,23 +72,42 @@ class TestTimeUT1:
             assert allclose_sec(t._delta_ut1_utc, -0.58682110003124965)
 
 
-@pytest.mark.skipif('not HAS_IERS_A')
-class TestTimeUT1_IERSA:
+class TestTimeUT1SpecificIERSTable:
+    def do_ut1_prediction_test(self, iers_type):
+        tnow = Time.now()
+        iers_tab = iers_type.open()
+        tnow.delta_ut1_utc, status = iers_tab.ut1_utc(tnow, return_status=True)
+        assert status == iers.FROM_IERS_A_PREDICTION
+        tnow_ut1_jd = tnow.ut1.jd
+        assert tnow_ut1_jd != tnow.jd
+
+        delta_ut1_utc = tnow.delta_ut1_utc
+        with iers.earth_rotation_table.set(iers_type.open()):
+            delta2, status2 = tnow.get_delta_ut1_utc(return_status=True)
+            assert status2 == status
+            assert delta2.to_value('s') == delta_ut1_utc
+
+            tnow_ut1 = tnow.ut1
+            assert tnow_ut1._delta_ut1_utc == delta_ut1_utc
+            assert tnow_ut1.jd != tnow.jd
+
+    @pytest.mark.skipif('not HAS_IERS_A')
     def test_ut1_iers_A(self):
-        tnow = Time.now()
-        iers_a = iers.IERS_A.open()
-        tnow.delta_ut1_utc, status = iers_a.ut1_utc(tnow, return_status=True)
-        assert status == iers.FROM_IERS_A_PREDICTION
-        tnow_ut1_jd = tnow.ut1.jd
-        assert tnow_ut1_jd != tnow.jd
+        self.do_ut1_prediction_test(iers.IERS_A)
 
-
-@pytest.mark.remote_data
-class TestTimeUT1_IERS_Auto:
+    @pytest.mark.remote_data
     def test_ut1_iers_auto(self):
+        self.do_ut1_prediction_test(iers.IERS_Auto)
+
+    def test_ut1_iers_B(self):
         tnow = Time.now()
-        iers_a = iers.IERS_Auto.open()
-        tnow.delta_ut1_utc, status = iers_a.ut1_utc(tnow, return_status=True)
-        assert status == iers.FROM_IERS_A_PREDICTION
-        tnow_ut1_jd = tnow.ut1.jd
-        assert tnow_ut1_jd != tnow.jd
+        iers_b = iers.IERS_B.open()
+        delta1, status1 = tnow.get_delta_ut1_utc(iers_b, return_status=True)
+        assert status1 == iers.TIME_BEYOND_IERS_RANGE
+
+        with iers.earth_rotation_table.set(iers.IERS_B.open()):
+            delta2, status2 = tnow.get_delta_ut1_utc(return_status=True)
+            assert status2 == status1
+
+            with pytest.raises(iers.IERSRangeError):
+                tnow.ut1

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -818,28 +818,25 @@ class earth_rotation_table(ScienceState):
 
     Examples
     --------
-    To temporarily use the IERS-B file packaged with astropy:
+    To temporarily use the IERS-B file packaged with astropy::
 
-    >>> from astropy.utils import iers
-    >>> from astropy.time import Time
-    >>> iers_b = iers.IERS_B.open(IERS_B_FILE)
-    >>> with iers.earth_rotation_table.set(iers_b):
-    ...     print(Time('2000-01-01').ut1.isot)
-    2000-01-01T00:00:00.355
+      >>> from astropy.utils import iers
+      >>> from astropy.time import Time
+      >>> iers_b = iers.IERS_B.open(iers.IERS_B_FILE)
+      >>> with iers.earth_rotation_table.set(iers_b):
+      ...     print(Time('2000-01-01').ut1.isot)
+      2000-01-01T00:00:00.355
 
-    To use the most recent IERS-A file for the whole session:
+    To use the most recent IERS-A file for the whole session::
 
-    >>> iers_a = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
-    >>> iers.earth_rotation_table.set(iers_a)  # doctest: +SKIP
-    <ScienceState earth_rotation_table: <IERS_A length=...>
-     year month  day    MJD   PolPMFlag_A ... PolPMFlag dX_2000A dY_2000A NutFlag
-                         d                ...           marcsec  marcsec
-    int64 int64 int64 float64     str1    ...    str1   float64  float64    str1
-    ...
+      >>> iers_a = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
+      >>> iers.earth_rotation_table.set(iers_a)  # doctest: +SKIP
+      <ScienceState earth_rotation_table: <IERS_A length=17463>...>
 
-    To go back to the default (of `~astropy.utils.iers.IERS_Auto`):
+    To go back to the default (of `~astropy.utils.iers.IERS_Auto`)::
 
-    >>> iers.earth_rotation_table.set(None)  # doctest: +SKIP
+      >>> iers.earth_rotation_table.set(None)  # doctest: +SKIP
+      <ScienceState earth_rotation_table: <IERS_Auto length=17428>...>
     """
     _value = None
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -27,7 +27,7 @@ from astropy.utils.compat import NUMPY_LT_1_17
 from astropy import utils
 from astropy.utils.exceptions import AstropyWarning
 
-__all__ = ['Conf', 'conf', 'earth_rotation_table',
+__all__ = ['Conf', 'conf', 'earth_orientation_table',
            'IERS', 'IERS_B', 'IERS_A', 'IERS_Auto',
            'FROM_IERS_B', 'FROM_IERS_A', 'FROM_IERS_A_PREDICTION',
            'TIME_BEFORE_IERS_RANGE', 'TIME_BEYOND_IERS_RANGE',
@@ -805,7 +805,7 @@ class IERS_Auto(IERS_A):
         return table
 
 
-class earth_rotation_table(ScienceState):
+class earth_orientation_table(ScienceState):
     """Default IERS table for Earth rotation and reference systems service.
 
     These tables are used to calculate the offsets between ``UT1`` and ``UTC``
@@ -823,20 +823,20 @@ class earth_rotation_table(ScienceState):
       >>> from astropy.utils import iers
       >>> from astropy.time import Time
       >>> iers_b = iers.IERS_B.open(iers.IERS_B_FILE)
-      >>> with iers.earth_rotation_table.set(iers_b):
+      >>> with iers.earth_orientation_table.set(iers_b):
       ...     print(Time('2000-01-01').ut1.isot)
       2000-01-01T00:00:00.355
 
     To use the most recent IERS-A file for the whole session::
 
       >>> iers_a = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
-      >>> iers.earth_rotation_table.set(iers_a)  # doctest: +SKIP
-      <ScienceState earth_rotation_table: <IERS_A length=17463>...>
+      >>> iers.earth_orientation_table.set(iers_a)  # doctest: +SKIP
+      <ScienceState earth_orientation_table: <IERS_A length=17463>...>
 
     To go back to the default (of `~astropy.utils.iers.IERS_Auto`)::
 
-      >>> iers.earth_rotation_table.set(None)  # doctest: +SKIP
-      <ScienceState earth_rotation_table: <IERS_Auto length=17428>...>
+      >>> iers.earth_orientation_table.set(None)  # doctest: +SKIP
+      <ScienceState earth_orientation_table: <IERS_Auto length=17428>...>
     """
     _value = None
 
@@ -845,5 +845,5 @@ class earth_rotation_table(ScienceState):
         if value is None:
             value = IERS_Auto.open()
         if not isinstance(value, IERS):
-            raise ValueError("earth_rotation_table requires an IERS Table.")
+            raise ValueError("earth_orientation_table requires an IERS Table.")
         return value

--- a/astropy/utils/state.py
+++ b/astropy/utils/state.py
@@ -56,8 +56,13 @@ class ScienceState:
                 self._parent._value = self._value
 
             def __repr__(self):
-                return ('<ScienceState {}: {!r}>'
-                        .format(self._parent.__name__, self._parent._value))
+                # Ensure we have a single-line repr, just in case our
+                # value is not something simple like a string.
+                value_repr, lb, _ = repr(self._parent._value).partition('\n')
+                if lb:
+                    value_repr += '...'
+                return ('<ScienceState {}: {}>'
+                        .format(self._parent.__name__, value_repr))
 
         ctx = _Context(cls, cls._value)
         value = cls.validate(value)

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -157,10 +157,7 @@ transformations.  For example::
   >>> iers_b.ut1_utc(t)  # doctest: +FLOAT_CMP
   <Quantity 0.1140827 s>
   >>> iers.earth_rotation_table.set(iers_b)
-  <ScienceState earth_rotation_table: <IERS_B length=...>
-  year month  day    MJD      PM_x   ... e_UT1_UTC  e_LOD   e_dX_2000A e_dY_2000A
-                      d      arcsec  ...     s        s       arcsec     arcsec
-  ...
+  <ScienceState earth_rotation_table: <IERS_B length=...>...>
   >>> t.ut1.iso
   '2010-01-01 00:00:00.114'
 
@@ -179,10 +176,7 @@ To reset to the default, pass in `None` (which is equivalent to passing in
 ``iers.IERS_Auto.open()``)::
 
   >>> iers.earth_rotation_table.set(None)  # doctest: +REMOTE_DATA
-  <ScienceState earth_rotation_table: <IERS_Auto length=...>
-   year month  day    MJD   PolPMFlag_A ... PolPMFlag dX_2000A dY_2000A NutFlag
-                       d                ...           marcsec  marcsec
-  ...
+  <ScienceState earth_rotation_table: <IERS_Auto length=...>...>
 
 To see the internal IERS data that gets used in astropy you can do the
 following::

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -29,7 +29,7 @@ and how this can be controlled.
 Basic usage
 -----------
 
-The IERS data are managed via a instances of the
+By default, the IERS data are managed via instances of the
 :class:`~astropy.utils.iers.IERS_Auto` class.  These instances are created
 internally within the relevant time and coordinate objects during
 transformations.  If the astropy data cache does not have the required IERS
@@ -47,7 +47,7 @@ machine.  Here is an example that shows the typical download progress bar::
 Note that you can forcibly clear the download cache as follows::
 
   >>> from astropy.utils.data import clear_download_cache
-  >>> clear_download_cache()
+  >>> clear_download_cache()  # doctest: +SKIP
 
 The default IERS data used automatically is updated by the service every 7 days
 and includes transforms dating back to 1973-01-01.
@@ -146,34 +146,50 @@ Direct table access
 -------------------
 
 In most cases the automatic interface will suffice, but you may need to
-directly load and manipulate IERS tables.  IERS-B values are provided as
-part of astropy and can be used for transformations.  For example::
+directly load and manipulate IERS tables.  IERS-B values are provided as part
+of astropy and can be used to calculate time offsets and polar motion
+directly, or set up for internal use in further time and coordinate
+transformations.  For example::
 
   >>> from astropy.utils import iers
   >>> t = Time('2010:001')
   >>> iers_b = iers.IERS_B.open()
   >>> iers_b.ut1_utc(t)  # doctest: +FLOAT_CMP
   <Quantity 0.1140827 s>
-  >>> t.delta_ut1_utc = iers_b.ut1_utc(t)
+  >>> iers.earth_rotation_table.set(iers_b)
+  <ScienceState earth_rotation_table: <IERS_B length=...>
+  year month  day    MJD      PM_x   ... e_UT1_UTC  e_LOD   e_dX_2000A e_dY_2000A
+                      d      arcsec  ...     s        s       arcsec     arcsec
+  ...
   >>> t.ut1.iso
   '2010-01-01 00:00:00.114'
 
 Instead of local copies of IERS files, one can also download them, using
-``iers.IERS_A_URL`` (or ``iers.IERS_A_URL_MIRROR``) and ``iers.IERS_B_URL``::
+``iers.IERS_A_URL`` (or ``iers.IERS_A_URL_MIRROR``) and ``iers.IERS_B_URL``,
+and then use those for future time and coordinate transformations (in this
+example, just for a single calculation, by using
+`~astropy.utils.iers.earth_rotation_table` as a context manager)::
 
   >>> iers_a = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
+  >>> with iers.earth_rotation_table.set(iers_a):  # doctest: +SKIP
+  ...     print(t.ut1.iso)
+  2010-01-01 00:00:00.114
 
-For coordinate transformations that require IERS polar motion values,
-setting the values manually can be done as follows (where one could also
-select IERS_B)::
+To reset to the default, pass in `None` (which is equivalent to passing in
+``iers.IERS_Auto.open()``)::
 
-  >>> iers.conf.auto_download = False
-  >>> iers.IERS.iers_table = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
+  >>> iers.earth_rotation_table.set(None)  # doctest: +REMOTE_DATA
+  <ScienceState earth_rotation_table: <IERS_Auto length=...>
+   year month  day    MJD   PolPMFlag_A ... PolPMFlag dX_2000A dY_2000A NutFlag
+                       d                ...           marcsec  marcsec
+  ...
 
 To see the internal IERS data that gets used in astropy you can do the
 following::
 
-  >>> dat = iers.IERS_Auto.open()  # doctest: +SKIP
+  >>> dat = iers.earth_rotation_table.get()  # doctest: +REMOTE_DATA
+  >>> type(dat)  # doctest: +REMOTE_DATA
+  <class 'astropy.utils.iers.iers.IERS_Auto'>
   >>> dat  # doctest: +SKIP
   <IERS_Auto length=16196>
    year month  day    MJD   PolPMFlag_A ... UT1Flag    PM_x     PM_y   PolPMFlag

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -156,8 +156,8 @@ transformations.  For example::
   >>> iers_b = iers.IERS_B.open()
   >>> iers_b.ut1_utc(t)  # doctest: +FLOAT_CMP
   <Quantity 0.1140827 s>
-  >>> iers.earth_rotation_table.set(iers_b)
-  <ScienceState earth_rotation_table: <IERS_B length=...>...>
+  >>> iers.earth_orientation_table.set(iers_b)
+  <ScienceState earth_orientation_table: <IERS_B length=...>...>
   >>> t.ut1.iso
   '2010-01-01 00:00:00.114'
 
@@ -165,23 +165,23 @@ Instead of local copies of IERS files, one can also download them, using
 ``iers.IERS_A_URL`` (or ``iers.IERS_A_URL_MIRROR``) and ``iers.IERS_B_URL``,
 and then use those for future time and coordinate transformations (in this
 example, just for a single calculation, by using
-`~astropy.utils.iers.earth_rotation_table` as a context manager)::
+`~astropy.utils.iers.earth_orientation_table` as a context manager)::
 
   >>> iers_a = iers.IERS_A.open(iers.IERS_A_URL)  # doctest: +SKIP
-  >>> with iers.earth_rotation_table.set(iers_a):  # doctest: +SKIP
+  >>> with iers.earth_orientation_table.set(iers_a):  # doctest: +SKIP
   ...     print(t.ut1.iso)
   2010-01-01 00:00:00.114
 
 To reset to the default, pass in `None` (which is equivalent to passing in
 ``iers.IERS_Auto.open()``)::
 
-  >>> iers.earth_rotation_table.set(None)  # doctest: +REMOTE_DATA
-  <ScienceState earth_rotation_table: <IERS_Auto length=...>...>
+  >>> iers.earth_orientation_table.set(None)  # doctest: +REMOTE_DATA
+  <ScienceState earth_orientation_table: <IERS_Auto length=...>...>
 
 To see the internal IERS data that gets used in astropy you can do the
 following::
 
-  >>> dat = iers.earth_rotation_table.get()  # doctest: +REMOTE_DATA
+  >>> dat = iers.earth_orientation_table.get()  # doctest: +REMOTE_DATA
   >>> type(dat)  # doctest: +REMOTE_DATA
   <class 'astropy.utils.iers.iers.IERS_Auto'>
   >>> dat  # doctest: +SKIP


### PR DESCRIPTION
Addresses the first item in #9227, that it would be good to allow users to determine what IERS table is used for all time and coordinate transformations in astropy (specifically, this is to help PINT use an up-to-date IERS-B file rather than `IERS_Auto`).

Here, this is done with a new `iers.earth_rotation_table` science state class, which is check in time and coordinates.

cc @aarchiba

EDIT: changed name to `earth_rotation_table`