### PR TITLE
TST: Tests for table and votable bytestring obj

### DIFF
--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -270,3 +270,8 @@ def test_gemini_v1_2():
     '''
     table = parse_single_table(get_pkg_data_filename('data/gemini.xml'))
     assert table is not None
+
+    tt = table.to_table()
+    assert tt['access_url'][0] == (
+        b'http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEMINI/'
+        b'S20120515S0064?runid=bx9b1o8cvk1qesrt')

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -63,7 +63,7 @@ def test_table(tmpdir):
     for field, type in zip(t.fields, field_types):
         name, d = type
         assert field.ID == name
-        assert field.datatype == d['datatype']
+        assert field.datatype == d['datatype'], f'{name} expected {d["datatype"]} but get {field.datatype}'  # noqa
         if 'arraysize' in d:
             assert field.arraysize == d['arraysize']
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import operator
 
 import pytest
@@ -676,6 +675,23 @@ def test_col_unicode_sandwich_create_from_str(Column):
     assert isinstance(c[0], str)
     assert isinstance(c[:0], table.Column)
     assert np.all(c[:2] == np.array([uba, 'def']))
+
+
+@pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))
+def test_col_unicode_sandwich_bytes_obj(Column):
+    """
+    Create a Column of dtype object with bytestring in it and make sure
+    it keeps the bytestring and not convert to str with accessed.
+    """
+    c = Column([None, b'def'])
+    assert c.dtype.char == 'O'
+    assert not c[0]
+    assert c[1] == b'def'
+    assert isinstance(c[1], bytes)
+    assert not isinstance(c[1], str)
+    assert isinstance(c[:0], table.Column)
+    assert np.all(c[:2] == np.array([None, b'def']))
+    assert not np.all(c[:2] == np.array([None, 'def']))
 
 
 @pytest.mark.parametrize('Column', (table.Column, table.MaskedColumn))


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to add tests for Table and VO Table that contain bytestring object.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Tests are taken from #8745 given that the PR is delayed. I think the tests are useful enough to be included now and will guard against unintentional behavior changes when we can revisit the other PR in the future.
