### PR TITLE
Expose erfa version information.

### DIFF
--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -183,15 +183,16 @@ STATUS_CODES['{{ func.pyname }}'] = {{ stat.doc_info.statuscodes|string }}
 {% endfor -%}
 
 
-# TODO: delete the functions below when they can get auto-generated
-# (current machinery doesn't support returning strings or non-status-codes)
+# TODO: These functions used to be needed to duplicate version information
+# in erfa; should they be deprecated in favour of just using them to create
+# ``_erfa.__version__`` or so?
 def version():
     """
     Returns the package version
     as defined in configure.ac
     in string format
     """
-    return "1.6.0"
+    return ufunc.erfa_version
 
 
 def version_major():
@@ -200,7 +201,7 @@ def version_major():
     as defined in configure.ac
     as integer
     """
-    return 1
+    return ufunc.erfa_version_major
 
 
 def version_minor():
@@ -209,7 +210,7 @@ def version_minor():
     as defined in configure.ac
     as integer
     """
-    return 6
+    return ufunc.erfa_version_minor
 
 
 def version_micro():
@@ -218,7 +219,7 @@ def version_micro():
     as defined in configure.ac
     as integer
     """
-    return 0
+    return ufunc.erfa_version_micro
 
 
 def sofa_version():
@@ -227,4 +228,4 @@ def sofa_version():
     as defined in configure.ac
     in string format
     """
-    return "20190722"
+    return ufunc.sofa_version

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -10,6 +10,23 @@ from astropy.time import Time
 from astropy.tests.helper import catch_warnings
 
 
+class TestVersion:
+    def test_basic(self):
+        assert hasattr(erfa.ufunc, 'erfa_version')
+        assert isinstance(erfa.ufunc.erfa_version, str)
+
+    def test_parts(self):
+        parts = erfa.ufunc.erfa_version.split('.')
+        assert len(parts) == 3
+        for p, attr in zip(parts, ('major', 'minor', 'micro')):
+            assert int(p) == getattr(erfa.ufunc,
+                                     f'erfa_version_{attr}')
+
+    def test_sofa_version(self):
+        assert hasattr(erfa.ufunc, 'sofa_version')
+        assert isinstance(erfa.ufunc.sofa_version, str)
+
+
 def test_erfa_wrapper():
     """
     Runs a set of tests that mostly make sure vectorization is

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -717,6 +717,8 @@ PyMODINIT_FUNC PyInit_ufunc(void)
 {
     /* module and its dict */
     PyObject *m, *d;
+    /* version information */
+    PyObject *version, *major, *minor, *micro, *sofa_version;
     /* structured dtypes and their definition */
     PyObject *dtype_def;
     PyArray_Descr *dt_double = NULL, *dt_int = NULL;
@@ -746,7 +748,30 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     if (d == NULL) {
         goto fail;
     }
-
+    /*
+     * Make the version information available in the module.
+     * Note that this gets run every time _erfa is imported,
+     * hence if the library is provided by the system rather
+     * than bundled with astropy, one correctly gets the version
+     * information from the system library.
+     */
+    version = PyUnicode_FromString(eraVersion());
+    major = PyLong_FromLong((long)eraVersionMajor());
+    minor = PyLong_FromLong((long)eraVersionMinor());
+    micro = PyLong_FromLong((long)eraVersionMicro());
+    sofa_version = PyUnicode_FromString(eraSofaVersion());
+    if (version == NULL || sofa_version == NULL ||
+            major == NULL || minor == NULL || micro == NULL) {
+        goto fail;
+    }
+    PyDict_SetItemString(d, "erfa_version", version);
+    PyDict_SetItemString(d, "erfa_version_major", major);
+    PyDict_SetItemString(d, "erfa_version_minor", minor);
+    PyDict_SetItemString(d, "erfa_version_micro", micro);
+    PyDict_SetItemString(d, "sofa_version", sofa_version);
+    /*
+     * Get ready for arrays and ufuncs
+     */
     import_array();
     import_umath();
     /*


### PR DESCRIPTION
@eteq - As a way to get back into erfa stuff, I wrote a quick wrapper to expose the erfa version information. The question now is exactly how to work with this on the python side. In astropy itself, there is a `version` module, which has `version`, `major`, and `minor` attributes, and `version` gets replicated as `__version__`.

But here, `core.py` defined *functions* that got those pieces of information. This seems somewhat inconsistent, but I have kept it for now. It would obviously be easy to define `_erfa.__version__` - but then I wondered whether it is actually right to let that be the `liberfa` function, when perhaps at some point the wrappers themselves needs version information (right now, there is some divergence already, since two extra ufuncs are added).

Another, smalller question, is whether it wouldn't be easier to just put the C functions inside the `ufunc` module (rather than have a new `erfa_version` module).

fixes #6240