### PR TITLE
DOC: compat is for internal use only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
             # If it's not a PR, don't upload
             if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
               rm -r docs/_build/html/*
-              rm -r docs/_build/html/.*
+              rm -rf docs/_build/html/.*
             else
               # If it is a PR, delete sources and doctrees, because it's a lot
               # of files which we don't really need to upload

--- a/astropy/utils/__init__.py
+++ b/astropy/utils/__init__.py
@@ -6,10 +6,11 @@ Public functions and classes in this subpackage are safe to be used by other
 packages, but this subpackage is for utilities that are primarily of use for
 developers or to implement python hacks.
 
-This subpackage also includes the `astropy.utils.compat` package,
+This subpackage also includes the ``astropy.utils.compat`` package,
 which houses utilities that provide compatibility and bugfixes across
 all versions of Python that Astropy supports. However, the content of this
-module is solely for internal use of ``astropy``, so use it at your own risk.
+module is solely for internal use of ``astropy`` and subject to changes
+without deprecations. Do not use it in external packages or code.
 
 """
 

--- a/astropy/utils/__init__.py
+++ b/astropy/utils/__init__.py
@@ -4,13 +4,16 @@ This subpackage contains developer-oriented utilities used by Astropy.
 
 Public functions and classes in this subpackage are safe to be used by other
 packages, but this subpackage is for utilities that are primarily of use for
-developers or to implement python hacks. This subpackage also includes the
-`astropy.utils.compat` package, which houses utilities that provide
-compatibility and bugfixes across all versions of Python that Astropy supports.
+developers or to implement python hacks.
+
+This subpackage also includes the `astropy.utils.compat` package,
+which houses utilities that provide compatibility and bugfixes across
+all versions of Python that Astropy supports. However, the content of this
+module is solely for internal use of ``astropy``, so use it at your own risk.
+
 """
 
-
-from .codegen import *
-from .decorators import *
-from .introspection import *
-from .misc import *
+from .codegen import *  # noqa
+from .decorators import *  # noqa
+from .introspection import *  # noqa
+from .misc import *  # noqa

--- a/astropy/utils/compat/__init__.py
+++ b/astropy/utils/compat/__init__.py
@@ -7,8 +7,9 @@ important for Astropy.
 Note that all public functions in the `astropy.utils.compat.misc` module are
 imported here for easier access.
 
-The content of this module is solely for internal use of ``astropy``,
-so use it at your own risk.
+The content of this module is solely for internal use of ``astropy``
+and subject to changes without deprecations. Do not use it in external
+packages or code.
 
 """
 

--- a/astropy/utils/compat/__init__.py
+++ b/astropy/utils/compat/__init__.py
@@ -6,9 +6,13 @@ important for Astropy.
 
 Note that all public functions in the `astropy.utils.compat.misc` module are
 imported here for easier access.
+
+The content of this module is solely for internal use of ``astropy``,
+so use it at your own risk.
+
 """
 
-from .misc import *
+from .misc import *  # noqa
 
 # Importing this module will also install monkey-patches defined in it
-from .numpycompat import *
+from .numpycompat import *  # noqa

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -29,10 +29,12 @@ The exception is below:
 .. note:: The ``astropy.utils.compat`` subpackage is not included in this
     documentation. It contains utility modules for compatibility with
     older/newer versions of python and numpy, as well as including some
-    bugfixes for the stdlib that are important for Astropy. It is recommended
+    bugfixes for the stdlib that are important for ``astropy``. It is recommended
     that developers at least glance over the source code for this subpackage,
     but most of it cannot be reliably included here because of the large
-    amount of version-specific code it contains.
+    amount of version-specific code it contains. Its content will be removed
+    without any deprecation period when it is no longer needed by ``astropy``,
+    so use it at your own risk.
 
 Reference/API
 =============

--- a/docs/utils/index.rst
+++ b/docs/utils/index.rst
@@ -32,9 +32,9 @@ The exception is below:
     bugfixes for the stdlib that are important for ``astropy``. It is recommended
     that developers at least glance over the source code for this subpackage,
     but most of it cannot be reliably included here because of the large
-    amount of version-specific code it contains. Its content will be removed
-    without any deprecation period when it is no longer needed by ``astropy``,
-    so use it at your own risk.
+    amount of version-specific code it contains. Its content is solely for
+    internal use of ``astropy`` and subject to changes without deprecations.
+    Do not use it in external packages or code.
 
 Reference/API
 =============


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to clarify that `astropy.utils.compat` is for internal use and is allowed to remove code without a deprecation period when the code is no longer needed for backward compatibility support; e.g., `NUMPY_LT_1_14`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9419 

Also a follow-up of #9436 