### PR TITLE
Swap default iers urls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -678,6 +678,9 @@ Other Changes and Additions
 - The leap seconds in the bundled ERFA library are now updated
   automatically. [#9365]
 
+- The default server for the IERS data files has been updated to reflect
+  long-term downtime of the canonical USNO server. [#9443, #9487]
+
 
 3.2.2 (2019-10-07)
 ==================

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -45,8 +45,8 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
-IERS_A_URL = 'https://datacenter.iers.org/data/9/finals2000A.all'
-IERS_A_URL_MIRROR = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
+IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
+IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -114,7 +114,7 @@ polar motion values:
   the IERS service.
 
 The IERS Service provides the default online table
-(`<https://datacenter.iers.org/data/9/finals2000A.all>`_) and updates the content
+(set by ``astropy.utils.iers.IERS_A_URL``) and updates the content
 once each 7 days.  The default value of ``auto_max_age`` is 30 days to avoid
 unnecessary network access, but one can reduce this to as low as 10 days.
 


### PR DESCRIPTION
This PR is a modification of #9443, switching which is default and which is mirror.

This change is based on an understanding that the USNO version is the "canonical" copy of hte IERS A table, and that the CDDIS mirror is the canonical one while the primary USNO server is offline.

This might not be worth it, except that when I tested this just now the CDDIS mirror is *much* faster than the IERS one, like at least 10x. I am a bit concerned this is a geography effect, though, as I am physically close to where I assume the gsfc.nasa.gov servers are.  @astrofrog and/or @bsipocz, can you check which of the following is faster for you (and by how much)?
*  wget ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all
* wget https://datacenter.iers.org/data/9/finals2000A.all

(I used `wget` for both since it gives download time and is fast on ftp.) 

Note also I marked this for 4.0, based on https://github.com/astropy/astropy/pull/9443#issuecomment-546662285 . That also means this should probably wait for https://github.com/astropy/astropy/pull/9486 before it can be merged since it conflicts with a few of the added items there.

cc @pllim (for #9443)