### PR TITLE
Improve error message for bad input to Time init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,9 @@ astropy.time
 - Made scalar ``Time`` and ``TimeDelta`` objects hashable based on JD, time
   scale, and location attributes. [#8912]
 
+- Improved error message when bad input is used to initialize a ``Time`` or
+  ``TimeDelta`` object and the format is specified. [#9296]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import os
 import copy
 import functools
 import datetime
@@ -1710,3 +1711,27 @@ def test_hash_time_delta():
     with pytest.raises(TypeError) as exc:
         hash(t[3])
     assert exc.value.args[0] == "unhashable type: 'TimeDelta' (value is masked)"
+
+
+def test_get_time_fmt_exception_messages():
+    with pytest.raises(ValueError) as err:
+        Time(10)
+    assert "No time format was given, and the input is" in str(err.value)
+
+    with pytest.raises(ValueError) as err:
+        Time('2000:001', format='not-a-format')
+    assert "Format 'not-a-format' is not one of the allowed" in str(err.value)
+
+    with pytest.raises(ValueError) as err:
+        Time('200')
+    assert 'Input values did not match any of the formats where' in str(err.value)
+
+    with pytest.raises(ValueError) as err:
+        Time('200', format='iso')
+    assert ('Input values did not match the format class iso:' + os.linesep +
+            'ValueError: Time 200 does not match iso format') == str(err.value)
+
+    with pytest.raises(ValueError) as err:
+        Time(200, format='iso')
+    assert ('Input values did not match the format class iso:' + os.linesep +
+            'TypeError: Input values for iso class must be strings') == str(err.value)

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1137,7 +1137,8 @@ of time.  Usage is most easily illustrated by examples::
   ...
   Traceback (most recent call last):
     ...
-  ValueError: Input values did not match the format class byear
+  ValueError: Input values did not match the format class byear:
+  ValueError: Cannot use Quantities for 'byear' format, as the interpretation would be ambiguous. Use float with Besselian year instead.
 
   >>> TimeDelta(10.*u.yr)            # With a quantity, no format is required
   <TimeDelta object: scale='None' format='jd' value=3652.5>


### PR DESCRIPTION
This addresses https://github.com/astropy/astropy/issues/9231#issuecomment-535517402, namely providing the upstream exception in the case where `format` is specified but the input value is bad.