### PR TITLE
Change default clip to False for consistency with matplotlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -244,6 +244,7 @@ astropy.visualization
 - Improved error checking for the ``slices=`` argument to ``WCSAxes``. [#9098]
 
 - Added support for more solar frames in WCSAxes. [#9275]
+
 - Add support for one dimensional plots to ``WCSAxes``. [#9266]
 
 astropy.wcs
@@ -500,6 +501,9 @@ astropy.utils
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
+
+- The default ``clip`` value is now ``False`` in ``ImageNormalize``.
+  [#9478]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -54,12 +54,12 @@ class ImageNormalize(Normalize):
         The stretch object to apply to the data.  The default is
         `~astropy.visualization.LinearStretch`.
     clip : bool, optional
-        If `True` (default), data values outside the [0:1] range are
-        clipped to the [0:1] range.
+        If `True`, data values outside the [0:1] range are clipped to
+        the [0:1] range.
     """
 
     def __init__(self, data=None, interval=None, vmin=None, vmax=None,
-                 stretch=LinearStretch(), clip=True):
+                 stretch=LinearStretch(), clip=False):
         # this super call checks for matplotlib
         super().__init__(vmin=vmin, vmax=vmax, clip=clip)
 


### PR DESCRIPTION
Fixes the issue reported in #8165.  This also makes plotting masked arrays consistent.

Note this is a breaking change.  @astrofrog, please review.

fix: #8165
fix: #9449 
