### PR TITLE
Corrected a spurious warning about the "value" attribute of VOTable <option>.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,10 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- Corrected a spurious warning issued for the ``value`` attribute of the
+  ``<OPTION>`` element in VOTable, as well as a test that erroneously
+  treated the warning as acceptable.  [#9470]
+
 astropy.logger
 ^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,10 +72,6 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
-- Corrected a spurious warning issued for the ``value`` attribute of the
-  ``<OPTION>`` element in VOTable, as well as a test that erroneously
-  treated the warning as acceptable.  [#9470]
-
 astropy.logger
 ^^^^^^^^^^^^^^
 
@@ -545,6 +541,10 @@ astropy.io.votable
 - Address issue #8995 by ignoring BINARY2 null mask bits for string values
   on parsing a VOTable.  In this way, the reader should never create masked
   values for string types. [#9057]
+  
+- Corrected a spurious warning issued for the ``value`` attribute of the
+  ``<OPTION>`` element in VOTable, as well as a test that erroneously
+  treated the warning as acceptable.  [#9470]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^

--- a/astropy/io/votable/tests/data/gemini.xml
+++ b/astropy/io/votable/tests/data/gemini.xml
@@ -75,8 +75,8 @@
       <PARAM name="ID" datatype="char" arraysize="*" value="" />
       <PARAM name="RESPONSEFORMAT" datatype="char" arraysize="*" value="application/x-votable+xml;content=datalink">
         <VALUES>
-          <OPTION value="application/x-votable+xml;content=datalink" />
-          <OPTION value="application/x-download-manifest+txt" />
+          <OPTION value="application/x-votable+xml;content=datalink" name="good"/>
+          <OPTION value="application/x-download-manifest+txt" spurious="bad"/>
         </VALUES>
       </PARAM>
     </GROUP>

--- a/astropy/io/votable/tests/data/validation.txt
+++ b/astropy/io/votable/tests/data/validation.txt
@@ -54,10 +54,6 @@ Validation report for /tmp/astropy-test-D69Wr6/lib.linux-x86_64-2.7/astropy/io/v
   <VALUES null="-32769"/>
   ^
 
-50: W48: Unknown attribute 'value' on OPTION
-    <OPTION name="bogus" value="whatever"/>
-    ^
-
 52: W10: Unknown tag 'IGNORE_ME'.  Ignoring
   <IGNORE_ME/>
   ^

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -220,7 +220,7 @@ class TestVerifyOptions:
     def test_verify_warn(self):
         with catch_warnings(VOWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), verify='warn')
-        assert len(w) == 23
+        assert len(w) == 24
 
     def test_verify_exception(self):
         with pytest.raises(VOWarning):
@@ -231,7 +231,7 @@ class TestVerifyOptions:
     def test_pedantic_false(self):
         with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), pedantic=False)
-        assert len(w) == 23
+        assert len(w) == 24
         # Make sure we don't yet emit a deprecation warning
         assert not any(isinstance(x.category, AstropyDeprecationWarning) for x in w)
 
@@ -251,7 +251,7 @@ class TestVerifyOptions:
         with conf.set_temp('verify', 'warn'):
             with catch_warnings(VOWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
-            assert len(w) == 23
+            assert len(w) == 24
 
     def test_conf_verify_exception(self):
         with conf.set_temp('verify', 'exception'):
@@ -271,7 +271,7 @@ class TestVerifyOptions:
 
             with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
-            assert len(w) == 23
+            assert len(w) == 24
             # Make sure we don't yet emit a deprecation warning
             assert not any(isinstance(x.category, AstropyDeprecationWarning) for x in w)
 

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -220,7 +220,7 @@ class TestVerifyOptions:
     def test_verify_warn(self):
         with catch_warnings(VOWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), verify='warn')
-        assert len(w) == 25
+        assert len(w) == 23
 
     def test_verify_exception(self):
         with pytest.raises(VOWarning):
@@ -231,7 +231,7 @@ class TestVerifyOptions:
     def test_pedantic_false(self):
         with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
             parse(get_pkg_data_filename('data/gemini.xml'), pedantic=False)
-        assert len(w) == 25
+        assert len(w) == 23
         # Make sure we don't yet emit a deprecation warning
         assert not any(isinstance(x.category, AstropyDeprecationWarning) for x in w)
 
@@ -251,7 +251,7 @@ class TestVerifyOptions:
         with conf.set_temp('verify', 'warn'):
             with catch_warnings(VOWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
-            assert len(w) == 25
+            assert len(w) == 23
 
     def test_conf_verify_exception(self):
         with conf.set_temp('verify', 'exception'):
@@ -271,7 +271,7 @@ class TestVerifyOptions:
 
             with catch_warnings(VOWarning, AstropyDeprecationWarning) as w:
                 parse(get_pkg_data_filename('data/gemini.xml'))
-            assert len(w) == 25
+            assert len(w) == 23
             # Make sure we don't yet emit a deprecation warning
             assert not any(isinstance(x.category, AstropyDeprecationWarning) for x in w)
 

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1038,7 +1038,7 @@ class Values(Element, _IDProperty):
                             (data.get('name'), data.get('value')))
                         warn_unknown_attrs(
                             'OPTION', data.keys(), config, pos,
-                            ['data', 'name'])
+                            ['value', 'name'])
                 elif tag == 'VALUES':
                     break
 


### PR DESCRIPTION
The table_test.py tests on gemini.xml exposed this bug but the "correct"
return value from several tests was incorrectly set to accept the spurious
warnings as acceptable.

There are still 23 warnings on the existing test file; at some point it
may be reasonable to look at the file by hand and determine whether it
can be made more conformant, and then carry out the tests in future
both on the conformant XML and the existing version, so as to have one
test that expects no warnings, and another that tests that warnings are
properly issued for bad XML.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->
