### PR TITLE
Get iers.org download to work

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,7 +278,7 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``astropy.utils.data.download_file`` now provides an `http_headers` keyword to
+- ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
   pass in specific request headers for the download. [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,6 +278,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- ``astropy.utils.data.download_file`` now provides an `http_headers` keyword to
+  pass in specific request headers for the download. [#9508]
+
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial
   array. [#9209]
@@ -800,7 +803,7 @@ Other Changes and Additions
   automatically. [#9365]
 
 - The default server for the IERS data files has been updated to reflect
-  long-term downtime of the canonical USNO server. [#9443, #9487]
+  long-term downtime of the canonical USNO server. [#9443, #9487, #9508]
 
 
 3.2.3 (2019-10-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -278,9 +278,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
-  pass in specific request headers for the download. It also now defaults to
-  providing ``User-Agent: Astropy`` and ``Accept: */*`` headers.  [#9508]
+- ``astropy.utils.data.download_file`` and
+  ``astropy.utils.data.get_readable_fileobj`` now provides an ``http_headers``
+  keyword to pass in specific request headers for the download. It also now
+  defaults to providing ``User-Agent: Astropy`` and ``Accept: */*``
+  headers. [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,7 +279,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
-  pass in specific request headers for the download. [#9508]
+  pass in specific request headers for the download. It also now defaults to
+  providing ``User-Agent: Astropy`` and ``Accept: */*`` headers.  [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -803,7 +803,7 @@ Other Changes and Additions
   automatically. [#9365]
 
 - The default server for the IERS data files has been updated to reflect
-  long-term downtime of the canonical USNO server. [#9443, #9487, #9508]
+  long-term downtime of the canonical USNO server. [#9487, #9508]
 
 
 3.2.3 (2019-10-27)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -194,7 +194,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
         is not a remote HTTP URL.) In the default case (None), the headers are
-        "User-Agent: astropy" and "Accept: */*".
+        ``User-Agent: astropy`` and ``Accept: */*``.
 
     Returns
     -------
@@ -1085,7 +1085,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
         is not a remote HTTP URL.) In the default case (None), the headers are
-        "User-Agent: astropy" and "Accept: */*".
+        ``User-Agent: astropy`` and ``Accept: */*``.
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -953,12 +953,13 @@ def check_free_space_in_dir(path, size):
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
-                               http_headers={'User-Agent': 'astropy',
-                                             'Accept': '*/*'}):
+                               http_headers=None):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
         remote_url = source_url
+    if http_headers is None:
+        http_headers = {}
 
     req = urllib.request.Request(source_url, headers=http_headers)
     with urllib.request.urlopen(req, timeout=timeout) as remote:
@@ -1019,7 +1020,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
-                  sources=None, pkgname='astropy', http_headers={}):
+                  sources=None, pkgname='astropy', http_headers=None):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1075,7 +1076,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
 
     http_headers : dict
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
-        are ignored if the ``remote_url`` is not http.)
+        are ignored if the protocol for the ``remote_url``/``sources`` entry
+        is not http.)
 
     Returns
     -------
@@ -1097,6 +1099,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         timeout = conf.remote_timeout
     if sources is None:
         sources = [remote_url]
+    if http_headers is None:
+        http_headers = {'User-Agent': 'astropy','Accept': '*/*'}
 
     missing_cache = ""
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -193,7 +193,7 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
     http_headers : dict
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
-        is not a remote http URL.)
+        is not a remote HTTP URL.)
 
     Returns
     -------
@@ -1083,7 +1083,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     http_headers : dict
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``remote_url``/``sources`` entry
-        is not http.)
+        is not HTTP.)
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -952,12 +952,15 @@ def check_free_space_in_dir(path, size):
 
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
-                               remote_url=None, cache=False, pkgname='astropy'):
+                               remote_url=None, cache=False, pkgname='astropy',
+                               http_headers={}):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
         remote_url = source_url
-    with urllib.request.urlopen(source_url, timeout=timeout) as remote:
+
+    req = urllib.request.Request(source_url, headers=http_headers)
+    with urllib.request.urlopen(req, timeout=timeout) as remote:
         # keep a hash to rename the local file to the hashed name
         hasher = hashlib.md5()
 
@@ -1015,7 +1018,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
-                  sources=None, pkgname='astropy'):
+                  sources=None, pkgname='astropy', http_headers={}):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1069,6 +1072,9 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``pkgname='astropy'`` the default cache location is
         ``~/.astropy/cache``.
 
+    http_headers : dict
+        Headers to pass into ``urlopen`` if needed.
+
     Returns
     -------
     local_path : str
@@ -1114,7 +1120,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
                     show_progress=show_progress,
                     cache=cache,
                     remote_url=remote_url,
-                    pkgname=pkgname)
+                    pkgname=pkgname,
+                    http_headers=http_headers)
             # Success!
             break
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -126,7 +126,7 @@ def _is_inside(path, parent_path):
 @contextlib.contextmanager
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                          show_progress=True, remote_timeout=None,
-                         sources=None):
+                         sources=None, http_headers=None):
     """Yield a readable, seekable file-like object from a file or URL.
 
     This supports passing filenames, URLs, and readable file-like objects,
@@ -190,6 +190,11 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         long waits for a primary server that is known to be inaccessible
         at the moment.
 
+    http_headers : dict
+        HTTP request headers to pass into ``urlopen`` if needed. (These headers
+        are ignored if the protocol for the ``name_or_obj``/``sources`` entry
+        is not a remote http URL.)
+
     Returns
     -------
     file : readable file-like object
@@ -219,7 +224,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         if is_url:
             name_or_obj = download_file(
                 name_or_obj, cache=cache, show_progress=show_progress,
-                timeout=remote_timeout, sources=sources)
+                timeout=remote_timeout, sources=sources,
+                http_headers=http_headers)
         fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -953,7 +953,8 @@ def check_free_space_in_dir(path, size):
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
-                               http_headers={}):
+                               http_headers={'User-Agent': 'astropy',
+                                             'Accept': '*/*'}):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
@@ -1073,7 +1074,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``~/.astropy/cache``.
 
     http_headers : dict
-        HTTP request headers to pass into ``urlopen`` if needed.
+        HTTP request headers to pass into ``urlopen`` if needed. (These headers
+        are ignored if the ``remote_url`` is not http.)
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1073,7 +1073,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``~/.astropy/cache``.
 
     http_headers : dict
-        Headers to pass into ``urlopen`` if needed.
+        HTTP request headers to pass into ``urlopen`` if needed.
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -190,10 +190,11 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         long waits for a primary server that is known to be inaccessible
         at the moment.
 
-    http_headers : dict
+    http_headers : dict or None
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
-        is not a remote HTTP URL.)
+        is not a remote HTTP URL.) In the default case (None), the headers are
+        "User-Agent: astropy" and "Accept: */*".
 
     Returns
     -------
@@ -1080,10 +1081,11 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``pkgname='astropy'`` the default cache location is
         ``~/.astropy/cache``.
 
-    http_headers : dict
+    http_headers : dict or None
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
-        are ignored if the protocol for the ``remote_url``/``sources`` entry
-        is not HTTP.)
+        are ignored if the protocol for the ``name_or_obj``/``sources`` entry
+        is not a remote HTTP URL.) In the default case (None), the headers are
+        "User-Agent: astropy" and "Accept: */*".
 
     Returns
     -------

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -43,16 +43,10 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
            'LeapSeconds', 'IERS_LEAP_SECOND_FILE', 'IERS_LEAP_SECOND_URL',
            'IETF_LEAP_SECOND_URL']
 
-# maps specific download urls to the additional http headers needed for them -
-# populated where specific urls are given below.
-SPECIAL_HTTP_HEADERS_NEEDED = {}
-
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
 IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
-SPECIAL_HTTP_HEADERS_NEEDED[IERS_A_URL_MIRROR] = {'User-Agent': 'astropy/iers',
-                                                  'Accept': '*/*'}
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description
@@ -97,8 +91,8 @@ def download_file(*args, **kwargs):
     the local ``iers.conf.remote_timeout`` value.
     """
     url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
-    if url in SPECIAL_HTTP_HEADERS_NEEDED:
-        kwargs['http_headers'] = SPECIAL_HTTP_HEADERS_NEEDED[url]
+    kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
+                                       'Accept': '*/*'})
 
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -96,6 +96,10 @@ def download_file(*args, **kwargs):
     ``**kwargs`` after temporarily setting the download_file remote timeout to
     the local ``iers.conf.remote_timeout`` value.
     """
+    url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
+    if url in SPECIAL_HTTP_HEADERS_NEEDED:
+        kwargs['http_headers'] = SPECIAL_HTTP_HEADERS_NEEDED[url]
+
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)
 
@@ -677,9 +681,6 @@ class IERS_Auto(IERS_A):
 
         for url in all_urls:
             try:
-                http_headers = {}
-                if url in SPECIAL_HTTP_HEADERS_NEEDED:
-                    http_headers.update(SPECIAL_HTTP_HEADERS_NEEDED[url])
                 filename = download_file(url, cache=True)
             except Exception as err:
                 err_list.append(str(err))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -43,10 +43,16 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
            'LeapSeconds', 'IERS_LEAP_SECOND_FILE', 'IERS_LEAP_SECOND_URL',
            'IETF_LEAP_SECOND_URL']
 
+# maps specific download urls to the additional http headers needed for them -
+# populated where specific urls are given below.
+SPECIAL_HTTP_HEADERS_NEEDED = {}
+
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
 IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
+SPECIAL_HTTP_HEADERS_NEEDED[IERS_A_URL_MIRROR] = {'User-Agent': 'astropy/iers',
+                                                  'Accept': '*/*'}
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description
@@ -671,6 +677,9 @@ class IERS_Auto(IERS_A):
 
         for url in all_urls:
             try:
+                http_headers = {}
+                if url in SPECIAL_HTTP_HEADERS_NEEDED:
+                    http_headers.update(SPECIAL_HTTP_HEADERS_NEEDED[url])
                 filename = download_file(url, cache=True)
             except Exception as err:
                 err_list.append(str(err))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -90,7 +90,6 @@ def download_file(*args, **kwargs):
     ``**kwargs`` after temporarily setting the download_file remote timeout to
     the local ``iers.conf.remote_timeout`` value.
     """
-    url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
     kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
                                        'Accept': '*/*'})
 

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -330,10 +330,21 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 @pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
 @pytest.mark.remote_data
 def test_iers_a_dl(iersa_url):
-    iers_tab = iers.IERS_A.open(iersa_url, cache=False)
+    iersa_tab = iers.IERS_A.open(iersa_url, cache=False)
     try:
         # some basic checks to ensure the format makes sense
-        assert len(iers_tab) > 0
-        assert 'UT1_UTC_A' in iers_tab.colnames
+        assert len(iersa_tab) > 0
+        assert 'UT1_UTC_A' in iersa_tab.colnames
     finally:
         iers.IERS_A.close()
+
+
+@pytest.mark.remote_data
+def test_iers_b_dl():
+    iersb_tab = iers.IERS_B.open(iers.IERS_B_URL, cache=False)
+    try:
+        # some basic checks to ensure the format makes sense
+        assert len(iersb_tab) > 0
+        assert 'UT1_UTC' in iersb_tab.colnames
+    finally:
+        iers.IERS_B.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -330,11 +330,9 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
                      "correctly to IERS Auto".format(name)))
 
 
-@pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
-@pytest.mark.xfail('TRAVIS')
 @pytest.mark.remote_data
-def test_iers_a_dl(iersa_url):
-    iersa_tab = iers.IERS_A.open(iersa_url, cache=False)
+def test_iers_a_dl():
+    iersa_tab = iers.IERS_A.open(iers.IERS_A_URL, cache=False)
     try:
         # some basic checks to ensure the format makes sense
         assert len(iersa_tab) > 0
@@ -343,7 +341,19 @@ def test_iers_a_dl(iersa_url):
         iers.IERS_A.close()
 
 
+# Issue with FTP, rework test into previous one when it's fixed
 @pytest.mark.xfail('TRAVIS')
+@pytest.mark.remote_data
+def test_iers_a_dl_mirror():
+    iersa_tab = iers.IERS_A.open(iers.IERS_A_URL_MIRROR, cache=False)
+    try:
+        # some basic checks to ensure the format makes sense
+        assert len(iersa_tab) > 0
+        assert 'UT1_UTC_A' in iersa_tab.colnames
+    finally:
+        iers.IERS_A.close()
+
+
 @pytest.mark.remote_data
 def test_iers_b_dl():
     iersb_tab = iers.IERS_B.open(iers.IERS_B_URL, cache=False)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -325,3 +325,15 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
             A[name][ok_A], B[name][i_B], rtol=1e-15,
             err_msg=("Bug #9206 IERS B parameter {} not copied over "
                      "correctly to IERS Auto".format(name)))
+
+
+@pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
+@pytest.mark.remote_data
+def test_iers_a_dl(iersa_url):
+    iers_tab = iers.IERS_A.open(iersa_url, cache=False)
+    try:
+        # some basic checks to ensure the format makes sense
+        assert len(iers_tab) > 0
+        assert 'UT1_UTC_A' in iers_tab.colnames
+    finally:
+        iers.IERS_A.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -331,7 +331,7 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 
 
 @pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
-@pytest.mark.skipif('not TRAVIS')
+@pytest.mark.xfail('TRAVIS')
 @pytest.mark.remote_data
 def test_iers_a_dl(iersa_url):
     iersa_tab = iers.IERS_A.open(iersa_url, cache=False)
@@ -343,7 +343,7 @@ def test_iers_a_dl(iersa_url):
         iers.IERS_A.close()
 
 
-@pytest.mark.skipif('not TRAVIS')
+@pytest.mark.xfail('TRAVIS')
 @pytest.mark.remote_data
 def test_iers_b_dl():
     iersb_tab = iers.IERS_B.open(iers.IERS_B_URL, cache=False)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -13,6 +13,9 @@ from astropy import units as u
 from astropy.table import QTable
 from astropy.time import Time, TimeDelta
 
+
+TRAVIS = os.environ.get('TRAVIS', False)
+
 FILE_NOT_FOUND_ERROR = getattr(__builtins__, 'FileNotFoundError', OSError)
 
 try:
@@ -328,6 +331,7 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 
 
 @pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
+@pytest.mark.skipif('not TRAVIS')
 @pytest.mark.remote_data
 def test_iers_a_dl(iersa_url):
     iersa_tab = iers.IERS_A.open(iersa_url, cache=False)
@@ -339,6 +343,7 @@ def test_iers_a_dl(iersa_url):
         iers.IERS_A.close()
 
 
+@pytest.mark.skipif('not TRAVIS')
 @pytest.mark.remote_data
 def test_iers_b_dl():
     iersb_tab = iers.IERS_B.open(iers.IERS_B_URL, cache=False)

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -330,6 +330,8 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
                      "correctly to IERS Auto".format(name)))
 
 
+# Issue with FTP, rework test into previous one when it's fixed
+@pytest.mark.xfail('TRAVIS')
 @pytest.mark.remote_data
 def test_iers_a_dl():
     iersa_tab = iers.IERS_A.open(iers.IERS_A_URL, cache=False)
@@ -341,8 +343,6 @@ def test_iers_a_dl():
         iers.IERS_A.close()
 
 
-# Issue with FTP, rework test into previous one when it's fixed
-@pytest.mark.xfail('TRAVIS')
 @pytest.mark.remote_data
 def test_iers_a_dl_mirror():
     iersa_tab = iers.IERS_A.open(iers.IERS_A_URL_MIRROR, cache=False)


### PR DESCRIPTION
This fixes #9499 - it adds a test that catches the original problem from #9499 and implements a combination of what @pllim and @StuartLittlefair suggested in #9499 of passing headers that apparently are required by the iers.org http server.

A subtle but important modification is that it allows `download_file` to pass in custom http headers.  I haven't directly tested that feature since this PR is focused on fixing #9499 and thereby tests it indirectly.  But I'm open to ideas about how one might test that (i.e. if there's some canonical web site that just returns in the result file the request headers or something like that...).

Note this should await merging until it can be rebased on #9182, because it quite plausible it will interact with it in possibly unexpected ways.

**EDIT -- NOTE TO REVIEWS: Check the numpy dev job that is allowed to fail because that same job deals with remote data tests.**