### PR TITLE
Add DataInfo get_sortable_arrays to allow mixins as key columns in join

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,11 @@ astropy.table
 - Allow adding a table column as a list of mixin-type objects, for instance
   ``t['q'] = [1 * u.m, 2 * u.m]``. [#9165]
 
+- Allow table ``join()`` using any sortable key column (e.g. Time), not
+  just ndarray subclasses. A column is considered sortable if there is a
+  ``<column>.info.get_sortable_arrays()`` method that is implemented.
+  [#9340]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -172,7 +172,9 @@ class ColumnInfo(BaseColumnInfo):
 
         For Column this is just the column itself.
 
-        :return: list of Column
+        Returns
+        -------
+        arrays : list of ndarray
         """
         return [self._parent]
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -165,6 +165,17 @@ class ColumnInfo(BaseColumnInfo):
 
         return self._parent_cls(length=length, **attrs)
 
+    def get_sortable_arrays(self):
+        """
+        Return a list of arrays which can be lexically sorted to represent
+        the order of the parent column.
+
+        For Column this is just the column itself.
+
+        :return: list of Column
+        """
+        return [self._parent]
+
 
 class BaseColumn(_ColumnGetitemShim, np.ndarray):
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -313,9 +313,9 @@ def test_join(table_types):
             t12 = join(t1, t2, keys='a', join_type=join_type)
         assert 'join requires masking column' in str(exc.value)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(TypeError) as exc:
         t12 = join(t1, t2, keys=['a', 'skycoord'])
-    assert 'not allowed as a key column' in str(exc.value)
+    assert 'one or more key columns are not sortable' in str(exc.value)
 
     # Join does work for a mixin which is a subclass of np.ndarray
     t12 = join(t1, t2, keys=['quantity'])

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1505,6 +1505,50 @@ def test_vstack_unicode():
     assert t2['a'].itemsize == 4
 
 
+def test_join_mixins_time_quantity():
+    """
+    Test for table join using non-ndarray key columns.
+    """
+    tm1 = Time([2, 1, 2], format='cxcsec')
+    q1 = [2, 1, 1] * u.m
+    idx1 = [1, 2, 3]
+    tm2 = Time([2, 3], format='cxcsec')
+    q2 = [2, 3] * u.m
+    idx2 = [10, 20]
+    t1 = Table([tm1, q1, idx1], names=['tm', 'q', 'idx'])
+    t2 = Table([tm2, q2, idx2], names=['tm', 'q', 'idx'])
+    # Output:
+    #
+    # <Table length=4>
+    #         tm            q    idx_1 idx_2
+    #                       m
+    #       object       float64 int64 int64
+    # ------------------ ------- ----- -----
+    # 0.9999999999969589     1.0     2    --
+    #   2.00000000000351     1.0     3    --
+    #   2.00000000000351     2.0     1    10
+    #  3.000000000000469     3.0    --    20
+
+    t12 = table.join(t1, t2, join_type='outer', keys=['tm', 'q'])
+    # Key cols are lexically sorted
+    assert np.all(t12['tm'] == Time([1, 2, 2, 3], format='cxcsec'))
+    assert np.all(t12['q'] == [1, 1, 2, 3] * u.m)
+    assert np.all(t12['idx_1'] == np.ma.array([2, 3, 1, 0], mask=[0, 0, 0, 1]))
+    assert np.all(t12['idx_2'] == np.ma.array([0, 0, 10, 20], mask=[1, 1, 0, 0]))
+
+
+def test_join_mixins_not_sortable():
+    """
+    Test for table join using non-ndarray key columns that are not sortable.
+    """
+    sc = SkyCoord([1, 2], [3, 4], unit='deg,deg')
+    t1 = Table([sc, [1, 2]], names=['sc', 'idx1'])
+    t2 = Table([sc, [10, 20]], names=['sc', 'idx2'])
+
+    with pytest.raises(TypeError, match='one or more key columns are not sortable'):
+        table.join(t1, t2, keys='sc')
+
+
 def test_get_out_class():
     c = table.Column([1, 2])
     mc = table.MaskedColumn([1, 2])

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1549,6 +1549,15 @@ def test_join_mixins_not_sortable():
         table.join(t1, t2, keys='sc')
 
 
+def test_join_non_1d_key_column():
+    c1 = [[1, 2], [3, 4]]
+    c2 = [1, 2]
+    t1 = Table([c1, c2], names=['a', 'b'])
+    t2 = t1.copy()
+    with pytest.raises(ValueError, match="key column 'a' must be 1-d"):
+        table.join(t1, t2, keys='a')
+
+
 def test_get_out_class():
     c = table.Column([1, 2])
     mc = table.MaskedColumn([1, 2])

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -139,6 +139,18 @@ class TimeInfo(MixinInfo):
                                      'yaml': 'jd1_jd2',
                                      None: 'jd1_jd2'}
 
+    def get_sortable_arrays(self):
+        """
+        Return a list of arrays which can be lexically sorted to represent
+        the order of the parent column.
+
+        :return: list of ndarray
+        """
+        parent = self._parent
+        jd_approx = parent.jd
+        jd_remainder = (parent - parent.__class__(jd_approx, format='jd')).jd
+        return [jd_approx, jd_remainder]
+
     @property
     def unit(self):
         return None

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -144,7 +144,9 @@ class TimeInfo(MixinInfo):
         Return a list of arrays which can be lexically sorted to represent
         the order of the parent column.
 
-        :return: list of ndarray
+        Returns
+        -------
+        arrays : list of ndarray
         """
         parent = self._parent
         jd_approx = parent.jd

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -196,6 +196,17 @@ class QuantityInfo(QuantityInfoBase):
 
         return out
 
+    def get_sortable_arrays(self):
+        """
+        Return a list of arrays which can be lexically sorted to represent
+        the order of the parent column.
+
+        For Quantity this is just the quantity itself.
+
+        :return: list of Quantity
+        """
+        return [self._parent]
+
 
 class Quantity(np.ndarray):
     """A `~astropy.units.Quantity` represents a number with some associated unit.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -203,7 +203,10 @@ class QuantityInfo(QuantityInfoBase):
 
         For Quantity this is just the quantity itself.
 
-        :return: list of Quantity
+
+        Returns
+        -------
+        arrays : list of ndarray
         """
         return [self._parent]
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -685,6 +685,17 @@ class BaseColumnInfo(DataInfo):
 
         return out
 
+    def get_sortable_arrays(self):
+        """
+        Return a list of arrays which can be lexically sorted to represent
+        the order of the parent column.
+
+        The base method raises NotImplementedError and must be overridden.
+
+        :return: list of Column
+        """
+        raise NotImplementedError(f'column {self.name} is not sortable')
+
 
 class MixinInfo(BaseColumnInfo):
 

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -692,7 +692,9 @@ class BaseColumnInfo(DataInfo):
 
         The base method raises NotImplementedError and must be overridden.
 
-        :return: list of Column
+        Returns
+        -------
+        arrays : list of ndarray
         """
         raise NotImplementedError(f'column {self.name} is not sortable')
 


### PR DESCRIPTION
Closes #7728 

Should be used as the base for #9287.