### PR TITLE
Adding performance message for Table.read with `memmap=True`

### DIFF
--- a/docs/table/performance.inc.rst
+++ b/docs/table/performance.inc.rst
@@ -55,13 +55,13 @@ subset of rows, but reading a full column load the whole table data into memory:
 
     >>> import numpy as np
     >>> from astropy.table import Table
-    >>> tbl = Table({ 'a': np.arange(1e7),
-    ...               'b': np.arange(1e7, dtype=float),
-    ...               'c': np.arange(1e7, dtype=float)})
+    >>> tbl = Table({'a': np.arange(1e7),
+    ...              'b': np.arange(1e7, dtype=float),
+    ...              'c': np.arange(1e7, dtype=float)})
     >>> tbl.write('test.fits', overwrite=True)
-    >>> table = Table.read('test.fits', memmap=True) # Very fast, doesn't actually load data
-    >>> table2 = tbl[:100] #  Fast, will read only first 100 rows
-    >>> print(table2) # accessing column data triggers the read
+    >>> table = Table.read('test.fits', memmap=True)  # Very fast, doesn't actually load data
+    >>> table2 = tbl[:100]  # Fast, will read only first 100 rows
+    >>> print(table2)  # Accessing column data triggers the read
      a    b    c  
     ---- ---- ----
     0.0  0.0  0.0
@@ -71,7 +71,7 @@ subset of rows, but reading a full column load the whole table data into memory:
     98.0 98.0 98.0
     99.0 99.0 99.0
     Length = 100 rows
-    >>> col = table['my_column'] # Will load all table into memory
+    >>> col = table['my_column']  # Will load all table into memory
 
 At the moment :meth:`~astropy.table.Table.read` does not support ``memmap=True`` for the HDF5 and 
 ASCII file formats.

--- a/docs/table/performance.inc.rst
+++ b/docs/table/performance.inc.rst
@@ -45,11 +45,11 @@ Read FITS with memmap=True
 
 By default :meth:`~astropy.table.Table.read` will read the whole table into memory, which 
 can take a lot of memory and can take a lot of time, depending on the table size and 
-file format. In some cases, it's possible to only read a subset of the table by choosing 
+file format. In some cases, it is possible to only read a subset of the table by choosing 
 the option ``memmap=True``.
 
 For FITS binary tables, the data is stored row by row, and it is possible to read only a 
-subset of rows, but reading a full column load the whole table data into memory:
+subset of rows, but reading a full column loads the whole table data into memory:
 
 .. doctest-skip::
 

--- a/docs/table/performance.inc.rst
+++ b/docs/table/performance.inc.rst
@@ -45,7 +45,7 @@ Read FITS with memmap=True
 
 By default :meth:`~astropy.table.Table.read` will read the whole table into memory, which 
 can take a lot of memory and can take a lot of time, depending on the table size and 
-file format. In some cases, it's possibly to only read a subset of the table by choosing 
+file format. In some cases, it's possible to only read a subset of the table by choosing 
 the option ``memmap=True``.
 
 For FITS binary tables, the data is stored row by row, and it is possible to read only a 
@@ -59,7 +59,7 @@ subset of rows, but reading a full column load the whole table data into memory:
     ...               'b': np.arange(1e7, dtype=float),
     ...               'c': np.arange(1e7, dtype=float)})
     >>> tbl.write('test.fits', overwrite=True)
-    >>> table = Table.read("test.fits", memmap=True) # Very fast, doesn't actually load data
+    >>> table = Table.read('test.fits', memmap=True) # Very fast, doesn't actually load data
     >>> table2 = tbl[:100] #  Fast, will read only first 100 rows
     >>> print(table2) # accessing column data triggers the read
      a    b    c  
@@ -71,7 +71,7 @@ subset of rows, but reading a full column load the whole table data into memory:
     98.0 98.0 98.0
     99.0 99.0 99.0
     Length = 100 rows
-    >>> col = table["my_column"] # Will load all table into memory
+    >>> col = table['my_column'] # Will load all table into memory
 
 At the moment :meth:`~astropy.table.Table.read` does not support ``memmap=True`` for the HDF5 and 
 ASCII file formats.

--- a/docs/table/performance.inc.rst
+++ b/docs/table/performance.inc.rst
@@ -39,3 +39,33 @@ then use ``serialize_method='data_mask'``.
 It uses the non-masked version of data and it is faster::
 
     >>> tm.write('tm.ecsv', overwrite=True, serialize_method='data_mask') # doctest: +SKIP
+
+Reading a large FITS file in |Table| using
+:meth:`~astropy.table.Table.read` when ``memmap=False`` can be very slow
+because it reads full |Table| in the memory. When you want to read a 
+large FITS file using :meth:`~astropy.table.Table.read`, then use ``memmap=True``.
+It does not load the data:
+
+.. doctest-skip::
+
+    >>> import numpy as np
+    >>> from astropy.table import Table
+    >>> tbl = Table({ 'a': np.arange(1e7),
+    ...               'b': np.arange(1e7, dtype=float),
+    ...               'c': np.arange(1e7, dtype=float)})
+    >>> tbl.write('test.fits', overwrite=True)
+    >>> t = Table.read('test.fits', memmap=True)
+
+When we use columns data it loads whole data. Reading a single or multiple |Column| is not 
+helpful because whole data will be loaded:
+
+.. doctest-skip::
+
+    >>> a = t['a']
+
+You can use ``memmap=True`` when want to slice data row-wise. |Table| will load only those
+ rows in memory:
+
+.. doctest-skip::
+
+    >>> t2 = t[:1_000]

--- a/docs/table/performance.inc.rst
+++ b/docs/table/performance.inc.rst
@@ -40,11 +40,11 @@ It uses the non-masked version of data and it is faster::
 
     >>> tm.write('tm.ecsv', overwrite=True, serialize_method='data_mask') # doctest: +SKIP
 
-Read FILE with memmap=True
+Read FITS with memmap=True
 --------------------------
 
 By default :meth:`~astropy.table.Table.read` will read the whole table into memory, which 
-will take a lot of memory and can take a lot of time, depending on the table size and 
+can take a lot of memory and can take a lot of time, depending on the table size and 
 file format. In some cases, it's possibly to only read a subset of the table by choosing 
 the option ``memmap=True``.
 
@@ -73,5 +73,5 @@ subset of rows, but reading a full column load the whole table data into memory:
     Length = 100 rows
     >>> col = table["my_column"] # Will load all table into memory
 
-Right now :meth:`~astropy.table.Table.read` does not supports ``memmap=True`` for HDF5 and ASCII 
-file formats.
+At the moment :meth:`~astropy.table.Table.read` does not support ``memmap=True`` for the HDF5 and 
+ASCII file formats.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8573

I added an example in performance docs to show an efficient way to use `Table.read()`.