### PR TITLE
Add info on creating multi-ext files to "Getting started" page of io.fits

### DIFF
--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -589,6 +589,42 @@ lines to accomplish the same behavior::
 This will write a single HDU to a FITS file without having to manually
 encapsulate it in an :class:`HDUList` object first.
 
+Creating a Multi-Extension Image File
+"""""""""""""""""""""""""""""""""""""
+
+In the previous example we created an :class:`HDUList` object with a single
+extension (a :class:`PrimaryHDU`). To create a file with multiple extensions we need to
+use :class:`ImageHDU`\s and append them to an :class:`HDUList`.
+
+First, let's create some more data::
+
+    >>> n2 = np.random.random((3, 3)) # A random 3x3 array
+    >>> n3 = np.random.random((100, 100)) # A random 100x100 array
+
+Note that the data shapes of the different extensions do not need to be the same. Next
+place the data into separate :class:`ImageHDU` objects::
+
+    >>> hdu2 = fits.ImageHDU(n2)
+    >>> hdu3 = fits.ImageHDU(n3)
+
+Now when we create the :class:`HDUList` we simply list all extensions we want to include::
+
+    >>> hdul = fits.HDUList([hdu, hdu2, hdu3])
+
+Because :class:`HDUList` acts like a :class:`list` we can also append an :class:`ImageHDU`
+to an already-existing :class:`HDUList`::
+
+    >>> hdul.append(hdu3)
+
+Multi-extension :class:`HDUList` are treated just like those with only a :class:`PrimaryHDU`,
+so to save the file use :func:`HDUList.writeto` as shown above.
+
+.. note::
+
+    The FITS standard enforces all files to have exactly one :class:`PrimaryHDU` that is the
+    first HDU present in the file. This standard is enforced during the call to
+    :func:`HDUList.writeto` and an error will be raised if it is not met. See the ``output_verify``
+    option in :func:`HDUList.writeto` for ways to fix or ignore these warnings.
 
 Creating a New Table File
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -575,7 +575,7 @@ Next, we create a :class:`PrimaryHDU` object to encapsulate the data::
 
     >>> hdu = fits.PrimaryHDU(n)
 
-We then create a HDUList to contain the newly created primary HDU, and write to
+We then create an :class:`HDUList` to contain the newly created primary HDU, and write to
 a new file::
 
     >>> hdul = fits.HDUList([hdu])

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -589,8 +589,8 @@ lines to accomplish the same behavior::
 This will write a single HDU to a FITS file without having to manually
 encapsulate it in an :class:`HDUList` object first.
 
-Creating a Multi-Extension Image File
-"""""""""""""""""""""""""""""""""""""
+Creating an Image File with Multiple Extensions
+"""""""""""""""""""""""""""""""""""""""""""""""
 
 In the previous example we created an :class:`HDUList` object with a single
 extension (a :class:`PrimaryHDU`). To create a file with multiple extensions we need to
@@ -598,8 +598,8 @@ use :class:`ImageHDU`\s and append them to an :class:`HDUList`.
 
 First, let's create some more data::
 
-    >>> n2 = np.random.random((3, 3)) # A random 3x3 array
-    >>> n3 = np.random.random((100, 100)) # A random 100x100 array
+    >>> n2 = np.ones((3, 3))
+    >>> n3 = np.ones((100, 100))
 
 Note that the data shapes of the different extensions do not need to be the same. Next
 place the data into separate :class:`ImageHDU` objects::
@@ -609,10 +609,10 @@ place the data into separate :class:`ImageHDU` objects::
 
 Now when we create the :class:`HDUList` we simply list all extensions we want to include::
 
-    >>> hdul = fits.HDUList([hdu, hdu2, hdu3])
+    >>> hdul = fits.HDUList([hdu, hdu2])
 
 Because :class:`HDUList` acts like a :class:`list` we can also append an :class:`ImageHDU`
-to an already-existing :class:`HDUList`::
+to an already existing :class:`HDUList`::
 
     >>> hdul.append(hdu3)
 

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -596,18 +596,18 @@ In the previous example we created an :class:`HDUList` object with a single
 extension (a :class:`PrimaryHDU`). To create a file with multiple extensions we need to
 use :class:`ImageHDU`\s and append them to an :class:`HDUList`.
 
-First, let's create some more data::
+First, we create some more data::
 
     >>> n2 = np.ones((3, 3))
     >>> n3 = np.ones((100, 100))
 
-Note that the data shapes of the different extensions do not need to be the same. Next
+Note that the data shapes of the different extensions do not need to be the same. Next,
 place the data into separate :class:`ImageHDU` objects::
 
     >>> hdu2 = fits.ImageHDU(n2)
     >>> hdu3 = fits.ImageHDU(n3)
 
-Now when we create the :class:`HDUList` we simply list all extensions we want to include::
+Now when we create the :class:`HDUList` we list all extensions we want to include::
 
     >>> hdul = fits.HDUList([hdu, hdu2])
 


### PR DESCRIPTION
The concept of using ``ImageHDU`` objects to construct files with more than one extension is not really addressed on the Getting Started page. This PR attempts to add that information in a simple way.

Maybe this is beyond what should be on this page, but I'm not sure it's explicitly called out anywhere else.