### PR TITLE
Mailmap clearup for 4.0

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -79,6 +79,7 @@ Erik M. Bray                 <erik.m.bray@gmail.com> <embray@stsci.edu>
 Erik M. Bray                 <erik.m.bray@gmail.com> <erik.bray@lri.fr>
 Esteban Pardo Sánchez        <stbnps@users.noreply.github.com>
 Francesco Montesano          <franz.bergesund@gmail.com>
+Geert Barentsen              <geert@barentsen.be> <hello@geert.io>
 Gerrit Schellenberger        <gerrit@uni-bonn.de>
 Giorgio Calderone            <giorgio.calderone@gmail.com> <gcalderone@users.noreply.github.com>
 Graham Kanarek               <graykanarek@gmail.com>
@@ -90,6 +91,8 @@ Henrik Norman                <Honke.norman@gmail.com> <hnorma@kth.se>
 Henrik Norman                <Honke.norman@gmail.com> <honke.norman@gmail.com>
 Himanshu Pathak              <hpathak336@gmail.com>
 Humna Awan                   <humna.awan@rutgers.edu>
+Ivo Busko                    <busko@stsci.edu>
+Ivo Busko                    <busko@stsci.edu> <New1trilha>
 Jake VanderPlas              <jakevdp@gmail.com>
 Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@uw.edu>
 Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@google.com>
@@ -98,6 +101,7 @@ Jane Rigby                   <jane.rigby@gmail.com>
 Jani Šumak                   <jani.sumak@gmail.com>
 Javier Pascual Granado       <javier@iaa.es>
 Larry Bradley                <larry.bradley@gmail.com>
+Larry Bradley                <larry.bradley@gmail.com> <larrybradley@users.noreply.github.com>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@sciops.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-109.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-144.esac.esa.int>
@@ -131,6 +135,7 @@ Karl Vyhmeister              <kvyh@users.noreply.github.com>
 Kelle Cruz                   <kellecruz@gmail.com>
 Kevin Gullikson              <kevin.gullikson@gmail.com>
 Kirill Tchernyshyov          <ktchernyshyov@pha.jhu.edu>
+Kyle Barbary                 <kylebarbary@gmail.com> <kbarbary@lbl.gov>
 Kyle Oman                    <koman@astro.rug.nl>
 Laura Watkins                <lauralwatkins@gmail.com>
 Lauren Glattly               <laurenglattly@gmail.com> <44421608+lglattly@users.noreply.github.com>
@@ -202,6 +207,7 @@ Thompson Le Blanc            <leblanc@stsci.edu>
 Thompson Le Blanc            <leblanc@stsci.edu> <tlcommodore@gmail.com>
 Tom Aldcroft                 <taldcroft@gmail.com> <aldcroft@dhcp-131-142-152-173.cfa.harvard.edu>
 Tom Donaldson                <tdonaldson@stsci.edu>
+Tom J Wilson                 <towilson@stsci.edu>
 Tyler Finethy                <tylfin@gmail.com>
 VSN Reddy Janga              <janga1997@gmail.com>
 Vishnunarayan K I            <appukuttancr@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -24,6 +24,8 @@ Anthony Horton               <anthony.horton@aao.gov.au>
 Asish Panda                  <asishrocks95@gmail.com>
 Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.local>
 Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.stsci.edu>
+Austen Groener               <Austen.Groener@gmail.com> <amg338@drexel.edu>
+Austen Groener               <Austen.Groener@gmail.com> <rocketboyausten@gmail.com>
 Axel Donath                  <axel.donath@mpi-hd.mpg.de>
 Axel Donath                  <axel.donath@mpi-hd.mpg.de> <donath@stud.uni-heidelberg.de>
 Benjamin Alan Weaver         <weaver@noao.edu> <baweaver@lbl.gov>
@@ -32,11 +34,13 @@ Benjamin Roulston            <benjamin.roulston@protonmail.com>
 Benjamin Winkel              <bwinkel@mpifr.de>  <bwinkel78@gmail.com>
 Bogdan Nicula                <bogdan@nicula.net>
 Brett Morris                 <brettmorris21@gmail.com> <bmmorris@uw.edu>
+Brian Svoboda                <bones253@gmail.com> <bsvo@lavabit.com>
 Brigitta Sipocz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
 Bryce Nordgren               <bnordgren@gmail.com>
 Christian Clauss             <cclauss@bluewin.ch>
 Christoph Gohlke             <cgohlke@uci.edu>
 Christopher Bonnett          <c.bonnett@gmail.com>
+Clara Brasseur               <cbrasseur@stsci.edu>
 Curtis McCully               <cmccully@lcogt.net>
 Dan Foreman-Mackey           <foreman.mackey@gmail.com>
 Dan Foreman-Mackey           <foreman.mackey@gmail.com>  <danfm@nyu.edu>
@@ -50,6 +54,11 @@ Daniel Datsev                <dan.datsev@gmail.com>
 Daniel Datsev                <dan.datsev@gmail.com> <fabled@vortex.(none)>
 Daniel Lenz                  <dlenz.bonn@gmail.com>
 Daria Cara                   <daria.cara.2@gmail.com>
+David Collom                 <dmcollom@gmail.com> <dcollom@dcollom-linux.lco.gtn>
+David Collom                 <dmcollom@gmail.com> <dcollom@lco.global>
+David Collom                 <dmcollom@gmail.com> <dcollom@localhost.localdomain>
+David Collom                 <dmcollom@gmail.com> <david.m.collom@gmail.com>
+David Grant                  <david.grant@physics.ox.ac.uk> <33813984+DavoGrant@users.noreply.github.com>
 David Kirkby                 <dkirkby@uci.edu>
 David Pérez-Suárez           <dps.helio@gmail.com>
 David Shupe                  <shupe@ipac.caltech.edu> <dave.shupe@gmail.com>
@@ -59,6 +68,7 @@ Demitri Muna                 <demitri.muna@gmail.com> <github@demitri.com>
 Derek Homeier                <dhomeie@gwdg.de> <derek.homeier@ens-lyon.fr>
 Douglas Burke                <dburke.gw@gmail.com>
 Dylan Gregersen              <gregersen.dylan@gmail.com>
+Edward Gomez                 <edward@gomez.me.uk>
 Elijah Bernstein-Cooper      <e.bernsteincooper@gmail.com> <ezbc@astro.wisc.edu>
 Emily Deibert                <emilydeibert@gmail.com>
 Emma Hogan                   <ehogan@gemini.edu>
@@ -76,6 +86,8 @@ Gustavo Bragança             <ga.braganca@gmail.com>
 Hannes Breytenbach           <hannes@saao.ac.za>
 Hans Moritz Günther          <moritz.guenther@gmx.de>
 Hans Moritz Günther          <moritz.guenther@gmx.de> <hgunther@mit.edu>
+Henrik Norman                <Honke.norman@gmail.com> <hnorma@kth.se>
+Henrik Norman                <Honke.norman@gmail.com> <honke.norman@gmail.com>
 Himanshu Pathak              <hpathak336@gmail.com>
 Humna Awan                   <humna.awan@rutgers.edu>
 Jake VanderPlas              <jakevdp@gmail.com>
@@ -85,6 +97,14 @@ James Turner                 <jturner@gemini.edu>
 Jane Rigby                   <jane.rigby@gmail.com>
 Jani Šumak                   <jani.sumak@gmail.com>
 Javier Pascual Granado       <javier@iaa.es>
+Larry Bradley                <larry.bradley@gmail.com>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@sciops.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-109.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-144.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-161.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-218.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-221.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-53.esac.esa.int>
 Jeff Taylor                  <jeff.c.taylor@gmail.com>
 Joe Hunkeler                 <jhunk@stsci.edu> <jhunkeler@gmail.com>
 John Parejko                 <parejkoj@uw.edu>
@@ -93,11 +113,16 @@ Johnny Greco                 <jgreco@astro.princeton.edu>
 Johnny Greco                 <jgreco@astro.princeton.edu>  <jgreco.astro@gmail.com>
 Jonathan Foster              <jonathan.bruce.foster@gmail.com>
 Jonathan Foster              <jonathan.bruce.foster@gmail.com>  <jonathan.b.foster@yale.edu>
+Jonathan Gagne               <jonathan.gagne.1@gmail.com>
+Jordan Mirocha               <mirochaj@gmail.com> <mirocha@rl1-140-39-dhcp.int.colorado.edu>
 Joseph Long                  <josephoenix@gmail.com> <jlong@stsci.edu>
 Joseph Long                  <josephoenix@gmail.com> <me@joseph-long.com>
 Joseph Schlitz               <jrschlitz0725@gmail.com>
+Juan Carlos Segovia          <juancarlos.segovia@gmail.com>
 Juan Luis Cano Rodríguez     <juanlu001@gmail.com>  <Juanlu001@users.noreply.github.com>
 Juan Luis Cano Rodríguez     <juanlu001@gmail.com>  <juanlu@satellogic.com>
+Julien Woillez               <jwoillez@gmail.com> <jwoillez@eso.org>
+Julien Woillez               <jwoillez@gmail.com> <jwoillez@gmail.org>
 Jurien Huisman               <huisman@strw.leidenuniv.nl>
 Kacper Kowalik               <xarthisius.kk@gmail.com>
 Kacper Kowalik               <xarthisius.kk@gmail.com> <xarthisius@gentoo.org>
@@ -114,15 +139,21 @@ Leonardo Ferreira            <leonardo.ferreira.furg@gmail.com> <[leonardo.ferre
 Lingyi Hu                    <hulingyi1995@yahoo.com.sg>
 Lisa Martin                  <48742903+lisamartin72@users.noreply.github.com>
 Lisa Walter                  <lisa@stsci.edu>
+Loïc Séguin-C                <loicseguin@gmail.com> <lsc@loicseguin.com>
 Luke G. Bouma                <lgbouma@users.noreply.github.com>
 Luke Kelley                  <lkelley@cfa.harvard.edu>
+Madhura Parikh               <madhuraparikh@gmail.com>
+Magnus Persson               <vilhelmp@gmail.com>
 Maneesh Yadav                <maneesh.yadav@sri.com>
 Mangala Gowri Krishnamoorthy <mangalagb@gmail.com>
 Marten van Kerkwijk          <mhvk@astro.utoronto.ca> <mhvk@swan.astro.utoronto.ca>
 Matt Davis                   <jiffyclub.programatic@gmail.com>
 Matteo Bachetti              <matteo@matteobachetti.it> <matteo.bachetti@irap.omp.eu>
 Matthew Craig                <mattwcraig@gmail.com>
+Matthieu Baumann             <baumannmatthieu0@gmail.com> <matthieu.baumann@astro.unistra.fr>
 Mavani Bhautik               <mavanibhautik@gmail.com>
+Michael Mommert              <mommermiscience@gmail.com> <michael.mommert@nau.edu>
+Michael Mommert              <mommermiscience@gmail.com> <mommermi@users.noreply.github.com>
 Michael Seifert              <michaelseifert04@yahoo.de>
 Michele Costa                <thenocturnalastrostudent@gmail.com>
 Miguel de Val-Borro          <miguel.deval@gmail.com>  <miguel@archlinux.net>

--- a/.mailmap
+++ b/.mailmap
@@ -4,9 +4,11 @@ Adam Ginsburg                <keflavich@gmail.com>
 Adam Ginsburg                <keflavich@gmail.com> <adam.g.ginsburg@gmail.com>
 Adam Ginsburg                <keflavich@gmail.com> <keflavich@yahoo.com>
 Adele Plunkett               <aplunket@eso.org>
+Adrian Price-Whelan          <adrian.prw@gmail.com>
 Adrian Price-Whelan          <adrian.prw@gmail.com> <adrianmpw@gmail.com>
 Albert Y. Shih               <ayshih@gmail.com>
 Aleh Khvalko                 <algerdnazgul@gmail.com>
+Aleksi Suutarinen            <aleksi.suutarinen@iki.fi> <aleksi.suutarinen@gmail.com>
 Alex Conley                  <alexander.conley@colorado.edu>
 Alex Conley                  <alexander.conley@colorado.edu> <alexanderconley@gmail.com>
 Alex Hagen                   <mr.alex.hagen@gmail.com>
@@ -17,6 +19,7 @@ Alexandre Beelen             <alexandre.beelen@ias.u-psud.fr> <alexandre.beelen@
 Amit Kumar                   <dtu.amit@gmail.com>
 Ana Posses                   <anaposses@gmail.com>
 Anany Shrey Jain             <ananyashreyjain1998@gmail.com>  <31594632+ananyashreyjain@users.noreply.github.com>
+Andy Casey                   <andycasey@gmail.com>
 Aniket Kulkarni              <kaniket21@gmail.com>
 Anirudh Katipally            <akatipally@abiomed.com>
 Anne Archibald               <peridot.faceted@gmail.com> <archibald@astron.nl>
@@ -36,11 +39,14 @@ Bogdan Nicula                <bogdan@nicula.net>
 Brett Morris                 <brettmorris21@gmail.com> <bmmorris@uw.edu>
 Brian Svoboda                <bones253@gmail.com> <bsvo@lavabit.com>
 Brigitta Sipocz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
+Brigitta Sipocz              <bsipocz@gmail.com> <bsipocz@users.noreply.github.com>
 Bryce Nordgren               <bnordgren@gmail.com>
 Christian Clauss             <cclauss@bluewin.ch>
 Christoph Gohlke             <cgohlke@uci.edu>
 Christopher Bonnett          <c.bonnett@gmail.com>
 Clara Brasseur               <cbrasseur@stsci.edu>
+Craig Jones                  <craig@brechmos.org>
+Craig Jones                  <craig@brechmos.org> <crjones@stsci.edu>
 Curtis McCully               <cmccully@lcogt.net>
 Dan Foreman-Mackey           <foreman.mackey@gmail.com>
 Dan Foreman-Mackey           <foreman.mackey@gmail.com>  <danfm@nyu.edu>
@@ -54,10 +60,10 @@ Daniel Datsev                <dan.datsev@gmail.com>
 Daniel Datsev                <dan.datsev@gmail.com> <fabled@vortex.(none)>
 Daniel Lenz                  <dlenz.bonn@gmail.com>
 Daria Cara                   <daria.cara.2@gmail.com>
+David Collom                 <dmcollom@gmail.com> <david.m.collom@gmail.com>
 David Collom                 <dmcollom@gmail.com> <dcollom@dcollom-linux.lco.gtn>
 David Collom                 <dmcollom@gmail.com> <dcollom@lco.global>
 David Collom                 <dmcollom@gmail.com> <dcollom@localhost.localdomain>
-David Collom                 <dmcollom@gmail.com> <david.m.collom@gmail.com>
 David Grant                  <david.grant@physics.ox.ac.uk> <33813984+DavoGrant@users.noreply.github.com>
 David Kirkby                 <dkirkby@uci.edu>
 David Pérez-Suárez           <dps.helio@gmail.com>
@@ -83,34 +89,40 @@ Geert Barentsen              <geert@barentsen.be> <hello@geert.io>
 Gerrit Schellenberger        <gerrit@uni-bonn.de>
 Giorgio Calderone            <giorgio.calderone@gmail.com> <gcalderone@users.noreply.github.com>
 Graham Kanarek               <graykanarek@gmail.com>
+Guillaume Pernot             <gpernot@praksys.org>
+Guillaume Pernot             <gpernot@praksys.org> <guillaume.pernot@lam.fr>
 Gustavo Bragança             <ga.braganca@gmail.com>
 Hannes Breytenbach           <hannes@saao.ac.za>
 Hans Moritz Günther          <moritz.guenther@gmx.de>
 Hans Moritz Günther          <moritz.guenther@gmx.de> <hgunther@mit.edu>
+Harry Ferguson               <ferguson@stsci.edu>
 Henrik Norman                <Honke.norman@gmail.com> <hnorma@kth.se>
 Henrik Norman                <Honke.norman@gmail.com> <honke.norman@gmail.com>
 Himanshu Pathak              <hpathak336@gmail.com>
 Humna Awan                   <humna.awan@rutgers.edu>
 Ivo Busko                    <busko@stsci.edu>
 Ivo Busko                    <busko@stsci.edu> <New1trilha>
+Jaime Andrés                 <jaime-andres.alvarado-montes@students.mq.edu.au>
 Jake VanderPlas              <jakevdp@gmail.com>
-Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@uw.edu>
 Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@google.com>
+Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@uw.edu>
+James McCormac               <jmccormac001@gmail.com>
 James Turner                 <jturner@gemini.edu>
 Jane Rigby                   <jane.rigby@gmail.com>
 Jani Šumak                   <jani.sumak@gmail.com>
-Javier Pascual Granado       <javier@iaa.es>
-Larry Bradley                <larry.bradley@gmail.com>
-Larry Bradley                <larry.bradley@gmail.com> <larrybradley@users.noreply.github.com>
-Javier Duran                 <javier.duran@sciops.esa.int> <jduran@sciops.esa.int>
+Javier Blasco                <atreo1@hotmail.com>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-109.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-144.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-161.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-218.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-221.esac.esa.int>
 Javier Duran                 <javier.duran@sciops.esa.int> <jduran@dhcp-10-66-197-53.esac.esa.int>
+Javier Duran                 <javier.duran@sciops.esa.int> <jduran@sciops.esa.int>
+Javier Pascual Granado       <javier@iaa.es>
 Jeff Taylor                  <jeff.c.taylor@gmail.com>
+Jennifer Karr                <karr@l-145-118-237-197.leidenuniv.nl>
 Joe Hunkeler                 <jhunk@stsci.edu> <jhunkeler@gmail.com>
+Johannes Zeman               <johannes.zeman@googlemail.com> <zeman@icp.uni-stuttgart.de>
 John Parejko                 <parejkoj@uw.edu>
 John Parejko                 <parejkoj@uw.edu> <parejkoj@gmail.com>
 Johnny Greco                 <jgreco@astro.princeton.edu>
@@ -137,6 +149,8 @@ Kevin Gullikson              <kevin.gullikson@gmail.com>
 Kirill Tchernyshyov          <ktchernyshyov@pha.jhu.edu>
 Kyle Barbary                 <kylebarbary@gmail.com> <kbarbary@lbl.gov>
 Kyle Oman                    <koman@astro.rug.nl>
+Larry Bradley                <larry.bradley@gmail.com>
+Larry Bradley                <larry.bradley@gmail.com> <larrybradley@users.noreply.github.com>
 Laura Watkins                <lauralwatkins@gmail.com>
 Lauren Glattly               <laurenglattly@gmail.com> <44421608+lglattly@users.noreply.github.com>
 Leo Singer                   <leo.singer@ligo.org> <leo.singer@nasa.gov>
@@ -166,11 +180,15 @@ Mihai Cara                   <mihail.cara@gmail.com> <mcara@itsd-osx22.home>
 Mike Alexandersen            <mikea@asiaa.sinica.edu.tw>
 Mikhail Minin                <mminin2010@gmail.com>
 Moataz Hisham                <mtzhisham@gmail.com>
+Nabil Freij                  <nabil.freij@gmail.com>
 Nadia Dencheva               <nadia.astropy@gmail.com> <dencheva@itsd-osx13.local>
 Nadia Dencheva               <nadia.astropy@gmail.com> <nadia.dencheva@gmail.com>
 Neil Crighton                <neilcrighton@gmail.com>
-Ole Streicher                <ole@aip.de> <olebole@debian.org>
+Nicholas Earl                <contact@nicholasearl.me>
+Nicholas Earl                <contact@nicholasearl.me> <nchlsearl@gmail.com>
+Nicholas Earl                <contact@nicholasearl.me> <nmearl@localhost.localdomain>
 Ole Streicher                <ole@aip.de> <debian@liska.ath.cx>
+Ole Streicher                <ole@aip.de> <olebole@debian.org>
 Patricio Rojo                <pato@das.uchile.cl> <pato@oan.cl>
 Pauline Barmby               <pbarmby@uwo.ca> <pbarmby@uwo.ca>
 Perry Greenfield             <perry@stsci.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -1,178 +1,182 @@
-Adam Ginsburg       <keflavich@gmail.com>
-Adam Ginsburg       <keflavich@gmail.com> Adam Ginsburg <adam.g.ginsburg@gmail.com>
-Adam Ginsburg       <keflavich@gmail.com> Adam Ginsburg <keflavich@yahoo.com>
-Adele Plunkett      <aplunket@eso.org>
-Alex Conley         <alexander.conley@colorado.edu> Alexander Conley <alexander.conley@colorado.edu>
-Alex Conley         <alexander.conley@colorado.edu> Alexander Conley <alexanderconley@gmail.com>
-Alex Hagen          <mr.alex.hagen@gmail.com>
-Asish Panda         <asishrocks95@gmail.com>
-Axel Donath         <axel.donath@mpi-hd.mpg.de>
-Bryce Nordgren      <bnordgren@gmail.com>
-Bogdan Nicula       <bogdan@nicula.net>
-Christopher Bonnett <c.bonnett@gmail.com>
-Christoph Gohlke    <cgohlke@uci.edu>
-Curtis McCully      <cmccully@lcogt.net>
-Daniel Bell         <stampsrule@gmail.com> Daniel <idaniel@me.com>
-Daniel Bell         <stampsrule@gmail.com> stampsrule <stampsrule@gmail.com>
-Daniel Datsev       <dan.datsev@gmail.com>
-Daniel Datsev       <dan.datsev@gmail.com> <fabled@vortex.(none)>
-David Pérez-Suárez  <dps.helio@gmail.com>
-Demitri Muna        <demitri.muna@gmail.com> <demitri@me.com>
-Demitri Muna        <demitri.muna@gmail.com> <beswiftly@gmail.com>
-Dylan Gregersen     <gregersen.dylan@gmail.com>
-Emma Hogan          <ehogan@gemini.edu>
-Moataz Hisham       <mtzhisham@gmail.com>
-Erik M. Bray        <erik.m.bray@gmail.com> <embray@stsci.edu>
-Erik M. Bray        <erik.m.bray@gmail.com> <erik.bray@lri.fr>
-Erik M. Bray        <erik.m.bray@gmail.com> Erik Bray <erik.m.bray@gmail.com>
-Gerrit Schellenberger <gerrit@uni-bonn.de>
-Gustavo Bragança    <ga.braganca@gmail.com>
-Hans Moritz Günther <moritz.guenther@gmx.de>
-Hans Moritz Günther <moritz.guenther@gmx.de> hamogu <hgunther@mit.edu>
-James Turner        <jturner@gemini.edu>
-Jeff Taylor         <jeff.c.taylor@gmail.com>
-Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik      <xarthisius@gentoo.org>
-Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik (Xarthisius) <xarthisius@gentoo.org>
-Kacper Kowalik      <xarthisius.kk@gmail.com> Kacper Kowalik (Xarthisius) <xarthisius.kk@gmail.com>
-Karan Grover        <karan@karan-HP-Pavilion-dm4-Notebook-PC.(none)>
-Karl Vyhmeister     <kvyh@users.noreply.github.com>
-Kirill Tchernyshyov <ktchernyshyov@pha.jhu.edu>
-Kelle Cruz          <kellecruz@gmail.com>
-Kevin Gullikson     <kevin.gullikson@gmail.com>
-Leonardo Ferreira <leonardo.ferreira.furg@gmail.com> [Leonardo Ferreira] <[leonardo.ferreira.furg@gmail.com]>
-Lisa Walter         <lisa@stsci.edu>
-Marten van Kerkwijk <mhvk@astro.utoronto.ca> <mhvk@swan.astro.utoronto.ca>
-Matt Davis          <jiffyclub.programatic@gmail.com>
-Nadia Dencheva      <nadia.astropy@gmail.com> <nadia.dencheva@gmail.com>
-Nadia Dencheva      <nadia.astropy@gmail.com> <dencheva@itsd-osx13.local>
-Neil Crighton       <neilcrighton@gmail.com>
-Perry Greenfield    <perry@stsci.edu>
-Pritish Chakraborty <chakrabortypritish@gmail.com>
-Ryan Cooke          <ryancooke86@gmail.com>
-Shantanu Srivastava <shan_mbic@rediffmail.com>
-Simon Conseil       <contact@saimon.org> Simon Conseil <simon.conseil@univ-lyon1.fr>
-Simon Conseil       <contact@saimon.org> Simon <contact@saimon.org>
-Simon Liedtke       <liedtke.simon@googlemail.com>
-Thomas Erben        <terben@astro.uni-bonn.de> <thomas@astro.uni-bonn.de>
-Thompson Le Blanc   <leblanc@stsci.edu>
-Thompson Le Blanc   <leblanc@stsci.edu> astrocaribe <tlcommodore@gmail.com>
-Tom Aldcroft        <taldcroft@gmail.com> <aldcroft@dhcp-131-142-152-173.cfa.harvard.edu>
-Zach Edwards        <Zachary.Astro@Gmail.com>
-Jonathan Foster     <jonathan.bruce.foster@gmail.com>
-David Kirkby         <dkirkby@uci.edu>
-Albert Y. Shih      <ayshih@gmail.com>
-Aleh Khvalko        <algerdnazgul@gmail.com>
-Elijah Bernstein-Cooper <e.bernsteincooper@gmail.com> <ezbc@astro.wisc.edu>
-Lingyi Hu           <hulingyi1995@yahoo.com.sg>
-Francesco Montesano <franz.bergesund@gmail.com>
-Daniel Lenz         <dlenz.bonn@gmail.com>
-Dan P. Cunningham   <dan.p.cunningham@gmail.com>
-Joseph Long         <josephoenix@gmail.com> <me@joseph-long.com>
-Brigitta Sipocz     <bsipocz@gmail.com> <b.sipocz@gmail.com>
-Rohit Patil         <rohit4change@yahoo.in> QuanTakeuchi <rohit4change@yahoo.in>
-Rohit Patil         <rohit4change@yahoo.in> QuanTakeuchi <Quan@Aries.(none)>
-Demitri Muna        <demitri.muna@gmail.com> Demitri Muna <github@demitri.com>
-Steve Crawford      <crawfordsm@gmail.com> Steven Crawford <crawfordsm@gmail.com>
-Steve Crawford      <crawfordsm@gmail.com> <crawfodsm@gmail.com>
-Anne Archibald      <peridot.faceted@gmail.com> Anne Archibald <archibald@astron.nl>
-Stuart Mumford      <stuart@mumford.me.uk> Stuart Mumford <stuart@cadair.com>
-Mihai Cara          <mihail.cara@gmail.com> Mihai Cara <mcara@itsd-osx22.home>
-Pey Lian Lim        <lim@stsci.edu> P. L. Lim <lim@stsci.edu>
-Pey Lian Lim        <lim@stsci.edu> P. L. Lim <2090236+pllim@users.noreply.github.com>
-Pey Lian Lim        <lim@stsci.edu> Pey Lian Lim <2090236+pllim@users.noreply.github.com>
-Jonathan Foster     <jonathan.bruce.foster@gmail.com> Jonathan Foster <jonathan.b.foster@yale.edu>
-Miguel de Val-Borro <miguel.deval@gmail.com> Miguel de Val-Borro <miguel@archlinux.net>
-Eric Depagne        <eric@depagne.org>
-Pratik Patel        <pratikpatel15133@gmail.com>
-Mavani Bhautik      <mavanibhautik@gmail.com>
-Aniket Kulkarni    <kaniket21@gmail.com>
-Sara Ogaz           <ogaz@stsci.edu>
-Sourabh Cheedella   <cheedella.sourabh@gmail.com>
-Sudheesh Singanamalla <sudheesh1995@outlook.com>
-Amit Kumar          <dtu.amit@gmail.com>
-Jake VanderPlas     <jakevdp@gmail.com> Jake VanderPlas <jakevdp@uw.edu>
-Matthew Craig       <mattwcraig@gmail.com> Matt Craig <mattwcraig@gmail.com>
-Sergio Pascual      <sergio.pasra@gmail.com> Sergio Pascual <sergiopr@fis.ucm.es>
-Laura Watkins       <lauralwatkins@gmail.com> Laura L Watkins <lauralwatkins@gmail.com>
-Axel Donath         <axel.donath@mpi-hd.mpg.de> Axel Donath <donath@stud.uni-heidelberg.de>
-Zé Vinicius         <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
-Ole Streicher       <ole@aip.de> Ole Streicher <debian@liska.ath.cx>
-Alex Rudy           <alex.rudy@gmail.com> Alexander Rudy <alex.rudy@gmail.com>
-Leo Singer          <leo.singer@ligo.org> Leo Singer <leo.singer@nasa.gov>
-Anthony Horton      <anthony.horton@aao.gov.au>
-Maneesh Yadav       <maneesh.yadav@sri.com>
-Esteban Pardo Sánchez <stbnps@users.noreply.github.com>
-John Parejko        <parejkoj@uw.edu> John K. Parejko <parejkoj@uw.edu> <parejkoj@gmail.com>
-John Parejko        <parejkoj@uw.edu> <parejkoj@gmail.com>
-Pauline Barmby      <pbarmby@uwo.ca> Pauline <pbarmby@uwo.ca>
-Joseph Long         <josephoenix@gmail.com> <jlong@stsci.edu>
-Graham Kanarek      <graykanarek@gmail.com>
-Jurien Huisman      <huisman@strw.leidenuniv.nl>
-Aarya Patil    <aaryapatil1996@gmail.com>
-Aarya Patil    <aaryapatil1996@gmail.com> <root@aaryas-MacBook-Pro.local>
-Ritwick DSouza      <ritwick.dsouza@outlook.com>
-Jake VanderPlas <jakevdp@gmail.com>
-Douglas Burke <dburke.gw@gmail.com>
-Benjamin Alan Weaver  <weaver@noao.edu> <benjamin.weaver@nyu.edu>
-Benjamin Alan Weaver  <weaver@noao.edu> <baweaver@lbl.gov>
-Asra Nizami <anizami@macalester.edu> <anizami@itsd-summer18.stsci.edu>
-Asra Nizami <anizami@macalester.edu> <anizami@itsd-summer18.local>
-Michele Costa  <thenocturnalastrostudent@gmail.com>
-Luke G. Bouma <lgbouma@users.noreply.github.com>
-VSN Reddy Janga <janga1997@gmail.com>
-Giorgio Calderone <giorgio.calderone@gmail.com> <gcalderone@users.noreply.github.com>
-Tyler Finethy <tylfin@gmail.com>
-Sam Verstocken <sam.verstocken@gmail.com>
-Mikhail Minin <mminin2010@gmail.com>
-Matteo Bachetti <matteo@matteobachetti.it> <matteo.bachetti@irap.omp.eu>
-Anirudh Katipally <akatipally@abiomed.com>
-David Shupe <shupe@ipac.caltech.edu> <dave.shupe@gmail.com>
-Adrian Price-Whelan <adrian.prw@gmail.com> <adrianmpw@gmail.com>
-Derek Homeier <dhomeie@gwdg.de> <derek.homeier@ens-lyon.fr>
-Brett Morris <brettmorris21@gmail.com> <bmmorris@uw.edu>
-Daniel D'Avella <ddavella@stsci.edu> <drdavella@gmail.com>
-Daniel D'Avella <ddavella@stsci.edu> Dan D'Avella <ddavella@stsci.edu>
-Stuart Littlefair <s.littlefair@shef.ac.uk> StuartLittlefair <s.littlefair@shef.ac.uk>
-Juan Luis Cano Rodríguez <juanlu001@gmail.com> Juan Luis Cano Rodríguez <juanlu@satellogic.com>
-Juan Luis Cano Rodríguez <juanlu001@gmail.com> Juan Luis Cano Rodríguez <Juanlu001@users.noreply.github.com>
-Joe Hunkeler <jhunk@stsci.edu> Joseph Hunkeler <jhunkeler@gmail.com>
-Dan Foreman-Mackey <foreman.mackey@gmail.com> Dan F-M <danfm@nyu.edu>
-Dan Foreman-Mackey <foreman.mackey@gmail.com> Dan F-M <foreman.mackey@gmail.com>
-Johnny Greco <jgreco@astro.princeton.edu> Johnny <jgreco@astro.princeton.edu>
-Zé Vinicius <jvmirca@gmail.com> mirca <jvmirca@gmail.com>
-Michael Seifert <michaelseifert04@yahoo.de> --system <michaelseifert04@yahoo.de>
-Michael Seifert <michaelseifert04@yahoo.de> MSeifert04 <michaelseifert04@yahoo.de>
-Vishnunarayan K I <appukuttancr@gmail.com> vn-ki <appukuttancr@gmail.com>
-Ritiek Malhotra <ritiekmalhotra123@gmail.com> ritiek <ritiekmalhotra123@gmail.com>
-Rohan Rajpal <rohan17089@iiitd.ac.in> rohanrajpal <rohan17089@iiitd.ac.in>
-Mangala Gowri Krishnamoorthy <mangalagb@gmail.com> mangalagb <mangalagb@gmail.com>
-Hannes Breytenbach <hannes@saao.ac.za> astromancer <hannes@saao.ac.za>
-Hannes Breytenbach <hannes@saao.ac.za> apodemus <hannes@saao.ac.za>
-Christian Clauss <cclauss@bluewin.ch> cclauss <cclauss@bluewin.ch>
-Eric Koch  <koch.eric.w@gmail.com> e-koch <koch.eric.w@gmail.com>
-Alexander Bakanov <bakanov.aleksandr@gmail.com> Aleksandr Bakanov <aleksandr_bakanov@epam.com>
-Emily Deibert <emilydeibert@gmail.com> emilydeibert <emilydeibert@gmail.com>
-Sanjeev Dubey <getsanjeevdubey@gmail.com> getsanjeev <getsanjeevdubey@gmail.com>
-Humna Awan <humna.awan@rutgers.edu> Humna <humna.awan@rutgers.edu>
-Daria Cara  <daria.cara.2@gmail.com> unknown <daria.cara.2@gmail.com>
-Jani Šumak  <jani.sumak@gmail.com> dasdachs <jani.sumak@gmail.com>
-Alexandre Beelen <alexandre.beelen@ias.u-psud.fr> alexandre beelen <alexandre.beelen@ias.u-psud.fr>
-Steve Crawford <crawfordsm@gmail.com> Steven Crawford <scrawford@stsci.edu>
-Steve Crawford <crawfordsm@gmail.com> crawfordsm <crawfordsm@gmail.com>
-Mike Alexandersen <mikea@asiaa.sinica.edu.tw> Mike Alexandersen (on Vancouver) <mikea@asiaa.sinica.edu.tw>
-Patricio Rojo <pato@das.uchile.cl> duckrojo <pato@oan.cl>
-Ana Posses <anaposses@gmail.com> anaposses <anaposses@gmail.com>
-Kyle Oman <koman@astro.rug.nl> K.A. Oman <koman@astro.rug.nl>
-Vital Fernández <vital.fernandez@gmail.com> Delosari <lativmail@gmail.com>
-Anany Shrey Jain <ananyashreyjain1998@gmail.com> ananyashreyjain <31594632+ananyashreyjain@users.noreply.github.com>
-Joseph Schlitz <jrschlitz0725@gmail.com> SG004 <jrschlitz0725@gmail.com>
-Benjamin Roulston <benjamin.roulston@protonmail.com> broulston <benjamin.roulston@protonmail.com>
-Himanshu Pathak <hpathak336@gmail.com> himanshupathak21061998 <hpathak336@gmail.com>
-Dan Taranu <dtaranu@astro.princeton.edu> taranu <dtaranu@astro.princeton.edu>
-Yash Kumar <yash.kmr.99@gmail.com> yashkmr99 <yash.kmr.99@gmail.com>
-Benjamin Winkel <bwinkel@mpifr.de> bwinkel <bwinkel78@gmail.com>
-Javier Pascual Granado <javier@iaa.es> JaviPG <javier@iaa.es>
-Javier Pascual Granado <javier@iaa.es> javier-iaa <javier@iaa.es>
-Rohit Kapoor <algorithm059@gmail.com> algo-circle <algorithm059@gmail.com>
-Jane Rigby <jane.rigby@gmail.com> janerigby <jane.rigby@gmail.com>
-Lisa Martin <48742903+lisamartin72@users.noreply.github.com>  lisamartin72 <48742903+lisamartin72@users.noreply.github.com>
+Aarya Patil                  <aaryapatil1996@gmail.com>
+Aarya Patil                  <aaryapatil1996@gmail.com> <root@aaryas-MacBook-Pro.local>
+Adam Ginsburg                <keflavich@gmail.com>
+Adam Ginsburg                <keflavich@gmail.com> <adam.g.ginsburg@gmail.com>
+Adam Ginsburg                <keflavich@gmail.com> <keflavich@yahoo.com>
+Adele Plunkett               <aplunket@eso.org>
+Adrian Price-Whelan          <adrian.prw@gmail.com> <adrianmpw@gmail.com>
+Albert Y. Shih               <ayshih@gmail.com>
+Aleh Khvalko                 <algerdnazgul@gmail.com>
+Alex Conley                  <alexander.conley@colorado.edu>
+Alex Conley                  <alexander.conley@colorado.edu> <alexanderconley@gmail.com>
+Alex Hagen                   <mr.alex.hagen@gmail.com>
+Alex Rudy                    <alex.rudy@gmail.com>
+Alexander Bakanov            <bakanov.aleksandr@gmail.com>  <aleksandr_bakanov@epam.com>
+Alexandre Beelen             <alexandre.beelen@ias.u-psud.fr>
+Alexandre Beelen             <alexandre.beelen@ias.u-psud.fr> <alexandre.beelen@lam.fr>
+Amit Kumar                   <dtu.amit@gmail.com>
+Ana Posses                   <anaposses@gmail.com>
+Anany Shrey Jain             <ananyashreyjain1998@gmail.com>  <31594632+ananyashreyjain@users.noreply.github.com>
+Aniket Kulkarni              <kaniket21@gmail.com>
+Anirudh Katipally            <akatipally@abiomed.com>
+Anne Archibald               <peridot.faceted@gmail.com> <archibald@astron.nl>
+Anthony Horton               <anthony.horton@aao.gov.au>
+Asish Panda                  <asishrocks95@gmail.com>
+Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.local>
+Asra Nizami                  <anizami@macalester.edu> <anizami@itsd-summer18.stsci.edu>
+Axel Donath                  <axel.donath@mpi-hd.mpg.de>
+Axel Donath                  <axel.donath@mpi-hd.mpg.de> <donath@stud.uni-heidelberg.de>
+Benjamin Alan Weaver         <weaver@noao.edu> <baweaver@lbl.gov>
+Benjamin Alan Weaver         <weaver@noao.edu> <benjamin.weaver@nyu.edu>
+Benjamin Roulston            <benjamin.roulston@protonmail.com>
+Benjamin Winkel              <bwinkel@mpifr.de>  <bwinkel78@gmail.com>
+Bogdan Nicula                <bogdan@nicula.net>
+Brett Morris                 <brettmorris21@gmail.com> <bmmorris@uw.edu>
+Brigitta Sipocz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
+Bryce Nordgren               <bnordgren@gmail.com>
+Christian Clauss             <cclauss@bluewin.ch>
+Christoph Gohlke             <cgohlke@uci.edu>
+Christopher Bonnett          <c.bonnett@gmail.com>
+Curtis McCully               <cmccully@lcogt.net>
+Dan Foreman-Mackey           <foreman.mackey@gmail.com>
+Dan Foreman-Mackey           <foreman.mackey@gmail.com>  <danfm@nyu.edu>
+Dan P. Cunningham            <dan.p.cunningham@gmail.com>
+Dan Taranu                   <dtaranu@astro.princeton.edu>
+Daniel Bell                  <stampsrule@gmail.com>
+Daniel Bell                  <stampsrule@gmail.com> <idaniel@me.com>
+Daniel D'Avella              <ddavella@stsci.edu>
+Daniel D'Avella              <ddavella@stsci.edu> <drdavella@gmail.com>
+Daniel Datsev                <dan.datsev@gmail.com>
+Daniel Datsev                <dan.datsev@gmail.com> <fabled@vortex.(none)>
+Daniel Lenz                  <dlenz.bonn@gmail.com>
+Daria Cara                   <daria.cara.2@gmail.com>
+David Kirkby                 <dkirkby@uci.edu>
+David Pérez-Suárez           <dps.helio@gmail.com>
+David Shupe                  <shupe@ipac.caltech.edu> <dave.shupe@gmail.com>
+Demitri Muna                 <demitri.muna@gmail.com> <beswiftly@gmail.com>
+Demitri Muna                 <demitri.muna@gmail.com> <demitri@me.com>
+Demitri Muna                 <demitri.muna@gmail.com> <github@demitri.com>
+Derek Homeier                <dhomeie@gwdg.de> <derek.homeier@ens-lyon.fr>
+Douglas Burke                <dburke.gw@gmail.com>
+Dylan Gregersen              <gregersen.dylan@gmail.com>
+Elijah Bernstein-Cooper      <e.bernsteincooper@gmail.com> <ezbc@astro.wisc.edu>
+Emily Deibert                <emilydeibert@gmail.com>
+Emma Hogan                   <ehogan@gemini.edu>
+Eric Depagne                 <eric@depagne.org>
+Eric Koch                    <koch.eric.w@gmail.com> <koch.eric.w@gmail.com>
+Erik M. Bray                 <erik.m.bray@gmail.com>
+Erik M. Bray                 <erik.m.bray@gmail.com> <embray@stsci.edu>
+Erik M. Bray                 <erik.m.bray@gmail.com> <erik.bray@lri.fr>
+Esteban Pardo Sánchez        <stbnps@users.noreply.github.com>
+Francesco Montesano          <franz.bergesund@gmail.com>
+Gerrit Schellenberger        <gerrit@uni-bonn.de>
+Giorgio Calderone            <giorgio.calderone@gmail.com> <gcalderone@users.noreply.github.com>
+Graham Kanarek               <graykanarek@gmail.com>
+Gustavo Bragança             <ga.braganca@gmail.com>
+Hannes Breytenbach           <hannes@saao.ac.za>
+Hans Moritz Günther          <moritz.guenther@gmx.de>
+Hans Moritz Günther          <moritz.guenther@gmx.de> <hgunther@mit.edu>
+Himanshu Pathak              <hpathak336@gmail.com>
+Humna Awan                   <humna.awan@rutgers.edu>
+Jake VanderPlas              <jakevdp@gmail.com>
+Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@uw.edu>
+Jake VanderPlas              <jakevdp@gmail.com> <jakevdp@google.com>
+James Turner                 <jturner@gemini.edu>
+Jane Rigby                   <jane.rigby@gmail.com>
+Jani Šumak                   <jani.sumak@gmail.com>
+Javier Pascual Granado       <javier@iaa.es>
+Jeff Taylor                  <jeff.c.taylor@gmail.com>
+Joe Hunkeler                 <jhunk@stsci.edu> <jhunkeler@gmail.com>
+John Parejko                 <parejkoj@uw.edu>
+John Parejko                 <parejkoj@uw.edu> <parejkoj@gmail.com>
+Johnny Greco                 <jgreco@astro.princeton.edu>
+Johnny Greco                 <jgreco@astro.princeton.edu>  <jgreco.astro@gmail.com>
+Jonathan Foster              <jonathan.bruce.foster@gmail.com>
+Jonathan Foster              <jonathan.bruce.foster@gmail.com>  <jonathan.b.foster@yale.edu>
+Joseph Long                  <josephoenix@gmail.com> <jlong@stsci.edu>
+Joseph Long                  <josephoenix@gmail.com> <me@joseph-long.com>
+Joseph Schlitz               <jrschlitz0725@gmail.com>
+Juan Luis Cano Rodríguez     <juanlu001@gmail.com>  <Juanlu001@users.noreply.github.com>
+Juan Luis Cano Rodríguez     <juanlu001@gmail.com>  <juanlu@satellogic.com>
+Jurien Huisman               <huisman@strw.leidenuniv.nl>
+Kacper Kowalik               <xarthisius.kk@gmail.com>
+Kacper Kowalik               <xarthisius.kk@gmail.com> <xarthisius@gentoo.org>
+Karan Grover                 <karan@karan-HP-Pavilion-dm4-Notebook-PC.(none)>
+Karl Vyhmeister              <kvyh@users.noreply.github.com>
+Kelle Cruz                   <kellecruz@gmail.com>
+Kevin Gullikson              <kevin.gullikson@gmail.com>
+Kirill Tchernyshyov          <ktchernyshyov@pha.jhu.edu>
+Kyle Oman                    <koman@astro.rug.nl>
+Laura Watkins                <lauralwatkins@gmail.com>
+Lauren Glattly               <laurenglattly@gmail.com> <44421608+lglattly@users.noreply.github.com>
+Leo Singer                   <leo.singer@ligo.org> <leo.singer@nasa.gov>
+Leonardo Ferreira            <leonardo.ferreira.furg@gmail.com> <[leonardo.ferreira.furg@gmail.com]>
+Lingyi Hu                    <hulingyi1995@yahoo.com.sg>
+Lisa Martin                  <48742903+lisamartin72@users.noreply.github.com>
+Lisa Walter                  <lisa@stsci.edu>
+Luke G. Bouma                <lgbouma@users.noreply.github.com>
+Luke Kelley                  <lkelley@cfa.harvard.edu>
+Maneesh Yadav                <maneesh.yadav@sri.com>
+Mangala Gowri Krishnamoorthy <mangalagb@gmail.com>
+Marten van Kerkwijk          <mhvk@astro.utoronto.ca> <mhvk@swan.astro.utoronto.ca>
+Matt Davis                   <jiffyclub.programatic@gmail.com>
+Matteo Bachetti              <matteo@matteobachetti.it> <matteo.bachetti@irap.omp.eu>
+Matthew Craig                <mattwcraig@gmail.com>
+Mavani Bhautik               <mavanibhautik@gmail.com>
+Michael Seifert              <michaelseifert04@yahoo.de>
+Michele Costa                <thenocturnalastrostudent@gmail.com>
+Miguel de Val-Borro          <miguel.deval@gmail.com>  <miguel@archlinux.net>
+Mihai Cara                   <mihail.cara@gmail.com> <mcara@itsd-osx22.home>
+Mike Alexandersen            <mikea@asiaa.sinica.edu.tw>
+Mikhail Minin                <mminin2010@gmail.com>
+Moataz Hisham                <mtzhisham@gmail.com>
+Nadia Dencheva               <nadia.astropy@gmail.com> <dencheva@itsd-osx13.local>
+Nadia Dencheva               <nadia.astropy@gmail.com> <nadia.dencheva@gmail.com>
+Neil Crighton                <neilcrighton@gmail.com>
+Ole Streicher                <ole@aip.de> <olebole@debian.org>
+Ole Streicher                <ole@aip.de> <debian@liska.ath.cx>
+Patricio Rojo                <pato@das.uchile.cl> <pato@oan.cl>
+Pauline Barmby               <pbarmby@uwo.ca> <pbarmby@uwo.ca>
+Perry Greenfield             <perry@stsci.edu>
+Pey Lian Lim                 <lim@stsci.edu>
+Pey Lian Lim                 <lim@stsci.edu> <2090236+pllim@users.noreply.github.com>
+Pratik Patel                 <pratikpatel15133@gmail.com>
+Pritish Chakraborty          <chakrabortypritish@gmail.com>
+Ritiek Malhotra              <ritiekmalhotra123@gmail.com>
+Ritwick DSouza               <ritwick.dsouza@outlook.com>
+Rohan Rajpal                 <rohan17089@iiitd.ac.in>
+Rohit Kapoor                 <algorithm059@gmail.com>
+Rohit Patil                  <rohit4change@yahoo.in>
+Rohit Patil                  <rohit4change@yahoo.in> <Quan@Aries.(none)>
+Ryan Cooke                   <ryancooke86@gmail.com>
+Sam Verstocken               <sam.verstocken@gmail.com>
+Sanjeev Dubey                <getsanjeevdubey@gmail.com>
+Sara Ogaz                    <ogaz@stsci.edu>
+Sergio Pascual               <sergio.pasra@gmail.com> <sergiopr@fis.ucm.es>
+Shantanu Srivastava          <shan_mbic@rediffmail.com>
+Simon Conseil                <contact@saimon.org>
+Simon Conseil                <contact@saimon.org> <simon.conseil@univ-lyon1.fr>
+Simon Liedtke                <liedtke.simon@googlemail.com>
+Sourabh Cheedella            <cheedella.sourabh@gmail.com>
+Steve Crawford               <crawfordsm@gmail.com>
+Steve Crawford               <crawfordsm@gmail.com> <crawfodsm@gmail.com>
+Steve Crawford               <crawfordsm@gmail.com> <scrawford@stsci.edu>
+Stuart Littlefair            <s.littlefair@shef.ac.uk>  <s.littlefair@shef.ac.uk>
+Stuart Mumford               <stuart@mumford.me.uk> <stuart@cadair.com>
+Sudheesh Singanamalla        <sudheesh1995@outlook.com>
+Sudheesh Singanamalla        <sudheesh1995@outlook.com> <t-sus@microsoft.com>
+Sushobhana Patra             <sushobhanapatra@gmail.com>
+Thomas Erben                 <terben@astro.uni-bonn.de> <thomas@astro.uni-bonn.de>
+Thompson Le Blanc            <leblanc@stsci.edu>
+Thompson Le Blanc            <leblanc@stsci.edu> <tlcommodore@gmail.com>
+Tom Aldcroft                 <taldcroft@gmail.com> <aldcroft@dhcp-131-142-152-173.cfa.harvard.edu>
+Tom Donaldson                <tdonaldson@stsci.edu>
+Tyler Finethy                <tylfin@gmail.com>
+VSN Reddy Janga              <janga1997@gmail.com>
+Vishnunarayan K I            <appukuttancr@gmail.com>
+Vital Fernández              <vital.fernandez@gmail.com>   <lativmail@gmail.com>
+Yannick Copin                <y.copin@ipnl.in2p3.fr> <yannick.copin@laposte.net>
+Yash Kumar                   <yash.kmr.99@gmail.com>
+Yash Sharma                  <yashrsharma44@gmail.com>
+Zach Edwards                 <Zachary.Astro@Gmail.com>
+Zé Vinicius                  <jvmirca@gmail.com>


### PR DESCRIPTION
Now everything should be easy, going forward.

The only potentially controversial thing is that I've added mailmap resolutions from coordinated packages (atm only astroquery and photutils), as having the canonical version in astropy core seems to be a good approach, one can always copy the latest over when it's needed for a release, etc.