### PR TITLE
TST: Handle nddata test warnings

### DIFF
--- a/astropy/nddata/mixins/tests/test_ndarithmetic.py
+++ b/astropy/nddata/mixins/tests/test_ndarithmetic.py
@@ -1,14 +1,14 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from astropy.nddata.nduncertainty import (StdDevUncertainty, VarianceUncertainty,
-                              InverseVariance,
-                              UnknownUncertainty,
-                              IncompatibleUncertaintiesException)
+from astropy.nddata.nduncertainty import (
+    StdDevUncertainty, VarianceUncertainty,
+    InverseVariance,
+    UnknownUncertainty,
+    IncompatibleUncertaintiesException)
 from astropy.nddata import NDDataRef
 from astropy.nddata import _testing as nd_testing
 
@@ -30,6 +30,7 @@ class StdDevUncertaintyUncorrelated(StdDevUncertainty):
 # Test with Data covers:
 # scalars, 1D, 2D and 3D
 # broadcasting between them
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
 @pytest.mark.parametrize(('data1', 'data2'), [
                          (np.array(5), np.array(10)),
                          (np.array(5), np.arange(10)),
@@ -84,6 +85,7 @@ def test_arithmetics_data_invalid():
 # identical units (even dimensionless unscaled vs. no unit),
 # equivalent units (such as meter and kilometer)
 # equivalent composite units (such as m/s and km/h)
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
 @pytest.mark.parametrize(('data1', 'data2'), [
     (np.array(5) * u.s, np.array(10) * u.s),
     (np.array(5) * u.s, np.arange(10) * u.h),
@@ -531,6 +533,7 @@ def test_arithmetics_varianceuncertainty_basic_with_correlation(
 # The point of this test is to compare the used formula to the theoretical one.
 # TODO: Maybe covering units too but I think that should work because of
 # the next tests. Also this may be reduced somehow.
+@pytest.mark.filterwarnings("ignore:divide by zero encountered in true_divide")
 @pytest.mark.parametrize(('cor', 'uncert1', 'data2'), [
     (-1, [1, 1, 3], [2, 2, 7]),
     (-0.5, [1, 1, 3], [2, 2, 7]),
@@ -707,6 +710,7 @@ def test_arithmetics_stddevuncertainty_one_missing():
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
+@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),
@@ -810,6 +814,7 @@ def test_arithmetics_stddevuncertainty_with_units(uncert1, uncert2):
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
+@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),
@@ -913,6 +918,7 @@ def test_arithmetics_varianceuncertainty_with_units(uncert1, uncert2):
 # Covering:
 # data with unit and uncertainty with unit (but equivalent units)
 # compared against correctly scaled NDDatas
+@pytest.mark.filterwarnings("ignore:.*encountered in true_divide.*")
 @pytest.mark.parametrize(('uncert1', 'uncert2'), [
     (np.array([1, 2, 3]) * u.m, None),
     (np.array([1, 2, 3]) * u.cm, None),

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -15,7 +15,7 @@ from astropy.wcs import WCS, FITSFixedWarning
 from astropy.tests.helper import catch_warnings
 from astropy.utils import NumpyRNGContext
 from astropy.utils.data import (get_pkg_data_filename, get_pkg_data_filenames,
-                           get_pkg_data_contents)
+                                get_pkg_data_contents)
 
 from astropy.nddata.ccddata import CCDData
 from astropy.nddata import _testing as nd_testing
@@ -643,6 +643,9 @@ def test_wcs_attribute(tmpdir):
     assert ccd_new_hdu_mod_wcs.header['CDELT2'] == ccd_new.wcs.wcs.cdelt[1]
 
 
+@pytest.mark.filterwarnings(
+    'ignore:Some non-standard WCS keywords were excluded')
+@pytest.mark.filterwarnings('ignore:.*made the change.*')
 def test_wcs_keywords_removed_from_header():
     """
     Test, for the file included with the nddata tests, that WCS keywords are
@@ -676,13 +679,12 @@ def test_wcs_SIP_coefficient_keywords_removed():
     # not being removed from the header even though they are WCS-related.
 
     data_file = get_pkg_data_filename('data/sip-wcs.fits')
+    test_keys = ['A_0_0', 'B_0_1']
 
     # Make sure the keywords added to this file for testing are there
-    hdu = fits.open(data_file)
-
-    test_keys = ['A_0_0', 'B_0_1']
-    for key in test_keys:
-        assert key in hdu[0].header
+    with fits.open(data_file) as hdu:
+        for key in test_keys:
+            assert key in hdu[0].header
 
     ccd = CCDData.read(data_file)
 
@@ -691,6 +693,7 @@ def test_wcs_SIP_coefficient_keywords_removed():
         assert key not in ccd.header
 
 
+@pytest.mark.filterwarnings('ignore')
 def test_wcs_keyword_removal_for_wcs_test_files():
     """
     Test, for the WCS test files, that keyword removal works as


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address test warnings in `nddata` when `-p no:warnings` is removed from `setup.cfg` and tests are run with `python setup.py test -P nddata --remote-data` command.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Part of a broader effort of #7928
