### PR TITLE
Fix astropy.visualization test warnings

### DIFF
--- a/astropy/utils/compat/context.py
+++ b/astropy/utils/compat/context.py
@@ -1,0 +1,11 @@
+import sys
+import contextlib
+
+__all__ = ['nullcontext']
+
+if sys.version_info[:2] < (3, 7):
+    @contextlib.contextmanager
+    def nullcontext():
+        yield None
+else:
+    from contextlib import nullcontext

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -9,7 +9,12 @@ import matplotlib.pyplot as plt
 
 from astropy.time import Time
 from astropy.visualization.time import time_support
+from astropy.utils.exceptions import ErfaWarning
+from astropy.utils.compat.context import nullcontext
 
+# Since some of the examples below use times/dates in the future, we use the
+# TAI time scale to avoid ERFA warnings about dubious years.
+DEFAULT_SCALE = 'tai'
 
 def get_ticklabels(axis):
     axis.figure.canvas.draw()
@@ -95,7 +100,8 @@ def test_formatter_locator(interval, expected):
     with time_support():
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time(interval[0]), Time(interval[1]))
+        ax.set_xlim(Time(interval[0], scale=DEFAULT_SCALE),
+                    Time(interval[1], scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         plt.close(fig)
 
@@ -125,7 +131,11 @@ def test_formats(format, expected):
     with time_support(format=format, simplify=False):
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
+        # Getting unix time and plot_date requires going through a scale for
+        # which ERFA emits a warning about the date being dubious
+        with pytest.warns(ErfaWarning) if format in ['unix', 'plot_date'] else nullcontext():
+            ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
+                        Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
         plt.close(fig)
@@ -137,8 +147,11 @@ def test_auto_formats(format, expected):
     with time_support(simplify=False):
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time(Time('2014-03-22T12:30:30.9'), format=format),
-                    Time('2077-03-22T12:30:32.1'))
+        # Getting unix time and plot_date requires going through a scale for
+        # which ERFA emits a warning about the date being dubious
+        with pytest.warns(ErfaWarning) if format in ['unix', 'plot_date'] else nullcontext():
+            ax.set_xlim(Time(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE), format=format),
+                        Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
         plt.close(fig)
@@ -158,7 +171,8 @@ def test_formats_simplify(format, expected):
     with time_support(format=format, simplify=True):
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
+        ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
+                    Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         plt.close(fig)
 
@@ -168,10 +182,11 @@ def test_plot():
     with time_support():
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
+        ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
+                    Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         ax.plot(Time(['2015-03-22T12:30:30.9',
                       '2018-03-22T12:30:30.9',
-                      '2021-03-22T12:30:30.9']))
+                      '2021-03-22T12:30:30.9'], scale=DEFAULT_SCALE))
         plt.close(fig)
 
 
@@ -183,13 +198,15 @@ def test_nested():
 
             fig = plt.figure()
             ax = fig.add_subplot(1, 1, 1)
-            ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
+            ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
+                        Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
             assert get_ticklabels(ax.xaxis) == ['2020', '2040', '2060']
             plt.close(fig)
 
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
-        ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
+        ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
+                    Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == ['2020-01-01 00:00:00.000',
                                             '2040-01-01 00:00:00.000',
                                             '2060-01-01 00:00:00.000']

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -16,9 +16,14 @@ from astropy.utils.compat.context import nullcontext
 # TAI time scale to avoid ERFA warnings about dubious years.
 DEFAULT_SCALE = 'tai'
 
+
 def get_ticklabels(axis):
     axis.figure.canvas.draw()
     return [x.get_text() for x in axis.get_ticklabels()]
+
+
+def teardown_function(function):
+    plt.close('all')
 
 
 # We first check that we get the expected labels for different time intervals
@@ -103,7 +108,6 @@ def test_formatter_locator(interval, expected):
         ax.set_xlim(Time(interval[0], scale=DEFAULT_SCALE),
                     Time(interval[1], scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
-        plt.close(fig)
 
 
 FORMAT_CASES = [
@@ -138,7 +142,6 @@ def test_formats(format, expected):
                         Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
-        plt.close(fig)
 
 
 @pytest.mark.parametrize(('format', 'expected'), FORMAT_CASES)
@@ -154,7 +157,6 @@ def test_auto_formats(format, expected):
                         Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
-        plt.close(fig)
 
 
 FORMAT_CASES_SIMPLIFY = [
@@ -174,7 +176,6 @@ def test_formats_simplify(format, expected):
         ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
                     Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
         assert get_ticklabels(ax.xaxis) == expected
-        plt.close(fig)
 
 
 def test_plot():
@@ -187,7 +188,6 @@ def test_plot():
         ax.plot(Time(['2015-03-22T12:30:30.9',
                       '2018-03-22T12:30:30.9',
                       '2021-03-22T12:30:30.9'], scale=DEFAULT_SCALE))
-        plt.close(fig)
 
 
 def test_nested():
@@ -201,7 +201,6 @@ def test_nested():
             ax.set_xlim(Time('2014-03-22T12:30:30.9', scale=DEFAULT_SCALE),
                         Time('2077-03-22T12:30:32.1', scale=DEFAULT_SCALE))
             assert get_ticklabels(ax.xaxis) == ['2020', '2040', '2060']
-            plt.close(fig)
 
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
@@ -210,4 +209,3 @@ def test_nested():
         assert get_ticklabels(ax.xaxis) == ['2020-01-01 00:00:00.000',
                                             '2040-01-01 00:00:00.000',
                                             '2060-01-01 00:00:00.000']
-        plt.close(fig)

--- a/astropy/visualization/tests/test_time.py
+++ b/astropy/visualization/tests/test_time.py
@@ -97,6 +97,7 @@ def test_formatter_locator(interval, expected):
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(Time(interval[0]), Time(interval[1]))
         assert get_ticklabels(ax.xaxis) == expected
+        plt.close(fig)
 
 
 FORMAT_CASES = [
@@ -127,6 +128,7 @@ def test_formats(format, expected):
         ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
+        plt.close(fig)
 
 
 @pytest.mark.parametrize(('format', 'expected'), FORMAT_CASES)
@@ -139,6 +141,7 @@ def test_auto_formats(format, expected):
                     Time('2077-03-22T12:30:32.1'))
         assert get_ticklabels(ax.xaxis) == expected
         ax.get_xlabel() == f'Time ({format})'
+        plt.close(fig)
 
 
 FORMAT_CASES_SIMPLIFY = [
@@ -157,6 +160,7 @@ def test_formats_simplify(format, expected):
         ax = fig.add_subplot(1, 1, 1)
         ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
         assert get_ticklabels(ax.xaxis) == expected
+        plt.close(fig)
 
 
 def test_plot():
@@ -168,6 +172,7 @@ def test_plot():
         ax.plot(Time(['2015-03-22T12:30:30.9',
                       '2018-03-22T12:30:30.9',
                       '2021-03-22T12:30:30.9']))
+        plt.close(fig)
 
 
 def test_nested():
@@ -180,6 +185,7 @@ def test_nested():
             ax = fig.add_subplot(1, 1, 1)
             ax.set_xlim(Time('2014-03-22T12:30:30.9'), Time('2077-03-22T12:30:32.1'))
             assert get_ticklabels(ax.xaxis) == ['2020', '2040', '2060']
+            plt.close(fig)
 
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
@@ -187,3 +193,4 @@ def test_nested():
         assert get_ticklabels(ax.xaxis) == ['2020-01-01 00:00:00.000',
                                             '2040-01-01 00:00:00.000',
                                             '2060-01-01 00:00:00.000']
+        plt.close(fig)

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -17,6 +17,10 @@ from astropy.coordinates import Angle
 from astropy.visualization.units import quantity_support
 
 
+def teardown_function(function):
+    plt.close('all')
+
+
 @pytest.mark.skipif('not HAS_PLT')
 def test_units():
     plt.figure()
@@ -35,8 +39,6 @@ def test_units():
         assert plt.gca().xaxis.get_units() == u.m
         assert plt.gca().yaxis.get_units() == u.kg
 
-    plt.close()
-
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_units_errbarr():
@@ -53,8 +55,6 @@ def test_units_errbarr():
 
         assert ax.xaxis.get_units() == u.s
         assert ax.yaxis.get_units() == u.m
-
-    plt.close()
 
 
 @pytest.mark.skipif('not HAS_PLT')
@@ -75,8 +75,6 @@ def test_incompatible_units():
         with pytest.raises(err_type):
             plt.plot([105, 210, 315] * u.kg)
 
-    plt.close()
-
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_quantity_subclass():
@@ -96,7 +94,6 @@ def test_quantity_subclass():
         assert plt.gca().xaxis.get_units() == u.deg
         assert plt.gca().yaxis.get_units() == u.kg
 
-    plt.close()
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_nested():
@@ -118,5 +115,3 @@ def test_nested():
 
         assert ax.xaxis.get_units() == u.arcsec
         assert ax.yaxis.get_units() == u.pc
-
-        plt.close()

--- a/astropy/visualization/tests/test_units.py
+++ b/astropy/visualization/tests/test_units.py
@@ -35,7 +35,7 @@ def test_units():
         assert plt.gca().xaxis.get_units() == u.m
         assert plt.gca().yaxis.get_units() == u.kg
 
-    plt.clf()
+    plt.close()
 
 
 @pytest.mark.skipif('not HAS_PLT')
@@ -54,7 +54,7 @@ def test_units_errbarr():
         assert ax.xaxis.get_units() == u.s
         assert ax.yaxis.get_units() == u.m
 
-    plt.clf()
+    plt.close()
 
 
 @pytest.mark.skipif('not HAS_PLT')
@@ -75,7 +75,7 @@ def test_incompatible_units():
         with pytest.raises(err_type):
             plt.plot([105, 210, 315] * u.kg)
 
-    plt.clf()
+    plt.close()
 
 
 @pytest.mark.skipif('not HAS_PLT')
@@ -96,6 +96,7 @@ def test_quantity_subclass():
         assert plt.gca().xaxis.get_units() == u.deg
         assert plt.gca().yaxis.get_units() == u.kg
 
+    plt.close()
 
 @pytest.mark.skipif('not HAS_PLT')
 def test_nested():
@@ -117,3 +118,5 @@ def test_nested():
 
         assert ax.xaxis.get_units() == u.arcsec
         assert ax.yaxis.get_units() == u.pc
+
+        plt.close()

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -16,6 +16,10 @@ ROOT = os.path.join(os.path.dirname(__file__))
 MSX_HEADER = fits.Header.fromtextfile(os.path.join(ROOT, 'data', 'msx_header'))
 
 
+def teardown_function(function):
+    plt.close('all')
+
+
 @ignore_matplotlibrc
 def test_getaxislabel():
 

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -20,6 +20,9 @@ from .test_images import BaseImageTests
 
 class TestDisplayWorldCoordinate(BaseImageTests):
 
+    def teardown_method(self, method):
+        plt.close('all')
+
     @ignore_matplotlibrc
     def test_overlay_coords(self, tmpdir):
         wcs = WCS(self.msx_header)

--- a/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
+++ b/astropy/visualization/wcsaxes/tests/test_display_world_coordinates.py
@@ -13,6 +13,7 @@ from astropy.time import Time
 from astropy.utils.data import get_pkg_data_filename
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.wcs import WCS
+from astropy.coordinates import galactocentric_frame_defaults
 
 from .test_images import BaseImageTests
 
@@ -155,7 +156,8 @@ class TestDisplayWorldCoordinate(BaseImageTests):
     def test_plot_coord_3d_transform(self):
         wcs = WCS(self.msx_header)
 
-        coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame='galactocentric')
+        with galactocentric_frame_defaults.set('latest'):
+            coord = SkyCoord(0 * u.kpc, 0 * u.kpc, 0 * u.kpc, frame='galactocentric')
 
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1, projection=wcs)

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -43,6 +43,9 @@ class BaseImageTests:
         slice_header = os.path.join(cls._data_dir, 'slice_header')
         cls.slice_header = fits.Header.fromtextfile(slice_header)
 
+    def teardown_method(self, method):
+        plt.close('all')
+
 
 class TestBasic(BaseImageTests):
 

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -27,6 +27,10 @@ MATPLOTLIB_LT_21 = LooseVersion(matplotlib.__version__) < LooseVersion("2.1")
 DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
 
+def teardown_function(function):
+    plt.close('all')
+
+
 @ignore_matplotlibrc
 def test_grid_regression():
     # Regression test for a bug that meant that if the rc parameter

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -315,7 +315,8 @@ def test_contour_empty():
     fig = plt.figure()
     ax = WCSAxes(fig, [0.1, 0.1, 0.8, 0.8])
     fig.add_axes(ax)
-    ax.contour(np.zeros((4, 4)), transform=ax.get_transform('world'))
+    with pytest.warns(UserWarning, match='No contour levels were found within the data range'):
+        ax.contour(np.zeros((4, 4)), transform=ax.get_transform('world'))
 
 
 @ignore_matplotlibrc

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -352,10 +352,9 @@ def test_sliced_ND_input(sub_wcs, wcs_slice):
     coord_meta['default_ticklabel_position'] = ['', 'b', 't']
     coord_meta['default_ticks_position'] = ['', 'btlr', 'btlr']
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=FutureWarning)
-        # Validate the axes initialize correctly
-        ax = plt.subplot(projection=sub_wcs, slices=slices_wcsaxes)
+    # Validate the axes initialize correctly
+    plt.subplot(projection=sub_wcs, slices=slices_wcsaxes)
+    plt.close('all')
 
 
 class LowLevelWCS5D(BaseLowLevelWCS):
@@ -407,6 +406,9 @@ class LowLevelWCS5D(BaseLowLevelWCS):
 
 
 class TestWCSAPI:
+
+    def teardown_method(self, method):
+        plt.close('all')
 
     @pytest.mark.remote_data(source='astropy')
     @pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -65,7 +65,7 @@ def wcs_4d():
     LONPOLE =                180.0 / [deg] Native longitude of celestial pole
     LATPOLE =                  0.0 / [deg] Native latitude of celestial pole
     """)
-    return WCS(header=header)
+    return WCS(header=fits.Header.fromstring(header, sep='\n'))
 
 
 @pytest.fixture
@@ -282,9 +282,8 @@ def test_coord_type_1d_2d_wcs_uncorrelated():
 
 
 def test_coord_meta_4d(wcs_4d):
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=FutureWarning)
-        _, coord_meta = transform_coord_meta_from_wcs(wcs_4d, RectangularFrame, slices=(0, 0, 'x', 'y'))
+
+    _, coord_meta = transform_coord_meta_from_wcs(wcs_4d, RectangularFrame, slices=(0, 0, 'x', 'y'))
 
     axislabel_position = coord_meta['default_axislabel_position']
     ticklabel_position = coord_meta['default_ticklabel_position']
@@ -296,9 +295,8 @@ def test_coord_meta_4d(wcs_4d):
 
 
 def test_coord_meta_4d_line_plot(wcs_4d):
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=FutureWarning)
-        _, coord_meta = transform_coord_meta_from_wcs(wcs_4d, RectangularFrame1D, slices=(0, 0, 0, 'x'))
+
+    _, coord_meta = transform_coord_meta_from_wcs(wcs_4d, RectangularFrame1D, slices=(0, 0, 0, 'x'))
 
     axislabel_position = coord_meta['default_axislabel_position']
     ticklabel_position = coord_meta['default_ticklabel_position']

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -395,6 +395,8 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                             location = EarthLocation(*self.wcs.obsgeo[:3], unit=u.m)
                     elif trefpos == 'geocenter':
                         location = EarthLocation(0, 0, 0, unit=u.m)
+                    elif trefpos == '':
+                        location = None
                     else:
                         # TODO: implement support for more locations when Time supports it
                         warnings.warn(f"Observation location '{trefpos}' is not "


### PR DESCRIPTION
This reduces the number of warnings that occur during the testing in astropy.visualization from 590 to 2 :tada: