### PR TITLE
Run each doctest in a tmpdir

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -23,6 +23,7 @@ os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 # Python process, and this configuration only matters if running pytest
 # directly, not from e.g. an IPython session.
 
+
 @pytest.fixture(autouse=True)
 def _docdir(request):
     """Run doctests in isolated tmpdir so outputs do not end up in repo"""

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -7,6 +7,7 @@
 
 import os
 import tempfile
+import pytest
 
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
@@ -21,3 +22,19 @@ os.mkdir(os.path.join(os.environ['XDG_CACHE_HOME'], 'astropy'))
 # them after testing, because they are only changed for the duration of the
 # Python process, and this configuration only matters if running pytest
 # directly, not from e.g. an IPython session.
+
+@pytest.fixture(autouse=True)
+def _docdir(request):
+    """Run doctests in isolated tmpdir so outputs do not end up in repo"""
+    # Trigger ONLY for doctestplus
+    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
+    if isinstance(request.node, doctest_plugin._doctest_textfile_item_cls):
+        # Don't apply this fixture to io.rst.  It reads files and doesn't write
+        if "io.rst" not in request.node.name:
+            tmpdir = request.getfixturevalue('tmpdir')
+            with tmpdir.as_cwd():
+                yield
+        else:
+            yield
+    else:
+        yield


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address our `doctestplus` documentation tests that litter the local checkout repo with output files.  I.e. after the doctests are run, the repo looks like:

```
$ git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	compressed_image.fits
	image_and_table.fits
	my_image.fits
	new.fits
	new1.fits
	new2.fits
	newtable.fits
	newtable2.fits
	out.fits
	table1.fits
	table2.fits
	table3.fits
	table4.fits
	test_file.fits
	test_group.fits
	values.dat
	variable_length_table.fits
```

The fix involves an auto-use pytest fixture that creates a `tmpdir` for each test in our documentation, except for those `io.rst`, which read files instead of writing them.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
