### PR TITLE
No longer import display plugin from test runner

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -413,7 +413,7 @@ class TestRunner(TestRunnerBase):
 
         return []
 
-    @keyword(default_value=['astropy.tests.plugins.display'])
+    @keyword(default_value=[])
     def plugins(self, plugins, kwargs):
         """
         plugins : list, optional


### PR DESCRIPTION
This will get rid of the deprecation warning reported in https://github.com/astropy/package-template/issues/435 - I think this may also be the cause of the warning about the plugin being registered twice - let's see in the CI logs.