### PR TITLE
Cleanup conflict headings and failing html_build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,8 +132,7 @@ jobs:
           command: |
             # If it's not a PR, don't upload
             if [ -z "${CIRCLE_PULL_REQUEST}" ]; then
-              rm -r docs/_build/html/*
-              rm -rf docs/_build/html/.*
+              rm -r docs/_build/html
             else
               # If it is a PR, delete sources and doctrees, because it's a lot
               # of files which we don't really need to upload

--- a/astropy/modeling/tests/example_models.py
+++ b/astropy/modeling/tests/example_models.py
@@ -220,14 +220,15 @@ models_1D = {
         'y_lim': [0, 10],
     },
 
-<<<<<<< HEAD
+
     Drude1D: {
         'parameters': [1.0, 8.0, 1.0],
         'x_values': [7.0, 8.0, 9.0, 10.0],
         'y_values': [0.17883212, 1.0, 0.21891892, 0.07163324],
         'x_lim': [1.0, 20.0],
         'y_lim': [0.0, 10.0]
-=======
+    },
+
     Exponential1D: {
         'parameters': [1, 1],
         'x_values': [0, 0.5, 1],
@@ -242,7 +243,6 @@ models_1D = {
         'y_values': [0, 1, 2],
         'x_lim': [1, np.e**2],
         'integral': (np.e**2 + 1),
->>>>>>> 472589f5d... Added Exponential1D and Logarithmic1D classes
     }
 }
 


### PR DESCRIPTION
This should fix the recent reason for CI failures. 

I would argue that we shouldn't even wait for CI, as it locally passes and without it, all the CI on the other PRs are failing.