### PR TITLE
Distribution rewrite that puts it at the bottom

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -208,8 +208,10 @@ astropy.timeseries
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
 
-- Quantity distributions now implement a ``to`` method that yields new
-  distributions of the expected kind for the starting distribution. [#9429]
+- ``Distribution`` was rewritten such that it deals better with subclasses.
+  As a result, Quantity distributions now behave correctly with ``to`` methods
+  yielding new distributions of the kind expected for the starting distribution,
+  and ``to_value`` yielding ``NdarrayDistribution`` instances. [#9429, #9442]
 
 astropy.units
 ^^^^^^^^^^^^^
@@ -466,6 +468,11 @@ astropy.timeseries
 
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
+
+- ``Distribution`` was rewritten such that it deals better with subclasses.
+  As a result, Quantity distributions now behave correctly with ``to`` methods
+  yielding new distributions of the kind expected for the starting distribution,
+  and ``to_value`` yielding ``NdarrayDistribution`` instances. [#9442]
 
 astropy.units
 ^^^^^^^^^^^^^

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -49,16 +49,23 @@ class Distribution:
         new_dtype = np.dtype({'names': ['samples'],
                               'formats': [(samples.dtype, (samples.shape[-1],))]})
         samples_cls = type(samples)
-        if not issubclass(samples_cls, Distribution):
-            # Make sure first letter is uppercase, but note that we can't use
-            # str.capitalize since that converts the rest of the name to lowercase.
-            new_name = samples_cls.__name__[0].upper() + samples_cls.__name__[1:] + cls.__name__
-            if new_name in cls._generated_subclasses:
-                new_cls = cls._generated_subclasses[new_name]
-            else:
-                new_cls = type(new_name, (cls, samples_cls),
-                               {'_samples_cls': samples_cls})
-                cls._generated_subclasses[new_name] = new_cls
+        new_cls = cls._generated_subclasses.get(samples_cls)
+        if new_cls is None:
+            # Make a new class with the combined name, inserting Distribution
+            # itself below the samples class since that way Quantity methods
+            # like ".to" just work (as .view() gets intercepted).  However,
+            # repr and str are problems, so we put those on top.
+            # TODO: try to deal with this at the lower level.  The problem is
+            # that array2string does not allow one to override how structured
+            # arrays are typeset, leading to all samples to be shown.  It may
+            # be possible to hack oneself out by temporarily becoming a void.
+            new_name = samples_cls.__name__ + cls.__name__
+            new_cls = type(
+                new_name,
+                (_DistributionRepr, samples_cls, ArrayDistribution),
+                {'_samples_cls': samples_cls})
+            cls._generated_subclasses[samples_cls] = new_cls
+
         self = samples.view(dtype=new_dtype, type=new_cls)
         # Get rid of trailing dimension of 1.
         self.shape = samples.shape[:-1]
@@ -67,13 +74,6 @@ class Distribution:
     @property
     def distribution(self):
         return self['samples']
-
-    def __getitem__(self, item):
-        result = super().__getitem__(item)
-        if item == 'samples':
-            return super(Distribution, result).view(self._samples_cls)
-        else:
-            return Distribution.__new__(self.__class__, result['samples'])
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         converted = []
@@ -116,45 +116,6 @@ class Distribution:
                     finals.append(result)
 
         return finals if len(finals) > 1 else finals[0]
-
-    # Override view so that we stay a Distribution version of the new type.
-    def view(self, dtype=None, type=None):
-        if type is None:
-            if issubclass(dtype, np.ndarray):
-                type = dtype
-                dtype = None
-            else:
-                raise ValueError('Cannot set just dtype for a Distribution.')
-
-        result = self.distribution.view(dtype, type)
-        return Distribution(result)
-
-    def __repr__(self):
-        reprarr = repr(self.distribution)
-        if reprarr.endswith('>'):
-            firstspace = reprarr.find(' ')
-            reprarr = reprarr[firstspace+1:-1]  # :-1] removes the ending '>'
-            return '<{} {} with n_samples={}>'.format(self.__class__.__name__,
-                                                      reprarr, self.n_samples)
-        else: # numpy array-like
-            firstparen = reprarr.find('(')
-            reprarr = reprarr[firstparen:]
-            return '{}{} with n_samples={}'.format(self.__class__.__name__,
-                                                    reprarr, self.n_samples)
-            return reprarr
-
-    def __str__(self):
-        distrstr = str(self.distribution)
-        toadd = f' with n_samples={self.n_samples}'
-        return distrstr + toadd
-
-    def _repr_latex_(self):
-        if hasattr(self.distribution, '_repr_latex_'):
-            superlatex = self.distribution._repr_latex_()
-            toadd = fr', \; n_{{\rm samp}}={self.n_samples}'
-            return superlatex[:-1] + toadd + superlatex[-1]
-        else:
-            return None
 
     @property
     def n_samples(self):
@@ -269,19 +230,78 @@ class Distribution:
         be_shape = self.shape + (bin_edges.size//self.size,)
         return nhists.reshape(nh_shape), bin_edges.reshape(be_shape)
 
-    # specialized overrides
-    def to(self, *args, **kwargs):
-        if not hasattr(self._samples_cls, 'to'):
-            raise AttributeError("this distribution's samples do not have a "
-                                 "``to`` method")
-        # note we use Distribution instead of self.__class__ here because
-        # the Distribution class figures out its class from the `__new__`
-        return self.__class__(self.distribution.to(*args, **kwargs))
 
-    def to_value(self, *args, **kwargs):
-        if not hasattr(self._samples_cls, 'to_value'):
-            raise AttributeError("this distribution's samples do not have a "
-                                 "``to_value`` method")
-        # note we use Distribution instead of self.__class__ here because
-        # the Distribution class figures out its class from the `__new__`
-        return self.__class__(self.distribution.to_value(*args, **kwargs))
+class ScalarDistribution(Distribution, np.void):
+    """Scalar distribution.
+
+    This class mostly exists to make `~numpy.array2print` possible for
+    all subclasses.  It is a scalar element, still with n_samples samples.
+    """
+    pass
+
+
+class ArrayDistribution(Distribution, np.ndarray):
+    # This includes the important overrride of view and __getitem__
+    # which are needed for all ndarray subclass Distributions, but not
+    # for the scalar one.
+    _samples_cls = np.ndarray
+
+    # Override view so that we stay a Distribution version of the new type.
+    def view(self, dtype=None, type=None):
+        if type is None:
+            if issubclass(dtype, np.ndarray):
+                type = dtype
+                dtype = None
+            else:
+                raise ValueError('Cannot set just dtype for a Distribution.')
+
+        result = self.distribution.view(dtype, type)
+        return Distribution(result)
+
+    # Override __getitem__ so that 'samples' is returned as the sample class.
+    def __getitem__(self, item):
+        result = super().__getitem__(item)
+        if item == 'samples':
+            # Here, we need to avoid our own redefinition of view.
+            return super(ArrayDistribution, result).view(self._samples_cls)
+        elif isinstance(result, np.void):
+            return result.view((ScalarDistribution, result.dtype))
+        else:
+            return result
+
+
+class _DistributionRepr:
+    def __repr__(self):
+        reprarr = repr(self.distribution)
+        if reprarr.endswith('>'):
+            firstspace = reprarr.find(' ')
+            reprarr = reprarr[firstspace+1:-1]  # :-1] removes the ending '>'
+            return '<{} {} with n_samples={}>'.format(self.__class__.__name__,
+                                                      reprarr, self.n_samples)
+        else:  # numpy array-like
+            firstparen = reprarr.find('(')
+            reprarr = reprarr[firstparen:]
+            return '{}{} with n_samples={}'.format(self.__class__.__name__,
+                                                   reprarr, self.n_samples)
+            return reprarr
+
+    def __str__(self):
+        distrstr = str(self.distribution)
+        toadd = f' with n_samples={self.n_samples}'
+        return distrstr + toadd
+
+    def _repr_latex_(self):
+        if hasattr(self.distribution, '_repr_latex_'):
+            superlatex = self.distribution._repr_latex_()
+            toadd = fr', \; n_{{\rm samp}}={self.n_samples}'
+            return superlatex[:-1] + toadd + superlatex[-1]
+        else:
+            return None
+
+
+class NdarrayDistribution(_DistributionRepr, ArrayDistribution):
+    pass
+
+
+# Ensure our base NdarrayDistribution is known.
+Distribution._generated_subclasses[np.ndarray] = NdarrayDistribution

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2340,10 +2340,7 @@ def _condition_arg(value):
     ValueError
         If value is not as expected
     """
-    if isinstance(value, (float, int, complex)):
-        return value
-
-    if isinstance(value, np.ndarray) and value.dtype.kind in ['i', 'f', 'c']:
+    if isinstance(value, (np.ndarray, float, int, complex)):
         return value
 
     avalue = np.array(value)

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1041,7 +1041,7 @@ class Quantity(np.ndarray):
                 raise
         # For single elements, ndarray.__getitem__ returns scalars; these
         # need a new view as a Quantity.
-        if type(out) is not type(self):
+        if not isinstance(out, np.ndarray):
             out = self._new_view(out)
         return out
 


### PR DESCRIPTION
As always, the alternative took longer than I thought, mostly because of a very tricky situation with `repr` - turns out we needed a scalar `Distribution` based on `np.void` as well (and then it became easy). Which in some way simplifies a bit of the code.

Personally, I like this approach better, as we no longer have to worry about what possible subclasses we might get.

The one thing that is lost now, though, is the addition of `n_samples` to the `repr` and `str`; it is possible to get this back, likely most easily using `__init_subclass__` or a metaclass, but I wasn't sure it was worth it. Personally, independently of this, I'd rather change the whole `repr` anyway, so that it doesn't by default show *all* samples, but rather something like
```
QuantityDistribution( [([1., 2., 3., ... 100 samples total ..., 97., 98., 99.],)] kpc)
```
EDIT: Or at the very least that it omits those samples and *then* tells one how many there are.

p.s. The changes in `index.rst` appear large only because a `DOS` file snuck in and my editor decided to make it unixy (change of end-of-lines); I can try to dosify it if needed.