### PR TITLE
Ignore reserved keywords when creating FITS header cards from Table meta

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -438,6 +438,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Implemented skip (after warning) of header cards with reserved
+  keywords in ``table_to_hdu``. [#9387]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -439,7 +439,7 @@ astropy.io.fits
 ^^^^^^^^^^^^^^^
 
 - Implemented skip (after warning) of header cards with reserved
-  keywords in ``table_to_hdu``. [#9387]
+  keywords in ``table_to_hdu``. [#9390]
 
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -460,8 +460,8 @@ def table_to_hdu(table, character_as_bytes=False):
         unsupported_cols = table.columns.not_isinstance((BaseColumn, Quantity, Time))
         if unsupported_cols:
             unsupported_names = [col.info.name for col in unsupported_cols]
-            raise ValueError('cannot write table with mixin column(s) {}'
-                         .format(unsupported_names))
+            raise ValueError(f'cannot write table with mixin column(s) '
+                             f'{unsupported_names}')
 
         time_cols = table.columns.isinstance(Time)
         if time_cols:
@@ -519,17 +519,17 @@ def table_to_hdu(table, character_as_bytes=False):
             except UnitScaleError:
                 scale = unit.scale
                 raise UnitScaleError(
-                    "The column '{}' could not be stored in FITS format "
-                    "because it has a scale '({})' that "
-                    "is not recognized by the FITS standard. Either scale "
-                    "the data or change the units.".format(col.name, str(scale)))
+                    f"The column '{col.name}' could not be stored in FITS "
+                    f"format because it has a scale '({str(scale)})' that "
+                    f"is not recognized by the FITS standard. Either scale "
+                    f"the data or change the units.")
             except ValueError:
                 # Warn that the unit is lost, but let the details depend on
                 # whether the column was serialized (because it was a
                 # quantity), since then the unit can be recovered by astropy.
                 warning = (
-                    "The unit '{}' could not be saved in native FITS format "
-                    .format(unit.to_string()))
+                    f"The unit '{unit.to_string()}' could not be saved in "
+                    f"native FITS format ")
                 if any('SerializedColumn' in item and 'name: '+col.name in item
                        for item in table.meta.get('comments', [])):
                     warning += (
@@ -564,8 +564,8 @@ def table_to_hdu(table, character_as_bytes=False):
     for key, value in table.meta.items():
         if is_column_keyword(key.upper()) or key.upper() in REMOVE_KEYWORDS:
             warnings.warn(
-                "Meta-data keyword {} will be ignored since it conflicts "
-                "with a FITS reserved keyword".format(key), AstropyUserWarning)
+                f"Meta-data keyword {key} will be ignored since it conflicts "
+                f"with a FITS reserved keyword", AstropyUserWarning)
             continue
 
         # Convert to FITS format
@@ -578,17 +578,15 @@ def table_to_hdu(table, character_as_bytes=False):
                     table_hdu.header.append((key, item))
                 except ValueError:
                     warnings.warn(
-                        "Attribute `{}` of type {} cannot be added to "
-                        "FITS Header - skipping".format(key, type(value)),
-                        AstropyUserWarning)
+                        f"Attribute `{key}` of type {type(value)} cannot be "
+                        f"added to FITS Header - skipping", AstropyUserWarning)
         else:
             try:
                 table_hdu.header[key] = value
             except ValueError:
                 warnings.warn(
-                    "Attribute `{}` of type {} cannot be added to FITS "
-                    "Header - skipping".format(key, type(value)),
-                    AstropyUserWarning)
+                    f"Attribute `{key}` of type {type(value)} cannot be "
+                    f"added to FITS Header - skipping", AstropyUserWarning)
     return table_hdu
 
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -566,6 +566,7 @@ def table_to_hdu(table, character_as_bytes=False):
             warnings.warn(
                 "Meta-data keyword {} will be ignored since it conflicts "
                 "with a FITS reserved keyword".format(key), AstropyUserWarning)
+            continue
 
         # Convert to FITS format
         if key == 'comments':

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -15,6 +15,7 @@ from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
 
 from . import FitsTestCase
+from ..connect import REMOVE_KEYWORDS
 
 
 class TestConvenience(FitsTestCase):
@@ -110,9 +111,7 @@ class TestConvenience(FitsTestCase):
         assert hdu.header.get('PCOUNT') == 0
         np.testing.assert_almost_equal(hdu.header.get('EXPTIME'), 3.21e1)
 
-    @pytest.mark.parametrize('card', ['XTENSION', 'BITPIX', 'PCOUNT', 'GCOUNT',
-                                      'NAXIS', 'NAXIS1', 'NAXIS2',
-                                      'TFIELDS', 'THEAP'])
+    @pytest.mark.parametrize('card', REMOVE_KEYWORDS)
     def test_table_to_hdu_warn_reserved(self, card):
         """
         Test warning for each keyword in ..connect.REMOVE_KEYWORDS, 1 by 1

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -95,7 +95,7 @@ class TestConvenience(FitsTestCase):
         """
         Regression test for https://github.com/astropy/astropy/issues/9387
         """
-        diagnose = 'be ignored since it conflicts with a FITS reserved keyword'
+        diag = 'be ignored since it conflicts with a FITS reserved keyword'
         ins_cards = {'EXPTIME': 32.1, 'XTENSION': 'NEWTABLE',
                      'NAXIS': 1, 'NAXIS1': 3, 'NAXIS2': 9,
                      'PCOUNT': 42, 'OBSERVER': 'Adams'}
@@ -104,14 +104,15 @@ class TestConvenience(FitsTestCase):
         table.meta.update(ins_cards)
 
         with pytest.warns(AstropyUserWarning,
-                          match=f'Meta-data keyword \w+ will {diagnose}') as w:
+                          match=rf'Meta-data keyword \w+ will {diag}') as w:
             hdu = fits.table_to_hdu(table)
 
         # This relies on the warnings being raised in the order of the
-        # meta dict (note that the first and last card are legitimate keys
+        # meta dict (note that the first and last card are legitimate keys)
+        assert len(w) == len(ins_cards) - 2
         for i, key in enumerate(list(ins_cards)[1:-1]):
             assert f'Meta-data keyword {key}' in str(w[i].message)
-            
+
         assert hdu.header.get('XTENSION') == 'BINTABLE'
         assert hdu.header.get('NAXIS') == 2
         assert hdu.header.get('NAXIS1') == 13
@@ -124,7 +125,7 @@ class TestConvenience(FitsTestCase):
         """
         Test warning for each keyword in ..connect.REMOVE_KEYWORDS, 1 by 1
         """
-        diagnose = 'be ignored since it conflicts with a FITS reserved keyword'
+        diag = 'be ignored since it conflicts with a FITS reserved keyword'
         res_cards = {'XTENSION': 'BINTABLE', 'BITPIX': 8,
                      'NAXIS': 2, 'NAXIS1': 12, 'NAXIS2': 3,
                      'PCOUNT': 0, 'GCOUNT': 1, 'TFIELDS': 2, 'THEAP': None}
@@ -139,7 +140,7 @@ class TestConvenience(FitsTestCase):
         assert table.meta.get(card) != res_cards[card]
 
         with pytest.warns(AstropyUserWarning,
-                          match=f'Meta-data keyword {card} will {diagnose}'):
+                          match=f'Meta-data keyword {card} will {diag}'):
             hdu = fits.table_to_hdu(table)
 
         assert hdu.header.get(card) == res_cards[card]


### PR DESCRIPTION
Fixes #9387 - `table_to_hdu` now passes over cards with reserved keywords found in `table.meta` after warning about them. One word of code added, plus test and additional test for cards with incompatible data types (`array`, `dict`).