### PR TITLE
Document that theta for Gaussian2DKernel can be a Quantity

### DIFF
--- a/astropy/convolution/kernels.py
+++ b/astropy/convolution/kernels.py
@@ -101,9 +101,9 @@ class Gaussian2DKernel(Kernel2D):
         Standard deviation of the Gaussian in x before rotating by theta.
     y_stddev : float
         Standard deviation of the Gaussian in y before rotating by theta.
-    theta : float
-        Rotation angle in radians. The rotation angle increases
-        counterclockwise.
+    theta : float or :class:`~astropy.units.Quantity`
+        Rotation angle. If passed as a float, it is assumed to be in radians.
+        The rotation angle increases counterclockwise.
     x_size : odd int, optional
         Size in x direction of the kernel array. Default = 8 * stddev.
     y_size : odd int, optional

--- a/astropy/convolution/tests/test_convolve_kernels.py
+++ b/astropy/convolution/tests/test_convolve_kernels.py
@@ -4,8 +4,9 @@ import itertools
 
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_allclose
 
+from astropy import units as u
 from astropy.convolution.convolve import convolve, convolve_fft
 from astropy.convolution.kernels import Gaussian2DKernel, Box2DKernel, Tophat2DKernel
 from astropy.convolution.kernels import Moffat2DKernel
@@ -127,3 +128,10 @@ class Test2DConvolutions:
         c1 = convolve(x, kernel1, boundary='fill')
 
         assert_almost_equal(c1, c2, decimal=12)
+
+
+def test_gaussian_2d_kernel_quantity():
+    # Make sure that the angle can be a quantity
+    kernel1 = Gaussian2DKernel(x_stddev=2, y_stddev=4, theta=45 * u.deg)
+    kernel2 = Gaussian2DKernel(x_stddev=2, y_stddev=4, theta=np.pi / 4)
+    assert_allclose(kernel1.array, kernel2.array)


### PR DESCRIPTION
I think this silently stated working when we implemented units in modeling. I've updated the docstring and added a unit test to make sure it doesn't break in future. Since it's not actually new here I'm not adding a changelog entry.

All convolution maintainers tagged for review, but I think one review will be enough!