### PR TITLE
Use released numpy for py3.8 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
         # Run test suite twice in a row without cleaning
         - DOUBLE_PLAY=False
         - USE_CI_HELPERS=True
+        # Use this for the dependencies when not using ci-helpers
+        - OTHER_DEPENDENCY_PREFERENCES=''
 
         # PEP8 errors/warnings:
         # E101 - mix of tabs and spaces
@@ -184,12 +186,14 @@ matrix:
                EXTRAS_INSTALL="docs"
 
         # Testing with Travis provided Python3.8. Change this job to a regular
-        # one once conda supports python3.8.
+        # one once conda supports python3.8. Make sure we use released numpy rather
+        # than some kind of dev coming natively from the Travis environment
         - language: python
           stage: Final tests
           dist: xenial
           python: 3.8-dev
           env: INSTALL_WITH_PIP=True EXTRAS_INSTALL="test" USE_CI_HELPERS=False
+               OTHER_DEPENDENCY_PREFERENCES='numpy==1.17.3'
 
     allow_failures:
       - os: linux
@@ -223,9 +227,9 @@ install:
       fi
     - if [[ $INSTALL_WITH_PIP == True ]]; then
         if [ -z $EXTRAS_INSTALL ]; then
-          pip install -e .;
+          pip install -e . ${OTHER_DEPENDENCY_PREFERENCES};
         else
-          pip install -e .[$EXTRAS_INSTALL];
+          pip install -e .[$EXTRAS_INSTALL] ${OTHER_DEPENDENCY_PREFERENCES};
         fi
       fi
 

--- a/astropy/modeling/tests/test_quantities_rotations.py
+++ b/astropy/modeling/tests/test_quantities_rotations.py
@@ -34,7 +34,7 @@ def test_against_wcslib(inp):
 
 
 @pytest.mark.parametrize(('inp'), [(40 * u.deg, -0.057 * u.rad), (21.5 * u.arcsec, 45.9 * u.deg)])
-def test_roundtrip_sky_rotaion(inp):
+def test_roundtrip_sky_rotation(inp):
     lon, lat, lon_pole = 42 * u.deg, (43 * u.deg).to(u.arcsec), (44 * u.deg).to(u.rad)
     n2c = models.RotateNative2Celestial(lon, lat, lon_pole)
     c2n = models.RotateCelestial2Native(lon, lat, lon_pole)

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -38,7 +38,7 @@ def test_against_wcslib(inp):
 
 
 @pytest.mark.parametrize(('inp'), [(0, 0), (40, -20.56), (21.5, 45.9)])
-def test_roundtrip_sky_rotaion(inp):
+def test_roundtrip_sky_rotation(inp):
     lon, lat, lon_pole = 42, 43, 44
     n2c = models.RotateNative2Celestial(lon, lat, lon_pole)
     c2n = models.RotateCelestial2Native(lon, lat, lon_pole)


### PR DESCRIPTION
I know we talked about that it's OK to use numpy dev for py38, but somehow I'm uneasy about not having any control over what version travis uses natively, so just stick for the released version for now (there should be wheels available already, so it shouldn't take long to install).

Also, I've added two minor unrelated typo fixes