### PR TITLE
Enable pickling and unpickling of constants

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ astropy.constants
 
 - Default constants now use CODATA 2018 and IAU 2015 definitions. [#8761]
 
+- Constants can be pickled and unpickled. [#9377]
+
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/constants/constant.py
+++ b/astropy/constants/constant.py
@@ -62,7 +62,8 @@ class ConstantMeta(type):
         exclude = set(['__new__', '__array_finalize__', '__array_wrap__',
                        '__dir__', '__getattr__', '__init__', '__str__',
                        '__repr__', '__hash__', '__iter__', '__getitem__',
-                       '__len__', '__bool__', '__quantity_subclass__'])
+                       '__len__', '__bool__', '__quantity_subclass__',
+                       '__setstate__'])
         for attr, value in vars(Quantity).items():
             if (isinstance(value, types.FunctionType) and
                     attr.startswith('__') and attr.endswith('__') and

--- a/astropy/constants/tests/test_pickle.py
+++ b/astropy/constants/tests/test_pickle.py
@@ -9,8 +9,8 @@ originals = [const.Constant('h_fake', 'Not Planck',
                             0.0, 'J s', 0.0, 'fakeref',
                             system='si'),
              const.h,
-             const.e]
-xfails = [True, True, True]
+             const.e.si]
+xfails = [False, False, False]
 
 
 @pytest.mark.parametrize(("original", "xfail"), zip(originals, xfails))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to enable constants to be pickled and unpickled. For some time, a test of pickling and unpickling constants has been included but it had all tests set to xfail.

EM constants can be pickled, but the system must be specified (similar to any other use of EM constants).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #5719 

