### PR TITLE
Timeseries fold()  to use  phase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,7 +245,7 @@ astropy.time
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
-- Addig ``epoch_phase`` and ``normalize_phase`` keywords to
+- Addig ``epoch_phase``, ``wrap_phase`` and ``normalize_phase`` keywords to
   ``TimeSeries.fold()`` to control the phase of the epoch and to return
   normalized phase rather than time for the folded TimeSeries. [#9455]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -245,6 +245,10 @@ astropy.time
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
+- Addig ``epoch_phase`` and ``normalize_phase`` keywords to
+  ``TimeSeries.fold()`` to control the phase of the epoch and to return
+  normalized phase rather than time for the folded TimeSeries. [#9455]
+
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
 
@@ -560,6 +564,8 @@ astropy.time
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
+
+- Keyword ``midpoint_epoch`` is renamed to ``epoch_time``. [#9455]
 
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -186,7 +186,7 @@ class TimeSeries(BaseTimeSeries):
             folded_time = (folded_time / period).decompose()
             period = period_sec = 1
         else:
-             epoch_phase = 0
+            epoch_phase = 0
 
         with folded._delay_required_column_checks():
             folded_time += epoch_phase * period

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -143,7 +143,7 @@ class TimeSeries(BaseTimeSeries):
 
     @deprecated_renamed_argument('midpoint_epoch', 'epoch_time', '4.0')
     def fold(self, period=None, epoch_time=None, epoch_phase=0,
-             wrap_phase_at=None, normalize_phase=False):
+             wrap_phase=None, normalize_phase=False):
         """
         Return a new `~astropy.timeseries.TimeSeries` folded with a period and
         epoch.
@@ -161,7 +161,7 @@ class TimeSeries(BaseTimeSeries):
             should be a dimensionless value, while if ``normalize_phase`` is
             ``False``, this should be a `~astropy.units.Quantity` with time
             units. Defaults to 0.
-        wrap_phase_at : float or `~astropy.units.Quantity`
+        wrap_phase : float or `~astropy.units.Quantity`
             The value of the phase above which values are wrapped back by one
             period. If ``normalize_phase`` is `True`, this should be a
             dimensionless value, while if ``normalize_phase`` is ``False``,
@@ -203,28 +203,28 @@ class TimeSeries(BaseTimeSeries):
                     raise UnitsError('epoch_phase should be a Quantity in units of time when normalize_phase=False')
                 epoch_phase_sec = epoch_phase.to_value(u.s)
 
-        if wrap_phase_at is None:
-            wrap_phase_at = period_sec / 2
+        if wrap_phase is None:
+            wrap_phase = period_sec / 2
         else:
             if normalize_phase:
-                if isinstance(wrap_phase_at, Quantity) and not wrap_phase_at.unit.is_equivalent(u.one):
-                    raise UnitsError('wrap_phase_at should be dimensionless when normalize_phase=True')
+                if isinstance(wrap_phase, Quantity) and not wrap_phase.unit.is_equivalent(u.one):
+                    raise UnitsError('wrap_phase should be dimensionless when normalize_phase=True')
                 else:
-                    if wrap_phase_at < 0 or wrap_phase_at > 1:
-                        raise ValueError('wrap_phase_at should be between 0 and 1')
+                    if wrap_phase < 0 or wrap_phase > 1:
+                        raise ValueError('wrap_phase should be between 0 and 1')
                     else:
-                        wrap_phase_at = wrap_phase_at * period_sec
+                        wrap_phase = wrap_phase * period_sec
             else:
-                if isinstance(wrap_phase_at, Quantity) and wrap_phase_at.unit.physical_type == 'time':
-                    if wrap_phase_at < 0 or wrap_phase_at > period:
-                        raise ValueError('wrap_phase_at should be between 0 and the period')
+                if isinstance(wrap_phase, Quantity) and wrap_phase.unit.physical_type == 'time':
+                    if wrap_phase < 0 or wrap_phase > period:
+                        raise ValueError('wrap_phase should be between 0 and the period')
                     else:
-                        wrap_phase_at = wrap_phase_at.to_value(u.s)
+                        wrap_phase = wrap_phase.to_value(u.s)
                 else:
-                    raise UnitsError('wrap_phase_at should be a Quantity in units of time when normalize_phase=False')
+                    raise UnitsError('wrap_phase should be a Quantity in units of time when normalize_phase=False')
 
-        relative_time_sec = (((self.time - epoch_time).sec + epoch_phase_sec + (period_sec - wrap_phase_at))
-                             % period_sec - (period_sec - wrap_phase_at))
+        relative_time_sec = (((self.time - epoch_time).sec + epoch_phase_sec + (period_sec - wrap_phase))
+                             % period_sec - (period_sec - wrap_phase))
 
         folded_time = TimeDelta(relative_time_sec * u.s)
 

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -8,7 +8,7 @@ from astropy.table import groups, QTable, Table
 from astropy.time import Time, TimeDelta
 from astropy import units as u
 from astropy.units import Quantity
-
+from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.timeseries.core import BaseTimeSeries, autocheck_required_columns
 
 __all__ = ['TimeSeries']
@@ -141,6 +141,7 @@ class TimeSeries(BaseTimeSeries):
         """
         return self['time']
 
+    @deprecated_renamed_argument('epoch_time', 'midpoint_epoch', '4.0')
     def fold(self, period=None, epoch_time=None, epoch_phase=0, normalize_phase=True,
              phase_length=1):
         """

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -142,8 +142,7 @@ class TimeSeries(BaseTimeSeries):
         return self['time']
 
     @deprecated_renamed_argument('midpoint_epoch', 'epoch_time', '4.0')
-    def fold(self, period=None, epoch_time=None, epoch_phase=0, normalize_phase=True,
-             phase_length=1):
+    def fold(self, period=None, epoch_time=None, epoch_phase=0, normalize_phase=True):
         """
         Return a new `~astropy.timeseries.TimeSeries` folded with a period and
         epoch.
@@ -161,9 +160,6 @@ class TimeSeries(BaseTimeSeries):
         normalize_phase : bool
             If False phase is returned as `~astropy.time.TimeDelta`, otherwise
             as dimensionless `~astropy.units.Quantity`.
-        phase_length : float
-            Length of phase to return, centered on ``epoch_phase``. Default is 1 to
-            return the full phase.
 
         Returns
         -------
@@ -193,9 +189,6 @@ class TimeSeries(BaseTimeSeries):
             folded.remove_column('time')
             folded.add_column(folded_time, name='time', index=0)
 
-        if phase_length < 1:
-            folded = folded[np.abs(folded['time'] - epoch_phase * period) <
-                            (period_sec * phase_length / 2)]
         return folded
 
     def __getitem__(self, item):

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -142,7 +142,8 @@ class TimeSeries(BaseTimeSeries):
         return self['time']
 
     @deprecated_renamed_argument('midpoint_epoch', 'epoch_time', '4.0')
-    def fold(self, period=None, epoch_time=None, epoch_phase=0, normalize_phase=True):
+    def fold(self, period=None, epoch_time=None, epoch_phase=0.5,
+             normalize_phase=True):
         """
         Return a new `~astropy.timeseries.TimeSeries` folded with a period and
         epoch.
@@ -156,10 +157,11 @@ class TimeSeries(BaseTimeSeries):
             time offset / phase will be ``epoch_phase``.
             Defaults to the first time in the time series.
         epoch_phase : float
-            Phase of the midpoint epoch. Defaults to 0.
+            Phase of ``epoch_time``. Defaults to 0.5. This keyword is ignored when
+            ``normalize_phase`` is `False`.
         normalize_phase : bool
-            If False phase is returned as `~astropy.time.TimeDelta`, otherwise
-            as dimensionless `~astropy.units.Quantity`.
+            If `False` phase is returned as `~astropy.time.TimeDelta`, otherwise
+            as a dimensionless `~astropy.units.Quantity`.
 
         Returns
         -------
@@ -183,6 +185,8 @@ class TimeSeries(BaseTimeSeries):
             self.time_phase = True
             folded_time = (folded_time / period).decompose()
             period = period_sec = 1
+        else:
+             epoch_phase = 0
 
         with folded._delay_required_column_checks():
             folded_time += epoch_phase * period

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -193,14 +193,16 @@ class TimeSeries(BaseTimeSeries):
 
         if normalize_phase:
             if isinstance(epoch_phase, Quantity) and epoch_phase.unit.physical_type != 'dimensionless':
-                raise UnitsError('epoch_phase should be a dimensionless Quantity or a float when normalize_phase=True')
+                raise UnitsError('epoch_phase should be a dimensionless Quantity '
+                                 'or a float when normalize_phase=True')
             epoch_phase_sec = epoch_phase * period_sec
         else:
             if epoch_phase == 0:
                 epoch_phase_sec = 0.
             else:
                 if not isinstance(epoch_phase, Quantity) or epoch_phase.unit.physical_type != 'time':
-                    raise UnitsError('epoch_phase should be a Quantity in units of time when normalize_phase=False')
+                    raise UnitsError('epoch_phase should be a Quantity in units '
+                                     'of time when normalize_phase=False')
                 epoch_phase_sec = epoch_phase.to_value(u.s)
 
         if wrap_phase is None:
@@ -208,7 +210,8 @@ class TimeSeries(BaseTimeSeries):
         else:
             if normalize_phase:
                 if isinstance(wrap_phase, Quantity) and not wrap_phase.unit.is_equivalent(u.one):
-                    raise UnitsError('wrap_phase should be dimensionless when normalize_phase=True')
+                    raise UnitsError('wrap_phase should be dimensionless when '
+                                     'normalize_phase=True')
                 else:
                     if wrap_phase < 0 or wrap_phase > 1:
                         raise ValueError('wrap_phase should be between 0 and 1')
@@ -221,10 +224,13 @@ class TimeSeries(BaseTimeSeries):
                     else:
                         wrap_phase = wrap_phase.to_value(u.s)
                 else:
-                    raise UnitsError('wrap_phase should be a Quantity in units of time when normalize_phase=False')
+                    raise UnitsError('wrap_phase should be a Quantity in units '
+                                     'of time when normalize_phase=False')
 
-        relative_time_sec = (((self.time - epoch_time).sec + epoch_phase_sec + (period_sec - wrap_phase))
-                             % period_sec - (period_sec - wrap_phase))
+        relative_time_sec = (((self.time - epoch_time).sec
+                              + epoch_phase_sec
+                              + (period_sec - wrap_phase)) % period_sec
+                             - (period_sec - wrap_phase))
 
         folded_time = TimeDelta(relative_time_sec * u.s)
 

--- a/astropy/timeseries/sampled.py
+++ b/astropy/timeseries/sampled.py
@@ -141,7 +141,7 @@ class TimeSeries(BaseTimeSeries):
         """
         return self['time']
 
-    @deprecated_renamed_argument('epoch_time', 'midpoint_epoch', '4.0')
+    @deprecated_renamed_argument('midpoint_epoch', 'epoch_time', '4.0')
     def fold(self, period=None, epoch_time=None, epoch_phase=0, normalize_phase=True,
              phase_length=1):
         """

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -158,16 +158,6 @@ def test_fold_phase():
     assert isinstance(tsf.time, u.Quantity)
     assert_allclose(tsf.time.value, [-0.375, -0.125, 0.125, 0.375, -0.375, 0.375], rtol=1e-6)
 
-    # Try half phase
-    tfs = ts.fold(period=4*u.s, phase_length=0.6)
-    assert len(tfs) == 5
-    assert_allclose(tfs.time.value, [0, 0.25, -0.25, 0, -0.25], atol=1e-3)
-
-    # Try half phase with epoch_phase
-    tfs = ts.fold(period=4*u.s, phase_length=0.6, epoch_phase=0.2)
-    assert len(tfs) == 5
-    assert_allclose(tfs.time.value, [0.2, 0.45, -0.05, 0.2, -0.05], atol=1e-3)
-
 
 def test_fold():
     times = Time([1, 2, 3, 8, 9, 12], format='unix')

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -148,15 +148,20 @@ def test_fold_phase():
     ts = TimeSeries(time=times)
     ts['flux'] = [1, 2, 3, 4, 5, 6]
 
-    # Try without midpoint epoch, as it should default to the first time
+    # Try without epoch_time and epoch_phase, as it should default to the first time
     tsf = ts.fold(period=3*u.s)
     assert isinstance(tsf.time, u.Quantity)
-    assert_allclose(tsf.time.value, [0, 1/3, -1/3, 1/3, -1/3, -1/3], rtol=1e-6)
+    assert_allclose(tsf.time.value, [0.5, 5/6, 1/6, 5/6, 1/6, 1/6], rtol=1e-6)
 
-    # Try with midpoint epoch
+    # Try epoch_phase
+    tsf = ts.fold(period=3*u.s, epoch_phase=0)
+    assert isinstance(tsf.time, u.Quantity)
+    assert_allclose(tsf.time.value, [0, 1 / 3, -1 / 3, 1 / 3, -1 / 3, -1 / 3], rtol=1e-6)
+        
+    # Try with epoch_time
     tsf = ts.fold(period=4 * u.s, epoch_time=Time(2.5, format='unix'))
     assert isinstance(tsf.time, u.Quantity)
-    assert_allclose(tsf.time.value, [-0.375, -0.125, 0.125, 0.375, -0.375, 0.375], rtol=1e-6)
+    assert_allclose(tsf.time.value, [0.125, 0.375, 0.625, 0.875, 0.125, 0.875], rtol=1e-6)
 
 
 def test_fold():

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -160,8 +160,8 @@ def test_fold():
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [-0.6, 0.4, 1.4, 0.0, 1.0, 0.8], rtol=1e-6, atol=1e-6)
 
-    # Now with wrap_phase_at set to the full period
-    tsf = ts.fold(period=3.2 * u.s, wrap_phase_at=3.2 * u.s)
+    # Now with wrap_phase set to the full period
+    tsf = ts.fold(period=3.2 * u.s, wrap_phase=3.2 * u.s)
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [0, 1, 2, 0.6, 1.6, 1.4], rtol=1e-6)
 
@@ -170,8 +170,8 @@ def test_fold():
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [0.8, -1.4, -0.4, 1.4, -0.8, -1.0], rtol=1e-6)
 
-    # And combining epoch_phase and wrap_phase_at
-    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.8 * u.s, wrap_phase_at=3.2 * u.s)
+    # And combining epoch_phase and wrap_phase
+    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.8 * u.s, wrap_phase=3.2 * u.s)
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [0.8, 1.8, 2.8, 1.4, 2.4, 2.2], rtol=1e-6)
 
@@ -188,8 +188,8 @@ def test_fold():
     assert isinstance(tsf.time, Quantity)
     assert_allclose(tsf.time.to_value(u.one), [-0.6/3.2, 0.4/3.2, 1.4/3.2, 0.0/3.2, 1.0/3.2, 0.8/3.2], rtol=1e-6, atol=1e-6)
 
-    # Now with wrap_phase_at set to the full period
-    tsf = ts.fold(period=3.2 * u.s, wrap_phase_at=1, normalize_phase=True)
+    # Now with wrap_phase set to the full period
+    tsf = ts.fold(period=3.2 * u.s, wrap_phase=1, normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
     assert_allclose(tsf.time.to_value(u.one), [0, 1/3.2, 2/3.2, 0.6/3.2, 1.6/3.2, 1.4/3.2], rtol=1e-6)
 
@@ -198,8 +198,8 @@ def test_fold():
     assert isinstance(tsf.time, Quantity)
     assert_allclose(tsf.time.to_value(u.one), [0.8/3.2, -1.4/3.2, -0.4/3.2, 1.4/3.2, -0.8/3.2, -1.0/3.2], rtol=1e-6)
 
-    # And combining epoch_phase and wrap_phase_at
-    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.25, wrap_phase_at=1, normalize_phase=True)
+    # And combining epoch_phase and wrap_phase
+    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.25, wrap_phase=1, normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
     assert_allclose(tsf.time.to_value(u.one), [0.8/3.2, 1.8/3.2, 2.8/3.2, 1.4/3.2, 2.4/3.2, 2.2/3.2], rtol=1e-6)
 
@@ -223,23 +223,23 @@ def test_fold_invalid_options():
     with pytest.raises(u.UnitsError, match=f'epoch_phase should be a dimensionless Quantity or a float when normalize_phase=True'):
         ts.fold(period=3.2 * u.s, epoch_phase=0.2 * u.s, normalize_phase=True)
 
-    with pytest.raises(u.UnitsError, match=f'wrap_phase_at should be a Quantity in units of time when normalize_phase=False'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=0.2)
+    with pytest.raises(u.UnitsError, match=f'wrap_phase should be a Quantity in units of time when normalize_phase=False'):
+        ts.fold(period=3.2 * u.s, wrap_phase=0.2)
 
-    with pytest.raises(u.UnitsError, match=f'wrap_phase_at should be dimensionless when normalize_phase=True'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=0.2 * u.s, normalize_phase=True)
+    with pytest.raises(u.UnitsError, match=f'wrap_phase should be dimensionless when normalize_phase=True'):
+        ts.fold(period=3.2 * u.s, wrap_phase=0.2 * u.s, normalize_phase=True)
 
-    with pytest.raises(ValueError, match=f'wrap_phase_at should be between 0 and the period'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=-0.1 * u.s)
+    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and the period'):
+        ts.fold(period=3.2 * u.s, wrap_phase=-0.1 * u.s)
 
-    with pytest.raises(ValueError, match=f'wrap_phase_at should be between 0 and the period'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=-4.2 * u.s)
+    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and the period'):
+        ts.fold(period=3.2 * u.s, wrap_phase=-4.2 * u.s)
 
-    with pytest.raises(ValueError, match=f'wrap_phase_at should be between 0 and 1'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=-0.1, normalize_phase=True)
+    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and 1'):
+        ts.fold(period=3.2 * u.s, wrap_phase=-0.1, normalize_phase=True)
 
-    with pytest.raises(ValueError, match='wrap_phase_at should be between 0 and 1'):
-        ts.fold(period=3.2 * u.s, wrap_phase_at=2.2, normalize_phase=True)
+    with pytest.raises(ValueError, match='wrap_phase should be between 0 and 1'):
+        ts.fold(period=3.2 * u.s, wrap_phase=2.2, normalize_phase=True)
 
 
 def test_pandas():

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -157,7 +157,7 @@ def test_fold_phase():
     tsf = ts.fold(period=3*u.s, epoch_phase=0)
     assert isinstance(tsf.time, u.Quantity)
     assert_allclose(tsf.time.value, [0, 1 / 3, -1 / 3, 1 / 3, -1 / 3, -1 / 3], rtol=1e-6)
-        
+
     # Try with epoch_time
     tsf = ts.fold(period=4 * u.s, epoch_time=Time(2.5, format='unix'))
     assert isinstance(tsf.time, u.Quantity)

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -154,15 +154,19 @@ def test_fold_phase():
     assert_allclose(tsf.time.value, [0, 1/3, -1/3, 1/3, -1/3, -1/3], rtol=1e-6)
 
     # Try with midpoint epoch
-    tsf = ts.fold(period=4 * u.s, epoch=Time(2.5, format='unix'))
+    tsf = ts.fold(period=4 * u.s, epoch_time=Time(2.5, format='unix'))
     assert isinstance(tsf.time, u.Quantity)
     assert_allclose(tsf.time.value, [-0.375, -0.125, 0.125, 0.375, -0.375, 0.375], rtol=1e-6)
 
     # Try half phase
-    tfs = ts.fold(period=4*u.s, phase_range=0.6)
+    tfs = ts.fold(period=4*u.s, phase_length=0.6)
     assert len(tfs) == 5
     assert_allclose(tfs.time.value, [0, 0.25, -0.25, 0, -0.25], atol=1e-3)
 
+    # Try half phase with epoch_phase
+    tfs = ts.fold(period=4*u.s, phase_length=0.6, epoch_phase=0.2)
+    assert len(tfs) == 5
+    assert_allclose(tfs.time.value, [0.2, 0.45, -0.05, 0.2, -0.05], atol=1e-3)
 
 
 def test_fold():
@@ -171,13 +175,13 @@ def test_fold():
     ts = TimeSeries(time=times)
     ts['flux'] = [1, 4, 4, 3, 2, 3]
 
-    # Try without midpoint epoch, as it should default to the first time
+    # Try without epoch time, as it should default to the first time
     tsf = ts.fold(period=3 * u.s, normalize_phase=False)
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [0, 1, -1, 1, -1, -1], rtol=1e-6)
 
-    # Try with midpoint epoch
-    tsf = ts.fold(period=4 * u.s, epoch=Time(2.5, format='unix'), normalize_phase=False)
+    # Try with epoch time
+    tsf = ts.fold(period=4 * u.s, epoch_time=Time(2.5, format='unix'), normalize_phase=False)
     assert isinstance(tsf.time, TimeDelta)
     assert_allclose(tsf.time.sec, [-1.5, -0.5, 0.5, 1.5, -1.5, 1.5], rtol=1e-6)
 

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -181,27 +181,39 @@ def test_fold():
     # wrapping at half the period.
     tsf = ts.fold(period=3.2 * u.s, normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
-    assert_allclose(tsf.time.to_value(u.one), [0, 1/3.2, -1.2/3.2, 0.6/3.2, -1.6/3.2, 1.4/3.2], rtol=1e-6)
+    assert_allclose(tsf.time.to_value(u.one),
+                    [0, 1/3.2, -1.2/3.2, 0.6/3.2, -1.6/3.2, 1.4/3.2],
+                    rtol=1e-6)
 
     # Try with epoch time
-    tsf = ts.fold(period=3.2 * u.s, epoch_time=Time(1.6, format='unix'), normalize_phase=True)
+    tsf = ts.fold(period=3.2 * u.s, epoch_time=Time(1.6, format='unix'),
+                  normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
-    assert_allclose(tsf.time.to_value(u.one), [-0.6/3.2, 0.4/3.2, 1.4/3.2, 0.0/3.2, 1.0/3.2, 0.8/3.2], rtol=1e-6, atol=1e-6)
+    assert_allclose(tsf.time.to_value(u.one),
+                    [-0.6/3.2, 0.4/3.2, 1.4/3.2, 0.0/3.2, 1.0/3.2, 0.8/3.2],
+                    rtol=1e-6, atol=1e-6)
 
     # Now with wrap_phase set to the full period
     tsf = ts.fold(period=3.2 * u.s, wrap_phase=1, normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
-    assert_allclose(tsf.time.to_value(u.one), [0, 1/3.2, 2/3.2, 0.6/3.2, 1.6/3.2, 1.4/3.2], rtol=1e-6)
+    assert_allclose(tsf.time.to_value(u.one),
+                    [0, 1/3.2, 2/3.2, 0.6/3.2, 1.6/3.2, 1.4/3.2],
+                    rtol=1e-6)
 
     # Now set epoch_phase to be 1/4 of the way through the phase
     tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.25, normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
-    assert_allclose(tsf.time.to_value(u.one), [0.8/3.2, -1.4/3.2, -0.4/3.2, 1.4/3.2, -0.8/3.2, -1.0/3.2], rtol=1e-6)
+    assert_allclose(tsf.time.to_value(u.one),
+                    [0.8/3.2, -1.4/3.2, -0.4/3.2, 1.4/3.2, -0.8/3.2, -1.0/3.2],
+                    rtol=1e-6)
 
     # And combining epoch_phase and wrap_phase
-    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.25, wrap_phase=1, normalize_phase=True)
+    tsf = ts.fold(period=3.2 * u.s, epoch_phase=0.25, wrap_phase=1,
+                  normalize_phase=True)
     assert isinstance(tsf.time, Quantity)
-    assert_allclose(tsf.time.to_value(u.one), [0.8/3.2, 1.8/3.2, 2.8/3.2, 1.4/3.2, 2.4/3.2, 2.2/3.2], rtol=1e-6)
+    assert_allclose(tsf.time.to_value(u.one),
+                    [0.8/3.2, 1.8/3.2, 2.8/3.2, 1.4/3.2, 2.4/3.2, 2.2/3.2],
+                    rtol=1e-6)
 
 
 def test_fold_invalid_options():
@@ -211,34 +223,48 @@ def test_fold_invalid_options():
     ts = TimeSeries(time=times)
     ts['flux'] = [1, 4, 4, 3, 2, 3]
 
-    with pytest.raises(u.UnitsError, match='period should be a Quantity in units of time'):
+    with pytest.raises(u.UnitsError,
+                       match='period should be a Quantity in units of time'):
         ts.fold(period=3.2)
 
-    with pytest.raises(u.UnitsError, match='period should be a Quantity in units of time'):
+    with pytest.raises(u.UnitsError,
+                       match='period should be a Quantity in units of time'):
         ts.fold(period=3.2 * u.m)
 
-    with pytest.raises(u.UnitsError, match=f'epoch_phase should be a Quantity in units of time when normalize_phase=False'):
+    with pytest.raises(u.UnitsError,
+                       match='epoch_phase should be a Quantity in units of '
+                             'time when normalize_phase=False'):
         ts.fold(period=3.2 * u.s, epoch_phase=0.2)
 
-    with pytest.raises(u.UnitsError, match=f'epoch_phase should be a dimensionless Quantity or a float when normalize_phase=True'):
+    with pytest.raises(u.UnitsError,
+                       match='epoch_phase should be a dimensionless Quantity '
+                             'or a float when normalize_phase=True'):
         ts.fold(period=3.2 * u.s, epoch_phase=0.2 * u.s, normalize_phase=True)
 
-    with pytest.raises(u.UnitsError, match=f'wrap_phase should be a Quantity in units of time when normalize_phase=False'):
+    with pytest.raises(u.UnitsError,
+                       match='wrap_phase should be a Quantity in units of '
+                             'time when normalize_phase=False'):
         ts.fold(period=3.2 * u.s, wrap_phase=0.2)
 
-    with pytest.raises(u.UnitsError, match=f'wrap_phase should be dimensionless when normalize_phase=True'):
+    with pytest.raises(u.UnitsError,
+                       match='wrap_phase should be dimensionless when '
+                             'normalize_phase=True'):
         ts.fold(period=3.2 * u.s, wrap_phase=0.2 * u.s, normalize_phase=True)
 
-    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and the period'):
+    with pytest.raises(ValueError,
+                       match='wrap_phase should be between 0 and the period'):
         ts.fold(period=3.2 * u.s, wrap_phase=-0.1 * u.s)
 
-    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and the period'):
+    with pytest.raises(ValueError,
+                       match='wrap_phase should be between 0 and the period'):
         ts.fold(period=3.2 * u.s, wrap_phase=-4.2 * u.s)
 
-    with pytest.raises(ValueError, match=f'wrap_phase should be between 0 and 1'):
+    with pytest.raises(ValueError,
+                       match='wrap_phase should be between 0 and 1'):
         ts.fold(period=3.2 * u.s, wrap_phase=-0.1, normalize_phase=True)
 
-    with pytest.raises(ValueError, match='wrap_phase should be between 0 and 1'):
+    with pytest.raises(ValueError,
+                       match='wrap_phase should be between 0 and 1'):
         ts.fold(period=3.2 * u.s, wrap_phase=2.2, normalize_phase=True)
 
 

--- a/docs/timeseries/analysis.rst
+++ b/docs/timeseries/analysis.rst
@@ -174,7 +174,7 @@ an epoch as a :class:`~astropy.time.Time`, which defines a zero time offset:
    :include-source:
    :context:
 
-    kepler_folded = kepler.fold(period=2.2 * u.day, midpoint_epoch='2009-05-02T20:53:40')
+    kepler_folded = kepler.fold(period=2.2 * u.day, epoch_time='2009-05-02T20:53:40')
 
     plt.plot(kepler_folded.time.jd, kepler_folded['sap_flux'], 'k.', markersize=1)
     plt.xlabel('Time from midpoint epoch (days)')
@@ -204,7 +204,7 @@ sigma-clipped median value.
 
    example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
    kepler = TimeSeries.read(example_data, format='kepler.fits')
-   kepler_folded = kepler.fold(period=2.2 * u.day, midpoint_epoch='2009-05-02T20:53:40')
+   kepler_folded = kepler.fold(period=2.2 * u.day, epoch_time='2009-05-02T20:53:40')
 
 .. plot::
    :include-source:

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -225,13 +225,13 @@ For more information on available periodogram algorithms, see
 We can now fold the time series using the period we've found above using the
 :meth:`~astropy.timeseries.TimeSeries.fold` method::
 
-    >>> ts_folded = ts.fold(period=period, midpoint_epoch=transit_time)  # doctest: +REMOTE_DATA
+    >>> ts_folded = ts.fold(period=period, epoch_time=transit_time)  # doctest: +REMOTE_DATA
 
 .. plot::
    :context:
    :nofigs:
 
-   ts_folded = ts.fold(period=period, midpoint_epoch=transit_time)
+   ts_folded = ts.fold(period=period, epoch_time=transit_time)
 
 Let's take a look at the folded time series:
 


### PR DESCRIPTION
This is to fix #9331 

This is the easy part of addressing the issue. There are two more questions remaining  (in addition to brainstorm on the API, I would consider this current one just a draft).

- currently I use `phase_range` as I originally though about it could also accept a tuple of e.g. (0.2, 0.7) to return only that part of the phase curve, but I don't think that being such a good idea any more.
- If e.g phase_range=2 is required, should we really return twice as long TimeSeries as the input?
- this current implementation uses a Quantity as `time` for the TimeSeries being returned. That wasn't considered a valid TimeSeries originally, but maybe we should reconsider, and set a "phase_time=True" attribute?

  
