### PR TITLE
DOC: Fix broken links

### DIFF
--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -571,11 +571,7 @@ class FITS_rec(np.recarray):
 
     @property
     def columns(self):
-        """
-        A user-visible accessor for the coldefs.
-
-        See https://aeon.stsci.edu/ssb/trac/pyfits/ticket/44
-        """
+        """A user-visible accessor for the coldefs."""
 
         return self._coldefs
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
-
 import gzip
 import itertools
 import io
@@ -727,7 +726,7 @@ def _convert_array(array, dtype):
             (np.issubdtype(array.dtype, np.number) and
              np.issubdtype(dtype, np.number))):
         # Includes a special case when both dtypes are at least numeric to
-        # account for ticket #218: https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218
+        # account for old Trac ticket 218 (now inaccessible).
         return array.view(dtype)
     else:
         return array.astype(dtype)

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -41,7 +41,7 @@ What is the development status of PyFITS?
 
 PyFITS was written and maintained by the Science Software Branch at the `Space
 Telescope Science Institute`_, and is licensed by AURA_ under a `3-clause BSD
-license`_ (see `LICENSE.txt`_ in the PyFITS source code).
+license`_.
 
 It is now exclusively developed as a component of Astropy
 (`astropy.io.fits`) rather than as a stand-alone module.  There are a few
@@ -52,19 +52,15 @@ bases is non-trivial.  The second is that there are many features of Astropy
 greatly.  Since PyFITS is already integrated into Astropy, it makes more sense
 to continue development there rather than make Astropy a dependency of PyFITS.
 
-PyFITS' past primary developer and active maintainer was Erik Bray.  There
+There
 is a `GitHub project`_ for PyFITS, but PyFITS is not actively developed anymore
 so patches and issue reports should be posted on the Astropy issue tracker.
-There is also a legacy `Trac site`_ with some older issue reports still open,
-but new issues should be submitted via GitHub if possible.
 
 The current (and last) stable release is 3.4.0.
 
 .. _Space Telescope Science Institute: http://www.stsci.edu/
 .. _AURA: https://www.aura-astronomy.org/
 .. _3-clause BSD license: https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22New_BSD_License.22_or_.22Modified_BSD_License.22.29
-.. _LICENSE.txt: https://aeon.stsci.edu/ssb/trac/pyfits/browser/trunk/LICENSE.txt
-.. _Trac site: https://aeon.stsci.edu/ssb/trac/pyfits/
 .. _GitHub project: https://github.com/spacetelescope/PyFITS
 
 

--- a/docs/io/fits/appendix/faq.rst
+++ b/docs/io/fits/appendix/faq.rst
@@ -52,7 +52,7 @@ bases is non-trivial.  The second is that there are many features of Astropy
 greatly.  Since PyFITS is already integrated into Astropy, it makes more sense
 to continue development there rather than make Astropy a dependency of PyFITS.
 
-There
+PyFITS' past primary developer and maintainer was Erik Bray. There
 is a `GitHub project`_ for PyFITS, but PyFITS is not actively developed anymore
 so patches and issue reports should be posted on the Astropy issue tracker.
 

--- a/docs/io/fits/appendix/header_transition.rst
+++ b/docs/io/fits/appendix/header_transition.rst
@@ -20,13 +20,6 @@ interface (whether due to similarities in the design, or backwards-compatibility
 support), there are enough differences that a full explanation of the new
 interface is merited.
 
-The Trac ticket discussing the initial motivation and changes to be made to the
-:class:`Header` class is `#64`_.  It may be worth reading for some of the
-background to this work, though this document contains a more complete
-description of the "final" product (which will continue to evolve).
-
-.. _#64: https://aeon.stsci.edu/ssb/trac/pyfits/ticket/64
-
 
 Background
 ==========

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -355,7 +355,7 @@ by adding the following to your ``sitecustomize.py`` file::
     sys.setdefaultencoding('utf-8')
 
 Note that in general, `this is not recommended
-<https://ziade.org/2008/01/08/syssetdefaultencoding-is-evil/>`_,
+<https://stackoverflow.com/questions/3828723/why-should-we-not-use-sys-setdefaultencodingutf-8-in-a-py-script>`_,
 because it can hide other Unicode encoding bugs in your application.
 However, if your application does not deal with text
 processing and you just want docstrings to work, this may be


### PR DESCRIPTION
Caught these during a check of the `linkcheck` cron job.

* Stop mentioning defunct STScI server.
* Replace `ziade.org` with StackOverflow because the former is now issuing sketchy certificate.

p.s. Since I am only worried about the cron job that only runs on `master`, I don't think these need backporting, but feel free to re-milestone if you feel otherwise.