### PR TITLE
Add hint for filtering multidim cols in to_pandas and io.ascii ECSV

### DIFF
--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -56,8 +56,11 @@ class EcsvHeader(basic.BasicHeader):
 
         for col in self.cols:
             if len(getattr(col, 'shape', ())) > 1:
-                raise ValueError("ECSV format does not support multidimensional column '{}'"
-                                 .format(col.info.name))
+                raise ValueError(
+                    f"ECSV format does not support multidimensional column '{col.info.name}'\n"
+                    'One can filter out such columns using:\n'
+                    'names = [name for name in tbl.colnames if len(tbl[name].shape) <= 1]\n'
+                    'tbl[names].write(...)')
 
         # Now assemble the header dict that will be serialized by the YAML dumper
         header = {'cols': self.cols, 'schema': 'astropy-2.0'}

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -184,11 +184,16 @@ def test_multidim_input():
     """
     Multi-dimensional column in input
     """
-    t = Table([np.arange(4).reshape(2, 2)], names=['a'])
+    t = Table([np.arange(4).reshape(2, 2), [1, 2]], names=['a', 'b'])
     out = StringIO()
-    with pytest.raises(ValueError) as err:
+    with pytest.raises(ValueError,
+                       match="ECSV format does not support multidimensional column 'a'"):
         t.write(out, format='ascii.ecsv')
-    assert 'ECSV format does not support multidimensional column' in str(err.value)
+
+    # Now check that the hint works
+    names = [name for name in t.colnames if len(t[name].shape) <= 1]
+    assert names == ['b']
+    ascii.write(t[names], out, format='ecsv')
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3269,12 +3269,14 @@ class Table:
 
         tbl = _encode_mixins(self)
 
-        badcols = [name for name, col in self.columns.items()
-                   if (getattr(col, 'ndim', 1) > 1)]
+        badcols = [name for name, col in self.columns.items() if len(col.shape) > 1]
         if badcols:
             raise ValueError(
-                "Cannot convert a table with multi-dimensional columns to a "
-                "pandas DataFrame. Offending columns are: {}".format(badcols))
+                f'Cannot convert a table with multidimensional columns to a '
+                f'pandas DataFrame. Offending columns are: {badcols}\n'
+                f'One can filter out such columns using:\n'
+                f'names = [name for name in tbl.colnames if len(tbl[name].shape) <= 1]\n'
+                f'tbl[names].to_pandas(...)')
 
         out = OrderedDict()
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1792,11 +1792,9 @@ class TestPandas:
         t['a'] = [1, 2, 3]
         t['b'] = np.ones((3, 2))
 
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(ValueError,
+                           match='Cannot convert a table with multidimensional columns'):
             t.to_pandas()
-        assert (exc.value.args[0] ==
-            "Cannot convert a table with multi-dimensional columns "
-            "to a pandas DataFrame. Offending columns are: ['b']")
 
     def test_mixin_pandas(self):
         t = table.QTable()


### PR DESCRIPTION
### Description

PR #9423 was not accepted by all as a way to deal with handling multidimensional columns in `to_pandas()` and `ascii.write`.  This takes a different approach and provides the 2-liner for users in this case, instead of embedding it as a new Table method.

Closes #9423