### PR TITLE
Add Table.drop_array_columns and improve Table.to_pandas

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -770,7 +770,6 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
         else:
             return super().tolist()
 
-
 class Column(BaseColumn):
     """Define a data column for use in a Table object.
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2967,12 +2967,15 @@ class Table:
         representation in pandas using ``np.datetime64`` or ``np.timedelta64``.
         See the example below.
 
+        Parameters
+        ----------
+        index : None, bool, str
+            Specify DataFrame index mode
+
         Returns
         -------
         dataframe : :class:`pandas.DataFrame`
             A pandas :class:`pandas.DataFrame` instance
-        index : None, bool, str
-            Specify DataFrame index mode
 
         Raises
         ------
@@ -3057,14 +3060,14 @@ class Table:
             encode_tbl = serialize.represent_mixins_as_columns(tbl)
             return encode_tbl
 
-        tbl = _encode_mixins(self)
-
         badcols = [name for name, col in self.columns.items()
                    if (getattr(col, 'ndim', 1) > 1)]
         if badcols:
             raise ValueError(
                 "Cannot convert a table with multi-dimensional columns to a "
                 "pandas DataFrame. Offending columns are: {}".format(badcols))
+
+        tbl = _encode_mixins(self)
 
         out = OrderedDict()
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1726,12 +1726,14 @@ class TestPandas:
         t = table.Table()
         t['a'] = [1, 2, 3]
         t['b'] = np.ones((3, 2))
+        t['c'] = [1, 2, 3] * u.m
+        t['d'] = np.ones((3, 2)) * u.m
 
         with pytest.raises(ValueError) as exc:
             t.to_pandas()
         assert (exc.value.args[0] ==
             "Cannot convert a table with multi-dimensional columns "
-            "to a pandas DataFrame. Offending columns are: ['b']")
+            "to a pandas DataFrame. Offending columns are: ['b', 'd']")
 
     def test_mixin_pandas(self):
         t = table.QTable()

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1876,6 +1876,16 @@ class TestPandas:
                     assert column.byteswap().newbyteorder().dtype == t2[name].dtype
 
 
+def test_drop_array_columns():
+    t = table.Table()
+    t['a'] = [1, 2, 3]
+    t['b'] = np.ones((3, 2))
+    t['c'] = [1, 2, 3] * u.m
+    t['d'] = np.ones((3, 2)) * u.m
+
+    t2 = t.drop_array_columns()
+    assert t2.colnames == ["a", "c"]
+
 @pytest.mark.usefixtures('table_types')
 class TestReplaceColumn(SetupData):
     def test_fail_replace_column(self, table_types):


### PR DESCRIPTION
This PR adds a new method `Table.drop_array_colums`. 

The motivation is to make it easy to convert a table to pandas or write it to an ASCII file, i.e. go to formats that don't support array columns.

At first I thought we'd add an option `drop_array_columns=True` with default to do this to `table.to_pandas` (see  https://groups.google.com/d/msg/astropy-dev/iOha8R59PX8/KM1dHbytAQAJ), but probably it's better to have the default be to raise an error and not just silently drop columns, and if so, then the extra method is probably the better API.

I also changed `Table.to_pandas` slightly, fixing the docstring, and checking and raising an error for array columns earlier.

At first I added an `Colum.is_scalar` attribute and wanted to use that, but then there were failing tests because sometimes `table["time_col"]` was a `Time` and not a `Column` object. Not sure if there is a better way to implement this functionality, or if the current implementation is fine. It's from the suggestion by @taldcroft in https://github.com/astropy/astropy/issues/4604#issuecomment-184425733

@taldcroft or @mhvk - Please review.