### PR TITLE
Quantity __array_function__ overrides for numpy.fft

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1477,7 +1477,7 @@ class Quantity(np.ndarray):
         ~astropy.units.UnitsError
             If operands have incompatible units.
         """
-        # A function should be in one of the following sets of dicts:
+        # A function should be in one of the following sets or dicts:
         # 1. SUBCLASS_SAFE_FUNCTIONS (set), if the numpy implementation
         #    supports Quantity; we pass on to ndarray.__array_function__.
         # 2. FUNCTION_HELPERS (dict), if the numpy implementation is usable

--- a/astropy/units/quantity_helper/function_helpers.py
+++ b/astropy/units/quantity_helper/function_helpers.py
@@ -178,8 +178,12 @@ function_helper = FunctionAssigner(FUNCTION_HELPERS)
 dispatched_function = FunctionAssigner(DISPATCHED_FUNCTIONS)
 
 
-@function_helper(helps={np.copy, np.asfarray, np.real_if_close,
-                        np.sort_complex, np.resize})
+@function_helper(helps={
+    np.copy, np.asfarray, np.real_if_close, np.sort_complex, np.resize,
+    np.fft.fft, np.fft.ifft, np.fft.rfft, np.fft.irfft,
+    np.fft.fft2, np.fft.ifft2, np.fft.rfft2, np.fft.irfft2,
+    np.fft.fftn, np.fft.ifftn, np.fft.rfftn, np.fft.irfftn,
+    np.fft.hfft, np.fft.ihfft})
 def invariant_a_helper(a, *args, **kwargs):
     return (a.view(np.ndarray),) + args, kwargs, a.unit, None
 
@@ -187,6 +191,11 @@ def invariant_a_helper(a, *args, **kwargs):
 @function_helper(helps={np.tril, np.triu})
 def invariant_m_helper(m, *args, **kwargs):
     return (m.view(np.ndarray),) + args, kwargs, m.unit, None
+
+
+@function_helper(helps={np.fft.fftshift, np.fft.ifftshift})
+def invariant_x_helper(x, *args, **kwargs):
+    return (x.view(np.ndarray),) + args, kwargs, x.unit, None
 
 
 # Note that ones_like does *not* work by default (unlike zeros_like) since if

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -30,7 +30,7 @@ def get_wrapped_functions(*modules):
     return wrapped_functions
 
 
-all_wrapped_functions = get_wrapped_functions(np)
+all_wrapped_functions = get_wrapped_functions(np, np.fft)
 all_wrapped = set(all_wrapped_functions.values())
 
 
@@ -1768,6 +1768,63 @@ class TestDatetimeFunctions(BasicTestSetup):
     def test_is_busday(self):
         with pytest.raises(TypeError):
             np.is_busday(self.q)
+
+
+@pytest.mark.xfail(NO_ARRAY_FUNCTION,
+                   reason="Needs __array_function__ support")
+class TestFFT(InvariantUnitTestSetup):
+    # These are all trivial, just preserve the unit.
+    def setup(self):
+        # Use real input; gets turned into complex as needed.
+        self.q = np.arange(128.).reshape(8, -1) * u.s
+
+    def test_fft(self):
+        self.check(np.fft.fft)
+
+    def test_ifft(self):
+        self.check(np.fft.ifft)
+
+    def test_rfft(self):
+        self.check(np.fft.rfft)
+
+    def test_irfft(self):
+        self.check(np.fft.irfft)
+
+    def test_fft2(self):
+        self.check(np.fft.fft2)
+
+    def test_ifft2(self):
+        self.check(np.fft.ifft2)
+
+    def test_rfft2(self):
+        self.check(np.fft.rfft2)
+
+    def test_irfft2(self):
+        self.check(np.fft.irfft2)
+
+    def test_fftn(self):
+        self.check(np.fft.fftn)
+
+    def test_ifftn(self):
+        self.check(np.fft.ifftn)
+
+    def test_rfftn(self):
+        self.check(np.fft.rfftn)
+
+    def test_irfftn(self):
+        self.check(np.fft.irfftn)
+
+    def test_hfft(self):
+        self.check(np.fft.hfft)
+
+    def test_ihfft(self):
+        self.check(np.fft.ihfft)
+
+    def test_fftshift(self):
+        self.check(np.fft.fftshift)
+
+    def test_ifftshift(self):
+        self.check(np.fft.ifftshift)
 
 
 untested_functions = set()

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -1761,10 +1761,6 @@ class TestDatetimeFunctions(BasicTestSetup):
             np.is_busday(self.q)
 
 
-should_be_tested_functions = {
-    np.apply_along_axis, np.apply_over_axes,
-    }
-
 untested_functions = set()
 financial_functions = {f for f in all_wrapped_functions.values()
                        if f in np.lib.financial.__dict__.values()}

--- a/astropy/units/tests/test_quantity_non_ufuncs.py
+++ b/astropy/units/tests/test_quantity_non_ufuncs.py
@@ -19,9 +19,18 @@ NO_ARRAY_FUNCTION = not ARRAY_FUNCTION_ENABLED
 
 # To get the functions that could be covered, we look for those that
 # are wrapped.  Of course, this does not give a full list pre-1.17.
-all_wrapped_functions = {name: f for name, f in np.__dict__.items()
-                         if callable(f) and hasattr(f, '__wrapped__')
-                         and f is not np.printoptions}
+def get_wrapped_functions(*modules):
+    wrapped_functions = {}
+    for mod in modules:
+        for name, f in mod.__dict__.items():
+            if f is np.printoptions:
+                continue
+            if callable(f) and hasattr(f, '__wrapped__'):
+                wrapped_functions[name] = f
+    return wrapped_functions
+
+
+all_wrapped_functions = get_wrapped_functions(np)
 all_wrapped = set(all_wrapped_functions.values())
 
 


### PR DESCRIPTION
They were so easy - all routines just need to propagate the unit - that I thought I might as well get it in. One step further for #8825.

@bsipocz - you'll see that I'm already labelling things both enhancement and bug - but it is a bug not to cover all of numpy...