### PR TITLE
Maintenance: Don't use NumPys re-exported Python built-ins.

### DIFF
--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1047,7 +1047,7 @@ def test_data_out_of_range(parallel, fast_reader, guess):
         fast_reader['parallel'] = parallel
         if fast_reader.get('use_fast_converter'):
             rtol = 1.e-15
-        elif np.iinfo(np.int).dtype == np.dtype(np.int32):
+        elif np.iinfo(np.int_).dtype == np.dtype(np.int32):
             # On 32bit the standard C parser (strtod) returns strings for these
             pytest.xfail("C parser cannot handle float64 on 32bit systems")
 
@@ -1123,7 +1123,7 @@ def test_data_at_range_limit(parallel, fast_reader, guess):
         fast_reader['parallel'] = parallel
         if fast_reader.get('use_fast_converter'):
             rtol = 1.e-15
-        elif np.iinfo(np.int).dtype == np.dtype(np.int32):
+        elif np.iinfo(np.int_).dtype == np.dtype(np.int32):
             # On 32bit the standard C parser (strtod) returns strings for these
             pytest.xfail("C parser cannot handle float64 on 32bit systems")
 

--- a/astropy/modeling/separable.py
+++ b/astropy/modeling/separable.py
@@ -96,7 +96,7 @@ def separability_matrix(transform):
     """
     if transform.n_inputs == 1 and transform.n_outputs > 1:
         return np.ones((transform.n_outputs, transform.n_inputs),
-                       dtype=np.bool)
+                       dtype=np.bool_)
     separable_matrix = _separable(transform)
     separable_matrix = np.where(separable_matrix != 0, True, False)
     return separable_matrix

--- a/astropy/nddata/tests/test_bitmask.py
+++ b/astropy/nddata/tests/test_bitmask.py
@@ -11,7 +11,7 @@ import pytest
 from astropy.nddata import bitmask
 
 
-MAX_INT_TYPE = np.maximum_sctype(np.int)
+MAX_INT_TYPE = np.maximum_sctype(np.int_)
 MAX_UINT_TYPE = np.maximum_sctype(np.uint)
 MAX_UINT_FLAG = np.left_shift(
     MAX_UINT_TYPE(1),

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -244,7 +244,7 @@ def test_sigma_clip_axis_tuple_3D():
     """
 
     data = np.sin(0.78 * np.arange(27)).reshape(3, 3, 3)
-    mask = np.zeros_like(data, dtype=np.bool)
+    mask = np.zeros_like(data, dtype=np.bool_)
 
     data_t = np.rollaxis(data, 1, 0)
     mask_t = np.rollaxis(mask, 1, 0)

--- a/astropy/table/_np_utils.pyx
+++ b/astropy/table/_np_utils.pyx
@@ -76,8 +76,8 @@ def join_inner(np.ndarray[DTYPE_t, ndim=1] idxs,
 
     cdef np.ndarray left_out = np.empty(n_out, dtype=DTYPE)
     cdef np.ndarray right_out = np.empty(n_out, dtype=DTYPE)
-    cdef np.ndarray left_mask = np.zeros(n_out, dtype=np.bool)
-    cdef np.ndarray right_mask = np.zeros(n_out, dtype=np.bool)
+    cdef np.ndarray left_mask = np.zeros(n_out, dtype=np.bool_)
+    cdef np.ndarray right_mask = np.zeros(n_out, dtype=np.bool_)
     cdef np.ndarray left_idxs = np.empty(max_key_idxs, dtype=DTYPE)
     cdef np.ndarray right_idxs = np.empty(max_key_idxs, dtype=DTYPE)
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1563,11 +1563,11 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
 
 def _validate_jd_for_storage(jd):
     if isinstance(jd, (float, int)):
-        return np.array(jd, dtype=np.float)
+        return np.array(jd, dtype=np.float_)
     if (isinstance(jd, np.generic)
         and (jd.dtype.kind == 'f' and jd.dtype.itemsize <= 8
              or jd.dtype.kind in 'iu')):
-        return np.array(jd, dtype=np.float)
+        return np.array(jd, dtype=np.float_)
     elif (isinstance(jd, np.ndarray)
           and jd.dtype.kind == 'f'
           and jd.dtype.itemsize == 8):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -259,7 +259,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     def world_to_array_index_values(self, *world_arrays):
         pixel_arrays = self.all_world2pix(*world_arrays, 0)[::-1]
-        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int) for pixel in pixel_arrays)
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
         return array_indices[0] if self.pixel_n_dim == 1 else array_indices
 
     @property

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -203,7 +203,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     def world_to_array_index_values(self, *world_arrays):
         pixel_arrays = self.world_to_pixel_values(*world_arrays, 0)[::-1]
-        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int) for pixel in pixel_arrays)
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
         return array_indices
 
     @property

--- a/docs/io/fits/usage/unfamiliar.rst
+++ b/docs/io/fits/usage/unfamiliar.rst
@@ -189,7 +189,7 @@ other a variable length array::
 
     >>> col1 = fits.Column(
     ...    name='var', format='PI()',
-    ...    array=np.array([[45, 56], [11, 12, 13]], dtype=np.object))
+    ...    array=np.array([[45, 56], [11, 12, 13]], dtype=np.object_))
     >>> col2 = fits.Column(name='xyz', format='2I', array=[[11, 3], [12, 4]])
     >>> hdu = fits.BinTableHDU.from_columns([col1, col2])
     >>> data = hdu.data

--- a/docs/nddata/mixins/ndarithmetic.rst
+++ b/docs/nddata/mixins/ndarithmetic.rst
@@ -172,7 +172,7 @@ resulting mask will be. There are several options.
   Custom functions are also possible::
 
       >>> def take_alternating_values(mask1, mask2, start=0):
-      ...     result = np.zeros(mask1.shape, dtype=np.bool)
+      ...     result = np.zeros(mask1.shape, dtype=np.bool_)
       ...     result[start::2] = mask1[start::2]
       ...     result[start+1::2] = mask2[start+1::2]
       ...     return result

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -750,7 +750,7 @@ The column data values, shape, and data type are specified in one of two ways:
   Examples include:
 
   - Python non-string type (float, int, bool)
-  - Numpy non-string type (e.g. np.float32, np.int64, np.bool_)
+  - Numpy non-string type (e.g. np.float32, np.int64)
   - Numpy.dtype array-protocol type strings (e.g. 'i4', 'f8', 'S15')
 
   If no ``dtype`` value is provided then the type is inferred using

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -750,7 +750,7 @@ The column data values, shape, and data type are specified in one of two ways:
   Examples include:
 
   - Python non-string type (float, int, bool)
-  - Numpy non-string type (e.g. np.float32, np.int64, np.bool)
+  - Numpy non-string type (e.g. np.float32, np.int64, np.bool_)
   - Numpy.dtype array-protocol type strings (e.g. 'i4', 'f8', 'S15')
 
   If no ``dtype`` value is provided then the type is inferred using
@@ -996,7 +996,7 @@ fields.  This might look something like::
                   # corresponding to self['params'][item] for each row.  This
                   # might not exist in some rows so mark as masked (missing) in
                   # those cases.
-                  mask = np.zeros(len(self), dtype=np.bool)
+                  mask = np.zeros(len(self), dtype=np.bool_)
                   item = item.upper()
                   values = [params.get(item) for params in self['params']]
                   for ii, value in enumerate(values):


### PR DESCRIPTION
As discussed in #6603 (and https://github.com/numpy/numpy/pull/6103) it's
unnecessary and misleading to use the Python types from the NumPy namespace.

With this PR this uses the default NumPy dtype corresponding to these
Python types.