### PR TITLE
Add a note about reading HDUs into Tables

### DIFF
--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -279,6 +279,13 @@ read in and a warning will be emitted::
     >>> t = Table.read('data.fits')  # doctest: +SKIP
     WARNING: hdu= was not specified but multiple tables are present, reading in first available table (hdu=1) [astropy.io.fits.connect]
 
+You can also read a table from the HDUs of an in-memory FITS file. This will
+round-trip any :ref:`mixin_columns` that were written to that HDU, using the
+header information to reconstruct them::
+
+    >>> hdulist = astropy.io.fits.open('data.fits') # doctest: +SKIP
+    >>> t = Table.read(hdulist[1])  # doctest: +SKIP
+
 Writing
 ^^^^^^^^
 


### PR DESCRIPTION
I'd asked on slack#units about round-tripping Quantities through FITS BinTables, and @saimn pointed out that one can just pass the HDU itself to `Table.read`. I didn't see that anywhere in the docs, so I've added it.