### PR TITLE
Auto-expand string width for Column insert

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -737,6 +737,10 @@ astropy.table
   as long as the custom unit is enabled during reading (otherwise, the unit
   will become an ``UnrecognizedUnit``). [#9015]
 
+- Fix bug where string values could be truncated when inserting into a
+  ``Column`` or ``MaskedColumn``, or when adding or inserting a row containing
+  string values. [#9559]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -142,22 +142,19 @@ def _expand_string_array_for_values(arr, values):
     arr_expanded : np.ndarray
 
     """
-    # If this is not a string type then just return original arr
-    if arr.dtype.kind not in ('U', 'S'):
-        return arr
+    if arr.dtype.kind in ('U', 'S'):
+        # Find the length of the longest string in the new values.
+        values_str_len = np.char.str_len(values).max()
 
-    # Find the length of the longest string in the new values.
-    values_str_len = np.char.str_len(values).max()
+        # Determine character repeat count of arr.dtype.  Returns a positive
+        # int or None (something like 'U0' is not possible in numpy).  If new values
+        # are longer than current then make a new (wider) version of arr.
+        arr_str_len = dtype_bytes_or_chars(arr.dtype)
+        if arr_str_len and values_str_len > arr_str_len:
+            arr_dtype = arr.dtype.byteorder + arr.dtype.kind + str(values_str_len)
+            arr = arr.astype(arr_dtype)
 
-    # Determine character repeat count of self.dtype.  Returns a positive
-    # int or None (something like 'U0' is not possible in numpy).  If new values
-    # are longer than current then make a new (wider) version of self.
-    arr_str_len = dtype_bytes_or_chars(arr.dtype)
-    if arr_str_len and values_str_len > arr_str_len:
-        arr_dtype = arr.dtype.byteorder + arr.dtype.kind + str(values_str_len)
-        return arr.astype(arr_dtype)
-    else:
-        return arr
+    return arr
 
 
 class ColumnInfo(BaseColumnInfo):

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1381,7 +1381,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             if self.dtype.kind == 'O':
                 mask = False
             else:
-                mask = np.zeros(np.broadcast(values).shape, dtype=bool)
+                mask = np.zeros(np.shape(values), dtype=bool)
         new_mask = np.insert(self_ma.mask, obj, mask, axis=axis)
         new_ma = np.ma.array(new_data, mask=new_mask, copy=False)
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -125,6 +125,41 @@ class FalseArray(np.ndarray):
                              .format(self.__class__.__name__))
 
 
+def _expand_string_array_for_values(arr, values):
+    """
+    For string-dtype return a version of ``arr`` that is wide enough for ``values``.
+    If ``arr`` is not string-dtype or does not need expansion then return ``arr``.
+
+    Parameters
+    ----------
+    arr : np.ndarray
+        Input array
+    values : scalar or array-like
+        Values for width comparison for string arrays
+
+    Returns
+    -------
+    arr_expanded : np.ndarray
+
+    """
+    # If this is not a string type then just return original arr
+    if arr.dtype.kind not in ('U', 'S'):
+        return arr
+
+    # Find the length of the longest string in the new values.
+    values_str_len = np.char.str_len(values).max()
+
+    # Determine character repeat count of self.dtype.  Returns a positive
+    # int or None (something like 'U0' is not possible in numpy).  If new values
+    # are longer than current then make a new (wider) version of self.
+    arr_str_len = dtype_bytes_or_chars(arr.dtype)
+    if arr_str_len and values_str_len > arr_str_len:
+        arr_dtype = arr.dtype.byteorder + arr.dtype.kind + str(values_str_len)
+        return arr.astype(arr_dtype)
+    else:
+        return arr
+
+
 class ColumnInfo(BaseColumnInfo):
     """
     Container for meta information like name, description, format.
@@ -1030,10 +1065,9 @@ class Column(BaseColumn):
             data = np.insert(self, obj, None, axis=axis)
             data[obj] = values
         else:
-            # Explicitly convert to dtype of this column.  Needed because numpy 1.7
-            # enforces safe casting by default, so .  This isn't the case for 1.6 or 1.8+.
-            values = np.asarray(values, dtype=self.dtype)
-            data = np.insert(self, obj, values, axis=axis)
+            self_for_insert = _expand_string_array_for_values(self, values)
+            data = np.insert(self_for_insert, obj, values, axis=axis)
+
         out = data.view(self.__class__)
         out.__array_finalize__(self)
         return out
@@ -1343,16 +1377,14 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             new_data = np.insert(self_ma.data, obj, None, axis=axis)
             new_data[obj] = values
         else:
-            # Explicitly convert to dtype of this column.  Needed because numpy 1.7
-            # enforces safe casting by default, so .  This isn't the case for 1.6 or 1.8+.
-            values = np.asarray(values, dtype=self.dtype)
+            self_ma = _expand_string_array_for_values(self_ma, values)
             new_data = np.insert(self_ma.data, obj, values, axis=axis)
 
         if mask is None:
             if self.dtype.kind == 'O':
                 mask = False
             else:
-                mask = np.zeros(values.shape, dtype=bool)
+                mask = np.zeros(np.broadcast(values).shape, dtype=bool)
         new_mask = np.insert(self_ma.mask, obj, mask, axis=axis)
         new_ma = np.ma.array(new_data, mask=new_mask, copy=False)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -319,6 +319,15 @@ class TestColumn():
         c1 = c.insert(1, [5, 6], axis=1)
         assert np.all(c1 == [[1, 5, 2], [3, 6, 4]])
 
+    def test_insert_string_expand(self, Column):
+        c = Column(['a', 'b'])
+        c1 = c.insert(0, 'abc')
+        assert np.all(c1 == ['abc', 'a', 'b'])
+
+        c = Column(['a', 'b'])
+        c1 = c.insert(0, ['c', 'def'])
+        assert np.all(c1 == ['c', 'def', 'a', 'b'])
+
     def test_insert_multidim(self, Column):
         c = Column([[1, 2],
                     [3, 4]], name='a', dtype=int)

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -328,6 +328,15 @@ class TestColumn():
         c1 = c.insert(0, ['c', 'def'])
         assert np.all(c1 == ['c', 'def', 'a', 'b'])
 
+    def test_insert_string_type_error(self, Column):
+        c = Column([1, 2])
+        with pytest.raises(ValueError, match='invalid literal for int'):
+            c.insert(0, 'string')
+
+        c = Column(['a', 'b'])
+        with pytest.raises(TypeError, match='string operation on non-string array'):
+            c.insert(0, 1)
+
     def test_insert_multidim(self, Column):
         c = Column([[1, 2],
                     [3, 4]], name='a', dtype=int)

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -693,7 +693,7 @@ class TestAddRow(SetupData):
         assert len(t) == 4
         assert np.all(t['a'] == np.array([1, 2, 3, 4]))
         assert np.allclose(t['b'], np.array([4.0, 5.1, 6.2, 7.2]))
-        assert np.all(t['c'] == np.array(['7', '8', '9', '1']))
+        assert np.all(t['c'] == np.array(['7', '8', '9', '10']))
 
     def test_add_with_dict(self, table_types):
         self._setup(table_types)

--- a/docs/table/index.rst
+++ b/docs/table/index.rst
@@ -228,7 +228,7 @@ Adding a new row of data to the table is as follows.  Note that the unit
 value is given in ``cm / s`` but will be added to the table as ``0.1 m / s`` in
 accord with the existing unit.
 
-  >>> t.add_row([-8, -9, 10 * u.cm / u.s, 11])
+  >>> t.add_row([-8, 'string', 10 * u.cm / u.s, 10])
   >>> len(t)
   4
 


### PR DESCRIPTION
This changes Column insert so that if you insert a string value that is longer than the available width then the column dtype is auto-expanded.

Example:
```
In [2]: c = Column(['a', 'b'])

In [3]: c
Out[3]: 
<Column dtype='str1' length=2>
a
b

In [4]: c.insert(1, 'longer!')
Out[4]: 
<Column dtype='str7' length=3>
      a
longer!
      b
```

cc: @mhvk @astrofrog @bsipocz 