### PR TITLE
Fix ignore_nan bug in median_absolute_deviation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -548,6 +548,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed ``median_absolute_deviation`` for the case where
+  ``ignore_nan=True`` and an input masked array contained both NaNs and
+  infs. [#9307]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -769,7 +769,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
             is_masked = True
             func = np.ma.median
             if ignore_nan:
-                data = np.ma.masked_invalid(data)
+                data = np.ma.masked_where(np.isnan(data), data, copy=False)
         elif ignore_nan:
             is_masked = False
             func = np.nanmedian

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -100,6 +100,19 @@ def test_median_absolute_deviation_nans():
     assert funcs.median_absolute_deviation(array) == 1
 
 
+def test_median_absolute_deviation_nans_masked():
+    """
+    Regression test to ensure ignore_nan=True gives same results for
+    ndarray and masked arrays that contain +/-inf.
+    """
+
+    data1 = np.array([1., np.nan, 2, np.inf])
+    data2 = np.ma.masked_array(data1, mask=False)
+    mad1 = funcs.median_absolute_deviation(data1, ignore_nan=True)
+    mad2 = funcs.median_absolute_deviation(data2, ignore_nan=True)
+    assert_equal(mad1, mad2)
+
+
 def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
     assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),


### PR DESCRIPTION
This PR fixes a bug in `median_absolute_deviation` for the case where `ignore_nan=True` and an input masked array contains both NaNs and infs.  Example of the bug:

```python
>>> from astropy.stats import median_absolute_deviation as mad
>>> data1 = np.array([1., np.nan, 2, np.inf])
>>> data2 = np.ma.masked_array(data1, mask=False)  # same as data1, but masked array

>>> mad(data1, ignore_nan=True)  # ndarray
1.0

>>> mad(data2, ignore_nan=True)  # masked array
0.5
```

The masked array result should be the same as the ndarray result.  It currently doesn't because the masked array case is ignoring both +/- `inf`s and NaNs.

