### PR TITLE
Allow axis in biweight stat functions to be a tuple of ints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,10 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- The ``biweight_location``, ``biweight_scale``, and
+  ``biweight_midvariance`` functions now allow for the ``axis``
+  keyword to be a tuple of integers. [#9309]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -91,7 +91,7 @@ def biweight_location(data, c=6.0, M=None, axis=None):
     if M is None:
         M = np.median(data, axis=axis)
     if axis is not None:
-        M = _expand_dims(M, axis=axis)
+        M = _expand_dims(M, axis=axis)  # NUMPY_LT_1_18
 
     # set up the differences
     d = data - M
@@ -103,7 +103,7 @@ def biweight_location(data, c=6.0, M=None, axis=None):
         return M  # return median if data is a constant array
 
     if axis is not None:
-        mad = _expand_dims(mad, axis=axis)
+        mad = _expand_dims(mad, axis=axis)  # NUMPY_LT_1_18
         const_mask = (mad == 0.)
         mad[const_mask] = 1.  # prevent divide by zero
 
@@ -333,7 +333,7 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
     if M is None:
         M = np.median(data, axis=axis)
     if axis is not None:
-        M = _expand_dims(M, axis=axis)
+        M = _expand_dims(M, axis=axis)  # NUMPY_LT_1_18
 
     # set up the differences
     d = data - M
@@ -345,7 +345,7 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
         return 0.  # return zero if data is a constant array
 
     if axis is not None:
-        mad = _expand_dims(mad, axis=axis)
+        mad = _expand_dims(mad, axis=axis)  # NUMPY_LT_1_18
         const_mask = (mad == 0.)
         mad[const_mask] = 1.  # prevent divide by zero
 

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -6,28 +6,10 @@ Tukey's biweight function.
 
 import numpy as np
 
-from .funcs import median_absolute_deviation
+from .funcs import _expand_dims, median_absolute_deviation
 
 __all__ = ['biweight_location', 'biweight_scale', 'biweight_midvariance',
            'biweight_midcovariance', 'biweight_midcorrelation']
-
-
-def _expand_dims(data, axis):
-    if isinstance(data, np.matrix):
-        data = np.asarray(data)
-    else:
-        data = np.asanyarray(data)
-
-    if type(axis) not in (tuple, list):
-        axis = (axis,)
-
-    out_ndim = len(axis) + data.ndim
-    axis = np.core.numeric.normalize_axis_tuple(axis, out_ndim)
-
-    shape_it = iter(data.shape)
-    shape = [1 if ax in axis else next(shape_it) for ax in range(out_ndim)]
-
-    return data.reshape(shape)
 
 
 def biweight_location(data, c=6.0, M=None, axis=None):

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -42,6 +42,51 @@ to convert it to 1-sigma standard deviation.
 """
 
 
+def _expand_dims(data, axis):
+    """
+    Expand the shape of an array.
+
+    Insert a new axis that will appear at the `axis` position in the
+    expanded array shape.
+
+    This function allows for tuple axis arguments.
+    ``numpy.expand_dims`` currently does not allow that, but it will in
+    numpy v1.18 (https://github.com/numpy/numpy/pull/14051).
+    ``_expand_dims`` can be replaced with ``numpy.expand_dims`` when the
+    minimum support numpy version is v1.18.
+
+    Parameters
+    ----------
+    data : array_like
+        Input array.
+    axis : int or tuple of ints
+        Position in the expanded axes where the new axis (or axes) is
+        placed.  A tuple of axes is now supported.  Out of range axes as
+        described above are now forbidden and raise an `AxisError`.
+
+    Returns
+    -------
+    result : ndarray
+        View of ``data`` with the number of dimensions increased.
+    """
+
+    if isinstance(data, np.matrix):
+        data = np.asarray(data)
+    else:
+        data = np.asanyarray(data)
+
+    if type(axis) not in (tuple, list):
+        axis = (axis,)
+
+    out_ndim = len(axis) + data.ndim
+    axis = np.core.numeric.normalize_axis_tuple(axis, out_ndim)
+
+    shape_it = iter(data.shape)
+    shape = [1 if ax in axis else next(shape_it) for ax in range(out_ndim)]
+
+    return data.reshape(shape)
+
+
 # TODO Note scipy dependency
 def binom_conf_interval(k, n, conf=0.68269, interval='wilson'):
     r"""Binomial proportion confidence interval given k successes,

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -13,9 +13,7 @@ import math
 
 import numpy as np
 
-from astropy.utils import isiterable
 from . import _stats
-
 
 __all__ = ['gaussian_fwhm_to_sigma', 'gaussian_sigma_to_fwhm',
            'binom_conf_interval', 'binned_binom_proportion',
@@ -768,9 +766,9 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
     ----------
     data : array-like
         Input array or object that can be converted to an array.
-    axis : {int, sequence of int, None}, optional
-        Axis along which the MADs are computed.  The default (`None`) is
-        to compute the MAD of the flattened array.
+    axis : `None`, int, or tuple of ints, optional
+        The axis or axes along which the MADs are computed.  The default
+        (`None`) is to compute the MAD of the flattened array.
     func : callable, optional
         The function used to compute the median. Defaults to `numpy.ma.median`
         for masked arrays, otherwise to `numpy.median`.
@@ -831,11 +829,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
 
     # broadcast the median array before subtraction
     if axis is not None:
-        if isiterable(axis):
-            for ax in sorted(list(axis)):
-                data_median = np.expand_dims(data_median, axis=ax)
-        else:
-            data_median = np.expand_dims(data_median, axis=axis)
+        data_median = _expand_dims(data_median, axis=axis)
 
     result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
 
@@ -870,10 +864,10 @@ def mad_std(data, axis=None, func=None, ignore_nan=False):
     ----------
     data : array-like
         Data array or object that can be converted to an array.
-    axis : {int, sequence of int, None}, optional
-        Axis along which the robust standard deviations are computed.
-        The default (`None`) is to compute the robust standard deviation
-        of the flattened array.
+    axis : `None`, int, or tuple of ints, optional
+        The axis or axes along which the robust standard deviations are
+        computed.  The default (`None`) is to compute the robust
+        standard deviation of the flattened array.
     func : callable, optional
         The function used to compute the median. Defaults to `numpy.ma.median`
         for masked arrays, otherwise to `numpy.median`.

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -40,6 +40,7 @@ to convert it to 1-sigma standard deviation.
 """
 
 
+# NUMPY_LT_1_18
 def _expand_dims(data, axis):
     """
     Expand the shape of an array.
@@ -73,7 +74,7 @@ def _expand_dims(data, axis):
     else:
         data = np.asanyarray(data)
 
-    if type(axis) not in (tuple, list):
+    if not isinstance(axis, (tuple, list)):
         axis = (axis,)
 
     out_ndim = len(axis) + data.ndim
@@ -829,7 +830,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
 
     # broadcast the median array before subtraction
     if axis is not None:
-        data_median = _expand_dims(data_median, axis=axis)
+        data_median = _expand_dims(data_median, axis=axis)  # NUMPY_LT_1_18
 
     result = func(np.abs(data - data_median), axis=axis, overwrite_input=True)
 

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -111,7 +111,7 @@ def test_biweight_location_axis_tuple():
     assert_equal(biweight_location(data, axis=-1),
                  biweight_location(data, axis=(2,)))
     assert_equal(biweight_location(data, axis=(0, 1)),
-                 biweight_location(data, axis=(0, 1)))
+                 biweight_location(data, axis=(1, 0)))
     assert_equal(biweight_location(data, axis=(0, 2)),
                  biweight_location(data, axis=(0, -1)))
     assert_equal(biweight_location(data, axis=(0, 1, 2)),
@@ -204,7 +204,7 @@ def test_biweight_scale_axis_tuple():
     assert_equal(biweight_scale(data, axis=-1),
                  biweight_scale(data, axis=(2,)))
     assert_equal(biweight_scale(data, axis=(0, 1)),
-                 biweight_scale(data, axis=(0, 1)))
+                 biweight_scale(data, axis=(1, 0)))
     assert_equal(biweight_scale(data, axis=(0, 2)),
                  biweight_scale(data, axis=(0, -1)))
     assert_equal(biweight_scale(data, axis=(0, 1, 2)),

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -2,11 +2,13 @@
 
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
+from numpy.testing import (assert_allclose, assert_array_almost_equal_nulp,
+                           assert_equal)
 
 from astropy.stats.biweight import (biweight_location, biweight_scale,
-                        biweight_midvariance, biweight_midcovariance,
-                        biweight_midcorrelation)
+                                    biweight_midvariance,
+                                    biweight_midcovariance,
+                                    biweight_midcorrelation)
 from astropy.tests.helper import catch_warnings
 from astropy.utils.misc import NumpyRNGContext
 
@@ -98,6 +100,26 @@ def test_biweight_location_axis_3d():
         assert_allclose(bw[y], bwi)
 
 
+def test_biweight_location_axis_tuple():
+    """Test a 3D array with a tuple axis keyword."""
+
+    data = np.arange(24).reshape(2, 3, 4)
+    data[0, 0] = 100.
+
+    assert_equal(biweight_location(data, axis=0),
+                 biweight_location(data, axis=(0,)))
+    assert_equal(biweight_location(data, axis=-1),
+                 biweight_location(data, axis=(2,)))
+    assert_equal(biweight_location(data, axis=(0, 1)),
+                 biweight_location(data, axis=(0, 1)))
+    assert_equal(biweight_location(data, axis=(0, 2)),
+                 biweight_location(data, axis=(0, -1)))
+    assert_equal(biweight_location(data, axis=(0, 1, 2)),
+                 biweight_location(data, axis=(2, 0, 1)))
+    assert_equal(biweight_location(data, axis=(0, 1, 2)),
+                 biweight_location(data, axis=None))
+
+
 def test_biweight_scale():
     # NOTE:  biweight_scale is covered by biweight_midvariance tests
     data = [1, 3, 5, 500, 2]
@@ -169,6 +191,28 @@ def test_biweight_midvariance_axis_3d():
             bwi.append(biweight_midvariance(data[:, y, i]))
         bwi = np.array(bwi)
         assert_allclose(bw[y], bwi)
+
+
+def test_biweight_scale_axis_tuple():
+    """Test a 3D array with a tuple axis keyword."""
+
+    data = np.arange(24).reshape(2, 3, 4)
+    data[0, 0] = 100.
+
+    assert_equal(biweight_scale(data, axis=0),
+                 biweight_scale(data, axis=(0,)))
+    assert_equal(biweight_scale(data, axis=-1),
+                 biweight_scale(data, axis=(2,)))
+    assert_equal(biweight_scale(data, axis=(0, 1)),
+                 biweight_scale(data, axis=(0, 1)))
+    assert_equal(biweight_scale(data, axis=(0, 2)),
+                 biweight_scale(data, axis=(0, -1)))
+    assert_equal(biweight_scale(data, axis=(0, 1, 2)),
+                 biweight_scale(data, axis=(2, 0, 1)))
+    assert_equal(biweight_scale(data, axis=(0, 1, 2)),
+                 biweight_scale(data, axis=None))
+    assert_equal(biweight_scale(data, axis=(0, 2), modify_sample_size=True),
+                 biweight_scale(data, axis=(0, -1), modify_sample_size=True))
 
 
 def test_biweight_midvariance_constant_axis():

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -102,10 +102,10 @@ def test_median_absolute_deviation_nans():
 
 def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]
-    assert_equal(funcs.median_absolute_deviation(array, axis=(1, 2)),
-                 np.zeros(5))
-    assert_equal(funcs.median_absolute_deviation(
-        array, axis=np.array([1, 2])), np.zeros(5))
+    mad1 = funcs.median_absolute_deviation(array, axis=(1, 2))
+    mad2 = funcs.median_absolute_deviation(array, axis=(2, 1))
+    assert_equal(mad1, np.zeros(5))
+    assert_equal(mad1, mad2)
 
 
 def test_median_absolute_deviation_quantity():


### PR DESCRIPTION
This PR allows the `axis` keyword in the biweight stat functions to be a tuple of `int`s.  Currently it can be only a single `int`.  To provide this functionality, this PR adds a (private) modified version of the `np.expand_dims` function that allows for multiple axes.  The updated function is not yet available in numpy, but should appear in v1.18 (https://github.com/numpy/numpy/pull/14051).

I also updated the `median_absolute_deviation` function to use the `_expand_dims` functions.  Doing that required fixing a test (arrays are not allowed as axis inputs in numpy functions).