### PR TITLE
Ensure that numpy functions also allow zeros, nan, inf to have arbitrary units.

### DIFF
--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -311,13 +311,42 @@ def _as_quantities(*args):
         raise NotImplementedError
 
 
-def _quantities2arrays(*args):
-    """Convert to Quantities with the unit of the first argument."""
-    qs = _as_quantities(*args)
-    unit = qs[0].unit
-    # Allow any units error to be raised.
-    arrays = tuple(q.to_value(unit) for q in qs)
-    return arrays, unit
+def _quantities2arrays(*args, unit_from_first=False):
+    """Convert to arrays in units of the first argument that has a unit.
+
+    If unit_from_first, take the unit of the first argument regardless
+    whether it actually defined a unit (e.g., dimensionless for arrays).
+    """
+
+    # Turn first argument into a quantity.
+    q = _as_quantity(args[0])
+    if len(args) == 1:
+        return (q.value,), q.unit
+
+    # If we care about the unit being explicit, then check whether this
+    # argument actually had a unit, or was likely inferred.
+    if not unit_from_first and (q.unit is q._default_unit
+                                and not hasattr(args[0], 'unit')):
+        # Here, the argument could still be things like [10*u.one, 11.*u.one]),
+        # i.e., properly dimensionless.  So, we only override with anything
+        # that has a unit not equivalent to dimensionless (fine to ignore other
+        # dimensionless units pass, even if explicitly given).
+        for arg in args[1:]:
+            trial = _as_quantity(arg)
+            if not trial.unit.is_equivalent(q.unit):
+                # Use any explicit unit not equivalent to dimensionless.
+                q = trial
+                break
+
+    # We use the private _to_own_unit method here instead of just
+    # converting everything to quantity and then do .to_value(qs0.unit)
+    # as we want to allow arbitrary unit for 0, inf, and nan.
+    try:
+        arrays = tuple((q._to_own_unit(arg)) for arg in args)
+    except TypeError:
+        raise NotImplementedError
+
+    return arrays, q.unit
 
 
 def _iterable_helper(*args, out=None, **kwargs):
@@ -435,7 +464,7 @@ def piecewise(x, condlist, funclist, *args, **kw):
 
 @function_helper
 def append(arr, values, *args, **kwargs):
-    arrays, unit = _quantities2arrays(arr, values)
+    arrays, unit = _quantities2arrays(arr, values, unit_from_first=True)
     return arrays + args, kwargs, unit, None
 
 
@@ -446,7 +475,8 @@ def insert(arr, obj, values, *args, **kwargs):
     if isinstance(obj, Quantity):
         raise NotImplementedError
 
-    (arr, values), unit = _quantities2arrays(arr, values)
+    (arr, values), unit = _quantities2arrays(arr, values,
+                                             unit_from_first=True)
     return (arr, obj, values) + args, kwargs, unit, None
 
 
@@ -573,7 +603,7 @@ def bincount(x, weights=None, minlength=0):
 
 @function_helper
 def digitize(x, bins, *args, **kwargs):
-    arrays, unit = _quantities2arrays(x, bins)
+    arrays, unit = _quantities2arrays(x, bins, unit_from_first=True)
     return arrays + args, kwargs, None, None
 
 


### PR DESCRIPTION
fixes #9141 

Also makes sure that things like `np.contenate((0, <some_quantity>, 0))` work.