### PR TITLE
Eliminate unnecessary 1+z factor from differential comoving volume

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1502,10 +1502,8 @@ class FLRW(Cosmology, metaclass=ABCMeta):
           Differential comoving volume per redshift per steradian at
           each input redshift."""
         dh = self._hubble_distance
-        da = self.angular_diameter_distance(z)
-        zp1 = 1.0 + z
-        return dh * ((zp1 * da) ** 2.0) / u.Quantity(self.efunc(z),
-                                                          u.steradian)
+        dm = self.comoving_transverse_distance(z)
+        return dh * (dm ** 2.0) / u.Quantity(self.efunc(z), u.steradian)
 
     def kpc_comoving_per_arcmin(self, z):
         """ Separation in transverse comoving kpc corresponding to an


### PR DESCRIPTION
### Description
Eliminate an unnecessary factor of 1 + z from the differential comoving volume using da = dm / (1 + z). This makes the code a little bit simpler and also makes it clearer that dVc = dm^2 d(dc).