### PR TITLE
Simplify powers of units if consistent within rounding errors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2669,6 +2669,9 @@ astropy.units
 
 - Fixed the LaTeX representation of units containing a superscript. [#9218]
 
+- Ensured that we simplify powers to smaller denominators if that is
+  consistent within rounding precision. [#9267]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2672,6 +2672,9 @@ astropy.units
 - Ensured that we simplify powers to smaller denominators if that is
   consistent within rounding precision. [#9267]
 
+- Ensured that the powers shown in a unit's repr are always correct,
+  not oversimplified. [#9267]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -17,6 +17,7 @@ Handles a "generic" string format for units
 import os
 import re
 import warnings
+from fractions import Fraction
 
 from . import core, utils
 from .base import Base
@@ -137,7 +138,7 @@ class Generic(Base):
 
         def t_SIGN(t):
             r'[+-](?=\d)'
-            t.value = float(t.value + '1')
+            t.value = int(t.value + '1')
             return t
 
         # This needs to be a function so we can force it to happen
@@ -357,7 +358,7 @@ class Generic(Base):
             '''
             frac : sign UINT division sign UINT
             '''
-            p[0] = (p[1] * p[2]) / (p[4] * p[5])
+            p[0] = Fraction(p[1] * p[2], p[4] * p[5])
 
         def p_sign(p):
             '''
@@ -367,7 +368,7 @@ class Generic(Base):
             if len(p) == 2:
                 p[0] = p[1]
             else:
-                p[0] = 1.0
+                p[0] = 1
 
         def p_product(p):
             '''
@@ -508,7 +509,7 @@ class Generic(Base):
                 out.append(cls._get_unit_name(base))
             else:
                 power = utils.format_power(power)
-                if '/' in power:
+                if '/' in power or '.' in power:
                     out.append('{}({})'.format(
                         cls._get_unit_name(base), power))
                 else:

--- a/astropy/units/format/utils.py
+++ b/astropy/units/format/utils.py
@@ -9,6 +9,7 @@ import warnings
 from fractions import Fraction
 
 from astropy.utils.misc import did_you_mean
+from ..utils import maybe_simple_fraction
 
 
 def get_grouped_by_powers(bases, powers):
@@ -113,17 +114,14 @@ def decompose_to_known_units(unit, func):
 def format_power(power):
     """
     Converts a value for a power (which may be floating point or a
-    `fractions.Fraction` object), into a string either looking like
-    an integer or a fraction.
+    `fractions.Fraction` object), into a string looking like either
+    an integer or a fraction, if the power is close to that.
     """
-    if not isinstance(power, Fraction):
-        if power % 1.0 != 0.0:
-            frac = Fraction.from_float(power)
-            power = frac.limit_denominator(10)
-            if power.denominator == 1:
-                power = int(power.numerator)
-        else:
-            power = int(power)
+    if not hasattr(power, 'denominator'):
+        power = maybe_simple_fraction(power)
+        if getattr(power, 'denonimator', None) == 1:
+            power = power.nominator
+
     return str(power)
 
 

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -5,6 +5,8 @@
 Regression tests for the units.format package
 """
 
+from fractions import Fraction
+
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
@@ -555,3 +557,15 @@ def test_double_superscript():
     assert (u.hourangle**2).to_string("latex") == r'$\mathrm{hourangle^{2}}$'
     assert (u.electron).to_string("latex") == r'$\mathrm{e^{-}}$'
     assert (u.electron**2).to_string("latex") == r'$\mathrm{electron^{2}}$'
+
+
+@pytest.mark.parametrize('power,expected', (
+    (1., 'm'), (2., 'm2'), (-10, '1 / m10'), (1.5, 'm(3/2)'), (2/3, 'm(2/3)'),
+    (7/11, 'm(7/11)'), (-1/64, '1 / m(1/64)'), (1/100, 'm(1/100)'),
+    (2/101, 'm(0.019801980198019802)'), (Fraction(2, 101), 'm(2/101)')))
+def test_powers(power, expected):
+    """Regression test for #9279 - powers should not be oversimplified."""
+    unit = u.m ** power
+    s = unit.to_string()
+    assert s == expected
+    assert unit == s

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -706,6 +706,11 @@ def test_fractional_powers():
     assert isinstance(x.powers[0], Fraction)
     assert x.powers[0] == Fraction(7, 6)
 
+    # Regression test for #9258.
+    x = (u.TeV ** (-2.2)) ** (1/-2.2)
+    assert isinstance(x.powers[0], Fraction)
+    assert x.powers[0] == Fraction(1, 1)
+
 
 def test_sqrt_mag():
     sqrt_mag = u.mag ** 0.5

--- a/astropy/units/tests/test_units.py
+++ b/astropy/units/tests/test_units.py
@@ -161,7 +161,7 @@ def test_unknown_unit():
 
 def test_multiple_solidus():
     with catch_warnings(u.UnitsWarning) as warning_lines:
-        assert u.Unit("m/s/kg").to_string() == u.m / (u.s * u.kg)
+        assert u.Unit("m/s/kg").to_string() == 'm / (kg s)'
 
     assert 'm/s/kg' in str(warning_lines[0].message)
     assert 'discouraged' in str(warning_lines[0].message)
@@ -694,7 +694,7 @@ def test_fractional_powers():
     assert_allclose(v2, v3)
     assert_allclose(v3, v4)
 
-    x = u.m ** (1.0 / 11.0)
+    x = u.m ** (1.0 / 101.0)
     assert isinstance(x.powers[0], float)
 
     x = u.m ** (3.0 / 7.0)


### PR DESCRIPTION
Realizes that crazy powers like (90071992547409917/90071992547409920)
are just unity.

EDIT: also ensure that the powers we *show* in `repr`, `str`, etc., are actually correct, not the nearest fraction with a denominator less than 10. This also ensures we can round-trip properly.

fixes gh-9258
fixes gh-9279