### PR TITLE
BUG: Raise Warning if non-existent table is selected with `hdu=` on single-table FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -661,7 +661,7 @@ astropy.io.fits
 - Implemented skip (after warning) of header cards with reserved
   keywords in ``table_to_hdu``. [#9390]
 
-- Add warning to ``read_table_fits`` when ``hdu=`` is selected, but
+- Add ``AstropyDeprecationWarning`` to ``read_table_fits`` when ``hdu=`` is selected, but
   does not match single present table HDU. [#9512]
 
 astropy.io.registry

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -661,6 +661,9 @@ astropy.io.fits
 - Implemented skip (after warning) of header cards with reserved
   keywords in ``table_to_hdu``. [#9390]
 
+- Add warning to ``read_table_fits`` when ``hdu=`` is selected, but
+  does not match single present table HDU. [#9512]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -167,7 +167,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
             if hdu is None:
                 warnings.warn("hdu= was not specified but multiple tables"
                               " are present, reading in first available"
-                              " table (hdu={})".format(first(tables)),
+                              f" table (hdu={first(tables)})",
                               AstropyUserWarning)
                 hdu = first(tables)
 
@@ -181,6 +181,11 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                 raise ValueError(f"No table found in hdu={hdu}")
 
         elif len(tables) == 1:
+            if hdu != 1:
+                warnings.warn(f"No table found in specified hdu={hdu},"
+                              " reading in first available "
+                              f"table (hdu={first(tables)}) instead!", 
+                              AstropyUserWarning)
             table = tables[first(tables)]
         else:
             raise ValueError("No table found")

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -11,8 +11,9 @@ from astropy import units as u
 from astropy.table import Table, serialize, meta, Column, MaskedColumn
 from astropy.table.table import has_info_class
 from astropy.time import Time
-from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.data_info import MixinInfo, serialize_context_as
+from astropy.utils.exceptions import (AstropyUserWarning,
+                                      AstropyDeprecationWarning)
 from . import HDUList, TableHDU, BinTableHDU, GroupsHDU
 from .column import KEYWORD_NAMES, _fortran_to_python_format
 from .convenience import table_to_hdu
@@ -158,7 +159,7 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
     if isinstance(input, HDUList):
 
         # Parse all table objects
-        tables = OrderedDict()
+        tables = dict()
         for ihdu, hdu_item in enumerate(input):
             if isinstance(hdu_item, (TableHDU, BinTableHDU, GroupsHDU)):
                 tables[ihdu] = hdu_item
@@ -181,12 +182,24 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                 raise ValueError(f"No table found in hdu={hdu}")
 
         elif len(tables) == 1:
-            if not (hdu is None or hdu in tables):
-                warnings.warn(f"No table found in specified hdu={hdu},"
-                              " reading in first available "
-                              f"table (hdu={first(tables)}) instead!",
-                              AstropyUserWarning)
+            if hdu is not None:
+                msg = None
+                try:
+                    hdi = input.index_of(hdu)
+                except KeyError:
+                    msg = f"Specified hdu={hdu} not found"
+                else:
+                    if hdi >= len(input):
+                        msg = f"Specified hdu={hdu} not found"
+                    elif hdi not in tables:
+                        msg = f"No table found in specified hdu={hdu}"
+                if msg is not None:
+                    warnings.warn(f"{msg}, reading in first available table "
+                                  f"(hdu={first(tables)}) instead. This will"
+                                  " result in an error in future versions!",
+                                  AstropyDeprecationWarning)
             table = tables[first(tables)]
+
         else:
             raise ValueError("No table found")
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -181,10 +181,10 @@ def read_table_fits(input, hdu=None, astropy_native=False, memmap=False,
                 raise ValueError(f"No table found in hdu={hdu}")
 
         elif len(tables) == 1:
-            if hdu != 1:
+            if not (hdu is None or hdu in tables):
                 warnings.warn(f"No table found in specified hdu={hdu},"
                               " reading in first available "
-                              f"table (hdu={first(tables)}) instead!", 
+                              f"table (hdu={first(tables)}) instead!",
                               AstropyUserWarning)
             table = tables[first(tables)]
         else:


### PR DESCRIPTION
Fixes an issue identified by @simonkrughoff :

On reading from a FITS file with only one `TABLE`-type extension, the `hdu=` argument is silently ignored when requesting a different HDU. In contrast, if there are multiple extensions, the appropriate `ValueError` is raised on selecting a non-existent or non-table HDU; a warning is given when no `hdu=` kwarg has been given.

This PR raises a warning about reading the default (i.e. first and only) table instead, if a different HDU was requested.
The risks for data integrity if the FITS file does not have the expected no. of table extensions might justify instead raising a `ValueError` here as well, but at a higher risk of breaking existing code, so it might be better to set a deprecation timeline for such behaviour.
Errors and warnings are a bit unspecific since they give the same message whether the HDU does not exist at all or is of a conflicting type.

Please assign to 4.1 if you feel this needs more discussion.