### PR TITLE
Adding test for TimeSeries join

### DIFF
--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -20,6 +20,8 @@ import numpy as np
 from astropy.utils import metadata
 from .table import Table, QTable, Row, Column, MaskedColumn
 from astropy.units import Quantity
+from astropy.time import Time
+from astropy.utils.compat import NUMPY_LT_1_17
 
 from . import _np_utils
 from .np_utils import fix_column_name, TableMergeError
@@ -857,7 +859,7 @@ def _join(left, right, keys=None, join_type='inner',
 
             out[out_name] = col_cls.info.new_like(cols, n_out, metadata_conflicts, out_name)
 
-            if issubclass(col_cls, Column):
+            if not NUMPY_LT_1_17 or issubclass(col_cls, (Column, Time)):
                 out[out_name][:] = np.where(right_mask,
                                             left[left_name].take(left_out),
                                             right[right_name].take(right_out))

--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.testing import assert_equal
 
 from astropy import units as u
-from astropy.table import Table, QTable, vstack
+from astropy.table import Table, QTable, vstack, join
 from astropy.time import Time
 
 from astropy.timeseries.sampled import TimeSeries
@@ -59,6 +59,16 @@ class CommonTimeSeriesTests:
         with pytest.raises(ValueError) as exc:
             ts.remove_columns(ts.colnames)
         assert 'TimeSeries object is invalid' in exc.value.args[0]
+
+    def test_join(self):
+        ts_other = self.series.copy()
+        ts_other.add_row(self._row)
+        ts_other['d'] = [11, 22, 33, 44]
+        ts_other.remove_columns(['a', 'b'])
+        ts = join(self.series, ts_other)
+        assert len(ts) == len(self.series)
+        ts = join(self.series, ts_other, join_type='outer')
+        assert len(ts) == len(ts_other)
 
 
 class TestTimeSeries(CommonTimeSeriesTests):

--- a/astropy/timeseries/tests/test_common.py
+++ b/astropy/timeseries/tests/test_common.py
@@ -73,7 +73,7 @@ class CommonTimeSeriesTests:
 
 class TestTimeSeries(CommonTimeSeriesTests):
 
-    _row = {'time': '2016-03-22T12:30:40', 'a': 1., 'b': 2, 'c': 'a'}
+    _row = {'time': '2016-03-23T12:30:40', 'a': 1., 'b': 2, 'c': 'a'}
 
     def setup_method(self, method):
         self.series = TimeSeries(time=INPUT_TIME, data=PLAIN_TABLE)
@@ -86,7 +86,7 @@ class TestTimeSeries(CommonTimeSeriesTests):
 
 class TestBinnedTimeSeries(CommonTimeSeriesTests):
 
-    _row = {'time_bin_start': '2016-03-22T12:30:40',
+    _row = {'time_bin_start': '2016-03-23T12:30:40',
             'time_bin_size': 2 * u.s, 'a': 1., 'b': 2, 'c': 'a'}
 
     def setup_method(self, method):


### PR DESCRIPTION
To address https://github.com/astropy/astropy/issues/8586


I think #7728 might be also fixed, but I can still generate cases that raise a an error in case of QTables, so would not claim that issue just yet.

```
NotImplementedError: join requires masking column 'aaa' but column type Quantity does not support masking
```