### PR TITLE
Prevent pytest from rewriting asserts in display plugin

### DIFF
--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This plugin provides customization of the header displayed by pytest for
-reporting purposes.
+reporting purposes. PYTEST_DONT_REWRITE
 """
 
 import os


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This resolves the following warning when running the `astropy` package unit tests:
```
/Users/jdavies/miniconda3/envs/astropy/lib/python3.7/site-packages/_pytest/config/__init__.py:545
  /Users/jdavies/miniconda3/envs/astropy/lib/python3.7/site-packages/_pytest/config/__init__.py:545: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: astropy.tests.plugins.display
    self.import_plugin(import_spec)
```
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
