### PR TITLE
Fix mistake in Table conftest table_type fixture

### DIFF
--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -125,12 +125,7 @@ def protocol(request):
 # (MaskedArray) column.
 @pytest.fixture(params=[False, True])
 def table_type(request):
-    # return MaskedTable if request.param else table.Table
-    try:
-        request.param
-        return MaskedTable
-    except AttributeError:
-        return table.Table
+    return MaskedTable if request.param else table.Table
 
 
 # Stuff for testing mixin columns

--- a/astropy/table/tests/test_pprint.py
+++ b/astropy/table/tests/test_pprint.py
@@ -40,8 +40,9 @@ class TestMultiD():
                          '<tr><td>10 .. 20</td><td>30 .. 40</td><td>50 .. 60</td></tr>',
                          '</table>']
         nbclass = table.conf.default_notebook_table_class
+        masked = 'masked=True ' if t.masked else ''
         assert t._repr_html_().splitlines() == [
-            f'<i>{table_type.__name__} masked={t.masked} length=2</i>',
+            f'<i>{table_type.__name__} {masked}length=2</i>',
             '<table id="table{id}" class="{nbclass}">'.format(id=id(t), nbclass=nbclass),
             '<thead><tr><th>col0 [2]</th><th>col1 [2]</th><th>col2 [2]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
@@ -79,8 +80,9 @@ class TestMultiD():
                          '<tr><td>10</td><td>30</td><td>50</td></tr>',
                          '</table>']
         nbclass = table.conf.default_notebook_table_class
+        masked = 'masked=True ' if t.masked else ''
         assert t._repr_html_().splitlines() == [
-            f'<i>{table_type.__name__} masked={t.masked} length=2</i>',
+            f'<i>{table_type.__name__} {masked}length=2</i>',
             '<table id="table{id}" class="{nbclass}">'.format(id=id(t), nbclass=nbclass),
             '<thead><tr><th>col0 [1,1]</th><th>col1 [1,1]</th><th>col2 [1,1]</th></tr></thead>',
             '<thead><tr><th>int64</th><th>int64</th><th>int64</th></tr></thead>',
@@ -127,7 +129,8 @@ class TestPprint():
         lines = t.pformat()
         assert lines == ['<No columns>']
         c = repr(t)
-        assert c.splitlines() == [f'<{table_type.__name__} masked={t.masked} length=0>',
+        masked = 'masked=True ' if t.masked else ''
+        assert c.splitlines() == [f'<{table_type.__name__} {masked}length=0>',
                                   '<No columns>']
 
     def test_format0(self, table_type):
@@ -428,10 +431,10 @@ class TestFormatWithMaskedElements():
         t['a'].format = '%4.2f {0:}'
         assert str(t['a']) == '   a   \n-------\n     --\n%4.2f 2\n     --'
 
-    def test_column_format_with_threshold(self, table_type):
+    def test_column_format_with_threshold_masked_table(self):
         from astropy import conf
         with conf.set_temp('max_lines', 8):
-            t = table_type([np.arange(20)], names=['a'])
+            t = Table([np.arange(20)], names=['a'], masked=True)
             t['a'].format = '%{0:}'
             t['a'].mask[0] = True
             t['a'].mask[-1] = True


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

I don't know quite how it happened, but the original commit for the `table_type` fixture (0ca29773f606db) contains duplicate and conflicting definitions (see below).  Somewhere along the line the first definition became the only one, and it just seems plain wrong.  I stumbled on this by complete chance and noticed that in current testing `table_type` is *always* `MaskedTable`.  So we have not been testing plain tables in that fixture for a very long time and indeed some tests needed update (fortunately no code as far as I can see).
```
@pytest.fixture(params=[False, True])
def table_type(request):
    # return MaskedTable if request.param else table.Table
    try:
        request.param
        return MaskedTable
    except AttributeError:
        return table.Table

...

@pytest.fixture(params=[False, True])
def table_type(request):
    return MaskedTable if request.param else table.Table
```


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

