### PR TITLE
Remove some deprecated things from astropy.coordinates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,11 @@ astropy.coordinates
 - Removed the ``recommended_units`` attribute from Representations; it was
   deprecated since 3.0. [#8892]
 
+- Removed the deprecated frame attribute classes, ``FrameAttribute``,
+  ``TimeFrameAttribute``,
+  ``QuantityFrameAttribute``,``CartesianRepresentationFrameAttribute``;
+  deprecated since 3.0. [#9326]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -220,6 +220,9 @@ astropy.coordinates
   ``QuantityFrameAttribute``,``CartesianRepresentationFrameAttribute``;
   deprecated since 3.0. [#9326]
 
+- Removed ``longitude`` and ``latitude`` attributes from ``EarthLocation``;
+  deprecated since 2.0. [#9326]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -21,8 +21,3 @@ from .sky_coordinate import *
 from .funcs import *
 from .calculation import *
 from .solar_system import *
-
-# This is for backwards-compatibility -- can be removed in v3.0 when the
-# deprecation warnings are removed
-from .attributes import (TimeFrameAttribute, QuantityFrameAttribute,
-                         CartesianRepresentationFrameAttribute)

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -495,41 +495,6 @@ class DifferentialAttribute(Attribute):
         return value, True
 
 
-# Backwards-compatibility: these are the only classes that were previously
-# released in v1.3
-class FrameAttribute(Attribute):
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn("FrameAttribute has been renamed to Attribute.",
-                      AstropyDeprecationWarning)
-        super().__init__(*args, **kwargs)
-
-
-class TimeFrameAttribute(TimeAttribute):
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn("TimeFrameAttribute has been renamed to TimeAttribute.",
-                      AstropyDeprecationWarning)
-        super().__init__(*args, **kwargs)
-
-
-class QuantityFrameAttribute(QuantityAttribute):
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn("QuantityFrameAttribute has been renamed to "
-                      "QuantityAttribute.", AstropyDeprecationWarning)
-        super().__init__(*args, **kwargs)
-
-
-class CartesianRepresentationFrameAttribute(CartesianRepresentationAttribute):
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn("CartesianRepresentationFrameAttribute has been renamed "
-                      "to CartesianRepresentationAttribute.",
-                      AstropyDeprecationWarning)
-        super().__init__(*args, **kwargs)
-
-
 # do this here to prevent a series of complicated circular imports
 from .earth import EarthLocation
 from .representation import CartesianRepresentation, BaseDifferential

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -22,19 +22,11 @@ from astropy.utils.decorators import lazyproperty, format_doc
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy import units as u
 from astropy.utils import (OrderedDescriptorContainer, ShapedLikeNDArray,
-                     check_broadcast)
+                           check_broadcast)
 from .transformations import TransformGraph
 from . import representation as r
 from .angles import Angle
 from .attributes import Attribute
-
-# Import old names for Attributes so we don't break backwards-compatibility
-# (some users rely on them being here, although that is not encouraged, as this
-# is not the public API location -- see attributes.py).
-from .attributes import (
-    TimeFrameAttribute, QuantityFrameAttribute,
-    EarthLocationAttribute, CoordinateAttribute,
-    CartesianRepresentationFrameAttribute)  # pylint: disable=W0611
 
 
 __all__ = ['BaseCoordinateFrame', 'frame_transform_graph',

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -16,7 +16,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from .angles import Longitude, Latitude
 from .representation import CartesianRepresentation, CartesianDifferential
 from .errors import UnknownSiteException
-from astropy.utils import data, deprecated
+from astropy.utils import data
 from astropy import _erfa as erfa
 
 __all__ = ['EarthLocation']
@@ -589,21 +589,9 @@ class EarthLocation(u.Quantity):
             u.Quantity(height * u.meter, self.unit, copy=False))
 
     @property
-    @deprecated('2.0', alternative='`lon`', obj_type='property')
-    def longitude(self):
-        """Longitude of the location, for the default ellipsoid."""
-        return self.geodetic[0]
-
-    @property
     def lon(self):
         """Longitude of the location, for the default ellipsoid."""
         return self.geodetic[0]
-
-    @property
-    @deprecated('2.0', alternative='`lat`', obj_type='property')
-    def latitude(self):
-        """Latitude of the location, for the default ellipsoid."""
-        return self.geodetic[1]
 
     @property
     def lat(self):

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -493,44 +493,6 @@ def test_regression_6347_3d():
     assert type(d2d_1) is type(d2d_10)
 
 
-def test_regression_6300():
-    """Check that importing old frame attribute names from astropy.coordinates
-    still works. See comments at end of #6300
-    """
-    from astropy.utils.exceptions import AstropyDeprecationWarning
-    from astropy.coordinates import CartesianRepresentation
-    from astropy.coordinates import (TimeFrameAttribute, QuantityFrameAttribute,
-                    CartesianRepresentationFrameAttribute)
-
-    with catch_warnings() as found_warnings:
-        attr = TimeFrameAttribute(default=Time("J2000"))
-
-        for w in found_warnings:
-            if issubclass(w.category, AstropyDeprecationWarning):
-                break
-        else:
-            assert False, "Deprecation warning not raised"
-
-    with catch_warnings() as found_warnings:
-        attr = QuantityFrameAttribute(default=5*u.km)
-
-        for w in found_warnings:
-            if issubclass(w.category, AstropyDeprecationWarning):
-                break
-        else:
-            assert False, "Deprecation warning not raised"
-
-    with catch_warnings() as found_warnings:
-        attr = CartesianRepresentationFrameAttribute(
-            default=CartesianRepresentation([5,6,7]*u.kpc))
-
-        for w in found_warnings:
-            if issubclass(w.category, AstropyDeprecationWarning):
-                break
-        else:
-            assert False, "Deprecation warning not raised"
-
-
 @pytest.mark.remote_data
 def test_gcrs_itrs_cartesian_repr():
     # issue 6436: transformation failed if coordinate representation was


### PR DESCRIPTION
This removes the old frame attribute classes (deprecated since v3.0), and the `EarthLocation` attribute names `longitude`/`latitude` (deprecated since v2.0). 