### PR TITLE
Make one of the slowest io.fits tests faster.

### DIFF
--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -1506,7 +1506,8 @@ class TestCompressedImage(FitsTestCase):
     def test_lossless_gzip_compression(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/198"""
 
-        noise = np.random.normal(size=(1000, 1000))
+        rng = np.random.RandomState(seed=42)
+        noise = rng.normal(size=(20, 20))
 
         chdu1 = fits.CompImageHDU(data=noise, compression_type='GZIP_1')
         # First make a test image with lossy compression and make sure it


### PR DESCRIPTION
Generate fewer random values in test.

EDIT:
Original: [`1.16s call   astropy/io/fits/tests/test_image.py::TestCompressedImage::test_lossless_gzip_compression`](https://travis-ci.org/astropy/astropy/jobs/586576960#L2134)

With changes: [`0.56s call     astropy/io/fits/tests/test_image.py::TestCompressedImage::test_lossless_gzip_compression`](https://travis-ci.org/astropy/astropy/jobs/586857021#L2153)

Locally the speedup was more pronounced 3s -> 0.4s.