### PR TITLE
Exclude infinite values when calculating limits in ManualInterval and MinMaxInterval

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -510,6 +510,10 @@ astropy.visualization
 - The default ``clip`` value is now ``False`` in ``ImageNormalize``.
   [#9478]
 
+- Infinite values are now excluded when calculating limits in
+  ``ManualInterval`` and ``MinMaxInterval``.  They were already
+  excluded in all other interval classes. [#9480]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -111,6 +111,7 @@ class ManualInterval(BaseInterval):
         vmax = np.max(values) if self.vmax is None else self.vmax
         return vmin, vmax
 
+
 class MinMaxInterval(BaseInterval):
     """
     Interval based on the minimum and maximum values in the data.

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -101,6 +101,9 @@ class ManualInterval(BaseInterval):
         self.vmax = vmax
 
     def get_limits(self, values):
+        # Make sure values is a Numpy array
+        values = np.asarray(values).ravel()
+
         # Filter out invalid values (inf, nan)
         values = values[np.isfinite(values)]
 
@@ -114,6 +117,9 @@ class MinMaxInterval(BaseInterval):
     """
 
     def get_limits(self, values):
+        # Make sure values is a Numpy array
+        values = np.asarray(values).ravel()
+
         # Filter out invalid values (inf, nan)
         values = values[np.isfinite(values)]
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -40,6 +40,8 @@ class BaseInterval(BaseTransform):
             The mininium and maximum image value in the interval.
         """
 
+        raise NotImplementedError('Needs to be implemented in a subclass.')
+
     def __call__(self, values, clip=True, out=None):
         """
         Transform values using this interval.
@@ -99,10 +101,12 @@ class ManualInterval(BaseInterval):
         self.vmax = vmax
 
     def get_limits(self, values):
-        vmin = np.nanmin(values) if self.vmin is None else self.vmin
-        vmax = np.nanmax(values) if self.vmax is None else self.vmax
-        return vmin, vmax
+        # Filter out invalid values (inf, nan)
+        values = values[np.isfinite(values)]
 
+        vmin = np.min(values) if self.vmin is None else self.vmin
+        vmax = np.max(values) if self.vmax is None else self.vmax
+        return vmin, vmax
 
 class MinMaxInterval(BaseInterval):
     """
@@ -110,7 +114,10 @@ class MinMaxInterval(BaseInterval):
     """
 
     def get_limits(self, values):
-        return np.nanmin(values), np.nanmax(values)
+        # Filter out invalid values (inf, nan)
+        values = values[np.isfinite(values)]
+
+        return np.min(values), np.max(values)
 
 
 class AsymmetricPercentileInterval(BaseInterval):
@@ -148,9 +155,8 @@ class AsymmetricPercentileInterval(BaseInterval):
         values = values[np.isfinite(values)]
 
         # Determine values at percentiles
-        vmin, vmax = np.nanpercentile(values,
-                                      (self.lower_percentile,
-                                       self.upper_percentile))
+        vmin, vmax = np.percentile(values, (self.lower_percentile,
+                                            self.upper_percentile))
 
         return vmin, vmax
 

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -4,9 +4,11 @@ import pytest
 import numpy as np
 
 from astropy.utils import NumpyRNGContext
-
-from astropy.visualization.interval import (ManualInterval, MinMaxInterval, PercentileInterval,
-                        AsymmetricPercentileInterval, ZScaleInterval)
+from astropy.visualization.interval import (ManualInterval,
+                                            MinMaxInterval,
+                                            PercentileInterval,
+                                            AsymmetricPercentileInterval,
+                                            ZScaleInterval)
 
 
 class TestInterval:

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -3,10 +3,11 @@
 import pytest
 import numpy as np
 
-from astropy.visualization.stretch import (LinearStretch, SqrtStretch, PowerStretch,
-                       PowerDistStretch, SquaredStretch, LogStretch,
-                       AsinhStretch, SinhStretch, HistEqStretch,
-                       ContrastBiasStretch)
+from astropy.visualization.stretch import (LinearStretch, SqrtStretch,
+                                           PowerStretch, PowerDistStretch,
+                                           SquaredStretch, LogStretch,
+                                           AsinhStretch, SinhStretch,
+                                           HistEqStretch, ContrastBiasStretch)
 
 
 DATA = np.array([0.00, 0.25, 0.50, 0.75, 1.00])


### PR DESCRIPTION
Infinite values are currently excluded when calculating limits in `AsymmetricPercentileInterval`, `PercentileInterval`, and `ZScaleInterval`, but not `ManualInterval` and `MinMaxInterval`.  This inconsistency leads to some unexpected behavior:

```python
from astropy.visualization import simple_norm
data = np.full((300, 300), np.nan)
data[50:-50, 50:-50] = np.random.random((200, 200))
data[100:150, 100:150] = np.inf

fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(10, 4))

norm = simple_norm(data, clip=False)  # uses MinMaxInterval
ax1.imshow(data, norm=norm)

norm = simple_norm(data, min_cut=data.min(), clip=False)  # uses ManualInterval
ax2.imshow(data, norm=norm)

norm = simple_norm(data, percent=100, clip=False)  # uses PercentileInterval
ax3.imshow(data, norm=norm)
```

![norm-inf](https://user-images.githubusercontent.com/4992897/67600517-4ccd4780-f740-11e9-94f7-79705a07c27e.png)

All three of these plots should look identical.

Also, the first two plots raise 3 separate `RunTimeWarning`s related to the presence of `np.inf` in the data.

After this PR, the first two plots match the last plot and no `RunTimeWarning`s are issued.

CC: @astrofrog 