### PR TITLE
MNT: Deprecate set_locale and rename it to _set_locale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -561,6 +561,9 @@ astropy.utils
 - Deprecated ``astropy.utils.timer`` module, which has been moved to
   ``astroquery.utils.timer`` and will be part of ``astroquery`` 0.4.0. [#9038]
 
+- Deprecated ``astropy.utils.misc.set_locale`` function, as it is meant for
+  internal use only. [#9471]
+
 - The implementation of ``data_info.DataInfo`` has changed (for a considerable
   performance boost). Generally, this should not affect simple subclasses, but
   because the class now uses ``__slots__`` any attributes on the class have to

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 from . import core
 from astropy.table import Table
 from . import cparser
-from astropy.utils import set_locale
+from astropy.utils.misc import _set_locale
 
 
 class FastBasic(metaclass=core.MetaBaseReader):
@@ -124,7 +124,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
             try_float = {}
             try_string = {}
 
-        with set_locale('C'):
+        with _set_locale('C'):
             data, comments = self.engine.read(try_int, try_float, try_string)
         out = self.make_table(data, comments)
 

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -362,7 +362,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
         2
         >>> test(sigma=2)
         2
-        >>> test(sig=2)
+        >>> test(sig=2)  # doctest: +SKIP
         2
 
     To deprecate an argument caught inside the ``**kwargs`` the
@@ -375,7 +375,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
 
         >>> test(sigma=2)
         2
-        >>> test(sig=2)
+        >>> test(sig=2)  # doctest: +SKIP
         2
 
     By default providing the new and old keyword will lead to an Exception. If
@@ -385,7 +385,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
         ... def test(sigma):
         ...     return sigma
 
-        >>> test(sig=2)
+        >>> test(sig=2)  # doctest: +SKIP
         2
 
     It is also possible to replace multiple arguments. The ``old_name``,
@@ -397,7 +397,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
         ... def test(alpha, beta):
         ...     return alpha, beta
 
-        >>> test(a=2, b=3)
+        >>> test(a=2, b=3)  # doctest: +SKIP
         (2, 3)
 
     In this case ``arg_in_kwargs`` and ``relax`` can be a single value (which

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -23,15 +23,13 @@ from itertools import zip_longest
 from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 
-import numpy as np
-
 from astropy.utils.decorators import deprecated
 
 
 __all__ = ['isiterable', 'silence', 'format_exception', 'NumpyRNGContext',
            'find_api_page', 'is_path_hidden', 'walk_skip_hidden',
-           'JsonCustomEncoder', 'indent', 'InheritDocstrings',
-           'OrderedDescriptor', 'OrderedDescriptorContainer', 'set_locale',
+           'JsonCustomEncoder', 'indent',
+           'OrderedDescriptor', 'OrderedDescriptorContainer',
            'ShapedLikeNDArray', 'check_broadcast', 'IncompatibleShapeError',
            'dtype_bytes_or_chars', 'unbroadcast']
 
@@ -515,10 +513,10 @@ class InheritDocstrings(type):
     For example::
 
         >>> import warnings
-        >>> from astropy.utils.misc import InheritDocstrings
         >>> with warnings.catch_warnings():
         ...     # Ignore deprecation warning
         ...     warnings.simplefilter('ignore')
+        ...     from astropy.utils.misc import InheritDocstrings
         ...     class A(metaclass=InheritDocstrings):
         ...         def wiggle(self):
         ...             "Wiggle the thingamajig"
@@ -858,7 +856,7 @@ LOCALE_LOCK = threading.Lock()
 
 
 @contextmanager
-def set_locale(name):
+def _set_locale(name):
     """
     Context manager to temporarily set the locale to ``name``.
 
@@ -866,7 +864,7 @@ def set_locale(name):
     function will use "." as the decimal point to enable consistent
     numerical string parsing.
 
-    Note that one cannot nest multiple set_locale() context manager
+    Note that one cannot nest multiple _set_locale() context manager
     statements as this causes a threading lock.
 
     This code taken from https://stackoverflow.com/questions/18593661/how-do-i-strftime-a-date-object-in-a-different-locale.
@@ -889,6 +887,12 @@ def set_locale(name):
                 yield
             finally:
                 locale.setlocale(locale.LC_ALL, saved)
+
+
+set_locale = deprecated('4.0')(_set_locale)
+set_locale.__doc__ = """Deprecated version of :func:`_set_locale` above.
+See https://github.com/astropy/astropy/issues/9196
+"""
 
 
 class ShapedLikeNDArray(metaclass=abc.ABCMeta):

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -9,7 +9,6 @@ import pytest
 import numpy as np
 
 from astropy.utils import data, misc
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 def test_isiterable():
@@ -79,17 +78,17 @@ def test_JsonCustomEncoder():
     assert newd == tmpd
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_inherit_docstrings():
-    with pytest.warns(AstropyDeprecationWarning, match="inherits docstring"):
-        class Base(metaclass=misc.InheritDocstrings):
-            def __call__(self, *args):
-                "FOO"
-                pass
+    class Base(metaclass=misc.InheritDocstrings):
+        def __call__(self, *args):
+            "FOO"
+            pass
 
-            @property
-            def bar(self):
-                "BAR"
-                pass
+        @property
+        def bar(self):
+            "BAR"
+            pass
 
     class Subclass(Base):
         def __call__(self, *args):
@@ -121,16 +120,16 @@ def test_set_locale():
     date = datetime(2000, 10, 1, 0, 0, 0)
     day_mon = date.strftime('%a, %b')
 
-    with misc.set_locale('en_US'):
+    with misc._set_locale('en_US'):
         assert date.strftime('%a, %b') == 'Sun, Oct'
 
-    with misc.set_locale('de_DE'):
+    with misc._set_locale('de_DE'):
         assert date.strftime('%a, %b') == 'So, Okt'
 
     # Back to original
     assert date.strftime('%a, %b') == day_mon
 
-    with misc.set_locale(current):
+    with misc._set_locale(current):
         assert date.strftime('%a, %b') == day_mon
 
 

--- a/astropy/utils/tests/test_timer.py
+++ b/astropy/utils/tests/test_timer.py
@@ -16,8 +16,6 @@ import pytest
 import numpy as np
 
 # LOCAL
-from astropy.utils.exceptions import (
-    AstropyUserWarning, AstropyDeprecationWarning)
 from astropy.utils.timer import RunTimePredictor
 from astropy.modeling.fitting import ModelsError
 
@@ -35,11 +33,10 @@ def func_to_time(x):
     return y
 
 
+@pytest.mark.filterwarnings("ignore")
 def test_timer():
     """Test function timer."""
-    with pytest.warns(AstropyDeprecationWarning,
-                      match='astroquery.utils.timer.RunTimePredictor'):
-        p = RunTimePredictor(func_to_time)
+    p = RunTimePredictor(func_to_time)
 
     # --- These must run before data points are introduced. ---
 
@@ -51,9 +48,7 @@ def test_timer():
 
     # --- These must run next to set up data points. ---
 
-    with pytest.warns(AstropyUserWarning, match="ufunc 'multiply' did not "
-                      "contain a loop with signature matching types"):
-        p.time_func([2.02, 2.04, 2.1, 'a', 2.3])
+    p.time_func([2.02, 2.04, 2.1, 'a', 2.3])
     p.time_func(2.2)  # Test OrderedDict
 
     assert p._funcname == 'func_to_time'

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -18,8 +18,8 @@ from astropy import modeling
 from astropy.utils.decorators import deprecated
 from astropy.utils.exceptions import AstropyUserWarning
 
-__all__ = ['timefunc', 'RunTimePredictor']
-__doctest_skip__ = ['timefunc']
+__all__ = []
+__doctest_skip__ = ['*']
 
 
 @deprecated('4.0', alternative='astroquery.utils.timer.timefunc')

--- a/astropy/wcs/tests/test_wcsprm.py
+++ b/astropy/wcs/tests/test_wcsprm.py
@@ -17,7 +17,7 @@ from astropy.wcs import _wcs
 from astropy.wcs.wcs import FITSFixedWarning
 from astropy.utils.data import (
     get_pkg_data_contents, get_pkg_data_fileobj, get_pkg_data_filename)
-from astropy.utils.misc import set_locale
+from astropy.utils.misc import _set_locale
 from astropy import units as u
 from astropy.units.core import UnitsWarning
 
@@ -848,7 +848,7 @@ def test_header_parse():
 
 def test_locale():
     try:
-        with set_locale('fr_FR'):
+        with _set_locale('fr_FR'):
             header = get_pkg_data_contents('data/locale.hdr',
                                            encoding='binary')
             with pytest.warns(FITSFixedWarning):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to deprecate the public API version of `set_locale()` and rename it to `_set_locale()` due to its dangerous nature. I also took the opportunity to get rid of more test warnings in `utils`, mainly caused by deprecation/deprecated thingies.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9196
