### PR TITLE
MNT: Use return_units for Box1D

### DIFF
--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -1652,12 +1652,7 @@ class Box1D(Fittable1DModel):
         """One dimensional Box model function"""
 
         inside = np.logical_and(x >= x_0 - width / 2., x <= x_0 + width / 2.)
-        result = np.select([inside], [amplitude], 0)
-
-        if isinstance(amplitude, Quantity):
-            return Quantity(result, unit=amplitude.unit, copy=False)
-        else:
-            return result
+        return np.select([inside], [amplitude], 0)
 
     @property
     def bounding_box(self):
@@ -1677,6 +1672,13 @@ class Box1D(Fittable1DModel):
             return None
         else:
             return {'x': self.x_0.unit}
+
+    @property
+    def return_units(self):
+        if self.amplitude.unit is None:
+            return None
+        else:
+            return {'y': self.amplitude.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
         return OrderedDict([('x_0', inputs_unit['x']),


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to utilize `return_units` in `Box1D` model.

I am trying to understand when to use `return_units` and when to hardcode unit conversion within `evaluate`. I am hoping that this PR would help me understand such things. From the documentation, I don't see why we cannot use `return_units` for `Box1D`. Did I miss something? The tests passed for me locally.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

cc @karllark 