### PR TITLE
Fix model mappings repr

### DIFF
--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -86,7 +86,7 @@ class Mapping(FittableModel):
         if self.name is None:
             return f'<Mapping({self.mapping})>'
         else:
-            return f'<Mapping({self.mapping}, name={self.name})>'
+            return f'<Mapping({self.mapping}, name={self.name!r})>'
 
     def evaluate(self, *args):
         if len(args) != self.n_inputs:
@@ -171,7 +171,7 @@ class Identity(Mapping):
         if self.name is None:
             return f'<Identity({self.n_inputs})>'
         else:
-            return f'<Identity({self.n_inputs}, name={self.name})>'
+            return f'<Identity({self.n_inputs}, name={self.name!r})>'
 
     @property
     def inverse(self):

--- a/astropy/modeling/tests/test_mappings.py
+++ b/astropy/modeling/tests/test_mappings.py
@@ -86,3 +86,13 @@ def test_fittable_compound():
     new_model = pfit(m, x, y_noisy)
     y_fit = new_model(x)
     assert_allclose(y_fit, y_real, atol=dy)
+
+
+def test_identity_repr():
+    m = Identity(1, name='foo')
+    assert repr(m) == "<Identity(1, name='foo')>"
+
+
+def test_mapping_repr():
+    m = Mapping([0, 1], name='foo')
+    assert repr(m) == "<Mapping([0, 1], name='foo')>"


### PR DESCRIPTION
Fixes missing quotes in the `Identity` and `Mapping` `repr`:

Before:

```python
>>> Identity(1, name='foo')
<Identity(1, name=foo)>

>>> Mapping([0, 1], name='foo')
<Mapping([0, 1], name=foo)>
```

After:
```python
>>> Identity(1, name='foo')
<Identity(1, name='foo')>

>>> Mapping([0, 1], name='foo')
<Mapping([0, 1], name='foo')>
```

I set the milestone to `3.2.2` since this should be easy to backport.  Feel free to change.