### PR TITLE
TST: Pin matplotlib for linkcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,9 +171,11 @@ matrix:
         # Run documentation link check in a cron job.
         # Was originally in CircleCI doc build but links are too flaky, so
         # we moved it here instead.
+        # NOTE: matplotlib pinning should be consistent with CircleCI HTML job.
         - os: linux
           stage: Cron tests
           env: SETUP_CMD='build_docs -b linkcheck' EVENT_TYPE='cron'
+               MATPLOTLIB_VERSION="<3.1"
                PIP_DEPENDENCIES="" CONDA_DEPENDENCIES=""
                INSTALL_WITH_PIP=True
                EXTRAS_INSTALL="docs"


### PR DESCRIPTION
**DO NOT MERGE**

Follow up of #9175. Link check failed with `matplotlib` warnings, which can be fixed by pinning `matplotlib` like our CircleCI HTML job... but how to do it correctly here?

https://travis-ci.org/astropy/astropy/jobs/586062770

```
...
WARNING: py:obj reference target not found: matplotlib.spines.get_window_extent

build finished with problems, 2 warnings.
```

**TODO**

- [x] Make sure `linkcheck` job passes. See https://travis-ci.org/astropy/astropy/jobs/586134757
- [x] Add Brigitta as co-author.
- [x] Undo temporary changes and squash them out.
- [x] Push clean commit with `[skip ci]` and point to the POC test log instead, since this PR only affects *cron job*.