### PR TITLE
Fix warnings during convolution tests

### DIFF
--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -763,7 +763,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         return fftmult
 
     if interpolate_nan:
-        with np.errstate(divide='ignore'):
+        with np.errstate(divide='ignore', invalid='ignore'):
             # divide by zeros are expected here; if the weight is zero, we want
             # the output to be nan or inf
             rifft = (ifftn(fftmult)) / bigimwt

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_allclose, assert_array_almost_equal_nulp
 
 from astropy.convolution.convolve import convolve_fft, convolve
 from astropy.utils.exceptions import AstropyUserWarning
-
+from astropy.utils.compat.context import nullcontext
 
 VALID_DTYPES = ('>f4', '<f4', '>f8', '<f8')
 VALID_DTYPE_MATRIX = list(itertools.product(VALID_DTYPES, VALID_DTYPES))
@@ -43,6 +43,19 @@ options_preserve_nan = list(itertools.product(BOUNDARY_OPTIONS,
                                               (True, False)))
 
 
+def expected_boundary_warning(boundary=None):
+    # Helper that returns the appropriate context manager for the boundary=None
+    # warning depending on the value of boundary.
+    if boundary is None:
+        ctx = pytest.warns(AstropyUserWarning,
+                           match='The convolve_fft version of boundary=None '
+                                 'is equivalent to the convolve boundary=\'fill\'')
+    else:
+        ctx = nullcontext()
+    return ctx
+
+
+
 def assert_floatclose(x, y):
     """Assert arrays are close to within expected floating point rounding.
 
@@ -67,14 +80,7 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -92,14 +98,7 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -117,14 +116,7 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -164,14 +156,7 @@ class TestConvolve1D:
 
         y = np.array([0.5, 0.5, 0.5], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -213,15 +198,7 @@ class TestConvolve1D:
 
         y = np.array([0., 1., 0.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel,
-                                 preserve_nan=preserve_nan)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -258,15 +235,7 @@ class TestConvolve1D:
 
         y = np.array([1.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel,
-                                 preserve_nan=preserve_nan)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -292,15 +261,7 @@ class TestConvolve1D:
 
         y = np.array([1., 1., 1.], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel,
-                                 preserve_nan=preserve_nan)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -484,14 +445,7 @@ class TestConvolve2D:
 
         y = np.array([[1.]], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -513,14 +467,7 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel)
@@ -542,15 +489,7 @@ class TestConvolve2D:
                       [1., 1., 1.],
                       [1., 1., 1.]], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 fill_value=np.nan if normalize_kernel else 0,
-                                 normalize_kernel=normalize_kernel)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              fill_value=np.nan if normalize_kernel else 0,
@@ -602,15 +541,7 @@ class TestConvolve2D:
                       [0., 1., 0.],
                       [0., 0., 0.]], dtype='float64')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 normalize_kernel=normalize_kernel,
-                                 preserve_nan=preserve_nan)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              normalize_kernel=normalize_kernel,
@@ -652,17 +583,7 @@ class TestConvolve2D:
         #                          )
         #     return
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary,
-                                 nan_treatment=nan_treatment,
-                                 # you cannot fill w/nan, you can only interpolate over it
-                                 fill_value=np.nan if normalize_kernel and nan_treatment=='interpolate' else 0,
-                                 normalize_kernel=normalize_kernel,
-                                 preserve_nan=preserve_nan)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary,
                              nan_treatment=nan_treatment,
                              # you cannot fill w/nan, you can only interpolate over it
@@ -743,13 +664,7 @@ class TestConvolve2D:
                       [-1., 0., -1.],
                       [1., -1., 1.]], dtype='float')
 
-        if boundary is None:
-            with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                              r"version of boundary=None is equivalent to the "
-                              r"convolve boundary='fill'"):
-                z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
-                                 normalize_kernel=False)
-        else:
+        with expected_boundary_warning(boundary=boundary):
             z = convolve_fft(x, y, boundary=boundary, nan_treatment='fill',
                              normalize_kernel=False)
 
@@ -776,12 +691,7 @@ def test_asymmetric_kernel(boundary):
 
     y = np.array([1, 2, 3], dtype='>f8')
 
-    if boundary is None:
-        with pytest.warns(AstropyUserWarning, match=r"The convolve_fft "
-                          r"version of boundary=None is equivalent to the "
-                          r"convolve boundary='fill'"):
-            z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
-    else:
+    with expected_boundary_warning(boundary=boundary):
         z = convolve_fft(x, y, boundary=boundary, normalize_kernel=False)
 
     if boundary in (None, 'fill'):
@@ -812,8 +722,9 @@ def test_input_unmodified(boundary, nan_treatment,
     x.flags.writeable = False
     y.flags.writeable = False
 
-    z = convolve_fft(x, y, boundary=boundary, nan_treatment=nan_treatment,
-                     normalize_kernel=normalize_kernel, preserve_nan=preserve_nan)
+    with expected_boundary_warning(boundary=boundary):
+        z = convolve_fft(x, y, boundary=boundary, nan_treatment=nan_treatment,
+                        normalize_kernel=normalize_kernel, preserve_nan=preserve_nan)
 
     assert np.all(np.array(array, dtype=dtype) == x)
     assert np.all(np.array(kernel, dtype=dtype) == y)
@@ -845,8 +756,9 @@ def test_input_unmodified_with_nan(boundary, nan_treatment,
     x_copy = x.copy()
     y_copy = y.copy()
 
-    z = convolve_fft(x, y, boundary=boundary, nan_treatment=nan_treatment,
-                 normalize_kernel=normalize_kernel, preserve_nan=preserve_nan)
+    with expected_boundary_warning(boundary=boundary):
+        z = convolve_fft(x, y, boundary=boundary, nan_treatment=nan_treatment,
+                        normalize_kernel=normalize_kernel, preserve_nan=preserve_nan)
 
     # ( NaN == NaN ) = False
     # Only compare non NaN values for canonical equivalence

--- a/astropy/convolution/tests/test_convolve_fft.py
+++ b/astropy/convolution/tests/test_convolve_fft.py
@@ -55,7 +55,6 @@ def expected_boundary_warning(boundary=None):
     return ctx
 
 
-
 def assert_floatclose(x, y):
     """Assert arrays are close to within expected floating point rounding.
 


### PR DESCRIPTION
This fixes all warnings (101 of them) that occurred during the astropy.convolution tests (and also removes more lines that it adds :tada:)

xref #7928