### PR TITLE
Allow longdouble values through input validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -369,6 +369,9 @@ astropy.time
 - Time formats that do not use ``val2`` now raise ValueError instead of
   silently ignoring a provided value. [#9373]
 
+- Custom time formats can now accept floating-point types with extended
+  precision. Existing time formats raise exceptions rather than discarding
+  extended precision through conversion to ordinary floating-point. [#9368]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2285,7 +2285,13 @@ def _make_array(val, copy=False):
     # Allow only float64, string or object arrays as input
     # (object is for datetime, maybe add more specific test later?)
     # This also ensures the right byteorder for float64 (closes #2942).
-    if not (val.dtype == np.float64 or val.dtype.kind in 'OSUMaV'):
+    if val.dtype == np.float64:
+        pass
+    elif val.dtype.kind in 'OSUMaV':
+        pass
+    elif val.dtype.kind == "f" and val.dtype.itemsize >= np.dtype(np.float64).itemsize:
+        pass
+    else:
         val = np.asanyarray(val, dtype=np.float64)
 
     return val

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2285,11 +2285,9 @@ def _make_array(val, copy=False):
     # Allow only float64, string or object arrays as input
     # (object is for datetime, maybe add more specific test later?)
     # This also ensures the right byteorder for float64 (closes #2942).
-    if val.dtype == np.float64:
+    if val.dtype.kind == "f" and val.dtype.itemsize >= np.dtype(np.float64).itemsize:
         pass
     elif val.dtype.kind in 'OSUMaV':
-        pass
-    elif val.dtype.kind == "f" and val.dtype.itemsize >= np.dtype(np.float64).itemsize:
         pass
     else:
         val = np.asanyarray(val, dtype=np.float64)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -184,9 +184,9 @@ class TimeFormat(metaclass=TimeFormatMeta):
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
         # val1 cannot contain nan, but val2 can contain nan
-        ok1 = (val1.dtype == np.double and np.all(np.isfinite(val1)) or
+        ok1 = (val1.dtype.kind == 'f' and val1.dtype.itemsize == 8 and np.all(np.isfinite(val1)) or
                val1.size == 0)
-        ok2 = val2 is None or (val2.dtype == np.double and
+        ok2 = val2 is None or (val2.dtype.kind == 'f' and val2.dtype.itemsize == 8 and
                                not np.any(np.isinf(val2))) or val2.size == 0
         if not (ok1 and ok2):
             raise TypeError('Input values for {} class must be finite doubles'
@@ -619,9 +619,6 @@ class TimeDatetime(TimeUnique):
         if not all(isinstance(val, datetime.datetime) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime objects'.format(self.name))
-        if val2 is not None:
-            raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):
@@ -901,9 +898,6 @@ class TimeString(TimeUnique):
         if val1.dtype.kind not in ('S', 'U') and val1.size:
             raise TypeError('Input values for {} class must be strings'
                             .format(self.name))
-        if val2 is not None:
-            raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def parse_string(self, timestr, subfmts):
@@ -1135,9 +1129,6 @@ class TimeDatetime64(TimeISOT):
                                 'datetime64 objects'.format(self.name))
             else:
                 val1 = np.array([], 'datetime64[D]')
-        if val2 is not None:
-            raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
 
         return val1, None
 
@@ -1408,9 +1399,6 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime.timedelta objects'.format(self.name))
-        if val2 is not None:
-            raise ValueError(
-                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -619,6 +619,9 @@ class TimeDatetime(TimeUnique):
         if not all(isinstance(val, datetime.datetime) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime objects'.format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):
@@ -898,6 +901,9 @@ class TimeString(TimeUnique):
         if val1.dtype.kind not in ('S', 'U') and val1.size:
             raise TypeError('Input values for {} class must be strings'
                             .format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def parse_string(self, timestr, subfmts):
@@ -1129,6 +1135,9 @@ class TimeDatetime64(TimeISOT):
                                 'datetime64 objects'.format(self.name))
             else:
                 val1 = np.array([], 'datetime64[D]')
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
 
         return val1, None
 
@@ -1399,6 +1408,9 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime.timedelta objects'.format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -1,7 +1,13 @@
-import pytest
 from itertools import count
 
+import pytest
+
+import numpy as np
+
+import astropy.units as u
+from astropy._erfa import DJM0
 from astropy.time import Time, TimeFormat
+from astropy.time.utils import day_frac
 
 
 class SpecificException(ValueError):
@@ -76,6 +82,8 @@ def test_custom_time_format_fine(custom_format_name):
 
     t = Time.now()
     getattr(t, custom_format_name)
+    t2 = Time(7, 9, format=custom_format_name)
+    getattr(t2, custom_format_name)
 
 
 def test_custom_time_format_forgot_property(custom_format_name):
@@ -127,3 +135,56 @@ def test_custom_time_format_problematic_name():
 
     finally:
         Time.FORMATS.pop("sort", None)
+
+
+def test_mjd_longdouble_preserves_precision(custom_format_name):
+    class CustomMJD(TimeFormat):
+        name = custom_format_name
+
+        def _check_val_type(self, val, val2):
+            val = np.longdouble(val)
+            if val2 is not None:
+                raise ValueError("Only one value permitted")
+            return val, 0
+
+        def set_jds(self, val, val2):
+            mjd1 = np.float64(np.floor(val))
+            mjd2 = np.float64(val - mjd1)
+            self.jd1, self.jd2 = day_frac(mjd1 + DJM0, mjd2)
+
+        @property
+        def value(self):
+            mjd1, mjd2 = day_frac(self.jd1 - DJM0, self.jd2)
+            return np.longdouble(mjd1) + np.longdouble(mjd2)
+
+    m = 58000.0
+    t = Time(m, format=custom_format_name)
+    t2 = Time(m + 2 * m * np.finfo(np.longdouble).eps, format=custom_format_name)
+    assert t != t2
+    assert isinstance(getattr(t, custom_format_name), np.longdouble)
+    assert getattr(t, custom_format_name) != getattr(t2, custom_format_name)
+
+
+def test_mjd_unit_validation():
+    with pytest.raises(u.UnitConversionError):
+        Time(58000 * u.m, format="mjd")
+
+
+def test_mjd_unit_conversion():
+    assert Time(58000 * u.day, format="mjd") == Time(58000 * u.day, format="mjd")
+    assert Time(58000 * u.day, format="mjd") != Time(58000 * u.s, format="mjd")
+    assert Time(58000 * u.day, format="mjd") == Time(58000 * 86400 * u.s, format="mjd")
+
+
+@pytest.mark.parametrize("f", ["mjd", "unix", "cxcsec"])
+def test_existing_types_refuse_longdoubles(f):
+    t = np.longdouble(getattr(Time(58000, format="mjd"), f))
+    t2 = t + np.finfo(np.longdouble).eps * 2 * t
+    try:
+        tm = Time(np.longdouble(t), format=f)
+    except ValueError:
+        # Time processing makes it always ValueError not TypeError
+        return
+    else:
+        # accepts long doubles, better preserve accuracy!
+        assert Time(np.longdouble(t2), format=f) != tm


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to make it possible for third-party code to take higher-precision floating-point values as input, in order to more easily work with the extended precision available from astropy Time objects. This would be relevant to #9361 for example. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9341 
