### PR TITLE
MNT: Update IERS A URLs due to USNO prolonged maintenance

### DIFF
--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -36,8 +36,8 @@ __all__ = ['Conf', 'conf',
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
-IERS_A_URL = 'https://maia.usno.navy.mil/ser7/finals2000A.all'
-IERS_A_URL_MIRROR = 'https://toshi.nofs.navy.mil/ser7/finals2000A.all'
+IERS_A_URL = 'https://datacenter.iers.org/data/9/finals2000A.all'
+IERS_A_URL_MIRROR = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description
@@ -420,7 +420,7 @@ class IERS_A(IERS):
     """IERS Table class targeted to IERS A, provided by USNO.
 
     These include rapid turnaround and predicted times.
-    See https://maia.usno.navy.mil/
+    See https://datacenter.iers.org/eop.php
 
     Notes
     -----

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -109,7 +109,7 @@ polar motion values:
   the IERS service.
 
 The IERS Service provides the default online table
-(`<https://maia.usno.navy.mil/ser7/finals2000A.all>`_) and updates the content
+(`<https://datacenter.iers.org/data/9/finals2000A.all>`_) and updates the content
 once each 7 days.  The default value of ``auto_max_age`` is 30 days to avoid
 unnecessary network access, but one can reduce this to as low as 10 days.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the impending prolonged USNO downtime, causing current IERS A table to be inaccessible unless we switch the URLs (the main one and its mirror) to non-USNO service providers.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9427 

p.s. I don't know how to put in a change log since this needs to be backported to 2.x, so it wouldn't make sense for me to insert the change log under 4.0? Do we even need a change log?

p.p.s. Do we need a follow up issue to revisit the URLs after April 2020?

cc @bhazelton and @bmorris3 