### PR TITLE
Cutout2d accept nddata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -615,6 +615,9 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- ``Cutout2D`` will now get the WCS from its first argument if that argument
+  has with WCS property. [#9492]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -15,6 +15,8 @@ from astropy.wcs.utils import proj_plane_pixel_area
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 
+from astropy.nddata import CCDData
+
 try:
     import skimage  # pylint: disable=W0611
     HAS_SKIMAGE = True
@@ -621,3 +623,17 @@ class TestCutout2D:
             w.all_pix2world(*w.wcs.crpix, 1), w.wcs.crval,
             rtol=0.0, atol=1e-6 * pscale
         )
+
+    def test_cutout_with_nddata_as_input(self):
+        # This is essentially a copy/paste of test_skycoord with the
+        # input a ccd with wcs attribute instead of passing the
+        # wcs separately.
+        ccd = CCDData(data=self.data, wcs=self.wcs, unit='adu')
+        c = Cutout2D(ccd, self.position, (3, 3))
+        skycoord_original = self.position.from_pixel(c.center_original[1],
+                                                     c.center_original[0],
+                                                     self.wcs)
+        skycoord_cutout = self.position.from_pixel(c.center_cutout[1],
+                                                   c.center_cutout[0], c.wcs)
+        assert_quantity_allclose(skycoord_original.ra, skycoord_cutout.ra)
+        assert_quantity_allclose(skycoord_original.dec, skycoord_cutout.dec)

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -636,6 +636,9 @@ class Cutout2D:
 
     def __init__(self, data, position, size, wcs=None, mode='trim',
                  fill_value=np.nan, copy=False):
+        if wcs is None:
+            wcs = getattr(data, 'wcs', None)
+
         if isinstance(position, SkyCoord):
             if wcs is None:
                 raise ValueError('wcs must be input if position is a '


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request uses the WCS on the first argument to `Cutout2D` if the attribute is present on the first argument.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9173

@astrofrog  -- I decided not to modify `support_nddata` for this case because it requires the first argument of the decorated function to be named `data`. That doesn't work for methods, where the first argument is `self`. In the interests of getting this done rapidly I just added a bit of logic to `Cutout2D`.

@larrybradley should probably look at this...