### PR TITLE
Prevent warnings when sorting/indexing times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -210,6 +210,8 @@ astropy.table
   found in the input data, and any missing key/value pairs are turned into
   missing data in the table. [#9425]
 
+- Prevent unecessary ERFA warnings when indexing by ``Time`` columns. [#9545]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -241,6 +243,8 @@ astropy.time
 - Introduce a new ``.to_value()`` method for ``Time`` (and adjusted the
   existing method for ``TimeDelta``) so that one can get values in a given
   ``format`` and possible ``subfmt`` (e.g., ``to_value('mjd', 'str')``. [#9361]
+
+- Prevent unecessary ERFA warnings when sorting ``Time`` objects. [#9545]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -109,7 +109,7 @@ class Index:
             for col in columns:
                 if isinstance(col, Time):
                     new_columns.append(col.jd)
-                    remainder = col - col.__class__(col.jd, format='jd')
+                    remainder = col - col.__class__(col.jd, format='jd', scale=col.scale)
                     new_columns.append(remainder.jd)
                 else:
                     new_columns.append(col)

--- a/astropy/table/tests/test_index.py
+++ b/astropy/table/tests/test_index.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
+
 import pytest
 import numpy as np
 
@@ -540,3 +542,14 @@ def test_get_index():
         get_index(t, names=['a'], table_copy=t[['a']])
     with pytest.raises(ValueError):
         get_index(t, names=None, table_copy=None)
+
+
+def test_table_index_time_warning(engine):
+    # Make sure that no ERFA warnings are emitted when indexing a table by
+    # a Time column with a non-default time scale
+    tab = Table()
+    tab['a'] = Time([1, 2, 3], format='jyear', scale='tai')
+    tab['b'] = [4, 3, 2]
+    with warnings.catch_warnings(record=True) as wlist:
+        tab.add_index(('a', 'b'), engine=engine)
+    assert len(wlist) == 0

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1580,7 +1580,7 @@ class Time(ShapedLikeNDArray):
         it uses :func:`~numpy.lexsort`, and hence no sort method can be chosen.
         """
         jd_approx = self.jd
-        jd_remainder = (self - self.__class__(jd_approx, format='jd')).jd
+        jd_remainder = (self - self.__class__(jd_approx, format='jd', scale=self.scale)).jd
         if axis is None:
             return np.lexsort((jd_remainder.ravel(), jd_approx.ravel()))
         else:

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import warnings
 import itertools
 import copy
 
@@ -380,6 +381,11 @@ class TestArithmetic:
             assert np.all(t0v[:-10] == ravel)
         else:
             assert np.all(self.t0.argsort(axis=None) == ravel)
+
+    def test_argsort_warning(self, masked):
+        with warnings.catch_warnings(record=True) as wlist:
+            Time([1, 2, 3], format='jd', scale='tai').argsort()
+        assert len(wlist) == 0
 
     def test_min(self, masked):
         assert self.t0.min() == self.t0[0, 0, 2]


### PR DESCRIPTION
@mhvk @taldcroft - I'm not 100% confident that this is the correct fix so please check! Basically it seems that we should avoid scale conversions when sorting times or indexing on time columns?

Fixes https://github.com/astropy/astropy/issues/9544

@pllim @bsipocz - just FYI this removes 255 warnings from the test suite :scream: 