### PR TITLE
fix bug with compound model inverse serialization

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2455,10 +2455,17 @@ class CompoundModel(Model):
             self.outputs = combine_labels(left.outputs, right.outputs)
             if inverse is None and self.both_inverses_exist():
                 self._has_inverse = True
-                self._inverse = CompoundModel('&',
-                                              self.left.inverse,
-                                              self.right.inverse,
-                                              inverse=self)
+                inv = CompoundModel('&',
+                                     self.left.inverse,
+                                     self.right.inverse,
+                                     inverse=self)
+                if left._user_inverse is not None or right._user_inverse is not None:
+                    self._user_inverse = inv
+                    if self.inverse._has_inverse:
+                        del self._user_inverse._user_inverse
+                        self.inverse._has_inverse = False
+                else:
+                    self._inverse = inv
         elif op == '|':
             if left.n_outputs != right.n_inputs:
                 raise ModelDefinitionError(
@@ -2475,10 +2482,17 @@ class CompoundModel(Model):
             self.outputs = right.outputs
             if inverse is None and self.both_inverses_exist():
                 self._has_inverse = True
-                self._inverse = CompoundModel('|',
-                                              self.right.inverse,
-                                              self.left.inverse,
-                                              inverse=self)
+                inv = CompoundModel('|',
+                                    self.right.inverse,
+                                    self.left.inverse,
+                                    inverse=self)
+                if left._user_inverse is not None or right._user_inverse is not None:
+                    self._user_inverse = inv
+                    if self.inverse._has_inverse:
+                        del self._user_inverse._user_inverse
+                    self.inverse._has_inverse = False
+                else:
+                    self._inverse = inv
         elif op == 'fix_inputs':
             if not isinstance(left, Model):
                 raise ValueError('First argument to "fix_inputs" must be an instance of an astropy Model.')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a problem with serialization of compound models when only one of them has a custom inverse. In this case the inverse was not written to file.

```
m1 = Polynomial1D(1) & Polynomial1D(1)
m2 = Polynomial1D(1) & Polynomial1D(1)
m1.inverse = m2
m = Shift(1) & Shift(2) | m1
fa = AsdfFile()
fa.tree['model'] = m
fa.write_to('model.asdf')
f = asdf.open('model.asdf').tree['model'].inverse
>           raise NotImplementedError("Inverse function not provided")
E           NotImplementedError: Inverse function not provided

```

