### PR TITLE
Address new warnings in time.

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1760,8 +1760,8 @@ class Time(ShapedLikeNDArray):
 
             >>> from astropy.utils.iers import TIME_BEFORE_IERS_RANGE
             >>> t = Time(['1961-01-01', '2000-01-01'], scale='utc')
-            >>> delta, status = t.get_delta_ut1_utc(return_status=True)
-            >>> status == TIME_BEFORE_IERS_RANGE
+            >>> delta, status = t.get_delta_ut1_utc(return_status=True)  # doctest: +REMOTE_DATA
+            >>> status == TIME_BEFORE_IERS_RANGE  # doctest: +REMOTE_DATA
             array([ True, False]...)
         """
         if iers_table is None:

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -674,7 +674,7 @@ class TimeStardate(TimeFromEpoch):
     unit = 0.397766856 # Stardate units per day
     epoch_val = '2318-07-05 11:00:00' # Date and time of stardate 00000.00
     epoch_val2 = None
-    epoch_scale = 'utc'
+    epoch_scale = 'tai'
     epoch_format = 'iso'
 
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1137,9 +1137,9 @@ class TestStardate:
     """Sync chronometers with Starfleet Command"""
 
     def test_iso_to_stardate(self):
-        assert str(Time('2320-01-01').stardate)[:7] == '1368.99'
-        assert str(Time('2330-01-01').stardate)[:8] == '10552.76'
-        assert str(Time('2340-01-01').stardate)[:8] == '19734.02'
+        assert str(Time('2320-01-01', scale='tai').stardate)[:7] == '1368.99'
+        assert str(Time('2330-01-01', scale='tai').stardate)[:8] == '10552.76'
+        assert str(Time('2340-01-01', scale='tai').stardate)[:8] == '19734.02'
 
     @pytest.mark.parametrize('dates',
                              [(10000, '2329-05-26 03:02'),


### PR DESCRIPTION
Mostly the new `Stardate` format, which probably should use TAI instead of UTC (see https://github.com/astropy/astropy/pull/7928#issuecomment-551305274). cc @SolarDrew. (Or should it be TDB? I guess really a galactic barycentric time might be more logical...)