### PR TITLE
fix typo in HighLevelWCSWrapper for  axis_correlation_matrix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -775,6 +775,8 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fix incorrect value returned by ``wcsapi.HighLevelWCSWrapper.axis_correlation_matrix``.
+  [#9554]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
@@ -68,4 +68,4 @@ class HighLevelWCSWrapper(HighLevelWCSMixin):
         """
         See `~astropy.wcs.wcsapi.BaseLowLevelWCS.axis_correlation_matrix`
         """
-        return self.low_level_wcs.pixel_bounds
+        return self.low_level_wcs.axis_correlation_matrix

--- a/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
@@ -71,7 +71,7 @@ def test_wrapper():
     assert wrapper.world_axis_units == ['deg', 'deg']
     assert wrapper.array_shape is None
     assert wrapper.pixel_bounds is None
-    assert wrapper.axis_correlation_matrix is None
+    assert np.all(wrapper.axis_correlation_matrix)
 
 
 def test_wrapper_invalid():


### PR DESCRIPTION
This fixes a small typo in the HighLevelWCSWrapper so that the axis_correlation_matrix from the low level object is correctly exposed.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address ...

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
