### PR TITLE
Implement support for Time in APE 14 FITS WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,7 +267,7 @@ astropy.wcs
   and ``world_axis_names``. [#9156]
 
 - Updated the WCS class to now correctly take and return ``Time`` objects in the
-  high-level APE 14 API (e.g. ``pixel_to_world``. [£9376]
+  high-level APE 14 API (e.g. ``pixel_to_world``. [#9376]
 
 API Changes
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -261,11 +261,13 @@ astropy.wcs
   slicing operations in turn. [#9210]
 
 - Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
-- Added a ``wcs_as_str`` function to ``astropy.wcs.wcsapi`` to show a summary
-- Added a ``wcs_info_str`` function to ``astropy.wcs.wcsapi`` to show a summary
   of an APE-14-compliant WCS as a string. [#8546, #9207]
+
 - Added two new optional attributes to the APE 14 low-level WCS: ``pixel_axis_names``
   and ``world_axis_names``. [#9156]
+
+- Updated the WCS class to now correctly take and return ``Time`` objects in the
+  high-level APE 14 API (e.g. ``pixel_to_world``. [£9376]
 
 API Changes
 -----------

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -200,16 +200,14 @@ def test_coord_type_1d_2d_wcs_correlated():
 
 def test_coord_type_1d_2d_wcs_uncorrelated():
     wcs = WCS(naxis=2)
-    wcs.wcs.ctype = ['WAVE', 'TIME']
+    wcs.wcs.ctype = ['WAVE', 'UTC']
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
     wcs.wcs.cunit = ['nm', 's']
     wcs.wcs.set()
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=FutureWarning)
-        _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame1D, slices=('x', 0))
+    _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame1D, slices=('x', 0))
 
     assert coord_meta['type'] == ['scalar', 'scalar']
     assert coord_meta['format_unit'] == [u.m, u.s]

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -388,7 +388,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     def time_from_reference_and_offset(offset):
                         if isinstance(offset, Time):
                             return offset
-                        return reference_time + offset * u.s
+                        return reference_time + u.Quantity(offset, unit=u.s)
 
                     def offset_from_time_and_reference(time):
                         return (time - reference_time).to_value(u.s)

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -393,7 +393,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     def offset_from_time_and_reference(time):
                         return (time - reference_time).to_value(u.s)
 
-                    classes[name] = (Time, time_from_reference_and_offset, (), {})
+                    classes[name] = (Time, (), {}, time_from_reference_and_offset)
                     components[i] = (name, 0, offset_from_time_and_reference)
 
         # Fallback: for any remaining components that haven't been identified, just

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -355,6 +355,12 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                     # Extract time scale
                     scale = self.wcs.ctype[i].lower()
 
+                    if scale == 'time':
+                        if self.wcs.timesys:
+                            scale = self.wcs.timesys.lower()
+                        else:
+                            scale = 'utc'
+
                     # Drop sub-scales
                     if '(' in scale:
                         pos = scale.index('(')
@@ -395,8 +401,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                                        "supported, setting location in Time to None", UserWarning)
                         location = None
 
-                    reference_time = Time(self.wcs.mjdref[0],
-                                          self.wcs.mjdref[1],
+                    reference_time = Time(np.nan_to_num(self.wcs.mjdref[0]),
+                                          np.nan_to_num(self.wcs.mjdref[1]),
                                           format='mjd', scale=scale,
                                           location=location)
 

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -151,8 +151,10 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
                 if len(rest) == 0:
                     klass_gen = klass
-                else:
+                elif len(rest) == 1:
                     klass_gen = rest[0]
+                else:
+                    raise ValueError("Tuples in world_axis_object_classes should have length 3 or 4")
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689
@@ -173,8 +175,10 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
                 if len(rest) == 0:
                     klass_gen = klass
-                else:
+                elif len(rest) == 1:
                     klass_gen = rest[0]
+                else:
+                    raise ValueError("Tuples in world_axis_object_classes should have length 3 or 4")
 
                 w = world_objects[ikey]
                 if not isinstance(w, klass):
@@ -241,8 +245,10 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
             klass, ar, kw, *rest = classes[key]
             if len(rest) == 0:
                 klass_gen = klass
-            else:
+            elif len(rest) == 1:
                 klass_gen = rest[0]
+            else:
+                raise ValueError("Tuples in world_axis_object_classes should have length 3 or 4")
             result.append(klass_gen(*args[key], *ar, **kwargs[key], **kw))
 
         if len(result) == 1:

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -130,7 +130,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         unique_match = True
         for w in world_objects:
             matches = []
-            for key, (klass, _, _) in classes.items():
+            for key, (klass, *_) in classes.items():
                 if isinstance(w, klass):
                     matches.append(key)
             if len(matches) == 1:
@@ -147,7 +147,13 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
         if unique_match:
 
-            for key, (klass, args, kwargs) in classes.items():
+            for key, (klass, *rest) in classes.items():
+
+                if len(rest) == 2:
+                    klass_gen = klass
+                    args, kwargs = rest
+                else:
+                    klass_gen, args, kwargs = rest
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689
@@ -158,12 +164,20 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
                     else:
                         objects[key] = world_by_key[key]
                 else:
-                    objects[key] = klass(world_by_key[key], *args, **kwargs)
+                    objects[key] = klass_gen(world_by_key[key], *args, **kwargs)
 
         else:
 
             for ikey, key in enumerate(classes):
-                klass, args, kwargs = classes[key]
+
+                klass, *rest = classes[key]
+
+                if len(rest) == 2:
+                    klass_gen = klass
+                    args, kwargs = rest
+                else:
+                    klass_gen, args, kwargs = rest
+
                 w = world_objects[ikey]
                 if not isinstance(w, klass):
                     raise ValueError("Expected the following order of world "
@@ -178,12 +192,15 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
                     else:
                         objects[key] = w
                 else:
-                    objects[key] = klass(w, *args, **kwargs)
+                    objects[key] = klass_gen(w, *args, **kwargs)
 
         # We now extract the attributes needed for the world values
         world = []
         for key, _, attr in components:
-            world.append(rec_getattr(objects[key], attr))
+            if callable(attr):
+                world.append(attr(objects[key]))
+            else:
+                world.append(rec_getattr(objects[key], attr))
 
         # Finally we convert to pixel coordinates
         pixel = self.low_level_wcs.world_to_pixel_values(*world)
@@ -223,8 +240,13 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         result = []
 
         for key in default_order(components):
-            klass, ar, kw = classes[key]
-            result.append(klass(*args[key], *ar, **kwargs[key], **kw))
+            klass, *rest = classes[key]
+            if len(rest) == 2:
+                klass_gen = klass
+                ar, kw = rest
+            else:
+                klass_gen, ar, kw = rest
+            result.append(klass_gen(*args[key], *ar, **kwargs[key], **kw))
 
         if len(result) == 1:
             return result[0]

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -147,13 +147,12 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
         if unique_match:
 
-            for key, (klass, *rest) in classes.items():
+            for key, (klass, args, kwargs, *rest) in classes.items():
 
-                if len(rest) == 2:
+                if len(rest) == 0:
                     klass_gen = klass
-                    args, kwargs = rest
                 else:
-                    klass_gen, args, kwargs = rest
+                    klass_gen = rest[0]
 
                 # FIXME: For now SkyCoord won't auto-convert upon initialization
                 # https://github.com/astropy/astropy/issues/7689
@@ -170,13 +169,12 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
 
             for ikey, key in enumerate(classes):
 
-                klass, *rest = classes[key]
+                klass, args, kwargs, *rest = classes[key]
 
-                if len(rest) == 2:
+                if len(rest) == 0:
                     klass_gen = klass
-                    args, kwargs = rest
                 else:
-                    klass_gen, args, kwargs = rest
+                    klass_gen = rest[0]
 
                 w = world_objects[ikey]
                 if not isinstance(w, klass):
@@ -240,12 +238,11 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         result = []
 
         for key in default_order(components):
-            klass, *rest = classes[key]
-            if len(rest) == 2:
+            klass, ar, kw, *rest = classes[key]
+            if len(rest) == 0:
                 klass_gen = klass
-                ar, kw = rest
             else:
-                klass_gen, ar, kw = rest
+                klass_gen = rest[0]
             result.append(klass_gen(*args[key], *ar, **kwargs[key], **kw))
 
         if len(result) == 1:

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -146,8 +146,11 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         * The third argument is a string giving the name of the property
           to access on the corresponding class from
-          `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_classes` in order to get numerical
-          values.
+          `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_classes` in
+          order to get numerical values. Alternatively, this argument can be a
+          callable Python object that taks a high-level coordinate object and
+          returns the numerical values suitable for passing to the low-level
+          WCS transformation methods.
 
         See the document
         `APE 14: A shared Python interface for World Coordinate Systems
@@ -177,6 +180,12 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         * The last tuple element must be a dictionary with the keyword
           arguments required to initialize the class.
+
+        For advanced use cases, the tuple can also contain four elements, where
+        an additional element is added between the first and second above. This
+        element should be a callable Python object that gets called instead of
+        the class and gets passed the positional and keyword arguments. It
+        should return an object of the type of the first element in the tuple.
 
         Note that we don't require the classes to be Astropy classes since there
         is no guarantee that Astropy will have all the classes to represent all

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -166,7 +166,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
         Each key of the dictionary is a string key from
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_object_components`, and each value is a
-        tuple with three elements:
+        tuple with three elements or four elements:
 
         * The first element of the tuple must be a class or a string specifying
           the fully-qualified name of a class, which will specify the actual
@@ -178,14 +178,13 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
           world coordinates should be passed as a positional argument, this this
           tuple should include `None` placeholders for the world coordinates.
 
-        * The last tuple element must be a dictionary with the keyword
+        * The third tuple element must be a dictionary with the keyword
           arguments required to initialize the class.
 
-        For advanced use cases, the tuple can also contain four elements, where
-        an additional element is added between the first and second above. This
-        element should be a callable Python object that gets called instead of
-        the class and gets passed the positional and keyword arguments. It
-        should return an object of the type of the first element in the tuple.
+        * Optionally, for advanced use cases, the fourth element (if present)
+          should be a callable Python object that gets called instead of the
+          class and gets passed the positional and keyword arguments. It should
+          return an object of the type of the first element in the tuple.
 
         Note that we don't require the classes to be Astropy classes since there
         is no guarantee that Astropy will have all the classes to represent all

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -717,7 +717,7 @@ def test_time_1d_location_unsupported():
 
 def test_time_1d_unsupported_ctype():
 
-    # For cases that we don't support yet, e.g. UT(...), use Quantity
+    # For cases that we don't support yet, e.g. UT(...), use Time and drop sub-scale
 
     # Case where the MJDREF is split into two for high precision
     header = Header.fromstring(HEADER_TIME_1D, sep='\n')
@@ -725,10 +725,10 @@ def test_time_1d_unsupported_ctype():
 
     wcs = WCS(header)
     with pytest.warns(UserWarning,
-                      match="Unrecognized time CTYPE=UT"):
+                      match="Dropping unsupported sub-scale WWV from scale UT"):
         time = wcs.pixel_to_world(10)
 
-    assert isinstance(time, Quantity)
+    assert isinstance(time, Time)
 
 
 ###############################################################################

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -498,6 +498,53 @@ def test_time_cube():
     assert_equal(k, 29)
 
 ###############################################################################
+# The following tests are to make sure that Time objects are constructed
+# correctly for a variety of combinations of WCS keywords
+###############################################################################
+
+
+HEADER_TIME_CUBE = """
+SIMPLE  = T
+BITPIX  = -32
+NAXIS   = 1
+NAXIS1  = 2048
+TIMESYS = 'UTC'
+TREFPOS = 'TOPOCENT'
+MJDREF  = 50002.6
+CTYPE1  = 'UTC'
+CRVAL1  = 5
+CUNIT1  = 's'
+CRPIX1  = 1.0
+CDELT1  = 2
+OBSGEO-B= -20
+OBSGEO-L= -70
+OBSGEO-H= 2530
+"""
+
+
+def assert_time_at(header, position, jd1, jd2, scale, format):
+    wcs = WCS(header)
+    time = wcs.pixel_to_world(position)
+    assert_allclose(time.jd1, jd1, rtol=1e-10)
+    assert_allclose(time.jd2, jd2, rtol=1e-10)
+    assert time.format == format
+    assert time.scale == scale
+
+
+def test_time_1d():
+
+    header = Header.fromstring(HEADER_TIME_CUBE, sep='\n')
+
+    assert_time_at(header, 1, 2450003, 0.1 + 7 / 3600 / 24, 'utc', 'mjd')
+
+    header['CTYPE1'] = 'TAI'
+    assert_time_at(header, 1, 2450003, 0.1 + 7 / 3600 / 24, 'tai', 'mjd')
+
+    header['CTYPE1'] = 'TAI'
+    assert_time_at(header, 1, 2450003, 0.1 + 7 / 3600 / 24, 'tai', 'mjd')
+
+
+###############################################################################
 # Extra corner cases
 ###############################################################################
 

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -521,6 +521,7 @@ OBSGEO-B= -70
 OBSGEO-H= 2530
 """
 
+
 @pytest.fixture
 def header_time_1d():
     return Header.fromstring(HEADER_TIME_1D, sep='\n')

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -563,6 +563,13 @@ def test_time_1d_values_deprecated(header_time_1d):
     assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, 'tt', 'mjd')
 
 
+def test_time_1d_values_time(header_time_1d):
+    header_time_1d['CTYPE1'] = 'TIME'
+    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, 'utc', 'mjd')
+    header_time_1d['TIMESYS'] = 'TAI'
+    assert_time_at(header_time_1d, 1, 2450003, 0.1 + 7 / 3600 / 24, 'tai', 'mjd')
+
+
 @pytest.mark.parametrize('scale', ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc'))
 def test_time_1d_roundtrip(header_time_1d, scale):
 


### PR DESCRIPTION
Currently, the APE 14 machinery (for FITS WCS) returns Quantity for time axes, with a warning that this will change in future and return ``Time`` objects. This PR now adjusts the FITS WCS APE 14 implementation to understand and return ``Time`` objects.

This brought up some limitations in the APE 14 API (again!). Basically, the issue is that unlike other coordinates, time coordinates in the WCS are actually relative not absolute times, and need to be converted to absolute times using other WCS metadata. So the low-level WCS values are relative, and the high-level WCS objects need to be absolute, but we can't currently just instantiate ``Time`` objects with relative time and use kwargs to add a reference time.

So there are several options:

* Modify Time so that we can instantiate it with offsets and have a e.g. ``reference_time`` kwargs that specifies how to construct the final absolute time. However this adds complication to the ``Time`` class that is probably not desirable, and doesn't solve the issue of going the other way (see below).

* Modify APE 14 to allow an optional distinction between the class used to represent high-level coordinates and the class constructor which could be an arbitrary callable object. This PR implements this approach and updates the APE 14 base classes to describe this.

Likewise, when going from world to pixel coordinates, we need to go from high level world -> low level world -> pixel and the first step also involves going from an absolute to a relative time, which can't be done by simple attribute access on ``Time``. Therefore, I also modified the APE to allow the WCS to specify a callable instead of a string for getting numerical values from a high-level coordinate object.

Before anyone suggests subclassing ``Time`` to provide this kind of functionality built-in, that won't work since we still need users to be able to specify vanilla ``Time`` objects to convert to pixel values :)

It's unfortunate that this requires updating the APE 14 API again (with additions, nothing breaking) but the implementation is actually pretty simple. @Cadair ran into the same issues when implementing support for time in GWCS.

Remaining to-dos:

* [x] Make sure we cover all cases for time CTYPEs
* [x] Fix and add tests for FITS WCS implementation
* [ ] <s>Consider adding/updating documentation accordingly</s>

Before I do these, I want to get feedback on the approach so far though. I'd really like to get this into 4.0 if possible.

Fixes https://github.com/astropy/astropy/issues/7957