### PR TITLE
Ensure we check leap seconds only when Time is actually used.

### DIFF
--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -1,6 +1,3 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from .formats import *
 from .core import *
-
-
-update_leap_seconds()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -95,6 +95,9 @@ SIDEREAL_TIME_MODELS = {
         'IAU1994': {'function': erfa.gst94, 'scales': ('ut1',)}}}
 
 
+_LEAP_SECONDS_CHECKED = False
+
+
 class TimeInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is
@@ -373,6 +376,17 @@ class Time(ShapedLikeNDArray):
     def __new__(cls, val, val2=None, format=None, scale=None,
                 precision=None, in_subfmt=None, out_subfmt=None,
                 location=None, copy=False):
+
+        # Because of import problems, this can only be done on
+        # first call of Time.
+        global _LEAP_SECONDS_CHECKED
+        if not _LEAP_SECONDS_CHECKED:
+            # *Must* set to True first as update_leap_seconds uses Time.
+            # In principle, this may cause wrong leap seconds in
+            # update_leap_seconds itself, but since expiration is in
+            # units of days, that is fine.
+            _LEAP_SECONDS_CHECKED = True
+            update_leap_seconds()
 
         if isinstance(val, cls):
             self = val.replicate(format=format, copy=copy)


### PR DESCRIPTION
I went with only calling `update_leap_seconds` on first call of `Time`. Somewhat ugly but it does work. Better suggestions most welcome...

fixes #9490