### PR TITLE
TST: Ignore test warnings in modeling

### DIFF
--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -55,10 +55,13 @@ class BlackBody1D(Fittable1DModel):
 
     Examples
     --------
+    >>> import warnings
     >>> from astropy.modeling import models
     >>> from astropy import units as u
-    >>> bb = models.BlackBody1D()
-    >>> bb(6000 * u.AA)  # doctest: +FLOAT_CMP
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')  # Ignore deprecation warning
+    ...     bb = models.BlackBody1D()
+    ...     bb(6000 * u.AA)  # doctest: +FLOAT_CMP
     <Quantity 1.3585381201978953e-15 erg / (cm2 Hz s)>
 
     .. plot::

--- a/astropy/modeling/tests/test_blackbody.py
+++ b/astropy/modeling/tests/test_blackbody.py
@@ -77,15 +77,16 @@ def test_blackbody_scipy():
 
 
 @pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
-@pytest.mark.filterwarnings(
-    r"ignore:Input contains invalid wavelength/frequency value\(s\)")
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm**2 * u.s * u.AA)
     wave = [0, 1000.0, 100000.0, 1e55]  # Angstrom
     temp = 10000.0  # Kelvin
-    with np.errstate(all='ignore'):
-        bb_lam = blackbody_lambda(wave, temp) * u.sr
+    with pytest.warns(
+            AstropyUserWarning,
+            match=r'Input contains invalid wavelength/frequency value\(s\)'):
+        with np.errstate(all='ignore'):
+            bb_lam = blackbody_lambda(wave, temp) * u.sr
     flux = bb_lam.to(photlam, u.spectral_density(wave * u.AA)) / u.sr
 
     # First element is NaN, last element is very small, others normal

--- a/astropy/modeling/tests/test_blackbody.py
+++ b/astropy/modeling/tests/test_blackbody.py
@@ -4,13 +4,14 @@
 import pytest
 import numpy as np
 
-from astropy.modeling.blackbody import BlackBody1D, blackbody_nu, blackbody_lambda, FNU
-from astropy.modeling.fitting import LevMarLSQFitter
-
-from astropy.tests.helper import assert_quantity_allclose, catch_warnings
 from astropy import constants as const
 from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose, catch_warnings
 from astropy.utils.exceptions import AstropyUserWarning
+
+from astropy.modeling.fitting import LevMarLSQFitter
+from astropy.modeling.blackbody import (
+    BlackBody1D, blackbody_nu, blackbody_lambda, FNU)
 
 try:
     from scipy import optimize, integrate  # noqa
@@ -21,6 +22,7 @@ except ImportError:
 __doctest_skip__ = ['*']
 
 
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
 class TestBlackbody1D:
 
     # Make sure the temperature equivalency automatically applies by trying
@@ -54,6 +56,7 @@ class TestBlackbody1D:
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
 def test_blackbody_scipy():
     """Test Planck function.
 
@@ -73,6 +76,9 @@ def test_blackbody_scipy():
     np.testing.assert_allclose(intflux, ans.value, rtol=0.01)  # 1% accuracy
 
 
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
+@pytest.mark.filterwarnings(
+    r"ignore:Input contains invalid wavelength/frequency value\(s\)")
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm**2 * u.s * u.AA)
@@ -94,6 +100,7 @@ def test_blackbody_overflow():
     assert flux.value == 0
 
 
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
 def test_blackbody_synphot():
     """Test that it is consistent with IRAF SYNPHOT BBFUNC."""
     # Solid angle of solar radius at 1 kpc
@@ -111,6 +118,7 @@ def test_blackbody_synphot():
         rtol=0.01)  # 1% accuracy
 
 
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
 def test_blackbody_exceptions_and_warnings():
     """Test exceptions."""
 
@@ -132,6 +140,7 @@ def test_blackbody_exceptions_and_warnings():
     assert 'invalid' in w[0].message.args[0]
 
 
+@pytest.mark.filterwarnings("ignore:BlackBody provides the same capabilities")
 def test_blackbody_array_temperature():
     """Regression test to make sure that the temperature can be an array."""
     flux = blackbody_nu(1.2 * u.mm, [100, 200, 300] * u.K)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -17,7 +17,7 @@ import astropy.units as u
 from astropy.tests.helper import assert_quantity_allclose
 
 try:
-    import scipy  # pylint: disable=W0611
+    import scipy  # pylint: disable=W0611 # noqa
 except ImportError:
     HAS_SCIPY = False
 else:
@@ -215,7 +215,7 @@ def test_custom_inverse_reset():
     """Test resetting a custom inverse to the model's default inverse."""
 
     class TestModel(Model):
-        inputs = ()
+        n_inputs = 0
         outputs = ('y',)
 
         @property
@@ -312,6 +312,7 @@ def test_render_model_1d():
                     assert ((flux - np.sum(boxed)) / flux) < 1e-7
 
 
+@pytest.mark.filterwarnings('ignore:invalid value encountered in less')
 def test_render_model_3d():
     imshape = (17, 21, 27)
     image = np.zeros(imshape)

--- a/astropy/modeling/tests/test_functional_models.py
+++ b/astropy/modeling/tests/test_functional_models.py
@@ -8,11 +8,10 @@ from numpy.testing import assert_allclose, assert_array_equal, assert_array_less
 from astropy.modeling import models, InputParameterError
 from astropy.coordinates import Angle
 from astropy.modeling import fitting
-from astropy.tests.helper import catch_warnings
-from astropy.utils.exceptions import AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning, AstropyUserWarning
 
 try:
-    from scipy import optimize  # pylint: disable=W0611
+    from scipy import optimize  # pylint: disable=W0611  # noqa
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -205,7 +204,9 @@ def test_Shift_model_levmar_fit():
     y = x+0.1
 
     fitter = fitting.LevMarLSQFitter()
-    fitted_model = fitter(init_model, x, y)
+    with pytest.warns(AstropyUserWarning,
+                      match='Model is linear in parameters'):
+        fitted_model = fitter(init_model, x, y)
 
     assert_allclose(fitted_model.parameters, [0.1], atol=1e-15)
 

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -13,7 +13,7 @@ from astropy.modeling.core import Model, FittableModel, Fittable1DModel
 from astropy.modeling.parameters import Parameter
 
 try:
-    from scipy import optimize  # pylint: disable=W0611
+    from scipy import optimize  # pylint: disable=W0611 # noqa
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -827,7 +827,6 @@ class TInputFormatter(Model):
     """
     n_inputs = 2
     n_outputs = 2
-    inputs = ('x', 'y')
     outputs = ('x', 'y')
 
     @staticmethod

--- a/astropy/modeling/tests/test_math_func.py
+++ b/astropy/modeling/tests/test_math_func.py
@@ -1,14 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
-from numpy.testing import assert_allclose#, assert_quantity_allclose
+import pytest
+from numpy.testing import assert_allclose
 
 from .. import math_functions
 
 x = np.linspace(-20, 360, 100)
-y = np.linspace(-20, 360, 100)
 
 
+@pytest.mark.filterwarnings(
+    r'ignore:Models in math_functions are experimental\.')
+@pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
 def test_math():
     for name in math_functions.__all__:
         model = getattr(math_functions, name)()
@@ -16,4 +19,4 @@ def test_math():
         if model.n_inputs == 1:
             assert_allclose(model(x), func(x))
         elif model.n_inputs == 2:
-            assert_allclose(model(x, y), func(x, y))
+            assert_allclose(model(x, x), func(x, x))

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -22,7 +22,7 @@ class TParModel(Model):
     A toy model to test parameters machinery
     """
     # standard_broadasting = False
-    inputs = ('x',)
+    n_inputs = 1
     outputs = ('x',)
     coeff = Parameter()
     e = Parameter()
@@ -155,8 +155,8 @@ def test_negative_axis():
 
     xxt = xx.T
     y = p1(xxt)
-    assert_allclose(y[: ,0], t1(xxt[: ,0]))
-    assert_allclose(y[: ,1], t2(xxt[: ,1]))
+    assert_allclose(y[:, 0], t1(xxt[:, 0]))
+    assert_allclose(y[:, 1], t2(xxt[:, 1]))
 
 
 def test_shapes():

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -335,6 +335,7 @@ class Fittable1DModelTester:
         self.y1 = np.arange(1, 10, .1)
         self.y2, self.x2 = np.mgrid[:10, :8]
 
+    @pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
     def test_input1D(self, model_class, test_parameters):
         """Test model with different input types."""
 
@@ -427,6 +428,7 @@ class Fittable1DModelTester:
         assert_allclose(fitted, expected, atol=self.fit_error)
 
     @pytest.mark.skipif('not HAS_SCIPY')
+    @pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
     def test_deriv_1D(self, model_class, test_parameters):
         """
         Test the derivative of a model by comparing results with an estimated
@@ -482,12 +484,15 @@ def create_model(model_class, test_parameters, use_constraints=True,
         return model_class(*test_parameters[parameter_key], **constraints)
 
 
+@pytest.mark.filterwarnings(r'ignore:Model is linear in parameters.*')
+@pytest.mark.filterwarnings(r'ignore:The fit may be unsuccessful.*')
 @pytest.mark.parametrize(('model_class', 'test_parameters'),
                          sorted(models_1D.items(), key=lambda x: str(x[0])))
 class TestFittable1DModels(Fittable1DModelTester):
     pass
 
 
+@pytest.mark.filterwarnings(r'ignore:Model is linear in parameters.*')
 @pytest.mark.parametrize(('model_class', 'test_parameters'),
                          sorted(models_2D.items(), key=lambda x: str(x[0])))
 class TestFittable2DModels(Fittable2DModelTester):

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -6,24 +6,26 @@ import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 
-from astropy.modeling.functional_models import (Gaussian1D,
-                                                Sersic1D, Sine1D, Linear1D,
-                                                Lorentz1D, Voigt1D, Const1D,
-                                                Box1D, Trapezoid1D, RickerWavelet1D,
-                                                Moffat1D, Gaussian2D, Const2D, Ellipse2D,
-                                                Disk2D, Ring2D, Box2D, TrapezoidDisk2D,
-                                                RickerWavelet2D, AiryDisk2D, Moffat2D, Sersic2D,
-                                                KingProjectedAnalytic1D)
+from astropy.modeling.functional_models import (
+    Gaussian1D,
+    Sersic1D, Sine1D, Linear1D,
+    Lorentz1D, Voigt1D, Const1D,
+    Box1D, Trapezoid1D, RickerWavelet1D,
+    Moffat1D, Gaussian2D, Const2D, Ellipse2D,
+    Disk2D, Ring2D, Box2D, TrapezoidDisk2D,
+    RickerWavelet2D, AiryDisk2D, Moffat2D, Sersic2D,
+    KingProjectedAnalytic1D)
 
-from astropy.modeling.powerlaws import (PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D,
-                                        ExponentialCutoffPowerLaw1D, LogParabola1D)
+from astropy.modeling.powerlaws import (
+    PowerLaw1D, BrokenPowerLaw1D, SmoothlyBrokenPowerLaw1D,
+    ExponentialCutoffPowerLaw1D, LogParabola1D)
 
 from astropy.modeling.polynomial import Polynomial1D, Polynomial2D
 
 from astropy.modeling.fitting import LevMarLSQFitter
 
 try:
-    from scipy import optimize
+    from scipy import optimize  # noqa
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
@@ -303,6 +305,9 @@ def test_models_bounding_box(model):
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.filterwarnings(r'ignore:.*:RuntimeWarning')
+@pytest.mark.filterwarnings(r'ignore:Model is linear in parameters.*')
+@pytest.mark.filterwarnings(r'ignore:The fit may be unsuccessful.*')
 @pytest.mark.parametrize('model', MODELS)
 def test_models_fitting(model):
 

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -76,6 +76,9 @@ def test_blackbody_fit():
     assert_quantity_allclose(b_fit.scale, 5.803783292762381e-17 * u.Jy / u.sr)
 
 
+@pytest.mark.filterwarnings(
+    r'ignore: Input contains invalid wavelength/frequency value\(s\)')
+@pytest.mark.filterwarnings(r'ignore:divide by zero encountered in log10.*')
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm ** 2 * u.s * u.AA)

--- a/astropy/modeling/tests/test_physical_models.py
+++ b/astropy/modeling/tests/test_physical_models.py
@@ -76,22 +76,23 @@ def test_blackbody_fit():
     assert_quantity_allclose(b_fit.scale, 5.803783292762381e-17 * u.Jy / u.sr)
 
 
-@pytest.mark.filterwarnings(
-    r'ignore: Input contains invalid wavelength/frequency value\(s\)')
-@pytest.mark.filterwarnings(r'ignore:divide by zero encountered in log10.*')
 def test_blackbody_overflow():
     """Test Planck function with overflow."""
     photlam = u.photon / (u.cm ** 2 * u.s * u.AA)
     wave = [0.0, 1000.0, 100000.0, 1e55]  # Angstrom
     temp = 10000.0  # Kelvin
-    with np.errstate(all="ignore"):
-        bb = BlackBody(temperature=temp * u.K, scale=1.0)
-        bb_lam = bb(wave) * u.sr
+    bb = BlackBody(temperature=temp * u.K, scale=1.0)
+    with pytest.warns(
+            AstropyUserWarning,
+            match=r'Input contains invalid wavelength/frequency value\(s\)'):
+        with np.errstate(all="ignore"):
+            bb_lam = bb(wave) * u.sr
     flux = bb_lam.to(photlam, u.spectral_density(wave * u.AA)) / u.sr
 
     # First element is NaN, last element is very small, others normal
     assert np.isnan(flux[0])
-    assert np.log10(flux[-1].value) < -134
+    with np.errstate(all="ignore"):
+        assert np.log10(flux[-1].value) < -134
     np.testing.assert_allclose(
         flux.value[1:-1], [0.00046368, 0.04636773], rtol=1e-3
     )  # 0.1% accuracy in PHOTLAM/sr

--- a/astropy/modeling/tests/test_quantities_fitting.py
+++ b/astropy/modeling/tests/test_quantities_fitting.py
@@ -160,6 +160,7 @@ def test_fitting_incompatible_units():
 
 
 @pytest.mark.skipif('not HAS_SCIPY')
+@pytest.mark.filterwarnings(r'ignore:The fit may be unsuccessful.*')
 @pytest.mark.parametrize('model', compound_models_no_units)
 def test_compound_without_units(model):
     x = np.linspace(-5, 5, 10) * u.Angstrom

--- a/astropy/modeling/tests/test_quantities_model.py
+++ b/astropy/modeling/tests/test_quantities_model.py
@@ -1,8 +1,11 @@
 # Various tests of models not related to evaluation, fitting, or parameters
+import warnings
+
 import pytest
 
-from astropy.tests.helper import assert_quantity_allclose
 from astropy import units as u
+from astropy.tests.helper import assert_quantity_allclose
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy.modeling.models import Mapping, Pix2Sky_TAN, Gaussian1D
 from astropy.modeling import models
@@ -111,7 +114,10 @@ def _allmodels():
         model = getattr(models, name)
         if type(model) is _ModelMeta:
             try:
-                m = model()
+                with warnings.catch_warnings():
+                    # Ignore deprecation warnings from BlackBody1D and MexicanHat
+                    warnings.simplefilter('ignore', category=AstropyDeprecationWarning)
+                    m = model()
             except Exception:
                 pass
             allmodels.append(m)

--- a/docs/modeling/example-fitting-constraints.rst
+++ b/docs/modeling/example-fitting-constraints.rst
@@ -14,6 +14,7 @@ Fitters support constrained fitting.
   to the data minus that constant. However, the fixed coefficient value is
   restored when evaluating the model, to fit the original data values::
 
+      >>> import warnings
       >>> import numpy as np
       >>> from astropy.modeling import models, fitting
       >>> x = np.arange(1, 10, .1)
@@ -24,7 +25,9 @@ Fitters support constrained fitting.
       >>> y = p1(x, model_set_axis=False)
       >>> p1.c0.fixed = True
       >>> pfit = fitting.LinearLSQFitter()
-      >>> new_model = pfit(p1, x, y)
+      >>> with warnings.catch_warnings():
+      ...     warnings.simplefilter('ignore')  # Ignore fit warning
+      ...     new_model = pfit(p1, x, y)
       >>> print(new_model)  # doctest: +SKIP
       Model: Polynomial1D
       Inputs: ('x',)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address `modeling` tests emitting `AstropyDeprecationWarning` when testing deprecated `BlackBody1D` and the `MexicanHat*` models, and other warnings.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Part of #7928