### PR TITLE
MNT: Remove OrderedDict from _parameter_units_for_data_units

### DIFF
--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -2,9 +2,7 @@
 """
 Model and functions related to blackbody radiation.
 """
-
 import warnings
-from collections import OrderedDict
 
 import numpy as np
 
@@ -157,8 +155,8 @@ class BlackBody1D(Fittable1DModel):
         return {'x': u.Hz}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('temperature', u.K),
-                            ('bolometric_flux', outputs_unit['y'] * u.Hz)])
+        return {'temperature': u.K,
+                'bolometric_flux': outputs_unit['y'] * u.Hz}
 
     @property
     def lambda_max(self):

--- a/astropy/modeling/functional_models.py
+++ b/astropy/modeling/functional_models.py
@@ -2,9 +2,6 @@
 
 """Mathematical models."""
 
-
-from collections import OrderedDict
-
 import numpy as np
 
 from astropy import units as u
@@ -185,9 +182,9 @@ class Gaussian1D(Fittable1DModel):
             return {'x': self.mean.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('mean', inputs_unit['x']),
-                            ('stddev', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'mean': inputs_unit['x'],
+                'stddev': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Gaussian2D(Fittable2DModel):
@@ -444,12 +441,12 @@ class Gaussian2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_mean', inputs_unit['x']),
-                            ('y_mean', inputs_unit['x']),
-                            ('x_stddev', inputs_unit['x']),
-                            ('y_stddev', inputs_unit['x']),
-                            ('theta', u.rad),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_mean': inputs_unit['x'],
+                'y_mean': inputs_unit['x'],
+                'x_stddev': inputs_unit['x'],
+                'y_stddev': inputs_unit['x'],
+                'theta': u.rad,
+                'amplitude': outputs_unit['z']}
 
 
 class Shift(Fittable1DModel):
@@ -497,7 +494,7 @@ class Shift(Fittable1DModel):
         return [d_offset]
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('offset', outputs_unit['y'])])
+        return {'offset': outputs_unit['y']}
 
 
 class Scale(Fittable1DModel):
@@ -557,7 +554,7 @@ class Scale(Fittable1DModel):
         unit = outputs_unit['y'] / inputs_unit['x']
         if unit == u.one:
             unit = None
-        return OrderedDict([('factor', unit)])
+        return {'factor': unit}
 
 
 class Multiply(Fittable1DModel):
@@ -594,7 +591,7 @@ class Multiply(Fittable1DModel):
         return [d_factor]
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('factor', outputs_unit['y'])])
+        return {'factor': outputs_unit['y']}
 
 
 class RedshiftScaleFactor(Fittable1DModel):
@@ -728,8 +725,8 @@ class Sersic1D(Fittable1DModel):
             return {'x': self.r_eff.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('r_eff', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'r_eff': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Sine1D(Fittable1DModel):
@@ -814,8 +811,8 @@ class Sine1D(Fittable1DModel):
             return {'x': 1. / self.frequency.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('frequency', inputs_unit['x'] ** -1),
-                            ('amplitude', outputs_unit['y'])])
+        return {'frequency': inputs_unit['x'] ** -1,
+                'amplitude': outputs_unit['y']}
 
 
 class Linear1D(Fittable1DModel):
@@ -873,8 +870,8 @@ class Linear1D(Fittable1DModel):
             return {'x': self.intercept.unit / self.slope.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('intercept', outputs_unit['y']),
-                            ('slope', outputs_unit['y'] / inputs_unit['x'])])
+        return {'intercept': outputs_unit['y'],
+                'slope': outputs_unit['y'] / inputs_unit['x']}
 
 
 class Planar2D(Fittable2DModel):
@@ -920,9 +917,9 @@ class Planar2D(Fittable2DModel):
         return [d_slope_x, d_slope_y, d_intercept]
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('intercept', outputs_unit['z']),
-                            ('slope_x', outputs_unit['z'] / inputs_unit['x']),
-                            ('slope_y', outputs_unit['z'] / inputs_unit['y'])])
+        return {'intercept': outputs_unit['z'],
+                'slope_x': outputs_unit['z'] / inputs_unit['x'],
+                'slope_y': outputs_unit['z'] / inputs_unit['y']}
 
 
 class Lorentz1D(Fittable1DModel):
@@ -1019,9 +1016,9 @@ class Lorentz1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('fwhm', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'fwhm': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Voigt1D(Fittable1DModel):
@@ -1123,10 +1120,10 @@ class Voigt1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('fwhm_L', inputs_unit['x']),
-                            ('fwhm_G', inputs_unit['x']),
-                            ('amplitude_L', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'fwhm_L': inputs_unit['x'],
+                'fwhm_G': inputs_unit['x'],
+                'amplitude_L': outputs_unit['y']}
 
 
 class Const1D(Fittable1DModel):
@@ -1203,7 +1200,7 @@ class Const1D(Fittable1DModel):
         return None
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('amplitude', outputs_unit['y'])])
+        return {'amplitude': outputs_unit['y']}
 
 
 class Const2D(Fittable2DModel):
@@ -1252,7 +1249,7 @@ class Const2D(Fittable2DModel):
         return None
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('amplitude', outputs_unit['z'])])
+        return {'amplitude': outputs_unit['z']}
 
 
 class Ellipse2D(Fittable2DModel):
@@ -1380,12 +1377,12 @@ class Ellipse2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('a', inputs_unit['x']),
-                            ('b', inputs_unit['x']),
-                            ('theta', u.rad),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'a': inputs_unit['x'],
+                'b': inputs_unit['x'],
+                'theta': u.rad,
+                'amplitude': outputs_unit['z']}
 
 
 class Disk2D(Fittable2DModel):
@@ -1463,10 +1460,10 @@ class Disk2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('R_0', inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'R_0': inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class Ring2D(Fittable2DModel):
@@ -1570,11 +1567,11 @@ class Ring2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('r_in', inputs_unit['x']),
-                            ('width', inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'r_in': inputs_unit['x'],
+                'width': inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class Delta1D(Fittable1DModel):
@@ -1682,9 +1679,9 @@ class Box1D(Fittable1DModel):
             return {'y': self.amplitude.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('width', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'width': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Box2D(Fittable2DModel):
@@ -1769,11 +1766,11 @@ class Box2D(Fittable2DModel):
                     'y': self.y_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['y']),
-                            ('x_width', inputs_unit['x']),
-                            ('y_width', inputs_unit['y']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['y'],
+                'x_width': inputs_unit['x'],
+                'y_width': inputs_unit['y'],
+                'amplitude': outputs_unit['z']}
 
 
 class Trapezoid1D(Fittable1DModel):
@@ -1868,10 +1865,10 @@ class Trapezoid1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('width', inputs_unit['x']),
-                            ('slope', outputs_unit['y'] / inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'width': inputs_unit['x'],
+                'slope': outputs_unit['y'] / inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class TrapezoidDisk2D(Fittable2DModel):
@@ -1945,11 +1942,11 @@ class TrapezoidDisk2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('R_0', inputs_unit['x']),
-                            ('slope', outputs_unit['z'] / inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'R_0': inputs_unit['x'],
+                'slope': outputs_unit['z'] / inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class MexicanHat1D(Fittable1DModel):
@@ -2035,9 +2032,9 @@ class MexicanHat1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('sigma', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'sigma': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class MexicanHat2D(Fittable2DModel):
@@ -2097,10 +2094,10 @@ class MexicanHat2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('sigma', inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'sigma': inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class AiryDisk2D(Fittable2DModel):
@@ -2198,10 +2195,10 @@ class AiryDisk2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('radius', inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'radius': inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class Moffat1D(Fittable1DModel):
@@ -2294,9 +2291,9 @@ class Moffat1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('gamma', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'gamma': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Moffat2D(Fittable2DModel):
@@ -2381,10 +2378,10 @@ class Moffat2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('gamma', inputs_unit['x']),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'gamma': inputs_unit['x'],
+                'amplitude': outputs_unit['z']}
 
 
 class Sersic2D(Fittable2DModel):
@@ -2503,11 +2500,11 @@ class Sersic2D(Fittable2DModel):
         # defined.
         if inputs_unit['x'] != inputs_unit['y']:
             raise UnitsError("Units of 'x' and 'y' inputs should match")
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('y_0', inputs_unit['x']),
-                            ('r_eff', inputs_unit['x']),
-                            ('theta', u.rad),
-                            ('amplitude', outputs_unit['z'])])
+        return {'x_0': inputs_unit['x'],
+                'y_0': inputs_unit['x'],
+                'r_eff': inputs_unit['x'],
+                'theta': u.rad,
+                'amplitude': outputs_unit['z']}
 
 
 class KingProjectedAnalytic1D(Fittable1DModel):
@@ -2640,9 +2637,9 @@ class KingProjectedAnalytic1D(Fittable1DModel):
             return {'x': self.r_core.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('r_core', inputs_unit['x']),
-                            ('r_tide', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'r_core': inputs_unit['x'],
+                'r_tide': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Logarithmic1D(Fittable1DModel):
@@ -2691,8 +2688,8 @@ class Logarithmic1D(Fittable1DModel):
             return {'x': self.tau.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('tau', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'tau': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class Exponential1D(Fittable1DModel):
@@ -2740,5 +2737,5 @@ class Exponential1D(Fittable1DModel):
             return {'x': self.tau.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('tau', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'tau': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1,11 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 This module contains models representing polynomials and polynomial series.
 """
-
-from collections import OrderedDict
-
 import numpy as np
 
 from .core import FittableModel, Model
@@ -836,11 +832,11 @@ class Polynomial1D(PolynomialModel):
             return {'x': self.c0.unit / self.c1.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        mapping = []
+        mapping = {}
         for i in range(self.degree + 1):
             par = getattr(self, f'c{i}')
-            mapping.append((par.name, outputs_unit['y'] / inputs_unit['x'] ** i))
-        return OrderedDict(mapping)
+            mapping[par.name] = outputs_unit['y'] / inputs_unit['x'] ** i
+        return mapping
 
 
 class Polynomial2D(PolynomialModel):
@@ -1002,14 +998,14 @@ class Polynomial2D(PolynomialModel):
                     'y': self.c0_0.unit / self.c0_1.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        mapping = []
+        mapping = {}
         for i in range(self.degree + 1):
             for j in range(self.degree + 1):
                 if i + j > 2:
                     continue
                 par = getattr(self, f'c{i}_{j}')
-                mapping.append((par.name, outputs_unit['z'] / inputs_unit['x'] ** i / inputs_unit['y'] ** j))
-        return OrderedDict(mapping)
+                mapping[par.name] = outputs_unit['z'] / inputs_unit['x'] ** i / inputs_unit['y'] ** j  # noqa
+        return mapping
 
 
 class Chebyshev2D(OrthoPolynomialBase):

--- a/astropy/modeling/powerlaws.py
+++ b/astropy/modeling/powerlaws.py
@@ -1,12 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
 """
 Power law model variants
 """
-
-
-from collections import OrderedDict
-
 import numpy as np
 
 from .core import Fittable1DModel
@@ -72,8 +67,8 @@ class PowerLaw1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class BrokenPowerLaw1D(Fittable1DModel):
@@ -146,8 +141,8 @@ class BrokenPowerLaw1D(Fittable1DModel):
             return {'x': self.x_break.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_break', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_break': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
@@ -382,8 +377,8 @@ class SmoothlyBrokenPowerLaw1D(Fittable1DModel):
             return {'x': self.x_break.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_break', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_break': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class ExponentialCutoffPowerLaw1D(Fittable1DModel):
@@ -447,9 +442,9 @@ class ExponentialCutoffPowerLaw1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('x_cutoff', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'x_cutoff': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 
 class LogParabola1D(Fittable1DModel):
@@ -514,5 +509,5 @@ class LogParabola1D(Fittable1DModel):
             return {'x': self.x_0.unit}
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('x_0', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'x_0': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}

--- a/docs/modeling/add-units.rst
+++ b/docs/modeling/add-units.rst
@@ -115,8 +115,8 @@ from both the models and the data. The following example shows the
 implementation for the 1D Gaussian::
 
     def _parameter_units_for_data_units(self, inputs_unit, outputs_unit):
-        return OrderedDict([('mean', inputs_unit['x']),
-                            ('stddev', inputs_unit['x']),
-                            ('amplitude', outputs_unit['y'])])
+        return {'mean': inputs_unit['x'],
+                'stddev': inputs_unit['x'],
+                'amplitude': outputs_unit['y']}
 
 With this method in place, the model can then be fit to data that has units.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to remove the unnecessary `OrderedDict` in model `_parameter_units_for_data_units` definitions.

**TODO**

- [x] Do we really want to go ahead with this? There must be a reason why @astrofrog used `OrderedDict`? But tests pass, so... 🤷‍♀ 
- [x] Do we need a change log if there is no behavorial change?
- [x] Change the rest of the models in `modeling` and make sure tests pass.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9403 