### PR TITLE
Set the Galactocentric frame parameter defaults using a ScienceState

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ astropy.coordinates
   ``CylindricalRepresentation`` of the coordinate, as is already available
   for other common representations. [#8857]
 
+- The default parameters for the ``Galactocentric`` frame are now controlled by
+  a ``ScienceState`` subclass, ``galactocentric_frame_defaults``. New
+  parameter sets will be added to this object periodically to keep up with
+  ever-improved measurements of the solar position and motion. [#9346]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,10 +267,14 @@ astropy.coordinates
 
 - Removed ``longitude`` and ``latitude`` attributes from ``EarthLocation``;
   deprecated since 2.0. [#9326]
+
 - The ``DifferentialAttribute`` for frame classes now passes through any input
   to the ``allowed_classes`` if only one allowed class is specified, i.e. this
   now allows passing a quantity in for frame attributes that use
   ``DifferentialAttribute``. [#9325]
+
+- Removed the deprecated ``galcen_ra`` and ``galcen_dec`` attributes from the
+  ``Galactocentric`` frame. [#9346]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -54,6 +54,7 @@ from astropy.coordinates.baseframe import frame_transform_graph
 # we define an __all__ because otherwise the transformation modules
 # get included
 __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
+           'galactocentric_frame_defaults',
            'Supergalactic', 'AltAz', 'GCRS', 'CIRS', 'ITRS', 'HCRS',
            'PrecessedGeocentric', 'GeocentricMeanEcliptic',
            'BarycentricMeanEcliptic', 'HeliocentricMeanEcliptic',

--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -20,7 +20,7 @@ from one frame to another frame of the same class) should be included in that
 module.  Transformation functions connecting the new frame to other frames
 should be in a separate module, which should be imported in this package's
 ``__init__.py`` to ensure the transformations are hooked up when this package is
-imported.  Placing the trasnformation functions in separate modules avoids
+imported.  Placing the transformation functions in separate modules avoids
 circular dependencies, because they need references to the frame classes.
 """
 
@@ -29,7 +29,7 @@ from .icrs import ICRS
 from .fk5 import FK5
 from .fk4 import FK4, FK4NoETerms
 from .galactic import Galactic
-from .galactocentric import Galactocentric
+from .galactocentric import Galactocentric, galactocentric_frame_defaults
 from .lsr import LSR, GalacticLSR
 from .supergalactic import Supergalactic
 from .altaz import AltAz

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -260,13 +260,12 @@ doc_footer = """
             [(  86.2585249 ,  28.85773187,  2.75625475e-05),
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
 
+    .. testcleanup:: *
 
-    # Reset the state after doctests above.
-    # TODO: this needs to be audited and removed if we change the default
-    # defaults (yes) for v4.1. This is a hack to get around the fact that
-    # the doctests here actually change the *class* state::
-
-        >>> galactocentric_frame_defaults._value = 'pre-v4.0'
+        # TODO: this needs to be audited and removed if we change the default
+        # defaults (yes) for v4.1. This is a hack to get around the fact that
+        # the doctests here actually change the *class* state:
+        galactocentric_frame_defaults._value = 'pre-v4.0'
 
 """
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import warnings
-
 import numpy as np
 
 from astropy import units as u
 from astropy.utils.state import ScienceState
 from astropy.utils.decorators import format_doc
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.coordinates.angles import Angle
 from astropy.coordinates.matrix_utilities import rotation_matrix, matrix_product, matrix_transpose
 from astropy.coordinates import representation as r
@@ -241,36 +238,12 @@ class Galactocentric(BaseCoordinateFrame):
     roll = QuantityAttribute(unit=u.deg)
 
     def __init__(self, *args, **kwargs):
-
-        # backwards-compatibility
-        if ('galcen_ra' in kwargs or 'galcen_dec' in kwargs):
-            warnings.warn("The arguments 'galcen_ra', and 'galcen_dec' are "
-                          "deprecated in favor of specifying the sky coordinate"
-                          " as a CoordinateAttribute using the 'galcen_coord' "
-                          "argument", AstropyDeprecationWarning)
-
-            galcen_kw = dict()
-            galcen_kw['ra'] = kwargs.pop('galcen_ra', self.galcen_coord.ra)
-            galcen_kw['dec'] = kwargs.pop('galcen_dec', self.galcen_coord.dec)
-            kwargs['galcen_coord'] = ICRS(**galcen_kw)
-
+        # Set default frame attribute values based on the ScienceState instance
+        # for the solar parameters defined above
         default_params = default_sun_galactocentric.get()
         for k in default_params:
             kwargs[k] = kwargs.get(k, default_params[k])
-
         super().__init__(*args, **kwargs)
-
-    @property
-    def galcen_ra(self):
-        warnings.warn("The attribute 'galcen_ra' is deprecated. Use "
-                      "'.galcen_coord.ra' instead.", AstropyDeprecationWarning)
-        return self.galcen_coord.ra
-
-    @property
-    def galcen_dec(self):
-        warnings.warn("The attribute 'galcen_dec' is deprecated. Use "
-                      "'.galcen_coord.dec' instead.", AstropyDeprecationWarning)
-        return self.galcen_coord.dec
 
     @classmethod
     def get_roll0(cls):

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -258,15 +258,16 @@ class Galactocentric(BaseCoordinateFrame):
     original definition of the frame in 2014. As such, the defaults are somewhat
     out of date relative to recent measurements made possible by, e.g., Gaia.
     The defaults can, however, be changed at runtime by setting the parameter
-    set name in `~astropy.coordinates.galactocentric_frame_defaults`. The
-    default parameter set is ``"pre-v4,0"``, indicating that the parameters
-    were adopted before ``astropy`` version 4.0. A regularly-updated parameter
-    set can instead be used by setting ``galactocentric_frame_defaults.set
-    ('latest')``, and other parameter set names may be added in future
-    versions. To find out the scientific papers that the current default
-    parameters are derived from, use ``galcen.frame_attribute_references``
-    (where ``galcen`` is an instance of this frame), which will update even if
-    the default parameter set is changed.
+    set name in `~astropy.coordinates.galactocentric_frame_defaults`.
+
+    The current default parameter set is ``"pre-v4.0"``, indicating that the
+    parameters were adopted before ``astropy`` version 4.0. A regularly-updated
+    parameter set can instead be used by setting
+    ``galactocentric_frame_defaults.set ('latest')``, and other parameter set
+    names may be added in future versions. To find out the scientific papers
+    that the current default parameters are derived from, use
+    ``galcen.frame_attribute_references`` (where ``galcen`` is an instance of
+    this frame), which will update even if the default parameter set is changed.
 
     The position of the Sun is assumed to be on the x axis of the final,
     right-handed system. That is, the x axis points from the position of

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -259,6 +259,13 @@ doc_footer = """
         <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
             [(  86.2585249 ,  28.85773187,  2.75625475e-05),
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
+
+    .. testcleanup::
+        # TODO: this needs to be audited and removed if we change the default
+        # defaults (yes) for v4.1. This is a hack to get around the fact that
+        # the doctests here actually change the *class* state:
+        galactocentric_frame_defaults._value = 'pre-v4.0'
+
 """
 
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -260,11 +260,13 @@ doc_footer = """
             [(  86.2585249 ,  28.85773187,  2.75625475e-05),
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
 
-    .. testcleanup::
-        # TODO: this needs to be audited and removed if we change the default
-        # defaults (yes) for v4.1. This is a hack to get around the fact that
-        # the doctests here actually change the *class* state:
-        galactocentric_frame_defaults._value = 'pre-v4.0'
+
+    # Reset the state after doctests above.
+    # TODO: this needs to be audited and removed if we change the default
+    # defaults (yes) for v4.1. This is a hack to get around the fact that
+    # the doctests here actually change the *class* state::
+
+        >>> galactocentric_frame_defaults._value = 'pre-v4.0'
 
 """
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -29,7 +29,7 @@ __all__ = ['Galactocentric']
 _ROLL0 = Angle(58.5986320306*u.degree)
 
 
-class default_sun_galactocentric(ScienceState):
+class galactocentric_frame_defaults(ScienceState):
     """The ScienceState instance that controls global setting of Galactocentric
     default solar motion parameters
     """
@@ -218,14 +218,14 @@ class Galactocentric(BaseCoordinateFrame):
     original definition of the frame in 2014. As such, the defaults are somewhat
     out of date relative to recent measurements made possible by, e.g., Gaia.
     The defaults can, however, be changed at runtime by setting the parameter
-    set name in ``astropy.coordinates.default_sun_galactocentric``. The default
+    set name in `~astropy.coordinates.galactocentric_frame_defaults. The default
     parameter set is ``"pre-v4,0"``, indicating that the parameters were adopted
     before ``astropy`` version 4.0. A regularly-updated parameter set can
-    instead be used by setting ``default_sun_galactocentric.set('latest')``, and
-    other parameter set names may be added in future versions. To find out the
-    scientific papers that the current default parameters are derived from, use
-    ``galcen.get_references()`` (where ``galcen`` is an instance of this frame),
-    which will update even if the default parameter set is changed.
+    instead be used by setting ``galactocentric_frame_defaults.set('latest')``,
+    and other parameter set names may be added in future versions. To find out
+    the scientific papers that the current default parameters are derived from,
+    use ``galcen.get_references()`` (where ``galcen`` is an instance of this
+    frame), which will update even if the default parameter set is changed.
 
     The position of the Sun is assumed to be on the x axis of the final,
     right-handed system. That is, the x axis points from the position of
@@ -257,8 +257,8 @@ class Galactocentric(BaseCoordinateFrame):
     def __init__(self, *args, **kwargs):
         # Set default frame attribute values based on the ScienceState instance
         # for the solar parameters defined above
-        default_params = default_sun_galactocentric.get()
-        self._references = default_sun_galactocentric._references
+        default_params = galactocentric_frame_defaults.get()
+        self._references = galactocentric_frame_defaults._references
         for k in default_params:
             kwargs[k] = kwargs.get(k, default_params[k])
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -110,7 +110,7 @@ class galactocentric_frame_defaults(ScienceState):
             attrs = dict()
             for k in value.frame_attributes:
                 attrs[k] = getattr(value, k)
-            cls._references = value.get_references()
+            cls._references = value.frame_attribute_references()
             return attrs
 
         else:
@@ -224,8 +224,9 @@ class Galactocentric(BaseCoordinateFrame):
     instead be used by setting ``galactocentric_frame_defaults.set('latest')``,
     and other parameter set names may be added in future versions. To find out
     the scientific papers that the current default parameters are derived from,
-    use ``galcen.get_references()`` (where ``galcen`` is an instance of this
-    frame), which will update even if the default parameter set is changed.
+    use ``galcen.frame_attribute_references`` (where ``galcen`` is an instance
+    of this frame), which will update even if the default parameter set is
+    changed.
 
     The position of the Sun is assumed to be on the x axis of the final,
     right-handed system. That is, the x axis points from the position of
@@ -258,9 +259,17 @@ class Galactocentric(BaseCoordinateFrame):
         # Set default frame attribute values based on the ScienceState instance
         # for the solar parameters defined above
         default_params = galactocentric_frame_defaults.get()
-        self._references = galactocentric_frame_defaults._references
+        self.frame_attribute_references = \
+            galactocentric_frame_defaults._references.copy()
+
         for k in default_params:
+            # If a frame attribute is set by the user, remove its reference
+            self.frame_attribute_references.pop(k, None)
+
+            # Keep the frame attribute if it is set by the user, otherwise use
+            # the default value
             kwargs[k] = kwargs.get(k, default_params[k])
+
         super().__init__(*args, **kwargs)
 
     @classmethod
@@ -275,12 +284,6 @@ class Galactocentric(BaseCoordinateFrame):
         # a property here because this module isn't actually part of the public
         # API, so it's better for it to be accessable from Galactocentric
         return _ROLL0
-
-    def get_references(self):
-        if self._references is None:
-            raise ValueError("No references were provided or are available for "
-                             "the current Galactocentric frame parameters.")
-        return self._references
 
 # ICRS to/from Galactocentric ----------------------->
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -260,12 +260,12 @@ doc_footer = """
             [(  86.2585249 ,  28.85773187,  2.75625475e-05),
              ( 289.77285255,  50.06290457,  8.59216010e+01)]>
 
-    .. testcleanup:: *
 
-        # TODO: this needs to be audited and removed if we change the default
-        # defaults (yes) for v4.1. This is a hack to get around the fact that
-        # the doctests here actually change the *class* state:
-        galactocentric_frame_defaults._value = 'pre-v4.0'
+    # TODO: this needs to be audited and removed if we change the default
+    # defaults (yes) for v4.1. This is a hack to get around the fact that
+    # the doctests here actually change the *class* state:
+
+        >>> galactocentric_frame_defaults._value = 'pre-v4.0'
 
 """
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -73,8 +73,8 @@ class default_sun_galactocentric(ScienceState):
     @classmethod
     def validate(cls, value):
         if value is None:
-            # the default is to always adopt the latest solar parameters
-            value = 'latest'
+            # the default is to use the original definition of this frame
+            value = 'pre-v4.0'
 
         if isinstance(value, str):
             return cls.get_solar_params_from_string(value)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -353,8 +353,8 @@ class Galactocentric(BaseCoordinateFrame):
                           'either (1) specify all Galactocentric frame '
                           'attributes explicitly when using the frame, '
                           'or (2) set the galactocentric_frame_defaults '
-                          'parameter set name explicitly. See {} for more '
-                          'information.'.format(docs_link),
+                          f'parameter set name explicitly. See {docs_link} for more '
+                          'information.',
                           AstropyDeprecationWarning)
 
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -50,19 +50,12 @@ class galactocentric_frame_defaults(ScienceState):
     - 'v4.0': The attribute values as updated in Astropy version 4.0.
     - 'latest': An alias of the most recent parameter set (currently: 'v4.0')
 
+    See :ref:`astropy-coordinates-galactocentric-defaults` for more information.
+
     Examples
     --------
-    As with other `~astropy.utils.state.ScienceState` subclasses, this class can
-    be used to globally set the frame defaults at runtime. For example, the
-    default parameter values can be seen by initializing the
-    `~astropy.coordinates.Galactocentric` frame with no arguments::
-
-        >>> from astropy.coordinates import Galactocentric
-        >>> Galactocentric()
-        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
-            (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
-
-    But, these can be modified using this class::
+    The default `~astropy.coordinates.Galactocentric` frame parameters can be
+    modified globally::
 
         >>> from astropy.coordinates import galactocentric_frame_defaults
         >>> galactocentric_frame_defaults.set('v4.0')

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -218,15 +218,15 @@ class Galactocentric(BaseCoordinateFrame):
     original definition of the frame in 2014. As such, the defaults are somewhat
     out of date relative to recent measurements made possible by, e.g., Gaia.
     The defaults can, however, be changed at runtime by setting the parameter
-    set name in `~astropy.coordinates.galactocentric_frame_defaults. The default
-    parameter set is ``"pre-v4,0"``, indicating that the parameters were adopted
-    before ``astropy`` version 4.0. A regularly-updated parameter set can
-    instead be used by setting ``galactocentric_frame_defaults.set('latest')``,
-    and other parameter set names may be added in future versions. To find out
-    the scientific papers that the current default parameters are derived from,
-    use ``galcen.frame_attribute_references`` (where ``galcen`` is an instance
-    of this frame), which will update even if the default parameter set is
-    changed.
+    set name in `~astropy.coordinates.galactocentric_frame_defaults`. The
+    default parameter set is ``"pre-v4,0"``, indicating that the parameters
+    were adopted before ``astropy`` version 4.0. A regularly-updated parameter
+    set can instead be used by setting ``galactocentric_frame_defaults.set
+    ('latest')``, and other parameter set names may be added in future
+    versions. To find out the scientific papers that the current default
+    parameters are derived from, use ``galcen.frame_attribute_references``
+    (where ``galcen`` is an instance of this frame), which will update even if
+    the default parameter set is changed.
 
     The position of the Sun is assumed to be on the x axis of the final,
     right-handed system. That is, the x axis points from the position of

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -42,6 +42,10 @@ class galactocentric_frame_defaults(ScienceState):
     def get_solar_params_from_string(arg):
         """Return Galactocentric solar parameters given string names for the parameter sets.
         """
+        # Resolve the meaning of 'latest': The latest parameter set is from v4.0
+        # - update this as newer parameter choices are added
+        if arg == 'latest':
+            arg = 'v4.0'
 
         params = dict()
         references = dict()
@@ -71,7 +75,7 @@ class galactocentric_frame_defaults(ScienceState):
             references['z_sun'] = \
                 'https://ui.adsabs.harvard.edu/#abs/2001ApJ...553..184C'
 
-        elif arg == 'latest':
+        elif arg == 'v4.0':
             params['galcen_distance'] = 8.122 * u.kpc
             references['galcen_distance'] = \
                 'https://ui.adsabs.harvard.edu/abs/2018A%26A...615L..15G'

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -30,8 +30,43 @@ _ROLL0 = Angle(58.5986320306*u.degree)
 
 
 class galactocentric_frame_defaults(ScienceState):
-    """The ScienceState instance that controls global setting of Galactocentric
-    default solar motion parameters
+    """This class controls the global setting of default values for the frame
+    attributes in the `~astropy.coordinates.Galactocentric` frame, which may be
+    updated in future versions of ``astropy``. Note that when using
+    `~astropy.coordinates.Galactocentric`, changing values here will not affect
+    any attributes that are set explicitly by passing values in to the
+    `~astropy.coordinates.Galactocentric` initializer, but will affect the
+    frame attribute values when using the frame as, e.g.,
+    ``coord.Galactocentric`` or ``coord.Galactocentric()`` with no explicit
+    arguments.
+
+    This class controls the parameter settings by specifying a string name,
+    which can be one of:
+
+    - 'pre-v4.0': The current default value, which sets the default frame
+      attribute values to their original (pre-version-4.0) values.
+    - 'v4.0': The attribute values as updated in version 4.0.
+    - 'latest': An alias of the most recent parameter set (currently: 'v4.0')
+
+    Examples
+    --------
+    As with other `~astropy.utils.state.ScienceState` subclasses, this class
+    can either be used to globally set the frame defaults at runtime, e.g.::
+
+        >>> from astropy.coordinates import (galactocentric_frame_defaults,
+        ...                                  Galactocentric)
+        >>> galactocentric_frame_defaults.set('v4.0')
+        >>> Galactocentric() # doctest: +FLOAT_CMP
+        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg)>
+
+    Or, it can be used as a context manager::
+
+        >>> with galactocentric_frame_defaults.set('pre-v4.0'):
+        ...     print(Galactocentric()) # doctest: +FLOAT_CMP
+        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
+
     """
 
     # the default is to use the original definition of this frame
@@ -40,7 +75,8 @@ class galactocentric_frame_defaults(ScienceState):
 
     @staticmethod
     def get_solar_params_from_string(arg):
-        """Return Galactocentric solar parameters given string names for the parameter sets.
+        """Return Galactocentric solar parameters given string names for the
+        parameter sets.
         """
         # Resolve the meaning of 'latest': The latest parameter set is from v4.0
         # - update this as newer parameter choices are added

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -58,10 +58,14 @@ class galactocentric_frame_defaults(ScienceState):
     modified globally::
 
         >>> from astropy.coordinates import galactocentric_frame_defaults
-        >>> galactocentric_frame_defaults.set('v4.0')
+        >>> _ = galactocentric_frame_defaults.set('v4.0')
         >>> Galactocentric() # doctest: +FLOAT_CMP
         <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
             (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg)>
+        >>> _ = galactocentric_frame_defaults.set('pre-v4.0')
+        >>> Galactocentric() # doctest: +FLOAT_CMP
+        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
 
     The default parameters can also be updated by using this class as a context
     manager::

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -38,37 +38,54 @@ class galactocentric_frame_defaults(ScienceState):
     updated in future versions of ``astropy``. Note that when using
     `~astropy.coordinates.Galactocentric`, changing values here will not affect
     any attributes that are set explicitly by passing values in to the
-    `~astropy.coordinates.Galactocentric` initializer, but will affect the
-    frame attribute values when using the frame as, e.g.,
-    ``coord.Galactocentric`` or ``coord.Galactocentric()`` with no explicit
-    arguments.
+    `~astropy.coordinates.Galactocentric` initializer. Modifying these defaults
+    will only affect the frame attribute values when using the frame as, e.g.,
+    ``Galactocentric`` or ``Galactocentric()`` with no explicit arguments.
 
     This class controls the parameter settings by specifying a string name,
     which can be one of:
 
     - 'pre-v4.0': The current default value, which sets the default frame
-      attribute values to their original (pre-version-4.0) values.
-    - 'v4.0': The attribute values as updated in version 4.0.
+      attribute values to their original (pre-astropy-v4.0) values.
+    - 'v4.0': The attribute values as updated in Astropy version 4.0.
     - 'latest': An alias of the most recent parameter set (currently: 'v4.0')
 
     Examples
     --------
-    As with other `~astropy.utils.state.ScienceState` subclasses, this class
-    can either be used to globally set the frame defaults at runtime, e.g.::
+    As with other `~astropy.utils.state.ScienceState` subclasses, this class can
+    be used to globally set the frame defaults at runtime. For example, the
+    default parameter values can be seen by initializing the
+    `~astropy.coordinates.Galactocentric` frame with no arguments::
 
-        >>> from astropy.coordinates import (galactocentric_frame_defaults,
-        ...                                  Galactocentric)
+        >>> from astropy.coordinates import Galactocentric
+        >>> Galactocentric()
+        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
+
+    But, these can be modified using this class::
+
+        >>> from astropy.coordinates import galactocentric_frame_defaults
         >>> galactocentric_frame_defaults.set('v4.0')
         >>> Galactocentric() # doctest: +FLOAT_CMP
         <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
             (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg)>
 
-    Or, it can be used as a context manager::
+    The default parameters can also be updated by using this class as a context
+    manager::
 
         >>> with galactocentric_frame_defaults.set('pre-v4.0'):
         ...     print(Galactocentric()) # doctest: +FLOAT_CMP
         <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
             (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
+
+    Again, changing the default parameter values will not affect frame
+    attributes that are explicitly specified::
+
+        >>> import astropy.units as u
+        >>> with galactocentric_frame_defaults.set('pre-v4.0'):
+        ...     print(Galactocentric(galcen_distance=8.0*u.kpc)) # doctest: +FLOAT_CMP
+        <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+            (266.4051, -28.936175)>, galcen_distance=8.0 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
 
     """
 

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -336,20 +336,21 @@ class Galactocentric(BaseCoordinateFrame):
         # deprecation warning to inform them that the defaults will change in
         # the future:
         if galactocentric_frame_defaults._value == 'pre-v4.0' and warn:
-            docs_link = ''  # TODO
+            docs_link = 'http://docs.astropy.org/en/latest/coordinates/galactocentric.html'
             warnings.warn('In v4.1 and later versions, the Galactocentric '
                           'frame will adopt default parameters that may update '
                           'with time. An updated default parameter set is '
                           'already available through the '
                           'astropy.coordinates.galactocentric_frame_defaults '
-                          'ScienceState object, as described in {} '
-                          'but the default is currently still set to '
-                          'the pre-v4.0 parameter defaults. The safest way to '
-                          'guard against changing default parameters in the '
-                          'future is to either (1) specify all Galactocentric '
-                          'frame attributes explicitly when using the frame, '
+                          'ScienceState object, as described in but the '
+                          'default is currently still set to the pre-v4.0 '
+                          'parameter defaults. The safest way to guard against '
+                          'changing default parameters in the future is to '
+                          'either (1) specify all Galactocentric frame '
+                          'attributes explicitly when using the frame, '
                           'or (2) set the galactocentric_frame_defaults '
-                          'parameter set name explicitly.'.format(docs_link),
+                          'parameter set name explicitly. See {} for more '
+                          'information.'.format(docs_link),
                           AstropyDeprecationWarning)
 
         super().__init__(*args, **kwargs)

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -34,11 +34,13 @@ class default_sun_galactocentric(ScienceState):
     default solar motion parameters
     """
 
-    _value = 'latest'
+    # the default is to use the original definition of this frame
+    _value = 'pre-v4.0'
 
     @staticmethod
     def get_solar_params_from_string(arg):
-        """ Return ... """
+        """Return Galactocentric solar parameters given string names for the parameter sets.
+        """
 
         params = dict()
 
@@ -72,10 +74,6 @@ class default_sun_galactocentric(ScienceState):
 
     @classmethod
     def validate(cls, value):
-        if value is None:
-            # the default is to use the original definition of this frame
-            value = 'pre-v4.0'
-
         if isinstance(value, str):
             return cls.get_solar_params_from_string(value)
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1181,6 +1181,11 @@ def test_galactocentric_default_warning():
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults)
 
+    # TODO: this needs to be audited and removed if we change the default
+    # defaults (yes) for v4.1. This is a hack to get around the fact that the
+    # doctests in galactocentric.py actually change the *class* state:
+    galactocentric_frame_defaults._value = 'pre-v4.0'
+
     # Make sure a warning is thrown if the frame is created with no args
     with pytest.warns(AstropyDeprecationWarning,
                       match="In v4.1 and later versions"):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -10,7 +10,7 @@ from astropy import units as u
 from astropy.tests.helper import (catch_warnings,
                                   assert_quantity_allclose as assert_allclose)
 from astropy.utils import OrderedDescriptorContainer
-from astropy.utils.exceptions import AstropyWarning
+from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy.coordinates import representation as r
 from astropy.coordinates.representation import REPRESENTATION_CLASSES
 from astropy.units import allclose
@@ -1139,3 +1139,53 @@ def test_component_names_repr():
 
     # Check that the letter "r" has not been replaced more than once in the Frame repr
     assert repr(frame).count("JUSTONCE") == 1
+
+
+def test_galactocentric_defaults():
+    from astropy.coordinates import (Galactocentric,
+                                     galactocentric_frame_defaults,
+                                     BaseCoordinateFrame,
+                                     CartesianDifferential)
+
+    with galactocentric_frame_defaults.set('pre-v4.0'):
+        galcen_pre40 = Galactocentric()
+
+    with galactocentric_frame_defaults.set('v4.0'):
+        galcen_40 = Galactocentric()
+
+    with galactocentric_frame_defaults.set('latest'):
+        galcen_latest = Galactocentric()
+
+    # parameters that changed
+    assert not u.allclose(galcen_pre40.galcen_distance,
+                          galcen_40.galcen_distance)
+    assert not u.allclose(galcen_pre40.z_sun, galcen_40.z_sun)
+
+    for k in galcen_40.get_frame_attr_names():
+        if isinstance(getattr(galcen_40, k), BaseCoordinateFrame):
+            continue  # skip coordinate comparison...
+
+        elif isinstance(getattr(galcen_40, k), CartesianDifferential):
+            assert u.allclose(getattr(galcen_40, k).d_xyz,
+                              getattr(galcen_latest, k).d_xyz)
+        else:
+            assert getattr(galcen_40, k) == getattr(galcen_latest, k)
+
+
+def test_galactocentric_default_warning():
+    from astropy.coordinates import (Galactocentric,
+                                     galactocentric_frame_defaults)
+
+    # Make sure a warning is thrown if the frame is created with no args
+    with pytest.warns(AstropyDeprecationWarning,
+                      match="In v4.1 and later versions"):
+        Galactocentric()
+
+    # Throw a warning even if only a subset of args are specified
+    with pytest.warns(AstropyDeprecationWarning,
+                      match="In v4.1 and later versions"):
+        Galactocentric(galcen_distance=8.2*u.kpc)
+
+    # No warning if using the latest parameter set:
+    with galactocentric_frame_defaults.set('latest'):
+        Galactocentric()

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1141,14 +1141,16 @@ def test_component_names_repr():
     assert repr(frame).count("JUSTONCE") == 1
 
 
+def teardown_galactocentric_defaults():
+    from astropy.coordinates import galactocentric_frame_defaults
+    galactocentric_frame_defaults._value = 'pre-v4.0'
+
+
 def test_galactocentric_defaults():
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults,
                                      BaseCoordinateFrame,
                                      CartesianDifferential)
-
-    # To restore this at end:
-    init_value = galactocentric_frame_defaults._value
 
     with galactocentric_frame_defaults.set('pre-v4.0'):
         galcen_pre40 = Galactocentric()
@@ -1174,17 +1176,12 @@ def test_galactocentric_defaults():
         else:
             assert getattr(galcen_40, k) == getattr(galcen_latest, k)
 
-    galactocentric_frame_defaults._value = init_value
+    teardown_galactocentric_defaults()
 
 
 def test_galactocentric_default_warning():
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults)
-
-    # TODO: this needs to be audited and removed if we change the default
-    # defaults (yes) for v4.1. This is a hack to get around the fact that the
-    # doctests in galactocentric.py actually change the *class* state:
-    galactocentric_frame_defaults._value = 'pre-v4.0'
 
     # Make sure a warning is thrown if the frame is created with no args
     with pytest.warns(AstropyDeprecationWarning,
@@ -1199,3 +1196,5 @@ def test_galactocentric_default_warning():
     # No warning if using the latest parameter set:
     with galactocentric_frame_defaults.set('latest'):
         Galactocentric()
+
+    teardown_galactocentric_defaults()

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1185,12 +1185,12 @@ def test_galactocentric_default_warning():
 
     # Make sure a warning is thrown if the frame is created with no args
     with pytest.warns(AstropyDeprecationWarning,
-                      match="In v4.1 and later versions"):
+                      match=r"In v4\.1 and later versions"):
         Galactocentric()
 
     # Throw a warning even if only a subset of args are specified
     with pytest.warns(AstropyDeprecationWarning,
-                      match="In v4.1 and later versions"):
+                      match=r"In v4\.1 and later versions"):
         Galactocentric(galcen_distance=8.2*u.kpc)
 
     # No warning if using the latest parameter set:

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1147,6 +1147,9 @@ def test_galactocentric_defaults():
                                      BaseCoordinateFrame,
                                      CartesianDifferential)
 
+    # To restore this at end:
+    init_value = galactocentric_frame_defaults._value
+
     with galactocentric_frame_defaults.set('pre-v4.0'):
         galcen_pre40 = Galactocentric()
 
@@ -1170,6 +1173,8 @@ def test_galactocentric_defaults():
                               getattr(galcen_latest, k).d_xyz)
         else:
             assert getattr(galcen_40, k) == getattr(galcen_latest, k)
+
+    galactocentric_frame_defaults._value = init_value
 
 
 def test_galactocentric_default_warning():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1141,7 +1141,9 @@ def test_component_names_repr():
     assert repr(frame).count("JUSTONCE") == 1
 
 
-def teardown_galactocentric_defaults():
+def reset_galactocentric_defaults():
+    # TODO: this can be removed, along with the "warning" test below, once we
+    # switch the default to 'latest' in v4.1
     from astropy.coordinates import galactocentric_frame_defaults
     galactocentric_frame_defaults._value = 'pre-v4.0'
 
@@ -1176,12 +1178,16 @@ def test_galactocentric_defaults():
         else:
             assert getattr(galcen_40, k) == getattr(galcen_latest, k)
 
-    teardown_galactocentric_defaults()
+    reset_galactocentric_defaults()
 
 
 def test_galactocentric_default_warning():
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults)
+
+    # Note: this is necessary because the doctests may alter the state of the
+    # class globally and simultaneously when the tests are run in parallel
+    reset_galactocentric_defaults()
 
     # Make sure a warning is thrown if the frame is created with no args
     with pytest.warns(AstropyDeprecationWarning,
@@ -1197,4 +1203,4 @@ def test_galactocentric_default_warning():
     with galactocentric_frame_defaults.set('latest'):
         Galactocentric()
 
-    teardown_galactocentric_defaults()
+    reset_galactocentric_defaults()

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -6,7 +6,10 @@ Description of the Galactocentric Coordinate Frame
 
 While many other frames implemented in `astropy.coordinates` are standardized in
 some way (e.g., defined by the IAU), there is no standard Milky Way
-Galactocentric reference frame. The `~astropy.coordinates.Galactocentric` frame
+reference frame with the center of the Milky Way as its origin. (This is
+distinct from `~astropy.coordinates.Galactic` coordinates, which point
+toward the Galactic Center but have their origin in the Solar System).
+The `~astropy.coordinates.Galactocentric` frame
 class is meant to be flexible enough to support all common definitions of such a
 transformation, but with reasonable default parameter values, such as the solar
 velocity relative to the Galactic center, the solar height above the Galactic
@@ -151,7 +154,7 @@ All of the frame-defining parameters of the
 `~astropy.coordinates.Galactocentric` frame are customizable and can be set by
 passing arguments in to the `~astropy.coordinates.Galactocentric` initializer.
 However, it is often convenient to use the frame without having to pass in every
-parameter. We have therefore tried to set reasonable default values for these
+parameter. Hence, the class comes with reasonable default values for these
 parameters, but more precise measurements of the solar position or motion in the
 Galaxy are constantly being made. The default values of the
 `~astropy.coordinates.Galactocentric` frame attributes will therefore be updated

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -1,9 +1,3 @@
-.. testcleanup::
-    # TODO: this needs to be audited and removed if we change the default
-    # defaults (yes) for v4.1. This is a hack to get around the fact that
-    # the doctests here actually change the *class* state:
-    galactocentric_frame_defaults._value = 'pre-v4.0'
-
 .. _coordinates-galactocentric:
 
 **************************************************

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -1,3 +1,9 @@
+.. testcleanup::
+    # TODO: this needs to be audited and removed if we change the default
+    # defaults (yes) for v4.1. This is a hack to get around the fact that
+    # the doctests here actually change the *class* state:
+    galactocentric_frame_defaults._value = 'pre-v4.0'
+
 .. _coordinates-galactocentric:
 
 **************************************************

--- a/docs/coordinates/galactocentric.rst
+++ b/docs/coordinates/galactocentric.rst
@@ -184,10 +184,14 @@ frame with no arguments::
 These default values can be modified using this class::
 
     >>> from astropy.coordinates import galactocentric_frame_defaults
-    >>> galactocentric_frame_defaults.set('v4.0')
+    >>> _ = galactocentric_frame_defaults.set('v4.0')
     >>> Galactocentric() # doctest: +FLOAT_CMP
     <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
         (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg)>
+    >>> _ = galactocentric_frame_defaults.set('pre-v4.0')
+    >>> Galactocentric() # doctest: +FLOAT_CMP
+    <Galactocentric Frame (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+        (266.4051, -28.936175)>, galcen_distance=8.3 kpc, galcen_v_sun=(11.1, 232.24, 7.25) km / s, z_sun=27.0 pc, roll=0.0 deg)>
 
 The default parameters can also be updated by using this class as a context
 manager to change the default parameter values locally to a piece of your code::
@@ -218,4 +222,4 @@ For example, in such code, we recommend adding something like this to your
 import block (here using ``'v4.0'`` as an example)::
 
     >>> import astropy.coordinates as coord
-    >>> coord.galactocentric_frame_defaults.set('v4.0')
+    >>> coord.galactocentric_frame_defaults.set('v4.0') # doctest: +SKIP

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -345,45 +345,45 @@ documentation::
   >>> sc = SkyCoord(1, 2, frame='icrs', unit='deg', obstime='2013-01-02 14:25:36')
   >>> sc.<TAB>  # doctest: +SKIP
   sc.T                                   sc.match_to_catalog_3d
-sc.altaz                               sc.match_to_catalog_sky
-sc.barycentrictrueecliptic             sc.name
-sc.cartesian                           sc.ndim
-sc.cirs                                sc.obsgeoloc
-sc.copy                                sc.obsgeovel
-sc.data                                sc.obstime
-sc.dec                                 sc.obswl
-sc.default_representation              sc.position_angle
-sc.diagonal                            sc.precessedgeocentric
-sc.distance                            sc.pressure
-sc.equinox                             sc.ra
-sc.fk4                                 sc.ravel
-sc.fk4noeterms                         sc.realize_frame
-sc.fk5                                 sc.relative_humidity
-sc.flatten                             sc.represent_as
-sc.frame                               sc.representation_component_names
-sc.frame_attributes                    sc.representation_component_units
-sc.frame_specific_representation_info  sc.representation_info
-sc.from_name                           sc.reshape
-sc.from_pixel                          sc.roll
-sc.galactic                            sc.search_around_3d
-sc.galactocentric                      sc.search_around_sky
-sc.galcen_distance                     sc.separation
-sc.gcrs                                sc.separation_3d
-sc.geocentrictrueecliptic              sc.shape
-sc.get_constellation                   sc.size
-sc.get_frame_attr_names                sc.skyoffset_frame
-sc.guess_from_table                    sc.spherical
-sc.has_data                            sc.spherical_offsets_to
-sc.hcrs                                sc.squeeze
-sc.heliocentrictrueecliptic            sc.supergalactic
-sc.icrs                                sc.swapaxes
-sc.info                                sc.take
-sc.is_equivalent_frame                 sc.temperature
-sc.is_frame_attr_default               sc.to_pixel
-sc.is_transformable_to                 sc.to_string
-sc.isscalar                            sc.transform_to
-sc.itrs                                sc.transpose
-sc.location                            sc.z_sun
+  sc.altaz                               sc.match_to_catalog_sky
+  sc.barycentrictrueecliptic             sc.name
+  sc.cartesian                           sc.ndim
+  sc.cirs                                sc.obsgeoloc
+  sc.copy                                sc.obsgeovel
+  sc.data                                sc.obstime
+  sc.dec                                 sc.obswl
+  sc.default_representation              sc.position_angle
+  sc.diagonal                            sc.precessedgeocentric
+  sc.distance                            sc.pressure
+  sc.equinox                             sc.ra
+  sc.fk4                                 sc.ravel
+  sc.fk4noeterms                         sc.realize_frame
+  sc.fk5                                 sc.relative_humidity
+  sc.flatten                             sc.represent_as
+  sc.frame                               sc.representation_component_names
+  sc.frame_attributes                    sc.representation_component_units
+  sc.frame_specific_representation_info  sc.representation_info
+  sc.from_name                           sc.reshape
+  sc.from_pixel                          sc.roll
+  sc.galactic                            sc.search_around_3d
+  sc.galactocentric                      sc.search_around_sky
+  sc.galcen_distance                     sc.separation
+  sc.gcrs                                sc.separation_3d
+  sc.geocentrictrueecliptic              sc.shape
+  sc.get_constellation                   sc.size
+  sc.get_frame_attr_names                sc.skyoffset_frame
+  sc.guess_from_table                    sc.spherical
+  sc.has_data                            sc.spherical_offsets_to
+  sc.hcrs                                sc.squeeze
+  sc.heliocentrictrueecliptic            sc.supergalactic
+  sc.icrs                                sc.swapaxes
+  sc.info                                sc.take
+  sc.is_equivalent_frame                 sc.temperature
+  sc.is_frame_attr_default               sc.to_pixel
+  sc.is_transformable_to                 sc.to_string
+  sc.isscalar                            sc.transform_to
+  sc.itrs                                sc.transpose
+  sc.location                            sc.z_sun
 
 Here we see many attributes and methods. The most recognizable may be the
 longitude and latitude attributes which are named ``ra`` and ``dec`` for the

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -345,47 +345,45 @@ documentation::
   >>> sc = SkyCoord(1, 2, frame='icrs', unit='deg', obstime='2013-01-02 14:25:36')
   >>> sc.<TAB>  # doctest: +SKIP
   sc.T                                   sc.match_to_catalog_3d
-  sc.altaz                               sc.match_to_catalog_sky
-  sc.barycentrictrueecliptic             sc.name
-  sc.cartesian                           sc.ndim
-  sc.cirs                                sc.obsgeoloc
-  sc.copy                                sc.obsgeovel
-  sc.data                                sc.obstime
-  sc.dec                                 sc.obswl
-  sc.default_representation              sc.position_angle
-  sc.diagonal                            sc.precessedgeocentric
-  sc.distance                            sc.pressure
-  sc.equinox                             sc.ra
-  sc.fk4                                 sc.ravel
-  sc.fk4noeterms                         sc.realize_frame
-  sc.fk5                                 sc.relative_humidity
-  sc.flatten                             sc.represent_as
-  sc.frame                               sc.representation
-  sc.frame_attributes                    sc.representation_component_names
-  sc.frame_specific_representation_info  sc.representation_component_units
-  sc.from_name                           sc.representation_info
-  sc.from_pixel                          sc.reshape
-  sc.galactic                            sc.roll
-  sc.galactocentric                      sc.search_around_3d
-  sc.galcen_dec                          sc.search_around_sky
-  sc.galcen_distance                     sc.separation
-  sc.galcen_ra                           sc.separation_3d
-  sc.gcrs                                sc.shape
-  sc.geocentrictrueecliptic              sc.size
-  sc.get_constellation                   sc.skyoffset_frame
-  sc.get_frame_attr_names                sc.spherical
-  sc.guess_from_table                    sc.spherical_offsets_to
-  sc.has_data                            sc.squeeze
-  sc.hcrs                                sc.supergalactic
-  sc.heliocentrictrueecliptic            sc.swapaxes
-  sc.icrs                                sc.take
-  sc.info                                sc.temperature
-  sc.is_equivalent_frame                 sc.to_pixel
-  sc.is_frame_attr_default               sc.to_string
-  sc.is_transformable_to                 sc.transform_to
-  sc.isscalar                            sc.transpose
-  sc.itrs                                sc.z_sun
-  sc.location
+sc.altaz                               sc.match_to_catalog_sky
+sc.barycentrictrueecliptic             sc.name
+sc.cartesian                           sc.ndim
+sc.cirs                                sc.obsgeoloc
+sc.copy                                sc.obsgeovel
+sc.data                                sc.obstime
+sc.dec                                 sc.obswl
+sc.default_representation              sc.position_angle
+sc.diagonal                            sc.precessedgeocentric
+sc.distance                            sc.pressure
+sc.equinox                             sc.ra
+sc.fk4                                 sc.ravel
+sc.fk4noeterms                         sc.realize_frame
+sc.fk5                                 sc.relative_humidity
+sc.flatten                             sc.represent_as
+sc.frame                               sc.representation_component_names
+sc.frame_attributes                    sc.representation_component_units
+sc.frame_specific_representation_info  sc.representation_info
+sc.from_name                           sc.reshape
+sc.from_pixel                          sc.roll
+sc.galactic                            sc.search_around_3d
+sc.galactocentric                      sc.search_around_sky
+sc.galcen_distance                     sc.separation
+sc.gcrs                                sc.separation_3d
+sc.geocentrictrueecliptic              sc.shape
+sc.get_constellation                   sc.size
+sc.get_frame_attr_names                sc.skyoffset_frame
+sc.guess_from_table                    sc.spherical
+sc.has_data                            sc.spherical_offsets_to
+sc.hcrs                                sc.squeeze
+sc.heliocentrictrueecliptic            sc.supergalactic
+sc.icrs                                sc.swapaxes
+sc.info                                sc.take
+sc.is_equivalent_frame                 sc.temperature
+sc.is_frame_attr_default               sc.to_pixel
+sc.is_transformable_to                 sc.to_string
+sc.isscalar                            sc.transform_to
+sc.itrs                                sc.transpose
+sc.location                            sc.z_sun
 
 Here we see many attributes and methods. The most recognizable may be the
 longitude and latitude attributes which are named ``ra`` and ``dec`` for the

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -90,7 +90,7 @@ def rv_to_gsr(c, v_sun=None):
 
     """
     if v_sun is None:
-        v_sun = coord.Galactocentric.galcen_v_sun.to_cartesian()
+        v_sun = coord.Galactocentric().galcen_v_sun.to_cartesian()
 
     gal = c.transform_to(coord.Galactic)
     cart_data = gal.data.to_cartesian()

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -44,7 +44,7 @@ icrs = coord.ICRS(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
 # `~astropy.coordinates.CartesianRepresentation` object using the
 # ``.to_cartesian()`` method of the
 # `~astropy.coordinates.CartesianDifferential` object ``galcen_v_sun``:
-v_sun = coord.Galactocentric.galcen_v_sun.to_cartesian()
+v_sun = coord.Galactocentric().galcen_v_sun.to_cartesian()
 
 ################################################################################
 # We now need to get a unit vector in the assumed Galactic frame from the sky


### PR DESCRIPTION
Based on @mhvk's suggestion in #9322, I decided to have a go at implementing the `Galactocentric` frame attributes as being derived from a `ScienceState` subclass. It wasn't too bad in the end to get this to work, and I think this is a nicer solution than #9322, so this would replace that PR.

With this, it no longer makes sense to list citations/references to papers that contain the measurements of the Solar parameters, because the defaults can change. So here I added a `.get_references()` method that retrieves a dictionary of references (mapping parameter name to paper(s)) that is updated by and kept in sync with the parameters by the `ScienceState` instance. One remaining TODO on this, below.

This includes commits from #9345, which are necessary for the functionality in this PR.

TODO:
* [x] Changelog entry
* [x] Rebase once / if #9345 is merged
* [x] If a frame attribute is set by the user, e.g., `Galactocentric(galcen_distance=...)`, remove the reference for that frame attribute
* [x] Expose the `ScienceState` subclass at the `astropy.coordinates` level?
* [x] Documentation, especially on how to change the default parameter set
* [x] Update the link to the documentation of this new functionality in the warning raised (see TODO in code comment)