### PR TITLE
Fix some pep8 issues

### DIFF
--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -235,7 +235,7 @@ class Card(_Verify):
             keyword = keyword.rstrip()
             keyword_upper = keyword.upper()
             if (len(keyword) <= KEYWORD_LENGTH and
-                self._keywd_FSC_RE.match(keyword_upper)):
+                    self._keywd_FSC_RE.match(keyword_upper)):
                 # For keywords with length > 8 they will be HIERARCH cards,
                 # and can have arbitrary case keywords
                 if keyword_upper == 'END':
@@ -356,7 +356,7 @@ class Card(_Verify):
             value = bool(value)
 
         if (conf.strip_header_whitespace and
-            (isinstance(oldvalue, str) and isinstance(value, str))):
+                (isinstance(oldvalue, str) and isinstance(value, str))):
             # Ignore extra whitespace when comparing the new value to the old
             different = oldvalue.rstrip() != value.rstrip()
         elif isinstance(oldvalue, bool) or isinstance(value, bool):
@@ -996,7 +996,7 @@ class Card(_Verify):
             # try not to use CONTINUE if the string value can fit in one line.
             # Instead, just truncate the comment
             if (isinstance(self.value, str) and
-                len(value) > (self.length - 10)):
+                    len(value) > (self.length - 10)):
                 output = self._format_long_image()
             else:
                 warnings.warn('Card is too long, comment will be truncated.',

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -117,15 +117,17 @@ TDISP_RE_DICT['EN'] = TDISP_RE_DICT['ES'] = \
 # D: Double-precision Floating Point with exponential
 #    (E but for double precision)
 # G: Double-precision Floating Point, may or may not show exponent
-TDISP_FMT_DICT = {'I' : '{{:{width}d}}',
-                  'B' : '{{:{width}b}}',
-                  'O' : '{{:{width}o}}',
-                  'Z' : '{{:{width}x}}',
-                  'F' : '{{:{width}.{precision}f}}',
-                  'G' : '{{:{width}.{precision}g}}'}
+TDISP_FMT_DICT = {
+    'I': '{{:{width}d}}',
+    'B': '{{:{width}b}}',
+    'O': '{{:{width}o}}',
+    'Z': '{{:{width}x}}',
+    'F': '{{:{width}.{precision}f}}',
+    'G': '{{:{width}.{precision}g}}'
+}
 TDISP_FMT_DICT['A'] = TDISP_FMT_DICT['L'] = '{{:>{width}}}'
 TDISP_FMT_DICT['E'] = TDISP_FMT_DICT['D'] =  \
-    TDISP_FMT_DICT['EN'] = TDISP_FMT_DICT['ES'] ='{{:{width}.{precision}e}}'
+    TDISP_FMT_DICT['EN'] = TDISP_FMT_DICT['ES'] = '{{:{width}.{precision}e}}'
 
 # tuple of column/field definition common names and keyword names, make
 # sure to preserve the one-to-one correspondence when updating the list(s).
@@ -1155,7 +1157,7 @@ class Column(NotifierMixin):
                     invalid[k] = (v, msg)
 
         if time_ref_pos is not None and time_ref_pos != '':
-            msg=None
+            msg = None
             if not isinstance(time_ref_pos, str):
                 msg = (
                     "Time coordinate reference position option (TRPOSn) must be "
@@ -1510,8 +1512,7 @@ class ColDefs(NotifierMixin):
         # columns can't be transferred
         # TODO: Catch exceptions here and raise an explicit error about
         # column format conversion
-        new_column.format = self._col_format_cls.from_column_format(
-                column.format)
+        new_column.format = self._col_format_cls.from_column_format(column.format)
 
         # Handle a few special cases of column format options that are not
         # compatible between ASCII an binary tables
@@ -2482,7 +2483,7 @@ def _parse_tdisp_format(tdisp):
 
     # Use appropriate regex for format type
     tdisp = tdisp.strip()
-    fmt_key = tdisp[0] if tdisp[0] !='E' or tdisp[1] not in 'NS' else tdisp[:2]
+    fmt_key = tdisp[0] if tdisp[0] != 'E' or tdisp[1] not in 'NS' else tdisp[:2]
     try:
         tdisp_re = TDISP_RE_DICT[fmt_key]
     except KeyError:
@@ -2538,7 +2539,7 @@ def _fortran_to_python_format(tdisp):
         raise VerifyError(f'Format {format_type} is not recognized.')
 
 
-def python_to_tdisp(format_string, logical_dtype = False):
+def python_to_tdisp(format_string, logical_dtype=False):
     """
     Turn the Python format string to a TDISP FITS compliant format string. Not
     all formats convert. these will cause a Warning and return None.
@@ -2568,7 +2569,7 @@ def python_to_tdisp(format_string, logical_dtype = False):
     if format_string[0] == '{' and format_string != "{}":
         fmt_str = format_string.lstrip("{:").rstrip('}')
     elif format_string[0] == '%':
-            fmt_str = format_string.lstrip("%")
+        fmt_str = format_string.lstrip("%")
     else:
         fmt_str = format_string
 

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -4,7 +4,6 @@
 import os
 import re
 import warnings
-from collections import OrderedDict
 
 from astropy.io import registry as io_registry
 from astropy import units as u

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1080,7 +1080,7 @@ def _stat_filename_or_fileobj(filename):
     noexist_or_empty = ((name and
                          (not os.path.exists(name) or
                           (os.path.getsize(name) == 0)))
-                         or (not name and loc == 0))
+                        or (not name and loc == 0))
 
     return name, closed, noexist_or_empty
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -497,7 +497,7 @@ class _File:
             # to properly process the FITS header (and handle the possibility
             # of a compressed file).
             self._file.seek(0)
-        except (OSError, OSError):
+        except OSError:
             return
 
         self._try_read_compressed(fileobj, magic, mode)

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -472,7 +472,8 @@ class _File:
         """Open a FITS file from a file object (including compressed files)."""
 
         closed = fileobj_closed(fileobj)
-        fmode = fileobj_mode(fileobj) or IO_FITS_MODES[mode]
+        # FIXME: this variable was unused, check if it was useful
+        # fmode = fileobj_mode(fileobj) or IO_FITS_MODES[mode]
 
         if mode == 'ostream':
             self._overwrite_existing(overwrite, fileobj, closed)

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -145,7 +145,7 @@ class _File:
 
         # Handle raw URLs
         if (isinstance(fileobj, str) and
-            mode not in ('ostream', 'append', 'update') and _is_url(fileobj)):
+                mode not in ('ostream', 'append', 'update') and _is_url(fileobj)):
             self.name = download_file(fileobj, cache=cache)
         # Handle responses from URL requests that have already been opened
         elif isinstance(fileobj, http.client.HTTPResponse):
@@ -201,7 +201,7 @@ class _File:
         # For 'ab+' mode, the pointer is at the end after the open in
         # Linux, but is at the beginning in Solaris.
         if (mode == 'ostream' or self.compression or
-            not hasattr(self._file, 'seek')):
+                not hasattr(self._file, 'seek')):
             # For output stream start with a truncated file.
             # For compressed files we can't really guess at the size
             self.size = 0
@@ -428,7 +428,7 @@ class _File:
 
         # The file will be overwritten...
         if ((self.file_like and hasattr(fileobj, 'len') and fileobj.len > 0) or
-            (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
+                (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
             if overwrite:
                 if self.file_like and hasattr(fileobj, 'truncate'):
                     fileobj.truncate(0)
@@ -496,7 +496,7 @@ class _File:
             # to properly process the FITS header (and handle the possibility
             # of a compressed file).
             self._file.seek(0)
-        except (OSError,OSError):
+        except (OSError, OSError):
             return
 
         self._try_read_compressed(fileobj, magic, mode)
@@ -522,7 +522,7 @@ class _File:
         # If there is not seek or tell methods then set the mode to
         # output streaming.
         if (not hasattr(self._file, 'seek') or
-            not hasattr(self._file, 'tell')):
+                not hasattr(self._file, 'tell')):
             self.mode = mode = 'ostream'
 
         if mode == 'ostream':
@@ -530,7 +530,7 @@ class _File:
 
         # Any "writeable" mode requires a write() method on the file object
         if (self.mode in ('update', 'append', 'ostream') and
-            not hasattr(self._file, 'write')):
+                not hasattr(self._file, 'write')):
             raise OSError("File-like object does not have a 'write' "
                           "method, required for mode '{}'.".format(self.mode))
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -545,8 +545,8 @@ def time_to_fits(table):
         jd12 = np.rollaxis(jd12, 0, jd12.ndim)
         newtable.replace_column(col.info.name, Column(jd12, unit='d'))
 
-        # Get column position(index)
-        n = table.colnames.index(col.info.name) + 1
+        # Get column position(index); FIXME: unused ?
+        # n = table.colnames.index(col.info.name) + 1
 
         # Time column-specific override keywords
         coord_meta[col.info.name]['coord_type'] = col.scale.upper()
@@ -566,7 +566,7 @@ def time_to_fits(table):
             # Compatibility of Time Scales and Reference Positions
             if col.scale in BARYCENTRIC_SCALES:
                 warnings.warn(
-                    'Earth Location "TOPOCENTER" for Time Column "{}" is incompatabile '
+                    'Earth Location "TOPOCENTER" for Time Column "{}" is incompatible '
                     'with scale "{}".'.format(col.info.name, col.scale.upper()),
                     AstropyUserWarning)
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -375,7 +375,7 @@ def _convert_time_column(col, column_info):
         # directly converted to Time, as they are absolute (relative
         # to a globally accepted zero point).
         if (column_info['ref_time']['val'] == 0 and
-            column_info['ref_time']['format'] in ['jd', 'mjd']):
+                column_info['ref_time']['format'] in ['jd', 'mjd']):
             # (jd1, jd2) where jd = jd1 + jd2
             if col.shape[-1] == 2 and col.ndim > 1:
                 return Time(col[..., 0], col[..., 1], scale=column_info['scale'],

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -727,7 +727,7 @@ class HDUList(list, _Verify):
                 name = name.strip().upper()
             # 'PRIMARY' should always work as a reference to the first HDU
             if ((name == _key or (_key == 'PRIMARY' and idx == 0)) and
-                (_ver is None or _ver == hdu.ver)):
+                    (_ver is None or _ver == hdu.ver)):
                 found = idx
                 break
 
@@ -1121,7 +1121,7 @@ class HDUList(list, _Verify):
             self._in_read_next_hdu = True
 
             if ('disable_image_compression' in kwargs and
-                kwargs['disable_image_compression']):
+                    kwargs['disable_image_compression']):
                 compressed.COMPRESSION_ENABLED = False
 
             # read all HDUs

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -375,10 +375,11 @@ class _ImageBaseHDU(_ValidHDU):
         # Added original_was_unsigned with the intent of facilitating the
         # special case of do_not_scale_image_data=True and uint=True
         # eventually.
-        if self._dtype_for_bitpix() is not None:
-            original_was_unsigned = self._dtype_for_bitpix().kind == 'u'
-        else:
-            original_was_unsigned = False
+        # FIXME: unused, maybe it should be useful?
+        # if self._dtype_for_bitpix() is not None:
+        #     original_was_unsigned = self._dtype_for_bitpix().kind == 'u'
+        # else:
+        #     original_was_unsigned = False
 
         if (self._do_not_scale_image_data or
                 (self._orig_bzero == 0 and self._orig_bscale == 1)):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -566,7 +566,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         # if data is touched, use data info.
         if self._data_loaded:
             if self.data is None:
-                shape, format = (), ''
                 nrows = 0
             else:
                 nrows = len(self.data)
@@ -576,7 +575,6 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
 
         # if data is not touched yet, use header info.
         else:
-            shape = ()
             nrows = self._header['NAXIS2']
             ncols = self._header['TFIELDS']
             format = ', '.join([self._header['TFORM' + str(j + 1)]

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -746,10 +746,6 @@ class Header:
 
             if not fileobj.simulateonly:
                 fileobj.flush()
-                try:
-                    offset = fileobj.tell()
-                except (AttributeError, OSError):
-                    offset = 0
                 fileobj.write(blocks.encode('ascii'))
                 fileobj.flush()
         finally:

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -194,8 +194,7 @@ class HeaderFormatter:
             else:
                 header = self._hdulist[hdukey].header
         except (IndexError, KeyError):
-            message = '{}: Extension {} not found.'.format(self.filename,
-                                                             hdukey)
+            message = '{}: Extension {} not found.'.format(self.filename, hdukey)
             if self.verbose:
                 log.warning(message)
             raise ExtensionNotFoundException(message)
@@ -211,7 +210,7 @@ class HeaderFormatter:
                         cards.append(crd)
                     else:  # Allow for wildcard access
                         cards.extend(crd)
-                except KeyError as e:  # Keyword does not exist
+                except KeyError:  # Keyword does not exist
                     if self.verbose:
                         log.warning('{filename} (HDU {hdukey}): '
                                     'Keyword {kw} not found.'.format(
@@ -446,7 +445,7 @@ def main(args=None):
             print_headers_as_comparison(args)
         else:
             print_headers_traditional(args)
-    except OSError as e:
+    except OSError:
         # A 'Broken pipe' OSError may occur when stdout is closed prematurely,
         # eg. when calling `fitsheader file.fits | head`. We let this pass.
         pass

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -23,12 +23,12 @@ class TestConvenience(FitsTestCase):
     def test_resource_warning(self):
         warnings.simplefilter('always', ResourceWarning)
         with catch_warnings() as w:
-            data = fits.getdata(self.data('test0.fits'))
-            assert len(w) == 0
+            fits.getdata(self.data('test0.fits'))
+        assert len(w) == 0
 
         with catch_warnings() as w:
-            header = fits.getheader(self.data('test0.fits'))
-            assert len(w) == 0
+            fits.getheader(self.data('test0.fits'))
+        assert len(w) == 0
 
     def test_fileobj_not_closed(self):
         """
@@ -39,11 +39,11 @@ class TestConvenience(FitsTestCase):
         """
 
         f = open(self.data('test0.fits'), 'rb')
-        data = fits.getdata(f)
+        fits.getdata(f)
         assert not f.closed
 
         f.seek(0)
-        header = fits.getheader(f)
+        fits.getheader(f)
         assert not f.closed
 
         f.close()  # Close it now

--- a/astropy/io/fits/tests/test_convenience.py
+++ b/astropy/io/fits/tests/test_convenience.py
@@ -23,11 +23,11 @@ class TestConvenience(FitsTestCase):
     def test_resource_warning(self):
         warnings.simplefilter('always', ResourceWarning)
         with catch_warnings() as w:
-            fits.getdata(self.data('test0.fits'))
+            _ = fits.getdata(self.data('test0.fits'))
         assert len(w) == 0
 
         with catch_warnings() as w:
-            fits.getheader(self.data('test0.fits'))
+            _ = fits.getheader(self.data('test0.fits'))
         assert len(w) == 0
 
     def test_fileobj_not_closed(self):
@@ -39,11 +39,11 @@ class TestConvenience(FitsTestCase):
         """
 
         f = open(self.data('test0.fits'), 'rb')
-        fits.getdata(f)
+        _ = fits.getdata(f)
         assert not f.closed
 
         f.seek(0)
-        fits.getheader(f)
+        _ = fits.getheader(f)
         assert not f.closed
 
         f.close()  # Close it now

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -595,7 +595,7 @@ class TestFileFunctions(FitsTestCase):
         # But opening in ostream or append mode should be okay, since they
         # allow writing new files
         for mode in ('ostream', 'append'):
-            with fits.open(self.temp('foobar.fits'), mode=mode):
+            with fits.open(self.temp('foobar.fits'), mode=mode) as _:
                 pass
 
             assert os.path.exists(self.temp('foobar.fits'))
@@ -604,24 +604,24 @@ class TestFileFunctions(FitsTestCase):
     def test_open_file_handle(self):
         # Make sure we can open a FITS file from an open file handle
         with open(self.data('test0.fits'), 'rb') as handle:
-            with fits.open(handle):
+            with fits.open(handle) as _:
                 pass
 
         with open(self.temp('temp.fits'), 'wb') as handle:
-            with fits.open(handle, mode='ostream'):
+            with fits.open(handle, mode='ostream') as _:
                 pass
 
         # Opening without explicitly specifying binary mode should fail
         with pytest.raises(ValueError):
             with open(self.data('test0.fits')) as handle:
-                with fits.open(handle):
+                with fits.open(handle) as _:
                     pass
 
         # All of these read modes should fail
         for mode in ['r', 'rt']:
             with pytest.raises(ValueError):
                 with open(self.data('test0.fits'), mode=mode) as handle:
-                    with fits.open(handle):
+                    with fits.open(handle) as _:
                         pass
 
         # These update or write modes should fail as well
@@ -629,37 +629,37 @@ class TestFileFunctions(FitsTestCase):
                      'a', 'at', 'a+', 'at+']:
             with pytest.raises(ValueError):
                 with open(self.temp('temp.fits'), mode=mode) as handle:
-                    with fits.open(handle):
+                    with fits.open(handle) as _:
                         pass
 
     def test_fits_file_handle_mode_combo(self):
         # This should work fine since no mode is given
         with open(self.data('test0.fits'), 'rb') as handle:
-            with fits.open(handle):
+            with fits.open(handle) as _:
                 pass
 
         # This should work fine since the modes are compatible
         with open(self.data('test0.fits'), 'rb') as handle:
-            with fits.open(handle, mode='readonly'):
+            with fits.open(handle, mode='readonly') as _:
                 pass
 
         # This should not work since the modes conflict
         with pytest.raises(ValueError):
             with open(self.data('test0.fits'), 'rb') as handle:
-                with fits.open(handle, mode='ostream'):
+                with fits.open(handle, mode='ostream') as _:
                     pass
 
     def test_open_from_url(self):
         file_url = 'file:///' + self.data('test0.fits').lstrip('/')
         with urllib.request.urlopen(file_url) as urlobj:
-            with fits.open(urlobj):
+            with fits.open(urlobj) as _:
                 pass
 
         # It will not be possible to write to a file that is from a URL object
         for mode in ('ostream', 'append', 'update'):
             with pytest.raises(ValueError):
                 with urllib.request.urlopen(file_url) as urlobj:
-                    with fits.open(urlobj, mode=mode):
+                    with fits.open(urlobj, mode=mode) as _:
                         pass
 
     @pytest.mark.remote_data(source='astropy')
@@ -743,7 +743,7 @@ class TestFileFunctions(FitsTestCase):
         'append' mode raises an error"""
 
         with pytest.raises(OSError):
-            with fits.open(self._make_gzip_file('append.gz'), mode='append'):
+            with fits.open(self._make_gzip_file('append.gz'), mode='append') as _:
                 pass
 
     def test_open_bzipped(self):

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -31,7 +31,8 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_hdu_get_size(self):
         with catch_warnings() as w:
-            t1 = fits.open(self.data('tb.fits'))
+            with fits.open(self.data('tb.fits')):
+                pass
         assert len(w) == 0
 
     def test_section(self, capsys):

--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -31,7 +31,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_hdu_get_size(self):
         with catch_warnings() as w:
-            with fits.open(self.data('tb.fits')):
+            with fits.open(self.data('tb.fits')) as _:
                 pass
         assert len(w) == 0
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -13,7 +13,7 @@ from astropy.time import Time, TimeDelta
 from astropy.time.core import BARYCENTRIC_SCALES
 from astropy.time.formats import FITS_DEPRECATED_SCALES
 from astropy.tests.helper import catch_warnings
-from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyUserWarning
 
 
 class TestFitsTime(FitsTestCase):

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -456,10 +456,10 @@ class TestFitsTime(FitsTestCase):
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
 
         with catch_warnings() as w:
-            tm = table_types.read(self.temp('time.fits'), astropy_native=True)
-            assert len(w) == 1
-            assert ('observatory position is not properly specified' in
-                    str(w[0].message))
+            table_types.read(self.temp('time.fits'), astropy_native=True)
+        assert len(w) == 1
+        assert ('observatory position is not properly specified' in
+                str(w[0].message))
 
         # Warning for default value of time reference position "TOPOCENTER"
         # not generated when there is no specified observatory position.
@@ -469,5 +469,5 @@ class TestFitsTime(FitsTestCase):
         bhdu = fits.BinTableHDU.from_columns([c])
         bhdu.writeto(self.temp('time.fits'), overwrite=True)
         with catch_warnings() as w:
-            tm = table_types.read(self.temp('time.fits'), astropy_native=True)
-            assert len(w) == 0
+            table_types.read(self.temp('time.fits'), astropy_native=True)
+        assert len(w) == 0

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -634,8 +634,7 @@ class TestImageFunctions(FitsTestCase):
         """
         Regression test for https://github.com/astropy/astropy/issues/6399
         """
-        hdu1 = fits.PrimaryHDU()
-        hdu2 = fits.ImageHDU(np.random.rand(100,100))
+        hdu2 = fits.ImageHDU(np.random.rand(100, 100))
         # The line below raised an exception in astropy 2.0, so if it does not
         # raise an error here, that is progress.
         hdu2.scale(type='uint8', bscale=1, bzero=0)

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3076,13 +3076,13 @@ class TestColumnFunctions(FitsTestCase):
         """
 
         with pytest.raises(AssertionError) as err:
-            fits.Column(1, format='I', array=[1, 2, 3, 4, 5])
+            _ = fits.Column(1, format='I', array=[1, 2, 3, 4, 5])
         assert 'Column name must be a string able to fit' in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
-                        coord_unit=2, coord_ref_point='1', coord_ref_value='1',
-                        coord_inc='1', time_ref_pos=1)
+            _ = fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
+                            coord_unit=2, coord_ref_point='1', coord_ref_value='1',
+                            coord_inc='1', time_ref_pos=1)
         err_msgs = ['keyword arguments to Column were invalid', 'TNULL', 'TDISP',
                     'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT', 'TRPOS']
         for msg in err_msgs:
@@ -3099,15 +3099,15 @@ class TestColumnFunctions(FitsTestCase):
         """
 
         with pytest.raises(VerifyError) as err:
-            fits.Column('a', format='B', start='a', array=[1, 2, 3])
+            _ = fits.Column('a', format='B', start='a', array=[1, 2, 3])
         assert "start option (TBCOLn) is not allowed for binary table columns" in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            fits.Column('a', format='I', start='a', array=[1, 2, 3])
+            _ = fits.Column('a', format='I', start='a', array=[1, 2, 3])
         assert "start option (TBCOLn) must be a positive integer (got 'a')." in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            fits.Column('a', format='I', start='-56', array=[1, 2, 3])
+            _ = fits.Column('a', format='I', start='-56', array=[1, 2, 3])
         assert "start option (TBCOLn) must be a positive integer (got -56)." in str(err.value)
 
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -193,7 +193,7 @@ class TestTableFunctions(FitsTestCase):
 
         # An alternative way to create a column-definitions object is from an
         # existing table.
-        xx = fits.ColDefs(tt[1])
+        _ = fits.ColDefs(tt[1])
 
         # now we write out the newly created table HDU to a FITS file:
         fout = fits.HDUList(fits.PrimaryHDU())
@@ -3076,13 +3076,13 @@ class TestColumnFunctions(FitsTestCase):
         """
 
         with pytest.raises(AssertionError) as err:
-            c = fits.Column(1, format='I', array=[1, 2, 3, 4, 5])
+            fits.Column(1, format='I', array=[1, 2, 3, 4, 5])
         assert 'Column name must be a string able to fit' in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            c = fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
-                            coord_unit=2, coord_ref_point='1', coord_ref_value='1',
-                            coord_inc='1', time_ref_pos=1)
+            fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
+                        coord_unit=2, coord_ref_point='1', coord_ref_value='1',
+                        coord_inc='1', time_ref_pos=1)
         err_msgs = ['keyword arguments to Column were invalid', 'TNULL', 'TDISP',
                     'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT', 'TRPOS']
         for msg in err_msgs:
@@ -3099,15 +3099,15 @@ class TestColumnFunctions(FitsTestCase):
         """
 
         with pytest.raises(VerifyError) as err:
-            c = fits.Column('a', format='B', start='a', array=[1, 2, 3])
+            fits.Column('a', format='B', start='a', array=[1, 2, 3])
         assert "start option (TBCOLn) is not allowed for binary table columns" in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            c = fits.Column('a', format='I', start='a', array=[1, 2, 3])
+            fits.Column('a', format='I', start='a', array=[1, 2, 3])
         assert "start option (TBCOLn) must be a positive integer (got 'a')." in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            c = fits.Column('a', format='I', start='-56', array=[1, 2, 3])
+            fits.Column('a', format='I', start='-56', array=[1, 2, 3])
         assert "start option (TBCOLn) must be a positive integer (got -56)." in str(err.value)
 
 

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -76,7 +76,7 @@ def comparerecords(a, b):
         if fieldb.dtype.char == 'S':
             fieldb = decode_ascii(fieldb)
         if (not isinstance(fielda, type(fieldb)) and not
-            isinstance(fieldb, type(fielda))):
+                isinstance(fieldb, type(fielda))):
             print("type(fielda): ", type(fielda), " fielda: ", fielda)
             print("type(fieldb): ", type(fieldb), " fieldb: ", fieldb)
             print(f'field {i} type differs')


### PR DESCRIPTION
I started by cleaning some unused imports, and finally did a bit more: fixing some indentation and whitespace issues, removing unused variables, etc.
Milestone set to 4.0 if that's possible, but it can be changed.