### PR TITLE
Remove version pinnings for docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,12 +110,10 @@ jobs:
             sudo apt install -y graphviz
       - run:
           name: Install Python dependencies
-          # NOTE: we pin matplotlib below due to a bug that affects plotting of
-          # quantities: https://github.com/matplotlib/matplotlib/issues/14274
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install "numpydoc<0.9" "matplotlib<3.1" "sphinx<2.2"
+            pip install numpydoc matplotlib sphinx
             pip install .[docs,all]
       - run:
           name: Make sure flake8 passes

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ python:
       extra_requirements:
         - docs
         - all
-    - requirements: docs/rtd_requirements.txt
 
 submodules:
   include: all

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1079,8 +1079,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     urllib.error.URLError
         Whenever there's a problem getting the remote file.
 
-    Note
-    ----
+    Notes
+    -----
     Because this returns a filename, another process could run
     clear_download_cache before you actually open the file, leaving
     you with a filename that no longer points to a usable file.
@@ -1283,8 +1283,8 @@ def download_files_in_parallel(urls,
     paths : list of str
         The local file paths corresponding to the downloaded URLs.
 
-    Note
-    ----
+    Notes
+    -----
     If a URL is unreachable, the downloading will grind to a halt and the
     exception will propagate upward, but an unpredictable number of
     files will have been successfully downloaded and will remain in

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -96,6 +96,8 @@ class WCSAxes(Axes):
     def __init__(self, fig, rect, wcs=None, transform=None, coord_meta=None,
                  transData=None, slices=None, frame_class=None,
                  **kwargs):
+        """
+        """
 
         super().__init__(fig, rect, **kwargs)
         self._bboxes = []

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -55,6 +55,8 @@ py:obj Transform
 py:obj Patch
 py:obj Figure
 py:obj AbstractPathEffect
+py:obj matplotlib.axis.Axes.get_window_extent
+py:obj matplotlib.spines.get_window_extent
 
 # numpy inherited docstrings
 py:obj dtype

--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -50,6 +50,11 @@ py:class astropy.time.core.TimeUnique
 
 # astropy.visualization
 py:class matplotlib.axes._subplots.WCSAxesSubplot
+py:obj Bbox
+py:obj Transform
+py:obj Patch
+py:obj Figure
+py:obj AbstractPathEffect
 
 # numpy inherited docstrings
 py:obj dtype

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,1 +1,0 @@
-matplotlib<3.1

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -21,13 +21,13 @@ instead by inputting the proper motion of Sgr A*.
 Note that, for brevity, we may refer to the solar system barycenter as just "the
 sun" in the examples below.
 
--------------------
+---
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -21,13 +21,11 @@ instead by inputting the proper motion of Sgr A*.
 Note that, for brevity, we may refer to the solar system barycenter as just "the
 sun" in the examples below.
 
----
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -16,13 +16,13 @@ This example is meant to demonstrate the capabilities of the
 planning, consider the `astroplan <https://astroplan.readthedocs.org/>`_
 package.
 
--------------------
+---
 
 *By: Erik Tollerud, Kelle Cruz*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/coordinates/plot_obs-planning.py
+++ b/examples/coordinates/plot_obs-planning.py
@@ -16,13 +16,11 @@ This example is meant to demonstrate the capabilities of the
 planning, consider the `astroplan <https://astroplan.readthedocs.org/>`_
 package.
 
----
 
 *By: Erik Tollerud, Kelle Cruz*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -32,13 +32,11 @@ See Also
   Triaxial Milky Way Halo", https://arxiv.org/abs/1003.1132
 * David Law's Sgr info page http://www.stsci.edu/~dlaw/Sgr/
 
----
 
 *By: Adrian Price-Whelan, Erik Tollerud*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -32,13 +32,13 @@ See Also
   Triaxial Milky Way Halo", https://arxiv.org/abs/1003.1132
 * David Law's Sgr info page http://www.stsci.edu/~dlaw/Sgr/
 
--------------------
+---
 
 *By: Adrian Price-Whelan, Erik Tollerud*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -14,13 +14,13 @@ frame relative to the bary- or Heliocentric frame. It also depends on the
 assumed solar velocity vector. Here we'll demonstrate how to perform this
 transformation using a sky position and barycentric radial-velocity.
 
--------------------
+---
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -14,13 +14,11 @@ frame relative to the bary- or Heliocentric frame. It also depends on the
 assumed solar velocity vector. Here we'll demonstrate how to perform this
 transformation using a sky position and barycentric radial-velocity.
 
----
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/create-mef.py
+++ b/examples/io/create-mef.py
@@ -7,13 +7,11 @@ Create a multi-extension FITS (MEF) file from scratch
 This example demonstrates how to create a multi-extension FITS (MEF)
 file from scratch using `astropy.io.fits`.
 
----
 
 *By: Erik Bray*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/create-mef.py
+++ b/examples/io/create-mef.py
@@ -7,13 +7,13 @@ Create a multi-extension FITS (MEF) file from scratch
 This example demonstrates how to create a multi-extension FITS (MEF)
 file from scratch using `astropy.io.fits`.
 
--------------------
+---
 
 *By: Erik Bray*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/io/fits-tables.py
+++ b/examples/io/fits-tables.py
@@ -12,13 +12,13 @@ The example uses `astropy.utils.data` to download multi-extension FITS (MEF)
 file, `astropy.io.fits` to investigate the header, and
 `astropy.table.Table` to explore the data.
 
--------------------
+---
 
 *By: Lia Corrales, Adrian Price-Whelan, and Kelle Cruz*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/io/fits-tables.py
+++ b/examples/io/fits-tables.py
@@ -12,13 +12,11 @@ The example uses `astropy.utils.data` to download multi-extension FITS (MEF)
 file, `astropy.io.fits` to investigate the header, and
 `astropy.table.Table` to explore the data.
 
----
 
 *By: Lia Corrales, Adrian Price-Whelan, and Kelle Cruz*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/modify-fits-header.py
+++ b/examples/io/modify-fits-header.py
@@ -7,13 +7,11 @@ Edit a FITS header
 This example describes how to edit a value in a FITS header
 using `astropy.io.fits`.
 
----
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/modify-fits-header.py
+++ b/examples/io/modify-fits-header.py
@@ -7,13 +7,13 @@ Edit a FITS header
 This example describes how to edit a value in a FITS header
 using `astropy.io.fits`.
 
--------------------
+---
 
 *By: Adrian Price-Whelan*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/io/plot_fits-image.py
+++ b/examples/io/plot_fits-image.py
@@ -9,13 +9,13 @@ This example opens an image stored in a FITS file and displays it to the screen.
 This example uses `astropy.utils.data` to download the file, `astropy.io.fits` to open
 the file, and `matplotlib.pyplot` to display the image.
 
--------------------
+---
 
 *By: Lia R. Corrales, Adrian Price-Whelan, Kelle Cruz*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/io/plot_fits-image.py
+++ b/examples/io/plot_fits-image.py
@@ -9,13 +9,11 @@ This example opens an image stored in a FITS file and displays it to the screen.
 This example uses `astropy.utils.data` to download the file, `astropy.io.fits` to open
 the file, and `matplotlib.pyplot` to display the image.
 
----
 
 *By: Lia R. Corrales, Adrian Price-Whelan, Kelle Cruz*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -7,13 +7,11 @@ Create a very large FITS file from scratch
 This example demonstrates how to create a large file (larger than will fit in
 memory) from scratch using `astropy.io.fits`.
 
----
 
 *By: Erik Bray*
 
 *License: BSD*
 
----
 """
 
 ##############################################################################

--- a/examples/io/skip_create-large-fits.py
+++ b/examples/io/skip_create-large-fits.py
@@ -7,13 +7,13 @@ Create a very large FITS file from scratch
 This example demonstrates how to create a large file (larger than will fit in
 memory) from scratch using `astropy.io.fits`.
 
--------------------
+---
 
 *By: Erik Bray*
 
 *License: BSD*
 
--------------------
+---
 """
 
 ##############################################################################

--- a/examples/io/split-jpeg-to-fits.py
+++ b/examples/io/split-jpeg-to-fits.py
@@ -10,13 +10,11 @@ FITS (image) file.
 This example uses `pillow <http://python-pillow.org>`_ to read the image,
 `matplotlib.pyplot` to display the image, and `astropy.io.fits` to save FITS files.
 
----
 
 *By: Erik Bray, Adrian Price-Whelan*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/io/split-jpeg-to-fits.py
+++ b/examples/io/split-jpeg-to-fits.py
@@ -10,13 +10,13 @@ FITS (image) file.
 This example uses `pillow <http://python-pillow.org>`_ to read the image,
 `matplotlib.pyplot` to display the image, and `astropy.io.fits` to save FITS files.
 
--------------------
+---
 
 *By: Erik Bray, Adrian Price-Whelan*
 
 *License: BSD*
 
--------------------
+---
 
 """
 

--- a/examples/template/example-template.py
+++ b/examples/template/example-template.py
@@ -10,13 +10,11 @@ The example uses <packages> to <do something> and <other package> to <do other
 thing>. Include links to referenced packages like this: `astropy.io.fits` to
 show the astropy.io.fits or like this `~astropy.io.fits`to show just 'fits'
 
----
 
 *By: <names>*
 
 *License: BSD*
 
----
 
 """
 

--- a/examples/template/example-template.py
+++ b/examples/template/example-template.py
@@ -10,13 +10,13 @@ The example uses <packages> to <do something> and <other package> to <do other
 thing>. Include links to referenced packages like this: `astropy.io.fits` to
 show the astropy.io.fits or like this `~astropy.io.fits`to show just 'fits'
 
--------------------
+---
 
 *By: <names>*
 
 *License: BSD*
 
--------------------
+---
 
 """
 


### PR DESCRIPTION
If this works, this fixes https://github.com/astropy/astropy/issues/9147

The Matplotlib pinning can definitely go, the sphinx ones I'm not sure, but will try.