### PR TITLE
Don't error if pytest-astropy-header is not installed

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -8,7 +8,11 @@ import os
 import builtins
 import tempfile
 
-from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+except ImportError:
+    PYTEST_HEADER_MODULES = {}
+
 from astropy.tests.helper import enable_deprecations_as_exceptions
 
 try:

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -169,14 +169,14 @@ class TestRunnerBase:
 
         """
 
-    _required_dependancies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus']
+    _required_dependencies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus', 'pytest_astropy_header']
     _missing_dependancy_error = "Test dependencies are missing. You should install the 'pytest-astropy' package."
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
         # Using the test runner will not work without these dependencies, but
         # pytest-openfiles is optional, so it's not listed here.
-        for module in cls._required_dependancies:
+        for module in cls._required_dependencies:
             spec = find_spec(module)
             # Checking loader accounts for packages that were uninstalled
             if spec is None or spec.loader is None:

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,11 @@ import os
 import pkg_resources
 import tempfile
 
-from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+try:
+    from pytest_astropy_header.display import PYTEST_HEADER_MODULES
+except ImportError:
+    PYTEST_HEADER_MODULES = {}
+
 import astropy
 
 if find_spec('asdf') is not None:


### PR DESCRIPTION
This fixes https://github.com/astropy/astropy/issues/9477 by making pytest-astropy-header an optional dependency when running the tests directly with pytest. I though this would be best for now rather than requiring people to install that plugin with a hard failure (since ``python setup.py test`` is still the recommended way to run tests and doesn't suffer from this issue, and with pytest one of the nice things is not *having* to install plugins usually).