### PR TITLE
BlackBody model

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,13 @@ astropy.modeling
   number of axes. [#9369]
 
 - Add many of the numpy ufunc functions as models. [#9401]
+- Add BlackBody model.  [#9282]
+  Deprecate BlackBody1D model and blackbody_nu and blackbody_lambda functions.
+- Add ``BlackBody`` model.  [#9282]
+  Deprecate ``BlackBody1D`` model and ``blackbody_nu`` and ``blackbody_lambda`` functions.
+- Add ``BlackBody`` model.
+  Deprecate ``BlackBody1D`` model and ``blackbody_nu`` and ``blackbody_lambda``
+  functions. [#9282]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,10 +90,7 @@ astropy.modeling
   number of axes. [#9369]
 
 - Add many of the numpy ufunc functions as models. [#9401]
-- Add BlackBody model.  [#9282]
-  Deprecate BlackBody1D model and blackbody_nu and blackbody_lambda functions.
-- Add ``BlackBody`` model.  [#9282]
-  Deprecate ``BlackBody1D`` model and ``blackbody_nu`` and ``blackbody_lambda`` functions.
+
 - Add ``BlackBody`` model.
   Deprecate ``BlackBody1D`` model and ``blackbody_nu`` and ``blackbody_lambda``
   functions. [#9282]
@@ -176,6 +173,8 @@ astropy.units
   ensure that all top-level numpy functions interact properly with
   ``Quantity``, preserving units also in operations like ``np.concatenate``.
   [#8808]
+
+- Add equivalencies for surface brightness units to spectral_density. [#9282]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -1,109 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 Model and functions related to blackbody radiation.
-
-.. _blackbody-planck-law:
-
-Blackbody Radiation
--------------------
-
-Blackbody flux is calculated with Planck law
-(:ref:`Rybicki & Lightman 1979 <ref-rybicki1979>`):
-
-.. math::
-
-    B_{\\lambda}(T) = \\frac{2 h c^{2} / \\lambda^{5}}{exp(h c / \\lambda k T) - 1}
-
-    B_{\\nu}(T) = \\frac{2 h \\nu^{3} / c^{2}}{exp(h \\nu / k T) - 1}
-
-where the unit of :math:`B_{\\lambda}(T)` is
-:math:`erg \\; s^{-1} cm^{-2} \\mathring{A}^{-1} sr^{-1}`, and
-:math:`B_{\\nu}(T)` is :math:`erg \\; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
-:func:`~astropy.modeling.blackbody.blackbody_lambda` and
-:func:`~astropy.modeling.blackbody.blackbody_nu` calculate the
-blackbody flux for :math:`B_{\\lambda}(T)` and :math:`B_{\\nu}(T)`,
-respectively.
-
-For blackbody representation as a model, see :class:`BlackBody1D`.
-
-.. _blackbody-examples:
-
-Examples
-^^^^^^^^
-
->>> import numpy as np
->>> from astropy import units as u
->>> from astropy.modeling.blackbody import blackbody_lambda, blackbody_nu
-
-Calculate blackbody flux for 5000 K at 100 and 10000 Angstrom while suppressing
-any Numpy warnings:
-
->>> wavelengths = [100, 10000] * u.AA
->>> temperature = 5000 * u.K
->>> with np.errstate(all='ignore'):
-...     flux_lam = blackbody_lambda(wavelengths, temperature)
-...     flux_nu = blackbody_nu(wavelengths, temperature)
->>> flux_lam  # doctest: +FLOAT_CMP
-<Quantity [  1.27452545e-108,  7.10190526e+005] erg / (Angstrom cm2 s sr)>
->>> flux_nu  # doctest: +FLOAT_CMP
-<Quantity [  4.25135927e-123,  2.36894060e-005] erg / (cm2 Hz s sr)>
-
-Alternatively, the same results for ``flux_nu`` can be computed using
-:class:`BlackBody1D` with blackbody representation as a model. The difference between
-this and the former approach is in one additional step outlined as follows:
-
->>> from astropy import constants as const
->>> from astropy.modeling import models
->>> temperature = 5000 * u.K
->>> bolometric_flux = const.sigma_sb * temperature ** 4 / np.pi
->>> bolometric_flux.to(u.erg / (u.cm * u.cm * u.s))  # doctest: +FLOAT_CMP
-<Quantity 1.12808367e+10 erg / (cm2 s)>
->>> wavelengths = [100, 10000] * u.AA
->>> bb_astro = models.BlackBody1D(temperature, bolometric_flux=bolometric_flux)
->>> bb_astro(wavelengths).to(u.erg / (u.cm * u.cm * u.Hz * u.s)) / u.sr  # doctest: +FLOAT_CMP
-<Quantity [4.25102471e-123, 2.36893879e-005] erg / (cm2 Hz s sr)>
-
-where ``bb_astro(wavelengths)`` computes the equivalent result as ``flux_nu`` above.
-
-Plot a blackbody spectrum for 5000 K:
-
-.. plot::
-
-    import matplotlib.pyplot as plt
-    import numpy as np
-    from astropy import constants as const
-    from astropy import units as u
-    from astropy.modeling.blackbody import blackbody_lambda
-
-    temperature = 5000 * u.K
-    wavemax = (const.b_wien / temperature).to(u.AA)  # Wien's displacement law
-    waveset = np.logspace(
-        0, np.log10(wavemax.value + 10 * wavemax.value), num=1000) * u.AA
-    with np.errstate(all='ignore'):
-        flux = blackbody_lambda(waveset, temperature)
-
-    fig, ax = plt.subplots(figsize=(8, 5))
-    ax.plot(waveset.value, flux.value)
-    ax.axvline(wavemax.value, ls='--')
-    ax.get_yaxis().get_major_formatter().set_powerlimits((0, 1))
-    ax.set_xlabel(r'$\\lambda$ ({0})'.format(waveset.unit))
-    ax.set_ylabel(r'$B_{\\lambda}(T)$')
-    ax.set_title('Blackbody, T = {0}'.format(temperature))
-
-Note that an array of temperatures can also be given instead of a single
-temperature. In this case, the Numpy broadcasting rules apply: for instance, if
-the frequency and temperature have the same shape, the output will have this
-shape too, while if the frequency is a 2-d array with shape ``(n, m)`` and the
-temperature is an array with shape ``(m,)``, the output will have a shape
-``(n, m)``.
-
-See Also
-^^^^^^^^
-
-.. _ref-rybicki1979:
-
-Rybicki, G. B., & Lightman, A. P. 1979, Radiative Processes in Astrophysics (New York, NY: Wiley)
-
 """
 
 import warnings
@@ -116,6 +13,7 @@ from .parameters import Parameter
 from astropy import constants as const
 from astropy import units as u
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils import deprecated
 
 __all__ = ['BlackBody1D', 'blackbody_nu', 'blackbody_lambda']
 
@@ -133,6 +31,11 @@ with warnings.catch_warnings():
     _has_buggy_expm1 = np.isnan(np.expm1(1000)) or np.isnan(np.expm1(1e10))
 
 
+@deprecated(
+    since="4.0",
+    alternative="astropy.physical_models.BlackBody",
+    message="BlackBody provides the same capabilities",
+)
 class BlackBody1D(Fittable1DModel):
     """
     One dimensional blackbody model.
@@ -263,6 +166,11 @@ class BlackBody1D(Fittable1DModel):
         return const.b_wien / self.temperature
 
 
+@deprecated(
+    since="4.0",
+    alternative="astropy.physical_models.BlackBody",
+    message="BlackBody provides the same capabilities",
+)
 def blackbody_nu(in_x, temperature):
     """Calculate blackbody flux per steradian, :math:`B_{\\nu}(T)`.
 
@@ -334,6 +242,11 @@ def blackbody_nu(in_x, temperature):
     return flux / u.sr  # Add per steradian to output flux unit
 
 
+@deprecated(
+    since="4.0",
+    alternative="astropy.physical_models.BlackBody",
+    message="BlackBody provides the same capabilities",
+)
 def blackbody_lambda(in_x, temperature):
     """Like :func:`blackbody_nu` but for :math:`B_{\\lambda}(T)`.
 

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -11,6 +11,7 @@ from .projections import *
 from .rotations import *
 from .polynomial import *
 from .functional_models import *
+from .physical_models import *
 from .powerlaws import *
 from .tabular import *
 from .blackbody import BlackBody1D

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -1,0 +1,192 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Models that have physical origins.
+"""
+
+import warnings
+from collections import OrderedDict
+
+import numpy as np
+
+from .core import Fittable1DModel
+from .parameters import Parameter
+from astropy import constants as const
+from astropy import units as u
+from astropy.utils.exceptions import AstropyUserWarning
+
+__all__ = ["BlackBody"]
+
+# Units
+FNU = u.erg / (u.cm ** 2 * u.s * u.Hz)
+FLAM = u.erg / (u.cm ** 2 * u.s * u.AA)
+SNU = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
+SLAM = u.erg / (u.cm ** 2 * u.s * u.AA * u.sr)
+
+# Some platform implementations of expm1() are buggy and Numpy uses
+# them anyways--the bug is that on certain large inputs it returns
+# NaN instead of INF like it should (it should only return NaN on a
+# NaN input
+# See https://github.com/astropy/astropy/issues/4171
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", RuntimeWarning)
+    _has_buggy_expm1 = np.isnan(np.expm1(1000)) or np.isnan(np.expm1(1e10))
+
+
+class BlackBody(Fittable1DModel):
+    """
+    One dimensional blackbody model.
+
+    Parameters
+    ----------
+    temperature : :class:`~astropy.units.Quantity`
+        Blackbody temperature.
+    scale : :class:`~astropy.units.Quantity`
+        Scale factor
+
+    Notes
+    -----
+
+    Model formula:
+
+        .. math:: B_{\\nu}(T) = A \\frac{2 h \\nu^{3} / c^{2}}{exp(h \\nu / k T) - 1}
+
+    Examples
+    --------
+    >>> from astropy.modeling import models
+    >>> from astropy import units as u
+    >>> bb = models.BlackBody()
+    >>> bb(6000 * u.AA)  # doctest: +FLOAT_CMP
+    <Quantity 1.3585381201978953e-15 erg / (cm2 Hz s)>
+
+    .. plot::
+        :include-source:
+
+        import numpy as np
+        import matplotlib.pyplot as plt
+
+        from astropy.modeling.models import BlackBody
+        from astropy.modeling.physical_models import SLAM
+        from astropy import units as u
+        from astropy.visualization import quantity_support
+
+        bb = BlackBody(temperature=5778*u.K)
+        wav = np.arange(1000, 110000) * u.AA
+        flux = bb(wav)
+
+        with quantity_support():
+            plt.figure()
+            plt.semilogx(wav, flux)
+            plt.axvline(bb.lambda_max.to(u.AA).value, ls='--')
+            plt.show()
+    """
+
+    # We parametrize this model with a temperature and a scale.
+    temperature = Parameter(default=5000, min=0, unit=u.K)
+    scale = Parameter(default=1, min=0)
+
+    # We allow values without units to be passed when evaluating the model, and
+    # in this case the input x values are assumed to be frequencies in Hz.
+    _input_units_allow_dimensionless = True
+
+    # We enable the spectral equivalency by default for the spectral axis
+    input_units_equivalencies = {"x": u.spectral()}
+
+    def evaluate(self, x, temperature, scale):
+        """Evaluate the model.
+
+        Parameters
+        ----------
+        x : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
+            Frequency at which to compute the blackbody. If no units are given,
+            this defaults to Hz.
+
+        temperature : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
+            Temperature of the blackbody. If no units are given, this defaults
+            to Kelvin.
+
+        scale : float, `~numpy.ndarray`, or `~astropy.units.Quantity`
+            Desired scale for the blackbody.
+
+        Returns
+        -------
+        y : number or ndarray
+            Blackbody spectrum. The units are determined from the units of
+            ``scale``.
+
+        .. note::
+
+            Use `numpy.errstate` to suppress Numpy warnings, if desired.
+
+        .. warning::
+
+            Output values might contain ``nan`` and ``inf``.
+
+        Raises
+        ------
+        ValueError
+            Invalid temperature.
+
+        ZeroDivisionError
+            Wavelength is zero (when converting to frequency).
+        """
+        # Convert to units for calculations, also force double precision
+        with u.add_enabled_equivalencies(u.spectral() + u.temperature()):
+            freq = u.Quantity(x, u.Hz, dtype=np.float64)
+            temp = u.Quantity(temperature, u.K, dtype=np.float64)
+
+        # Check if input values are physically possible
+        if np.any(temp < 0):
+            raise ValueError(f"Temperature should be positive: {temp}")
+        if not np.all(np.isfinite(freq)) or np.any(freq <= 0):
+            warnings.warn(
+                "Input contains invalid wavelength/frequency value(s)",
+                AstropyUserWarning,
+            )
+
+        log_boltz = const.h * freq / (const.k_B * temp)
+        boltzm1 = np.expm1(log_boltz)
+
+        if _has_buggy_expm1:
+            # Replace incorrect nan results with infs--any result of 'nan' is
+            # incorrect unless the input (in log_boltz) happened to be nan to begin
+            # with.  (As noted in #4393 ideally this would be replaced by a version
+            # of expm1 that doesn't have this bug, rather than fixing incorrect
+            # results after the fact...)
+            boltzm1_nans = np.isnan(boltzm1)
+            if np.any(boltzm1_nans):
+                if boltzm1.isscalar and not np.isnan(log_boltz):
+                    boltzm1 = np.inf
+                else:
+                    boltzm1[np.where(~np.isnan(log_boltz) & boltzm1_nans)] = np.inf
+
+        # Calculate blackbody flux
+        bb_nu = 2.0 * const.h * freq ** 3 / (const.c ** 2 * boltzm1)
+        flux = bb_nu.to(FNU, u.spectral_density(freq))
+
+        # Add per steradian to output flux unit
+        fnu = scale * flux / u.sr
+
+        # If the bolometric_flux parameter has no unit, we should drop the /Hz
+        # and return a unitless value. This occurs for instance during fitting,
+        # since we drop the units temporarily.
+        if hasattr(scale, "unit"):
+            return fnu
+        else:
+            return fnu
+
+    @property
+    def input_units(self):
+        # The input units are those of the 'x' value, which should always be
+        # Hz. Because we do this, and because input_units_allow_dimensionless
+        # is set to True, dimensionless values are assumed to be in Hz.
+        return {"x": u.Hz}
+
+    def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
+        return OrderedDict(
+            [("temperature", u.K), ("bolometric_flux", outputs_unit["y"] * u.Hz)]
+        )
+
+    @property
+    def lambda_max(self):
+        """Peak wavelength when the curve is expressed as power density."""
+        return const.b_wien / self.temperature

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -1,0 +1,139 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Tests for physical functions."""
+
+import pytest
+import numpy as np
+
+from astropy.modeling.physical_models import BlackBody
+from astropy.modeling.fitting import LevMarLSQFitter
+
+from astropy.tests.helper import assert_quantity_allclose, catch_warnings
+from astropy import units as u
+from astropy.utils.exceptions import AstropyUserWarning
+
+try:
+    from scipy import optimize, integrate  # noqa
+
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+__doctest_skip__ = ["*"]
+
+
+# BlackBody tests
+
+
+@pytest.mark.parametrize("temperature", (3000 * u.K, 2726.85 * u.deg_C))
+def test_evaluate(temperature):
+
+    b = BlackBody(temperature=temperature, scale=1.0)
+
+    assert_quantity_allclose(b(1.4 * u.micron), 486787299458.15656 * u.MJy / u.sr)
+    assert_quantity_allclose(b(214.13747 * u.THz), 486787299458.15656 * u.MJy / u.sr)
+
+
+def test_weins_law():
+    b = BlackBody(293.0 * u.K)
+    assert_quantity_allclose(b.lambda_max, 9.890006672986939 * u.micron)
+    assert_quantity_allclose(b.nu_max, 17.22525080856469 * u.THz)
+
+
+def test_sefanboltzman_law():
+    b = BlackBody(293.0 * u.K)
+    assert_quantity_allclose(b.bolometric_flux, 133.02471751812573 * u.W / (u.m * u.m))
+
+
+def test_return_units_nounits():
+    # return has no units when temperature has no units
+    b = BlackBody(1000.0, scale=1.0)
+    assert not isinstance(b(1.0 * u.micron), u.Quantity)
+
+    # return has "standard" units when scale has no units
+    b = BlackBody(1000.0 * u.K, scale=1.0)
+    assert isinstance(b(1.0 * u.micron), u.Quantity)
+    assert b(1.0 * u.micron).unit == u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
+
+    # return has scale units when scale has units
+    b = BlackBody(1000.0 * u.K, scale=1.0 * u.MJy / u.sr)
+    assert isinstance(b(1.0 * u.micron), u.Quantity)
+    assert b(1.0 * u.micron).unit == u.MJy / u.sr
+
+
+@pytest.mark.skipif("not HAS_SCIPY")
+def test_fit():
+
+    fitter = LevMarLSQFitter()
+
+    b = BlackBody(3000 * u.K)
+
+    wav = np.array([0.5, 5, 10]) * u.micron
+    fnu = np.array([1, 10, 5]) * u.Jy / u.sr
+
+    b_fit = fitter(b, wav, fnu, maxiter=1000)
+
+    assert_quantity_allclose(b_fit.temperature, 2840.74382317 * u.K)
+    assert_quantity_allclose(b_fit.scale, 5803783.33328)
+
+
+def test_blackbody_overflow():
+    """Test Planck function with overflow."""
+    photlam = u.photon / (u.cm ** 2 * u.s * u.AA)
+    wave = [0.0, 1000.0, 100000.0, 1e55]  # Angstrom
+    temp = 10000.0  # Kelvin
+    with np.errstate(all="ignore"):
+        bb = BlackBody(temperature=temp * u.K, scale=1.0)
+        bb_lam = bb(wave) * u.sr
+    flux = bb_lam.to(photlam, u.spectral_density(wave * u.AA)) / u.sr
+
+    # First element is NaN, last element is very small, others normal
+    assert np.isnan(flux[0])
+    assert np.log10(flux[-1].value) < -134
+    np.testing.assert_allclose(
+        flux.value[1:-1], [0.00046368, 0.04636773], rtol=1e-3
+    )  # 0.1% accuracy in PHOTLAM/sr
+    with np.errstate(all="ignore"):
+        flux = bb(1.0 * u.AA)
+    assert flux.value == 0
+
+
+def test_blackbody_exceptions_and_warnings():
+    """Test exceptions."""
+
+    # Negative temperature
+    with pytest.raises(ValueError) as exc:
+        bb = BlackBody(-100 * u.K)
+        bb(1.0 * u.micron)
+    assert exc.value.args[0] == "Temperature should be positive: [-100.] K"
+
+    bb = BlackBody(5000 * u.K)
+
+    # Zero wavelength given for conversion to Hz
+    with catch_warnings(AstropyUserWarning) as w:
+        bb(0 * u.AA)
+    assert len(w) == 1
+    assert "invalid" in w[0].message.args[0]
+
+    # Negative wavelength given for conversion to Hz
+    with catch_warnings(AstropyUserWarning) as w:
+        bb(-1.0 * u.AA)
+    assert len(w) == 1
+    assert "invalid" in w[0].message.args[0]
+
+
+def test_blackbody_array_temperature():
+    """Regression test to make sure that the temperature can be an array."""
+    multibb = BlackBody([100, 200, 300] * u.K)
+    flux = multibb(1.2 * u.mm)
+    np.testing.assert_allclose(
+        flux.value, [1.804908e-12, 3.721328e-12, 5.638513e-12], rtol=1e-5
+    )
+
+    flux = multibb([2, 4, 6] * u.mm)
+    np.testing.assert_allclose(
+        flux.value, [6.657915e-13, 3.420677e-13, 2.291897e-13], rtol=1e-5
+    )
+
+    multibb = BlackBody(np.ones(4) * u.K)
+    flux = multibb(np.ones((3, 4)) * u.mm)
+    assert flux.shape == (3, 4)

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -182,6 +182,10 @@ def spectral_density(wav, factor=None):
     phot_L_la = astrophys.photon / (si.s * si.AA)
     phot_L_nu = astrophys.photon / (si.s * si.Hz)
 
+    # surface brigthness
+    S_la = cgs.erg / si.angstrom / si.cm ** 2 / si.s / si.sr
+    S_nu = cgs.erg / si.Hz / si.cm ** 2 / si.s / si.sr
+
     def converter(x):
         return x * (wav.to_value(si.AA, spectral()) ** 2 / c_Aps)
 
@@ -263,6 +267,8 @@ def spectral_density(wav, factor=None):
         (phot_L_la, phot_L_nu, converter_phot_L_la_phot_L_nu, iconverter_phot_L_la_phot_L_nu),
         (phot_L_nu, L_nu, converter_phot_L_nu_to_L_nu, iconverter_phot_L_nu_to_L_nu),
         (phot_L_nu, L_la, converter_phot_L_nu_to_L_la, iconverter_phot_L_nu_to_L_la),
+        # surface brightness
+        (S_la, S_nu, converter, iconverter),
     ], "spectral_density", {'wav': wav, 'factor': factor})
 
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -182,9 +182,21 @@ def spectral_density(wav, factor=None):
     phot_L_la = astrophys.photon / (si.s * si.AA)
     phot_L_nu = astrophys.photon / (si.s * si.Hz)
 
-    # surface brigthness
+    # surface brigthness (flux equiv)
     S_la = cgs.erg / si.angstrom / si.cm ** 2 / si.s / si.sr
     S_nu = cgs.erg / si.Hz / si.cm ** 2 / si.s / si.sr
+    nu_S_nu = cgs.erg / si.cm ** 2 / si.s / si.sr
+    la_S_la = nu_S_nu
+    phot_S_la = astrophys.photon / (si.cm ** 2 * si.s * si.AA * si.sr)
+    phot_S_nu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz * si.sr)
+
+    # surface brightness (luminosity equiv)
+    SL_nu = cgs.erg / si.s / si.Hz / si.sr
+    SL_la = cgs.erg / si.s / si.angstrom / si.sr
+    nu_SL_nu = cgs.erg / si.s / si.sr
+    la_SL_la = nu_SL_nu
+    phot_SL_la = astrophys.photon / (si.s * si.AA * si.sr)
+    phot_SL_nu = astrophys.photon / (si.s * si.Hz * si.sr)
 
     def converter(x):
         return x * (wav.to_value(si.AA, spectral()) ** 2 / c_Aps)
@@ -267,8 +279,24 @@ def spectral_density(wav, factor=None):
         (phot_L_la, phot_L_nu, converter_phot_L_la_phot_L_nu, iconverter_phot_L_la_phot_L_nu),
         (phot_L_nu, L_nu, converter_phot_L_nu_to_L_nu, iconverter_phot_L_nu_to_L_nu),
         (phot_L_nu, L_la, converter_phot_L_nu_to_L_la, iconverter_phot_L_nu_to_L_la),
-        # surface brightness
+        # surface brightness (flux equiv)
         (S_la, S_nu, converter, iconverter),
+        (S_nu, nu_S_nu, converter_f_nu_to_nu_f_nu, iconverter_f_nu_to_nu_f_nu),
+        (S_la, la_S_la, converter_f_la_to_la_f_la, iconverter_f_la_to_la_f_la),
+        (phot_S_la, S_la, converter_phot_f_la_to_f_la, iconverter_phot_f_la_to_f_la),
+        (phot_S_la, S_nu, converter_phot_f_la_to_f_nu, iconverter_phot_f_la_to_f_nu),
+        (phot_S_la, phot_S_nu, converter_phot_f_la_phot_f_nu, iconverter_phot_f_la_phot_f_nu),
+        (phot_S_nu, S_nu, converter_phot_f_nu_to_f_nu, iconverter_phot_f_nu_to_f_nu),
+        (phot_S_nu, S_la, converter_phot_f_nu_to_f_la, iconverter_phot_f_nu_to_f_la),
+        # surface brightness (luminosity equiv)
+        (SL_la, SL_nu, converter, iconverter),
+        (SL_nu, nu_SL_nu, converter_L_nu_to_nu_L_nu, iconverter_L_nu_to_nu_L_nu),
+        (SL_la, la_SL_la, converter_L_la_to_la_L_la, iconverter_L_la_to_la_L_la),
+        (phot_SL_la, SL_la, converter_phot_L_la_to_L_la, iconverter_phot_L_la_to_L_la),
+        (phot_SL_la, SL_nu, converter_phot_L_la_to_L_nu, iconverter_phot_L_la_to_L_nu),
+        (phot_SL_la, phot_SL_nu, converter_phot_L_la_phot_L_nu, iconverter_phot_L_la_phot_L_nu),
+        (phot_SL_nu, SL_nu, converter_phot_L_nu_to_L_nu, iconverter_phot_L_nu_to_L_nu),
+        (phot_SL_nu, SL_la, converter_phot_L_nu_to_L_la, iconverter_phot_L_nu_to_L_la),
     ], "spectral_density", {'wav': wav, 'factor': factor})
 
 

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -461,6 +461,22 @@ def test_spectraldensity5():
         phot_L_nu, flux_L_la, u.spectral_density(wave)), flux_phot_L_nu, rtol=1e-6)
 
 
+def test_spectraldensity6():
+    """ Test surface brightness conversions. """
+    slam = u.erg / (u.cm ** 2 * u.s * u.AA * u.sr)
+    snu = u.erg / (u.cm ** 2 * u.s * u.Hz * u.sr)
+
+    wave = u.Quantity([4956.8, 4959.55, 4962.3], u.AA)
+    sb_flam = [3.9135e-14, 4.0209e-14, 3.9169e-14]
+    sb_fnu = [3.20735792e-25, 3.29903646e-25, 3.21727226e-25]
+
+    # S(nu) <--> S(lambda)
+    assert_allclose(snu.to(
+        slam, sb_fnu, u.spectral_density(wave)), sb_flam, rtol=1e-6)
+    assert_allclose(slam.to(
+        snu, sb_flam, u.spectral_density(wave)), sb_fnu, rtol=1e-6)
+
+
 def test_equivalent_units():
     from astropy.units import imperial
     with u.add_enabled_units(imperial):

--- a/docs/modeling/blackbody_deprecated.rst
+++ b/docs/modeling/blackbody_deprecated.rst
@@ -1,0 +1,121 @@
+Blackbody (deprecated capabilities)
+===================================
+
+blackbody functions (deprecated)
+--------------------------------
+
+Prior to astropy v4.0, two simple functions were provided to compute
+a blackbody in frequency and wavelength based units -
+:func:`~astropy.modeling.blackbody.blackbody_nu`
+and :func:`~astropy.modeling.blackbody.blackbody_lambda`.
+These functions are deprecated as they same
+results can be obtained using the
+:class:`~astropy.modeling.blackbody.BlackBody1D` model which also
+provides all the benefits of being a full astropy.modeling  model.
+
+For the :func:`~astropy.modeling.blackbody.blackbody_lambda` and
+:func:`~astropy.modeling.blackbody.blackbody_nu` functions, the
+flux is calculated with Planck law
+(:ref:`Rybicki & Lightman 1979 <ref-rybicki1979>`):
+
+.. math::
+
+    B_{\\lambda}(T) = \\frac{2 h c^{2} / \\lambda^{5}}{exp(h c / \\lambda k T) - 1}
+
+    B_{\\nu}(T) = \\frac{2 h \\nu^{3} / c^{2}}{exp(h \\nu / k T) - 1}
+
+where the unit of :math:`B_{\\lambda}(T)` is
+:math:`erg \\; s^{-1} cm^{-2} \\mathring{A}^{-1} sr^{-1}`, and
+:math:`B_{\\nu}(T)` is :math:`erg \\; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
+:func:`~astropy.modeling.blackbody.blackbody_lambda` and
+:func:`~astropy.modeling.blackbody.blackbody_nu` calculate the
+blackbody flux for :math:`B_{\\lambda}(T)` and :math:`B_{\\nu}(T)`,
+respectively.
+
+Note that an array of temperatures can also be given instead of a single
+temperature. In this case, the Numpy broadcasting rules apply: for instance, if
+the frequency and temperature have the same shape, the output will have this
+shape too, while if the frequency is a 2-d array with shape ``(n, m)`` and the
+temperature is an array with shape ``(m,)``, the output will have a shape
+``(n, m)``.
+
+BlackBody1D and blackbody_nu/blackbody_lam
+------------------------------------------
+
+The equivalency between the
+:class:`~astropy.modeling.blackbody.BlackBody1D`
+:func:`~astropy.modeling.blackbody.blackbody_nu` and
+:func:`~astropy.modeling.blackbody.blackbody_lambda`
+is shown in the plot below.
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.modeling.blackbody import blackbody_lambda, blackbody_nu
+    from astropy.modeling.blackbody import BlackBody1D
+    import astropy.units as u
+    from astropy import constants as const
+
+    wavelengths = np.logspace(np.log10(1000), np.log10(3e4), num=1000) * u.AA
+
+    # blackbody parameters
+    temperature = 10000 * u.K
+
+    # provides the result in ergs/(cm^2 Hz s sr)
+    spectrum_lam = blackbody_lambda(wavelengths, temperature)
+
+    # provides the results in ergs/(cm^2 A s sr)
+    spectrum_nu = blackbody_nu(wavelengths, temperature)
+
+    # BlackBody1D provides the results in W/m^2
+    #   the amplitude is specified as bolometric flux in ergs(cm^2 s)
+    bolometric_flux = const.sigma_sb * temperature ** 4 / np.pi
+    bolometric_flux.to(u.erg / (u.cm * u.cm * u.s))
+    bb_astro = BlackBody1D(temperature=temperature, bolometric_flux=bolometric_flux)
+
+    # plot the nu and lam results from both methods
+    fig, ax = plt.subplots(ncols=2, figsize=(8.0, 4.0))
+
+    # lambda forms
+    ax[0].plot(wavelengths, spectrum_lam, label="spectrum_lam", linewidth=6, alpha=0.5)
+
+    # the BlackBody1D has to be converted to the spectrum_nu units
+    ax[0].plot(
+        wavelengths,
+        bb_astro(wavelengths).to(
+            u.erg / (u.cm * u.cm * u.Angstrom * u.s),
+            equivalencies=u.spectral_density(wavelengths),) / u.sr,
+        label="BB1D_lam")
+
+    # nu forms
+    ax[1].plot(wavelengths, spectrum_nu, label="spectrum_nu", linewidth=6, alpha=0.5)
+
+    # the BlackBody1D has to be converted to the spectrum_lam units
+    ax[1].plot(
+        wavelengths,
+        bb_astro(wavelengths).to(u.erg / (u.cm * u.cm * u.Hz * u.s)) / u.sr,
+        label="BB1D_nu")
+
+    ax[0].set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
+    ax[0].set_ylabel(r"$Flux$ [{}]".format(spectrum_lam.unit))
+    ax[1].set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
+    ax[1].set_ylabel(r"$Flux$ [{}]".format(spectrum_nu.unit))
+    ax[0].set_xscale("log")
+    ax[0].set_yscale("log")
+    ax[1].set_xscale("log")
+    ax[1].set_yscale("log")
+    ax[0].legend(loc="best")
+    ax[1].legend(loc="best")
+
+    plt.tight_layout()
+    plt.show()
+
+See Also
+^^^^^^^^
+
+.. _ref-rybicki1979:
+
+Rybicki, G. B., & Lightman, A. P. 1979, Radiative Processes in Astrophysics (New York, NY: Wiley)

--- a/docs/modeling/blackbody_deprecated.rst
+++ b/docs/modeling/blackbody_deprecated.rst
@@ -1,53 +1,14 @@
 :orphan:
 
-Blackbody (deprecated capabilities)
-===================================
+Blackbody Module (deprecated capabilities)
+==========================================
 
-Blackbody functions (deprecated)
---------------------------------
-
-Prior to astropy v4.0, two simple functions were provided to compute
-a blackbody in frequency and wavelength based units -
-:func:`~astropy.modeling.blackbody.blackbody_nu`
-and :func:`~astropy.modeling.blackbody.blackbody_lambda`.
-These functions are deprecated as they same
-results can be obtained using the
-:class:`~astropy.modeling.blackbody.BlackBody1D` model which also
-provides all the benefits of being a full astropy.modeling  model.
-
-For the :func:`~astropy.modeling.blackbody.blackbody_lambda` and
-:func:`~astropy.modeling.blackbody.blackbody_nu` functions, the
-flux is calculated with Planck law
-(:ref:`Rybicki & Lightman 1979 <ref-rybicki1979>`):
-
-.. math::
-
-    B_{\lambda}(T) = \frac{2 h c^{2} / \lambda^{5}}{exp(h c / \lambda k T) - 1}
-
-    B_{\nu}(T) = \frac{2 h \nu^{3} / c^{2}}{exp(h \nu / k T) - 1}
-
-where the unit of :math:`B_{\lambda}(T)` is
-:math:`ergs \; s^{-1} cm^{-2} \mathring{A}^{-1} sr^{-1}`, and
-:math:`B_{\nu}(T)` is :math:`ergs \; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
-:func:`~astropy.modeling.blackbody.blackbody_lambda` and
-:func:`~astropy.modeling.blackbody.blackbody_nu` calculate the
-blackbody flux for :math:`B_{\lambda}(T)` and :math:`B_{\nu}(T)`,
-respectively.
-
-Note that an array of temperatures can also be given instead of a single
-temperature. In this case, the Numpy broadcasting rules apply: for instance, if
-the frequency and temperature have the same shape, the output will have this
-shape too, while if the frequency is a 2-d array with shape ``(n, m)`` and the
-temperature is an array with shape ``(m,)``, the output will have a shape
-``(n, m)``.
-
-BlackBody1D and blackbody_nu/blackbody_lam
-------------------------------------------
+BlackBody1D class
+-----------------
 
 The equivalency between the
+:class:`~astropy.modeling.physical_models.BlackBody` and
 :class:`~astropy.modeling.blackbody.BlackBody1D`
-:func:`~astropy.modeling.blackbody.blackbody_nu` and
-:func:`~astropy.modeling.blackbody.blackbody_lambda`
 is shown in the plot below.
 
 .. plot::
@@ -56,50 +17,92 @@ is shown in the plot below.
     import numpy as np
     import matplotlib.pyplot as plt
 
-    from astropy.modeling.blackbody import blackbody_lambda, blackbody_nu
     from astropy.modeling.blackbody import BlackBody1D
+    from astropy.modeling.models import BlackBody
     import astropy.units as u
-    from astropy import constants as const
 
     wavelengths = np.logspace(np.log10(1000), np.log10(3e4), num=1000) * u.AA
 
     # blackbody parameters
     temperature = 10000 * u.K
 
-    # provides the result in ergs/(cm^2 Hz s sr)
-    spectrum_lam = blackbody_lambda(wavelengths, temperature)
+    # BlackBody1D is normalized by default to have a bolometric flux of 1
+    bb1d = BlackBody1D(temperature)
 
-    # provides the results in ergs/(cm^2 A s sr)
+    # default results from BlackBody same units as BlackBody1D
+    bb = BlackBody(temperature)
+
+    # plot the results from both methods
+    fig, ax = plt.subplots(ncols=1, figsize=(4.0, 4.0))
+
+    ax.plot(wavelengths, bb1d(wavelengths) / u.sr, label="BlackBody1D", linewidth=6, alpha=0.5)
+
+    # divide by bolometric flux to get equivalent of BlackBody1D
+    ax.plot(wavelengths, bb(wavelengths)/bb.bolometric_flux.value, label="BlackBody")
+
+
+    ax.set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
+    ax.set_ylabel(r"$Flux$ [{}]".format(bb(wavelengths).unit))
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.legend(loc="best")
+
+    plt.tight_layout()
+    plt.show()
+
+blackbody functions (deprecated)
+--------------------------------
+
+Prior to astropy v4.0, two simple functions were provided to compute
+a blackbody in frequency and wavelength based units -
+:func:`~astropy.modeling.blackbody.blackbody_nu`
+and :func:`~astropy.modeling.blackbody.blackbody_lambda`.
+These functions are deprecated as they same
+results can be obtained using the
+:class:`~astropy.modeling.physical_models.BlackBody` model.
+
+Equivalent results between
+and :class:`~astropy.modeling.physical_models.BlackBody` and the
+func:`~astropy.modeling.blackbody.blackbody_nu` and
+func:`~astropy.modeling.blackbody.blackbody_lambda` is shown in the plot below.
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.modeling.blackbody import blackbody_lambda, blackbody_nu
+    from astropy.modeling.models import BlackBody
+    import astropy.units as u
+
+    wavelengths = np.logspace(np.log10(1000), np.log10(3e4), num=1000) * u.AA
+
+    # blackbody parameters
+    temperature = 10000 * u.K
+
+    # provides the results in ergs/(cm^2 Hz s sr)
     spectrum_nu = blackbody_nu(wavelengths, temperature)
 
-    # BlackBody1D provides the results in W/m^2
-    #   the amplitude is specified as bolometric flux in ergs(cm^2 s)
-    bolometric_flux = const.sigma_sb * temperature ** 4 / np.pi
-    bolometric_flux.to(u.erg / (u.cm * u.cm * u.s))
-    bb_astro = BlackBody1D(temperature=temperature, bolometric_flux=bolometric_flux)
+    # provides the result in ergs/(cm^2 A s sr)
+    spectrum_lam = blackbody_lambda(wavelengths, temperature)
+
+    # default results from BlackBody same units as blackbody_nu
+    bb_nu = BlackBody(temperature)
+
+    # use scale to change results units for Blackbody to match blackbody_lambda
+    bb_lam = BlackBody(temperature, scale=1.0 * u.erg / (u.cm ** 2 * u.AA * u.s * u.sr))
 
     # plot the nu and lam results from both methods
     fig, ax = plt.subplots(ncols=2, figsize=(8.0, 4.0))
 
     # lambda forms
-    ax[0].plot(wavelengths, spectrum_lam, label="spectrum_lam", linewidth=6, alpha=0.5)
-
-    # the BlackBody1D has to be converted to the spectrum_nu units
-    ax[0].plot(
-        wavelengths,
-        bb_astro(wavelengths).to(
-            u.erg / (u.cm * u.cm * u.Angstrom * u.s),
-            equivalencies=u.spectral_density(wavelengths),) / u.sr,
-        label="BB1D_lam")
+    ax[0].plot(wavelengths, spectrum_lam, label="blackbody_lambda", linewidth=6, alpha=0.5)
+    ax[0].plot(wavelengths, bb_lam(wavelengths), label="BlackBody")
 
     # nu forms
-    ax[1].plot(wavelengths, spectrum_nu, label="spectrum_nu", linewidth=6, alpha=0.5)
-
-    # the BlackBody1D has to be converted to the spectrum_lam units
-    ax[1].plot(
-        wavelengths,
-        bb_astro(wavelengths).to(u.erg / (u.cm * u.cm * u.Hz * u.s)) / u.sr,
-        label="BB1D_nu")
+    ax[1].plot(wavelengths, spectrum_nu, label="blackbody_nu", linewidth=6, alpha=0.5)
+    ax[1].plot(wavelengths, bb_nu(wavelengths), label="BlackBody")
 
     ax[0].set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
     ax[0].set_ylabel(r"$Flux$ [{}]".format(spectrum_lam.unit))
@@ -114,14 +117,6 @@ is shown in the plot below.
 
     plt.tight_layout()
     plt.show()
-
-See Also
-^^^^^^^^
-
-.. _ref-rybicki1979:
-
-Rybicki, G. B., & Lightman, A. P. 1979, Radiative Processes in Astrophysics (New York, NY: Wiley)
-
 
 API for deprecated model/functions
 ----------------------------------

--- a/docs/modeling/blackbody_deprecated.rst
+++ b/docs/modeling/blackbody_deprecated.rst
@@ -1,7 +1,9 @@
+:orphan:
+
 Blackbody (deprecated capabilities)
 ===================================
 
-blackbody functions (deprecated)
+Blackbody functions (deprecated)
 --------------------------------
 
 Prior to astropy v4.0, two simple functions were provided to compute
@@ -20,16 +22,16 @@ flux is calculated with Planck law
 
 .. math::
 
-    B_{\\lambda}(T) = \\frac{2 h c^{2} / \\lambda^{5}}{exp(h c / \\lambda k T) - 1}
+    B_{\lambda}(T) = \frac{2 h c^{2} / \lambda^{5}}{exp(h c / \lambda k T) - 1}
 
-    B_{\\nu}(T) = \\frac{2 h \\nu^{3} / c^{2}}{exp(h \\nu / k T) - 1}
+    B_{\nu}(T) = \frac{2 h \nu^{3} / c^{2}}{exp(h \nu / k T) - 1}
 
-where the unit of :math:`B_{\\lambda}(T)` is
-:math:`erg \\; s^{-1} cm^{-2} \\mathring{A}^{-1} sr^{-1}`, and
-:math:`B_{\\nu}(T)` is :math:`erg \\; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
+where the unit of :math:`B_{\lambda}(T)` is
+:math:`ergs \; s^{-1} cm^{-2} \mathring{A}^{-1} sr^{-1}`, and
+:math:`B_{\nu}(T)` is :math:`ergs \; s^{-1} cm^{-2} Hz^{-1} sr^{-1}`.
 :func:`~astropy.modeling.blackbody.blackbody_lambda` and
 :func:`~astropy.modeling.blackbody.blackbody_nu` calculate the
-blackbody flux for :math:`B_{\\lambda}(T)` and :math:`B_{\\nu}(T)`,
+blackbody flux for :math:`B_{\lambda}(T)` and :math:`B_{\nu}(T)`,
 respectively.
 
 Note that an array of temperatures can also be given instead of a single
@@ -119,3 +121,9 @@ See Also
 .. _ref-rybicki1979:
 
 Rybicki, G. B., & Lightman, A. P. 1979, Radiative Processes in Astrophysics (New York, NY: Wiley)
+
+
+API for deprecated model/functions
+----------------------------------
+
+.. automodapi:: astropy.modeling.blackbody

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -99,6 +99,8 @@ Advanced Topics
 Pre-Defined Models
 ==================
 
+.. To be expanded to include all pre-defined models
+
 .. toctree::
    :maxdepth: 2
 

--- a/docs/modeling/index.rst
+++ b/docs/modeling/index.rst
@@ -96,6 +96,14 @@ Advanced Topics
    Adding support for units to models <add-units.rst>
 
 
+Pre-Defined Models
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   Physical Models <physical_models.rst>
+
 Examples
 ========
 

--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -1,18 +1,84 @@
 Physical Models
 ***************
 
-These are models that are physics motivated (as opposed to mathematically motivated).
+These are models that are physical motivated, generally as solutions to
+physical problems.  This is in contrast to those that are mathematically motivated,
+generally as solutions to mathematical problems.
 
 BlackBody
 =========
 
-The :class:`~astropy.modeling.physical_models.BlackBody` model is the bee's knees!
-Details and an example needed.
+.. _blackbody-planck-law:
+
+The :class:`~astropy.modeling.physical_models.BlackBody` model provides a model
+for using `Planck's Law <https://en.wikipedia.org/wiki/Planck%27s_law/>`_.
+The blackbody function is
+
+.. math::
+
+   B_{\nu}(T) = A \frac{2 h \nu^{3} / c^{2}}{exp(h \nu / k T) - 1}
+
+where :math:`\nu` is the frequency, :math:`T` is the temperature,
+:math:`A` is the scaling factor,
+:math:`h` is the Plank constant, :math:`c` is the speed of light, and
+:math:`k` is the Boltzmann constant.
+
+The two parameters of the model the scaling factor ``scale`` (A) and
+the absolute temperature ``temperature`` (T).  If the ``scale`` factor does not
+have units, then the result is in units of spectral radiance, specifically
+ergs/(cm^2 Hz s sr).  If the ``scale`` factor is passed with spectral radiance units,
+then the result is in those units (e.g., ergs/(cm^2 A s sr) or MJy/sr).
+Setting the ``scale`` factor with units of ergs/(cm^2 A s sr) will give the
+Planck function as :math:`B_\lambda`.
+The temperature can be passed as a Quantity with any supported temperature unit.
+If temperature
+is passed without a unit, it is assumed to be in Kelvin.
+
+An example plot for a blackbody with a temperature of 10000 K and a scale of 1 is
+shown below.  A scale of 1 shows the Planck function with no scaling in the
+default units returned by :class:`~astropy.modeling.physical_models.BlackBody`.
+
+.. plot::
+    :include-source:
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    from astropy.modeling.models import BlackBody
+    import astropy.units as u
+
+    wavelengths = np.logspace(np.log10(1000), np.log10(3e4), num=1000) * u.AA
+
+    # blackbody parameters
+    temperature = 10000 * u.K
+
+    # BlackBody1D provides the results in ergs/(cm^2 Hz s sr) when scale has no units
+    bb = BlackBody(temperature=temperature, scale=10000.0)
+    bb_result = bb(wavelengths)
+
+    fig, ax = plt.subplots(ncols=1)
+    ax.plot(wavelengths, bb_result, '-')
+
+    ax.set_xscale('log')
+    ax.set_xlabel(r"$\lambda$ [{}]".format(wavelengths.unit))
+    ax.set_ylabel(r"$F(\lambda)$ [{}]".format(bb_result.unit))
+
+    plt.tight_layout()
+    plt.show()
+
+The ``bolometric_flux`` member function gives the bolometric flux using
+:math:`\sigma T^4/\pi` where :math:`\sigma` is the Stefan-Boltzmann constant.
+
+The ``lambda_max`` and ``nu_max`` member functions give the wavelength and
+frequency of the maximum for :math:`B_\lambda` and :math:`B_\nu`,
+respectively, calculated using `Wein's Law
+<https://en.wikipedia.org/wiki/Wien%27s_displacement_law>`_.
 
 .. note::
 
-    Prior to v4.0, the BlackBody1D and the functions blackbody_nu and blackbody_lambda
-    were provided.  BlackBody1D was a more limited blackbody model that was
-    specific to integrated fluxes from sources.  The capabilites of all three
+    Prior to v4.0, the ``BlackBody1D`` and the functions ``blackbody_nu`` and ``blackbody_lambda``
+    were provided.  ``BlackBody1D`` was a more limited blackbody model that was
+    specific to integrated fluxes from sources.  See :doc:`blackbody_deprecated`
+    and `astropy issue #9066 <https://github.com/astropy/astropy/issues/9066>`_ for details.
+    The capabilities of all three
     can be obtained with :class:`~astropy.modeling.physical_models.BlackBody`.
-    See :doc:`blackbody_deprecated` for details.

--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -31,8 +31,6 @@ then the result is in those units (e.g., ergs/(cm^2 A s sr) or MJy/sr).
 Setting the ``scale`` factor with units of ergs/(cm^2 A s sr) will give the
 Planck function as :math:`B_\lambda`.
 The temperature can be passed as a Quantity with any supported temperature unit.
-If temperature
-is passed without a unit, it is assumed to be in Kelvin.
 
 An example plot for a blackbody with a temperature of 10000 K and a scale of 1 is
 shown below.  A scale of 1 shows the Planck function with no scaling in the
@@ -66,19 +64,21 @@ default units returned by :class:`~astropy.modeling.physical_models.BlackBody`.
     plt.tight_layout()
     plt.show()
 
-The ``bolometric_flux`` member function gives the bolometric flux using
+The :meth:`~astropy.modeling.physical_models.BlackBody.bolometric_flux` member
+function gives the bolometric flux using
 :math:`\sigma T^4/\pi` where :math:`\sigma` is the Stefan-Boltzmann constant.
 
-The ``lambda_max`` and ``nu_max`` member functions give the wavelength and
-frequency of the maximum for :math:`B_\lambda` and :math:`B_\nu`,
-respectively, calculated using `Wein's Law
+The :meth:`~astropy.modeling.physical_models.BlackBody.lambda_max` and
+:meth:`~astropy.modeling.physical_models.BlackBody.nu_max` member functions
+give the wavelength and frequency of the maximum for :math:`B_\lambda`
+and :math:`B_\nu`, respectively, calculated using `Wein's Law
 <https://en.wikipedia.org/wiki/Wien%27s_displacement_law>`_.
 
 .. note::
 
     Prior to v4.0, the ``BlackBody1D`` and the functions ``blackbody_nu`` and ``blackbody_lambda``
     were provided.  ``BlackBody1D`` was a more limited blackbody model that was
-    specific to integrated fluxes from sources.  See :doc:`blackbody_deprecated`
-    and `astropy issue #9066 <https://github.com/astropy/astropy/issues/9066>`_ for details.
-    The capabilities of all three
+    specific to integrated fluxes from sources.  The capabilities of all three
     can be obtained with :class:`~astropy.modeling.physical_models.BlackBody`.
+    See :doc:`blackbody_deprecated`
+    and `astropy issue #9066 <https://github.com/astropy/astropy/issues/9066>`_ for details.

--- a/docs/modeling/physical_models.rst
+++ b/docs/modeling/physical_models.rst
@@ -1,0 +1,18 @@
+Physical Models
+***************
+
+These are models that are physics motivated (as opposed to mathematically motivated).
+
+BlackBody
+=========
+
+The :class:`~astropy.modeling.physical_models.BlackBody` model is the bee's knees!
+Details and an example needed.
+
+.. note::
+
+    Prior to v4.0, the BlackBody1D and the functions blackbody_nu and blackbody_lambda
+    were provided.  BlackBody1D was a more limited blackbody model that was
+    specific to integrated fluxes from sources.  The capabilites of all three
+    can be obtained with :class:`~astropy.modeling.physical_models.BlackBody`.
+    See :doc:`blackbody_deprecated` for details.

--- a/docs/modeling/reference_api.rst
+++ b/docs/modeling/reference_api.rst
@@ -16,8 +16,8 @@ Pre-Defined Models
 ******************
 
 .. automodapi:: astropy.modeling.functional_models
+.. automodapi:: astropy.modeling.physical_models
 .. automodapi:: astropy.modeling.powerlaws
-.. automodapi:: astropy.modeling.blackbody
 .. automodapi:: astropy.modeling.polynomial
 .. automodapi:: astropy.modeling.projections
 .. automodapi:: astropy.modeling.rotations

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -173,7 +173,8 @@ These three conventions are implemented in
 Spectral Flux / Luminosity Density Units
 ----------------------------------------
 
-There is also support for spectral flux and luminosity density units. Their use
+There is also support for spectral flux and luminosity density units
+and their equivalent surface brightness units. Their use
 is more complex, since it is necessary to also supply the location in the
 spectrum for which the conversions will be done, and the units of those spectral
 locations.  The function that handles these unit conversions is


### PR DESCRIPTION
BlackBody model that is a straightforward implementation of Planck's Law.   This implementation is more flexible than the existing BlackBody1D model.

Added surface brightness equivalencies to the spectral_density equivalencies.  Useful for BlackBody and in general.

Docs and tests are included in this PR.

The BlackBody is the 1st model located in physical_models.py.  Other physics motivated models should go in this file (distinguished from functional_models.py that are those that are more mathematically motivated).  A later PR can/could move some models from functional to physical as appropriate.

This new function replaces the existing blackbody_lambda and blackbody_nu functions and BlackBody1D model.  See #9066 for discussion of why this is desirable.  These existing functions have been deprecated as part of this PR.  Documentation showing how to reproduce the results from all three with BlackBody has been included.

Closes #9066 