### PR TITLE
TST: Ignore another mil URL in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -245,6 +245,7 @@ linkcheck_retry = 5
 linkcheck_ignore = ['https://journals.aas.org/manuscript-preparation/',
                     'https://maia.usno.navy.mil/',
                     'https://www.usno.navy.mil/USNO/time/gps/usno-gps-time-transfer',
+                    'https://aa.usno.navy.mil/publications/docs/Circular_179.php',
                     r'https://github\.com/astropy/astropy/(?:issues|pull)/\d+']
 linkcheck_timeout = 180
 linkcheck_anchors = False


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address failed `linkcheck` cron job due to blocking by `mil` domain. The URL works when I tried on my browser but not in CI.

I skipped CI because this only affects the cron job.
