### PR TITLE
VO table no longer access char field as bytes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,9 +231,6 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
-- For FIELDs with datatype="char", store the values as strings instead 
-  of bytes. [#9505]
-
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
@@ -377,6 +374,9 @@ astropy.io.registry
 
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
+
+- For FIELDs with datatype="char", store the values as strings instead
+  of bytes. [#9505]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -231,6 +231,9 @@ astropy.io.registry
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 
+- For FIELDs with datatype="char", store the values as strings instead 
+  of bytes. [#9505]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -1430,7 +1430,7 @@ def table_column_to_votable_datatype(column):
     if column.dtype.char == 'O':
         if votable_string_dtype is not None:
             string_dtype = votable_string_dtype
-            return {'datatype': string_dtype, 'arraysize': '*'}
+            return {'datatype': votable_string_dtype, 'arraysize': '*'}
         elif isinstance(column[0], np.ndarray):
             dtype, shape = _all_matching_dtype(column)
             if dtype is not False:

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -1429,7 +1429,6 @@ def table_column_to_votable_datatype(column):
         votable_string_dtype = column.info.meta.get('_votable_string_dtype')
     if column.dtype.char == 'O':
         if votable_string_dtype is not None:
-            string_dtype = votable_string_dtype
             return {'datatype': votable_string_dtype, 'arraysize': '*'}
         elif isinstance(column[0], np.ndarray):
             dtype, shape = _all_matching_dtype(column)

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1085,7 +1085,7 @@ class W54(VOTableSpecWarning):
 class W55(VOTableSpecWarning):
     """
     When non-ASCII characters are detected when reading
-    a TABLEDATA value for a FIELD with datatype="char", we
+    a TABLEDATA value for a FIELD with ``datatype="char"``, we
     can issue this warning.
     """
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1082,6 +1082,19 @@ class W54(VOTableSpecWarning):
     default_args = ('1.3',)
 
 
+class W55(VOTableSpecWarning):
+    """
+    When non-ASCII characters are detected when reading
+    a TABLEDATA value for a FIELD with datatype="char", we
+    can issue this warning.
+    """
+
+    message_template = (
+        'FIELD ({}) has datatype="char" but contains non-ASCII '
+        'value ({})')
+    default_args = ('', '')
+
+
 class E01(VOWarning, ValueError):
     """
     The size specifier for a ``char`` or ``unicode`` field must be
@@ -1446,6 +1459,18 @@ class E23(VOTableSpecWarning):
 
     message_template = "Invalid timeorigin attribute '{}'"
     default_args = ('x',)
+
+
+class E24(VOWarning, ValueError):
+    """
+    Non-ASCII unicode values cannot be written in BINARY or BINARY2 serialization
+    when the FIELD datatype="char".
+    """
+
+    message_template = (
+        'Attempt to write non-ASCII value ({}) to FIELD ({}) which '
+        'has datatype="char"')
+    default_args = ('', '')
 
 
 def _get_warning_and_exception_classes(prefix):

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1463,7 +1463,7 @@ class E23(VOTableSpecWarning):
 
 class E24(VOWarning, ValueError):
     """
-    Non-ASCII unicode values should not be written when the FIELD datatype="char",
+    Non-ASCII unicode values should not be written when the FIELD ``datatype="char"``,
     and cannot be written in BINARY or BINARY2 serialization.
     """
 

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1463,8 +1463,8 @@ class E23(VOTableSpecWarning):
 
 class E24(VOWarning, ValueError):
     """
-    Non-ASCII unicode values cannot be written in BINARY or BINARY2 serialization
-    when the FIELD datatype="char".
+    Non-ASCII unicode values should not be written when the FIELD datatype="char",
+    and cannot be written in BINARY or BINARY2 serialization.
     """
 
     message_template = (

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -273,5 +273,5 @@ def test_gemini_v1_2():
 
     tt = table.to_table()
     assert tt['access_url'][0] == (
-        b'http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEMINI/'
-        b'S20120515S0064?runid=bx9b1o8cvk1qesrt')
+        'http://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEMINI/'
+        'S20120515S0064?runid=bx9b1o8cvk1qesrt')

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -73,12 +73,27 @@ def test_unicode_as_char():
         arraysize='*', config=config)
     c = converters.get_converter(field, config=config)
 
-    c.parse("XXX")  # ASCII succeeds
-
+    # Test parsing.
+    c.parse('XYZ')  # ASCII succeeds
     with pytest.raises(
             exceptions.W55,
             match=r'FIELD \(unicode_in_char\) has datatype="char" but contains non-ASCII value'):
         c.parse("zła")  # non-ASCII
+
+    # Test output.
+    c.output('XYZ', False)  # ASCII str succeeds
+    c.output(b'XYZ', False)  # ASCII bytes succeeds
+    value = 'zła'
+    value_bytes = value.encode('utf-8')
+    with pytest.raises(
+            exceptions.E24,
+            match=r'E24: Attempt to write non-ASCII value'):
+        c.output(value, False)  # non-ASCII str raises
+    with pytest.raises(
+            exceptions.E24,
+            match=r'E24: Attempt to write non-ASCII value'):
+        c.output(value_bytes, False)  # non-ASCII bytes raises
+
 
 
 def test_unicode_as_char_binary():

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -68,7 +68,6 @@ def test_unicode_mask():
 
 def test_unicode_as_char():
     config = {'verify': 'exception'}
-    #with catch_warnings(exceptions.W55) as w:
     field = tree.Field(
         None, name='unicode_in_char', datatype='char',
         arraysize='*', config=config)
@@ -77,8 +76,8 @@ def test_unicode_as_char():
     c.parse("XXX")  # ASCII succeeds
 
     with pytest.raises(
-        exceptions.W55,
-        match=r'.*FIELD \(unicode_in_char\) has datatype="char" but contains non-ASCII value.*'):
+            exceptions.W55,
+            match=r'FIELD \(unicode_in_char\) has datatype="char" but contains non-ASCII value'):
         c.parse("zła")  # non-ASCII
 
 
@@ -87,18 +86,18 @@ def test_unicode_as_char_binary():
 
     field = tree.Field(
         None, name='unicode_in_char', datatype='char',
-         arraysize='*', config=config)
+        arraysize='*', config=config)
     c = converters.get_converter(field, config=config)
     c._binoutput_var('abc', False)  # ASCII succeeds
-    with pytest.raises(exceptions.E24, match=r".*E24: Attempt to write non-ASCII value.*"):
+    with pytest.raises(exceptions.E24, match=r"E24: Attempt to write non-ASCII value"):
         c._binoutput_var('zła', False)
 
     field = tree.Field(
         None, name='unicode_in_char', datatype='char',
-         arraysize='3', config=config)
+        arraysize='3', config=config)
     c = converters.get_converter(field, config=config)
     c._binoutput_fixed('xyz', False)
-    with pytest.raises(exceptions.E24, match=r".*E24: Attempt to write non-ASCII value.*"):
+    with pytest.raises(exceptions.E24, match=r"E24: Attempt to write non-ASCII value"):
         c._binoutput_fixed('zła', False)
 
 

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -95,7 +95,6 @@ def test_unicode_as_char():
         c.output(value_bytes, False)  # non-ASCII bytes raises
 
 
-
 def test_unicode_as_char_binary():
     config = {'verify': 'exception'}
 

--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -65,6 +65,29 @@ def test_unicode_mask():
     assert c.output("Foo", True) == ''
 
 
+def test_unicode_as_char():
+    config = {'verify': 'exception'}
+    with catch_warnings(exceptions.W55) as w:
+        field = tree.Field(
+            None, name='unicode_in_char', datatype='char',
+            config=config)
+        c = converters.get_converter(field, config=config)
+
+        c.parse("XXX")  # ASCII
+        c.parse("zła")  # non-ASCII
+    assert len(w) == 1
+
+
+@raises(exceptions.E24)
+def test_unicode_as_char_binary():
+    config = {'verify': 'warn'}
+    field = tree.Field(
+        None, name='unicode_in_char', datatype='char',
+        config=config)
+    c = converters.get_converter(field, config=config)
+    c._binoutput_var('zła', False)
+
+
 @raises(exceptions.E02)
 def test_wrong_number_of_elements():
     config = {'verify': 'exception'}

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -75,10 +75,10 @@ def _test_regression(tmpdir, _python_based=False, binary_mode=1):
 
     dtypes = [
         (('string test', 'string_test'), '|O8'),
-        (('fixed string test', 'string_test_2'), '|S10'),
+        (('fixed string test', 'string_test_2'), '<U10'),
         ('unicode_test', '|O8'),
         (('unicode test', 'fixed_unicode_test'), '<U10'),
-        (('string array test', 'string_array_test'), '|S4'),
+        (('string array test', 'string_array_test'), '<U4'),
         ('unsignedByte', '|u1'),
         ('short', '<i2'),
         ('int', '<i4'),
@@ -284,10 +284,10 @@ class TestParse:
 
     def test_fixed_string_test(self):
         assert issubclass(self.array['string_test_2'].dtype.type,
-                          np.string_)
+                          np.unicode_)
         assert_array_equal(
             self.array['string_test_2'],
-            [b'Fixed stri', b'0123456789', b'XXXX', b'', b''])
+            ['Fixed stri', '0123456789', 'XXXX', '', ''])
 
     def test_unicode_test(self):
         assert issubclass(self.array['unicode_test'].dtype.type,

--- a/astropy/io/votable/tests/vo_test.py
+++ b/astropy/io/votable/tests/vo_test.py
@@ -249,7 +249,7 @@ def test_select_columns_by_index():
         get_pkg_data_filename('data/regression.xml'), columns=columns).get_first_table()  # noqa
     array = table.array
     mask = table.array.mask
-    assert array['string_test'][0] == b"String & test"
+    assert array['string_test'][0] == "String & test"
     columns = ['string_test', 'unsignedByte', 'bitarray']
     for c in columns:
         assert not np.all(mask[c])
@@ -262,7 +262,7 @@ def test_select_columns_by_name():
         get_pkg_data_filename('data/regression.xml'), columns=columns).get_first_table()  # noqa
     array = table.array
     mask = table.array.mask
-    assert array['string_test'][0] == b"String & test"
+    assert array['string_test'][0] == "String & test"
     for c in columns:
         assert not np.all(mask[c])
     assert np.all(mask['unicode_test'])
@@ -280,8 +280,7 @@ class TestParse:
                           np.object_)
         assert_array_equal(
             self.array['string_test'],
-            [b'String & test', b'String &amp; test', b'XXXX',
-             b'', b''])
+            ['String & test', 'String &amp; test', 'XXXX', '', ''])
 
     def test_fixed_string_test(self):
         assert issubclass(self.array['string_test_2'].dtype.type,

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -1531,6 +1531,10 @@ class Field(SimpleElement, _IDProperty, _NameProperty, _XtypeProperty,
         if (isinstance(self.converter, converters.FloatingPoint) and
                 self.converter.output_format != '{!r:>}'):
             column.format = self.converter.output_format
+        elif isinstance(self.converter, converters.Char):
+            column.info.meta['_votable_string_dtype'] = 'char'
+        elif isinstance(self.converter, converters.UnicodeChar):
+            column.info.meta['_votable_string_dtype'] = 'unicodeChar'
 
     @classmethod
     def from_table_column(cls, votable, column):

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -99,8 +99,6 @@ def test_votable(capsys):
     showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
                     '--table-id', 'main_table', '--max-width', '50'])
     out, err = capsys.readouterr()
-    print('output:')
-    print(out.splitlines())
     assert out.splitlines() == [
         '   string_test    string_test_2 ... bitarray2 [16]',
         '----------------- ------------- ... --------------',

--- a/astropy/table/tests/test_showtable.py
+++ b/astropy/table/tests/test_showtable.py
@@ -99,6 +99,8 @@ def test_votable(capsys):
     showtable.main([os.path.join(VOTABLE_ROOT, 'data/regression.xml'),
                     '--table-id', 'main_table', '--max-width', '50'])
     out, err = capsys.readouterr()
+    print('output:')
+    print(out.splitlines())
     assert out.splitlines() == [
         '   string_test    string_test_2 ... bitarray2 [16]',
         '----------------- ------------- ... --------------',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the issue of VO table parsing `char` field as bytes unnecessarily.

This does change a subtle behavior, so it should only go into a major release. I suspect it would affect packages downstream, e.g., `astroquery.vo_conesearch` or whoever is parsing VO table using `Table.read()` and then decoding bytes to UTF-8 themselves.

So, the gist is that VO table parser was relying on bytes vs str to differentiate between `char` and `unicodeChar` fields. A quick glance at VO table standards did not seem to indicate that this is a rule from the standards. Since I can't ask Mike D anymore, I am wildly guessing that the behavior was something that was just convenient to do at the time in Python 2 but turned into a nuisance in Python 3.

**Note to reviewers:** Those who are familiar with the VO standards and use VO table a lot should really look at this carefully and think about the implications of merging this.

**TODO:**

- [x] Wait for in-depth discussions from VO table stakeholders.
- [x] Add change log.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8716 

Supersedes #8745 