### PR TITLE
Add set_world_aspect to WCSAxes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,8 @@ astropy.utils
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
+- Added `astropy.visualization.WCSAxes.set_world_aspect()` to set the aspect
+  of WCSAxes in world coordinates. [#9410]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -758,6 +758,16 @@ class WCSAxes(Axes):
         kwargs : dict
             Keyword arguments are handed to
             `matplotib.axes.Axes.set_aspect`.
+
+        Warnings
+        --------
+        Setting an equal world aspect only makes sense when the transformation
+        from pixel to world coordinates is linear.
+
+        Notes
+        -----
+        The aspect is calculated using the ratio of the difference between
+        pixel and world coordinates at (0, 0) and (1, 1) in pixel coordinates.
         """
         xunit, yunit = self.wcs.world_axis_units
         x0, y0 = self.wcs.pixel_to_world_values((0, ), (0, ))

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -757,7 +757,7 @@ class WCSAxes(Axes):
              times the width in world coordinates.
         kwargs : dict
             Keyword arguments are handed to
-            `matplotib.axes.Axes.set_aspect`.
+            :meth:`~matplotib.axes.Axes.set_aspect`.
 
         Warnings
         --------

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -746,6 +746,34 @@ class WCSAxes(Axes):
                 if spine in coord.axislabels.get_visible_axes():
                     coord.tick_params(**kwargs)
 
+    def set_world_aspect(self, aspect, **kwargs):
+        """
+        Set the aspect of the axes in world coordinates.
+
+        Parameters
+        ----------
+        aspect : float
+             A circle will be stretched such that the height is *aspect*
+             times the width in world coordinates.
+        kwargs : dict
+            Keyword arguments are handed to
+            `matplotib.axes.Axes.set_aspect`.
+        """
+        xunit, yunit = self.wcs.world_axis_units
+        x0, y0 = self.wcs.pixel_to_world_values((0, ), (0, ))
+        x1, y1 = self.wcs.pixel_to_world_values((1, ), (1, ))
+
+        cdelt = ((x1 - x0) * u.Unit(xunit), (y1 - y0) * u.Unit(yunit))
+
+        try:
+            equal_world_aspect = float(np.abs(cdelt[1] / cdelt[0]))
+        except TypeError:
+            raise RuntimeError('Axis units must be of the same '
+                               'physical units to set the same '
+                               'world aspect '
+                               f'(units are x:{xunit}, y:{yunit}).')
+        self.set_aspect(equal_world_aspect * aspect, **kwargs)
+
 
 # In the following, we put the generated subplot class in a temporary class and
 # we then inherit it - if we don't do this, the generated class appears to

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -18,6 +18,7 @@ from astropy.time import Time
 from astropy.units import Quantity
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
 from astropy.wcs import WCS
+from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.visualization.wcsaxes.frame import RectangularFrame, RectangularFrame1D
 from astropy.visualization.wcsaxes.wcsapi import (WCSWorld2PixelTransform,
                                                   transform_coord_meta_from_wcs,
@@ -422,3 +423,30 @@ class TestWCSAPI:
         ax.set_xlim(-0.5, 148.5)
         ax.set_ylim(-0.5, 148.5)
         return fig
+
+
+def test_set_world_aspect():
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = ['x', 'y']
+    wcs.wcs.cunit = ['km', 'km']
+    wcs.wcs.crpix = [614.5, 856.5]
+    wcs.wcs.cdelt = [6.25, 6.25]
+    wcs.wcs.crval = [0., 0.]
+
+    fig = plt.figure()
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs)
+    ax.set_world_aspect(1)
+    assert ax.get_aspect() == 1
+
+    # Check with different cdelt values
+    wcs.wcs.cdelt = [1, 2]
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs)
+    ax.set_world_aspect(1)
+    assert ax.get_aspect() == 2
+
+    # Check that different units errors
+    wcs.wcs.cunit = ['s', 'km']
+    ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8], wcs=wcs)
+    with pytest.raises(RuntimeError,
+                       match='Axis units must be of the same physical units'):
+        ax.set_world_aspect(1)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
Adds `set_world_aspect` to `WCSAxes`, to set the display aspect in world coordinates (as opposed to pixel coordinates). I have copied the normal [set_aspect()](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.set_aspect.html) API, but haven't allowed a string of 'auto' or 'equal' to be passed, since I think it's easy enough for `1` to be passed for equal, and the normal `set_aspect('auto')` can be used in the 'auto' case.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9399
