### PR TITLE
Fix input data type validation for Bayesian Blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -700,6 +700,9 @@ astropy.stats
 
 - Fixed a bug where ``bayesian_blocks`` returned a single edge. [#8560]
 
+- Fixed input data type validation for ``bayesian_blocks`` to work int
+  arrays. [#9513]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -213,10 +213,6 @@ class FitnessFunc:
         """
         # validate array input
         t = np.asarray(t, dtype=float)
-        if x is not None:
-            x = np.asarray(x)
-        if sigma is not None:
-            sigma = np.asarray(sigma)
 
         # find unique values of t
         t = np.array(t)
@@ -242,7 +238,8 @@ class FitnessFunc:
         # if x is specified, then we need to simultaneously sort t and x
         else:
             # TODO: allow broadcasted x?
-            x = np.asarray(x)
+            x = np.asarray(x, dtype=float)
+
             if x.shape not in [(), (1,), (t.size,)]:
                 raise ValueError("x does not match shape of t")
             x += np.zeros_like(t)
@@ -257,7 +254,7 @@ class FitnessFunc:
         if sigma is None:
             sigma = 1
         else:
-            sigma = np.asarray(sigma)
+            sigma = np.asarray(sigma, dtype=float)
             if sigma.shape not in [(), (1,), (t.size,)]:
                 raise ValueError('sigma does not match the shape of x')
 

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -27,7 +27,8 @@ def test_duplicate_events(rseed=0):
     t = rng.rand(100)
     t[80:] = t[:20]
 
-    x = np.ones_like(t)
+    # Using int array as a regression test for gh-6877
+    x = np.ones(t.shape, dtype=int)
     x[:20] += 1
 
     with pytest.warns(AstropyUserWarning,


### PR DESCRIPTION
This is a quick fix to close #6877