### PR TITLE
Allow subformats for Numeric Time formats like MJD, JD

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -212,6 +212,15 @@ astropy.time
 - Improved error message when bad input is used to initialize a ``Time`` or
   ``TimeDelta`` object and the format is specified. [#9296]
 
+- Allow numeric time formats to be initialized with numpy ``longdouble``,
+  ``Decimal`` instances, and strings.  One can select just one of these
+  using ``in_subfmt``.  The output can be similarly set using ``out_subfmt``.
+  [#9361]
+
+- Introduce a new ``.to_value()`` method for ``Time`` (and adjusted the
+  existing method for ``TimeDelta``) so that one can get values in a given
+  ``format`` and possible ``subfmt`` (e.g., ``to_value('mjd', 'str')``. [#9361]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
@@ -498,6 +507,11 @@ astropy.time
 - Time formats (implemented in subclasses of ``TimeFormat``) now have
   their input and output routines more thoroughly validated, making it more
   difficult to create damaged ``Time`` objects. [#9375]
+
+- The ``TimeDelta.to_value()`` method now can also take the ``format`` name
+  as its argument, in which case the value will be calculated using the
+  ``TimeFormat`` machinery. For this case, one can also pass a ``subfmt``
+  argument to retrieve the value in another form than ``float``. [#9361]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -932,6 +932,8 @@ class Time(ShapedLikeNDArray):
             else:
                 tm = self.replicate(format=format)
 
+            # Go via kwargs to ensure that custom TimeFormat subclasses
+            # created in astropy versions <= 4.0 do not break.
             kwargs = {'out_subfmt': subfmt} if subfmt is not None else {}
             try:
                 value = tm._shaped_like_input(tm._time.to_value(
@@ -1634,7 +1636,7 @@ class Time(ShapedLikeNDArray):
         elif attr in self.FORMATS:
             return self.to_value(attr)
 
-        if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
+        elif attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
             if self.scale is None:
                 raise ScaleValueError("Cannot convert TimeDelta with "
                                       "undefined scale to any defined scale.")

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1634,14 +1634,6 @@ class Time(ShapedLikeNDArray):
         elif attr in self.FORMATS:
             return self.to_value(attr)
 
-        elif '_' in attr:
-            fmt, _, out_subfmt = attr.rpartition('_')
-            if fmt in self.FORMATS:
-                try:
-                    return self.to_value(fmt, subfmt=out_subfmt)
-                except Exception:
-                    pass  # Rather raise AttributeError below.
-
         if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
             if self.scale is None:
                 raise ScaleValueError("Cannot convert TimeDelta with "

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -791,9 +791,9 @@ class Time(ShapedLikeNDArray):
     @precision.setter
     def precision(self, val):
         del self.cache
-        if not isinstance(val, int) or val < 0 or val > 19:
+        if not isinstance(val, int) or val < 0 or val > 9:
             raise ValueError('precision attribute must be an int between '
-                             '0 and 19')
+                             '0 and 9')
         self._time.precision = val
 
     @property

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -791,9 +791,9 @@ class Time(ShapedLikeNDArray):
     @precision.setter
     def precision(self, val):
         del self.cache
-        if not isinstance(val, int) or val < 0 or val > 9:
+        if not isinstance(val, int) or val < 0 or val > 19:
             raise ValueError('precision attribute must be an int between '
-                             '0 and 9')
+                             '0 and 19')
         self._time.precision = val
 
     @property

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1612,7 +1612,23 @@ class Time(ShapedLikeNDArray):
                 cache[attr] = value
             return cache[attr]
 
-        elif attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
+        elif '_' in attr:
+            fmt, _, out_subfmt = attr.rpartition('_')
+            if fmt in self.FORMATS and any(
+                    out_subfmt == subfmt[0] for subfmt in
+                    getattr(self.FORMATS[fmt], 'subfmts', ())):
+                cache = self.cache['format']
+                if attr not in cache:
+                    if fmt == self.format:
+                        tm = self
+                    else:
+                        tm = self.replicate(format=fmt)
+                    value = tm._shaped_like_input(tm._time.to_value(
+                        parent=tm, out_subfmt=out_subfmt))
+                cache[attr] = value
+                return cache[attr]
+
+        if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)
             if self.scale is None:
                 raise ScaleValueError("Cannot convert TimeDelta with "
                                       "undefined scale to any defined scale.")

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1625,7 +1625,7 @@ class Time(ShapedLikeNDArray):
                         tm = self.replicate(format=fmt)
                     value = tm._shaped_like_input(tm._time.to_value(
                         parent=tm, out_subfmt=out_subfmt))
-                cache[attr] = value
+                    cache[attr] = value
                 return cache[attr]
 
         if attr in TIME_SCALES:  # allowed ones done above (self.SCALES)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1518,6 +1518,7 @@ class TimeDeltaFormat(TimeFormat, metaclass=TimeDeltaFormatMeta):
 
         return scale
 
+
 class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
 
     def set_jds(self, val1, val2):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -343,7 +343,8 @@ class TimeNumeric(TimeFormat):
                 'and second values are only allowed for doubles.'
                 .format(self.name))
 
-        for subfmt, dtype, convert, _ in self.subfmts:
+        subfmts = self._select_subfmts(self.in_subfmt)
+        for subfmt, dtype, convert, _ in subfmts:
             if np.issubdtype(val1.dtype, dtype):
                 break
         else:

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -385,8 +385,8 @@ class TimeMJD(TimeFormat):
     subfmts = (('float64', None, np.add),
                ('float128', None, twoval_to_float128),
                ('O', decimal_to_twoval, twoval_to_decimal),
-               ('U', decimal_to_twoval, twoval_to_string),
-               ('S', bytes_to_twoval, twoval_to_bytes),
+               ('str', decimal_to_twoval, twoval_to_string),
+               ('bytes', bytes_to_twoval, twoval_to_bytes),
     )
 
     def _check_val_type(self, val1, val2):
@@ -428,7 +428,7 @@ class TimeMJD(TimeFormat):
         jd2 = self.jd2
         subfmt = self._select_subfmts(self.out_subfmt)[0]
         kwargs = {}
-        if subfmt[0] in 'SU':
+        if subfmt[0] in ('str', 'bytes'):
             kwargs['fmt'] = f'.{self.precision}f'
         return subfmt[2](jd1, jd2, **kwargs)
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -419,7 +419,7 @@ class TimeMJD(TimeNumeric):
         self.jd1, self.jd2 = day_frac(jd1, jd2)
 
     def to_value(self, **kwargs):
-        jd1 = self.jd1 - erfa.DJM0  # This cannot loose precision.
+        jd1 = self.jd1 - erfa.DJM0  # This cannot lose precision.
         jd2 = self.jd2
         return super().to_value(jd1=jd1, jd2=jd2, **kwargs)
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -966,11 +966,14 @@ class TestNumericalSubFormat:
         dt = (Time("58000", format="mjd", scale="tai")
               - Time("58001", format="mjd", scale="tai"))
 
-        value = getattr(dt, "_".join((f, s)))
+        value = dt.to_value(f, s)
         assert isinstance(value, t)
+        value2 = getattr(dt, "_".join((f, s)))
+        assert isinstance(value2, t)
         dt.format = f
         dt.out_subfmt = s
         assert isinstance(dt.value, t)
+        assert isinstance(dt.to_value(), t)
 
 
 class TestSofaErrors:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -960,17 +960,17 @@ class TestNumericalSubFormat:
         assert t_s_2 == t2_s_40, "Different precision should produce the same results"
 
     @pytest.mark.parametrize("f, s, t", [("sec", "long", np.longdouble),
-                                      ("sec", "decimal", Decimal),
-                                      ("sec", "str", str)])
+                                         ("sec", "decimal", Decimal),
+                                         ("sec", "str", str)])
     def test_timedelta_basic(self, f, s, t):
         dt = (Time("58000", format="mjd", scale="tai")
               - Time("58001", format="mjd", scale="tai"))
 
-        assert isinstance(getattr(dt, "_".join((f,s))), t)
+        value = getattr(dt, "_".join((f, s)))
+        assert isinstance(value, t)
         dt.format = f
         dt.out_subfmt = s
         assert isinstance(dt.value, t)
-        assert isinstance(dt.to_value(), t)
 
 
 class TestSofaErrors:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -859,18 +859,18 @@ class TestSubFormat:
 
 class TestNumericalSubFormat:
     def test_explicit_example(self):
-        t = Time('54321.000000000001', format='mjd', precision=13)
+        t = Time('54321.000000000001', format='mjd')
         assert t == Time(54321, 1e-12, format='mjd')
         assert t.mjd == 54321.  # Lost precision!
         assert t.value == 54321.  # Lost precision!
         assert t.to_value() == 54321.  # Lost precision!
-        assert t.to_value(subfmt='str') == '54321.0000000000010'
-        assert t.to_value('mjd', 'bytes') == b'54321.0000000000010'
+        assert t.to_value(subfmt='str') == '54321.000000000001'
+        assert t.to_value('mjd', 'bytes') == b'54321.000000000001'
         t.out_subfmt = 'str'
-        assert t.value == '54321.0000000000010'
-        assert t.to_value() == '54321.0000000000010'
-        assert t.mjd == '54321.0000000000010'
-        assert t.to_value(subfmt='bytes') == b'54321.0000000000010'
+        assert t.value == '54321.000000000001'
+        assert t.to_value() == '54321.000000000001'
+        assert t.mjd == '54321.000000000001'
+        assert t.to_value(subfmt='bytes') == b'54321.000000000001'
         assert t.to_value(subfmt='float') == 54321.  # Lost precision!
 
     def test_subformat_input(self):
@@ -888,39 +888,41 @@ class TestNumericalSubFormat:
     def test_subformat_output(self, out_subfmt):
         i = 54321
         f = np.array([0., 1e-9, 1e-12])
-        t = Time(i, f, format='mjd', out_subfmt=out_subfmt, precision=13)
+        t = Time(i, f, format='mjd', out_subfmt=out_subfmt)
         t_value = t.value
-        expected = np.array([f'{i}.' + f'{_f:14.13f}'.split('.')[1]
-                             for _f in f], dtype=out_subfmt)
+        expected = np.array(['54321.0',
+                             '54321.000000001',
+                             '54321.000000000001'], dtype=out_subfmt)
         assert np.all(t_value == expected)
+        assert np.all(Time(expected, format='mjd') == t)
 
         # Explicit sub-format.
-        t = Time(i, f, format='mjd', precision=13)
+        t = Time(i, f, format='mjd')
         t_mjd_subfmt = t.to_value(subfmt=out_subfmt)
         assert np.all(t_mjd_subfmt == expected)
 
     def test_explicit_other_formats(self):
-        t = Time('2451544.5333981', format='jd', scale='tai', precision=8)
+        t = Time('2451544.5333981', format='jd', scale='tai')
         assert t == Time(2451544.5, .0333981, format='jd', scale='tai')
-        assert t.to_value(subfmt='str') == '2451544.53339810'
-        t = Time('2000.54321', format='decimalyear', precision=6)
+        assert t.to_value(subfmt='str') == '2451544.5333981'
+        t = Time('2000.54321', format='decimalyear')
         assert t == Time(2000., 0.54321, format='decimalyear')
-        assert t.to_value(subfmt='str') == '2000.543210'
-        t = Time('100.0123456', format='cxcsec', precision=6)
+        assert t.to_value(subfmt='str') == '2000.54321'
+        t = Time('100.0123456', format='cxcsec')
         assert t == Time(100.0123456, format='cxcsec')
-        assert t.to_value(subfmt='str') == '100.012346'
-        t = Time('100.0123456', format='unix', precision=7)
+        assert t.to_value(subfmt='str') == '100.0123456'
+        t = Time('100.0123456', format='unix')
         assert t == Time(100.0123456, format='unix')
         assert t.to_value(subfmt='str') == '100.0123456'
         t = Time('100.0123456', format='gps')
         assert t == Time(100.0123456, format='gps')
-        assert t.to_value(subfmt='str') == '100.012'
+        assert t.to_value(subfmt='str') == '100.0123456'
         t = Time('1950.1', format='byear', scale='tai')
         assert t == Time(1950.1, format='byear', scale='tai')
-        assert t.to_value(subfmt='str') == '1950.100'
+        assert t.to_value(subfmt='str') == '1950.1'
         t = Time('2000.1', format='jyear', scale='tai')
         assert t == Time(2000.1, format='jyear', scale='tai')
-        assert t.to_value(subfmt='str') == '2000.100'
+        assert t.to_value(subfmt='str') == '2000.1'
 
     def test_basic_subformat_setting(self):
         t = Time('2001', format='jyear', scale='tai')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -941,28 +941,18 @@ class TestNumericalSubFormat:
         t_mjd_subfmt = t.to_value(subfmt=out_subfmt)
         assert np.all(t_mjd_subfmt == expected)
 
-    def test_explicit_other_formats(self):
-        t = Time('2451544.5333981', format='jd', scale='tai')
-        assert t == Time(2451544.5, .0333981, format='jd', scale='tai')
-        assert t.to_value(subfmt='str') == '2451544.5333981'
-        t = Time('2000.54321', format='decimalyear')
-        assert t == Time(2000., 0.54321, format='decimalyear')
-        assert t.to_value(subfmt='str') == '2000.54321'
-        t = Time('100.0123456', format='cxcsec')
-        assert t == Time(100.0123456, format='cxcsec')
-        assert t.to_value(subfmt='str') == '100.0123456'
-        t = Time('100.0123456', format='unix')
-        assert t == Time(100.0123456, format='unix')
-        assert t.to_value(subfmt='str') == '100.0123456'
-        t = Time('100.0123456', format='gps')
-        assert t == Time(100.0123456, format='gps')
-        assert t.to_value(subfmt='str') == '100.0123456'
-        t = Time('1950.1', format='byear', scale='tai')
-        assert t == Time(1950.1, format='byear', scale='tai')
-        assert t.to_value(subfmt='str') == '1950.1'
-        t = Time('2000.1', format='jyear', scale='tai')
-        assert t == Time(2000.1, format='jyear', scale='tai')
-        assert t.to_value(subfmt='str') == '2000.1'
+    @pytest.mark.parametrize('fmt,string,val1,val2', [
+        ('jd', '2451544.5333981', 2451544.5, .0333981),
+        ('decimalyear', '2000.54321', 2000., .54321),
+        ('cxcsec', '100.0123456', 100.0123456, None),
+        ('unix', '100.0123456', 100.0123456, None),
+        ('gps', '100.0123456', 100.0123456, None),
+        ('byear', '1950.1', 1950.1, None),
+        ('jyear', '2000.1', 2000.1, None)])
+    def test_explicit_string_other_formats(self, fmt, string, val1, val2):
+        t = Time(string, format=fmt)
+        assert t == Time(val1, val2, format=fmt)
+        assert t.to_value(subfmt='str') == string
 
     def test_basic_subformat_setting(self):
         t = Time('2001', format='jyear', scale='tai')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -972,7 +972,7 @@ class TestNumericalSubFormat:
     def test_basic_subformat_cache_does_not_crash(self):
         t = Time('2001', format='jyear', scale='tai')
         t.to_value('mjd', subfmt='str')
-        assert 'mjd_str' in t.cache['format']
+        assert ('mjd', 'str') in t.cache['format']
         t.to_value('mjd', 'str')
 
     @pytest.mark.parametrize("fmt", ["jd", "mjd", "cxcsec", "unix", "gps", "jyear"])

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -895,6 +895,30 @@ class TestNumericalSubFormat:
         t_mjd_subfmt = getattr(t, f'mjd_{out_subfmt}')
         assert np.all(t_mjd_subfmt == expected)
 
+    def test_explicit_other_formats(self):
+        t = Time('2451544.5333981', format='jd', scale='tai', precision=8)
+        assert t == Time(2451544.5, .0333981, format='jd', scale='tai')
+        assert t.jd_str == '2451544.53339810'
+        t = Time('2000.54321', format='decimalyear', precision=6)
+        assert t == Time(2000., 0.54321, format='decimalyear')
+        assert t.decimalyear_str == '2000.543210'
+        t = Time('100.0123456', format='cxcsec', precision=6)
+        assert t == Time(100.0123456, format='cxcsec')
+        assert t.cxcsec_str == '100.012346'
+        t = Time('100.0123456', format='unix', precision=7)
+        assert t == Time(100.0123456, format='unix')
+        assert t.unix_str == '100.0123456'
+        t = Time('100.0123456', format='gps')
+        assert t == Time(100.0123456, format='gps')
+        assert t.gps_str == '100.012'
+        # Note: cannot fully test _str format since byear_str exists.
+        t = Time('1950.1', format='byear', scale='tai', out_subfmt='str')
+        assert t == Time(1950.1, format='byear', scale='tai')
+        assert t.value == '1950.100'
+        t = Time('2000.1', format='jyear', scale='tai', out_subfmt='str')
+        assert t == Time(2000.1, format='jyear', scale='tai')
+        assert t.value == '2000.100'
+
 
 class TestSofaErrors:
     """Test that erfa status return values are handled correctly"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1016,6 +1016,28 @@ class TestNumericalSubFormat:
         assert isinstance(dt.value, t)
         assert isinstance(dt.to_value(), t)
 
+    def test_wrong_in_subfmt(self):
+        with pytest.raises(ValueError, match='not among selected'):
+            Time("58000", format='mjd', in_subfmt='float')
+
+        with pytest.raises(ValueError, match='not among selected'):
+            Time(np.longdouble(58000), format='mjd', in_subfmt='float')
+
+        with pytest.raises(ValueError, match='not among selected'):
+            Time(58000., format='mjd', in_subfmt='str')
+
+        with pytest.raises(ValueError, match='not among selected'):
+            Time(58000., format='mjd', in_subfmt='long')
+
+    def test_wrong_out_subfmt(self):
+        t = Time(58000., format='mjd')
+        with pytest.raises(ValueError, match='must match one'):
+            t.to_value(subfmt='parrot')
+
+        t.out_subfmt = 'parrot'
+        with pytest.raises(ValueError):
+            t.value
+
 
 class TestSofaErrors:
     """Test that erfa status return values are handled correctly"""

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -7,7 +7,6 @@ import pytest
 
 import numpy as np
 
-import astropy.units as u
 from astropy._erfa import DJM0
 from astropy.time import Time, TimeFormat
 from astropy.time.utils import day_frac
@@ -156,17 +155,6 @@ def test_mjd_longdouble_preserves_precision(custom_format_name):
     assert t != t2
     assert isinstance(getattr(t, custom_format_name), np.longdouble)
     assert getattr(t, custom_format_name) != getattr(t2, custom_format_name)
-
-
-def test_mjd_unit_validation():
-    with pytest.raises(u.UnitConversionError):
-        Time(58000 * u.m, format="mjd")
-
-
-def test_mjd_unit_conversion():
-    assert Time(58000 * u.day, format="mjd") == Time(58000 * u.day, format="mjd")
-    assert Time(58000 * u.day, format="mjd") != Time(58000 * u.s, format="mjd")
-    assert Time(58000 * u.day, format="mjd") == Time(58000 * 86400 * u.s, format="mjd")
 
 
 @pytest.mark.parametrize("f", ["mjd", "unix", "cxcsec"])

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -1,5 +1,7 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
 from datetime import date
-from itertools import count, product
+from itertools import count
 
 import pytest
 

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -157,28 +157,6 @@ def test_mjd_longdouble_preserves_precision(custom_format_name):
     assert getattr(t, custom_format_name) != getattr(t2, custom_format_name)
 
 
-@pytest.mark.parametrize("f", ["mjd", "unix", "cxcsec"])
-def test_existing_types_refuse_longdoubles(f):
-    t = np.longdouble(getattr(Time(58000, format="mjd"), f))
-    t2 = t + np.finfo(np.longdouble).eps * 2 * t
-    try:
-        tm = Time(np.longdouble(t), format=f)
-    except ValueError:
-        # Time processing makes it always ValueError not TypeError
-        return
-    else:
-        # accepts long doubles, better preserve accuracy!
-        assert Time(np.longdouble(t2), format=f) != tm
-
-
-@pytest.mark.parametrize("f", ["mjd", "unix", "cxcsec"])
-def test_existing_types_ok_with_float64(f):
-    t = np.float64(getattr(Time(58000, format="mjd"), f))
-    t2 = t + np.finfo(np.float64).eps * 2 * t
-    tm = Time(np.float64(t), format=f)
-    assert Time(np.float64(t2), format=f) != tm
-
-
 @pytest.mark.parametrize(
     "jd1, jd2",
     [
@@ -285,25 +263,3 @@ def test_custom_format_can_return_any_iterable(custom_format_name, thing):
                         custom_format_name)) == type(thing)
     assert np.all(getattr(Time(5, format=custom_format_name),
                           custom_format_name) == thing)
-
-
-# Converted from doctest in astropy/test/formats.py for debugging
-def test_ymdhms():
-    t = Time({'year': 2015, 'month': 2, 'day': 3,
-              'hour': 12, 'minute': 13, 'second': 14.567},
-             scale='utc')
-    # NOTE: actually comes back as np.void for some reason
-    # NOTE: not necessarily a python int; might be an int32
-    assert t.ymdhms.year == 2015
-
-
-# There are two stages of validation now - one on input into a format, so that
-# the format conversion code has tidy matched arrays to work with, and the
-# other when object construction does not go through a format object. Or at
-# least, the format object is constructed with "from_jd=True". In this case the
-# normal input validation does not happen but the new input validation does,
-# and can ensure that strange broadcasting anomalies can't happen.
-# This form of construction uses from_jd=True.
-def test_broadcasting_writeable():
-    t = Time('J2015') + np.linspace(-1, 1, 10)*u.day
-    t[2] = Time(58000, format="mjd")

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -277,8 +277,8 @@ class TestTimeDelta:
     def test_to_value(self):
         dt = TimeDelta(86400.0, format='sec')
         assert dt.to_value('jd') == 1.
-        assert dt.to_value('jd', 'str') == '1.000'
-        assert dt.to_value(subfmt='str') == '86400.000'
+        assert dt.to_value('jd', 'str') == '1.0'
+        assert dt.to_value(subfmt='str') == '86400.0'
         with pytest.raises(ValueError,
                            match='format is not one.*trying to parse it'):
             dt.to_value('julian')

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -278,10 +278,13 @@ class TestTimeDelta:
         dt = TimeDelta(86400.0, format='sec')
         assert dt.to_value('jd') == 1.
         assert dt.to_value('jd', 'str') == '1.0'
-        assert dt.to_value(subfmt='str') == '86400.0'
+        assert dt.to_value('sec', subfmt='str') == '86400.0'
         with pytest.raises(ValueError, match=("not one of the known formats.*"
                                               "failed to parse as a unit")):
             dt.to_value('julian')
+
+        with pytest.raises(TypeError, match='missing required format or unit'):
+            dt.to_value()
 
 
 class TestTimeDeltaScales:

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -279,8 +279,8 @@ class TestTimeDelta:
         assert dt.to_value('jd') == 1.
         assert dt.to_value('jd', 'str') == '1.0'
         assert dt.to_value(subfmt='str') == '86400.0'
-        with pytest.raises(ValueError,
-                           match='format is not one.*trying to parse it'):
+        with pytest.raises(ValueError, match=("not one of the known formats.*"
+                                              "failed to parse as a unit")):
             dt.to_value('julian')
 
 

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -285,7 +285,6 @@ class TestTimeDelta:
             dt.to_value('julian')
 
 
-
 class TestTimeDeltaScales:
     """Test scale conversion for Time Delta.
     Go through @taldcroft's list of expected behavior from #1932"""

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -279,7 +279,6 @@ class TestTimeDelta:
         assert dt.to_value('jd') == 1.
         assert dt.to_value('jd', 'str') == '1.000'
         assert dt.to_value(subfmt='str') == '86400.000'
-        assert dt.sec_str == '86400.000'
         with pytest.raises(ValueError,
                            match='format is not one.*trying to parse it'):
             dt.to_value('julian')

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -1,12 +1,12 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import functools
 import itertools
-import numpy as np
 import operator
+from decimal import Decimal
+from datetime import timedelta
 
 import pytest
-
-from datetime import timedelta
+import numpy as np
 
 from astropy.time import (Time, TimeDelta, OperandTypeError, ScaleValueError,
                           TIME_SCALES, STANDARD_TIME_SCALES, TIME_DELTA_SCALES)
@@ -266,6 +266,24 @@ class TestTimeDelta:
         dt.format = 'datetime'
         assert dt.value == timedelta(days=1)
         assert dt.format == 'datetime'
+
+    def test_from_non_float(self):
+        dt = TimeDelta('1.000000000000001', format='jd')
+        assert dt != TimeDelta(1.000000000000001, format='jd')  # precision loss.
+        assert dt == TimeDelta(1, .000000000000001, format='jd')
+        dt2 = TimeDelta(Decimal('1.000000000000001'), format='jd')
+        assert dt2 == dt
+
+    def test_to_value(self):
+        dt = TimeDelta(86400.0, format='sec')
+        assert dt.to_value('jd') == 1.
+        assert dt.to_value('jd', 'str') == '1.000'
+        assert dt.to_value(subfmt='str') == '86400.000'
+        assert dt.sec_str == '86400.000'
+        with pytest.raises(ValueError,
+                           match='format is not one.*trying to parse it'):
+            dt.to_value('julian')
+
 
 
 class TestTimeDeltaScales:

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -134,10 +134,23 @@ class TestTimeDeltaQuantity:
         assert dt.to_value('s') == q.to_value(u.second)
         # Following goes through "format", but should be the same.
         assert dt.to_value('sec') == q.to_value(u.second)
+
+    def test_quantity_output_errors(self):
+        dt = TimeDelta(250., format='sec')
         with pytest.raises(u.UnitsError):
             dt.to(u.m)
         with pytest.raises(u.UnitsError):
             dt.to_value(u.m)
+        with pytest.raises(u.UnitsError):
+            dt.to_value(unit=u.m)
+        with pytest.raises(ValueError, match=("not one of the known formats.*"
+                                              "failed to parse as a unit")):
+            dt.to_value('parrot')
+        with pytest.raises(TypeError):
+            dt.to_value('sec', unit=u.s)
+        with pytest.raises(TypeError):
+            # TODO: would be nice to make this work!
+            dt.to_value(u.s, subfmt='str')
 
     def test_valid_quantity_operations1(self):
         """Check adding/substracting/comparing a time-valued quantity works

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -128,8 +128,12 @@ class TestTimeDeltaQuantity:
         dt = TimeDelta(q)
         assert dt.to(u.day) == q
         assert dt.to_value(u.day) == q.value
+        assert dt.to_value('day') == q.value
         assert dt.to(u.second).value == q.to_value(u.second)
         assert dt.to_value(u.second) == q.to_value(u.second)
+        assert dt.to_value('s') == q.to_value(u.second)
+        # Following goes through "format", but should be the same.
+        assert dt.to_value('sec') == q.to_value(u.second)
         with pytest.raises(u.UnitsError):
             dt.to(u.m)
         with pytest.raises(u.UnitsError):

--- a/astropy/time/utils.py
+++ b/astropy/time/utils.py
@@ -105,7 +105,10 @@ def quantity_day_frac(val1, val2=None):
         # But at least try normal conversion, since equivalencies may be set.
         return val1.to_value(u.day), 0.
 
-    if factor >= 1.:
+    if factor == 1.:
+        return day_frac(val1.value, 0.)
+
+    if factor > 1:
         return day_frac(val1.value, 0., factor=factor)
     else:
         divisor = u.day.to(val1.unit)
@@ -183,10 +186,26 @@ def split(a):
 _enough_decimal_places = 34  # to represent two doubles
 
 
+def longdouble_to_twoval(val1, val2=None):
+    if val2 is None:
+        val2 = val1.dtype.type(0.)
+    else:
+        best_type = np.result_type(val1.dtype, val2.dtype)
+        val1 = val1.astype(best_type, copy=False)
+        val2 = val2.astype(best_type, copy=False)
+
+    # day_frac is independent of dtype, as long as the dtype
+    # are the same and no factor or divisor is given.
+    i, f = day_frac(val1, val2)
+    return i.astype(float, copy=False), f.astype(float, copy=False)
+
+
 def decimal_to_twoval1(val1, val2=None):
     with decimal.localcontext() as ctx:
         ctx.prec = _enough_decimal_places
-        i, f = divmod(decimal.Decimal(val1), 1)
+        d = decimal.Decimal(val1)
+        i = round(d)
+        f = d - i
     return float(i), float(f)
 
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -73,7 +73,7 @@ The full power of output representation is available via the
 `subformat`_, for example using ``numpy.longdouble`` as the output type
 for higher precision::
 
-  >>> t.to_value('mjd', 'long')  # doctest: +FLOAT_CMP
+  >>> t.to_value('mjd', 'long')  # doctest: +SKIP
   array([51179.00000143, 55197.        ], dtype=float128)
 
 The default representation can be changed by setting the `format` attribute::
@@ -263,9 +263,10 @@ can have higher precision than the standard 64-bit float::
   >>> tm.to_value('mjd', subfmt='decimal')  # doctest: +SKIP
   Decimal('51544.00000000000000099920072216264')
   >>> tm.to_value('mjd', subfmt='str')
-  Decimal('51544.000000000000001')
+  '51544.000000000000001'
 
-The complete list of |TIME| subformat options is below:
+The complete list of subformat options for the |TIME| formats that
+have them is:
 
 ================ ========================================
 Format           Subformats
@@ -286,7 +287,8 @@ Format           Subformats
 ``yday``         date_hms, date_hm, date
 ================ ========================================
 
-The complete list of |TimeDelta| subformat options is below:
+The complete list of subformat options for the |TimeDelta| formats
+that have them is:
 
 ================ ========================================
 Format           Subformats

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -68,6 +68,14 @@ formats by requesting the corresponding |Time| attributes::
   >>> t.mjd  # doctest: +FLOAT_CMP
   array([51179.00000143, 55197.        ])
 
+The full power of output representation is available via the
+`~astropy.time.Time.to_value` method which also allows controlling the
+`subformat`_, for example using ``numpy.longdouble`` as the output type
+for higher precision::
+
+  >>> t.to_value('mjd', 'long')  # doctest: +FLOAT_CMP
+  array([51179.00000143, 55197.        ], dtype=float128)
+
 The default representation can be changed by setting the `format` attribute::
 
   >>> t.format = 'fits'
@@ -211,22 +219,15 @@ preserved::
   >>> t.value
   '2000-01-02T00:00:00.000'
 
-
 Subformat
 """""""""
 
-The time format classes :class:`~astropy.time.TimeISO`,
-:class:`~astropy.time.TimeISOT`, :class:`~astropy.time.TimeFITS`, and
-:class:`~astropy.time.TimeYearDayTime` support the concept of
-subformats.  This allows for variations on the basic theme of a format in both
-the input string parsing and the output.
+Many of the available time format classes support the concept of a
+subformat.  This allows for variations on the basic theme of a format in both
+the input parsing / validation and the output
 
-The supported subformats are ``date_hms``, ``date_hm``, and ``date``
-for all but the :class:`~astropy.time.TimeFITS` format; the latter
-does not support ``date_hm`` but does support ``longdate_hms`` and
-``longdate`` for years before the year 0 and after the year 10000.  The
-table below illustrates these subformats for ``iso``, ``fits``, ``yday``
-formats:
+The table below illustrates available subformats for the string formats
+ ``iso``, ``fits``, ``yday`` formats:
 
 ========  ============ ==============================
 Format    Subformat    Input / output
@@ -241,6 +242,58 @@ Format    Subformat    Input / output
 ``yday``  date_hm      2001:032:03:04
 ``yday``  date         2001:032
 ========  ============ ==============================
+
+Numerical formats such as ``mjd``, ``jyear``, or ``cxcsec`` all support the
+subformats: ``'float'``, ``'long'``, ``'decimal'``, ``'str'``, and ``'bytes'``.
+Here, ``'long'`` uses ``numpy.longdouble`` for somewhat enhanced precision (with
+the enhancement depending on platform), and ``'decimal'`` instances of
+:class:`decimal.Decimal` for full precision.  For the ``'str'`` and ``'bytes'``
+sub-formats, the number of digits is also chosen such that time values are
+represented accurately.
+
+When used on input, these formats allow creating a time using a single input
+value that accurately captures the value to the full available precision in
+|Time|.  Conversely, the single value on output using |Time|
+`~astropy.time.Time.to_value` or |TimeDelta| `~astropy.time.TimeDelta.to_value`
+can have higher precision than the standard 64-bit float::
+
+  >>> tm = Time('51544.000000000000001', format='mjd')  # String input
+  >>> tm.mjd  # float64 output loses last digit but Decimal gets it
+  51544.0
+  >>> tm.to_value('mjd', subfmt='decimal')  # doctest: +SKIP
+  Decimal('51544.00000000000000099920072216264')
+  >>> tm.to_value('mjd', subfmt='str')
+  Decimal('51544.000000000000001')
+
+The complete list of |TIME| subformat options is below:
+
+================ ========================================
+Format           Subformats
+================ ========================================
+``byear``        float, long, decimal, str, bytes
+``cxcsec``       float, long, decimal, str, bytes
+``datetime64``   date_hms, date_hm, date
+``decimalyear``  float, long, decimal, str, bytes
+``fits``         date_hms, date, longdate_hms, longdate
+``gps``          float, long, decimal, str, bytes
+``iso``          date_hms, date_hm, date
+``isot``         date_hms, date_hm, date
+``jd``           float, long, decimal, str, bytes
+``jyear``        float, long, decimal, str, bytes
+``mjd``          float, long, decimal, str, bytes
+``plot_date``    float, long, decimal, str, bytes
+``unix``         float, long, decimal, str, bytes
+``yday``         date_hms, date_hm, date
+================ ========================================
+
+The complete list of |TimeDelta| subformat options is below:
+
+================ ========================================
+Format           Subformats
+================ ========================================
+``jd``           float, long, decimal, str, bytes
+``sec``          float, long, decimal, str, bytes
+================ ========================================
 
 Time from epoch formats
 """""""""""""""""""""""
@@ -436,9 +489,9 @@ The allowed |Time| arguments to create a time object are listed below:
 **precision** : int between 0 and 9 inclusive
     Decimal precision when outputting seconds as floating point
 **in_subfmt** : str
-    Unix glob to select subformats for parsing string input times
+    Unix glob to select subformats for parsing input times
 **out_subfmt** : str
-    Unix glob to select subformats for outputting string times
+    Unix glob to select subformat for outputting times
 **location** : |EarthLocation| or tuple, optional
     If a tuple, 3 |Quantity| items with length units for geocentric coordinates,
     or a longitude, latitude, and optional height for geodetic coordinates.
@@ -519,7 +572,7 @@ in_subfmt
 ^^^^^^^^^
 
 The ``in_subfmt`` argument provides a mechanism to select one or more
-`subformat`_ values from the available subformats for string input.  Multiple
+`subformat`_ values from the available subformats for input. Multiple
 allowed subformats can be selected using Unix-style wildcard characters, in
 particular ``*`` and ``?``, as documented in the Python `fnmatch
 <https://docs.python.org/3/library/fnmatch.html>`_ module.
@@ -556,6 +609,10 @@ matching subformat is used.
   '2000-01-01 02:03:04.000'
   >>> Time('2000-01-01 02:03:04', out_subfmt='date*').iso
   '2000-01-01 02:03:04.000'
+  >>> Time('50814.123456789012345', format='mjd', out_subfmt='str').mjd
+  '50814.123456789012345'
+
+See also the `subformat`_ section.
 
 location
 ^^^^^^^^
@@ -998,8 +1055,17 @@ Use of the |TimeDelta| object is easily illustrated in the few examples below::
   '2010-01-08 18:00:00.000' '2010-01-16 12:00:00.000' '2010-01-24 06:00:00.000'
   '2010-02-01 00:00:00.000']>
 
+The |TimeDelta| has a `~astropy.time.TimeDelta.to_value` method which supports
+controlling the type of the output representation by providing either a format
+name and optional `subformat`_ or a valid astropy unit::
+
+  >>> dt.to_value(u.hr)
+  744.0
+  >>> dt.to_value('jd', 'str')
+  '31.0'
+
 Time Scales for Time Deltas
----------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Above, one sees that the difference between two UTC times is a |TimeDelta|
 with a scale of TAI.  This is because a UTC time difference cannot be uniquely

--- a/docs/timeseries/times.rst
+++ b/docs/timeseries/times.rst
@@ -63,15 +63,14 @@ and ``scale`` attributes::
     >>> ts.time.format = 'unix'
     >>> ts  # doctest: +FLOAT_CMP
     <TimeSeries length=5>
-           time          flux
-          object       float64
-    ------------------ -------
-          1458649831.0     1.0
-          1458649834.0     3.0
-          1458649837.0     4.0
-          1458649840.0     2.0
-          1458649843.0     4.0
-
+        time       flux
+       object    float64
+    ------------ -------
+    1458649831.0     1.0
+    1458649834.0     3.0
+    1458649837.0     4.0
+    1458649840.0     2.0
+    1458649843.0     4.0
 
 Times relative to other times
 =============================


### PR DESCRIPTION
Inspired by #9358, a trial to allow `Decimal` and `str` input for `format='mjd'`, and also allow one to select such output. This could be easily extended to `jd`, etc.

With this PR (EDIT: updated to `str, bytes`)
```
In [1]: from astropy.time import Time

In [2]: from decimal import Decimal

In [3]: Time('54321.01234567890123456789', format='mjd')
Out[3]: <Time object: scale='utc' format='mjd' value=54321.012>

In [4]: Time(b'54321.01234567890123456789', format='mjd', precision=19)
Out[4]: <Time object: scale='utc' format='mjd' value=b'54321.0123456789012345580'>

In [5]: Time(Decimal('54321.01234567890123456789'), format='mjd')
Out[5]: <Time object: scale='utc' format='mjd' value=54321.01234567890123455802254>

In [6]: t = Time(54321., [0., 1e-9, 1e-12], format='mjd', precision=13)

In [7]: t.value
Out[7]: array([54321., 54321., 54321.])

In [8]: t.out_subfmt = 'str'

In [9]: t.value
Out[9]: 
array(['54321.0000000000000', '54321.0000000010000',
       '54321.0000000000010'], dtype='<U19')

In [10]: t.out_subfmt = 'object'

In [11]: t.value
Out[11]: 
array([Decimal('54321.0'), Decimal('54321.00000000100000002722922'),
       Decimal('54321.00000000000099997787828')], dtype=object)

In [12]: t.out_subfmt = 'float128'

In [13]: t.value
Out[13]: array([54321., 54321., 54321.], dtype=float128)

In [14]: t.value - t.value[0]
Out[14]: array([0.00000000e+00, 1.00000008e-09, 9.98312544e-13], dtype=float128)
```

cc @aarchiba, @taldcroft 