### PR TITLE
Allow masked array inputs to biweight stat functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -134,6 +134,9 @@ astropy.stats
 - Added an ``ignore_nan`` option to the ``biweight_location``,
   ``biweight_scale``, and ``biweight_midvariance`` functions. [#9457]
 
+- A numpy ``MaskedArray`` can now be input to the ``biweight_location``,
+  ``biweight_scale``, and ``biweight_midvariance`` functions. [#9466]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -815,7 +815,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
             is_masked = True
             func = np.ma.median
             if ignore_nan:
-                data = np.ma.masked_where(np.isnan(data), data, copy=False)
+                data = np.ma.masked_where(np.isnan(data), data, copy=True)
         elif ignore_nan:
             is_masked = False
             func = np.nanmedian

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -113,6 +113,9 @@ def test_median_absolute_deviation_nans_masked():
     mad2 = funcs.median_absolute_deviation(data2, ignore_nan=True)
     assert_equal(mad1, mad2)
 
+    # ensure that input masked array is not modified
+    assert np.isnan(data2[1])
+
 
 def test_median_absolute_deviation_multidim_axis():
     array = np.ones((5, 4, 3)) * np.arange(5)[:, np.newaxis, np.newaxis]


### PR DESCRIPTION
This PR allows `MaskedArray` input to the `biweight_location`, `biweight_scale`, and `biweight_midvariance` functions.

While testing this PR, I also discovered a small bug in `median_absolute_deviation` that I introduced in #9307 (astropy-dev) where masked array inputs could change after calling the function.  This PR also fixes that (and adds a regression test).