### PR TITLE
Inputs on Model instances

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,11 @@ astropy.modeling
 - New function ``fix_inputs`` to generate new models from others by fixing
   specific inputs variable values to constants. [#9135]
 
+- ``inputs`` and ``outputs`` are now model instance attributes, and ``n_inputs``
+  and ``n_outputs`` are class attributes. Backwards compatible default values of
+  ``inputs`` and ``outputs`` are generated. ``Model.inputs`` and ``Model.outputs``
+  are now settable which allows renaming them on per user case. [#9298]
+
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -29,10 +29,16 @@ class TransformType(AstropyAsdfType):
             model.bounding_box = yamlutil.tagged_tree_to_custom_tree(node['bounding_box'], ctx)
 
         if "inputs" in node:
-            model.inputs = node["inputs"]
+            if model.n_inputs == 1:
+                model.inputs = (node["inputs"],)
+            else:
+                model.inputs = tuple(node["inputs"])
 
         if "outputs" in node:
-            model.outputs = node["outputs"]
+            if model.n_outputs == 1:
+                model.outputs = (node["outputs"],)
+            else:
+                model.outputs = tuple(node["outputs"])
 
         return model
 
@@ -67,8 +73,9 @@ class TransformType(AstropyAsdfType):
             else:
                 bb = [list(item) for item in model.bounding_box]
             node['bounding_box'] = yamlutil.custom_tree_to_tagged_tree(bb, ctx)
-        node['inputs'] = model.inputs
-        node['outputs'] = model.outputs
+        if type(model.__class__.inputs) != property:
+            node['inputs'] = model.inputs
+            node['outputs'] = model.outputs
 
     @classmethod
     def to_tree_transform(cls, model, ctx):

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -28,6 +28,12 @@ class TransformType(AstropyAsdfType):
         if 'bounding_box' in node:
             model.bounding_box = yamlutil.tagged_tree_to_custom_tree(node['bounding_box'], ctx)
 
+        if "inputs" in node:
+            model.inputs = node["inputs"]
+
+        if "outputs" in node:
+            model.outputs = node["outputs"]
+
         return model
 
     @classmethod
@@ -61,6 +67,8 @@ class TransformType(AstropyAsdfType):
             else:
                 bb = [list(item) for item in model.bounding_box]
             node['bounding_box'] = yamlutil.custom_tree_to_tagged_tree(bb, ctx)
+        node['inputs'] = model.inputs
+        node['outputs'] = model.outputs
 
     @classmethod
     def to_tree_transform(cls, model, ctx):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -749,19 +749,19 @@ class Model(metaclass=_ModelMeta):
 
         self._inputs = val
         self._initialize_unit_support()
-        args = ("self",) + val
-        new_call = make_function_with_signature(self.__call__,
-                                                args,
-                                                [('model_set_axis', None),
-                                                 ('with_bounding_box', False),
-                                                 ('fill_value', np.nan),
-                                                 ('equivalencies', None),
-                                                 ('inputs_map', None)])
+        #args = ("self",) + val
+        #new_call = make_function_with_signature(self.__call__,
+        #                                        args,
+        #                                        [('model_set_axis', None),
+        #                                         ('with_bounding_box', False),
+        #                                         ('fill_value', np.nan),
+        #                                         ('equivalencies', None),
+        #                                         ('inputs_map', None)])
         ##update_wrapper(new_call, self)
         ##self.__class__.__call__ = new_call
-        import functools
-        new_call = functools.update_wrapper(self.__class__.__call__, new_call)
-        self.__call__ = new_call
+        #import functools
+        #new_call = functools.update_wrapper(self.__class__.__call__, new_call)
+        #self.__call__ = new_call
 
     @property
     def outputs(self):
@@ -2239,6 +2239,8 @@ class FittableModel(Model):
     col_fit_deriv = True
     fittable = True
 
+    def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
 
 class Fittable1DModel(FittableModel):
     """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -730,7 +730,7 @@ class Model(metaclass=_ModelMeta):
             f"""Class {self.__class__.__name__} defines class attributes ``inputs``.
             This has been deprecated in v4.0 and support will be removed in v4.1.
             Starting with v4.0 classes must defnie a class attribute ``n_inputs``.
-            Please consult the documentaiton for details.
+            Please consult the documentation for details.
             """, AstropyDeprecationWarning)
 
     def _default_inputs_outputs(self):
@@ -801,7 +801,6 @@ class Model(metaclass=_ModelMeta):
                     return 0
 
         return self.__class__.n_outputs
-
 
     def _initialize_unit_support(self):
         """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -924,7 +924,6 @@ class Model(metaclass=_ModelMeta):
             new_args = args
         return generic_call(self, *new_args, **kwargs)
 
-
     # *** Properties ***
     @property
     def name(self):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -213,8 +213,8 @@ class _ModelMeta(abc.ABCMeta):
             >>> SkyRotation
             <class 'astropy.modeling.core.SkyRotation'>
             Name: SkyRotation (Rotation2D)
-            Inputs: ('x', 'y')
-            Outputs: ('x', 'y')
+            N_inputs: 2
+            N_outputs: 2
             Fittable parameters: ('angle',)
             >>> issubclass(SkyRotation, Rotation2D)
             True
@@ -371,10 +371,7 @@ class _ModelMeta(abc.ABCMeta):
             if hasattr(cls, '__qualname__'):
                 wrapper.__qualname__ = '{0}.{1}'.format(
                         cls.__qualname__, wrapper.__name__)
-        #if "n_inputs" in members:
-        #    print("members", cls.name, members['n_inputs'])
-        #if ('__call__' not in members and 'inputs' in members and
-        #        isinstance(members['inputs'], tuple)):
+
         if ('__call__' not in members and 'n_inputs' in members and
             isinstance(members['n_inputs'], int) and members['n_inputs'] > 0):
             n_inputs = members['n_inputs']
@@ -403,8 +400,7 @@ class _ModelMeta(abc.ABCMeta):
             #
             # The following code creates the __call__ function with these
             # two keyword arguments.
-            #inputs = ()#members['inputs']
-            #nputs = tuple(['x'+str(i) for i in range(members['n_inputs'])])
+
             args = ('self',) + inputs
             new_call = make_function_with_signature(
                     __call__, args, [('model_set_axis', None),
@@ -746,22 +742,8 @@ class Model(metaclass=_ModelMeta):
 
     @inputs.setter
     def inputs(self, val):
-
         self._inputs = val
         self._initialize_unit_support()
-        #args = ("self",) + val
-        #new_call = make_function_with_signature(self.__call__,
-        #                                        args,
-        #                                        [('model_set_axis', None),
-        #                                         ('with_bounding_box', False),
-        #                                         ('fill_value', np.nan),
-        #                                         ('equivalencies', None),
-        #                                         ('inputs_map', None)])
-        ##update_wrapper(new_call, self)
-        ##self.__class__.__call__ = new_call
-        #import functools
-        #new_call = functools.update_wrapper(self.__class__.__call__, new_call)
-        #self.__call__ = new_call
 
     @property
     def outputs(self):
@@ -887,8 +869,6 @@ class Model(metaclass=_ModelMeta):
         Evaluate this model using the given input(s) and the parameter values
         that were specified when the model was instantiated.
         """
-        #kw = dict(zip(self.inputs, inputs))
-        #kwargs.update(kw)
 
         return generic_call(self, *inputs, **kwargs)
 
@@ -2241,6 +2221,7 @@ class FittableModel(Model):
 
     def __call__(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)
+
 
 class Fittable1DModel(FittableModel):
     """

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -725,11 +725,11 @@ class Model(metaclass=_ModelMeta):
         self._inputs_deprecation()
 
     def _inputs_deprecation(self):
-        if hasattr(self.__class__, 'n_inputs') and isinstance(self.__class__.n_inputs, property):
+        if hasattr(self.__class__, 'inputs') and isinstance(self.__class__.inputs, tuple):
             warnings.warn(
             f"""Class {self.__class__.__name__} defines class attributes ``inputs``.
             This has been deprecated in v4.0 and support will be removed in v4.1.
-            Starting with v4.0 classes must defnie a class attribute ``n_inputs``.
+            Starting with v4.0 classes must define a class attribute ``n_inputs``.
             Please consult the documentation for details.
             """, AstropyDeprecationWarning)
 

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -569,9 +569,6 @@ class Multiply(Fittable1DModel):
         Factor by which to multiply a coordinate.
     """
 
-    inputs = ('x',)
-    outputs = ('y',)
-
     factor = Parameter(default=1)
     linear = True
     fittable = True

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -62,7 +62,7 @@ class Mapping(FittableModel):
             self.outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         else:
             self.inputs = tuple('x' + str(idx)
-                                 for idx in range(n_inputs))
+                                for idx in range(n_inputs))
             self.outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
         self._input_units_strict = {key: False for key in self._inputs}

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -68,7 +68,6 @@ class Mapping(FittableModel):
         self._input_units_strict = {key: False for key in self._inputs}
         self._input_units_allow_dimensionless = {key: False for key in self._inputs}
 
-
     @property
     def n_inputs(self):
         return self._n_inputs

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -47,31 +47,35 @@ class Mapping(FittableModel):
     linear = True  # FittableModel is non-linear by default
 
     def __init__(self, mapping, n_inputs=None, name=None, meta=None):
+
         if n_inputs is None:
-            self._inputs = tuple('x' + str(idx)
-                                 for idx in range(max(mapping) + 1))
+            self._n_inputs = max(mapping) + 1
         else:
-            self._inputs = tuple('x' + str(idx)
+            self._n_inputs = n_inputs
+
+        self._n_outputs = len(mapping)
+        super().__init__(name=name, meta=meta)
+
+        if n_inputs is None:
+            self.inputs = tuple('x' + str(idx)
+                                for idx in range(max(mapping) + 1))
+            self.outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
+        else:
+            self.inputs = tuple('x' + str(idx)
                                  for idx in range(n_inputs))
-        self._outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
+            self.outputs = tuple('x' + str(idx) for idx in range(len(mapping)))
         self._mapping = mapping
         self._input_units_strict = {key: False for key in self._inputs}
         self._input_units_allow_dimensionless = {key: False for key in self._inputs}
-        super().__init__(name=name, meta=meta)
+
 
     @property
-    def inputs(self):
-        """
-        The name(s) of the input variable(s) on which a model is evaluated.
-        """
-
-        return self._inputs
+    def n_inputs(self):
+        return self._n_inputs
 
     @property
-    def outputs(self):
-        """The name(s) of the output(s) of the model."""
-
-        return self._outputs
+    def n_outputs(self):
+        return self._n_outputs
 
     @property
     def mapping(self):
@@ -122,6 +126,8 @@ class Mapping(FittableModel):
         inv = self.__class__(mapping)
         inv._inputs = self._outputs
         inv._outputs = self._inputs
+        inv._n_inputs = len(inv._inputs)
+        inv._n_outputs = len(inv._outputs)
         return inv
 
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1420,6 +1420,8 @@ class SIP(Model):
                               model_set_axis=model_set_axis, **b_coeff)
         super().__init__(n_models=n_models, model_set_axis=model_set_axis,
                          name=name, meta=meta)
+        self._inputs = ("u", "v")
+        self._outputs = ("x", "y")
 
     def __repr__(self):
         return '<{}({!r})>'.format(self.__class__.__name__,

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -163,8 +163,8 @@ class OrthoPolynomialBase(PolynomialBase):
         {keyword: value} pairs, representing {parameter_name: value}
     """
 
-    inputs = ('x', 'y')
-    outputs = ('z',)
+    n_inputs = 2
+    n_outputs = 1
 
     def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
                  y_domain=None, y_window=None, n_models=None,
@@ -337,9 +337,9 @@ class Chebyshev1D(PolynomialModel):
     third Chebyshev polynomial (T2) is 2x^2-1, but if x was specified with
     units, 2x^2 and -1 would have incompatible units.
     """
+    n_inputs = 1
+    n_outputs = 1
 
-    inputs = ('x',)
-    outputs = ('y',)
     _separable = True
 
     def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
@@ -443,9 +443,9 @@ class Hermite1D(PolynomialModel):
     third Hermite polynomial (H2) is 4x^2-2, but if x was specified with units,
     4x^2 and -2 would have incompatible units.
     """
+    n_inputs = 1
+    n_outputs = 1
 
-    inputs = ('x')
-    outputs = ('y')
     _separable = True
 
     def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
@@ -675,9 +675,10 @@ class Legendre1D(PolynomialModel):
     units, 1.5x^2 and -0.5 would have incompatible units.
     """
 
-    inputs = ('x',)
-    outputs = ('y',)
-    _separable = False
+    n_inputs = 1
+    n_outputs = 1
+
+    _separable = True
 
     def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
@@ -768,8 +769,9 @@ class Polynomial1D(PolynomialModel):
 
     """
 
-    inputs = ('x',)
-    outputs = ('y',)
+    n_inputs = 1
+    n_outputs = 1
+
     _separable = True
 
     def __init__(self, degree, domain=[-1, 1], window=[-1, 1], n_models=None,
@@ -869,8 +871,9 @@ class Polynomial2D(PolynomialModel):
         keyword: value pairs, representing parameter_name: value
     """
 
-    inputs = ('x', 'y')
-    outputs = ('z',)
+    n_inputs = 2
+    n_outputs = 1
+
     _separable = False
 
     def __init__(self, degree, x_domain=[-1, 1], y_domain=[-1, 1],
@@ -1267,8 +1270,9 @@ class _SIP1D(PolynomialBase):
     and SIP should be used instead.
     """
 
-    inputs = ('u', 'v')
-    outputs = ('w',)
+    n_inputs = 2
+    n_outputs = 1
+
     _separable = False
 
     def __init__(self, order, coeff_prefix, n_models=None,
@@ -1391,8 +1395,9 @@ class SIP(Model):
     .. [1] `David Shupe, et al, ADASS, ASP Conference Series, Vol. 347, 2005 <http://adsabs.harvard.edu/abs/2005ASPC..347..491S>`_
     """
 
-    inputs = ('u', 'v')
-    outputs = ('x', 'y')
+    n_inputs = 2
+    n_outputs = 2
+
     _separable = False
 
     def __init__(self, crpix, a_order, b_order, a_coeff={}, b_coeff={},
@@ -1461,8 +1466,9 @@ class InverseSIP(Model):
 
     """
 
-    inputs = ('x', 'y')
-    outputs = ('u', 'v')
+    n_inputs = 2
+    n_outputs = 2
+
     _separable = False
 
     def __init__(self, ap_order, bp_order, ap_coeff={}, bp_coeff={},

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -119,11 +119,19 @@ class Projection(Model):
 class Pix2SkyProjection(Projection):
     """Base class for all Pix2Sky projections."""
 
-    inputs = ('x', 'y')
-    outputs = ('phi', 'theta')
+    #inputs = ('x', 'y')
+    #outputs = ('phi', 'theta')
+    n_inputs = 2
+    n_outputs = 2
 
     _input_units_strict = True
     _input_units_allow_dimensionless = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._inputs = ('x', 'y')
+        self._outputs = ('phi', 'theta')
+
 
     @property
     def input_units(self):
@@ -137,11 +145,21 @@ class Pix2SkyProjection(Projection):
 class Sky2PixProjection(Projection):
     """Base class for all Sky2Pix projections."""
 
-    inputs = ('phi', 'theta')
-    outputs = ('x', 'y')
+    #inputs = ('phi', 'theta')
+    #outputs = ('x', 'y')
+
+    n_inputs = 2
+    n_outputs = 2
 
     _input_units_strict = True
     _input_units_allow_dimensionless = True
+
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._inputs = ('phi', 'theta')
+        self._outputs = ('x', 'y')
+
 
     @property
     def input_units(self):
@@ -1948,9 +1966,10 @@ class AffineTransformation2D(Model):
         translation to apply to the inputs
     """
 
-    inputs = ('x', 'y')
-    outputs = ('x', 'y')
-
+    #inputs = ('x', 'y')
+    #outputs = ('x', 'y')
+    n_inputs = 2
+    n_outputs = 2
     standard_broadcasting = False
 
     _separable = False
@@ -1979,6 +1998,11 @@ class AffineTransformation2D(Model):
             raise InputParameterError(
                 "Expected translation vector to be a 2 element row or column "
                 "vector array")
+
+    def __init__(self, matrix=matrix, translation=translation, **kwargs):
+        super().__init__(matrix=matrix, translation=translation, **kwargs)
+        self.inputs = ("x", "y")
+        self.outputs = ("x", "y")
 
     @property
     def inverse(self):
@@ -2059,10 +2083,7 @@ class AffineTransformation2D(Model):
         if self.translation.unit is None and self.matrix.unit is None:
             return None
         elif self.translation.unit is not None:
-            return {'x': self.translation.unit,
-                    'y': self.translation.unit
-                    }
+            return dict(zip(self.inputs, [self.translation.unit] * 2)) 
+
         else:
-            return {'x': self.matrix.unit,
-                    'y': self.matrix.unit
-                    }
+            return dict(zip(self.inputs, [self.matrix.unit] * 2)) 

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -1958,10 +1958,9 @@ class AffineTransformation2D(Model):
         translation to apply to the inputs
     """
 
-    #inputs = ('x', 'y')
-    #outputs = ('x', 'y')
     n_inputs = 2
     n_outputs = 2
+
     standard_broadcasting = False
 
     _separable = False

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -132,7 +132,6 @@ class Pix2SkyProjection(Projection):
         self._inputs = ('x', 'y')
         self._outputs = ('phi', 'theta')
 
-
     @property
     def input_units(self):
         return {'x': u.deg, 'y': u.deg}
@@ -145,21 +144,16 @@ class Pix2SkyProjection(Projection):
 class Sky2PixProjection(Projection):
     """Base class for all Sky2Pix projections."""
 
-    #inputs = ('phi', 'theta')
-    #outputs = ('x', 'y')
-
     n_inputs = 2
     n_outputs = 2
 
     _input_units_strict = True
     _input_units_allow_dimensionless = True
 
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._inputs = ('phi', 'theta')
         self._outputs = ('x', 'y')
-
 
     @property
     def input_units(self):
@@ -2083,7 +2077,6 @@ class AffineTransformation2D(Model):
         if self.translation.unit is None and self.matrix.unit is None:
             return None
         elif self.translation.unit is not None:
-            return dict(zip(self.inputs, [self.translation.unit] * 2)) 
-
+            return dict(zip(self.inputs, [self.translation.unit] * 2))
         else:
-            return dict(zip(self.inputs, [self.matrix.unit] * 2)) 
+            return dict(zip(self.inputs, [self.matrix.unit] * 2))

--- a/astropy/modeling/projections.py
+++ b/astropy/modeling/projections.py
@@ -119,8 +119,6 @@ class Projection(Model):
 class Pix2SkyProjection(Projection):
     """Base class for all Pix2Sky projections."""
 
-    #inputs = ('x', 'y')
-    #outputs = ('phi', 'theta')
     n_inputs = 2
     n_outputs = 2
 
@@ -129,8 +127,8 @@ class Pix2SkyProjection(Projection):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._inputs = ('x', 'y')
-        self._outputs = ('phi', 'theta')
+        self.inputs = ('x', 'y')
+        self.outputs = ('phi', 'theta')
 
     @property
     def input_units(self):
@@ -152,8 +150,8 @@ class Sky2PixProjection(Projection):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._inputs = ('phi', 'theta')
-        self._outputs = ('x', 'y')
+        self.inputs = ('phi', 'theta')
+        self.outputs = ('x', 'y')
 
     @property
     def input_units(self):

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -129,8 +129,8 @@ class EulerAngleRotation(_EulerRotation, Model):
         where each character denotes an axis in 3D space.
     """
 
-    inputs = ('alpha', 'delta')
-    outputs = ('alpha', 'delta')
+    n_inputs = 2
+    n_outputs = 2
 
     phi = Parameter(default=0, getter=_to_orig_unit, setter=_to_radian)
     theta = Parameter(default=0, getter=_to_orig_unit, setter=_to_radian)
@@ -152,6 +152,9 @@ class EulerAngleRotation(_EulerRotation, Model):
             raise TypeError("All parameters should be of the same type - float or Quantity.")
 
         super().__init__(phi=phi, theta=theta, psi=psi, **kwargs)
+        self._inputs = ('alpha', 'delta')
+        self._outputs = ('alpha', 'delta')
+
 
     def inverse(self):
         return self.__class__(phi=-self.psi,
@@ -206,14 +209,13 @@ class RotateNative2Celestial(_SkyRotation):
 
     Notes
     -----
-    If ``lon``, ``lat`` and ``lon_pole`` are numerical values they should be in units of deg.
+    If ``lon``, ``lat`` and ``lon_pole`` are numerical values they
+    should be in units of deg. Inputs are angles on the native sphere.
+    Outputs are angles on the celestial sphere.
     """
 
-    #: Inputs are angles on the native sphere
-    inputs = ('phi_N', 'theta_N')
-
-    #: Outputs are angles on the celestial sphere
-    outputs = ('alpha_C', 'delta_C')
+    n_inputs = 2
+    n_outputs = 2
 
     @property
     def input_units(self):
@@ -227,6 +229,8 @@ class RotateNative2Celestial(_SkyRotation):
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
         super().__init__(lon, lat, lon_pole, **kwargs)
+        self.inputs = ('phi_N', 'theta_N')
+        self.outputs = ('alpha_C', 'delta_C')
 
     def evaluate(self, phi_N, theta_N, lon, lat, lon_pole):
         """
@@ -275,14 +279,12 @@ class RotateCelestial2Native(_SkyRotation):
 
     Notes
     -----
-    If ``lon``, ``lat`` and ``lon_pole`` are numerical values they should be in units of deg.
+    If ``lon``, ``lat`` and ``lon_pole`` are numerical values they should be
+    in units of deg. Inputs are angles on the celestial sphere.
+    Outputs are angles on the native sphere.
     """
-
-    #: Inputs are angles on the celestial sphere
-    inputs = ('alpha_C', 'delta_C')
-
-    #: Outputs are angles on the native sphere
-    outputs = ('phi_N', 'theta_N')
+    n_inputs = 2
+    n_outputs = 2
 
     @property
     def input_units(self):
@@ -296,6 +298,11 @@ class RotateCelestial2Native(_SkyRotation):
 
     def __init__(self, lon, lat, lon_pole, **kwargs):
         super().__init__(lon, lat, lon_pole, **kwargs)
+
+        # Inputs are angles on the celestial sphere
+        self.inputs = ('alpha_C', 'delta_C')
+        # Outputs are angles on the native sphere
+        self.outputs = ('phi_N', 'theta_N')
 
     def evaluate(self, alpha_C, delta_C, lon, lat, lon_pole):
         """
@@ -340,9 +347,9 @@ class Rotation2D(Model):
     angle : float or `~astropy.units.Quantity`
         Angle of rotation (if float it should be in deg).
     """
+    n_inputs = 2
+    n_outputs = 2
 
-    inputs = ('x', 'y')
-    outputs = ('x', 'y')
     _separable = False
 
     angle = Parameter(default=0.0, getter=_to_orig_unit, setter=_to_radian)

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -155,7 +155,6 @@ class EulerAngleRotation(_EulerRotation, Model):
         self._inputs = ('alpha', 'delta')
         self._outputs = ('alpha', 'delta')
 
-
     def inverse(self):
         return self.__class__(phi=-self.psi,
                               theta=-self.theta,

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -353,6 +353,11 @@ class Rotation2D(Model):
 
     angle = Parameter(default=0.0, getter=_to_orig_unit, setter=_to_radian)
 
+    def __init__(self, angle=angle, **kwargs):
+        super().__init__(angle=angle, **kwargs)
+        self._inputs = ("x", "y")
+        self._outputs = ("x", "y")
+
     @property
     def inverse(self):
         """Inverse rotation."""

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -84,7 +84,6 @@ class _Tabular(Model):
     fittable = False
 
     standard_broadcasting = False
-    #outputs = ('y',)
 
     @property
     @abc.abstractmethod
@@ -149,8 +148,8 @@ class _Tabular(Model):
         default_keywords = [
             ('Model', self.__class__.__name__),
             ('Name', self.name),
-            ('Inputs', self.inputs),
-            ('Outputs', self.outputs),
+            ('N_inputs', self.n_inputs),
+            ('N_outputs', self.n_outputs),
             ('Parameters', ""),
             ('  points', self.points),
             ('  lookup_table', self.lookup_table),

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -84,7 +84,7 @@ class _Tabular(Model):
     fittable = False
 
     standard_broadcasting = False
-    outputs = ('y',)
+    #outputs = ('y',)
 
     @property
     @abc.abstractmethod
@@ -102,7 +102,7 @@ class _Tabular(Model):
         if n_models > 1:
             raise NotImplementedError('Only n_models=1 is supported.')
         super().__init__(**kwargs)
-
+        self.outputs = ("y",)
         if lookup_table is None:
             raise ValueError('Must provide a lookup table.')
 
@@ -301,8 +301,7 @@ def tabular_model(dim, name=None):
         raise ValueError('Lookup table must have at least one dimension.')
 
     table = np.zeros([2] * dim)
-    inputs = tuple(f'x{idx}' for idx in range(table.ndim))
-    members = {'lookup_table': table, 'inputs': inputs}
+    members = {'lookup_table': table, 'n_inputs': dim, 'n_outputs': 1}
 
     if dim == 1:
         members['_separable'] = True

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -282,8 +282,8 @@ def tabular_model(dim, name=None):
     >>> print(tab)
     <class 'abc.Tabular2D'>
     Name: Tabular2D
-    Inputs: (u'x0', u'x1')
-    Outputs: (u'y',)
+    N_inputs: 2
+    N_outputs: 1
 
     >>> points = ([1, 2, 3], [1, 2, 3])
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -321,7 +321,6 @@ def test_compound_with_polynomials_1d(poly):
     assert_allclose(result, result_compound)
 
 
-
 def test_fix_inputs():
     g1 = Gaussian2D(1, 0, 0, 1, 2)
     g2 = Gaussian2D(1.5, .5, -.2, .5, .3)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -291,9 +291,8 @@ def test_invalid_operands():
         Rotation2D(90) + Gaussian1D(1, 0, 0.1)
 
 
-@pytest.mark.parametrize('poly', [Chebyshev2D(1, 2), Polynomial2D(2), Legendre2D(1, 2),
-                                  Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
-def test_compound_with_polynomials(poly):
+@pytest.mark.parametrize('poly', [Chebyshev2D(1, 2), Polynomial2D(2), Legendre2D(1, 2)])
+def test_compound_with_polynomials_2d(poly):
     """
     Tests that polynomials are scaled when used in compound models.
     Issue #3699
@@ -305,6 +304,22 @@ def test_compound_with_polynomials(poly):
     result_compound = model(x, y)
     result = shift(poly(x, y))
     assert_allclose(result, result_compound)
+
+
+@pytest.mark.parametrize('poly', [Chebyshev1D(5), Legendre1D(5), Polynomial1D(5)])
+def test_compound_with_polynomials_1d(poly):
+    """
+    Tests that polynomials are scaled when used in compound models.
+    Issue #3699
+    """
+    poly.parameters = [1, 2, 3, 4, 1, 2]
+    shift = Shift(3)
+    model = poly | shift
+    x, y = np.mgrid[:20, :37]
+    result_compound = model(x)
+    result = shift(poly(x))
+    assert_allclose(result, result_compound)
+
 
 
 def test_fix_inputs():

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -465,3 +465,15 @@ def test_rename_1d(model_class):
 def test_rename_2d(model_class):
     new_model = model_class.rename(name='Test2D')
     assert new_model.name == 'Test2D'
+
+
+def test_rename_inputs_outputs():
+    g2 = models.Gaussian2D(10, 2, 3, 1, 2)
+    assert g2.inputs == ("x", "y")
+    assert g2.outputs == ("z",)
+
+    with pytest.raises(ValueError):
+        g2.inputs = ("w", )
+
+    with pytest.raises(ValueError):
+        g2.outputs = ("w", "e")

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -113,9 +113,9 @@ def test_custom_model_signature():
     sig = signature(model_a.__init__)
     assert list(sig.parameters.keys()) == ['self', 'args', 'meta', 'name', 'kwargs']
     sig = signature(model_a.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+    assert list(sig.parameters.keys()) == ['self', 'inputs', 'model_set_axis',
                                            'with_bounding_box', 'fill_value',
-                                           'equivalencies', 'inputs_map']
+                                           'equivalencies', 'inputs_map', 'new_inputs']
 
     @custom_model
     def model_b(x, a=1, b=2):
@@ -127,9 +127,9 @@ def test_custom_model_signature():
     assert list(sig.parameters.keys()) == ['self', 'a', 'b', 'kwargs']
     assert [x.default for x in sig.parameters.values()] == [sig.empty, 1, 2, sig.empty]
     sig = signature(model_b.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+    assert list(sig.parameters.keys()) == ['self', 'inputs', 'model_set_axis',
                                            'with_bounding_box', 'fill_value',
-                                           'equivalencies', 'inputs_map']
+                                           'equivalencies', 'inputs_map', 'new_inputs']
 
     @custom_model
     def model_c(x, y, a=1, b=2):
@@ -141,9 +141,9 @@ def test_custom_model_signature():
     assert list(sig.parameters.keys()) == ['self', 'a', 'b', 'kwargs']
     assert [x.default for x in sig.parameters.values()] == [sig.empty, 1, 2, sig.empty]
     sig = signature(model_c.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'y', 'model_set_axis',
+    assert list(sig.parameters.keys()) == ['self', 'inputs', 'model_set_axis',
                                            'with_bounding_box', 'fill_value',
-                                           'equivalencies', 'inputs_map']
+                                           'equivalencies', 'inputs_map', 'new_inputs']
 
 
 def test_custom_model_subclass():
@@ -167,9 +167,9 @@ def test_custom_model_subclass():
     sig = signature(model_b.__init__)
     assert list(sig.parameters.keys()) == ['self', 'a', 'kwargs']
     sig = signature(model_b.__call__)
-    assert list(sig.parameters.keys()) == ['self', 'x', 'model_set_axis',
+    assert list(sig.parameters.keys()) == ['self', 'inputs', 'model_set_axis',
                                            'with_bounding_box', 'fill_value',
-                                           'equivalencies', 'inputs_map']
+                                           'equivalencies', 'inputs_map', 'new_inputs']
 
 
 def test_custom_model_parametrized_decorator():

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -65,8 +65,8 @@ def test_inputless_model():
     """
 
     class TestModel(Model):
-        inputs = ()
-        outputs = ('y',)
+
+        n_outputs = 1
         a = Parameter()
 
         @staticmethod
@@ -419,13 +419,13 @@ print(repr(Gaussian1D.rename('CustomGaussian')))
 MODEL_RENAME_EXPECTED = b"""
 <class 'astropy.modeling.functional_models.Gaussian1D'>
 Name: Gaussian1D
-Inputs: ('x',)
-Outputs: ('y',)
+N_inputs: 1
+N_outputs: 1
 Fittable parameters: ('amplitude', 'mean', 'stddev')
 <class '__main__.CustomGaussian'>
 Name: CustomGaussian (Gaussian1D)
-Inputs: ('x',)
-Outputs: ('y',)
+N_inputs: 1
+N_outputs: 1
 Fittable parameters: ('amplitude', 'mean', 'stddev')
 """.strip()
 
@@ -456,32 +456,12 @@ def test_rename_path(tmpdir):
                          [models.Gaussian1D, models.Polynomial1D,
                           models.Shift, models.Tabular1D])
 def test_rename_1d(model_class):
-    new_model = model_class.rename(name='Test1D', inputs=('r',), outputs=('q',))
+    new_model = model_class.rename(name='Test1D')
     assert new_model.name == 'Test1D'
-    assert new_model.inputs == ('r',)
-    assert new_model.outputs == ('q',)
 
 
 @pytest.mark.parametrize('model_class',
                          [models.Gaussian2D, models.Polynomial2D, models.Tabular2D])
 def test_rename_2d(model_class):
-    new_model = model_class.rename(name='Test2D', inputs=('r', 't'), outputs=('q',))
+    new_model = model_class.rename(name='Test2D')
     assert new_model.name == 'Test2D'
-    assert new_model.inputs == ('r', 't')
-    assert new_model.outputs == ('q',)
-
-    new_model = model_class.rename(inputs=('r', 't'), outputs=('q',))
-    assert new_model.name == model_class.name
-    assert new_model.inputs == ('r', 't')
-    assert new_model.outputs == ('q',)
-
-
-def test_rename_invalid():
-    with pytest.raises(TypeError):
-        models.Gaussian1D.rename(inputs=('w'))
-    with pytest.raises(TypeError):
-        models.Gaussian1D.rename(outputs=('w'))
-    with pytest.raises(ValueError):
-        models.Gaussian2D.rename(inputs=('w',))
-    with pytest.raises(ValueError):
-        models.Gaussian2D.rename(outputs=('w', 'e'))

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -825,7 +825,8 @@ class TInputFormatter(Model):
     """
     A toy model to test input/output formatting.
     """
-
+    n_inputs = 2
+    n_outputs = 2
     inputs = ('x', 'y')
     outputs = ('x', 'y')
 
@@ -856,7 +857,7 @@ def test_format_input_arrays_transposed():
 @pytest.mark.parametrize('model',
                          [models.Gaussian2D(), models.Polynomial2D(1,),
                           models.Pix2Sky_TAN(), models.Tabular2D(lookup_table=np.ones((4,5)))])
-def test_call_keyword_args1(model):
+def test_call_keyword_args_2(model):
     """
     Test calling a model with positional, keywrd and a mixture of both arguments.
     """
@@ -868,3 +869,91 @@ def test_call_keyword_args1(model):
     assert_allclose(positional, model(r=1, t=2))
     assert_allclose(positional, model(1, t=2))
     assert_allclose(positional, model(1, 2))
+
+    with pytest.raises(ValueError):
+        model(1, 2, 3)
+
+    with pytest.raises(ValueError):
+        model(1)
+
+    with pytest.raises(ValueError):
+        model(1, 2, t=12, r=3)
+
+
+@pytest.mark.parametrize('model',
+                         [models.Gaussian1D(), models.Polynomial1D(1,),
+                          models.Tabular1D(lookup_table=np.ones((5,))),
+                          models.Rotation2D(), models.Pix2Sky_TAN()])
+def test_call_keyword_args_1(model):
+    """
+    Test calling a model with positional, keywrd and a mixture of both arguments.
+    """
+    positional = model(1)
+    assert_allclose(positional, model(x=1))
+
+    model.inputs = ('r',)
+    assert_allclose(positional, model(r=1))
+
+    with pytest.raises(ValueError):
+        model(1, 2, 3)
+
+    with pytest.raises(ValueError):
+        model()
+
+    with pytest.raises(ValueError):
+        model(1, 2, t=12, r=3)
+
+
+@pytest.mark.parametrize('model',
+                         [models.Gaussian2D() | models.Polynomial1D(1,),
+                          models.Gaussian1D() & models.Polynomial1D(1,),
+                          models.Gaussian2D() + models.Polynomial2D(1,),
+                          models.Gaussian2D() - models.Polynomial2D(1,),
+                          models.Gaussian2D() * models.Polynomial2D(1,),
+                          models.Identity(2) | models.Polynomial2D(1),
+                          models.Mapping((1,)) | models.Polynomial1D(1)])
+def test_call_keyword_args_1(model):
+    """
+    Test calling a model with positional, keywrd and a mixture of both arguments.
+    """
+    positional = model(1, 2)
+    model.inputs = ('r', 't')
+    assert_allclose(positional, model(r=1, t = 2))
+
+    assert_allclose(positional, model(1, t=2))
+
+    with pytest.raises(ValueError):
+        model(1, 2, 3)
+
+    with pytest.raises(ValueError):
+        model()
+
+    with pytest.raises(ValueError):
+        model(1, 2, t=12, r=3)
+
+
+@pytest.mark.parametrize('model',
+                         [models.Identity(2), models.Mapping((0, 1)),
+                          models.Mapping((1,))])
+def test_call_keyword_mappings(model):
+    """
+    Test calling a model with positional, keywrd and a mixture of both arguments.
+    """
+    positional = model(1, 2)
+    assert_allclose(positional, model(x0=1, x1=2))
+    assert_allclose(positional, model(1, x1=2))
+
+    model.inputs = ('r', 't')
+    assert_allclose(positional, model(r=1, t=2))
+    assert_allclose(positional, model(1, t=2))
+    assert_allclose(positional, model(1, 2))
+
+    with pytest.raises(ValueError):
+        model(1, 2, 3)
+
+    with pytest.raises(ValueError):
+        model(1)
+
+    with pytest.raises(ValueError):
+        model(1, 2, t=12, r=3)
+

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -956,4 +956,3 @@ def test_call_keyword_mappings(model):
 
     with pytest.raises(ValueError):
         model(1, 2, t=12, r=3)
-

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -626,8 +626,10 @@ class TestSingleInputSingleOutputTwoModel:
 
 
 class TModel_1_2(FittableModel):
-    inputs = ('x',)
-    outputs = ('y', 'z')
+    #inputs = ('x',)
+    #outputs = ('y', 'z')
+    n_inputs =1
+    n_outputs = 2
 
     p1 = Parameter()
     p2 = Parameter()

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -857,6 +857,7 @@ def test_format_input_arrays_transposed():
 @pytest.mark.parametrize('model',
                          [models.Gaussian2D(), models.Polynomial2D(1,),
                           models.Pix2Sky_TAN(), models.Tabular2D(lookup_table=np.ones((4,5)))])
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_call_keyword_args_2(model):
     """
     Test calling a model with positional, keywrd and a mixture of both arguments.
@@ -884,6 +885,7 @@ def test_call_keyword_args_2(model):
                          [models.Gaussian1D(), models.Polynomial1D(1,),
                           models.Tabular1D(lookup_table=np.ones((5,))),
                           models.Rotation2D(), models.Pix2Sky_TAN()])
+@pytest.mark.skipif('not HAS_SCIPY')
 def test_call_keyword_args_1(model):
     """
     Test calling a model with positional, keywrd and a mixture of both arguments.

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -851,3 +851,20 @@ def test_format_input_arrays_transposed():
     input = np.array([[1, 1]]).T, np.array([[2, 2]]).T
     result = model(*input)
     assert_allclose(result, input)
+
+
+@pytest.mark.parametrize('model',
+                         [models.Gaussian2D(), models.Polynomial2D(1,),
+                          models.Pix2Sky_TAN(), models.Tabular2D(lookup_table=np.ones((4,5)))])
+def test_call_keyword_args1(model):
+    """
+    Test calling a model with positional, keywrd and a mixture of both arguments.
+    """
+    positional = model(1, 2)
+    assert_allclose(positional, model(x=1, y=2))
+    assert_allclose(positional, model(1, y=2))
+
+    model.inputs = ('r', 't')
+    assert_allclose(positional, model(r=1, t=2))
+    assert_allclose(positional, model(1, t=2))
+    assert_allclose(positional, model(1, 2))

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -626,8 +626,7 @@ class TestSingleInputSingleOutputTwoModel:
 
 
 class TModel_1_2(FittableModel):
-    #inputs = ('x',)
-    #outputs = ('y', 'z')
+
     n_inputs =1
     n_outputs = 2
 

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -27,8 +27,6 @@ def setter2(val, model):
 
 class SetterModel(FittableModel):
 
-    #inputs = ('x', 'y')
-    #outputs = ('z',)
     n_inputs = 2
     n_outputs = 1
 

--- a/astropy/modeling/tests/test_parameters.py
+++ b/astropy/modeling/tests/test_parameters.py
@@ -27,8 +27,10 @@ def setter2(val, model):
 
 class SetterModel(FittableModel):
 
-    inputs = ('x', 'y')
-    outputs = ('z',)
+    #inputs = ('x', 'y')
+    #outputs = ('z',)
+    n_inputs = 2
+    n_outputs = 1
 
     xc = Parameter(default=1, setter=setter1)
     yc = Parameter(default=1, setter=setter2)
@@ -625,6 +627,7 @@ def test_non_broadcasting_parameters():
     c = np.array([[1, 2, 3, 4], [1, 2, 3, 4]])
 
     class TestModel(Model):
+
         p1 = Parameter()
         p2 = Parameter()
         p3 = Parameter()

--- a/astropy/modeling/tests/test_polynomial.py
+++ b/astropy/modeling/tests/test_polynomial.py
@@ -273,6 +273,11 @@ def test_sip_hst():
     astwcs_result = wobj.sip_pix2foc([coords], 1)[0] - rel_coords
     assert_allclose(sip(1, 1), astwcs_result)
 
+    # Test changing of inputs and calling it with keyword argumenrts.
+    sip.inputs = ("r", "t")
+    assert_allclose(sip(r=1, t=1), astwcs_result)
+    assert_allclose(sip(1, t=1), astwcs_result)
+
 
 def test_sip_irac():
     """Test forward and inverse SIP againts astropy.wcs"""

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -444,6 +444,7 @@ def test_compound_return_units():
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
+
         @property
         def input_units(self):
             """ Input units. """

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -118,7 +118,6 @@ class TestInputUnits():
             self.model(4 * u.s, 3)
         assert exc.value.args[0] == ("MyTestModel: Units of input 'x', s (time), could not be "
                                      "converted to required input units of deg (angle)")
-        print('allow', self.model.input_units_allow_dimensionless)
         with pytest.raises(UnitsError) as exc:
             self.model(3, 3)
         assert exc.value.args[0] == ("MyTestModel: Units of input 'x', (dimensionless), could "

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -437,8 +437,6 @@ def test_compound_return_units():
 
     class PassModel(Model):
 
-        #inputs = ('x', 'y')
-        #outputs = ('x', 'y')
         n_inputs = 2
         n_outputs = 2
 

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -85,8 +85,9 @@ def test_evaluate_with_quantities_and_equivalencies():
 
 
 class MyTestModel(Model):
-    inputs = ('a', 'b')
-    outputs = ('f',)
+
+    n_inputs = 2
+    n_outputs = 1
 
     def evaluate(self, a, b):
         print('a', a)
@@ -107,7 +108,7 @@ class TestInputUnits():
 
     def test_input_units(self):
 
-        self.model._input_units = {'a': u.deg}
+        self.model._input_units = {'x': u.deg}
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
         assert_quantity_allclose(self.model(4 * u.rad, 2), 8 * u.rad)
@@ -115,17 +116,17 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', s (time), could not be "
                                      "converted to required input units of deg (angle)")
-
+        print('allow', self.model.input_units_allow_dimensionless)
         with pytest.raises(UnitsError) as exc:
             self.model(3, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', (dimensionless), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', (dimensionless), could "
                                      "not be converted to required input units of deg (angle)")
 
     def test_input_units_allow_dimensionless(self):
 
-        self.model._input_units = {'a': u.deg}
+        self.model._input_units = {'x': u.deg}
         self.model._input_units_allow_dimensionless = True
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
@@ -133,14 +134,14 @@ class TestInputUnits():
 
         with pytest.raises(UnitsError) as exc:
             self.model(4 * u.s, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', s (time), could not be "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', s (time), could not be "
                                      "converted to required input units of deg (angle)")
 
         assert_quantity_allclose(self.model(3, 3), 9)
 
     def test_input_units_strict(self):
 
-        self.model._input_units = {'a': u.deg}
+        self.model._input_units = {'x': u.deg}
         self.model._input_units_strict = True
 
         assert_quantity_allclose(self.model(3 * u.deg, 4), 12 * u.deg)
@@ -151,23 +152,23 @@ class TestInputUnits():
 
     def test_input_units_equivalencies(self):
 
-        self.model._input_units = {'a': u.micron}
+        self.model._input_units = {'x': u.micron}
 
         with pytest.raises(UnitsError) as exc:
             self.model(3 * u.PHz, 3)
-        assert exc.value.args[0] == ("MyTestModel: Units of input 'a', PHz (frequency), could "
+        assert exc.value.args[0] == ("MyTestModel: Units of input 'x', PHz (frequency), could "
                                      "not be converted to required input units of "
                                      "micron (length)")
 
-        self.model.input_units_equivalencies = {'a': u.spectral()}
+        self.model.input_units_equivalencies = {'x': u.spectral()}
 
         assert_quantity_allclose(self.model(3 * u.PHz, 3),
                                 3 * (3 * u.PHz).to(u.micron, equivalencies=u.spectral()))
 
     def test_return_units(self):
 
-        self.model._input_units = {'a': u.deg}
-        self.model._return_units = {'f': u.rad}
+        self.model._input_units = {'z': u.deg}
+        self.model._return_units = {'z': u.rad}
 
         result = self.model(3 * u.deg, 4)
 
@@ -179,7 +180,7 @@ class TestInputUnits():
         # Check that return_units also works when giving a single unit since
         # there is only one output, so is unambiguous.
 
-        self.model._input_units = {'a': u.deg}
+        self.model._input_units = {'x': u.deg}
         self.model._return_units = u.rad
 
         result = self.model(3 * u.deg, 4)
@@ -436,18 +437,22 @@ def test_compound_return_units():
 
     class PassModel(Model):
 
-        inputs = ('x', 'y')
-        outputs = ('x', 'y')
+        #inputs = ('x', 'y')
+        #outputs = ('x', 'y')
+        n_inputs = 2
+        n_outputs = 2
 
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
         @property
         def input_units(self):
             """ Input units. """
-            return {'x': u.deg, 'y': u.deg}
+            return {'x0': u.deg, 'x1': u.deg}
 
         @property
         def return_units(self):
             """ Output units. """
-            return {'x': u.deg, 'y': u.deg}
+            return {'x0': u.deg, 'x1': u.deg}
 
         def evaluate(self, x, y):
             return x.value, y.value

--- a/docs/modeling/compound-models.rst
+++ b/docs/modeling/compound-models.rst
@@ -131,8 +131,8 @@ few terms where there have been points of confusion:
       >>> Gaussian1D
       <class 'astropy.modeling.functional_models.Gaussian1D'>
       Name: Gaussian1D
-      Inputs: ('x',)
-      Outputs: ('y',)
+      N_inputs: 1
+      N_outputs: 1
       Fittable parameters: ('amplitude', 'mean', 'stddev')
 
   We can then create a model *instance* by passing in values for the three

--- a/docs/modeling/new-model.rst
+++ b/docs/modeling/new-model.rst
@@ -91,33 +91,31 @@ example if it must be non-negative).  See the example in
     from astropy.modeling import Fittable1DModel, Parameter
 
     class Gaussian1D(Fittable1DModel):
-        inputs = ('x',)
-        outputs = ('y',)
+        n_inputs = 1
+        n_outputs = 1
 
         amplitude = Parameter()
         mean = Parameter()
         stddev = Parameter()
 
-The ``inputs`` and ``outputs`` class attributes must be tuples of strings
+The ``n_inputs`` and ``n_outputs`` class attributes must be integers
 indicating the number of independent variables that are input to evaluate the
 model, and the number of outputs it returns.  The labels of the inputs and
-outputs (in this case ``'x'`` and ``'y'`` respectively) are currently used for
-informational purposes only and have no requirements on them other than that
-they do not conflict with parameter names.  Outputs may have the same labels as
-inputs (eg. ``inputs = ('x', 'y')`` and ``outputs = ('x', 'y')``).  However,
-inputs must not conflict with each other (eg. ``inputs = ('x', 'x')`` is
-incorrect) and likewise for outputs.  The lengths of these tuples are
-important for specifying the correct number of inputs and outputs.  These
-attributes supersede the ``n_inputs`` and ``n_outputs`` attributes in older
-versions of this package.
+outputs, ``inputs`` and ``outputs``, are generated automatically. it is possible
+to overwrite the default ones by assigning the desired values in the class ``__init__``
+method, after calling ``super``. ``outputs`` and ``inputs`` must be tuples of
+strings with length ``n_outputs`` and ``n_inputs`` respectively.
+Outputs may have the same labels as inputs (eg. ``inputs = ('x', 'y')`` and ``outputs = ('x', 'y')``).
+However, inputs must not conflict with each other (eg. ``inputs = ('x', 'x')`` is
+incorrect) and likewise for outputs.
 
 There are two helpful base classes in the modeling package that can be used to
-avoid specifying ``inputs`` and ``outputs`` for most common models.  These are
+avoid specifying ``n_inputs`` and ``n_outputs`` for most common models.  These are
 `~astropy.modeling.Fittable1DModel` and `~astropy.modeling.Fittable2DModel`.
 For example, the real `~astropy.modeling.functional_models.Gaussian1D` model is
 actually a subclass of `~astropy.modeling.Fittable1DModel`.  This helps cut
-down on boilerplate by not having to specify ``inputs`` and ``outputs`` for
-many models (follow the link to Gaussian1D to see its source code, for
+down on boilerplate by not having to specify ``n_inputs``, ``n_outputs``, ``inputs``
+and ``outputs`` for many models (follow the link to Gaussian1D to see its source code, for
 example).
 
 Fittable models can be linear or nonlinear in a regression sense. The default
@@ -279,4 +277,3 @@ input``.
 
     The above example is essentially equivalent to the built-in
     `~astropy.modeling.functional_models.Linear1D` model.
-    


### PR DESCRIPTION
@astrofrog @Cadair @perrygreenfield  Please review as this is a substantial change.

The current `Model` base class defines two class variables - `inputs` and `outputs` - both tuples of strings, the names of inputs and outputs of that model. There are use cases when it is useful from a user point of view to be able to change the names, especially of the inputs. An example is a WCS transform which takes ("x", "y", "spectral_order"), instead of (""x00", "x10", "x01"). The fact that these are class variables makes it difficult to do so.
Enabling change of names of inputs will allow better interface to gwcs using the `fix_inputs` operator.

`Model.inputs` and `Model.outputs` are used to derive `Model.n_inputs` and `Model.n_outputs`. While the first two are not intrinsically needed by a Model to function, the last two are essential. 

This PR changes the base class `Model` to make `n_inputs` and `n_outputs` class variables and `inputs` and `outputs` - instance variables. Care is taken to make the changes within modeling in such a way that they are backwards compatible, essentially providing default values which match the original values of `inputs` and `outputs`.

What is the effect on user defined models which already define `inputs` and `outputs` as class variables?

- The changes are transparent if they continue to use the models as before
   - evaluating them musing positional arguments
   - evaluating them using keyword arguments with the old inputs as keys
- They won't be able to evaluate the models with renamed inputs. For this to work they will need to change their models to redefine `n_inputs`, `n_outputs`, `inputs` and `outputs`.

It may be possible to raise a `DeprecationWarning` if it is detected that there are models which define `inputs` as class variables. Is this necessary?

I'd appreciate any comments.

 
TODO:
[ ] fix documentation
[ ] possibly add DeprecationWarnings