### PR TITLE
Add a classmethod to retrieve a Galactocentric frame with modern solar position/motion parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -213,6 +213,11 @@ astropy.coordinates
 - Removed the ``recommended_units`` attribute from Representations; it was
   deprecated since 3.0. [#8892]
 
+- Added a new classmethod to the ``Galactocentric`` frame,
+  ``Galactocentric.get_latest``, to retrieve a frame instance with a more
+  modern set of solar position and motion parameters based on recent
+  measurements from Gaia. [#9322]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -81,6 +81,19 @@ doc_footer = """
             [( -9.6083819 ,  -9.40062188,  6.52056066),
              (-21.28302307,  18.76334013,  7.84693855)]>
 
+    This uses a somewhat out-of-date set of parameters for the solar position
+    and motion in a Galactocentric sense: If your code or analysis does not
+    depend sensitively on these values, and you are just interested in
+    retrieving the latest measurements of these quantities, you can instead use
+    the ``.get_latest()`` classmethod to retrieve a frame with newer parameter
+    values::
+
+        >>> c.transform_to(coord.Galactocentric.get_latest()) # doctest: +FLOAT_CMP
+        <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg): (x, y, z) in kpc
+            [( -9.43489286, -9.40062188, 6.51345359),
+            (-21.11044918, 18.76334013, 7.83175149)]>
+
     To specify a custom set of parameters, you have to include extra keyword
     arguments when initializing the Galactocentric frame object::
 
@@ -89,6 +102,16 @@ doc_footer = """
             ( 266.4051, -28.936175)>, galcen_distance=8.1 kpc, galcen_v_sun=( 11.1,  232.24,  7.25) km / s, z_sun=27.0 pc, roll=0.0 deg): (x, y, z) in kpc
             [( -9.40785924,  -9.40062188,  6.52066574),
              (-21.08239383,  18.76334013,  7.84798135)]>
+
+    This also works using the ``.get_latest()`` classmethod, where the specified
+    keyword will only overwrite the keyword you pass in, and all other values
+    will be taken from the "latest" parameters::
+
+        >>> c.transform_to(coord.Galactocentric.get_latest(galcen_distance=8.1*u.kpc)) # doctest: +FLOAT_CMP
+        <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.1 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg): (x, y, z) in kpc
+            [( -9.41284763, -9.40062188, 6.51346272),
+            (-21.08839478, 18.76334013, 7.83184184)]>
 
     Similarly, transforming from the Galactocentric frame to another coordinate frame::
 
@@ -99,6 +122,17 @@ doc_footer = """
         <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
             [(  86.22349059, 28.83894138,  4.39157788e-05),
              ( 289.66802652, 49.88763881,  8.59640735e+01)]>
+
+    To specify data with the newer, modern set of solar parameters, pass the
+    data in to the ``get_latest()`` classmethod::
+
+        >>> c = coord.Galactocentric.get_latest(x=[-8.3, 4.5] * u.kpc,
+        ...                                     y=[0., 81.52] * u.kpc,
+        ...                                     z=[0.027, 24.12] * u.kpc)
+        >>> c.transform_to(coord.ICRS) # doctest: +FLOAT_CMP
+        <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
+            [( 88.22423301, 29.88672864,  0.17813456),
+            (289.72864549, 49.9865043 , 85.93949064)]>
 
     Or, with custom specification of the Galactic center::
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -117,8 +117,13 @@ doc_footer = """
 class Galactocentric(BaseCoordinateFrame):
     r"""
     A coordinate or frame in the Galactocentric system. This frame
-    requires specifying the Sun-Galactic center distance, and optionally
-    the height of the Sun above the Galactic midplane.
+    assumes default values for the Sun-Galactic center distance,
+    the height of the Sun above the Galactic midplane, and the solar motion,
+    but these values (as described below in this docstring) are now somewhat
+    out of date. You can set all of these values manually to your favorite,
+    updated measurements, by passing in frame attributes, or use the
+    ``Galactocentric.get_latest()`` class method to set the defaults to a more
+    modern set of parameters that may change between Astropy releases.
 
     The position of the Sun is assumed to be on the x axis of the final,
     right-handed system. That is, the x axis points from the position of
@@ -185,6 +190,43 @@ class Galactocentric(BaseCoordinateFrame):
         # a property here because this module isn't actually part of the public
         # API, so it's better for it to be accessable from Galactocentric
         return _ROLL0
+
+    @classmethod
+    def get_latest(cls, *args, **kwargs):
+        """This classmethod serves as an alternate initializer for
+        `~astropy.coordinates.Galacotcentric` that assumes more modern (and
+        constantly updated) parameters for the solar position and motion in a
+        Galactocentric context. As such, this classmethod acts exactly like the
+        initializer, but with different default frame attribute choices: That
+        is, you can explicitly pass in frame attributes to overwrite these
+        defaults, or pass in data to initialize this frame.
+
+        The current latest parameter choices come from:
+        * The default distance to the Galactic Center is 8.122 kpc from the
+          GRAVITY collaboration:
+          https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G/abstract
+        * The default height of the Sun above the Galactic midplane is taken to
+          be 20.8 pc, as measured by Bennett & Bovy (2019):
+          https://ui.adsabs.harvard.edu/abs/2019MNRAS.482.1417B/abstract
+        * The default solar velocity relative to the Galactic center is taken
+          from a combination of the GRAVITY collaboration and the Reid &
+          Brunthaler (2004) proper motion of Sgr A*:
+          https://ui.adsabs.harvard.edu/abs/2004ApJ...616..872R/abstract
+          https://ui.adsabs.harvard.edu/abs/2018RNAAS...2..210D/abstract
+
+        See the docstring for the initializer of this
+        `~astropy.coordinates.Galacotcentric` class for information about the
+        frame and its default component (data) names.
+        """
+
+        kwargs['galcen_distance'] = kwargs.pop('galcen_distance', 8.122 * u.kpc)
+        kwargs['galcen_v_sun'] = kwargs.pop(
+            'galcen_v_sun',
+            r.CartesianDifferential([12.9, 245.6, 7.78] * u.km/u.s))
+        kwargs['z_sun'] = kwargs.pop('z_sun', 20.8*u.pc)
+
+        return cls(*args, **kwargs)
+
 
 # ICRS to/from Galactocentric ----------------------->
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -1,21 +1,19 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-
 import numpy as np
 
 from astropy import units as u
 from astropy.utils.decorators import format_doc
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.coordinates.angles import Angle
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 from astropy.coordinates import representation as r
-from astropy.coordinates.baseframe import (BaseCoordinateFrame, frame_transform_graph,
-                         RepresentationMapping, base_doc)
-from astropy.coordinates.attributes import (Attribute, CoordinateAttribute,
-                          QuantityAttribute,
-                          DifferentialAttribute)
+from astropy.coordinates.baseframe import (BaseCoordinateFrame,
+                                           frame_transform_graph,
+                                           base_doc)
+from astropy.coordinates.attributes import (CoordinateAttribute,
+                                            QuantityAttribute,
+                                            DifferentialAttribute)
 from astropy.coordinates.transformations import AffineTransform
 from astropy.coordinates.errors import ConvertError
 
@@ -174,34 +172,6 @@ class Galactocentric(BaseCoordinateFrame):
 
     z_sun = QuantityAttribute(default=27.*u.pc)
     roll = QuantityAttribute(default=0.*u.deg)
-
-    def __init__(self, *args, **kwargs):
-
-        # backwards-compatibility
-        if ('galcen_ra' in kwargs or 'galcen_dec' in kwargs):
-            warnings.warn("The arguments 'galcen_ra', and 'galcen_dec' are "
-                          "deprecated in favor of specifying the sky coordinate"
-                          " as a CoordinateAttribute using the 'galcen_coord' "
-                          "argument", AstropyDeprecationWarning)
-
-            galcen_kw = dict()
-            galcen_kw['ra'] = kwargs.pop('galcen_ra', self.galcen_coord.ra)
-            galcen_kw['dec'] = kwargs.pop('galcen_dec', self.galcen_coord.dec)
-            kwargs['galcen_coord'] = ICRS(**galcen_kw)
-
-        super().__init__(*args, **kwargs)
-
-    @property
-    def galcen_ra(self):
-        warnings.warn("The attribute 'galcen_ra' is deprecated. Use "
-                      "'.galcen_coord.ra' instead.", AstropyDeprecationWarning)
-        return self.galcen_coord.ra
-
-    @property
-    def galcen_dec(self):
-        warnings.warn("The attribute 'galcen_dec' is deprecated. Use "
-                      "'.galcen_coord.dec' instead.", AstropyDeprecationWarning)
-        return self.galcen_coord.dec
 
     @classmethod
     def get_roll0(cls):

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -360,32 +360,31 @@ documentation::
   sc.fk4noeterms                         sc.realize_frame
   sc.fk5                                 sc.relative_humidity
   sc.flatten                             sc.represent_as
-  sc.frame                               sc.representation
-  sc.frame_attributes                    sc.representation_component_names
-  sc.frame_specific_representation_info  sc.representation_component_units
-  sc.from_name                           sc.representation_info
-  sc.from_pixel                          sc.reshape
-  sc.galactic                            sc.roll
-  sc.galactocentric                      sc.search_around_3d
-  sc.galcen_dec                          sc.search_around_sky
+  sc.frame                               sc.representation_component_names
+  sc.frame_attributes                    sc.representation_component_units
+  sc.frame_specific_representation_info  sc.representation_info
+  sc.from_name                           sc.reshape
+  sc.from_pixel                          sc.roll
+  sc.galactic                            sc.search_around_3d
+  sc.galactocentric                      sc.search_around_sky
   sc.galcen_distance                     sc.separation
-  sc.galcen_ra                           sc.separation_3d
-  sc.gcrs                                sc.shape
-  sc.geocentrictrueecliptic              sc.size
-  sc.get_constellation                   sc.skyoffset_frame
-  sc.get_frame_attr_names                sc.spherical
-  sc.guess_from_table                    sc.spherical_offsets_to
-  sc.has_data                            sc.squeeze
-  sc.hcrs                                sc.supergalactic
-  sc.heliocentrictrueecliptic            sc.swapaxes
-  sc.icrs                                sc.take
-  sc.info                                sc.temperature
-  sc.is_equivalent_frame                 sc.to_pixel
-  sc.is_frame_attr_default               sc.to_string
-  sc.is_transformable_to                 sc.transform_to
-  sc.isscalar                            sc.transpose
-  sc.itrs                                sc.z_sun
-  sc.location
+  sc.gcrs                                sc.separation_3d
+  sc.geocentrictrueecliptic              sc.shape
+  sc.get_constellation                   sc.size
+  sc.get_frame_attr_names                sc.skyoffset_frame
+  sc.guess_from_table                    sc.spherical
+  sc.has_data                            sc.spherical_offsets_to
+  sc.hcrs                                sc.squeeze
+  sc.heliocentrictrueecliptic            sc.supergalactic
+  sc.icrs                                sc.swapaxes
+  sc.info                                sc.take
+  sc.is_equivalent_frame                 sc.temperature
+  sc.is_frame_attr_default               sc.to_pixel
+  sc.is_transformable_to                 sc.to_string
+  sc.isscalar                            sc.transform_to
+  sc.itrs                                sc.transpose
+  sc.location                            sc.z_sun
+
 
 Here we see many attributes and methods. The most recognizable may be the
 longitude and latitude attributes which are named ``ra`` and ``dec`` for the


### PR DESCRIPTION
As noted in #9199, thanks to Gaia, we now have new, much more precise measurements of the solar motion, sun-galactic center distance, and solar height above the midplane, which are all parameters of the `Galactocentric` coordinate frame. Unlike most other frames in `astropy.coordinates`, these values are not standardized in the same way (e.g., there is no official IAU reference frame). Still, the parameters that are in the `Galactocentric` frame are now somewhat out of date, and different from what many people now adopt: It would therefore be good to provide a way to retrieve a frame with newer values.

We discussed a few options for how to do this:
1. Just update the parameters and tell people that the frame could change. I decided that the disadvantages of this were too great to go through with it, even though it would be the simplest programmatically! Disadvantages: (a) users who update may have their analysis code change spontaneously, (2) this would require updating all of the doctest values every time the defaults are changed, (3) this doesn't provide any kind of history of the parameter values
2. Add a function or classmethod to retrieve the frame with a specified "version" of the parameters. This could be a nice way of doing it, and would fit in well conceptually with the "ScienceState". But this adds a lot of overhead in terms of "versioning" machinery.
3. Keep the defaults in the class initializer, but add a classmethod that allows retrieving the "latest" parameter values. This is what I ended up going with in this PR.

This fixes #9199 