### PR TITLE
Temporarily switch off uploading artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
             # If it's not a PR, don't upload
             if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
               rm -r docs/_build/html/*
+              rm -r docs/_build/html/.*
             else
               # If it is a PR, delete sources and doctrees, because it's a lot
               # of files which we don't really need to upload


### PR DESCRIPTION
As discussed with @astrofrog on slack, we better switch of artifact upload while freezing, to further cut back on queue time.

I did it the very ugly way to make it more obvious to notice in case we forget about switching it back on when we're over the peak of the  busy period.
