### PR TITLE
Validate inputs and outputs from custom time formats

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -416,6 +416,9 @@ astropy.time
 - Custom time formats can now accept floating-point types with extended
   precision. Existing time formats raise exceptions rather than discarding
   extended precision through conversion to ordinary floating-point. [#9368]
+- Time formats (implemented in subclasses of ``TimeFormat``) now have
+  their input and output routines more thoroughly validated, making it more
+  difficult to create damaged ``Time`` objects. [#9375]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -418,12 +418,12 @@ class Time(ShapedLikeNDArray):
                 # check the location can be broadcast to self's shape.
                 self.location = np.broadcast_to(self.location, self.shape,
                                                 subok=True)
-            except Exception:
+            except Exception as e:
                 raise ValueError('The location with shape {} cannot be '
                                  'broadcast against time with shape {}. '
                                  'Typically, either give a single location or '
                                  'one for each time.'
-                                 .format(self.location.shape, self.shape))
+                                 .format(self.location.shape, self.shape)) from e
 
     def _init_from_vals(self, val, val2, format, scale, copy,
                         precision=None, in_subfmt=None, out_subfmt=None):

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -418,12 +418,12 @@ class Time(ShapedLikeNDArray):
                 # check the location can be broadcast to self's shape.
                 self.location = np.broadcast_to(self.location, self.shape,
                                                 subok=True)
-            except Exception as e:
+            except Exception as err:
                 raise ValueError('The location with shape {} cannot be '
                                  'broadcast against time with shape {}. '
                                  'Typically, either give a single location or '
                                  'one for each time.'
-                                 .format(self.location.shape, self.shape)) from e
+                                 .format(self.location.shape, self.shape)) from err
 
     def _init_from_vals(self, val, val2, format, scale, copy,
                         precision=None, in_subfmt=None, out_subfmt=None):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1462,7 +1462,11 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
 
 
 def _validate_jd_for_storage(jd):
-    if isinstance(jd, (np.float, np.float64, np.float32, np.float16)):
+    if isinstance(jd, (float, int)):
+        return np.array(jd, dtype=np.float)
+    if (isinstance(jd, np.generic)
+        and (jd.dtype.kind == 'f' and jd.dtype.itemsize <= 8
+             or jd.dtype.kind in 'iu')):
         return np.array(jd, dtype=np.float)
     elif (isinstance(jd, np.ndarray)
           and jd.dtype.kind == 'f'
@@ -1481,15 +1485,17 @@ def _broadcast_writeable(jd1, jd2):
     # warn-on-write, even the one that wasn't modified, and
     # require "C" only clears the flag if it actually copied
     # anything.
-    s = np.broadcast(jd1, jd2).shape
-    if jd1.shape == s:
+    shape = np.broadcast(jd1, jd2).shape
+    if jd1.shape == shape:
         s_jd1 = jd1
     else:
-        s_jd1 = np.require(np.broadcast_to(jd1, s), requirements=["C", "W"])
-    if jd2.shape == s:
+        s_jd1 = np.require(np.broadcast_to(jd1, shape),
+                           requirements=["C", "W"])
+    if jd2.shape == shape:
         s_jd2 = jd2
     else:
-        s_jd2 = np.require(np.broadcast_to(jd2, s), requirements=["C", "W"])
+        s_jd2 = np.require(np.broadcast_to(jd2, shape),
+                           requirements=["C", "W"])
     return s_jd1, s_jd2
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -628,6 +628,19 @@ class TestVal2:
         with pytest.raises(ValueError):
             Time([0.0, 50000.0], [0.0, 1.0, 2.0], format='mjd', scale='tai')
 
+    def test_broadcast_not_writable(self):
+        val = (2458000 + np.arange(3))[:, None]
+        val2 = np.linspace(0, 1, 4, endpoint=False)
+        t = Time(val=val, val2=val2, format="jd", scale="tai")
+        t_b = Time(val=val+0*val2, val2=0*val+val2, format="jd", scale="tai")
+        t_i = Time(val=57990, val2=0.3, format="jd", scale="tai")
+        t_b[1, 2] = t_i
+        t[1, 2] = t_i
+        assert t_b[1, 2] == t[1, 2], "writing worked"
+        assert t_b[0, 2] == t[0, 2], "broadcasting didn't cause problems"
+        assert t_b[1, 1] == t[1, 1], "broadcasting didn't cause problems"
+        assert np.all(t_b == t), "behaved as expected"
+
 
 class TestSubFormat:
     """Test input and output subformat functionality"""
@@ -1312,11 +1325,10 @@ def test_writeable_flag():
     t[1] = 10.0
     assert allclose_sec(t[1].value, 10.0)
 
-    # Scalar is not writeable
+    # Scalar is writeable because it gets boxed into a zero-d array
     t = Time('2000:001', scale='utc')
-    with pytest.raises(ValueError) as err:
-        t[()] = '2000:002'
-    assert 'scalar Time object is read-only.' in str(err.value)
+    t[()] = '2000:002'
+    assert t.value.startswith('2000:002')
 
     # Transformed attribute is not writeable
     t = Time(['2000:001', '2000:002'], scale='utc')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -641,6 +641,18 @@ class TestVal2:
         assert t_b[1, 1] == t[1, 1], "broadcasting didn't cause problems"
         assert np.all(t_b == t), "behaved as expected"
 
+    def test_broadcast_one_not_writable(self):
+        val = (2458000 + np.arange(3))
+        val2 = np.arange(1)
+        t = Time(val=val, val2=val2, format="jd", scale="tai")
+        t_b = Time(val=val+0*val2, val2=0*val+val2, format="jd", scale="tai")
+        t_i = Time(val=57990, val2=0.3, format="jd", scale="tai")
+        t_b[1] = t_i
+        t[1] = t_i
+        assert t_b[1] == t[1], "writing worked"
+        assert t_b[0] == t[0], "broadcasting didn't cause problems"
+        assert np.all(t_b == t), "behaved as expected"
+
 
 class TestSubFormat:
     """Test input and output subformat functionality"""

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -62,6 +62,10 @@ class TestTimeComparisons:
         assert np.all(t1_gt_t2_0 == np.array([True, True, True, True, True,
                                               True, True, True, True, True]))
 
+    def test_time_boolean(self):
+        t1_0_gt_t2_0 = self.t1[0] > self.t2[0]
+        assert t1_0_gt_t2_0 is True
+
     def test_timedelta(self):
         dt = self.t2 - self.t1
         with pytest.raises(TypeError):

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -196,7 +196,11 @@ def test_existing_types_ok_with_float64(f):
         (np.arange(3), np.arange(4)),
         ("foo", "bar"),
         (1j, 2j),
-        (np.longdouble(3), np.longdouble(5)),
+        pytest.param(
+            np.longdouble(3), np.longdouble(5),
+            marks=pytest.mark.skipif(
+                np.longdouble().itemsize > 8,
+                reason="long double == double on this platform")),
         ({1: 2}, {3: 4}),
         ({1, 2}, {3, 4}),
         ([1, 2], [3, 4]),

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -180,6 +180,7 @@ def test_existing_types_refuse_longdoubles(f):
         # accepts long doubles, better preserve accuracy!
         assert Time(np.longdouble(t2), format=f) != tm
 
+
 @pytest.mark.parametrize(
     "jd1, jd2",
     [

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -199,7 +199,7 @@ def test_existing_types_ok_with_float64(f):
         pytest.param(
             np.longdouble(3), np.longdouble(5),
             marks=pytest.mark.skipif(
-                np.longdouble().itemsize > 8,
+                np.longdouble().itemsize == np.dtype(float).itemsize,
                 reason="long double == double on this platform")),
         ({1: 2}, {3: 4}),
         ({1, 2}, {3, 4}),

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -181,6 +181,14 @@ def test_existing_types_refuse_longdoubles(f):
         assert Time(np.longdouble(t2), format=f) != tm
 
 
+@pytest.mark.parametrize("f", ["mjd", "unix", "cxcsec"])
+def test_existing_types_ok_with_float64(f):
+    t = np.float64(getattr(Time(58000, format="mjd"), f))
+    t2 = t + np.finfo(np.float64).eps * 2 * t
+    tm = Time(np.float64(t), format=f)
+    assert Time(np.float64(t2), format=f) != tm
+
+
 @pytest.mark.parametrize(
     "jd1, jd2",
     [
@@ -293,3 +301,15 @@ def test_ymdhms():
     # NOTE: actually comes back as np.void for some reason
     # NOTE: not necessarily a python int; might be an int32
     assert t.ymdhms.year == 2015
+
+
+# There are two stages of validation now - one on input into a format, so that
+# the format conversion code has tidy matched arrays to work with, and the
+# other when object construction does not go through a format object. Or at
+# least, the format object is constructed with "from_jd=True". In this case the
+# normal input validation does not happen but the new input validation does,
+# and can ensure that strange broadcasting anomalies can't happen.
+# This form of construction uses from_jd=True.
+def test_broadcasting_writeable():
+    t = Time('J2015') + np.linspace(-1, 1, 10)*u.day
+    t[2] = Time(58000, format="mjd")

--- a/astropy/time/tests/test_custom_formats.py
+++ b/astropy/time/tests/test_custom_formats.py
@@ -1,4 +1,5 @@
-from itertools import count
+from datetime import date
+from itertools import count, product
 
 import pytest
 
@@ -87,25 +88,15 @@ def test_custom_time_format_fine(custom_format_name):
 
 
 def test_custom_time_format_forgot_property(custom_format_name):
-    class Custom(TimeFormat):
-        name = custom_format_name
+    with pytest.raises(ValueError):
+        class Custom(TimeFormat):
+            name = custom_format_name
 
-        def set_jds(self, val, val2):
-            self.jd1, self.jd2 = val, val2
+            def set_jds(self, val, val2):
+                self.jd1, self.jd2 = val, val2
 
-        def value(self):
-            return self.jd1, self.jd2
-
-    t = Time.now()
-    with pytest.raises(AttributeError):
-        getattr(t, custom_format_name)
-
-    t.format = custom_format_name
-    with pytest.raises(AttributeError):
-        t.value
-
-    with pytest.raises(AttributeError):
-        Time(7, 9, format=custom_format_name).value
+            def value(self):
+                return self.jd1, self.jd2
 
 
 def test_custom_time_format_problematic_name():
@@ -188,3 +179,116 @@ def test_existing_types_refuse_longdoubles(f):
     else:
         # accepts long doubles, better preserve accuracy!
         assert Time(np.longdouble(t2), format=f) != tm
+
+@pytest.mark.parametrize(
+    "jd1, jd2",
+    [
+        ("foo", None),
+        (np.arange(3), np.arange(4)),
+        ("foo", "bar"),
+        (1j, 2j),
+        (np.longdouble(3), np.longdouble(5)),
+        ({1: 2}, {3: 4}),
+        ({1, 2}, {3, 4}),
+        ([1, 2], [3, 4]),
+        (lambda: 4, lambda: 7),
+        (np.arange(3), np.arange(4)),
+    ],
+)
+def test_custom_format_cannot_make_bogus_jd1(custom_format_name, jd1, jd2):
+    class Custom(TimeFormat):
+        name = custom_format_name
+
+        def set_jds(self, val, val2):
+            self.jd1, self.jd2 = jd1, jd2
+
+        @property
+        def value(self):
+            return self.jd1 + self.jd2
+
+    with pytest.raises((ValueError, TypeError)):
+        Time(5, format=custom_format_name)
+
+
+def test_custom_format_scalar_jd1_jd2_okay(custom_format_name):
+    class Custom(TimeFormat):
+        name = custom_format_name
+
+        def set_jds(self, val, val2):
+            self.jd1, self.jd2 = 7.0, 3.0
+
+        @property
+        def value(self):
+            return self.jd1 + self.jd2
+
+    getattr(Time(5, format=custom_format_name), custom_format_name)
+
+
+@pytest.mark.parametrize(
+    "thing",
+    [
+        1,
+        1.0,
+        np.longdouble(1),
+        1.0j,
+        "foo",
+        b"foo",
+        Time(5, format="mjd"),
+        lambda: 7,
+        np.datetime64('2005-02-25'),
+        date(2006, 2, 25),
+    ],
+)
+def test_custom_format_can_return_any_scalar(custom_format_name, thing):
+    class Custom(TimeFormat):
+        name = custom_format_name
+
+        def set_jds(self, val, val2):
+            self.jd1, self.jd2 = 2., 0.
+
+        @property
+        def value(self):
+            return np.array(thing)
+
+    assert type(getattr(Time(5, format=custom_format_name),
+                        custom_format_name)) == type(thing)
+    assert np.all(getattr(Time(5, format=custom_format_name),
+                          custom_format_name) == thing)
+
+
+@pytest.mark.parametrize(
+    "thing",
+    [
+        (1, 2),
+        [1, 2],
+        np.array([2, 3]),
+        np.array([2, 3, 5, 7]),
+        {6: 7},
+        {1, 2},
+    ],
+)
+def test_custom_format_can_return_any_iterable(custom_format_name, thing):
+    class Custom(TimeFormat):
+        name = custom_format_name
+
+        def set_jds(self, val, val2):
+            self.jd1, self.jd2 = 2., 0.
+
+        @property
+        def value(self):
+            return thing
+
+    assert type(getattr(Time(5, format=custom_format_name),
+                        custom_format_name)) == type(thing)
+    assert np.all(getattr(Time(5, format=custom_format_name),
+                          custom_format_name) == thing)
+
+
+# Converted from doctest in astropy/test/formats.py for debugging
+def test_ymdhms():
+    t = Time({'year': 2015, 'month': 2, 'day': 3,
+              'hour': 12, 'minute': 13, 'second': 14.567},
+             scale='utc')
+    # NOTE: actually comes back as np.void for some reason
+    # NOTE: not necessarily a python int; might be an int32
+    assert t.ymdhms.year == 2015


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->
Currently implementing custom time formats is difficult because the jd1 and jd2 values they produce are not validated; and the values they return when asked to export jd1 and jd2 are constrained by peculiar restrictions. This code enforces that jd1 and jd2 are floats or arrays of floats with matching shapes. It also permits, and tests, a variety of peculiar return types.

The main headache on the return types is the issue of "boxing" scalars in zero-dimensional arrays and unboxing them.

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

