### PR TITLE
Use raise ... from to get tracebacks

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -495,6 +495,8 @@ class Time(ShapedLikeNDArray):
         else:
             formats = [(format, self.FORMATS[format])]
 
+        assert formats
+        problems = {}
         for name, cls in formats:
             try:
                 return cls(val, val2, scale, precision, in_subfmt, out_subfmt)
@@ -504,14 +506,18 @@ class Time(ShapedLikeNDArray):
                 # If ``format`` specified then there is only one possibility, so raise
                 # immediately and include the upstream exception message to make it
                 # easier for user to see what is wrong.
-                if format is not None:
-                    raise ValueError(f'Input values did not match the format class {format}:' +
-                                     os.linesep +
-                                     f'{err.__class__.__name__}: {err}')
+                if len(formats)==1:
+                    raise ValueError(
+                        f'Input values did not match the format class {format}:'
+                        + os.linesep
+                        + f'{err.__class__.__name__}: {err}'
+                    ) from err
+                else:
+                    problems[name] = err
         else:
-            raise ValueError('Input values did not match any of the formats where '
-                             'the format keyword is optional {}'
-                             .format([name for name, cls in formats]))
+            raise ValueError(f'Input values did not match any of the formats '
+                             f'where the format keyword is optional: '
+                             f'{problems}') from problems[formats[0][0]]
 
     @classmethod
     def now(cls):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -86,6 +86,11 @@ class TimeFormatMeta(type):
         # it is not a user-accessible format and is only used for initialization into
         # a different format.
         if 'name' in members and cls.name != 'astropy_time':
+            # FIXME: check here that we're not introducing a collision with
+            # an existing method or attribute; problem is it could be either
+            # astropy.time.Time or astropy.time.TimeDelta, and at the point
+            # where this is run neither of those classes have necessarily been
+            # constructed yet.
             mcls._registry[cls.name] = cls
 
         if 'subfmts' in members:

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -1,0 +1,26 @@
+import pytest
+
+from astropy.time import Time, TimeFormat
+
+
+def test_custom_time_format_exception():
+    class SpecificException(ValueError):
+        pass
+
+    # Note there is no way to remove this after the test!
+    class Custom(TimeFormat):
+        name = "custom_time_format_test"
+
+        def set_jds(self, val, val2):
+            raise SpecificException
+
+    # with pytest.raises(SpecificException):
+    #    Time(7., format="custom_time_format_test")
+    try:
+        Time(7.0, format="custom_time_format_test")
+    except SpecificException:
+        # This is not what astropy does but it is fine too
+        pass
+    except ValueError as e:
+        assert (hasattr(e, "__cause__")
+                and isinstance(e.__cause__, SpecificException))

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -120,11 +120,10 @@ def test_custom_time_format_problematic_name():
         assert t.sort() == t, "bogus time format clobbers everyone's Time objects"
 
         t.format = "sort"
-        t.value
-
-        t2 = Time(7, 9, format="sort").value
-        if not isinstance(t2, tuple):
+        if not isinstance(t.value, tuple):
             pytest.xfail("No good way to detect that `sort` is invalid")
-        assert t2 == (7, 9)
+
+        assert Time(7, 9, format="sort").value == (7, 9)
+
     finally:
         Time.FORMATS.pop("sort", None)


### PR DESCRIPTION
When an error occurs in format conversion, it is captured and re-raised
as a ValueError. This is necessary for format guessing but it can make
error reporting vague. Use raise ... from so that tracebacks go all the
way back to the line where the original exception was raised.
