### PR TITLE
Expose reading and setting of the ERFA leap second table

### DIFF
--- a/astropy/_erfa/__init__.py
+++ b/astropy/_erfa/__init__.py
@@ -3,4 +3,4 @@
 from .core import *
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,
                     dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
-from .interface import leap_seconds
+from .helpers import leap_seconds

--- a/astropy/_erfa/__init__.py
+++ b/astropy/_erfa/__init__.py
@@ -2,5 +2,5 @@
 
 from .core import *
 from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,
-                    dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf,
-                    get_leap_seconds, set_leap_seconds)
+                    dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
+from .interface import leap_seconds

--- a/astropy/_erfa/__init__.py
+++ b/astropy/_erfa/__init__.py
@@ -1,3 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 from .core import *
+from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_eraLEAPSECOND, dt_pv,
+                    dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf,
+                    get_leap_seconds, set_leap_seconds)

--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -38,15 +38,12 @@ from astropy.utils.exceptions import ErfaError, ErfaWarning
 from astropy.utils.misc import check_broadcast
 
 from . import ufunc
-from .ufunc import (dt_eraASTROM, dt_eraLDBODY, dt_pv,
-                    dt_sign, dt_type, dt_ymdf, dt_hmsf, dt_dmsf)
 
 __all__ = ['ErfaError', 'ErfaWarning',
            {{ funcs|map(attribute='pyname')|surround("'","'")|join(", ") }},
            {{ constants|map(attribute='name')|surround("'","'")|join(", ") }},
            # TODO: delete the functions below when they can get auto-generated
-           'version', 'version_major', 'version_minor', 'version_micro', 'sofa_version',
-           'dt_eraASTROM', 'dt_eraLDBODY', 'dt_pv', 'dt_ymdf', 'dt_hmsf', 'dt_dmsf']
+           'version', 'version_major', 'version_minor', 'version_micro', 'sofa_version']
 
 
 # <---------------------------------Error-handling---------------------------->

--- a/astropy/_erfa/helpers.py
+++ b/astropy/_erfa/helpers.py
@@ -1,6 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
-Interfaces to the ERFA library, in particular for leap seconds.
+Helpers to interact with the ERFA library, in particular for leap seconds.
 """
 from datetime import datetime, timedelta
 from warnings import warn

--- a/astropy/_erfa/interface.py
+++ b/astropy/_erfa/interface.py
@@ -1,0 +1,177 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Interfaces to the ERFA library, in particular for leap seconds.
+"""
+from datetime import datetime, timedelta
+from warnings import warn
+
+import numpy as np
+
+from astropy.utils.decorators import classproperty
+from astropy.utils.exceptions import AstropyWarning
+
+from .ufunc import get_leap_seconds, set_leap_seconds, dt_eraLEAPSECOND
+
+
+class leap_seconds:
+    """Leap second management.
+
+    This singleton class allows access to ERFA's leap second table,
+    using the methods 'get', 'set', and 'update'.
+
+    One can also check expiration with 'expires' and 'expired'.
+
+    Note that usage of the class is similar to a ``ScienceState`` class,
+    but it cannot be used as a context manager.
+    """
+    _expires = None
+    """Explicit expiration date inferred from leap-second table."""
+    _expiration_days = 180
+    """Number of days beyond last leap second at which table expires."""
+
+    def __init__(self):
+        raise RuntimeError("This class is a singleton.  Do not instantiate.")
+
+    @classmethod
+    def get(cls):
+        """Get the current leap-second table used internally."""
+        return get_leap_seconds()
+
+    @classmethod
+    def validate(cls, table):
+        """Validate a leap-second table.
+
+        Raises
+        ------
+        ValueError
+            If the leap seconds in the table are not on the 1st of January or
+            July, or if the sorted TAI-UTC do not increase in increments of 1.
+        """
+        try:
+            day = table['day']
+        except Exception:
+            day = 1
+
+        # Take care of astropy Table.
+        if hasattr(table, '__array__'):
+            table = table.__array__()[list(dt_eraLEAPSECOND.names)]
+
+        table = np.array(table, dtype=dt_eraLEAPSECOND, copy=False,
+                         ndmin=1)
+
+        # Simple sanity checks.
+        if table.ndim > 1:
+            raise ValueError("can only pass in one-dimensional tables.")
+
+        if not np.all(((day == 1) &
+                       (table['month'] == 1) | (table['month'] == 7)) |
+                      (table['year'] < 1972)):
+            raise ValueError("leap seconds inferred that are not on "
+                             "1st of January or 1st of July.")
+
+        if np.any((table['year'][:-1] > 1970) &
+                  (np.diff(table['tai_utc']) != 1)):
+            raise ValueError("jump in TAI-UTC by something else than one.")
+
+        return table
+
+    @classmethod
+    def set(cls, table=None):
+        """Set the ERFA leap second table.
+
+        Note that it is generally safer to update the leap-second table than
+        to set it directly, since most tables do not have the pre-1970 changes
+        in TAI-UTC that are part of the built-in ERFA table.
+
+        Parameters
+        ----------
+        table : array-like or `None`
+            Leap-second table that should at least hold columns of 'year',
+            'month', and 'tai_utc'.  Only simple validation is done before it
+            is being used, so care need to be taken that entries are correct.
+            If `None`, reset the ERFA table to its built-in values.
+
+        Raises
+        ------
+        ValueError
+            If the leap seconds in the table are not on the 1st of January or
+            July, or if the sorted TAI-UTC do not increase in increments of 1.
+        """
+        set_leap_seconds(None if table is None else cls.validate(table))
+        cls._expires = getattr(table, 'expires', None)
+
+    @classproperty
+    def expires(cls):
+        """The expiration date of the current ERFA table.
+
+        This is either a date inferred from the last table used to update or
+        set the leap-second array, or a number of days beyond the last leap
+        second.
+        """
+        if cls._expires is None:
+            last = cls.get()[-1]
+            return (datetime(last['year'], last['month'], 1) +
+                    timedelta(cls._expiration_days))
+        else:
+            return cls._expires
+
+    @classproperty
+    def expired(cls):
+        """Whether the leap second table is valid beyond the present."""
+        return cls.expires < datetime.now()
+
+    @classmethod
+    def update(cls, table):
+        """Add any leap seconds not already present to the ERFA table.
+
+        This method matches leap seconds with those present in the ERFA table,
+        and extends the latter as necessary.
+
+        If the ERFA leap seconds file was corrupted, it will be reset.
+
+        If the table is corrupted, the ERFA file will be unchanged.
+
+        Parameters
+        ----------
+        table : array-like or `~astropy.utils.iers.LeapSeconds`
+            Array or table with TAI-UTC from leap seconds.  Should have
+            'year', 'month', and 'tai_utc' columns.
+
+        Returns
+        -------
+        n_update : int
+            Number of items updated.
+
+        Raises
+        ------
+        ValueError
+            If the leap seconds in the table are not on the 1st of January or
+            July, or if the sorted TAI-UTC do not increase in increments of 1.
+        """
+        expires = getattr(table, 'expires', None)
+        table = cls.validate(table)
+
+        # Get erfa table and check it is OK; if not, reset it.
+        try:
+            erfa_ls = cls.validate(cls.get())
+        except Exception:
+            cls.set()
+            erfa_ls = cls.get()
+
+        # Create the combined array and use it (validating the combination).
+        ls = np.union1d(erfa_ls, table)
+        cls.set(ls)
+
+        # If the update table has an expiration beyond that inferred from
+        # the new leap second second array, use it (but, now that the new
+        # array is set, do not allow exceptions due to misformed expires).
+        try:
+            if expires is not None and expires > cls.expires:
+                cls._expires = expires
+
+        except Exception as exc:
+            warn("table 'expires' attribute ignored as comparing it "
+                 "with a datetime raised an error:\n" + str(exc),
+                 AstropyWarning)
+
+        return len(ls) - len(erfa_ls)

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from datetime import datetime
 
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -241,9 +243,9 @@ def test_float32_input():
     np.testing.assert_allclose(out32, out64, rtol=1.e-5)
 
 
-class TestLeapSeconds:
+class TestLeapSecondsBasics:
     def test_get_leap_seconds(self):
-        leap_seconds = erfa.get_leap_seconds()
+        leap_seconds = erfa.leap_seconds.get()
         assert isinstance(leap_seconds, np.ndarray)
         assert leap_seconds.dtype is erfa.dt_eraLEAPSECOND
         # Very basic sanity checks.
@@ -253,22 +255,113 @@ class TestLeapSeconds:
                       (leap_seconds['month'] <= 12))
         assert np.all(abs(leap_seconds['tai_utc'] < 1000.))
 
-    def test_reset_leap_seconds_simple(self):
-        leap_seconds = erfa.get_leap_seconds()
-        erfa.set_leap_seconds()
-        new_leap_seconds = erfa.get_leap_seconds()
-        assert_array_equal(leap_seconds, new_leap_seconds)
+    def test_leap_seconds_expires(self):
+        expires = erfa.leap_seconds.expires
+        assert isinstance(expires, datetime)
+        last_ls = erfa.leap_seconds.get()[-1]
+        dt_last = datetime(last_ls['year'], last_ls['month'], 1)
+        assert expires > dt_last
+
+
+class TestLeapSeconds:
+    """Test basic methods to control the ERFA leap-second table."""
+    def setup(self):
+        self.erfa_ls = erfa.leap_seconds.get()
+        self.expires = erfa.leap_seconds.expires
+        self._expires = erfa.leap_seconds._expires
+
+    def teardown(self):
+        erfa.leap_seconds.set(self.erfa_ls)
+        erfa.leap_seconds._expires = self._expires
+
+    def test_set_reset_leap_seconds(self):
+        erfa.leap_seconds.set()
+        leap_seconds = erfa.leap_seconds.get()
+
+        erfa.leap_seconds.set(leap_seconds[:-2])
+        new_leap_seconds = erfa.leap_seconds.get()
+        assert_array_equal(new_leap_seconds, leap_seconds[:-2])
+
+        erfa.leap_seconds.set()
+        reset_leap_seconds = erfa.leap_seconds.get()
+        assert_array_equal(reset_leap_seconds, leap_seconds)
 
     def test_set_leap_seconds(self):
         assert erfa.dat(2018, 1, 1, 0.) == 37.0
-        leap_seconds = erfa.get_leap_seconds()
+        leap_seconds = erfa.leap_seconds.get()
+        # Set to a table that misses the 2017 leap second.
         part_leap_seconds = leap_seconds[leap_seconds['year'] < 2017]
-        try:
-            erfa.set_leap_seconds(part_leap_seconds)
-            new_leap_seconds = erfa.get_leap_seconds()
-            assert_array_equal(new_leap_seconds, part_leap_seconds)
-            # Check the 2017 leap second is indeed missing.
-            assert erfa.dat(2018, 1, 1, 0.) == 36.0
-        finally:
-            erfa.set_leap_seconds()
+        erfa.leap_seconds.set(part_leap_seconds)
+        new_leap_seconds = erfa.leap_seconds.get()
+        assert_array_equal(new_leap_seconds, part_leap_seconds)
+        # Check the 2017 leap second is indeed missing.
+        assert erfa.dat(2018, 1, 1, 0.) == 36.0
+        # And that this would be expected from the expiration date.
+        assert erfa.leap_seconds.expires < datetime(2018, 1, 1)
+        assert erfa.leap_seconds.expired
+        # Reset and check it is back.
+        erfa.leap_seconds.set()
         assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+    @pytest.mark.parametrize('table,match', [
+        ([(2017, 3, 10.)], 'January'),
+        ([(2017, 1, 1.),
+          (2017, 7, 3.)], 'jump'),
+        ([[(2017, 1, 1.)],
+          [(2017, 7, 2.)]], 'dimension')])
+    def test_validation(self, table, match):
+        with pytest.raises(ValueError, match=match):
+            erfa.leap_seconds.set(table)
+        # Check leap-second table is not corrupted.
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls)
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+    def test_update_leap_seconds(self):
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+        leap_seconds = erfa.leap_seconds.get()
+        # Get old and new leap seconds
+        old_leap_seconds = leap_seconds[leap_seconds['year'] < 2017]
+        new_leap_seconds = leap_seconds[leap_seconds['year'] >= 2017]
+        # Updating with either of these should do nothing.
+        n_update = erfa.leap_seconds.update(new_leap_seconds)
+        assert n_update == 0
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls)
+        n_update = erfa.leap_seconds.update(old_leap_seconds)
+        assert n_update == 0
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls)
+
+        # But after setting to older part, update with newer should work.
+        erfa.leap_seconds.set(old_leap_seconds)
+        # Check the 2017 leap second is indeed missing.
+        assert erfa.dat(2018, 1, 1, 0.) == 36.0
+        # Update with missing leap seconds.
+        n_update = erfa.leap_seconds.update(new_leap_seconds)
+        assert n_update == len(new_leap_seconds)
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+        # Also a final try with overlapping data.
+        erfa.leap_seconds.set(old_leap_seconds)
+        n_update = erfa.leap_seconds.update(leap_seconds)
+        assert n_update == len(new_leap_seconds)
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+    def test_with_expiration(self):
+        class ExpiringArray(np.ndarray):
+            expires = datetime(2345, 1, 1)
+
+        leap_seconds = erfa.leap_seconds.get()
+        erfa.leap_seconds.set(leap_seconds.view(ExpiringArray))
+        assert erfa.leap_seconds.expires == ExpiringArray.expires
+
+        # Get old and new leap seconds
+        old_leap_seconds = leap_seconds[:-10]
+        new_leap_seconds = leap_seconds[-10:]
+
+        erfa.leap_seconds.set(old_leap_seconds)
+        # Check expiration is reset
+        assert erfa.leap_seconds.expires != ExpiringArray.expires
+        # Update with missing leap seconds.
+        n_update = erfa.leap_seconds.update(
+            new_leap_seconds.view(ExpiringArray))
+        assert n_update == len(new_leap_seconds)
+        assert erfa.leap_seconds.expires == ExpiringArray.expires

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -14,6 +14,7 @@
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
 #include "erfa.h"
+#include "erfaextra.h"
 #include "erfa_additions.h"
 
 #define MODULE_DOCSTRING \
@@ -23,6 +24,28 @@
     "Python wrappers are also provided, which convert between\n" \
     "trailing dimensions and structured dtypes where necessary,\n" \
     "and combine status codes."
+#define GET_LEAP_SECONDS_DOCSTRING \
+    "get_leap_seconds()\n\n" \
+    "Access the leap second table used in ERFA.\n\n" \
+    "Returns\n" \
+    "-------\n" \
+    "leap_seconds : `~numpy.ndarray`\n" \
+    "    With structured dtype `~astropy._erfa.dt_eraLEAPSECOND`,\n" \
+    "    containing items 'year', 'month', and 'tai_utc'."
+#define SET_LEAP_SECONDS_DOCSTRING \
+    "set_leap_seconds([table])\n\n" \
+    "Set the leap second table used in ERFA.\n\n" \
+    "Parameters\n" \
+    "----------\n" \
+    "leap_seconds : array-like, optional\n" \
+    "    With structured dtype `~astropy._erfa.dt_eraLEAPSECOND`,\n" \
+    "    containing items 'year', 'month', and 'tai_utc'.\n" \
+    "    If not given, reset to the ERFA built-in table.\n\n" \
+    "Notes\n" \
+    "-----\n" \
+    "No sanity checks are done on the input; it is simply coerced\n" \
+    "to the correct dtype."
+
 
 static inline void copy_to_double3(char *ptr, npy_intp s, double d[3]) {
     char *p = ptr;
@@ -582,9 +605,90 @@ fail:
 }
 
 /*
+ * LEAP SECOND ACCESS
+ */
+static PyArray_Descr *dt_eraLEAPSECOND = NULL;  /* Set in PyInit_ufunc */
+
+static PyObject *
+get_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *NPY_UNUSED(args)) {
+    eraLEAPSECOND *leapseconds;
+    npy_intp count;
+    PyArrayObject *array;
+    /* Get the leap seconds from ERFA */
+    count = (npy_intp)eraGetLeapSeconds(&leapseconds);
+    if (count < 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Unpexected failure to get ERFA leap seconds.");
+        return NULL;
+    }
+    /* Allocate an array to hold them */
+    Py_INCREF(dt_eraLEAPSECOND);
+    array = (PyArrayObject *)PyArray_NewFromDescr(
+        &PyArray_Type, dt_eraLEAPSECOND, 1, &count, NULL, NULL, 0, NULL);
+    if (array == NULL) {
+        return NULL;
+    }
+    /* Copy the leap seconds over into the array */
+    memcpy(PyArray_DATA(array), leapseconds, count*sizeof(eraLEAPSECOND));
+    return (PyObject *)array;
+}
+
+static PyObject *
+set_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *args) {
+    PyObject *leap_seconds = NULL;
+    PyArrayObject *array;
+    static PyArrayObject *leap_second_array = NULL;
+
+    if (!PyArg_ParseTuple(args, "|O:set_leap_seconds", &leap_seconds)) {
+        return NULL;
+    }
+    if (leap_seconds) {
+        /*
+         * Convert the input to an array with the proper dtype;
+         * Ensure a copy is made so one cannot change the data by changing
+         * the input array.
+         */
+        Py_INCREF(dt_eraLEAPSECOND);
+        array = (PyArrayObject *)PyArray_FromAny(leap_seconds, dt_eraLEAPSECOND,
+                    1, 1, (NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY), NULL);
+        if (array == NULL) {
+            return NULL;
+        }
+        if (PyArray_SIZE(array) == 0) {
+            PyErr_SetString(PyExc_ValueError,
+                            "Leap second array must have at least one entry.");
+        }
+        /*
+         * Use the array for the new leap seconds.
+         */
+        eraSetLeapSeconds(PyArray_DATA(array), PyArray_SIZE(array));
+    }
+    else {
+        /*
+         * If no input is given, reset leap second table.
+         */
+        array = NULL;
+        eraSetLeapSeconds(NULL, 0);
+    }
+    /*
+     * If we allocated a leap second array before, deallocate it,
+     * and set it to remember any allocation from PyArray_FromAny.
+     */
+    if (leap_second_array != NULL) {
+        Py_DECREF(leap_second_array);
+    }
+    leap_second_array = array;
+    Py_RETURN_NONE;
+}
+
+/*
  * UFUNC MODULE DEFINITIONS AND INITIALIZATION
  */
 static PyMethodDef ErfaUFuncMethods[] = {
+    {"get_leap_seconds", (PyCFunction)get_leap_seconds,
+         METH_NOARGS, GET_LEAP_SECONDS_DOCSTRING},
+    {"set_leap_seconds", (PyCFunction)set_leap_seconds,
+         METH_VARARGS, SET_LEAP_SECONDS_DOCSTRING},
     {NULL, NULL, 0, NULL}
 };
 
@@ -708,11 +812,18 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         );
     PyArray_DescrAlignConverter(dtype_def, &dt_eraASTROM);
     Py_DECREF(dtype_def);
+    /* eraLEAPSECOND */
+    dtype_def = Py_BuildValue("[(s, s), (s, s), (s, s)]",
+                              "year", "i4", "month", "i4", "tai_utc", "f8");
+    PyArray_DescrAlignConverter(dtype_def, &dt_eraLEAPSECOND);
+    Py_DECREF(dtype_def);
+
     if (dt_double == NULL || dt_int == NULL ||
         dt_pv == NULL || dt_pvdpv == NULL ||
         dt_ymdf == NULL || dt_hmsf == NULL || dt_dmsf == NULL ||
         dt_sign == NULL || dt_type == NULL ||
-        dt_eraLDBODY == NULL || dt_eraASTROM == NULL) {
+        dt_eraLDBODY == NULL || dt_eraASTROM == NULL ||
+        dt_eraLEAPSECOND == NULL) {
         goto fail;
     }
     /* Make the structured dtypes available in the module */
@@ -725,6 +836,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
     PyDict_SetItemString(d, "dt_type", (PyObject *)dt_type);
     PyDict_SetItemString(d, "dt_eraLDBODY", (PyObject *)dt_eraLDBODY);
     PyDict_SetItemString(d, "dt_eraASTROM", (PyObject *)dt_eraASTROM);
+    PyDict_SetItemString(d, "dt_eraLEAPSECOND", (PyObject *)dt_eraLEAPSECOND);
     /*
      * Define the ufuncs.  For those without structured dtypes,
      * the ufunc creation uses the static variables defined above;
@@ -799,5 +911,6 @@ decref:
     Py_XDECREF(dt_type);
     Py_XDECREF(dt_eraASTROM);
     Py_XDECREF(dt_eraLDBODY);
+    Py_XDECREF(dt_eraLEAPSECOND);
     return m;
 }

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -606,6 +606,15 @@ fail:
 
 /*
  * LEAP SECOND ACCESS
+ *
+ * Getting/Setting ERFAs built-in TAI-UTC table.
+ *
+ * TODO: the whole procedure is not sub-interpreter safe.
+ * In this module, one might get dt_eraLEAPSECOND out of the module dict,
+ * and store the leap_second array in a per-module struct (see PEP 3121).
+ * But one then would also have to adapt erfa/dat.c to not use a
+ * static leap second table.  Possibly best might be to copy dat.c here
+ * and put the table into the per-module struct as well.
  */
 static PyArray_Descr *dt_eraLEAPSECOND = NULL;  /* Set in PyInit_ufunc */
 

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -651,7 +651,7 @@ set_leap_seconds(PyObject *NPY_UNUSED(module), PyObject *args) {
     if (!PyArg_ParseTuple(args, "|O:set_leap_seconds", &leap_seconds)) {
         return NULL;
     }
-    if (leap_seconds) {
+    if (leap_seconds != NULL && leap_seconds != Py_None) {
         /*
          * Convert the input to an array with the proper dtype;
          * Ensure a copy is made so one cannot change the data by changing

--- a/cextern/erfa/dat.c
+++ b/cextern/erfa/dat.c
@@ -1,14 +1,5 @@
 #include "erfa.h"
-#include "erfaextra.h"
-
-static eraLEAPSECOND *changes = 0;
-static int NDAT = 0;
-
-void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count)
-{
-   changes = leapseconds;
-   NDAT = count;
-}
+#include "erfadatextra.h"
 
 int eraDat(int iy, int im, int id, double fd, double *deltat)
 /*
@@ -202,11 +193,11 @@ int eraDat(int iy, int im, int id, double fd, double *deltat)
 /* Number of Delta(AT) changes */
    enum { _NDAT = (int) (sizeof _changes / sizeof _changes[0]) };
 
-/* Initialise leap seconds if needed */
-   if ( NDAT == 0) {
-      NDAT = _NDAT;
-      changes = (eraLEAPSECOND *)_changes;
-   }
+/* Get/initialise leap-second if needed */
+   int NDAT;
+   eraLEAPSECOND *changes;
+
+   NDAT = eraDatini(_changes, _NDAT, &changes);
 
 /* Miscellaneous local variables */
    int j, i, m;

--- a/cextern/erfa/erfadatextra.c
+++ b/cextern/erfa/erfadatextra.c
@@ -1,0 +1,38 @@
+#include "erfa.h"
+#include "erfaextra.h"
+
+static eraLEAPSECOND *changes;
+static int NDAT = 0;
+
+
+int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
+{
+    if (NDAT == 0) {
+        double delat;
+        int stat = eraDat(2000, 1, 1, 0., &delat);
+        if (stat != 0 || NDAT == 0) {
+            return -1;
+        }
+    }
+    *leapseconds = changes;
+    return NDAT;
+}
+
+void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+{
+    changes = leapseconds;
+    NDAT = count;
+}
+
+/*
+ * For internal use in dat.c
+ */
+int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
+              eraLEAPSECOND **leapseconds)
+{
+    if (NDAT == 0) {
+        eraSetLeapSeconds((eraLEAPSECOND *)builtin, n_builtin);
+    }
+    *leapseconds = changes;
+    return NDAT;
+}

--- a/cextern/erfa/erfadatextra.h
+++ b/cextern/erfa/erfadatextra.h
@@ -1,0 +1,2 @@
+int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
+              eraLEAPSECOND **leapseconds);

--- a/cextern/erfa/erfaextra.h
+++ b/cextern/erfa/erfaextra.h
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2016-2017, NumFOCUS Foundation. 
+** Copyright (C) 2016-2017, NumFOCUS Foundation.
 **
 ** Licensed under a 3-clause BSD style license - see LICENSE
 **
@@ -15,35 +15,35 @@ extern "C" {
 #endif
 
 
-/* 
+/*
 ** Returns the package version
 ** as defined in configure.ac
 ** in string format
 */
 const char* eraVersion(void);
 
-/* 
+/*
 ** Returns the package major version
 ** as defined in configure.ac
 ** as integer
 */
 int eraVersionMajor(void);
 
-/* 
+/*
 ** Returns the package minor version
 ** as defined in configure.ac
 ** as integer
 */
 int eraVersionMinor(void);
 
-/* 
+/*
 ** Returns the package micro version
 ** as defined in configure.ac
 ** as integer
 */
 int eraVersionMicro(void);
 
-/* 
+/*
 ** Returns the orresponding SOFA version
 ** as defined in configure.ac
 ** in string format
@@ -52,14 +52,14 @@ const char* eraSofaVersion(void);
 
 
 
-/* 
-** Update leap seconds (not supported by SOFA)
+/*
+** Get and set leap seconds (not supported by SOFA)
 */
-void eraUpdateLeapSeconds(eraLEAPSECOND *leapseconds, int count);
+int eraGetLeapSeconds(eraLEAPSECOND **leapseconds);
+void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count);
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* _ERFA_EXTRA_H */
-


### PR DESCRIPTION
@eteq - this is step 1 to using/updating the leap second table. I went a bit beyond @jwoillez's implementation by also allowing one to *retrieve* the current leap second table, using a new `eraGetLeapSeconds`. With that, it seemed it would be better to also rename `eraUpdateLeapSeconds` to `eraSetLeapSeconds`.

One can now retrieve these as structured arrays using ~`_erfa.get_leap_second_table` and `_erfa.set_leap_second_table`.~ EDIT (name change): `erfa.get_leap_seconds` and `_erfa.set_leap_seconds`.

EDIT 2: I hid the C functions behind a new leap_second singleton, with `get`, `set`, and `update` methods.