### PR TITLE
Update ERFA leap seconds using new IERS LeapSecond class.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ sudo: false
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
+# tzdata is included to ensure system leap seconds are up to date.
 addons:
     apt:
         packages:
             - graphviz
             - language-pack-de
+            - tzdata
 
 env:
     global:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -658,6 +658,8 @@ Other Changes and Additions
 - The bundled ERFA was updated to version 1.6.0 (based on SOFA 20190722).
   This includes a fix that avoids precision loss for negative JDs. [#9323]
 
+- The leap seconds in the bundled ERFA library are now updated
+  automatically. [#9365]
 
 
 3.2.2 (2019-10-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -241,6 +241,9 @@ astropy.utils
   coordinate transformations can now be set, either in a context or per
   session, using ``astropy.utils.iers.earth_rotation_table``. [#9244]
 
+- A new ``astropy.utils.iers.LeapSeconds`` class has been added to track
+  leap seconds. [#9365]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -35,7 +35,6 @@ import numpy as np
 
 from .bst import MinValue, MaxValue
 from .sorted_array import SortedArray
-from astropy.time import Time
 
 
 class QueryError(ValueError):
@@ -78,7 +77,9 @@ class Index:
         return SlicedIndex(self, slice(0, 0, None), original=True)
 
     def __init__(self, columns, engine=None, unique=False):
+        # Local imports to avoid import problems.
         from .table import Table, Column
+        from astropy.time import Time
 
         if engine is not None and not isinstance(engine, type):
             # create from data

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -20,7 +20,6 @@ import numpy as np
 from astropy.utils import metadata
 from .table import Table, QTable, Row, Column, MaskedColumn
 from astropy.units import Quantity
-from astropy.time import Time
 from astropy.utils.compat import NUMPY_LT_1_17
 
 from . import _np_utils
@@ -798,6 +797,8 @@ def _join(left, right, keys=None, join_type='inner',
     joined_table : `~astropy.table.Table` object
         New table containing the result of the join operation.
     """
+    from astropy.time import Time
+
     # Store user-provided col_name_map until the end
     _col_name_map = col_name_map
 

--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -1,3 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .formats import *
 from .core import *
+
+
+update_leap_seconds()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2417,5 +2417,5 @@ def update_leap_seconds(files=None):
 
     except Exception as exc:
         warn("leap-second auto-update failed due to the following "
-             "exception: " + str(exc), AstropyWarning)
+             f"exception: {exc!r}", AstropyWarning)
         return 0

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2399,9 +2399,9 @@ def update_leap_seconds(files=None):
     Parameters
     ----------
     files : list of path, optional
-        List of files/URLs to attempt to open.  By default, uses those defined
-        by `astropy.utils.iers.LeapSecond.open`, which includes the table used
-        by ERFA itself, so if we're up to date already, nothing will happen.
+        List of files/URLs to attempt to open.  By default, uses defined by
+        `astropy.utils.iers.LeapSeconds.auto_open`, which includes the table
+        used by ERFA itself, so if that is up to date, nothing will happen.
 
     Returns
     -------

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -12,6 +12,7 @@ import copy
 import operator
 from datetime import datetime, date, timedelta
 from time import strftime, strptime
+from warnings import warn
 
 import numpy as np
 
@@ -21,6 +22,7 @@ from astropy.units import UnitConversionError
 from astropy.utils import ShapedLikeNDArray
 from astropy.utils.compat.misc import override__dir__
 from astropy.utils.data_info import MixinInfo, data_info_factory
+from astropy.utils.exceptions import AstropyWarning
 from .utils import day_frac
 from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
@@ -30,8 +32,9 @@ from .formats import TimeFromEpoch  # pylint: disable=W0611
 
 from astropy.extern import _strptime
 
-__all__ = ['Time', 'TimeDelta', 'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
-           'ScaleValueError', 'OperandTypeError', 'TimeInfo']
+__all__ = ['Time', 'TimeDelta',  'TimeInfo', 'update_leap_seconds',
+           'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
+           'ScaleValueError', 'OperandTypeError']
 
 
 STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
@@ -2382,3 +2385,37 @@ class OperandTypeError(TypeError):
             "'{}' and '{}'".format(op_string,
                                      left.__class__.__name__,
                                      right.__class__.__name__))
+
+
+def update_leap_seconds(files=None):
+    """If the current ERFA leap second table is out of date, try to update it.
+
+    Uses `astropy.utils.iers.LeapSeconds.auto_open` to try to find an
+    up-to-date table.  See that routine for the definition of "out of date".
+
+    In order to make it safe to call this any time, all exceptions are turned
+    into warnings,
+
+    Parameters
+    ----------
+    files : list of path, optional
+        List of files/URLs to attempt to open.  By default, uses those defined
+        by `astropy.utils.iers.LeapSecond.open`, which includes the table used
+        by ERFA itself, so if we're up to date already, nothing will happen.
+
+    Returns
+    -------
+    n_update : int
+        Number of items updated.
+
+    """
+    try:
+        from astropy.utils import iers
+
+        table = iers.LeapSeconds.auto_open(files)
+        return erfa.leap_seconds.update(table)
+
+    except Exception as exc:
+        warn("leap-second auto-update failed due to the following "
+             "exception: " + str(exc), AstropyWarning)
+        return 0

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -1,0 +1,83 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from datetime import datetime, timedelta
+
+import pytest
+
+from astropy import _erfa as erfa
+from astropy.utils import iers
+from astropy.utils.exceptions import AstropyWarning
+
+from astropy.time import update_leap_seconds
+
+
+class TestUpdateLeapSeconds:
+    def setup(self):
+        self.built_in = iers.LeapSeconds.from_iers_leap_seconds()
+        self.erfa_ls = iers.LeapSeconds.from_erfa()
+        now = datetime.now()
+        self.good_enough = now + timedelta(150)
+
+    def teardown(self):
+        self.erfa_ls.update_erfa_leap_seconds(initialize_erfa=True)
+
+    def test_auto_update_leap_seconds(self):
+        # Sanity check.
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+        # Set expired leap seconds
+        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        # Check the 2017 leap second is indeed missing.
+        assert erfa.dat(2018, 1, 1, 0.) == 36.0
+
+        # Update with missing leap seconds.
+        n_update = update_leap_seconds([iers.IERS_LEAP_SECOND_FILE])
+        assert n_update >= 1
+        assert erfa.leap_seconds.expires == self.built_in.expires
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+        # Doing it again does not change anything
+        n_update2 = update_leap_seconds([iers.IERS_LEAP_SECOND_FILE])
+        assert n_update2 == 0
+        assert erfa.dat(2018, 1, 1, 0.) == 37.0
+
+    @pytest.mark.remote_data
+    def test_never_expired_if_connected(self):
+        assert self.erfa_ls.expires > datetime.now()
+        assert self.erfa_ls.expires >= self.good_enough
+
+    @pytest.mark.remote_data
+    def test_auto_update_always_good(self):
+        self.erfa_ls.update_erfa_leap_seconds(initialize_erfa='only')
+        update_leap_seconds()
+        assert not erfa.leap_seconds.expired
+        assert erfa.leap_seconds.expires > self.good_enough
+
+    def test_auto_update_bad_file(self):
+        with pytest.warns(AstropyWarning, match='FileNotFound'):
+            update_leap_seconds(['nonsense'])
+
+    def test_auto_update_corrupt_file(self, tmpdir):
+        bad_file = str(tmpdir.join('no_expiration'))
+        with open(iers.IERS_LEAP_SECOND_FILE) as fh:
+
+            lines = fh.readlines()
+        with open(bad_file, 'w') as fh:
+            fh.write('\n'.join([line for line in lines
+                                if not line.startswith('#')]))
+
+        with pytest.warns(AstropyWarning,
+                          match='ValueError.*did not find expiration'):
+            update_leap_seconds([bad_file])
+
+    def test_auto_update_expired_file(self, tmpdir):
+        # Set up expired ERFA leap seconds.
+        expired = self.erfa_ls[self.erfa_ls['year'] < 2017]
+        expired.update_erfa_leap_seconds(initialize_erfa='empty')
+        # Create similarly expired file.
+        expired_file = str(tmpdir.join('expired.dat'))
+        with open(expired_file, 'w') as fh:
+            fh.write('\n'.join(['# File expires on 28 June 2010'] +
+                               [str(item) for item in expired]))
+
+        with pytest.warns(iers.IERSStaleWarning):
+            update_leap_seconds(['erfa', expired_file])

--- a/astropy/utils/iers/data/Leap_Second.dat
+++ b/astropy/utils/iers/data/Leap_Second.dat
@@ -1,0 +1,41 @@
+#  Value of TAI-UTC in second valid beetween the initial value until
+#  the epoch given on the next line. The last line reads that NO
+#  leap second was introduced since the corresponding date
+#  Updated through IERS Bulletin 58 issued in July 2019
+#
+#
+#  File expires on 28 June 2020
+#
+#
+#    MJD        Date        TAI-UTC (s)
+#           day month year
+#    ---    --------------   ------
+#
+    41317.0    1  1 1972       10
+    41499.0    1  7 1972       11
+    41683.0    1  1 1973       12
+    42048.0    1  1 1974       13
+    42413.0    1  1 1975       14
+    42778.0    1  1 1976       15
+    43144.0    1  1 1977       16
+    43509.0    1  1 1978       17
+    43874.0    1  1 1979       18
+    44239.0    1  1 1980       19
+    44786.0    1  7 1981       20
+    45151.0    1  7 1982       21
+    45516.0    1  7 1983       22
+    46247.0    1  7 1985       23
+    47161.0    1  1 1988       24
+    47892.0    1  1 1990       25
+    48257.0    1  1 1991       26
+    48804.0    1  7 1992       27
+    49169.0    1  7 1993       28
+    49534.0    1  7 1994       29
+    50083.0    1  1 1996       30
+    50630.0    1  7 1997       31
+    51179.0    1  1 1999       32
+    53736.0    1  1 2006       33
+    54832.0    1  1 2009       34
+    56109.0    1  7 2012       35
+    57204.0    1  7 2015       36
+    57754.0    1  1 2017       37

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1132,11 +1132,15 @@ class LeapSeconds(QTable):
 
         Parameters
         ----------
-        initialize_erfa : bool, or 'only'
+        initialize_erfa : bool, or 'only', or 'empty'
             Initialize the ERFA leap second table to its built-in value before
             trying to expand it.  This is generally not needed but can help
             in case it somehow got corrupted.  If equal to 'only', the ERFA
             table is reinitialized and no attempt it made to update it.
+            If 'empty', the leap second table is emptied before updating, i.e.,
+            it is overwritten altogether (note that this may break things in
+            surprising ways, as most leap second tables do not include pre-1970
+            pseudo leap-seconds; you were warned).
 
         Returns
         -------
@@ -1153,6 +1157,11 @@ class LeapSeconds(QTable):
             by calling this method with an appropriate value for
             ``initialize_erfa``.
         """
+        if initialize_erfa == 'empty':
+            # Initialize to empty and update is the same as overwrite.
+            erfa.leap_seconds.set(self)
+            return len(self)
+
         if initialize_erfa:
             erfa.leap_seconds.set()
             if initialize_erfa == 'only':

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -926,7 +926,7 @@ class LeapSeconds(QTable):
         introduced, i.e., mid-January or mid-July.  Expiration days are thus
         generally at least 150 days after the present.  For the auto-loading,
         a list comprised of the table shipped with astropy, and files and
-        URLs in ``~astropy.utils.iers.conf`` are tried, returning the first
+        URLs in `~astropy.utils.iers.Conf` are tried, returning the first
         that is sufficiently new, or the newest among them all.
         """
         if file is None:
@@ -972,7 +972,7 @@ class LeapSeconds(QTable):
         Bulletin C is released about 10 days after a possible leap second is
         introduced, i.e., mid-January or mid-July.  Expiration days are thus
         generally at least 150 days after the present.  We look for a file
-        that expires more than 180 - `~astropy.utils.iers.conf.auto_max_age`
+        that expires more than 180 - `~astropy.utils.iers.Conf.auto_max_age`
         after the present.
         """
         good_enough = datetime.now() + timedelta(180-conf.auto_max_age)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1070,7 +1070,7 @@ class LeapSeconds(QTable):
         file : path, optional
             Full local or network path to the file holding leap-second data
             in a format consistent with that used by IERS.  By default, uses
-            `astropy.utils.iers.IERS_LEAP_SECOND_FILE`.
+            ``iers.IERS_LEAP_SECOND_FILE``.
 
         Notes
         -----
@@ -1089,7 +1089,7 @@ class LeapSeconds(QTable):
         file : path, optional
             Full local or network path to the file holding leap-second data
             in a format consistent with that used by IETF.  Up to date versions
-            can be retrieved from `astropy.utils.iers.IETF_LEAP_SECOND_URL`.
+            can be retrieved from ``iers.IETF_LEAP_SECOND_URL``.
 
         Notes
         -----

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -866,6 +866,11 @@ class earth_orientation_table(ScienceState):
 
 class LeapSeconds(QTable):
     _re_expires = re.compile(r'^#.*File expires on[:\s]+(\d+\s\w+\s\d+)\s*$')
+    _expires = None
+
+    @property
+    def expires(self):
+        return self._expires
 
     @classmethod
     def _read_leap_seconds(cls, file, **kwargs):
@@ -890,7 +895,7 @@ class LeapSeconds(QTable):
 
         self = cls.read(lines, format='ascii.basic', data_start=0,
                         **kwargs)
-        self.expires = expires
+        self._expires = expires
         return self
 
     @classmethod
@@ -915,7 +920,7 @@ class LeapSeconds(QTable):
     @classmethod
     def from_erfa(cls):
         self = cls(erfa.leap_seconds.get())
-        self.expires = erfa.leap_seconds.expires
+        self._expires = erfa.leap_seconds.expires
         return self
 
     def update_erfa_leap_seconds(self, initialize_erfa=False):

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -925,7 +925,7 @@ class LeapSeconds(QTable):
         introduced, i.e., mid-January or mid-July.  Expiration days are thus
         generally at least 150 days after the present.  For the auto-loading,
         a list comprised of the table shipped with astropy, and files and
-        URLs in `~astropy.utils.iers.conf` are tried, returning the first
+        URLs in ``~astropy.utils.iers.conf`` are tried, returning the first
         that is sufficiently new, or the newest among them all.
         """
         if file is None:
@@ -1037,7 +1037,7 @@ class LeapSeconds(QTable):
         expiration date by matching with 'File expires'.
         """
         expires = None
-        # Find lines with data as well as expiration.
+        # Find expiration date.
         with get_readable_fileobj(file) as fh:
             lines = fh.readlines()
             for line in lines:
@@ -1046,9 +1046,8 @@ class LeapSeconds(QTable):
                     expires = datetime.strptime(match.groups()[0],
                                                 '%d %B %Y')
                     break
-
-        if not expires:
-            raise ValueError(f'Did not find expiration date in {file}')
+            else:
+                raise ValueError(f'did not find expiration date in {file}')
 
         self = cls.read(lines, format='ascii.basic', data_start=0,
                         **kwargs)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -9,6 +9,8 @@ celestial-to-terrestrial coordinate transformations
 (in `astropy.coordinates`).
 """
 
+import re
+from datetime import datetime, timedelta
 from warnings import warn
 
 try:
@@ -21,8 +23,13 @@ import numpy as np
 from astropy import config as _config
 from astropy import units as u
 from astropy.table import QTable, MaskedColumn
+<<<<<<< HEAD
 from astropy.utils.data import get_pkg_data_filename, clear_download_cache
 from astropy.utils.state import ScienceState
+=======
+from astropy.utils.data import (get_pkg_data_filename, clear_download_cache,
+                                get_readable_fileobj)
+>>>>>>> Introduce a LeapSeconds class that can read TAI-UTC tables.
 from astropy.utils.compat import NUMPY_LT_1_17
 from astropy import utils
 from astropy.utils.exceptions import AstropyWarning
@@ -33,7 +40,9 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
            'TIME_BEFORE_IERS_RANGE', 'TIME_BEYOND_IERS_RANGE',
            'IERS_A_FILE', 'IERS_A_URL', 'IERS_A_URL_MIRROR', 'IERS_A_README',
            'IERS_B_FILE', 'IERS_B_URL', 'IERS_B_README',
-           'IERSRangeError', 'IERSStaleWarning']
+           'IERSRangeError', 'IERSStaleWarning',
+           'LeapSeconds', 'IERS_LEAP_SECOND_FILE', 'IERS_LEAP_SECOND_URL',
+           'IETF_LEAP_SECOND_URL']
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
@@ -45,6 +54,11 @@ IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 IERS_B_FILE = get_pkg_data_filename('data/eopc04_IAU2000.62-now')
 IERS_B_URL = 'http://hpiers.obspm.fr/iers/eop/eopc04/eopc04_IAU2000.62-now'
 IERS_B_README = get_pkg_data_filename('data/ReadMe.eopc04_IAU2000')
+
+# LEAP SECONDS default file name, URL, and alternative format/URL
+IERS_LEAP_SECOND_FILE = get_pkg_data_filename('data/Leap_Second.dat')
+IERS_LEAP_SECOND_URL = 'https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat'
+IETF_LEAP_SECOND_URL = 'https://www.ietf.org/timezones/data/leap-seconds.list'
 
 # Status/source values returned by IERS.ut1_utc
 FROM_IERS_B = 0
@@ -847,3 +861,52 @@ class earth_orientation_table(ScienceState):
         if not isinstance(value, IERS):
             raise ValueError("earth_orientation_table requires an IERS Table.")
         return value
+
+
+class LeapSeconds(QTable):
+    _re_expires = re.compile(r'^#.*File expires on[:\s]+(\d+\s\w+\s\d+)\s*$')
+
+    @classmethod
+    def _read_leap_seconds(cls, file, **kwargs):
+        """Read a leap-second table.
+
+        Finds data by removing comment lines, and identifies the
+        expiration date by matching with 'File expires'.
+        """
+        expires = None
+        # Find lines with data as well as expiration.
+        with get_readable_fileobj(file) as fh:
+            lines = fh.readlines()
+            for line in lines:
+                match = cls._re_expires.match(line)
+                if match:
+                    expires = datetime.strptime(match.groups()[0],
+                                                '%d %B %Y')
+                    break
+
+        if not expires:
+            raise ValueError(f'Did not find expiration date in {file}')
+
+        self = cls.read(lines, format='ascii.basic', data_start=0,
+                        **kwargs)
+        self.expires = expires
+        return self
+
+    @classmethod
+    def from_iers_leap_seconds(cls, file=IERS_LEAP_SECOND_FILE):
+        return cls._read_leap_seconds(
+            file, names=['mjd', 'day', 'month', 'year', 'tai_utc'])
+
+    @classmethod
+    def from_leap_seconds_list(cls, file):
+        names = ['ntp_seconds', 'tai_utc', 'comment', 'day', 'month', 'year']
+        self = cls._read_leap_seconds(file, names=names,
+                                      exclude_names=names[2:])
+        self['mjd'] = (self['ntp_seconds']/86400 + 15020).round()
+        # Note: cannot use Time in this routine.
+        dt = [datetime(1900, 1, 1) + timedelta(mjd-15020)
+              for mjd in self['mjd']]
+        self['day'] = [d.day for d in dt]
+        self['month'] = [d.month for d in dt]
+        self['year'] = [d.year for d in dt]
+        return self

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -865,6 +865,22 @@ class earth_orientation_table(ScienceState):
 
 
 class LeapSeconds(QTable):
+    """Leap seconds class, holding TAI-UTC differences.
+
+    The table should hold columns 'year', 'month', 'tai_utc'.
+
+    Methods are provided to initialize the table from IERS ``Leap_Second.dat``,
+    IETF/ntp ``leap-seconds.list``, or built-in ERFA/SOFA.
+
+    Notes
+    -----
+    Astropy has a built-in ``iers.IERS_LEAP_SECONDS_FILE``. Up to date versions
+    can be downloaded from ``iers.IERS_LEAP_SECONDS_URL`` or
+    ``iers.LEAP_SECONDS_LIST_URL``.  Many systems also store a version
+    of ``leap-seconds.list`` for use with ``ntp`` (e.g., on Debian/Ubuntu
+    systems, ``/usr/share/zoneinfo/leap-seconds.list``).
+    """
+
     _re_expires = re.compile(r'^#.*File expires on[:\s]+(\d+\s\w+\s\d+)\s*$')
     _expires = None
 

--- a/astropy/utils/iers/tests/data/leap-seconds.list
+++ b/astropy/utils/iers/tests/data/leap-seconds.list
@@ -1,0 +1,255 @@
+#
+#	In the following text, the symbol '#' introduces
+#	a comment, which continues from that symbol until
+#	the end of the line. A plain comment line has a
+#	whitespace character following the comment indicator.
+#	There are also special comment lines defined below.
+#	A special comment will always have a non-whitespace
+#	character in column 2.
+#
+#	A blank line should be ignored.
+#
+#	The following table shows the corrections that must
+#	be applied to compute International Atomic Time (TAI)
+#	from the Coordinated Universal Time (UTC) values that
+#	are transmitted by almost all time services.
+#
+#	The first column shows an epoch as a number of seconds
+#	since 1 January 1900, 00:00:00 (1900.0 is also used to
+#	indicate the same epoch.) Both of these time stamp formats
+#	ignore the complexities of the time scales that were
+#	used before the current definition of UTC at the start
+#	of 1972. (See note 3 below.)
+#	The second column shows the number of seconds that
+#	must be added to UTC to compute TAI for any timestamp
+#	at or after that epoch. The value on each line is
+#	valid from the indicated initial instant until the
+#	epoch given on the next one or indefinitely into the
+#	future if there is no next line.
+#	(The comment on each line shows the representation of
+#	the corresponding initial epoch in the usual
+#	day-month-year format. The epoch always begins at
+#	00:00:00 UTC on the indicated day. See Note 5 below.)
+#
+#	Important notes:
+#
+#	1. Coordinated Universal Time (UTC) is often referred to
+#	as Greenwich Mean Time (GMT). The GMT time scale is no
+#	longer used, and the use of GMT to designate UTC is
+#	discouraged.
+#
+#	2. The UTC time scale is realized by many national
+#	laboratories and timing centers. Each laboratory
+#	identifies its realization with its name: Thus
+#	UTC(NIST), UTC(USNO), etc. The differences among
+#	these different realizations are typically on the
+#	order of a few nanoseconds (i.e., 0.000 000 00x s)
+#	and can be ignored for many purposes. These differences
+#	are tabulated in Circular T, which is published monthly
+#	by the International Bureau of Weights and Measures
+#	(BIPM). See www.bipm.org for more information.
+#
+#	3. The current definition of the relationship between UTC
+#	and TAI dates from 1 January 1972. A number of different
+#	time scales were in use before that epoch, and it can be
+#	quite difficult to compute precise timestamps and time
+#	intervals in those "prehistoric" days. For more information,
+#	consult:
+#
+#		The Explanatory Supplement to the Astronomical
+#		Ephemeris.
+#	or
+#		Terry Quinn, "The BIPM and the Accurate Measurement
+#		of Time," Proc. of the IEEE, Vol. 79, pp. 894-905,
+#		July, 1991. <http://dx.doi.org/10.1109/5.84965>
+#		reprinted in:
+#		   Christine Hackman and Donald B Sullivan (eds.)
+#		   Time and Frequency Measurement
+#		   American Association of Physics Teachers (1996)
+#		   <http://tf.nist.gov/general/pdf/1168.pdf>, pp. 75-86
+#
+#	4. The decision to insert a leap second into UTC is currently
+#	the responsibility of the International Earth Rotation and
+#	Reference Systems Service. (The name was changed from the
+#	International Earth Rotation Service, but the acronym IERS
+#	is still used.)
+#
+#	Leap seconds are announced by the IERS in its Bulletin C.
+#
+#	See www.iers.org for more details.
+#
+#	Every national laboratory and timing center uses the
+#	data from the BIPM and the IERS to construct UTC(lab),
+#	their local realization of UTC.
+#
+#	Although the definition also includes the possibility
+#	of dropping seconds ("negative" leap seconds), this has
+#	never been done and is unlikely to be necessary in the
+#	foreseeable future.
+#
+#	5. If your system keeps time as the number of seconds since
+#	some epoch (e.g., NTP timestamps), then the algorithm for
+#	assigning a UTC time stamp to an event that happens during a positive
+#	leap second is not well defined. The official name of that leap
+#	second is 23:59:60, but there is no way of representing that time
+#	in these systems.
+#	Many systems of this type effectively stop the system clock for
+#	one second during the leap second and use a time that is equivalent
+#	to 23:59:59 UTC twice. For these systems, the corresponding TAI
+#	timestamp would be obtained by advancing to the next entry in the
+#	following table when the time equivalent to 23:59:59 UTC
+#	is used for the second time. Thus the leap second which
+#	occurred on 30 June 1972 at 23:59:59 UTC would have TAI
+#	timestamps computed as follows:
+#
+#	...
+#	30 June 1972 23:59:59 (2287785599, first time):	TAI= UTC + 10 seconds
+#	30 June 1972 23:59:60 (2287785599,second time):	TAI= UTC + 11 seconds
+#	1  July 1972 00:00:00 (2287785600)		TAI= UTC + 11 seconds
+#	...
+#
+#	If your system realizes the leap second by repeating 00:00:00 UTC twice
+#	(this is possible but not usual), then the advance to the next entry
+#	in the table must occur the second time that a time equivalent to
+#	00:00:00 UTC is used. Thus, using the same example as above:
+#
+#	...
+#       30 June 1972 23:59:59 (2287785599):		TAI= UTC + 10 seconds
+#       30 June 1972 23:59:60 (2287785600, first time):	TAI= UTC + 10 seconds
+#       1  July 1972 00:00:00 (2287785600,second time):	TAI= UTC + 11 seconds
+#	...
+#
+#	in both cases the use of timestamps based on TAI produces a smooth
+#	time scale with no discontinuity in the time interval. However,
+#	although the long-term behavior of the time scale is correct in both
+#	methods, the second method is technically not correct because it adds
+#	the extra second to the wrong day.
+#
+#	This complexity would not be needed for negative leap seconds (if they
+#	are ever used). The UTC time would skip 23:59:59 and advance from
+#	23:59:58 to 00:00:00 in that case. The TAI offset would decrease by
+#	1 second at the same instant. This is a much easier situation to deal
+#	with, since the difficulty of unambiguously representing the epoch
+#	during the leap second does not arise.
+#
+#	Some systems implement leap seconds by amortizing the leap second
+#	over the last few minutes of the day. The frequency of the local
+#	clock is decreased (or increased) to realize the positive (or
+#	negative) leap second. This method removes the time step described
+#	above. Although the long-term behavior of the time scale is correct
+#	in this case, this method introduces an error during the adjustment
+#	period both in time and in frequency with respect to the official
+#	definition of UTC.
+#
+#	Questions or comments to:
+#		Judah Levine
+#		Time and Frequency Division
+#		NIST
+#		Boulder, Colorado
+#		Judah.Levine@nist.gov
+#
+#	Last Update of leap second values:   8 July 2016
+#
+#	The following line shows this last update date in NTP timestamp
+#	format. This is the date on which the most recent change to
+#	the leap second data was added to the file. This line can
+#	be identified by the unique pair of characters in the first two
+#	columns as shown below.
+#
+#$	 3676924800
+#
+#	The NTP timestamps are in units of seconds since the NTP epoch,
+#	which is 1 January 1900, 00:00:00. The Modified Julian Day number
+#	corresponding to the NTP time stamp, X, can be computed as
+#
+#	X/86400 + 15020
+#
+#	where the first term converts seconds to days and the second
+#	term adds the MJD corresponding to the time origin defined above.
+#	The integer portion of the result is the integer MJD for that
+#	day, and any remainder is the time of day, expressed as the
+#	fraction of the day since 0 hours UTC. The conversion from day
+#	fraction to seconds or to hours, minutes, and seconds may involve
+#	rounding or truncation, depending on the method used in the
+#	computation.
+#
+#	The data in this file will be updated periodically as new leap
+#	seconds are announced. In addition to being entered on the line
+#	above, the update time (in NTP format) will be added to the basic
+#	file name leap-seconds to form the name leap-seconds.<NTP TIME>.
+#	In addition, the generic name leap-seconds.list will always point to
+#	the most recent version of the file.
+#
+#	This update procedure will be performed only when a new leap second
+#	is announced.
+#
+#	The following entry specifies the expiration date of the data
+#	in this file in units of seconds since the origin at the instant
+#	1 January 1900, 00:00:00. This expiration date will be changed
+#	at least twice per year whether or not a new leap second is
+#	announced. These semi-annual changes will be made no later
+#	than 1 June and 1 December of each year to indicate what
+#	action (if any) is to be taken on 30 June and 31 December,
+#	respectively. (These are the customary effective dates for new
+#	leap seconds.) This expiration date will be identified by a
+#	unique pair of characters in columns 1 and 2 as shown below.
+#	In the unlikely event that a leap second is announced with an
+#	effective date other than 30 June or 31 December, then this
+#	file will be edited to include that leap second as soon as it is
+#	announced or at least one month before the effective date
+#	(whichever is later).
+#	If an announcement by the IERS specifies that no leap second is
+#	scheduled, then only the expiration date of the file will
+#	be advanced to show that the information in the file is still
+#	current -- the update time stamp, the data and the name of the file
+#	will not change.
+#
+#	Updated through IERS Bulletin C58
+#	File expires on:  28 June 2020
+#
+#@	3802291200
+#
+2272060800	10	# 1 Jan 1972
+2287785600	11	# 1 Jul 1972
+2303683200	12	# 1 Jan 1973
+2335219200	13	# 1 Jan 1974
+2366755200	14	# 1 Jan 1975
+2398291200	15	# 1 Jan 1976
+2429913600	16	# 1 Jan 1977
+2461449600	17	# 1 Jan 1978
+2492985600	18	# 1 Jan 1979
+2524521600	19	# 1 Jan 1980
+2571782400	20	# 1 Jul 1981
+2603318400	21	# 1 Jul 1982
+2634854400	22	# 1 Jul 1983
+2698012800	23	# 1 Jul 1985
+2776982400	24	# 1 Jan 1988
+2840140800	25	# 1 Jan 1990
+2871676800	26	# 1 Jan 1991
+2918937600	27	# 1 Jul 1992
+2950473600	28	# 1 Jul 1993
+2982009600	29	# 1 Jul 1994
+3029443200	30	# 1 Jan 1996
+3076704000	31	# 1 Jul 1997
+3124137600	32	# 1 Jan 1999
+3345062400	33	# 1 Jan 2006
+3439756800	34	# 1 Jan 2009
+3550089600	35	# 1 Jul 2012
+3644697600	36	# 1 Jul 2015
+3692217600	37	# 1 Jan 2017
+#
+#	the following special comment contains the
+#	hash value of the data in this file computed
+#	use the secure hash algorithm as specified
+#	by FIPS 180-1. See the files in ~/pub/sha for
+#	the details of how this hash value is
+#	computed. Note that the hash computation
+#	ignores comments and whitespace characters
+#	in data lines. It includes the NTP values
+#	of both the last modification time and the
+#	expiration time of the file, but not the
+#	white space on those lines.
+#	the hash line is also ignored in the
+#	computation.
+#
+#h 	f28827d2 f263b6c3 ec0f19eb a3e0dbf0 97f3fa30

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -1,0 +1,49 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import urllib.request
+
+import pytest
+import numpy as np
+
+from astropy.time import Time
+from astropy.utils.iers import iers
+from astropy.utils.data import get_pkg_data_filename
+
+
+# Test leap_seconds.list in test/data.
+LEAP_SECOND_LIST = get_pkg_data_filename('data/leap-seconds.list')
+
+
+class TestReading:
+    """Basic tests that leap seconds can be read."""
+
+    def verify_day_month_year(self, ls):
+        assert np.all(ls['day'] == 1)
+        assert np.all((ls['month'] == 1) | (ls['month'] == 7) |
+                      (ls['year'] < 1970))
+        assert np.all(ls['year'] >= 1960)
+        t = Time({'year': ls['year'], 'month': ls['month'], 'day': ls['day']},
+                 format='ymdhms')
+        assert np.all(t == Time(ls['mjd'], format='mjd'))
+
+    def test_read_leap_second_dat(self):
+        ls = iers.LeapSeconds.from_iers_leap_seconds(
+            iers.IERS_LEAP_SECOND_FILE)
+        # Below, >= to take into account we might ship and updated file.
+        assert ls.expires >= Time('2020-06-28')
+        assert ls['mjd'][0] == 41317
+        assert ls['tai_utc'][0] == 10
+        assert ls['mjd'][-1] >= 57754
+        assert ls['tai_utc'][-1] >= 37
+        self.verify_day_month_year(ls)
+
+    @pytest.mark.parametrize('file', (
+        LEAP_SECOND_LIST,
+        "file:" + urllib.request.pathname2url(LEAP_SECOND_LIST)))
+    def test_read_leap_seconds_list(self, file):
+        ls = iers.LeapSeconds.from_leap_seconds_list(file)
+        assert ls.expires == Time('2020-06-28')
+        assert ls['mjd'][0] == 41317
+        assert ls['tai_utc'][0] == 10
+        assert ls['mjd'][-1] == 57754
+        assert ls['tai_utc'][-1] == 37
+        self.verify_day_month_year(ls)

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -3,10 +3,13 @@ import urllib.request
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
+from astropy import _erfa as erfa
 from astropy.time import Time
 from astropy.utils.iers import iers
 from astropy.utils.data import get_pkg_data_filename
+
 
 
 # Test leap_seconds.list in test/data.
@@ -47,3 +50,115 @@ class TestReading:
         assert ls['mjd'][-1] == 57754
         assert ls['tai_utc'][-1] == 37
         self.verify_day_month_year(ls)
+
+
+class ERFALeapSecondsSafe:
+    def setup(self):
+        # Keep current leap-second table and expiration.
+        self.erfa_ls = self._erfa_ls = erfa.leap_seconds.get()
+        self._expires = erfa.leap_seconds._expires
+
+    def teardown(self):
+        # Restore leap-second table and expiration.
+        erfa.leap_seconds.set(self.erfa_ls)
+        erfa.leap_seconds._expires = self._expires
+
+
+class TestFromERFA(ERFALeapSecondsSafe):
+    def test_get_erfa_ls(self):
+        ls = iers.LeapSeconds.from_erfa()
+        assert ls.colnames == ['year', 'month', 'tai_utc']
+        assert ls.expires == erfa.leap_seconds.expires
+        ls_array = np.array(ls['year', 'month', 'tai_utc'])
+        assert np.all(ls_array == self.erfa_ls)
+
+    def test_get_modified_erfa_ls(self):
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        ls = iers.LeapSeconds.from_erfa()
+        ls_array = np.array(ls['year', 'month', 'tai_utc'])
+        assert np.all(ls_array == self.erfa_ls[:-2])
+
+
+class TestUpdateLeapSeconds(ERFALeapSecondsSafe):
+    def setup(self):
+        super().setup()
+        # Read default leap second table.
+        self.ls = iers.LeapSeconds.from_iers_leap_seconds()
+        # For tests, reset ERFA table to built-in default.
+        erfa.leap_seconds.set()
+        self.erfa_ls = erfa.leap_seconds.get()
+
+    def test_built_in_up_to_date(self):
+        """Leap second should match between built-in and ERFA."""
+        erfa_since_1970 = self.erfa_ls[self.erfa_ls['year'] > 1970]
+        assert len(self.ls) >= len(erfa_since_1970), \
+            "built-in leap seconds out of date"
+        assert len(self.ls) <= len(erfa_since_1970), \
+            "ERFA leap seconds out of date"
+        overlap = np.array(self.ls['year', 'month', 'tai_utc'])
+        assert np.all(overlap == erfa_since_1970.astype(overlap.dtype))
+
+    def test_update_with_built_in(self):
+        """An update with built-in should not do anything."""
+        n_update = self.ls.update_erfa_leap_seconds()
+        assert n_update == 0
+        new_erfa_ls = erfa.leap_seconds.get()
+        assert np.all(new_erfa_ls == self.erfa_ls)
+
+    @pytest.mark.parametrize('n_short', (1, 3))
+    def test_update(self, n_short):
+        """Check whether we can recover removed leap seconds."""
+        erfa.leap_seconds.set(self.erfa_ls[:-n_short])
+        n_update = self.ls.update_erfa_leap_seconds()
+        assert n_update == n_short
+        new_erfa_ls = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls, self.erfa_ls)
+        # Check that a second update does not do anything.
+        n_update2 = self.ls.update_erfa_leap_seconds()
+        assert n_update2 == 0
+        new_erfa_ls2 = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls2, self.erfa_ls)
+
+    def test_update_initialize_erfa(self):
+        # With pre-initialization, update does nothing.
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        n_update = self.ls.update_erfa_leap_seconds(initialize_erfa=True)
+        assert n_update == 0
+        new_erfa_ls = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls, self.erfa_ls)
+
+    def test_bad_jump(self):
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        bad = self.ls.copy()
+        bad['tai_utc'][-1] = 5
+        with pytest.raises(ValueError, match='jump'):
+            bad.update_erfa_leap_seconds()
+        # With an error the ERFA table should not change.
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls[:-2])
+
+        # Unless we initialized it beforehand.
+        with pytest.raises(ValueError, match='jump'):
+            bad.update_erfa_leap_seconds(initialize_erfa=True)
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls)
+
+        # Of course, we get no errors if we initialize only.
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        n_update = bad.update_erfa_leap_seconds(initialize_erfa='only')
+        assert n_update == 0
+        new_erfa_ls = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls, self.erfa_ls)
+
+    def test_bad_day(self):
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        bad = self.ls.copy()
+        bad['day'][-1] = 5
+        with pytest.raises(ValueError, match='not on 1st'):
+            bad.update_erfa_leap_seconds()
+
+    def test_bad_month(self):
+        erfa.leap_seconds.set(self.erfa_ls[:-2])
+        bad = self.ls.copy()
+        bad['month'][-1] = 5
+        with pytest.raises(ValueError, match='January'):
+            bad.update_erfa_leap_seconds()
+        assert_array_equal(erfa.leap_seconds.get(), self.erfa_ls[:-2])

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import urllib.request
+import os
+from datetime import datetime, timedelta
 
 import pytest
 import numpy as np
@@ -9,11 +11,21 @@ from astropy import _erfa as erfa
 from astropy.time import Time
 from astropy.utils.iers import iers
 from astropy.utils.data import get_pkg_data_filename
+from astropy.tests.helper import catch_warnings
 
+
+SYSTEM_FILE = '/usr/share/zoneinfo/leap-seconds.list'
 
 
 # Test leap_seconds.list in test/data.
 LEAP_SECOND_LIST = get_pkg_data_filename('data/leap-seconds.list')
+
+
+def test_configuration():
+    # This test just ensures things stay consistent.
+    # Adjust if changes are made.
+    assert iers.conf.iers_leap_second_auto_url == iers.IERS_LEAP_SECOND_URL
+    assert iers.conf.ietf_leap_second_auto_url == iers.IETF_LEAP_SECOND_URL
 
 
 class TestReading:
@@ -39,6 +51,12 @@ class TestReading:
         assert ls['tai_utc'][-1] >= 37
         self.verify_day_month_year(ls)
 
+    def test_open_leap_second_dat(self):
+        ls = iers.LeapSeconds.from_iers_leap_seconds(
+            iers.IERS_LEAP_SECOND_FILE)
+        ls2 = iers.LeapSeconds.open(iers.IERS_LEAP_SECOND_FILE)
+        assert np.all(ls == ls2)
+
     @pytest.mark.parametrize('file', (
         LEAP_SECOND_LIST,
         "file:" + urllib.request.pathname2url(LEAP_SECOND_LIST)))
@@ -51,8 +69,201 @@ class TestReading:
         assert ls['tai_utc'][-1] == 37
         self.verify_day_month_year(ls)
 
+    @pytest.mark.parametrize('file', (
+        LEAP_SECOND_LIST,
+        "file:" + urllib.request.pathname2url(LEAP_SECOND_LIST)))
+    def test_open_leap_seconds_list(self, file):
+        ls = iers.LeapSeconds.from_leap_seconds_list(file)
+        ls2 = iers.LeapSeconds.open(file)
+        assert np.all(ls == ls2)
+
+    @pytest.mark.skipif(not os.path.isfile(SYSTEM_FILE),
+                        reason=f'system does not have {SYSTEM_FILE}')
+    def test_open_system_file(self):
+        ls = iers.LeapSeconds.open(SYSTEM_FILE)
+        assert ls.expires > datetime.now()
+
+
+def make_fake_file(expiration, tmpdir):
+    """copy the built-in IERS file but set a different expiration date."""
+    ls = iers.LeapSeconds.from_iers_leap_seconds()
+    fake_file = str(tmpdir.join('fake_leap_seconds.dat'))
+    with open(fake_file, 'w') as fh:
+        fh.write('\n'.join([f'#  File expires on {expiration}']
+                           + str(ls).split('\n')[2:-1]))
+        return fake_file
+
+
+def test_fake_file(tmpdir):
+    fake_file = make_fake_file('28 June 2345', tmpdir)
+    fake = iers.LeapSeconds.from_iers_leap_seconds(fake_file)
+    assert fake.expires == datetime(2345, 6, 28)
+
+
+class TestAutoOpenExplicitLists:
+    def test_auto_open_simple(self):
+        # Note: files allowed to be expired.
+        with catch_warnings(iers.IERSStaleWarning):
+            ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
+        assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+
+    def test_auto_open_erfa(self):
+        with catch_warnings(iers.IERSStaleWarning):
+            ls = iers.LeapSeconds.auto_open(['erfa',
+                                             iers.IERS_LEAP_SECOND_FILE])
+        assert ls.meta['data_url'] in ['erfa', iers.IERS_LEAP_SECOND_FILE]
+
+    def test_fake_future_file(self, tmpdir):
+        fake_file = make_fake_file('28 June 2345', tmpdir)
+        # Try as system file for auto_open, setting auto_max_age such
+        # that any ERFA or system files are guaranteed to be expired,
+        # while the fake file is guaranteed to be OK.
+        with iers.conf.set_temp('auto_max_age', -100000):
+            ls = iers.LeapSeconds.auto_open([
+                'erfa', iers.IERS_LEAP_SECOND_FILE, fake_file])
+            assert ls.expires == datetime(2345, 6, 28)
+            assert ls.meta['data_url'] == str(fake_file)
+            # And as URL
+            fake_url = "file:" + urllib.request.pathname2url(fake_file)
+            ls2 = iers.LeapSeconds.auto_open([
+                'erfa', iers.IERS_LEAP_SECOND_FILE, fake_url])
+            assert ls2.expires == datetime(2345, 6, 28)
+            assert ls2.meta['data_url'] == str(fake_url)
+
+    def test_fake_expired_file(self, tmpdir):
+        fake_file1 = make_fake_file('28 June 2010', tmpdir)
+        fake_file2 = make_fake_file('27 June 2012', tmpdir)
+        # Ignore warnings about possibly expired built-in file.
+        with catch_warnings(iers.IERSStaleWarning):
+            # Between these and the built-in one, the built-in file is best.
+            ls = iers.LeapSeconds.auto_open([fake_file1, fake_file2,
+                                             iers.IERS_LEAP_SECOND_FILE])
+        assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+
+        # But if we remove the built-in one, the least expired one will be
+        # used.
+        # used and we get a warning that it is stale.
+        with catch_warnings(iers.IERSStaleWarning) as w:
+            ls2 = iers.LeapSeconds.auto_open([fake_file1, fake_file2])
+        assert ls2.meta['data_url'] == fake_file2
+        assert ls2.expires == datetime(2012, 6, 27)
+        assert len(w) == 1
+
+
+@pytest.mark.remote_data
+class TestRemoteURLs:
+    # In these tests, the results may be cached.
+    # This is fine - no need to download again.
+    def test_iers_url(self):
+        ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_URL])
+        assert ls.expires > datetime.now()
+
+    def test_ietf_url(self):
+        ls = iers.LeapSeconds.auto_open([iers.IETF_LEAP_SECOND_URL])
+        assert ls.expires > datetime.now()
+
+
+class TestDefaultAutoOpen:
+    """Test auto_open with different _auto_open_files."""
+    def setup(self):
+        self.good_enough = (datetime.now() +
+                            timedelta(179 - iers.conf.auto_max_age))
+        self._auto_open_files = iers.LeapSeconds._auto_open_files.copy()
+
+    def teardown(self):
+        iers.LeapSeconds._auto_open_files = self._auto_open_files
+
+    def remove_auto_open_files(self, *files):
+        """Remove some files from the auto-opener.
+
+        The default set is restored in teardown.
+        """
+        for f in files:
+            iers.LeapSeconds._auto_open_files.remove(f)
+
+    def test_erfa_found(self):
+        # Set huge maximum age such that whatever ERFA has is OK.
+        # Since it is checked first, it should thus be found.
+        with iers.conf.set_temp('auto_max_age', 100000):
+            ls = iers.LeapSeconds.open()
+        assert ls.meta['data_url'] == 'erfa'
+
+    def test_builtin_found(self):
+        # Set huge maximum age such that built-in file is always OK.
+        # If we remove 'erfa', it should thus be found.
+        self.remove_auto_open_files('erfa')
+        with iers.conf.set_temp('auto_max_age', 100000):
+            ls = iers.LeapSeconds.open()
+        assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+
+    def test_fake_future_file(self, tmpdir):
+        fake_file = make_fake_file('28 June 2345', tmpdir)
+        # Try as system file for auto_open, setting auto_max_age such
+        # that any ERFA or system files are guaranteed to be expired.
+        with iers.conf.set_temp('auto_max_age', -100000), \
+                iers.conf.set_temp('system_leap_second_file', fake_file):
+            ls = iers.LeapSeconds.open()
+        assert ls.expires == datetime(2345, 6, 28)
+        assert ls.meta['data_url'] == str(fake_file)
+        # And as URL
+        fake_url = "file:" + urllib.request.pathname2url(fake_file)
+        with iers.conf.set_temp('auto_max_age', -100000), \
+                iers.conf.set_temp('iers_leap_second_auto_url', fake_url):
+            ls2 = iers.LeapSeconds.open()
+        assert ls2.expires == datetime(2345, 6, 28)
+        assert ls2.meta['data_url'] == str(fake_url)
+
+    def test_fake_expired_file(self, tmpdir):
+        self.remove_auto_open_files('erfa', 'iers_leap_second_auto_url',
+                                    'ietf_leap_second_auto_url')
+        fake_file = make_fake_file('28 June 2010', tmpdir)
+        with iers.conf.set_temp('system_leap_second_file', fake_file):
+            # If we try this directly, the built-in file will be found.
+            ls = iers.LeapSeconds.open()
+            assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+
+            # But if we remove the built-in one, the expired one will be
+            # used and we get a warning that it is stale.
+            self.remove_auto_open_files(iers.IERS_LEAP_SECOND_FILE)
+            with catch_warnings(iers.IERSStaleWarning) as w:
+                ls2 = iers.LeapSeconds.open()
+            assert ls2.meta['data_url'] == fake_file
+            assert ls2.expires == datetime(2010, 6, 28)
+            assert len(w) == 1
+
+    @pytest.mark.skipif(not os.path.isfile(SYSTEM_FILE),
+                        reason=f'system does not have {SYSTEM_FILE}')
+    def test_system_file_always_good_enough(self, tmpdir):
+        self.remove_auto_open_files('erfa')
+        with iers.conf.set_temp('system_leap_second_file', SYSTEM_FILE):
+            ls = iers.LeapSeconds.open()
+            assert ls.expires > self.good_enough
+            assert ls.meta['data_url'] in (iers.IERS_LEAP_SECOND_FILE,
+                                           SYSTEM_FILE)
+
+            # Also check with a "built-in" file that is expired
+            fake_file = make_fake_file('28 June 2017', tmpdir)
+            iers.LeapSeconds._auto_open_files[0] = fake_file
+            ls2 = iers.LeapSeconds.open()
+            assert ls2.expires > self.good_enough
+            assert ls2.meta['data_url'] == SYSTEM_FILE
+
+    @pytest.mark.remote_data
+    def test_auto_open_urls_always_good_enough(self):
+        # Avoid using the erfa, built-in and system files, as they might
+        # be good enough already.
+        self.remove_auto_open_files('erfa', iers.IERS_LEAP_SECOND_FILE,
+                                    'system_leap_second_file')
+        ls = iers.LeapSeconds.open()
+        assert ls.expires > self.good_enough
+        assert ls.meta['data_url'].startswith('http')
+
 
 class ERFALeapSecondsSafe:
+    """Base class for tests that change the ERFA leap-second tables.
+
+    It ensures the original state is restored.
+    """
     def setup(self):
         # Keep current leap-second table and expiration.
         self.erfa_ls = self._erfa_ls = erfa.leap_seconds.get()
@@ -77,6 +288,11 @@ class TestFromERFA(ERFALeapSecondsSafe):
         ls = iers.LeapSeconds.from_erfa()
         ls_array = np.array(ls['year', 'month', 'tai_utc'])
         assert np.all(ls_array == self.erfa_ls[:-2])
+
+    def test_open(self):
+        ls = iers.LeapSeconds.open('erfa')
+        ls_array = np.array(ls['year', 'month', 'tai_utc'])
+        assert np.all(ls_array == self.erfa_ls)
 
 
 class TestUpdateLeapSeconds(ERFALeapSecondsSafe):

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -351,6 +351,20 @@ class TestUpdateLeapSeconds(ERFALeapSecondsSafe):
         new_erfa_ls = erfa.leap_seconds.get()
         assert_array_equal(new_erfa_ls, self.erfa_ls)
 
+    def test_update_overwrite(self):
+        n_update = self.ls.update_erfa_leap_seconds(initialize_erfa='empty')
+        assert n_update == len(self.ls)
+        new_erfa_ls = erfa.leap_seconds.get()
+        assert new_erfa_ls['year'].min() > 1970
+        n_update2 = self.ls.update_erfa_leap_seconds()
+        assert n_update2 == 0
+        new_erfa_ls2 = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls2, new_erfa_ls)
+        n_update3 = self.ls.update_erfa_leap_seconds(initialize_erfa=True)
+        assert n_update3 == 0
+        new_erfa_ls3 = erfa.leap_seconds.get()
+        assert_array_equal(new_erfa_ls3, self.erfa_ls)
+
     def test_bad_jump(self):
         erfa.leap_seconds.set(self.erfa_ls[:-2])
         bad = self.ls.copy()

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -18,7 +18,7 @@ transformations.
 .. note:: The package also provides machinery to track leap seconds.  Since it
           generally should not be necessary to deal with those by hand, this
           is not discussed below.  For details, see the documentation of
-          `~astropy.utils.iers.LeapSecond`.
+          `~astropy.utils.iers.LeapSeconds`.
 
 Getting started
 ===============

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -9,11 +9,16 @@ Introduction
 
 The `~astropy.utils.iers` package provides access to the tables provided by
 the International Earth Rotation and Reference Systems (IERS) service, in
-particular allowing interpolation of published UT1-UTC values for given
-times.  These are used in `astropy.time` to provide UT1 values.  The polar
-motions are also used for determining Earth orientation for
-celestial-to-terrestrial coordinate transformations
-(in `astropy.coordinates`).
+particular files allowing interpolation of published UT1-UTC and polar motion
+values for given times.  The UT1-UTC values are used in `astropy.time` to
+provide UT1 values, and the polar motions are used in `astropy.coordinates` to
+determine Earth orientation for celestial-to-terrestrial coordinate
+transformations.
+
+.. note:: The package also provides machinery to track leap seconds.  Since it
+          generally should not be necessary to deal with those by hand, this
+          is not discussed below.  For details, see the documentation of
+          `~astropy.utils.iers.LeapSecond`.
 
 Getting started
 ===============


### PR DESCRIPTION
A separate follow-up on #9329, which uses a new `astropy.utils.iers.LeapSecond` class to update the ERFA leap seconds. Here, updates are either gotten from IERS or from IETF.

cc also @aarchiba, whose comments made clear that my previous attempt, which used the IERS tables, was just not going to work (see #9334).