### PR TITLE
Clarify comment about removing deprecated representation attribute on frame classes

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -134,6 +134,7 @@ def _normalize_representation_type(kwargs):
     old-style argument ``representation``, add it back in to the kwargs dict
     as ``representation_type``.
     """
+    # TODO: remove this in a future LTS release, along with properties below
     if 'representation' in kwargs:
         if 'representation_type' in kwargs:
             raise ValueError("Both `representation` and `representation_type` "
@@ -771,7 +772,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
     def differential_type(self, value):
         self.set_representation_cls(s=value)
 
-    # TODO: remove these in a future version
+    # TODO: remove this property in a future LTS release
     @property
     def representation(self):
         _representation_deprecation()

--- a/astropy/coordinates/sky_coordinate_parsers.py
+++ b/astropy/coordinates/sky_coordinate_parsers.py
@@ -198,7 +198,7 @@ def _get_frame_without_data(args, kwargs):
         if attr in kwargs:
             frame_cls_kwargs[attr] = kwargs.pop(attr)
 
-    # TODO: deprecate representation, remove this in future
+    # TODO: remove this in a future LTS release
     _normalize_representation_type(kwargs)
 
     if 'representation_type' in kwargs:


### PR DESCRIPTION
This fixes #8886.

~~We added `.representation_type` (to be consistent with `.differential_type`) back in v3.0 (I think) and agreed to a long deprecation and removal cycle. The time has come to deprecate this now unadvertised attribute, and start to think about removing it in a future LTS release.~~

EDIT: It turns out the attribute was already deprecated with a custom warning! It looks like [we did this for 3.2.1](https://github.com/astropy/astropy/commit/2698d8c67880953def13011e60a96976833e56e4).
So now this PR will just rephrase the comment to remove confusion. I think this still fixes the issue above, as that was mainly about the ambiguous comment.