### PR TITLE
Copy flake8 rules from Travis so users can easily run flake8 before committing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -112,7 +112,43 @@ bitmap = static/wininst_background.bmp
 auto_use = True
 
 [flake8]
-exclude = extern,*parsetab.py,*lextab.py
+exclude = 
+    extern
+    *parsetab.py
+    *lextab.py
+    astropy/_erfa/core.py
+    .eggs
+    build
+    .tox
+    docs/_build
+    docs/generated
+
+# PEP8 errors/warnings:
+# E101 - mix of tabs and spaces
+# W191 - use of tabs
+# W291 - trailing whitespace
+# W292 - no newline at end of file
+# W293 - trailing whitespace
+# W391 - blank line at end of file
+# E111 - 4 spaces per indentation level
+# E112 - 4 spaces per indentation level
+# E113 - 4 spaces per indentation level
+# E301 - expected 1 blank line, found 0
+# E302 - expected 2 blank lines, found 0
+# E303 - too many blank lines (3)
+# E304 - blank lines found after function decorator
+# E305 - expected 2 blank lines after class or function definition
+# E306 - expected 1 blank line before a nested definition
+# E502 - the backslash is redundant between brackets
+# E722 - do not use bare except
+# E901 - SyntaxError or IndentationError
+# E902 - IOError
+# E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree
+# # F821: undefined name  # Note: Removed for now because of heavy use of units.si
+# F822: undefined name in __all__
+# F823: local variable name referenced before assignment
+select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
+
 
 [pycodestyle]
 exclude = extern,*parsetab.py,*lextab.py


### PR DESCRIPTION
Now python setup.py flake8 and plain flake8 return manageable lists of
errors. With setup.py only the package proper is linted, with plain
flake8 everything is apart from explicit excludes. For now I excluded
the python files generated from the docs, but they should probably be
fixed?