### PR TITLE
Pass input through DifferentialAttribute input to allowed class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -222,6 +222,10 @@ astropy.coordinates
 
 - Removed ``longitude`` and ``latitude`` attributes from ``EarthLocation``;
   deprecated since 2.0. [#9326]
+- The ``DifferentialAttribute`` for frame classes now passes through any input
+  to the ``allowed_classes`` if only one allowed class is specified, i.e. this
+  now allows passing a quantity in for frame attributes that use
+  ``DifferentialAttribute``. [#9325]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -183,7 +183,7 @@ class TimeAttribute(Attribute):
             except Exception as err:
                 raise ValueError(
                     'Invalid time input {}={!r}\n{}'.format(self.name,
-                                                               value, err))
+                                                            value, err))
             converted = True
 
         # Set attribute as read-only for arrays (not allowed by numpy
@@ -486,11 +486,14 @@ class DifferentialAttribute(Attribute):
         """
 
         if not isinstance(value, self.allowed_classes):
-            raise TypeError('Tried to set a DifferentialAttribute with '
-                            'an unsupported Differential type {}. Allowed '
-                            'classes are: {}'
-                            .format(value.__class__,
-                                    self.allowed_classes))
+            if len(self.allowed_classes) == 1:
+                value = self.allowed_classes[0](value)
+            else:
+                raise TypeError('Tried to set a DifferentialAttribute with '
+                                'an unsupported Differential type {}. Allowed '
+                                'classes are: {}'
+                                .format(value.__class__,
+                                        self.allowed_classes))
 
         return value, True
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -90,6 +90,37 @@ def test_frame_subclass_attribute_descriptor():
     assert mfk4.newattr == 'world'
 
 
+def test_differentialattribute():
+    from astropy.coordinates import BaseCoordinateFrame
+    from astropy.coordinates.attributes import DifferentialAttribute
+
+    # Test logic of passing input through to allowed class
+    vel = [1, 2, 3]*u.km/u.s
+    dif = r.CartesianDifferential(vel)
+
+    class TestFrame(BaseCoordinateFrame):
+        attrtest = DifferentialAttribute(
+            default=dif, allowed_classes=[r.CartesianDifferential])
+
+    frame1 = TestFrame()
+    frame2 = TestFrame(attrtest=dif)
+    frame3 = TestFrame(attrtest=vel)
+
+    assert np.all(frame1.attrtest.d_xyz == frame2.attrtest.d_xyz)
+    assert np.all(frame1.attrtest.d_xyz == frame3.attrtest.d_xyz)
+
+    # This shouldn't work if there is more than one allowed class:
+    class TestFrame2(BaseCoordinateFrame):
+        attrtest = DifferentialAttribute(
+            default=dif, allowed_classes=[r.CartesianDifferential,
+                                          r.CylindricalDifferential])
+
+    frame1 = TestFrame2()
+    frame2 = TestFrame2(attrtest=dif)
+    with pytest.raises(TypeError):
+        TestFrame2(attrtest=vel)
+
+
 def test_create_data_frames():
     from astropy.coordinates.builtin_frames import ICRS
 


### PR DESCRIPTION
While working on #9322, I remembered an annoyance with the `Galactocentric` frame class: when specifying a solar velocity, it must be passed in as a `CartesianDifferential` object even though we only allow passing in cartesian velocities (and this requires typing a lot of characters!). For example:
```python
>>> coord.Galactocentric(galcen_v_sun=coord.CartesianDifferential([1., 2., 3.]*u.km/u.s))
```
Here, because `galcen_v_sun` requires a `CartesianDifferential`, it wouldn't be ambiguous to accept the quantity itself:
```python
>>> coord.Galactocentric(galcen_v_sun=[1., 2., 3.]*u.km/u.s)
```
but the above currently fails.

This PR adds support for the 2nd snippet above, by passing through the input to a `DifferentialAttribute` to the `allow_classes` if only one `allowed_class` is present. 