### PR TITLE
fix incorrect markup on emacs setup page

### DIFF
--- a/docs/development/codeguide_emacs.rst
+++ b/docs/development/codeguide_emacs.rst
@@ -40,7 +40,7 @@ Delete trailing white spaces
 One can `delete trailing whitespace
 <https://www.emacswiki.org/emacs/DeletingWhitespace#toc3>`_ with ``M-x
 delete-trailing-whitespace``. To ensure this is done every time a python file
-is saved, use::
+is saved, use:
 
 .. code-block:: scheme
 


### PR DESCRIPTION
The emacs example at  https://docs.astropy.org/en/v3.2.2/development/codeguide_emacs.html#delete-trailing-white-spaces is not being rendered correctly. I assume this is because the `::` caused the code-block directive to be rendered as an element, rather than as a directive.

I have not run this through a sphinx build to check whether it fixes the problem or not.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->