### PR TITLE
Removing catching MaskedArrayFutureWarning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,8 +83,7 @@ matrix:
     fast_finish: true
 
     include:
-        # Try MacOS X. Use a slightly old numpy version to help test against
-        # all supported numpy versions.
+        # Try MacOS X.
         - os: osx
           stage: Cron tests
           env: SETUP_CMD='test --remote-data=astropy'
@@ -98,7 +97,7 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time.
         - os: linux
-          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.13
+          env: PYTHON_VERSION=3.6 NUMPY_VERSION=1.16
                INSTALL_CMD='python setup.py build_ext --inplace'
                PIP_DEPENDENCIES='pytest-astropy'
                TEST_CMD='pytest --open-files --doctest-rst'

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -9,15 +9,6 @@ from copy import deepcopy
 import numpy as np
 from numpy import ma
 
-# Remove this when Numpy no longer emits this warning and that Numpy version
-# becomes the minimum required version for Astropy.
-# https://github.com/astropy/astropy/issues/6285
-try:
-    from numpy.ma.core import MaskedArrayFutureWarning
-except ImportError:
-    # For Numpy versions that do not raise this warning.
-    MaskedArrayFutureWarning = None
-
 from astropy.units import Unit, Quantity
 from astropy.utils.console import color_print
 from astropy.utils.metadata import MetaData
@@ -1389,15 +1380,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         # update indices
         self.info.adjust_indices(index, value, len(self))
 
-        # Remove this when Numpy no longer emits this warning and that
-        # Numpy version becomes the minimum required version for Astropy.
-        # https://github.com/astropy/astropy/issues/6285
-        if MaskedArrayFutureWarning is None:
-            ma.MaskedArray.__setitem__(self, index, value)
-        else:
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', MaskedArrayFutureWarning)
-                ma.MaskedArray.__setitem__(self, index, value)
+        ma.MaskedArray.__setitem__(self, index, value)
 
     # We do this to make the methods show up in the API docs
     name = BaseColumn.name


### PR DESCRIPTION
With supporting only numpy 1.16+, we can remove catching this warning (basically reverting #6261)

closes #6285

@pllim - I believe your #8506 will pass on top of this