### PR TITLE
Imply that multiple obstimes are allowed in SkyCoord

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -166,9 +166,9 @@ class SkyCoord(ShapedLikeNDArray):
         only one unit is supplied then it applies to both ``LON`` and
         ``LAT``.
     obstime : valid `~astropy.time.Time` initializer, optional
-        Time of observation
+        Time(s) of observation.
     equinox : valid `~astropy.time.Time` initializer, optional
-        Coordinate frame equinox
+        Coordinate frame equinox.
     representation_type : str or Representation class
         Specifies the representation, e.g. 'spherical', 'cartesian', or
         'cylindrical'.  This affects the positional args and other keyword args


### PR DESCRIPTION
A small change, but since multiple times are valid I think an improvement. Fixes #9256.