### PR TITLE
Partial revert of #8904 for MaskedArray and numpy <= 1.15

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -23,6 +23,7 @@ from astropy.utils.console import color_print
 from astropy.utils.metadata import MetaData
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.misc import dtype_bytes_or_chars
+from astropy.utils.compat import NUMPY_LT_1_15
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -979,6 +980,11 @@ class Column(BaseColumn):
 
             if self.dtype.char == 'S':
                 other = self._encode_str(other)
+
+            if NUMPY_LT_1_15 and (isinstance(self, np.ma.MaskedArray) or
+                                  isinstance(other, np.ma.MaskedArray)):
+                # On numpy 1.14, MaskedArray subclass comparison is broken.
+                return getattr(self.data, op)(other)
 
             # Now just let the regular ndarray.__eq__, etc., take over.
             result = getattr(super(), op)(other)

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -7,7 +7,7 @@ from astropy.utils import minversion
 
 
 __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
-           'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
+           'NUMPY_LT_1_15', 'NUMPY_LT_1_16', 'NUMPY_LT_1_17']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
@@ -15,5 +15,6 @@ __all__ = ['NUMPY_LT_1_14', 'NUMPY_LT_1_14_1', 'NUMPY_LT_1_14_2',
 NUMPY_LT_1_14 = not minversion('numpy', '1.14')
 NUMPY_LT_1_14_1 = not minversion('numpy', '1.14.1')
 NUMPY_LT_1_14_2 = not minversion('numpy', '1.14.2')
+NUMPY_LT_1_15 = not minversion('numpy', '1.15')
 NUMPY_LT_1_16 = not minversion('numpy', '1.16')
 NUMPY_LT_1_17 = not minversion('numpy', '1.17')


### PR DESCRIPTION
fixes #9388

@astrofrog - Note that I didn't add a changelog entry (as somehow it was at 3.2.2). I may also be targeting the wrong branch - feel free to adjust (or let me know what to do).