### PR TITLE
Adding pandas Int64 support [fix #9280]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -132,6 +132,9 @@ astropy.table
 - Added new ``Table`` method ``.round()``, which rounds numeric columns to the
   specified number of decimals. [#9862]
 
+- Updated ``to_pandas()`` and ``from_pandas()`` to use and support Pandas
+  nullable integer data type for masked integer data. [#9541]
+
 - The HDF5 writer, ``write_table_hdf5()``, now allows passing through
   additional keyword arguments to the ``h5py.Group.create_dataset()``. [#9602]
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3526,6 +3526,14 @@ class Table:
 
         for name, column, data, mask, unit in zip(names, columns, datas, masks, units):
 
+            if column.dtype.kind in ['u', 'i'] and np.any(mask):
+                # Special-case support for pandas nullable int
+                np_dtype = str(column.dtype).lower()
+                data = np.zeros(shape=column.shape, dtype=np_dtype)
+                data[~mask] = column[~mask]
+                out[name] = MaskedColumn(data=data, name=name, mask=mask, unit=unit, copy=False)
+                continue
+
             if data.dtype.kind == 'O':
                 # If all elements of an object array are string-like or np.nan
                 # then coerce back to a native numpy str/unicode array.

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3425,7 +3425,8 @@ class Table:
             else:
                 out[name] = column
 
-            if out[name].dtype.byteorder not in ('=', '|'):
+            if (hasattr(out[name].dtype, 'byteorder') and
+                out[name].dtype.byteorder not in ('=', '|')):
                 out[name] = out[name].byteswap().newbyteorder()
 
         kwargs = {'index': out.pop(index)} if index else {}

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3417,7 +3417,9 @@ class Table:
         for name, column in tbl.columns.items():
             if isinstance(column, MaskedColumn) and np.any(column.mask):
                 if column.dtype.kind in ['i', 'u']:
-                    out[name] = Series(column, dtype='Int64')
+                    # str(type) must be int<n> or uint<n>, convert to
+                    pd_dtype = str(column.dtype).replace('i', 'I').replace('u', 'U')
+                    out[name] = Series(column, dtype=pd_dtype)
                 elif column.dtype.kind in ['f', 'c']:
                     out[name] = column.filled(np.nan)
                 else:
@@ -3425,8 +3427,8 @@ class Table:
             else:
                 out[name] = column
 
-            if (hasattr(out[name].dtype, 'byteorder') and
-                out[name].dtype.byteorder not in ('=', '|')):
+            if (hasattr(out[name].dtype, 'byteorder')
+                    and out[name].dtype.byteorder not in ('=', '|')):
                 out[name] = out[name].byteswap().newbyteorder()
 
         kwargs = {'index': out.pop(index)} if index else {}

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3353,7 +3353,7 @@ class Table:
           2002-01-01  2.0    6.0     8.0 00:03:20
 
         """
-        from pandas import DataFrame
+        from pandas import DataFrame, Series
 
         if index is not False:
             if index in (None, True):
@@ -3417,10 +3417,7 @@ class Table:
         for name, column in tbl.columns.items():
             if isinstance(column, MaskedColumn) and np.any(column.mask):
                 if column.dtype.kind in ['i', 'u']:
-                    out[name] = column.astype(float).filled(np.nan)
-                    warnings.warn(
-                        "converted column '{}' from integer to float".format(
-                            name), TableReplaceWarning, stacklevel=3)
+                    out[name] = Series(column, dtype='Int64')
                 elif column.dtype.kind in ['f', 'c']:
                     out[name] = column.filled(np.nan)
                 else:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -3293,7 +3293,7 @@ class Table:
         """
         return groups.table_group_by(self, keys)
 
-    def to_pandas(self, index=None):
+    def to_pandas(self, index=None, use_nullable_int=True):
         """
         Return a :class:`pandas.DataFrame` instance
 
@@ -3304,7 +3304,7 @@ class Table:
         then no DataFrame index will be specified.  If ``index`` is the name of
         a column in the table then that will be the DataFrame index.
 
-        In additional to vanilla columns or masked columns, this supports Table
+        In addition to vanilla columns or masked columns, this supports Table
         mixin columns like Quantity, Time, or SkyCoord.  In many cases these
         objects have no analog in pandas and will be converted to a "encoded"
         representation using only Column or MaskedColumn.  The exception is
@@ -3312,12 +3312,20 @@ class Table:
         representation in pandas using ``np.datetime64`` or ``np.timedelta64``.
         See the example below.
 
+        Parameters
+        ----------
+        index : None, bool, str
+            Specify DataFrame index mode
+        use_nullable_int : bool, default=True
+            Convert integer MaskedColumn to pandas nullable integer type.
+            If ``use_nullable_int=False`` or the pandas version does not support
+            nullable integer types (version < 0.24), then the column is converted
+            to float with NaN for missing elements and a warning is issued.
+
         Returns
         -------
         dataframe : :class:`pandas.DataFrame`
             A pandas :class:`pandas.DataFrame` instance
-        index : None, bool, str
-            Specify DataFrame index mode
 
         Raises
         ------
@@ -3417,11 +3425,19 @@ class Table:
         for name, column in tbl.columns.items():
             if isinstance(column, MaskedColumn) and np.any(column.mask):
                 if column.dtype.kind in ['i', 'u']:
-                    # str(type) must be int<n> or uint<n>, convert to
-                    pd_dtype = str(column.dtype).replace('i', 'I').replace('u', 'U')
+                    pd_dtype = str(column.dtype)
+                    if use_nullable_int:
+                        # Convert int64 to Int64, uint32 to UInt32, etc for nullable types
+                        pd_dtype = pd_dtype.replace('i', 'I').replace('u', 'U')
                     out[name] = Series(column, dtype=pd_dtype)
+
+                    # If pandas is older than 0.24 the type may have turned to float
+                    if column.dtype.kind != out[name].dtype.kind:
+                        warnings.warn(
+                            f"converted column '{name}' from {column.dtype} to {out[name].dtype}",
+                            TableReplaceWarning, stacklevel=3)
                 elif column.dtype.kind in ['f', 'c']:
-                    out[name] = column.filled(np.nan)
+                    out[name] = column
                 else:
                     out[name] = column.astype(object).filled(np.nan)
             else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1986,9 +1986,7 @@ class TestPandas:
                        2584288728310999296]
         t['Source'].mask = [False, False, False]
 
-        with pytest.warns(TableReplaceWarning,
-                          match="converted column 'a' from integer to float"):
-            d = t.to_pandas()
+        d = t.to_pandas()
 
         t2 = table.Table.from_pandas(d)
 
@@ -1996,12 +1994,9 @@ class TestPandas:
             assert np.all(column.data == t2[name].data)
             if hasattr(t2[name], 'mask'):
                 assert np.all(column.mask == t2[name].mask)
-            # Masked integer type comes back as float.  Nothing we can do about this.
+
             if column.dtype.kind == 'i':
-                if np.any(column.mask):
-                    assert t2[name].dtype.kind == 'f'
-                else:
-                    assert t2[name].dtype.kind == 'i'
+                assert t2[name].dtype.kind == 'i'
                 assert_array_equal(column.data,
                                    t2[name].data.astype(column.dtype))
             else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1844,6 +1844,20 @@ class TestPandas:
             else:
                 assert t[column].byteswap().newbyteorder().dtype == t2[column].dtype
 
+    @pytest.mark.parametrize('unsigned', ['u', ''])
+    @pytest.mark.parametrize('bits', [8, 16, 32, 64])
+    def test_nullable_int(self, unsigned, bits):
+        np_dtype = f'{unsigned}int{bits}'
+        c = MaskedColumn([1, 2], mask=[False, True], dtype=np_dtype)
+        t = Table([c])
+        df = t.to_pandas()
+        pd_dtype = np_dtype.replace('i', 'I').replace('u', 'U')
+        assert str(df['col0'].dtype) == pd_dtype
+        t2 = Table.from_pandas(df)
+        assert str(t2['col0'].dtype) == np_dtype
+        assert np.all(t2['col0'].mask == [False, True])
+        assert np.all(t2['col0'] == c)
+
     def test_2d(self):
 
         t = table.Table()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address issue #9280. Adding support for pandas nullable integers in the `Table.to_pandas` function, as suggested by @mar-ses. We're new to contributing to `Table`, so we're happy to iterate if generating a pandas table from a combination of masked arrays and a pandas `Series` doesn't jive with the Table style.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9280.
