### PR TITLE
Quantity behaviour for np.isclose, np.allclose; some others

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1625,12 +1625,12 @@ class Quantity(np.ndarray):
     # Calculation: override methods that do not make sense.
 
     def all(self, axis=None, out=None):
-        raise NotImplementedError("cannot evaluate truth value of quantities. "
-                                  "Evaluate array with q.value.all(...)")
+        raise TypeError("cannot evaluate truth value of quantities. "
+                        "Evaluate array with q.value.all(...)")
 
     def any(self, axis=None, out=None):
-        raise NotImplementedError("cannot evaluate truth value of quantities. "
-                                  "Evaluate array with q.value.any(...)")
+        raise TypeError("cannot evaluate truth value of quantities. "
+                        "Evaluate array with q.value.any(...)")
 
     # Calculation: numpy functions that can be overridden with methods.
 

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -104,15 +104,11 @@ if NUMPY_LT_1_18:
 # np.ediff1d is from setops, but we support it anyway; the others
 # currently return NotImplementedError.
 # TODO: move latter to UNSUPPORTED? Would raise TypeError instead.
-SUBCLASS_SAFE_FUNCTIONS |= {
-    np.ediff1d,
-    np.all, np.any, np.sometrue, np.alltrue}
+SUBCLASS_SAFE_FUNCTIONS |= {np.ediff1d}
 
-# Subclass safe, but possibly better if overridden (e.g., with different
-# default arguments for isclose, allclose).
+# Subclass safe, but possibly better if overridden.
 # TODO: decide on desired behaviour.
 SUBCLASS_SAFE_FUNCTIONS |= {
-    np.isclose, np.allclose,
     np.array2string, np.array_repr, np.array_str}
 
 # Nonsensical for quantities.
@@ -120,7 +116,7 @@ UNSUPPORTED_FUNCTIONS |= {
     np.packbits, np.unpackbits, np.unravel_index,
     np.ravel_multi_index, np.ix_, np.cov, np.corrcoef,
     np.busday_count, np.busday_offset, np.datetime_as_string,
-    np.is_busday}
+    np.is_busday, np.all, np.any, np.sometrue, np.alltrue}
 
 # The following are not just unsupported, but so unlikely to be thought
 # to be supported that we ignore them in testing.  (Kept in a separate
@@ -545,6 +541,17 @@ def percentile(a, q, *args, **kwargs):
 @function_helper
 def count_nonzero(a, *args, **kwargs):
     return (a.value,) + args, kwargs, None, None
+
+
+@function_helper(helps={np.isclose, np.allclose})
+def close(a, b, rtol=1e-05, atol=1e-08, *args, **kwargs):
+    from astropy.units import Quantity
+
+    (a, b), unit = _quantities2arrays(a, b, unit_from_first=True)
+    # Allow number without a unit as having the unit.
+    atol = Quantity(atol, unit).value
+
+    return (a, b, rtol, atol) + args, kwargs, None, None
 
 
 @function_helper

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -161,11 +161,15 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         self.check(np.rot90)
 
     def test_broadcast_to(self):
-        # TODO: should we change the default for subok?
+        # Decided *not* to change default for subok for Quantity, since
+        # that would be contrary to the docstring and might break code.
         self.check(np.broadcast_to, (3, 3, 3), subok=True)
+        out = np.broadcast_to(self.q, (3, 3, 3))
+        assert type(out) is np.ndarray  # NOT Quantity
 
     def test_broadcast_arrays(self):
-        # TODO: should we change the default for subok?
+        # Decided *not* to change default for subok for Quantity, since
+        # that would be contrary to the docstring and might break code.
         q2 = np.ones((3, 3, 3)) / u.s
         o1, o2 = np.broadcast_arrays(self.q, q2, subok=True)
         assert isinstance(o1, u.Quantity)
@@ -173,6 +177,9 @@ class TestShapeManipulation(InvariantUnitTestSetup):
         assert o1.shape == o2.shape == (3, 3, 3)
         assert np.all(o1 == self.q)
         assert np.all(o2 == q2)
+        a1, a2 = np.broadcast_arrays(self.q, q2)
+        assert type(a1) is np.ndarray
+        assert type(a2) is np.ndarray
 
 
 class TestArgFunctions(NoUnitTestSetup):

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1559,9 +1559,8 @@ class TestSortFunctions(InvariantUnitTestSetup):
 
 
 class TestStringFunctions(metaclass=CoverageMeta):
-    # For all these functions, we could change it to work on Quantity,
-    # but it would mean deviating from the docstring.  Not clear whether
-    # that is worth it.
+    # For these, making behaviour work means deviating only slightly from
+    # the docstring, and by default they fail miserably.  So, might as well.
     def setup(self):
         self.q = np.arange(3.) * u.Jy
 
@@ -1571,14 +1570,17 @@ class TestStringFunctions(metaclass=CoverageMeta):
         expected = str(self.q)
         assert out == expected
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_array_repr(self):
         out = np.array_repr(self.q)
-        expected = (np.array_repr(self.q.value)[:-1] +
-                    ', {!r})'.format(str(self.q.unit)))
-        assert out == expected
+        assert out == "Quantity([0., 1., 2.], unit='Jy')"
+        q2 = self.q.astype('f4')
+        out2 = np.array_repr(q2)
+        assert out2 == "Quantity([0., 1., 2.], unit='Jy', dtype=float32)"
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                       reason="Needs __array_function__ support")
     def test_array_str(self):
         out = np.array_str(self.q)
         expected = str(self.q)

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -150,7 +150,8 @@ Quantities Float Comparison with np.isclose Fails
 -------------------------------------------------
 
 Comparing Quantities floats using the NumPy function `~numpy.isclose` fails on
-NumPy 1.9 as the comparison between ``a`` and ``b`` is made using the formula
+NumPy versions before 1.17 as the comparison between ``a`` and ``b``
+is made using the formula
 
 .. math::
 
@@ -160,14 +161,14 @@ This will result in the following traceback when using this with Quantities::
 
     >>> from astropy import units as u, constants as const
     >>> import numpy as np
-    >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s)  # doctest: +SKIP
     Traceback (most recent call last):
     ...
     UnitConversionError: Can only apply 'add' function to dimensionless quantities when other argument is not a quantity (unless the latter is all zero/infinity/nan)
 
-One solution is::
+If one cannot upgrade to numpy 1.17 or later, one solution is::
 
-    >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s, atol=1e-8 * u.mm / u.s) # doctest: +SKIP
+    >>> np.isclose(500 * u.km/u.s, 300 * u.km / u.s, atol=1e-8 * u.mm / u.s)
     False
 
 Quantities in np.linspace Failure on NumPy 1.10


### PR DESCRIPTION
Following on #9462, this changes the Quantity implementation for `isclose` and `allclose` to assume a default unit of the first argument for `atol` (including for its default of 1e-8). It sticks with the docstring behaviour for `np.broadcast_*` to avoid breaking existing code. It also explicitly disallows `np.any`, `np.all` (which is most logical but changes the error raised), and makes `array_repr`, `array_str` and `array2string` work (former two slightly hacky). All the latter failed for all but dimensionless arrays.

fixes #9462