### PR TITLE
remove deprecated _naxis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -111,6 +111,10 @@ astropy.modeling
 
 - Add ``Drude1D`` model. [#9452]
 
+- Added analytical King model (KingProjectedAnalytic1D) [#9084]
+
+- Added Exponential1D and Logarithmic1D models [#9351]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 
@@ -358,9 +362,7 @@ astropy.modeling
 
 - Many private attributes and methods have changed (see documentation). [#8769]
 
-- Added analytical King model (KingProjectedAnalytic1D) [#9084]
-
-- Added Exponential1D and Logarithmic1D models [#9351]
+- The deprecated ``rotations.rotation_matrix_from_angle`` was removed. [#9363]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -68,10 +68,6 @@ __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
 
 __doctest_skip__ = ['WCS.all_world2pix']
 
-NAXIS_DEPRECATE_MESSAGE = """
-Private attributes "_naxis1" and "_naxis2" have been deprecated since v3.1.
-Instead use the "pixel_shape" property which returns a list of NAXISj keyword values.
-"""
 
 if _wcs is not None:
     _parsed_version = _wcs.__version__.split('.')
@@ -2699,26 +2695,6 @@ reduce these to 2 dimensions using the naxis kwarg.
             if ftpr is not None:
                 ftpr.tofile(f, sep=',')
                 f.write(f') # color={color}, width={width:d} \n')
-
-    @property
-    def _naxis1(self):
-        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
-        return self._naxis[0]
-
-    @_naxis1.setter
-    def _naxis1(self, value):
-        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
-        self._naxis[0] = value
-
-    @property
-    def _naxis2(self):
-        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
-        return self._naxis[1]
-
-    @_naxis2.setter
-    def _naxis2(self, value):
-        warnings.warn(NAXIS_DEPRECATE_MESSAGE, AstropyDeprecationWarning)
-        self._naxis[1] = value
 
     def _get_naxis(self, header=None):
         _naxis = []


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes part of #8888 - removes the deprecated `_naxis1` and `_naxis2` from astropy.wcs.
I didn't add a change log entry as these were private, though I can add one if necessary.

The deprecated `rotations.rotation_matrix_from_angle` was removed in #9369, I added a log message about this here. Also noticed that some of the new additions to modeling were under `API Changes` instead of `New Features` and moved them.

