### PR TITLE
TST: Fix typo in deprecation warning

### DIFF
--- a/astropy/tests/plugins/display.py
+++ b/astropy/tests/plugins/display.py
@@ -7,12 +7,13 @@ import warnings
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 try:
-    from pytest_astropy_header.display import PYTEST_HEADER_MODULES, TESTED_VERSIONS
+    from pytest_astropy_header.display import (PYTEST_HEADER_MODULES,
+                                               TESTED_VERSIONS)
 except ImportError:
     PYTEST_HEADER_MODULES = {}
     TESTED_VERSIONS = {}
 
 warnings.warn('The astropy.tests.plugins.display plugin has been deprecated. '
-              'See the pytest-astropy documentation for information on '
-              'migrating to using pytest-astropy to customize the pytest '
-              'header.', AstropyDeprecationWarning)
+              'See the pytest-astropy-header documentation for information on '
+              'migrating to using pytest-astropy-header to customize the '
+              'pytest header.', AstropyDeprecationWarning)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address typo of package name in the deprecation warning for the display plugin.

There is no point in running CI for this one, so I skipped CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->