### PR TITLE
fix a bug within discretize_oversample_1D/2D()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -471,6 +471,10 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug in ``discretize_oversample_1D/2D()`` from ``astropy.convolution.utils``,
+  which might occasionally introduce unexpected oversampling grid dimensions due 
+  to a numerical precision issue. [#9293]
+  
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -216,6 +216,4 @@ def test_discretize_oversample():
     assert values.shape == (35, 10)
     assert_allclose(vmax, 0.927, atol=1e-3)
     assert vmax_yx == (25, 5)
-    assert np.allclose(values_center, values_osf1)
-    
-    
+    assert_allclose(values_center, values_osf1)

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -194,9 +194,10 @@ def test_float_y_range_exception():
         discretize_model(f, (-10, 11), (-10.002, 11.23))
     assert exc.value.args[0] == ("The difference between the upper an lower"
                                  " limit of 'y_range' must be a whole number.")
-    
+
+
 def test_discretize_oversample():
-    gauss_2D = Gaussian2D(amplitude=1.0, x_mean=5., 
+    gauss_2D = Gaussian2D(amplitude=1.0, x_mean=5.,
                     y_mean=125., x_stddev=0.75, y_stddev=3)
     values = discretize_model(gauss_2D,
                  x_range=[0, 10],
@@ -204,9 +205,17 @@ def test_discretize_oversample():
                  mode='oversample', factor=10)
     vmax = np.max(values)
     vmax_yx = np.unravel_index(values.argmax(), values.shape)
-    
+    values_osf1 = discretize_model(gauss_2D,
+                                   x_range=[0, 10],
+                                   y_range=[100, 135],
+                                   mode='oversample', factor=1)
+    values_center = discretize_model(gauss_2D,
+                                   x_range=[0, 10],
+                                   y_range=[100, 135],
+                                   mode = 'center')
     assert values.shape == (35, 10)
     assert_allclose(vmax, 0.927, atol=1e-3)
     assert vmax_yx == (25, 5)
+    assert np.allclose(values_center, values_osf1)
     
     

--- a/astropy/convolution/tests/test_discretize.py
+++ b/astropy/convolution/tests/test_discretize.py
@@ -194,3 +194,19 @@ def test_float_y_range_exception():
         discretize_model(f, (-10, 11), (-10.002, 11.23))
     assert exc.value.args[0] == ("The difference between the upper an lower"
                                  " limit of 'y_range' must be a whole number.")
+    
+def test_discretize_oversample():
+    gauss_2D = Gaussian2D(amplitude=1.0, x_mean=5., 
+                    y_mean=125., x_stddev=0.75, y_stddev=3)
+    values = discretize_model(gauss_2D,
+                 x_range=[0, 10],
+                 y_range=[100, 135],
+                 mode='oversample', factor=10)
+    vmax = np.max(values)
+    vmax_yx = np.unravel_index(values.argmax(), values.shape)
+    
+    assert values.shape == (35, 10)
+    assert_allclose(vmax, 0.927, atol=1e-3)
+    assert vmax_yx == (25, 5)
+    
+    

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -248,14 +248,14 @@ def discretize_oversample_1D(model, x_range, factor=10):
     """
     # Evaluate model on oversampled grid
     x = np.linspace(x_range[0] - 0.5 * (1 - 1 / factor),
-                    x_range[1] + 0.5 * (1 - 1 / factor),
-                    num=(x_range[1] - x_range[0] + 1) * factor)   
+                    x_range[1] - 0.5 * (1 + 1 / factor),
+                    num = (x_range[1] - x_range[0]) * factor)   
 
     values = model(x)
 
     # Reshape and compute mean
     values = np.reshape(values, (x.size // factor, factor))
-    return values.mean(axis=1)[:-1]
+    return values.mean(axis=1)
 
 
 def discretize_oversample_2D(model, x_range, y_range, factor=10):
@@ -264,11 +264,11 @@ def discretize_oversample_2D(model, x_range, y_range, factor=10):
     """
     # Evaluate model on oversampled grid
     x = np.linspace(x_range[0] - 0.5 * (1 - 1 / factor),
-                    x_range[1] + 0.5 * (1 - 1 / factor),
-                    num=(x_range[1] - x_range[0] + 1) * factor)
+                    x_range[1] - 0.5 * (1 + 1 / factor),
+                    num = (x_range[1] - x_range[0]) * factor)
     y = np.linspace(y_range[0] - 0.5 * (1 - 1 / factor),
-                    y_range[1] + 0.5 * (1 - 1 / factor),
-                    num=(y_range[1] - y_range[0] + 1) * factor)    
+                    y_range[1] - 0.5 * (1 + 1 / factor),
+                    num = (y_range[1] - y_range[0]) * factor)    
 
     x_grid, y_grid = np.meshgrid(x, y)
     values = model(x_grid, y_grid)
@@ -276,7 +276,7 @@ def discretize_oversample_2D(model, x_range, y_range, factor=10):
     # Reshape and compute mean
     shape = (y.size // factor, factor, x.size // factor, factor)
     values = np.reshape(values, shape)
-    return values.mean(axis=3).mean(axis=1)[:-1, :-1]
+    return values.mean(axis=3).mean(axis=1)
 
 
 def discretize_integrate_1D(model, x_range):

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -247,8 +247,9 @@ def discretize_oversample_1D(model, x_range, factor=10):
     Discretize model by taking the average on an oversampled grid.
     """
     # Evaluate model on oversampled grid
-    x = np.arange(x_range[0] - 0.5 * (1 - 1 / factor),
-                  x_range[1] + 0.5 * (1 + 1 / factor), 1. / factor)
+    x = np.linspace(x_range[0] - 0.5 * (1 - 1 / factor),
+                    x_range[1] + 0.5 * (1 - 1 / factor),
+                    num=(x_range[1] - x_range[0] + 1) * factor)   
 
     values = model(x)
 
@@ -262,11 +263,13 @@ def discretize_oversample_2D(model, x_range, y_range, factor=10):
     Discretize model by taking the average on an oversampled grid.
     """
     # Evaluate model on oversampled grid
-    x = np.arange(x_range[0] - 0.5 * (1 - 1 / factor),
-                  x_range[1] + 0.5 * (1 + 1 / factor), 1. / factor)
+    x = np.linspace(x_range[0] - 0.5 * (1 - 1 / factor),
+                    x_range[1] + 0.5 * (1 - 1 / factor),
+                    num=(x_range[1] - x_range[0] + 1) * factor)
+    y = np.linspace(y_range[0] - 0.5 * (1 - 1 / factor),
+                    y_range[1] + 0.5 * (1 - 1 / factor),
+                    num=(y_range[1] - y_range[0] + 1) * factor)    
 
-    y = np.arange(y_range[0] - 0.5 * (1 - 1 / factor),
-                  y_range[1] + 0.5 * (1 + 1 / factor), 1. / factor)
     x_grid, y_grid = np.meshgrid(x, y)
     values = model(x_grid, y_grid)
 

--- a/astropy/convolution/utils.py
+++ b/astropy/convolution/utils.py
@@ -249,7 +249,7 @@ def discretize_oversample_1D(model, x_range, factor=10):
     # Evaluate model on oversampled grid
     x = np.linspace(x_range[0] - 0.5 * (1 - 1 / factor),
                     x_range[1] - 0.5 * (1 + 1 / factor),
-                    num = (x_range[1] - x_range[0]) * factor)   
+                    num = (x_range[1] - x_range[0]) * factor)
 
     values = model(x)
 
@@ -268,7 +268,7 @@ def discretize_oversample_2D(model, x_range, y_range, factor=10):
                     num = (x_range[1] - x_range[0]) * factor)
     y = np.linspace(y_range[0] - 0.5 * (1 - 1 / factor),
                     y_range[1] - 0.5 * (1 + 1 / factor),
-                    num = (y_range[1] - y_range[0]) * factor)    
+                    num = (y_range[1] - y_range[0]) * factor)
 
     x_grid, y_grid = np.meshgrid(x, y)
     values = model(x_grid, y_grid)


### PR DESCRIPTION
replace np.arange() with np.linspace() for calculating the oversampling grid; np.arange() is often not consistent in the output vector length if step is non-integer.

related to https://github.com/astropy/astropy/issues/8492

closes #8492