### PR TITLE
Add unit argument to Table.from_pandas

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -633,7 +633,7 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
-- Support for unicode parsing. Currently supported superscripts are Ohm,
+- Support for unicode parsing. Currently supported are superscripts, Ohm,
   Ångström, and the micro-sign. [#9348]
 
 - Accept non-unit type annotations in @quantity_input. [#8984]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,7 +148,7 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
-- ``Table.from_pandas`` no supports a ``units`` dictionary as argument to pass units
+- ``Table.from_pandas`` now supports a ``units`` dictionary as argument to pass units
   for columns in the ``DataFrame``. [#9472]
 
 astropy.tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -148,6 +148,8 @@ astropy.stats
 
 astropy.table
 ^^^^^^^^^^^^^
+- ``Table.from_pandas`` no supports a ``units`` dictionary as argument to pass units
+  for columns in the ``DataFrame``. [#9472]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3372,7 +3372,7 @@ class Table:
         return DataFrame(out, **kwargs)
 
     @classmethod
-    def from_pandas(cls, dataframe, index=False):
+    def from_pandas(cls, dataframe, index=False, units=None):
         """
         Create a `~astropy.table.Table` from a :class:`pandas.DataFrame` instance
 
@@ -3386,6 +3386,9 @@ class Table:
             A pandas :class:`pandas.DataFrame` instance
         index : bool
             Include the index column in the returned table (default=False)
+        units: dict
+            A dict mapping column names to to a `~astropy.units.Unit`.
+            The columns will have the specified unit in the Table.
 
         Returns
         -------
@@ -3443,7 +3446,12 @@ class Table:
             datas.insert(0, np.array(dataframe.index))
             masks.insert(0, np.zeros(len(dataframe), dtype=bool))
 
-        for name, column, data, mask in zip(names, columns, datas, masks):
+        if units is None:
+            units = [None] * len(names)
+        else:
+            units = [units.get(name) for name in names]
+
+        for name, column, data, mask, unit in zip(names, columns, datas, masks, units):
 
             if data.dtype.kind == 'O':
                 # If all elements of an object array are string-like or np.nan
@@ -3477,9 +3485,9 @@ class Table:
 
             else:
                 if np.any(mask):
-                    out[name] = MaskedColumn(data=data, name=name, mask=mask)
+                    out[name] = MaskedColumn(data=data, name=name, mask=mask, unit=unit)
                 else:
-                    out[name] = Column(data=data, name=name)
+                    out[name] = Column(data=data, name=name, unit=unit)
 
         return cls(out)
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3449,6 +3449,15 @@ class Table:
         if units is None:
             units = [None] * len(names)
         else:
+            if not isinstance(units, Mapping):
+                raise TypeError('Expected a Mapping "column-name" -> "unit"')
+
+            not_found = set(units.keys()) - set(names)
+            if not_found:
+                warnings.warn('`units` contains additionial columns: {}'.format(
+                    not_found
+                ))
+
             units = [units.get(name) for name in names]
 
         for name, column, data, mask, unit in zip(names, columns, datas, masks, units):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1956,6 +1956,16 @@ class TestPandas:
         assert t['x'].unit == u.m
         assert t['t'].unit == u.s
 
+        # test error if not a mapping
+        with pytest.raises(TypeError):
+            table.Table.from_pandas(df, units=[u.m, u.s])
+
+        # test warning is raised if additional columns in units dict
+        with pytest.warns(UserWarning) as record:
+            table.Table.from_pandas(df, units={'x': u.m, 't': u.s, 'y': u.m})
+        assert len(record) == 1
+        assert "{'y'}" in record[0].message.args[0]
+
 
 @pytest.mark.usefixtures('table_types')
 class TestReplaceColumn(SetupData):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1946,6 +1946,16 @@ class TestPandas:
                 else:
                     assert column.byteswap().newbyteorder().dtype == t2[name].dtype
 
+    def test_units(self):
+        import pandas as pd
+        import astropy.units as u
+
+        df = pd.DataFrame({'x': [1, 2, 3], 't': [1.3, 1.2, 1.8]})
+        t = table.Table.from_pandas(df, units={'x': u.m, 't': u.s})
+
+        assert t['x'].unit == u.m
+        assert t['t'].unit == u.s
+
 
 @pytest.mark.usefixtures('table_types')
 class TestReplaceColumn(SetupData):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
This adds the kwarg `units` to `Table.from_pandas` to be able to set units for columns 
of the dataframe. This is a dict mapping column names to units.


Let me know, what you think on this.