### PR TITLE
Validate wcs input to WCSAxes

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -113,6 +113,7 @@ class WCSAxes(Axes):
             # data->pixel mapping
             self.transData = transData
 
+        self._validate_wcs(wcs)
         self.reset_wcs(wcs=wcs, slices=slices, transform=transform, coord_meta=coord_meta)
         self._hide_parent_artists()
         self.format_coord = self._display_world_coords
@@ -122,6 +123,12 @@ class WCSAxes(Axes):
         self._wcsaxesartist = _WCSAxesArtist()
         self.add_artist(self._wcsaxesartist)
         self._drawn = False
+
+    @staticmethod
+    def _validate_wcs(wcs):
+        if wcs.pixel_n_dim != 2:
+            raise ValueError(f'wcs input to WCSAxes must have 2 dimensions '
+                             f'(got {wcs.pixel_n_dim})')
 
     def _display_world_coords(self, x, y):
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -27,6 +27,22 @@ MATPLOTLIB_LT_21 = LooseVersion(matplotlib.__version__) < LooseVersion("2.1")
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
 
+def test_wcs_validate():
+    header = {
+        'CTYPE3': 'WAVE    ', 'CUNIT3': 'Angstrom',
+        'CDELT3': 0.2, 'CRPIX3': 0, 'CRVAL3': 10, 'NAXIS3': 5,
+        'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg',
+        'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4,
+        'CTYPE1': 'HPLN-TAN', 'CUNIT1': 'deg',
+        'CDELT1': 0.4, 'CRPIX1': 2, 'CRVAL1': 1, 'NAXIS1': 3}
+    wcs = WCS(header)
+
+    fig = plt.figure()
+    with pytest.raises(ValueError,
+                       match='wcs input to WCSAxes must have 2 dimensions'):
+        ax = fig.gca(projection=wcs)
+
+
 @ignore_matplotlibrc
 def test_grid_regression():
     # Regression test for a bug that meant that if the rc parameter


### PR DESCRIPTION
Currently handing a `wcs` with 3 dimensions raises the cryptic error:

```python
    ax = fig.gca(projection=wcs)
  File "//miniconda3/envs/dev/lib/python3.7/site-packages/matplotlib/figure.py", line 1932, in gca
    return self.add_subplot(1, 1, 1, **kwargs)
  File "//miniconda3/envs/dev/lib/python3.7/site-packages/matplotlib/figure.py", line 1414, in add_subplot
    a = subplot_class_factory(projection_class)(self, *args, **kwargs)
  File "//miniconda3/envs/dev/lib/python3.7/site-packages/matplotlib/axes/_subplots.py", line 69, in __init__
    self._axes_class.__init__(self, fig, self.figbox, **kwargs)
  File "/Users/dstansby/github/astropy/astropy/visualization/wcsaxes/core.py", line 117, in __init__
    self.reset_wcs(wcs=wcs, slices=slices, transform=transform, coord_meta=coord_meta)
  File "/Users/dstansby/github/astropy/astropy/visualization/wcsaxes/core.py", line 370, in reset_wcs
    transform, coord_meta = transform_coord_meta_from_wcs(self.wcs, self.frame_class, slices=slices)
  File "/Users/dstansby/github/astropy/astropy/visualization/wcsaxes/wcsapi.py", line 30, in transform_coord_meta_from_wcs
    raise ValueError("WCS has more than 2 pixel dimensions, so "
ValueError: WCS has more than 2 pixel dimensions, so 'slices' should be set
```

This PR does some validation on the `wcs` given to `WCSAxes` to check it has the right number of dimensions. The error raised is now:
```python
ValueError: wcs input to WCSAxes must have 2 dimensions (got 3)
```

Code to reproduce:
```python
import numpy as np
import astropy.wcs
import matplotlib.pyplot as plt

header = {
    'CTYPE3': 'WAVE    ', 'CUNIT3': 'Angstrom', 'CDELT3': 0.2, 'CRPIX3': 0, 'CRVAL3': 10, 'NAXIS3': 5,
    'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 4,
    'CTYPE1': 'HPLN-TAN', 'CUNIT1': 'deg', 'CDELT1': 0.4, 'CRPIX1': 2, 'CRVAL1': 1, 'NAXIS1': 3}
wcs = astropy.wcs.WCS(header)

fig = plt.figure()
ax = fig.gca(projection=wcs)
```