### PR TITLE
Add support for parsing unicode in the units module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,6 +152,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Support for unicode micro prefix. [#9348]
+
 - Accept non-unit type annotations in @quantity_input. [#8984]
 
 - For numpy 1.17 and later, the new ``__array_function__`` protocol is used to

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -152,7 +152,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
-- Support for unicode micro prefix. [#9348]
+- Support for unicode parsing.
+  Supported at the moment are superscripts and the micro-sign. [#9348]
 
 - Accept non-unit type annotations in @quantity_input. [#8984]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,7 +153,7 @@ astropy.units
 ^^^^^^^^^^^^^
 
 - Support for unicode parsing.
-  Supported at the moment are superscripts, Ohm and the micro-sign. [#9348]
+  Supported at the moment are superscripts, Ohm, Ångström,  and the micro-sign. [#9348]
 
 - Accept non-unit type annotations in @quantity_input. [#8984]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,7 +153,7 @@ astropy.units
 ^^^^^^^^^^^^^
 
 - Support for unicode parsing.
-  Supported at the moment are superscripts and the micro-sign. [#9348]
+  Supported at the moment are superscripts, Ohm and the micro-sign. [#9348]
 
 - Accept non-unit type annotations in @quantity_input. [#8984]
 

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2231,7 +2231,7 @@ def _add_prefixes(u, excludes=[], namespace=None, prefixes=False):
                 # for some formatters.
                 if prefix == 'u':
                     format['latex'] = r'\mu ' + u.get_format_name('latex')
-                    format['unicode'] = 'μ' + u.get_format_name('unicode')
+                    format['unicode'] = '\N{MICRO SIGN}' + u.get_format_name('unicode')
 
                 for key, val in u._format.items():
                     format.setdefault(key, prefix + val)

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2171,7 +2171,7 @@ si_prefixes = [
     (['d'], ['deci'], 1e-1),
     (['c'], ['centi'], 1e-2),
     (['m'], ['milli'], 1e-3),
-    (['u', '\N{MICRO SIGN}', '\N{GREEK SMALL LETTER MU}'], ['micro'], 1e-6),
+    (['u'], ['micro'], 1e-6),
     (['n'], ['nano'], 1e-9),
     (['p'], ['pico'], 1e-12),
     (['f'], ['femto'], 1e-15),

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2171,7 +2171,7 @@ si_prefixes = [
     (['d'], ['deci'], 1e-1),
     (['c'], ['centi'], 1e-2),
     (['m'], ['milli'], 1e-3),
-    (['u'], ['micro'], 1e-6),
+    (['u', '\N{MICRO SIGN}', '\N{GREEK SMALL LETTER MU}'], ['micro'], 1e-6),
     (['n'], ['nano'], 1e-9),
     (['p'], ['pico'], 1e-12),
     (['f'], ['femto'], 1e-15),

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -528,7 +528,7 @@ class Generic(Base):
     def _convert_deg(cls, m):
         if len(m.string) == 1:
             return 'deg'
-        return m.group().replace('°', 'deg_')
+        return m.string.replace('°', 'deg_')
 
     @classmethod
     def parse(cls, s, debug=False):

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -457,12 +457,6 @@ class Generic(Base):
             return registry['percent']
 
         if not s.isascii():
-            # common normalization of unicode strings to avoid
-            # having to deal with multiple representations of
-            # the same character. This normalizes to "composed" form
-            # and will e.g. convert OHM SIGN to GREEK CAPITAL LETTER OMEGA
-            s = unicodedata.normalize('NFC', s)
-
             if s[0] == '\N{MICRO SIGN}':
                 s = 'u' + s[1:]
             if s[-1] == '\N{GREEK CAPITAL LETTER OMEGA}':
@@ -528,6 +522,10 @@ class Generic(Base):
         if not isinstance(s, str):
             s = s.decode('ascii')
         elif not s.isascii():
+            # common normalization of unicode strings to avoid
+            # having to deal with multiple representations of
+            # the same character. This normalizes to "composed" form
+            # and will e.g. convert OHM SIGN to GREEK CAPITAL LETTER OMEGA
             s = unicodedata.normalize('NFC', s)
             # Translate some basic unicode items that we'd like to support on
             # input but are not standard.

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -18,6 +18,7 @@ import os
 import re
 import warnings
 from fractions import Fraction
+import unicodedata
 
 from . import core, utils
 from .base import Base
@@ -456,11 +457,17 @@ class Generic(Base):
             return registry['percent']
 
         if not s.isascii():
+            # common normalization of unicode strings to avoid
+            # having to deal with multiple representations of
+            # the same character. This normalizes to "composed" form
+            # and will e.g. convert OHM SIGN to GREEK CAPITAL LETTER OMEGA
+            s = unicodedata.normalize('NFC', s)
+
             if s[0] == '\N{MICRO SIGN}':
                 s = 'u' + s[1:]
-            if s[-1] == '\N{OHM SIGN}':
+            if s[-1] == '\N{GREEK CAPITAL LETTER OMEGA}':
                 s = s[:-1] + 'Ohm'
-            elif s[-1] == '\N{ANGSTROM SIGN}':
+            elif s[-1] == '\N{LATIN CAPITAL LETTER A WITH RING ABOVE}':
                 s = s[:-1] + 'Angstrom'
 
         if s in registry:
@@ -476,8 +483,6 @@ class Generic(Base):
     _translations = {
         '\N{GREEK SMALL LETTER MU}': '\N{MICRO SIGN}',
         '\N{MINUS SIGN}': '-',
-        '\N{GREEK CAPITAL LETTER OMEGA}': '\N{OHM SIGN}',
-        '\N{LATIN CAPITAL LETTER A WITH RING ABOVE}': '\N{ANGSTROM SIGN}'
     }
     # key in the translations dict must be the codepoint
     _translations = {ord(k):v for k, v in _translations.items()}
@@ -523,6 +528,7 @@ class Generic(Base):
         if not isinstance(s, str):
             s = s.decode('ascii')
         elif not s.isascii():
+            s = unicodedata.normalize('NFC', s)
             # Translate some basic unicode items that we'd like to support on
             # input but are not standard.
             s = s.translate(cls._translations)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -466,9 +466,14 @@ class Generic(Base):
         else:
             raise ValueError()
 
-    _translations = str.maketrans({
+    _translations = {
         '\N{GREEK SMALL LETTER MU}': '\N{MICRO SIGN}',
-        '\N{MINUS SIGN}': '-'})
+        '\N{MINUS SIGN}': '-',
+        '\N{OHM SIGN}': 'Ohm',
+        '\N{GREEK CAPITAL LETTER OMEGA}': 'Ohm',
+    }
+    # key in the translations dict must be the codepoint
+    _translations = {ord(k):v for k, v in _translations.items()}
     """Character translations that should be applied before parsing a string.
 
     Note that this does explicitly *not* generally translate MICRO SIGN to u,

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -486,12 +486,10 @@ class Generic(Base):
         else:
             raise ValueError()
 
-    _translations = {
+    _translations = str.maketrans({
         '\N{GREEK SMALL LETTER MU}': '\N{MICRO SIGN}',
         '\N{MINUS SIGN}': '-',
-    }
-    # key in the translations dict must be the codepoint
-    _translations = {ord(k):v for k, v in _translations.items()}
+    })
     """Character translations that should be applied before parsing a string.
 
     Note that this does explicitly *not* generally translate MICRO SIGN to u,

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -38,7 +38,6 @@ def _is_ascii(s):
             return False
 
 
-
 def _to_string(cls, unit):
     if isinstance(unit, core.CompositeUnit):
         parts = []

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -25,20 +25,22 @@ from astropy.utils import classproperty
 from astropy.utils.misc import did_you_mean
 
 
-UNICODE_TRANSLATION = {
-    ord('\N{SUPERSCRIPT MINUS}'): ord('-'),
-    ord('\N{SUPERSCRIPT PLUS SIGN}'): ord('+'),
-    ord('\N{SUPERSCRIPT ZERO}'): ord('0'),
-    ord('\N{SUPERSCRIPT ONE}'): ord('1'),
-    ord('\N{SUPERSCRIPT TWO}'): ord('2'),
-    ord('\N{SUPERSCRIPT THREE}'): ord('3'),
-    ord('\N{SUPERSCRIPT FOUR}'): ord('4'),
-    ord('\N{SUPERSCRIPT FIVE}'): ord('5'),
-    ord('\N{SUPERSCRIPT SIX}'): ord('6'),
-    ord('\N{SUPERSCRIPT SEVEN}'): ord('7'),
-    ord('\N{SUPERSCRIPT EIGHT}'): ord('8'),
-    ord('\N{SUPERSCRIPT NINE}'): ord('9'),
-}
+UNICODE_TRANSLATION = str.maketrans({
+    '\N{SUPERSCRIPT MINUS}': '-',
+    '\N{SUPERSCRIPT PLUS SIGN}': '+',
+    '\N{SUPERSCRIPT ZERO}': '0',
+    '\N{SUPERSCRIPT ONE}': '1',
+    '\N{SUPERSCRIPT TWO}': '2',
+    '\N{SUPERSCRIPT THREE}': '3',
+    '\N{SUPERSCRIPT FOUR}': '4',
+    '\N{SUPERSCRIPT FIVE}': '5',
+    '\N{SUPERSCRIPT SIX}': '6',
+    '\N{SUPERSCRIPT SEVEN}': '7',
+    '\N{SUPERSCRIPT EIGHT}': '8',
+    '\N{SUPERSCRIPT NINE}': '9',
+    '\N{MINUS SIGN}': '-',
+    '\N{GREEK SMALL LETTER ALPHA}': '\N{MICRO SIGN}',
+})
 
 
 def _to_string(cls, unit):

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -17,6 +17,7 @@ Handles a "generic" string format for units
 import os
 import re
 import warnings
+import sys
 from fractions import Fraction
 import unicodedata
 
@@ -24,6 +25,18 @@ from . import core, utils
 from .base import Base
 from astropy.utils import classproperty
 from astropy.utils.misc import did_you_mean
+
+
+def _is_ascii(s):
+    if sys.version_info >= (3, 7, 0):
+        return s.isascii()
+    else:
+        try:
+            s.encode('ascii')
+            return True
+        except UnicodeEncodeError:
+            return False
+
 
 
 def _to_string(cls, unit):
@@ -456,7 +469,7 @@ class Generic(Base):
         if s == '%':
             return registry['percent']
 
-        if not s.isascii():
+        if not _is_ascii(s):
             if s[0] == '\N{MICRO SIGN}':
                 s = 'u' + s[1:]
             if s[-1] == '\N{GREEK CAPITAL LETTER OMEGA}':
@@ -521,7 +534,7 @@ class Generic(Base):
     def parse(cls, s, debug=False):
         if not isinstance(s, str):
             s = s.decode('ascii')
-        elif not s.isascii():
+        elif not _is_ascii(s):
             # common normalization of unicode strings to avoid
             # having to deal with multiple representations of
             # the same character. This normalizes to "composed" form

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -541,8 +541,7 @@ class Generic(Base):
         result = cls._do_parse(s, debug=debug)
         # Check for excess solidi, but exclude fractional exponents (accepted)
         n_slashes = s.count('/')
-        n_fractions = len(re.findall(r'\(\d+/\d+\)', s))
-        if n_slashes > 1 and (n_slashes - n_fractions) > 1:
+        if n_slashes > 1 and (n_slashes - len(re.findall(r'\(\d+/\d+\)', s))) > 1:
             warnings.warn(
                 "'{}' contains multiple slashes, which is "
                 "discouraged by the FITS standard".format(s),

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -25,6 +25,22 @@ from astropy.utils import classproperty
 from astropy.utils.misc import did_you_mean
 
 
+UNICODE_TRANSLATION = {
+    ord('\N{SUPERSCRIPT MINUS}'): ord('-'),
+    ord('\N{SUPERSCRIPT PLUS SIGN}'): ord('+'),
+    ord('\N{SUPERSCRIPT ZERO}'): ord('0'),
+    ord('\N{SUPERSCRIPT ONE}'): ord('1'),
+    ord('\N{SUPERSCRIPT TWO}'): ord('2'),
+    ord('\N{SUPERSCRIPT THREE}'): ord('3'),
+    ord('\N{SUPERSCRIPT FOUR}'): ord('4'),
+    ord('\N{SUPERSCRIPT FIVE}'): ord('5'),
+    ord('\N{SUPERSCRIPT SIX}'): ord('6'),
+    ord('\N{SUPERSCRIPT SEVEN}'): ord('7'),
+    ord('\N{SUPERSCRIPT EIGHT}'): ord('8'),
+    ord('\N{SUPERSCRIPT NINE}'): ord('9'),
+}
+
+
 def _to_string(cls, unit):
     if isinstance(unit, core.CompositeUnit):
         parts = []
@@ -468,6 +484,8 @@ class Generic(Base):
     def parse(cls, s, debug=False):
         if not isinstance(s, str):
             s = s.decode('ascii')
+
+        s = s.translate(UNICODE_TRANSLATION)
 
         result = cls._do_parse(s, debug=debug)
         # Check for excess solidi, but exclude fractional exponents (accepted)

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -492,12 +492,19 @@ class Generic(Base):
 
     _superscript_translations = str.maketrans(_superscripts, '-+0123456789')
     _regex_superscript = re.compile(f'[{_superscripts}]+')
+    _regex_deg = re.compile('°([CF])?')
 
     @classmethod
     def _convert_superscript(cls, m):
         return '({})'.format(
             m.group().translate(cls._superscript_translations)
         )
+
+    @classmethod
+    def _convert_deg(cls, m):
+        if len(m.string) == 1:
+            return 'deg'
+        return m.group().replace('°', 'deg_')
 
     @classmethod
     def parse(cls, s, debug=False):
@@ -512,6 +519,7 @@ class Generic(Base):
         # that mixes of superscripts and regular numbers fail.
         # TODO: could one not look for superscripts in the parser/lexer?
         s = cls._regex_superscript.sub(cls._convert_superscript, s)
+        s = cls._regex_deg.sub(cls._convert_deg, s)
 
         result = cls._do_parse(s, debug=debug)
         # Check for excess solidi, but exclude fractional exponents (accepted)

--- a/astropy/units/si.py
+++ b/astropy/units/si.py
@@ -30,7 +30,7 @@ def_unit(['m', 'meter'], namespace=_ns, prefixes=True,
 
 def_unit(['micron'], um, namespace=_ns,
          doc="micron: alias for micrometer (um)",
-         format={'latex': r'\mu m', 'unicode': 'μm'})
+         format={'latex': r'\mu m', 'unicode': '\N{MICRO SIGN}m'})
 
 def_unit(['Angstrom', 'AA', 'angstrom'], 0.1 * nm, namespace=_ns,
          doc="ångström: 10 ** -10 m",

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -586,3 +586,14 @@ def test_powers(power, expected):
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit
     assert u.Unit(string) == unit
+
+
+@pytest.mark.parametrize('string', [
+    'g\N{MICRO SIGN}',
+    'g\N{MINUS SIGN}',
+    'm\N{SUPERSCRIPT MINUS}1',
+    'm+\N{SUPERSCRIPT ONE}',
+    'm\N{MINUS SIGN}\N{SUPERSCRIPT ONE}'])
+def test_unicode_failures(string):
+    with pytest.raises(ValueError):
+        u.Unit(string)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -588,6 +588,7 @@ def test_powers(power, expected):
     ('\N{ANGSTROM SIGN}', u.Angstrom),
     ('\N{ANGSTROM SIGN} \N{OHM SIGN}', u.Angstrom * u.Ohm),
     ('\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', u.Angstrom),
+    ('\N{LATIN CAPITAL LETTER A}\N{COMBINING RING ABOVE}', u.Angstrom),
     ('°C', u.deg_C),
     ('°', u.deg),
 ])

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -575,6 +575,7 @@ def test_powers(power, expected):
 @pytest.mark.parametrize('string,unit', [
     ('\N{MICRO SIGN}g', u.microgram),
     ('\N{GREEK SMALL LETTER MU}g', u.microgram),
+    ('g\N{MINUS SIGN}1', u.g**(-1)),
     ('m\N{SUPERSCRIPT MINUS}\N{SUPERSCRIPT ONE}', 1 / u.m),
     ('m s\N{SUPERSCRIPT MINUS}\N{SUPERSCRIPT ONE}', u.m / u.s),
     ('m\N{SUPERSCRIPT TWO}', u.m**2),
@@ -584,3 +585,4 @@ def test_powers(power, expected):
 ])
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit
+    assert u.Unit(string) == unit

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -582,6 +582,8 @@ def test_powers(power, expected):
     ('m\N{SUPERSCRIPT PLUS SIGN}\N{SUPERSCRIPT TWO}', u.m**2),
     ('m\N{SUPERSCRIPT THREE}', u.m**3),
     ('m\N{SUPERSCRIPT ONE}\N{SUPERSCRIPT ZERO}', u.m**10),
+    ('°C', u.deg_C),
+    ('°', u.deg),
 ])
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -34,7 +34,8 @@ from astropy.units.utils import is_effectively_unity
     (["mag"], u.mag),
     (["mag(ct/s)"], u.MagUnit(u.ct / u.s)),
     (["dex"], u.dex),
-    (["dex(cm s**-2)", "dex(cm/s2)"], u.DexUnit(u.cm / u.s**2))])
+    (["dex(cm s**-2)", "dex(cm/s2)"], u.DexUnit(u.cm / u.s**2)),
+])
 def test_unit_grammar(strings, unit):
     for s in strings:
         print(s)
@@ -569,3 +570,11 @@ def test_powers(power, expected):
     s = unit.to_string()
     assert s == expected
     assert unit == s
+
+
+@pytest.mark.parametrize('string,unit', [
+    ('\N{MICRO SIGN}g', u.microgram),
+    ('\N{GREEK SMALL LETTER MU}g', u.microgram),
+])
+def test_unicode(string, unit):
+    assert u_format.Generic.parse(string) == unit

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -584,6 +584,10 @@ def test_powers(power, expected):
     ('m\N{SUPERSCRIPT ONE}\N{SUPERSCRIPT ZERO}', u.m**10),
     ('\N{GREEK CAPITAL LETTER OMEGA}', u.ohm),
     ('\N{OHM SIGN}', u.ohm), # deprecated but for compatibility
+    ('\N{MICRO SIGN}\N{GREEK CAPITAL LETTER OMEGA}', u.microOhm),
+    ('\N{ANGSTROM SIGN}', u.Angstrom),
+    ('\N{ANGSTROM SIGN} \N{OHM SIGN}', u.Angstrom * u.Ohm),
+    ('\N{LATIN CAPITAL LETTER A WITH RING ABOVE}', u.Angstrom),
     ('°C', u.deg_C),
     ('°', u.deg),
 ])
@@ -597,7 +601,9 @@ def test_unicode(string, unit):
     'g\N{MINUS SIGN}',
     'm\N{SUPERSCRIPT MINUS}1',
     'm+\N{SUPERSCRIPT ONE}',
-    'm\N{MINUS SIGN}\N{SUPERSCRIPT ONE}'])
+    'm\N{MINUS SIGN}\N{SUPERSCRIPT ONE}',
+    'm\N{ANGSTROM SIGN}',
+])
 def test_unicode_failures(string):
     with pytest.raises(ValueError):
         u.Unit(string)

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -575,6 +575,12 @@ def test_powers(power, expected):
 @pytest.mark.parametrize('string,unit', [
     ('\N{MICRO SIGN}g', u.microgram),
     ('\N{GREEK SMALL LETTER MU}g', u.microgram),
+    ('m\N{SUPERSCRIPT MINUS}\N{SUPERSCRIPT ONE}', 1 / u.m),
+    ('m s\N{SUPERSCRIPT MINUS}\N{SUPERSCRIPT ONE}', u.m / u.s),
+    ('m\N{SUPERSCRIPT TWO}', u.m**2),
+    ('m\N{SUPERSCRIPT PLUS SIGN}\N{SUPERSCRIPT TWO}', u.m**2),
+    ('m\N{SUPERSCRIPT THREE}', u.m**3),
+    ('m\N{SUPERSCRIPT ONE}\N{SUPERSCRIPT ZERO}', u.m**10),
 ])
 def test_unicode(string, unit):
     assert u_format.Generic.parse(string) == unit

--- a/astropy/units/tests/test_format.py
+++ b/astropy/units/tests/test_format.py
@@ -582,6 +582,8 @@ def test_powers(power, expected):
     ('m\N{SUPERSCRIPT PLUS SIGN}\N{SUPERSCRIPT TWO}', u.m**2),
     ('m\N{SUPERSCRIPT THREE}', u.m**3),
     ('m\N{SUPERSCRIPT ONE}\N{SUPERSCRIPT ZERO}', u.m**10),
+    ('\N{GREEK CAPITAL LETTER OMEGA}', u.ohm),
+    ('\N{OHM SIGN}', u.ohm), # deprecated but for compatibility
     ('°C', u.deg_C),
     ('°', u.deg),
 ])


### PR DESCRIPTION
### Description

As a first simple step in adding feature #9347, this PR adds two unicode symbols
as possible representations for the micro prefix `MICRO SIGN` and `GREEK SMALL LETTER MU`.

While the second one is strictly speaking not correct, it probably appears often enough in the wild to be useful to support.