### PR TITLE
Updating astropy helpers to v3.2.2

### DIFF
--- a/ah_bootstrap.py
+++ b/ah_bootstrap.py
@@ -79,6 +79,13 @@ CFG_OPTIONS = [
 
 # Start off by parsing the setup.cfg file
 
+_err_help_msg = """
+If the problem persists consider installing astropy_helpers manually using pip
+(`pip install astropy_helpers`) or by manually downloading the source archive,
+extracting it, and installing by running `python setup.py install` from the
+root of the extracted source code.
+"""
+
 SETUP_CFG = ConfigParser()
 
 if os.path.exists('setup.cfg'):
@@ -919,14 +926,6 @@ def _silence():
     if not exception_occurred:
         sys.stdout = old_stdout
         sys.stderr = old_stderr
-
-
-_err_help_msg = """
-If the problem persists consider installing astropy_helpers manually using pip
-(`pip install astropy_helpers`) or by manually downloading the source archive,
-extracting it, and installing by running `python setup.py install` from the
-root of the extracted source code.
-"""
 
 
 class _AHBootstrapSystemExit(SystemExit):


### PR DESCRIPTION
So far there is no more changes in helpers, so was a bit hesitated to call it 4.0, but it's nicer to keep it 3.2.2 in order to backport for the imminent release on the 3.2.x branch here.