### PR TITLE
add a way to sidestep common invalid but interpretable units in CCDData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Add a way for technically invalid but unambiguous units in a fits header to be
+  parsed by ``CCDData``. [#9397]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -149,6 +149,15 @@ class CCDData(NDDataArray):
         This method uses :func:`fits_ccddata_writer` with the provided
         parameters.
 
+    Attributes
+    ----------
+    known_invalid_fits_unit_strings
+        A dictionary that maps commonly-used fits unit name strings that are
+        technically invalid to the correct valid unit type (or unit string).
+        This is primarily for variant names like "ELECTRONS/S" which are not
+        formally valid, but are unambiguous and frequently enough encountered
+        that it is convenient to map them to the correct unit.
+
     Notes
     -----
     `~astropy.nddata.CCDData` objects can be easily converted to a regular
@@ -409,6 +418,11 @@ class CCDData(NDDataArray):
         else:
             self.meta[key] = value
 
+    # A dictionary mapping "known" invalid fits unit
+    known_invalid_fits_unit_strings = {'ELECTRONS/S': u.electron/u.s,
+                                       'ELECTRONS': u.electron,
+                                       'electrons': u.electron}
+
 
 # These need to be importable by the tests...
 _KEEP_THESE_KEYWORDS_IN_HEADER = [
@@ -608,6 +622,9 @@ def fits_ccddata_reader(filename, hdu=0, unit=None, hdu_uncertainty='UNCERT',
                 # Convert the BUNIT header keyword to a unit and if that's not
                 # possible raise a meaningful error message.
                 try:
+                    kifus = CCDData.known_invalid_fits_unit_strings
+                    if fits_unit_string in kifus:
+                        fits_unit_string = kifus[fits_unit_string]
                     fits_unit_string = u.Unit(fits_unit_string)
                 except ValueError:
                     raise ValueError(

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -121,6 +121,15 @@ def test_initialize_from_fits_with_invalid_unit_in_header(tmpdir):
         CCDData.read(filename)
 
 
+def test_initialize_from_fits_with_technically_invalid_but_not_really(tmpdir):
+    hdu = fits.PrimaryHDU(np.ones((2, 2)))
+    hdu.header['bunit'] = 'ELECTRONS/S'
+    filename = tmpdir.join('afile.fits').strpath
+    hdu.writeto(filename)
+    ccd = CCDData.read(filename)
+    assert ccd.unit == u.electron/u.s
+
+
 def test_initialize_from_fits_with_data_in_different_extension(tmpdir):
     fake_img = np.arange(4).reshape(2, 2)
     hdu1 = fits.PrimaryHDU()


### PR DESCRIPTION
This PR addresses an annoyance I've encountered several times now.  It's nominally a dupe #7608 but it's also related to #7619.

Arguably, this PR is actually counter to some of the discussion in #7619 but I'm raising it because it's not clear #7619 got resolved, and I keep running into this particular case.  So my concrete proposal in this PR is to have a very explicit set of "known bad but unambiguous" units that `CCDData` knows how to translate.  I'm not proposing we promise that this list is complete or anything like that, but instead to think of it more like the `from_name` machinery in SkyCoord, which is very convenient even if it isn't always 100% reliable.

So basically this PR sets up machinery to do this, and populates with the specific case of #7608 with the expectation that we can add more in the future as users encounter them.  I'd say they have to justify them, which I'm doing here via #7608.

cc @mwcraig @MSeifert04 