### PR TITLE
Added Python 3.8 32-bit build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,10 +32,10 @@ jobs:
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.8
-          command: /opt/python/cp38-cp38m/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp38-cp38/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
       - run:
           name: Run tests for Python 3.8
-          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38m/bin/python setup.py test --parallel=4 -a "--durations=50"
+          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python setup.py test --parallel=4 -a "--durations=50"
 
   image-tests-mpl212:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
       - run:
           name: Install dependencies for Python 3.8
-          command: /opt/python/cp38-cp38/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+          command: /opt/python/cp38-cp38/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.8
           command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python setup.py test --parallel=4 -a "--durations=50"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,12 @@ jobs:
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
+      - run:
+          name: Install dependencies for Python 3.8
+          command: /opt/python/cp38-cp38m/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2 pandas
+      - run:
+          name: Run tests for Python 3.8
+          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38m/bin/python setup.py test --parallel=4 -a "--durations=50"
 
   image-tests-mpl212:
     docker:

--- a/astropy/modeling/tests/test_rotations.py
+++ b/astropy/modeling/tests/test_rotations.py
@@ -37,7 +37,7 @@ def test_against_wcslib(inp):
     assert_allclose(minv(*radec), xy, atol=1e-12)
 
 
-@pytest.mark.parametrize(('inp'), [(0, 0), (40, -20.56), (21.5, 45.9)])
+@pytest.mark.parametrize(('inp'), [(1e-5, 1e-4), (40, -20.56), (21.5, 45.9)])
 def test_roundtrip_sky_rotation(inp):
     lon, lat, lon_pole = 42, 43, 44
     n2c = models.RotateNative2Celestial(lon, lat, lon_pole)


### PR DESCRIPTION
While trying to build 32-bit wheels for Python 3.8 I saw a test failure so I think we should make sure we test this configuration here.