### PR TITLE
Fix 9168: convolution fails if kernel is a (unitless) quantity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ astropy.constants
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug [#9168] where having a kernel defined using unitless astropy
+  quantity objects would result in a crash [#9300]
+
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -54,6 +54,9 @@ BOUNDARY_OPTIONS = [None, 'fill', 'wrap', 'extend']
 
 
 def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None, mask=None, fill_value=None):
+    # strip quantity attributes
+    if hasattr(input, 'unit'):
+        input = input.value
     # Alias input
     input = input.array if isinstance(input, Kernel) else input
     output = input

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -54,11 +54,11 @@ BOUNDARY_OPTIONS = [None, 'fill', 'wrap', 'extend']
 
 
 def _copy_input_if_needed(input, dtype=float, order='C', nan_treatment=None, mask=None, fill_value=None):
+    # Alias input
+    input = input.array if isinstance(input, Kernel) else input
     # strip quantity attributes
     if hasattr(input, 'unit'):
         input = input.value
-    # Alias input
-    input = input.array if isinstance(input, Kernel) else input
     output = input
     # Copy input
     try:

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -40,6 +40,26 @@ except ImportError:
     HAS_PANDAS = False
 
 
+def test_regressiontest_issue9168():
+
+    from astropy import units as u
+
+    x = np.array([[1., 2., 3.],
+                  [4., 5., 6.],
+                  [7., 8., 9.]],)
+
+    kernel_fwhm = 1*u.arcsec
+    pixel_size = 1*u.arcsec
+
+    kernel = Gaussian2DKernel(stddev=kernel_fwhm/pixel_size)
+
+    result = convolve_fft(x, kernel, boundary='fill', fill_value=np.nan,
+                          preserve_nan=True)
+    result = convolve(x, kernel, boundary='fill', fill_value=np.nan,
+                      preserve_nan=True)
+
+
+
 class TestConvolve1D:
     def test_list(self):
         """

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -40,31 +40,6 @@ except ImportError:
     HAS_PANDAS = False
 
 
-def test_regressiontest_issue9168():
-    """
-    Issue #9168 pointed out that kernels can be (unitless) quantities, which
-    leads to crashes when inplace modifications are made to arrays in
-    convolve/convolve_fft, so we now strip the quantity aspects off of kernels.
-    """
-
-    from astropy import units as u
-
-    x = np.array([[1., 2., 3.],
-                  [4., 5., 6.],
-                  [7., 8., 9.]],)
-
-    kernel_fwhm = 1*u.arcsec
-    pixel_size = 1*u.arcsec
-
-    kernel = Gaussian2DKernel(stddev=kernel_fwhm/pixel_size)
-
-    result = convolve_fft(x, kernel, boundary='fill', fill_value=np.nan,
-                          preserve_nan=True)
-    result = convolve(x, kernel, boundary='fill', fill_value=np.nan,
-                      preserve_nan=True)
-
-
-
 class TestConvolve1D:
     def test_list(self):
         """
@@ -984,3 +959,27 @@ def test_uninterpolated_nan_regions(boundary, normalize_kernel):
     result = convolve(image, kernel, boundary=boundary, nan_treatment='interpolate',
                       normalize_kernel=normalize_kernel)
     assert(~np.any(np.isnan(result))) # Note: negation
+
+
+def test_regressiontest_issue9168():
+    """
+    Issue #9168 pointed out that kernels can be (unitless) quantities, which
+    leads to crashes when inplace modifications are made to arrays in
+    convolve/convolve_fft, so we now strip the quantity aspects off of kernels.
+    """
+
+    from astropy import units as u
+
+    x = np.array([[1., 2., 3.],
+                  [4., 5., 6.],
+                  [7., 8., 9.]],)
+
+    kernel_fwhm = 1*u.arcsec
+    pixel_size = 1*u.arcsec
+
+    kernel = Gaussian2DKernel(stddev=kernel_fwhm/pixel_size)
+
+    result = convolve_fft(x, kernel, boundary='fill', fill_value=np.nan,
+                          preserve_nan=True)
+    result = convolve(x, kernel, boundary='fill', fill_value=np.nan,
+                      preserve_nan=True)

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -41,6 +41,11 @@ except ImportError:
 
 
 def test_regressiontest_issue9168():
+    """
+    Issue #9168 pointed out that kernels can be (unitless) quantities, which
+    leads to crashes when inplace modifications are made to arrays in
+    convolve/convolve_fft, so we now strip the quantity aspects off of kernels.
+    """
 
     from astropy import units as u
 

--- a/astropy/convolution/tests/test_convolve.py
+++ b/astropy/convolution/tests/test_convolve.py
@@ -7,6 +7,8 @@ import numpy.ma as ma
 from astropy.convolution.convolve import convolve, convolve_fft
 from astropy.convolution.kernels import Gaussian2DKernel
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy import units as u
+
 
 from numpy.testing import (assert_array_almost_equal_nulp,
                            assert_array_almost_equal,
@@ -968,8 +970,6 @@ def test_regressiontest_issue9168():
     convolve/convolve_fft, so we now strip the quantity aspects off of kernels.
     """
 
-    from astropy import units as u
-
     x = np.array([[1., 2., 3.],
                   [4., 5., 6.],
                   [7., 8., 9.]],)
@@ -977,7 +977,7 @@ def test_regressiontest_issue9168():
     kernel_fwhm = 1*u.arcsec
     pixel_size = 1*u.arcsec
 
-    kernel = Gaussian2DKernel(stddev=kernel_fwhm/pixel_size)
+    kernel = Gaussian2DKernel(x_stddev=kernel_fwhm/pixel_size)
 
     result = convolve_fft(x, kernel, boundary='fill', fill_value=np.nan,
                           preserve_nan=True)


### PR DESCRIPTION
Note that convolution doesn't preserve units anyway, so this is just enforcing unit stripping a little more aggressively