### PR TITLE
Check downloaded files are the right length

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -570,6 +570,10 @@ astropy.utils
 - Fixed ``find_api_page`` access by using custom request headers and HTTPS
   when version is specified. [#9032]
 
+- Make ``download_file`` (and by extension ``get_readable_fileobj`` and others)
+  check the size of downloaded files against the size claimed by the server.
+  [#9302]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1046,8 +1046,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
 
             dlmsg = f"Downloading {remote_url}"
             with ProgressBarOrSpinner(size, dlmsg, file=progress_stream) as p:
-                with NamedTemporaryFile(delete=False) as f:
-                    try:
+                try:
+                    with NamedTemporaryFile(delete=False) as f:
                         bytes_read = 0
                         block = remote.read(conf.download_block_size)
                         while block:
@@ -1063,17 +1063,17 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                                     "Download failed."
                                     .format(size, bytes_read)
                                 )
-                        if size is not None and bytes_read < size:
-                            raise urllib.error.ContentTooShortError(
-                                "File was supposed to be {} bytes but we only "
-                                "got {} bytes. Download failed."
-                                .format(size, bytes_read),
-                                content=None,
-                            )
-                    except BaseException:
-                        if os.path.exists(f.name):
-                            os.remove(f.name)
-                        raise
+                    if size is not None and bytes_read < size:
+                        raise urllib.error.ContentTooShortError(
+                            "File was supposed to be {} bytes but we only "
+                            "got {} bytes. Download failed."
+                            .format(size, bytes_read),
+                            content=None,
+                        )
+                except BaseException:
+                    if os.path.exists(f.name):
+                        os.remove(f.name)
+                    raise
 
         if cache:
             _acquire_download_cache_lock()

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1056,6 +1056,20 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None):
                             bytes_read += len(block)
                             p.update(bytes_read)
                             block = remote.read(conf.download_block_size)
+                            if size is not None and bytes_read > size:
+                                raise urllib.error.URLError(
+                                    "File was supposed to be {} bytes but server "
+                                    "provides more, at least {} bytes. "
+                                    "Download failed."
+                                    .format(size, bytes_read)
+                                )
+                        if size is not None and bytes_read < size:
+                            raise urllib.error.ContentTooShortError(
+                                "File was supposed to be {} bytes but we only "
+                                "got {} bytes. Download failed."
+                                .format(size, bytes_read),
+                                content=None,
+                            )
                     except BaseException:
                         if os.path.exists(f.name):
                             os.remove(f.name)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -519,7 +519,6 @@ def test_nested_get_readable_fileobj():
     assert fileobj.closed and fileobj2.closed
 
 
-@pytest.mark.remote_data(source='astropy')
 def test_download_file_wrong_size(monkeypatch):
     import contextlib
     from astropy.utils.data import download_file
@@ -551,6 +550,12 @@ def test_download_file_wrong_size(monkeypatch):
         download_file(TESTURL, cache=False)
 
     report_length = 1023
+    real_length = 1023
+    fn = download_file(TESTURL, cache=False)
+    with open(fn, "rb") as f:
+        assert f.read() == b"a"*real_length
+
+    report_length = None
     real_length = 1023
     fn = download_file(TESTURL, cache=False)
     with open(fn, "rb") as f:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2,6 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import hashlib
+import io
 import os
 import pathlib
 import sys
@@ -516,3 +517,41 @@ def test_nested_get_readable_fileobj():
         #assert fileobj2.closed
 
     assert fileobj.closed and fileobj2.closed
+
+
+@pytest.mark.remote_data(source='astropy')
+def test_download_file_wrong_size(monkeypatch):
+    import contextlib
+    from astropy.utils.data import download_file
+
+    @contextlib.contextmanager
+    def mockurl(remote_url, timeout=None):
+        yield MockURL()
+
+    class MockURL:
+        def __init__(self):
+            self.reader = io.BytesIO(b"a"*real_length)
+
+        def info(self):
+            return {"Content-Length": str(report_length)}
+
+        def read(self, length=None):
+            return self.reader.read(length)
+
+    monkeypatch.setattr(urllib.request, "urlopen", mockurl)
+
+    with pytest.raises(urllib.error.ContentTooShortError):
+        report_length = 1024
+        real_length = 1023
+        download_file(TESTURL, cache=False)
+
+    with pytest.raises(urllib.error.URLError):
+        report_length = 1023
+        real_length = 1024
+        download_file(TESTURL, cache=False)
+
+    report_length = 1023
+    real_length = 1023
+    fn = download_file(TESTURL, cache=False)
+    with open(fn, "rb") as f:
+        assert f.read() == b"a"*real_length


### PR DESCRIPTION
Current behaviour is for download_file to treat as a success any condition that doesn't actually raise an exception, but in #8793 users report that server problems are resulting in incomplete IERS files being downloaded and used, leading to cryptic errors. This PR checks the size on download, raising an exception if the server provides too many or too few bytes. The authoritative size also comes from the server, of course, but this should at worst never be triggered and at best catch the above-mentioned dropping downloads.