### PR TITLE
Add working to method to distribution class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,6 +159,9 @@ astropy.timeseries
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
 
+- Quantity distributions now implement a ``to`` method that yields new
+  distributions of the expected kind for the starting distribution. [#9429]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -268,3 +268,10 @@ class Distribution:
         bin_edges = np.array(bin_edges)
         be_shape = self.shape + (bin_edges.size//self.size,)
         return nhists.reshape(nh_shape), bin_edges.reshape(be_shape)
+
+    # specialized overrides
+    def to(self, *args, **kwargs):
+        if not hasattr(self._samples_cls, 'to'):
+            raise TypeError("this Quantity's distribution does not have a "
+                            "``to`` method")
+        return self.__class__(self.distribution.to(*args, **kwargs))

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -272,6 +272,6 @@ class Distribution:
     # specialized overrides
     def to(self, *args, **kwargs):
         if not hasattr(self._samples_cls, 'to'):
-            raise TypeError("this Quantity's distribution does not have a "
-                            "``to`` method")
+            raise AttributeError("this Quantity's distribution does not have a "
+                                 "``to`` method")
         return self.__class__(self.distribution.to(*args, **kwargs))

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -272,15 +272,16 @@ class Distribution:
     # specialized overrides
     def to(self, *args, **kwargs):
         if not hasattr(self._samples_cls, 'to'):
-            raise AttributeError("this Quantity's distribution does not have a "
+            raise AttributeError("this distribution's samples do not have a "
                                  "``to`` method")
         # note we use Distribution instead of self.__class__ here because
         # the Distribution class figures out its class from the `__new__`
-        return Distribution(self.distribution.to(*args, **kwargs))
-
+        return self.__class__(self.distribution.to(*args, **kwargs))
 
     def to_value(self, *args, **kwargs):
-        raise AttributeError('to_value cannot be used on Distribution '
-                             'because it is ambiguous. Use '
-                             '.distribution.to_value() or e.g. '
-                             '.pdf_mean().to_value() instead')
+        if not hasattr(self._samples_cls, 'to_value'):
+            raise AttributeError("this distribution's samples do not have a "
+                                 "``to_value`` method")
+        # note we use Distribution instead of self.__class__ here because
+        # the Distribution class figures out its class from the `__new__`
+        return self.__class__(self.distribution.to_value(*args, **kwargs))

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -277,3 +277,10 @@ class Distribution:
         # note we use Distribution instead of self.__class__ here because
         # the Distribution class figures out its class from the `__new__`
         return Distribution(self.distribution.to(*args, **kwargs))
+
+
+    def to_value(self, *args, **kwargs):
+        raise AttributeError('to_value cannot be used on Distribution '
+                             'because it is ambiguous. Use '
+                             '.distribution.to_value() or e.g. '
+                             '.pdf_mean().to_value() instead')

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -274,4 +274,6 @@ class Distribution:
         if not hasattr(self._samples_cls, 'to'):
             raise AttributeError("this Quantity's distribution does not have a "
                                  "``to`` method")
-        return self.__class__(self.distribution.to(*args, **kwargs))
+        # note we use Distribution instead of self.__class__ here because
+        # the Distribution class figures out its class from the `__new__`
+        return Distribution(self.distribution.to(*args, **kwargs))

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -315,3 +315,9 @@ def test_array_repr_latex():
 
     distr = Distribution(arr)
     assert distr._repr_latex_() is None
+
+
+def test_distr_to():
+    distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
+    todistr = distr.to(u.m)
+    assert_quantity_allclose(distr.pdf_mean.to(u.m), todistr.pdf_mean)

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -328,3 +328,13 @@ def test_nonq_to():
     distr = ds.normal(10, n_samples=100, std=1)
     with pytest.raises(AttributeError):
         distr.to(u.m)
+
+
+def test_to_value():
+    distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
+    with pytest.raises(AttributeError):
+        distr.to_value(u.m)
+
+    distr = ds.normal(10, n_samples=100, std=1)
+    with pytest.raises(AttributeError):
+        distr.to_value(u.m)

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -323,18 +323,20 @@ def test_distr_to():
     assert_quantity_allclose(distr.pdf_mean.to(u.m), todistr.pdf_mean)
 
 
-def test_nonq_to():
+def test_distr_noq_to():
     # this is an array distribution not a quantity
     distr = ds.normal(10, n_samples=100, std=1)
     with pytest.raises(AttributeError):
         distr.to(u.m)
 
 
-def test_to_value():
+def test_distr_to_value():
     distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
-    with pytest.raises(AttributeError):
-        distr.to_value(u.m)
+    tovdistr = distr.to_value(u.m)
+    assert np.allclose(distr.pdf_mean.to_value(u.m), tovdistr.pdf_mean)
 
+
+def test_distr_noq_to_value():
     distr = ds.normal(10, n_samples=100, std=1)
     with pytest.raises(AttributeError):
         distr.to_value(u.m)

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -321,3 +321,10 @@ def test_distr_to():
     distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
     todistr = distr.to(u.m)
     assert_quantity_allclose(distr.pdf_mean.to(u.m), todistr.pdf_mean)
+
+
+def test_nonq_to():
+    # this is an array distribution not a quantity
+    distr = ds.normal(10, n_samples=100, std=1)
+    with pytest.raises(AttributeError):
+        distr.to(u.m)


### PR DESCRIPTION
It turns out Quantity `Distribution`s' `to` method wasn't working quite right (thanks @astrofrog for pointing this out!), because it was implicitly using the `Quantity` `to` instead of one that was distribution-aware.  This PR adds an explicit implementation of `to` to `Distribution` (for the Quantity and sub-classes case, at least).  

One could debatably see this as a bug, but it's not really clear that this was originally intended, so I'm categorizing it as a new feature (and therefore can go into 4.0 without any backports)

cc @astrofrog 