### PR TITLE
Raise instead of silently ignore when val2 is provided but will be ignored

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -361,7 +361,7 @@ astropy.time
   instead of the bundled ``IERS_B`` file. [#9226]
 
 - Time formats that do not use ``val2`` now raise ValueError instead of
-  silently ignoring a provided value.
+  silently ignoring a provided value. [#9373]
 
 
 astropy.timeseries

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -360,6 +360,10 @@ astropy.time
 - ``Time.get_ut1_utc`` now uses the auto-updated ``IERS_Auto`` by default,
   instead of the bundled ``IERS_B`` file. [#9226]
 
+- Time formats that do not use ``val2`` now raise ValueError instead of
+  silently ignoring a provided value.
+
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -616,10 +616,12 @@ class TimeDatetime(TimeUnique):
     name = 'datetime'
 
     def _check_val_type(self, val1, val2):
-        # Note: don't care about val2 for this class
         if not all(isinstance(val, datetime.datetime) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime objects'.format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):
@@ -896,10 +898,12 @@ class TimeString(TimeUnique):
     """
 
     def _check_val_type(self, val1, val2):
-        # Note: don't care about val2 for these classes
         if val1.dtype.kind not in ('S', 'U') and val1.size:
             raise TypeError('Input values for {} class must be strings'
                             .format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def parse_string(self, timestr, subfmts):
@@ -1125,13 +1129,15 @@ class TimeDatetime64(TimeISOT):
     name = 'datetime64'
 
     def _check_val_type(self, val1, val2):
-        # Note: don't care about val2 for this class`
         if not val1.dtype.kind == 'M':
             if val1.size > 0:
                 raise TypeError('Input values for {} class must be '
                                 'datetime64 objects'.format(self.name))
             else:
                 val1 = np.array([], 'datetime64[D]')
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
 
         return val1, None
 
@@ -1285,7 +1291,7 @@ class TimeBesselianEpoch(TimeEpochDate):
             raise ValueError("Cannot use Quantities for 'byear' format, "
                              "as the interpretation would be ambiguous. "
                              "Use float with Besselian year instead. ")
-
+        # FIXME: is val2 really okay here?
         return super()._check_val_type(val1, val2)
 
 
@@ -1399,10 +1405,12 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
     name = 'datetime'
 
     def _check_val_type(self, val1, val2):
-        # Note: don't care about val2 for this class
         if not all(isinstance(val, datetime.timedelta) for val in val1.flat):
             raise TypeError('Input values for {} class must be '
                             'datetime.timedelta objects'.format(self.name))
+        if val2 is not None:
+            raise ValueError(
+                f'{self.name} objects do not accept a val2 but you provided {val2}')
         return val1, None
 
     def set_jds(self, val1, val2):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -600,10 +600,10 @@ class TestBasic:
 class TestVal2:
     """Tests related to val2"""
 
-    def test_val2_ignored(self):
-        """Test that val2 is ignored for string input"""
-        t = Time('2001:001', 'ignored', scale='utc')
-        assert t.yday == '2001:001:00:00:00.000'
+    def test_unused_val2_raises(self):
+        """Test that providing val2 is for string input lets user know we won't use it"""
+        with pytest.raises(ValueError):
+            Time('2001:001', 'ignored', scale='utc')
 
     def test_val2(self):
         """Various tests of the val2 input"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -600,10 +600,19 @@ class TestBasic:
 class TestVal2:
     """Tests related to val2"""
 
-    def test_unused_val2_raises(self):
+    @pytest.mark.parametrize("d", [
+        dict(val="2001:001", val2="ignored", scale="utc"),
+        dict(val={'year': 2015, 'month': 2, 'day': 3,
+                  'hour': 12, 'minute': 13, 'second': 14.567},
+             val2="ignored", scale="utc"),
+        dict(val=np.datetime64('2005-02-25'), val2="ignored", scale="utc"),
+        dict(val=datetime.datetime(2000, 1, 2, 12, 0, 0),
+             val2="ignored", scale="utc"),
+    ])
+    def test_unused_val2_raises(self, d):
         """Test that providing val2 is for string input lets user know we won't use it"""
         with pytest.raises(ValueError):
-            Time('2001:001', 'ignored', scale='utc')
+            Time(**d)
 
     def test_val2(self):
         """Various tests of the val2 input"""


### PR DESCRIPTION
Currently various Time functions that don't use val2 will silently ignore the value provided by the user. With this PR a ValueError is raised instead.