### PR TITLE
Remove extra files from the doc build before upload to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
               # If it is a PR, delete sources and doctrees, because it's a lot
               # of files which we don't really need to upload
               rm -r docs/_build/html/_sources
+              rm -r docs/_build/html/_modules
               rm -r docs/_build/html/.doctrees
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,19 @@ jobs:
             LC_ALL: C
             LANG: C
 
+      - run:
+          name: Prepare for upload
+          command: |
+            # If it's not a PR, don't upload
+            if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
+              rm -r docs/_build/html/*
+            else
+              # If it is a PR, delete sources and doctrees, because it's a lot
+              # of files which we don't really need to upload
+              rm -r docs/_build/html/_sources
+              rm -r docs/_build/html/.doctrees
+            fi
+
       - store_artifacts:
           path: docs/_build/html
 


### PR DESCRIPTION
This is an alternative to #9426 which also massively reduces the number of files we upload from ~5400 to ~3000 which should result in a ~45% speedup in the upload step. Like #9426 it also skips upload on non-PR builds.

```
$ find docs/_build/html/ -type f | wc -l                                                                                                                                                                                                                                                                                       
5417
$ find docs/_build/html/.doctrees -type f | wc -l                                                                                                                                                                                                                                                                              
1210
$ find docs/_build/html/_sources -type f | wc -l                                                                                                                                                                                                                                                                               
1209
```

The last doc build took 11:46 to upload the artifacts, this build took 6:06.

@bsipocz 