### PR TITLE
Fix version range for patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,15 @@ matrix:
             - $INSTALL_CMD
             - $TEST_CMD
 
+        - os: linux
+          env: PYTHON_VERSION=3.5 NUMPY_VERSION=1.14
+               INSTALL_CMD='python setup.py build_ext --inplace'
+               PIP_DEPENDENCIES='pytest-astropy'
+               TEST_CMD='pytest --open-files --doctest-rst'
+          script:
+            - $INSTALL_CMD
+            - $TEST_CMD
+
         # Now try with all optional dependencies. We also include the --readonly
         # flag to make sure no files are being written to the temporary install
         # location during testing. We also use this build to make sure that the

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -23,7 +23,7 @@ from astropy.utils.console import color_print
 from astropy.utils.metadata import MetaData
 from astropy.utils.data_info import BaseColumnInfo, dtype_info_name
 from astropy.utils.misc import dtype_bytes_or_chars
-from astropy.utils.compat import NUMPY_LT_1_15
+from astropy.utils.compat import NUMPY_LT_1_14, NUMPY_LT_1_15
 from . import groups
 from . import pprint
 from .np_utils import fix_column_name
@@ -981,8 +981,9 @@ class Column(BaseColumn):
             if self.dtype.char == 'S':
                 other = self._encode_str(other)
 
-            if NUMPY_LT_1_15 and (isinstance(self, np.ma.MaskedArray) or
-                                  isinstance(other, np.ma.MaskedArray)):
+            if (not NUMPY_LT_1_14 and NUMPY_LT_1_15 and
+                    (isinstance(self, np.ma.MaskedArray) or
+                     isinstance(other, np.ma.MaskedArray))):
                 # On numpy 1.14, MaskedArray subclass comparison is broken.
                 return getattr(self.data, op)(other)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -10,6 +10,7 @@ import numpy as np
 from astropy.tests.helper import assert_follows_unicode_guidelines, catch_warnings
 from astropy import table
 from astropy import units as u
+from astropy.utils.compat import NUMPY_LT_1_14, NUMPY_LT_1_15
 
 
 class TestColumn():
@@ -153,7 +154,15 @@ class TestColumn():
         assert np.all(c.unit == u.cm)
 
     def test_quantity_comparison(self, Column):
+
         # regression test for gh-6532
+
+        # On Numpy 1.14 and with masked arrays, this does not work as the bug
+        # was not fixed in this case due to issues with Numpy, so we do not
+        # expect this to work properly.
+        if Column is table.MaskedColumn and NUMPY_LT_1_15 and not NUMPY_LT_1_14:
+            pytest.xfail()
+
         c = Column([1, 2100, 3], unit='Hz')
         q = 2 * u.kHz
         check = c < q


### PR DESCRIPTION
@bsipocz @mhvk - the fix in https://github.com/astropy/astropy/pull/9389 did not actually apply to Numpy 1.13 so I've fixed that here. In addition, the test originally added for the fix that was partially reverted in https://github.com/astropy/astropy/pull/9389 **did** include a text for masked arrays (via the fixture), so I've now marked this as an expected failure when using Numpy 1.14 since we do expect it to fail as the bug fix was reverted. To make sure everything is working properly I've also added a Travis job for 1.14.

With this, I believe that the wheels should now build cleanly and we can actually revert the fix in the wheel building which was to test with Numpy 1.16 instead of Numpy 1.14 for Python 3.7.