### PR TITLE
Adding python3.8 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ env:
         - EXTRAS_INSTALL=""
         # Run test suite twice in a row without cleaning
         - DOUBLE_PLAY=False
+        - USE_CI_HELPERS=True
 
         # PEP8 errors/warnings:
         # E101 - mix of tabs and spaces
@@ -182,6 +183,14 @@ matrix:
                INSTALL_WITH_PIP=True
                EXTRAS_INSTALL="docs"
 
+        # Testing with Travis provided Python3.8. Change this job to a regular
+        # one once conda supports python3.8.
+        - language: python
+          stage: Final tests
+          dist: xenial
+          python: 3.8-dev
+          env: INSTALL_WITH_PIP=True EXTRAS_INSTALL="test" USE_CI_HELPERS=False
+
     allow_failures:
       - os: linux
         stage: Final tests
@@ -208,8 +217,10 @@ before_install:
 
 
 install:
-    - git clone git://github.com/astropy/ci-helpers.git
-    - source ci-helpers/travis/setup_conda.sh
+    - if [[ $USE_CI_HELPERS == True ]]; then
+        git clone git://github.com/astropy/ci-helpers.git;
+        source ci-helpers/travis/setup_conda.sh;
+      fi
     - if [[ $INSTALL_WITH_PIP == True ]]; then
         if [ -z $EXTRAS_INSTALL ]; then
           pip install -e .;

--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -23,7 +23,12 @@ enable_deprecations_as_exceptions(
     # This is a workaround for the OpenSSL deprecation warning that comes from
     # the `requests` module. It only appears when both asdf and sphinx are
     # installed. This can be removed once pyopenssl 1.7.20+ is released.
-    modules_to_ignore_on_import=['requests'])
+    modules_to_ignore_on_import=['requests'],
+    warnings_to_ignore_by_pyver={
+        # This warning shows up in mpl <3.1.2 on python 3.8,
+        # remove once 3.1.2 is released
+        (3, 8): set([(r"In future, it will be an error for 'np.bool_' scalars "
+                       "to be interpreted as an index", DeprecationWarning),])})
 
 if HAS_MATPLOTLIB:
     matplotlib.use('Agg')


### PR DESCRIPTION
The new python 3.8.0 is not yet available via conda, thus this cannot be added yet with the usual ci-helpers way.

However, no dependencies are available as wheels for python38 just yet, so in the meantime  this job would build them.
(or alternatively we could use, e.g. numpy dev nightly wheel)