### PR TITLE
Fixes deprecation that is raised when importing numpy.testing.utils

### DIFF
--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -8,7 +8,6 @@ import itertools
 
 import pytest
 import numpy as np
-from numpy.testing import utils
 
 from . import irafutil
 from astropy.modeling import models, fitting
@@ -276,27 +275,25 @@ class TestParameters:
         """
 
         new_model = self.linear_fitter(self.model, self.x, self.y)
-        utils.assert_allclose(new_model.parameters,
-                              np.array(
-                                  [4826.1066602783685, 952.8943813407858,
-                                   12.641236013982386,
-                                   -1.7910672553339604,
-                                   0.90252884366711317]),
-                              rtol=10 ** (-2))
+        np.testing.assert_allclose(
+            new_model.parameters,
+            np.array([4826.1066602783685, 952.8943813407858, 12.641236013982386,
+                      -1.7910672553339604, 0.90252884366711317]),
+            rtol=10 ** (-2))
 
     def testPolynomial1D(self):
         d = {'c0': 11, 'c1': 12, 'c2': 13, 'c3': 14}
         p1 = models.Polynomial1D(3, **d)
-        utils.assert_equal(p1.parameters, [11, 12, 13, 14])
+        np.testing.assert_equal(p1.parameters, [11, 12, 13, 14])
 
     def test_poly1d_multiple_sets(self):
         p1 = models.Polynomial1D(3, n_models=3)
-        utils.assert_equal(p1.parameters, [0.0, 0.0, 0.0, 0, 0, 0,
-                                           0, 0, 0, 0, 0, 0])
-        utils.assert_array_equal(p1.c0, [0, 0, 0])
+        np.testing.assert_equal(p1.parameters, [0.0, 0.0, 0.0, 0, 0, 0,
+                                                0, 0, 0, 0, 0, 0])
+        np.testing.assert_array_equal(p1.c0, [0, 0, 0])
         p1.c0 = [10, 10, 10]
-        utils.assert_equal(p1.parameters, [10.0, 10.0, 10.0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_equal(p1.parameters, [10.0, 10.0, 10.0, 0, 0,
+                                                0, 0, 0, 0, 0, 0, 0])
 
     def test_par_slicing(self):
         """
@@ -304,20 +301,20 @@ class TestParameters:
         """
         p1 = models.Polynomial1D(3, n_models=3)
         p1.c0[:2] = [10, 10]
-        utils.assert_equal(p1.parameters, [10.0, 10.0, 0.0, 0, 0,
-                                           0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_equal(p1.parameters, [10.0, 10.0, 0.0, 0, 0,
+                                                0, 0, 0, 0, 0, 0, 0])
 
     def test_poly2d(self):
         p2 = models.Polynomial2D(degree=3)
         p2.c0_0 = 5
-        utils.assert_equal(p2.parameters, [5, 0, 0, 0, 0, 0, 0, 0, 0, 0])
+        np.testing.assert_equal(p2.parameters, [5, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
     def test_poly2d_multiple_sets(self):
         kw = {'c0_0': [2, 3], 'c1_0': [1, 2], 'c2_0': [4, 5],
               'c0_1': [1, 1], 'c0_2': [2, 2], 'c1_1': [5, 5]}
         p2 = models.Polynomial2D(2, **kw)
-        utils.assert_equal(p2.parameters, [2, 3, 1, 2, 4, 5,
-                                           1, 1, 2, 2, 5, 5])
+        np.testing.assert_equal(p2.parameters, [2, 3, 1, 2, 4, 5,
+                                                1, 1, 2, 2, 5, 5])
 
     def test_shift_model_parameters1d(self):
         sh1 = models.Shift(2)
@@ -329,7 +326,7 @@ class TestParameters:
         sc1 = models.Scale([2, 2])
         sc1.factor = [3, 3]
         assert np.all(sc1.factor == [3, 3])
-        utils.assert_array_equal(sc1.factor.value, [3, 3])
+        np.testing.assert_array_equal(sc1.factor.value, [3, 3])
 
 
 class TestMultipleParameterSets:
@@ -346,7 +343,7 @@ class TestMultipleParameterSets:
         Test that a change to one parameter as a set propagates to param_sets.
         """
         self.gmodel.amplitude = [1, 10]
-        utils.assert_almost_equal(
+        np.testing.assert_almost_equal(
             self.gmodel.param_sets,
             np.array([[1.,
                        10],
@@ -362,7 +359,7 @@ class TestMultipleParameterSets:
         param_sets.
         """
         self.gmodel.amplitude[0] = 11
-        utils.assert_almost_equal(
+        np.testing.assert_almost_equal(
             self.gmodel.param_sets,
             np.array([[11.,
                        10],
@@ -374,8 +371,8 @@ class TestMultipleParameterSets:
 
     def test_change_parameters(self):
         self.gmodel.parameters = [13, 10, 9, 5.2, 0.4, 0.7]
-        utils.assert_almost_equal(self.gmodel.amplitude.value, [13., 10.])
-        utils.assert_almost_equal(self.gmodel.mean.value, [9., 5.2])
+        np.testing.assert_almost_equal(self.gmodel.amplitude.value, [13., 10.])
+        np.testing.assert_almost_equal(self.gmodel.mean.value, [9., 5.2])
 
 
 class TestParameterInitialization:
@@ -647,4 +644,6 @@ def test_setter():
     model = SetterModel(xc=-1, yc=3, p=np.pi)
 
     for x, y in pars:
-        utils.assert_almost_equal(model(x, y), (x + 1)**2 + (y - np.pi * 3)**2)
+        np.testing.assert_almost_equal(
+            model(x, y),
+            (x + 1)**2 + (y - np.pi * 3)**2)


### PR DESCRIPTION
I noticed these failures in the cron job test run: https://travis-ci.org/astropy/astropy/jobs/587485543#L863

Since the warning has been there since NumPy 1.15 we probably should backport this (if possible).