### PR TITLE
Add message indicating import numpy failed

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -107,14 +107,14 @@ def _check_numpy():
     try:
         import numpy
     except ImportError:
-        import_fail = 'Cannot import numpy at all.'
+        import_fail = 'Numpy is not installed.'
     else:
         from .utils import minversion
         requirement_met = minversion(numpy, __minimum_numpy_version__)
 
     if not requirement_met:
-        msg = ("Numpy version {0} or later must be installed to use "
-               "Astropy. {1}".format(__minimum_numpy_version__, import_fail))
+        msg = (f"Numpy version {__minimum_numpy_version__} or later must "
+               f"be installed to use Astropy. {import_fail}")
         raise ImportError(msg)
 
     return numpy

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -103,18 +103,18 @@ def _check_numpy():
     # Note: We could have used distutils.version for this comparison,
     # but it seems like overkill to import distutils at runtime.
     requirement_met = False
-
+    import_fail = ''
     try:
         import numpy
     except ImportError:
-        pass
+        import_fail = 'Cannot import numpy at all.'
     else:
         from .utils import minversion
         requirement_met = minversion(numpy, __minimum_numpy_version__)
 
     if not requirement_met:
-        msg = ("Numpy version {} or later must be installed to use "
-               "Astropy".format(__minimum_numpy_version__))
+        msg = ("Numpy version {0} or later must be installed to use "
+               "Astropy. {1}".format(__minimum_numpy_version__, import_fail))
         raise ImportError(msg)
 
     return numpy


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request supplements the `astropy._check_numpy()` function with additional information if `import numpy` fails outright.  There is no change to the functionality of `_check_numpy()`.

I couldn't find any existing tests of `astropy._check_numpy()`.  If there is such a test, where should I look for it?

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9398
