### PR TITLE
Remove deprecated code in io.fits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -420,6 +420,13 @@ astropy.io.fits
   As a result of this change, the private subclass ``CompImageHeader`` now always
   should be passed an explicit ``image_header``. [#9229]
 
+- Removed the deprecated ``tolerance`` option in ``fitsdiff`` and
+  ``io.fits.diff`` classes. [#9520]
+
+- Removed deprecated keyword arguments for ``CompImageHDU``:
+  ``compressionType``, ``tileSize``, ``hcompScale``, ``hcompSmooth``,
+  ``quantizeLevel``. [#9520]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -11,7 +11,6 @@ import io
 import operator
 import os.path
 import textwrap
-import warnings
 
 from collections import defaultdict
 from inspect import signature
@@ -27,9 +26,8 @@ from astropy.utils.decorators import deprecated_renamed_argument
 # HDUList is used in one of the doctests
 from .hdu.hdulist import fitsopen, HDUList  # pylint: disable=W0611
 from .hdu.table import _TableLikeHDU
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.utils.diff import (report_diff_values, fixed_width_indent,
-                           where_not_allclose, diff_values)
+                                where_not_allclose, diff_values)
 
 __all__ = ['FITSDiff', 'HDUDiff', 'HeaderDiff', 'ImageDataDiff', 'RawDataDiff',
            'TableDataDiff']
@@ -205,7 +203,7 @@ class FITSDiff(_BaseDiff):
     def __init__(self, a, b, ignore_hdus=[], ignore_keywords=[],
                  ignore_comments=[], ignore_fields=[],
                  numdiffs=10, rtol=0.0, atol=0.0,
-                 ignore_blanks=True, ignore_blank_cards=True, tolerance=None):
+                 ignore_blanks=True, ignore_blank_cards=True):
         """
         Parameters
         ----------
@@ -253,8 +251,7 @@ class FITSDiff(_BaseDiff):
             are considered to be different.
             The underlying function used for comparison is `numpy.allclose`.
 
-            .. versionchanged:: 2.0
-               ``rtol`` replaces the deprecated ``tolerance`` argument.
+            .. versionadded:: 2.0
 
         atol : float, optional
             The allowed absolute difference. See also ``rtol`` parameter.
@@ -300,14 +297,6 @@ class FITSDiff(_BaseDiff):
         self.numdiffs = numdiffs
         self.rtol = rtol
         self.atol = atol
-
-        if tolerance is not None:  # This should be removed in the next astropy version
-            warnings.warn(
-                '"tolerance" was deprecated in version 2.0 and will be removed in '
-                'a future version. Use argument "rtol" instead.',
-                AstropyDeprecationWarning)
-            self.rtol = tolerance  # when tolerance is provided *always* ignore `rtol`
-                                   # during the transition/deprecation period
 
         self.ignore_blanks = ignore_blanks
         self.ignore_blank_cards = ignore_blank_cards
@@ -462,7 +451,7 @@ class HDUDiff(_BaseDiff):
 
     def __init__(self, a, b, ignore_keywords=[], ignore_comments=[],
                  ignore_fields=[], numdiffs=10, rtol=0.0, atol=0.0,
-                 ignore_blanks=True, ignore_blank_cards=True, tolerance=None):
+                 ignore_blanks=True, ignore_blank_cards=True):
         """
         Parameters
         ----------
@@ -504,8 +493,7 @@ class HDUDiff(_BaseDiff):
             are considered to be different.
             The underlying function used for comparison is `numpy.allclose`.
 
-            .. versionchanged:: 2.0
-               ``rtol`` replaces the deprecated ``tolerance`` argument.
+            .. versionadded:: 2.0
 
         atol : float, optional
             The allowed absolute difference. See also ``rtol`` parameter.
@@ -528,14 +516,6 @@ class HDUDiff(_BaseDiff):
 
         self.rtol = rtol
         self.atol = atol
-
-        if tolerance is not None:  # This should be removed in the next astropy version
-            warnings.warn(
-                '"tolerance" was deprecated in version 2.0 and will be removed in '
-                'a future version. Use argument "rtol" instead.',
-                AstropyDeprecationWarning)
-            self.rtol = tolerance  # when tolerance is provided *always* ignore `rtol`
-                                   # during the transition/deprecation period
 
         self.numdiffs = numdiffs
         self.ignore_blanks = ignore_blanks
@@ -655,8 +635,7 @@ class HeaderDiff(_BaseDiff):
     """
 
     def __init__(self, a, b, ignore_keywords=[], ignore_comments=[],
-                 rtol=0.0, atol=0.0, ignore_blanks=True, ignore_blank_cards=True,
-                 tolerance=None):
+                 rtol=0.0, atol=0.0, ignore_blanks=True, ignore_blank_cards=True):
         """
         Parameters
         ----------
@@ -694,8 +673,7 @@ class HeaderDiff(_BaseDiff):
             are considered to be different.
             The underlying function used for comparison is `numpy.allclose`.
 
-            .. versionchanged:: 2.0
-               ``rtol`` replaces the deprecated ``tolerance`` argument.
+            .. versionadded:: 2.0
 
         atol : float, optional
             The allowed absolute difference. See also ``rtol`` parameter.
@@ -717,14 +695,6 @@ class HeaderDiff(_BaseDiff):
 
         self.rtol = rtol
         self.atol = atol
-
-        if tolerance is not None:  # This should be removed in the next astropy version
-            warnings.warn(
-                '"tolerance" was deprecated in version 2.0 and will be removed in '
-                'a future version. Use argument "rtol" instead.',
-                AstropyDeprecationWarning)
-            self.rtol = tolerance  # when tolerance is provided *always* ignore `rtol`
-                                   # during the transition/deprecation period
 
         self.ignore_blanks = ignore_blanks
         self.ignore_blank_cards = ignore_blank_cards
@@ -962,7 +932,7 @@ class ImageDataDiff(_BaseDiff):
       of pixels in the arrays.
     """
 
-    def __init__(self, a, b, numdiffs=10, rtol=0.0, atol=0.0, tolerance=None):
+    def __init__(self, a, b, numdiffs=10, rtol=0.0, atol=0.0):
         """
         Parameters
         ----------
@@ -991,8 +961,7 @@ class ImageDataDiff(_BaseDiff):
             are considered to be different.
             The underlying function used for comparison is `numpy.allclose`.
 
-            .. versionchanged:: 2.0
-               ``rtol`` replaces the deprecated ``tolerance`` argument.
+            .. versionadded:: 2.0
 
         atol : float, optional
             The allowed absolute difference. See also ``rtol`` parameter.
@@ -1003,14 +972,6 @@ class ImageDataDiff(_BaseDiff):
         self.numdiffs = numdiffs
         self.rtol = rtol
         self.atol = atol
-
-        if tolerance is not None:  # This should be removed in the next astropy version
-            warnings.warn(
-                '"tolerance" was deprecated in version 2.0 and will be removed in '
-                'a future version. Use argument "rtol" instead.',
-                AstropyDeprecationWarning)
-            self.rtol = tolerance  # when tolerance is provided *always* ignore `rtol`
-                                   # during the transition/deprecation period
 
         self.diff_dimensions = ()
         self.diff_pixels = []
@@ -1215,8 +1176,7 @@ class TableDataDiff(_BaseDiff):
     those columns.
     """
 
-    def __init__(self, a, b, ignore_fields=[], numdiffs=10, rtol=0.0, atol=0.0,
-                 tolerance=None):
+    def __init__(self, a, b, ignore_fields=[], numdiffs=10, rtol=0.0, atol=0.0):
         """
         Parameters
         ----------
@@ -1249,8 +1209,7 @@ class TableDataDiff(_BaseDiff):
             are considered to be different.
             The underlying function used for comparison is `numpy.allclose`.
 
-            .. versionchanged:: 2.0
-               ``rtol`` replaces the deprecated ``tolerance`` argument.
+            .. versionadded:: 2.0
 
         atol : float, optional
             The allowed absolute difference. See also ``rtol`` parameter.
@@ -1262,14 +1221,6 @@ class TableDataDiff(_BaseDiff):
         self.numdiffs = numdiffs
         self.rtol = rtol
         self.atol = atol
-
-        if tolerance is not None:  # This should be removed in the next astropy version
-            warnings.warn(
-                '"tolerance" was deprecated in version 2.0 and will be removed in '
-                'a future version. Use argument "rtol" instead.',
-                AstropyDeprecationWarning)
-            self.rtol = tolerance  # when tolerance is provided *always* ignore `rtol`
-                                   # during the transition/deprecation period
 
         self.common_columns = []
         self.common_column_names = set()

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -4,12 +4,9 @@ import glob
 import logging
 import os
 import sys
-import textwrap
-import warnings
 
 from astropy.io import fits
 from astropy.io.fits.util import fill
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
 log = logging.getLogger('fitsdiff')
@@ -105,12 +102,6 @@ def handle_options(argv=None):
         metavar='INTEGER',
         help='Max number of data differences (image pixel or table element) '
              'to report per extension (default %(default)s).')
-
-    parser.add_argument(
-        '-d', '--difference-tolerance', type=float, default=None,
-        dest='tolerance', metavar='NUMBER',
-        help='DEPRECATED. Alias for "--relative-tolerance". '
-             'Deprecated, provided for backward compatibility (default %(default)s).')
 
     parser.add_argument(
         '-r', '--rtol', '--relative-tolerance', type=float, default=None,
@@ -286,13 +277,6 @@ def main(args=None):
 
     opts = handle_options(args)
 
-    if opts.tolerance is not None:
-        warnings.warn(
-            '"-d" ("--difference-tolerance") was deprecated in version 2.0 '
-            'and will be removed in a future version. '
-            'Use "-r" ("--relative-tolerance") instead.',
-            AstropyDeprecationWarning)
-        opts.rtol = opts.tolerance
     if opts.rtol is None:
         opts.rtol = 0.0
     if opts.atol is None:

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -3,8 +3,8 @@ import pytest
 import numpy as np
 
 from astropy.io.fits.column import Column
-from astropy.io.fits.diff import (FITSDiff, HeaderDiff, ImageDataDiff, TableDataDiff,
-                    HDUDiff)
+from astropy.io.fits.diff import (FITSDiff, HeaderDiff, ImageDataDiff,
+                                  TableDataDiff, HDUDiff)
 from astropy.io.fits.hdu import HDUList, PrimaryHDU, ImageHDU
 from astropy.io.fits.hdu.table import BinTableHDU
 from astropy.io.fits.header import Header
@@ -146,33 +146,6 @@ class TestDiff(FitsTestCase):
         assert diff.identical
         diff = HeaderDiff(ha, hb, rtol=1e-6, atol=1e-6)
         assert not diff.identical
-
-    def test_deprecation_tolerance(self):
-        """Verify uses of tolerance and rtol.
-        This test should be removed in the next astropy version."""
-
-        ha = Header([('B', 1.0), ('C', 0.1)])
-        hb = ha.copy()
-        hb['B'] = 1.00001
-        hb['C'] = 0.100001
-        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
-            diff = HeaderDiff(ha, hb, tolerance=1e-6)
-            assert warning_lines[0].category == AstropyDeprecationWarning
-            assert (str(warning_lines[0].message) == '"tolerance" was '
-                    'deprecated in version 2.0 and will be removed in a '
-                    'future version. Use argument "rtol" instead.')
-            assert (diff.diff_keyword_values == {'C': [(0.1, 0.100001)],
-                                                 'B': [(1.0, 1.00001)]})
-            assert not diff.identical
-
-        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
-            # `rtol` is always ignored when `tolerance` is provided
-            diff = HeaderDiff(ha, hb, rtol=1e-6, tolerance=1e-5)
-            assert warning_lines[0].category == AstropyDeprecationWarning
-            assert (str(warning_lines[0].message) == '"tolerance" was '
-                    'deprecated in version 2.0 and will be removed in a '
-                    'future version. Use argument "rtol" instead.')
-            assert diff.identical
 
     def test_ignore_blanks(self):
         with fits.conf.set_temp('strip_header_whitespace', False):

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -9,8 +9,6 @@ from astropy.io.fits.convenience import writeto
 from astropy.io.fits.hdu import PrimaryHDU, hdulist
 from astropy.io.fits import Header, ImageHDU, HDUList
 from astropy.io.fits.scripts import fitsdiff
-from astropy.tests.helper import catch_warnings
-from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.version import version
 
 
@@ -162,33 +160,6 @@ Primary HDU:\n\n   Data contains differences:
          ?  ^
      1 different pixels found (1.00% different).\n""".format(version, tmp_a, tmp_b)
         assert err == ""
-
-    def test_fitsdiff_script_both_d_and_r(self, capsys):
-        a = np.arange(100).reshape(10, 10)
-        hdu_a = PrimaryHDU(data=a)
-        b = a.copy()
-        hdu_b = PrimaryHDU(data=b)
-        tmp_a = self.temp('testa.fits')
-        tmp_b = self.temp('testb.fits')
-        hdu_a.writeto(tmp_a)
-        hdu_b.writeto(tmp_b)
-        with catch_warnings(AstropyDeprecationWarning) as warning_lines:
-            fitsdiff.main(["-r", "1e-4", "-d", "1e-2", tmp_a, tmp_b])
-            # `rtol` is always ignored when `tolerance` is provided
-            assert warning_lines[0].category == AstropyDeprecationWarning
-            assert (str(warning_lines[0].message) ==
-                    '"-d" ("--difference-tolerance") was deprecated in version 2.0 '
-                    'and will be removed in a future version. '
-                    'Use "-r" ("--relative-tolerance") instead.')
-        out, err = capsys.readouterr()
-        assert out == """
- fitsdiff: {}
- a: {}
- b: {}
- Maximum number of different data values to be reported: 10
- Relative tolerance: 0.01, Absolute tolerance: 0.0
-
-No differences found.\n""".format(version, tmp_a, tmp_b)
 
     def test_wildcard(self):
         tmp1 = self.temp("tmp_file1")


### PR DESCRIPTION
- The `tolerance` option in `fitsdiff` and `io.fits.diff` classes, was deprecated in 2.0
- Some options for `CompImageHDU`, was deprecated in 2013.

Milestoned for 4.0 if this not too late :pray: 