### PR TITLE
Fixed determination of tick labels for all-sky images when coord_wrap < 360

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -313,7 +313,7 @@ astropy.visualization
   label. [#9392]
 
 - Fixed the display of tick labels when plotting all sky images that have a
-  coord_wrap less than 360. [#9541]
+  coord_wrap less than 360. [#9542]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,9 @@ astropy.visualization
   ``coords[i].set_auto_axislabel(False)`` or by explicitly setting an axis
   label. [#9392]
 
+- Fixed the display of tick labels when plotting all sky images that have a
+  coord_wrap less than 360. [#9541]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/coordinate_range.py
+++ b/astropy/visualization/wcsaxes/coordinate_range.py
@@ -19,7 +19,7 @@ def wrap_180(values):
     return values_new
 
 
-def find_coordinate_range(transform, extent, coord_types, coord_units):
+def find_coordinate_range(transform, extent, coord_types, coord_units, coord_wraps):
     """
     Find the range of coordinates to use for ticks/grids
 
@@ -36,7 +36,9 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
         Whether each coordinate is a ``'longitude'``, ``'latitude'``, or
         ``'scalar'`` value.
     coord_units : list of `astropy.units.Unit`
-        The units for each coordinate
+        The units for each coordinate.
+    coord_wraps : list of float
+        The wrap angles for longitudes.
     """
     # Sample coordinates on a NX x NY grid.
     from . import conf
@@ -116,8 +118,8 @@ def find_coordinate_range(transform, extent, coord_types, coord_units):
         x_range = xw_max - xw_min
         if coord_type == 'longitude':
             if x_range > 300.:
-                xw_min = 0.
-                xw_max = 360 - np.spacing(360.)
+                xw_min = coord_wraps[coord_index] - 360
+                xw_max = coord_wraps[coord_index] - np.spacing(360.)
             elif xw_min < 0.:
                 xw_min = max(-180., xw_min - 0.1 * x_range)
                 xw_max = min(+180., xw_max + 0.1 * x_range)

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -154,7 +154,8 @@ class CoordinatesMap:
         return find_coordinate_range(self._transform,
                                      extent,
                                      [coord.coord_type for coord in self if coord.coord_index is not None],
-                                     [coord.coord_unit for coord in self if coord.coord_index is not None])
+                                     [coord.coord_unit for coord in self if coord.coord_index is not None],
+                                     [coord.coord_wrap for coord in self if coord.coord_index is not None])
 
     def _as_table(self):
 

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -918,3 +918,41 @@ def test_1d_plot_put_varying_axis_on_bottom_lon(spatial_wcs_2d_small_angle, slic
     assert ax.coords[bottom_axis].ticks.get_visible_axes() == ['b']
 
     return fig
+
+
+@pytest.mark.remote_data(source='astropy')
+@pytest.mark.mpl_image_compare(baseline_dir=IMAGE_REFERENCE_DIR,
+                               tolerance=0, style={})
+def test_allsky_labels_wrap():
+
+    # Regression test for a bug that caused some tick labels to not be shown
+    # when looking at all-sky maps in the case where coord_wrap < 360
+
+    fig = plt.figure(figsize=(4, 4))
+
+    icen = 0
+
+    for ctype in [('GLON-CAR', 'GLAT-CAR'), ('HGLN-CAR', 'HGLT-CAR')]:
+
+        for cen in [0, 90, 180, 270]:
+
+            icen += 1
+
+            wcs = WCS(naxis=2)
+            wcs.wcs.ctype = ctype
+            wcs.wcs.crval = cen, 0
+            wcs.wcs.crpix = 360.5, 180.5
+            wcs.wcs.cdelt = -0.5, 0.5
+
+            ax = fig.add_subplot(8, 1, icen, projection=wcs)
+            ax.set_xlim(-0.5, 719.5)
+            ax.coords[0].set_ticks(spacing=50 * u.deg)
+            ax.coords[0].set_ticks_position('b')
+            ax.coords[0].set_auto_axislabel(False)
+            ax.coords[1].set_auto_axislabel(False)
+            ax.coords[1].set_ticklabel_visible(False)
+            ax.coords[1].set_ticks_visible(False)
+
+    fig.subplots_adjust(hspace=2, left=0.05, right=0.95, bottom=0.1, top=0.95)
+
+    return fig


### PR DESCRIPTION
This fixes a bug that caused labels on WCSAxes plots for all-sky images to not appear correctly in cases where coord_wrap < 360. Image from the regression test (the four top axes have coord_wrap=360, the bottom four 180, and each row has a different crval1):

**Before**

![before](https://user-images.githubusercontent.com/314716/68301384-cac21480-0097-11ea-9724-3af4777d4340.png)


**After**

![after](https://user-images.githubusercontent.com/314716/68301403-d01f5f00-0097-11ea-9d16-70965b1d0626.png)

Note that there are still some issues illustrated in the top four axes when the tick spacing is not a divisor of 360 but this is actually an issue that's been around since the start and will require some more work to fix. I will open an issue for that.
