### PR TITLE
Add config option to set default User-Agent for http_headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -608,7 +608,9 @@ astropy.utils
   ``astropy.utils.data.get_readable_fileobj`` now provides an ``http_headers``
   keyword to pass in specific request headers for the download. It also now
   defaults to providing ``User-Agent: Astropy`` and ``Accept: */*``
-  headers. [#9508]
+  headers. The default ``User-Agent`` value can be set with a new
+  ``astropy.data.conf.default_http_user_agent`` configuration item.
+  [#9508, #9564]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial

--- a/astropy/astropy.cfg
+++ b/astropy/astropy.cfg
@@ -127,16 +127,22 @@
 ## URL for astropy remote data site.
 # dataurl = http://data.astropy.org/
 
-## Time to wait for remote data query (in seconds).
-# remote_timeout = 3.0
+## Mirror URL for astropy remote data site.
+# dataurl_mirror = http://www.astropy.org/astropy-data/
 
-## Block size for computing MD5 file hashes.
-# hash_block_size = 65536
+## Default User-Agent for HTTP request headers.
+# default_http_user_agent = astropy
+
+## Time to wait for remote data query (in seconds).
+# remote_timeout = 10.0
+
+## Block size for computing file hashes.
+# compute_hash_block_size = 65536
 
 ## Number of bytes of remote data to download per step.
 # download_block_size = 65536
 
-## Number of times to try to get the lock while accessing the data cache before
+## Number of seconds to try to get the lock while accessing the data cache before
 ## giving up.
 # download_cache_lock_attempts = 5
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -63,6 +63,11 @@ class Conf(_config.ConfigNamespace):
     dataurl_mirror = _config.ConfigItem(
         'http://www.astropy.org/astropy-data/',
         'Mirror URL for astropy remote data site.')
+    default_http_user_agent = _config.ConfigItem(
+        'astropy',
+        'Default User-Agent for HTTP request headers. This can be overwritten'
+        'for a particular call via http_headers option, where available.'
+        'This only provides the default value when not set by https_headers.')
     remote_timeout = _config.ConfigItem(
         10.,
         'Time to wait for remote data queries (in seconds).',
@@ -194,7 +199,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
         is not a remote HTTP URL.) In the default case (None), the headers are
-        ``User-Agent: astropy`` and ``Accept: */*``.
+        ``User-Agent: some_value`` and ``Accept: */*``, where ``some_value``
+        is set by ``astropy.utils.data.conf.default_http_user_agent``.
 
     Returns
     -------
@@ -1085,7 +1091,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
         are ignored if the protocol for the ``name_or_obj``/``sources`` entry
         is not a remote HTTP URL.) In the default case (None), the headers are
-        ``User-Agent: astropy`` and ``Accept: */*``.
+        ``User-Agent: some_value`` and ``Accept: */*``, where ``some_value``
+        is set by ``astropy.utils.data.conf.default_http_user_agent``.
 
     Returns
     -------
@@ -1108,7 +1115,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     if sources is None:
         sources = [remote_url]
     if http_headers is None:
-        http_headers = {'User-Agent': 'astropy','Accept': '*/*'}
+        http_headers = {'User-Agent': conf.default_http_user_agent,
+                        'Accept': '*/*'}
 
     missing_cache = ""
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to add a configuration item for downstream packages to set their own default User-Agent value in HTTP request headers. This was suggested by @adrn in #9560 and #9508 

**~This PR depends on #9508 being merged first. I'll add more stuff to this when that one is merged. Note to self: Probably need to adjust the change log modified in #9508 too?~**

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9560 
