### PR TITLE
add numpy ufuncs as models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,7 @@ astropy.modeling
 - Add a new model representing a sequence of rotations in 3D around an arbitrary
   number of axes. [#9369]
 
+- Add many of the numpy ufunc functions as models. [#9401]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -22,6 +22,7 @@ from .tags.time.time import *
 from .tags.time.timedelta import *
 from .tags.transform.basic import *
 from .tags.transform.compound import *
+from .tags.transform.math import *
 from .tags.transform.polynomial import *
 from .tags.transform.projections import *
 from .tags.transform.tabular import *

--- a/astropy/io/misc/asdf/tags/transform/math.py
+++ b/astropy/io/misc/asdf/tags/transform/math.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from numpy.testing import assert_array_equal
+
+from asdf import yamlutil
+
+from astropy import modeling
+from astropy.modeling.math_functions import __all__ as math_classes
+from astropy.modeling.math_functions import *
+from astropy.modeling import math_functions
+from .basic import TransformType
+
+
+__all__ = ['NpUfuncType']
+
+
+class NpUfuncType(TransformType):
+    name = "transform/math_functions"
+    version = '1.0.0'
+    types = ['astropy.modeling.math_functions.'+ kl for kl in math_classes]
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        klass_name = math_functions._make_class_name(node['func_name'])
+        klass = getattr(math_functions, klass_name)
+        return klass()
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'func_name': model.func.__name__}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -38,6 +38,13 @@ test_models = [
 ]
 
 
+math_models = []
+for kl in astmodels.math.__all__:
+    klass = getattr(astmodels.math, kl)
+    math_models.append(klass())
+
+test_models.extend(math_models)
+
 def test_transforms_compound(tmpdir):
     tree = {
         'compound':

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -39,11 +39,13 @@ test_models = [
 
 
 math_models = []
+
 for kl in astmodels.math.__all__:
     klass = getattr(astmodels.math, kl)
     math_models.append(klass())
 
 test_models.extend(math_models)
+
 
 def test_transforms_compound(tmpdir):
     tree = {

--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -42,10 +42,12 @@ def ufunc_model(name):
     nout = ufunc.nout
     if nin == 1:
         separable = True
+
         def evaluate(self, x):
             return self.func(x)
     else:
         separable = False
+
         def evaluate(self, x, y):
             return self.func(x, y)
 

--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 from astropy.modeling.core import Model
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 trig_ufuncs = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "arctan2",
@@ -26,10 +27,6 @@ class _NPUfuncModel(Model):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    def evaluate(self, x):
-        warnings.warn("Models in math_functions are experimental.")
-        return self.func(x)
-
 
 def _make_class_name(name):
     """ Make a ufunc model class name from the name of the ufunc. """
@@ -44,11 +41,13 @@ def ufunc_model(name):
         separable = True
 
         def evaluate(self, x):
+            warnings.warn("Models in math_functions are experimental.", AstropyUserWarning)
             return self.func(x)
     else:
         separable = False
 
         def evaluate(self, x, y):
+            warnings.warn("Models in math_functions are experimental.", AstropyUserWarning)
             return self.func(x, y)
 
     klass_name = _make_class_name(name)

--- a/astropy/modeling/math_functions.py
+++ b/astropy/modeling/math_functions.py
@@ -1,0 +1,67 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import warnings
+import numpy as np
+
+from astropy.modeling.core import Model
+
+
+trig_ufuncs = ["sin", "cos", "tan", "arcsin", "arccos", "arctan", "arctan2",
+               "hypot", "sinh", "cosh", "tanh", "arcsinh", "arccosh",
+               "arctanh", "deg2rad", "rad2deg"]
+
+
+math_ops = ["add", "subtract", "multiply", "divide", "logaddexp", "logaddexp2",
+            "true_divide", "floor_divide", "negative", "positive", "power",
+            "remainder", "mod", "fmod", "divmod", "absolute", "fabs", "rint",
+            "exp", "exp2", "log", "log2", "log10", "expm1", "log1p", "sqrt",
+            "square", "cbrt", "reciprocal"]
+
+
+supported_ufuncs = trig_ufuncs + math_ops
+
+
+class _NPUfuncModel(Model):
+    _is_dynamic = True
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def evaluate(self, x):
+        warnings.warn("Models in math_functions are experimental.")
+        return self.func(x)
+
+
+def _make_class_name(name):
+    """ Make a ufunc model class name from the name of the ufunc. """
+    return name[0].upper() + name[1:] + 'Ufunc'
+
+
+def ufunc_model(name):
+    ufunc = getattr(np, name)
+    nin = ufunc.nin
+    nout = ufunc.nout
+    if nin == 1:
+        separable = True
+        def evaluate(self, x):
+            return self.func(x)
+    else:
+        separable = False
+        def evaluate(self, x, y):
+            return self.func(x, y)
+
+    klass_name = _make_class_name(name)
+
+    members = {'n_inputs': nin, 'n_outputs': nout, 'func': ufunc,
+               'linear': False, 'fittable': False, '_separable': separable,
+               '_is_dynamic': True, 'evaluate': evaluate}
+
+    return type(str(klass_name), (_NPUfuncModel,), members)
+
+
+__all__ = []
+
+for name in supported_ufuncs:
+    m = ufunc_model(name)
+    klass_name = m.__name__
+    globals()[klass_name] = m
+    __all__.append(klass_name)

--- a/astropy/modeling/models.py
+++ b/astropy/modeling/models.py
@@ -14,6 +14,7 @@ from .functional_models import *
 from .powerlaws import *
 from .tabular import *
 from .blackbody import BlackBody1D
+from . import math_functions as math
 
 
 """

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -8,6 +8,7 @@ from .. import math_functions
 x = np.linspace(-20, 360, 100)
 y = np.linspace(-20, 360, 100)
 
+
 def test_math():
     for name in math_functions.__all__:
         model = getattr(math_functions, name)()

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -1,0 +1,18 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_allclose#, assert_quantity_allclose
+
+from .. import math_functions
+
+x = np.linspace(-20, 360, 100)
+y = np.linspace(-20, 360, 100)
+
+def test_math():
+    for name in math_functions.__all__:
+        model = getattr(math_functions, name)()
+        print('name', name)
+        if model.n_inputs == 1:
+            assert_allclose(model(x), model.func(x))
+        elif model.n_inputs == 2:
+            assert_allclose(model(x, y), model.func(x, y))

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -12,8 +12,8 @@ y = np.linspace(-20, 360, 100)
 def test_math():
     for name in math_functions.__all__:
         model = getattr(math_functions, name)()
-        print('name', name)
+        func = getattr(np, model.func.__name__)
         if model.n_inputs == 1:
-            assert_allclose(model(x), model.func(x))
+            assert_allclose(model(x), func(x))
         elif model.n_inputs == 2:
-            assert_allclose(model(x, y), model.func(x, y))
+            assert_allclose(model(x, y), func(x, y))


### PR DESCRIPTION
This PR adds many of the numpy ufuncs as models in astropy.modeling.

The schema is defined in spacetelescope/asdf-standard#210.