### PR TITLE
Change name of table.cstack to dstack

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -185,7 +185,7 @@ astropy.table
 - ``MaskedColumn.data`` will now return a plain ``MaskedArray`` rather than
   the previous (unintended) ``masked_BaseColumn``. [#8855]
 
-- Added depth-wise stacking ``cstack()`` in higher level table operation.
+- Added depth-wise stacking ``dstack()`` in higher level table operation.
   It help will in stacking table column depth-wise. [#8939]
 
 - Added a new table equality method ``values_equal()`` which allows comparison

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -42,7 +42,7 @@ from .column import Column, MaskedColumn, StringTruncateWarning, ColumnInfo
 from .groups import TableGroups, ColumnGroups
 from .table import (Table, QTable, TableColumns, Row, TableFormatter,
                     NdarrayMixin, TableReplaceWarning)
-from .operations import join, setdiff, hstack, cstack, vstack, unique, TableMergeError
+from .operations import join, setdiff, hstack, dstack, vstack, unique, TableMergeError
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray
 from .soco import SCEngine

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -5,7 +5,7 @@ High-level table operations:
 - setdiff()
 - hstack()
 - vstack()
-- cstack()
+- dstack()
 """
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
@@ -233,7 +233,7 @@ def setdiff(table1, table2, keys=None):
     return t12_diff
 
 
-def cstack(tables, join_type='outer', metadata_conflicts='warn'):
+def dstack(tables, join_type='outer', metadata_conflicts='warn'):
     """
     Stack columns within tables depth-wise
 
@@ -279,7 +279,7 @@ def cstack(tables, join_type='outer', metadata_conflicts='warn'):
       --- ---
         5   7
         6   8
-      >>> print(cstack([t1, t2]))
+      >>> print(dstack([t1, t2]))
       a [2]  b [2]
       ------ ------
       1 .. 5 3 .. 7
@@ -291,7 +291,7 @@ def cstack(tables, join_type='outer', metadata_conflicts='warn'):
 
     n_rows = set(len(table) for table in tables)
     if len(n_rows) != 1:
-        raise ValueError('Table lengths must all match for cstack')
+        raise ValueError('Table lengths must all match for dstack')
     n_row = n_rows.pop()
 
     out = vstack(tables, join_type, metadata_conflicts)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1039,7 +1039,7 @@ class TestCStack():
                               ' 6.  foo  3'], format='ascii')
 
     @staticmethod
-    def compare_cstack(tables, out):
+    def compare_dstack(tables, out):
         for ii, tbl in enumerate(tables):
             for name, out_col in out.columns.items():
                 if name in tbl.colnames:
@@ -1059,15 +1059,15 @@ class TestCStack():
                     # Column missing for this table, out must have a mask with all True.
                     assert np.all(out[name].mask[:, ii])
 
-    def test_cstack_table_column(self, operation_table_type):
+    def test_dstack_table_column(self, operation_table_type):
         """Stack a table with 3 cols and one column (gets auto-converted to Table).
         """
         self._setup(operation_table_type)
         t2 = self.t1.copy()
-        out = table.cstack([self.t1, t2['a']])
-        self.compare_cstack([self.t1, t2[('a',)]], out)
+        out = table.dstack([self.t1, t2['a']])
+        self.compare_dstack([self.t1, t2[('a',)]], out)
 
-    def test_cstack_basic_outer(self, operation_table_type):
+    def test_dstack_basic_outer(self, operation_table_type):
         if operation_table_type is QTable:
             pytest.xfail('Quantity columns do not support masking.')
         self._setup(operation_table_type)
@@ -1076,56 +1076,56 @@ class TestCStack():
         t4 = self.t4
         t4['a'].mask[0] = True
         # Test for non-masked table
-        t12 = table.cstack([t1, t2], join_type='outer')
+        t12 = table.dstack([t1, t2], join_type='outer')
         assert type(t12) is operation_table_type
         assert type(t12['a']) is type(t1['a'])
         assert type(t12['b']) is type(t1['b'])
-        self.compare_cstack([t1, t2], t12)
+        self.compare_dstack([t1, t2], t12)
 
         # Test for masked table
-        t124 = table.cstack([t1, t2, t4], join_type='outer')
+        t124 = table.dstack([t1, t2, t4], join_type='outer')
         assert type(t124) is operation_table_type
         assert type(t124['a']) is type(t4['a'])
         assert type(t124['b']) is type(t4['b'])
-        self.compare_cstack([t1, t2, t4], t124)
+        self.compare_dstack([t1, t2, t4], t124)
 
-    def test_cstack_basic_inner(self, operation_table_type):
+    def test_dstack_basic_inner(self, operation_table_type):
         self._setup(operation_table_type)
         t1 = self.t1
         t2 = self.t2
         t4 = self.t4
 
         # Test for masked table
-        t124 = table.cstack([t1, t2, t4], join_type='inner')
+        t124 = table.dstack([t1, t2, t4], join_type='inner')
         assert type(t124) is operation_table_type
         assert type(t124['a']) is type(t4['a'])
         assert type(t124['b']) is type(t4['b'])
-        self.compare_cstack([t1, t2, t4], t124)
+        self.compare_dstack([t1, t2, t4], t124)
 
-    def test_cstack_multi_dimension_column(self, operation_table_type):
+    def test_dstack_multi_dimension_column(self, operation_table_type):
         self._setup(operation_table_type)
         t3 = self.t3
         t5 = self.t5
         t2 = self.t2
-        t35 = table.cstack([t3, t5])
+        t35 = table.dstack([t3, t5])
         assert type(t35) is operation_table_type
         assert type(t35['a']) is type(t3['a'])
         assert type(t35['b']) is type(t3['b'])
-        self.compare_cstack([t3, t5], t35)
+        self.compare_dstack([t3, t5], t35)
 
         with pytest.raises(TableMergeError):
-            table.cstack([t2, t3])
+            table.dstack([t2, t3])
 
-    def test_cstack_different_length_table(self, operation_table_type):
+    def test_dstack_different_length_table(self, operation_table_type):
         self._setup(operation_table_type)
         t2 = self.t2
         t6 = self.t6
         with pytest.raises(ValueError):
-            table.cstack([t2, t6])
+            table.dstack([t2, t6])
 
-    def test_cstack_single_table(self):
+    def test_dstack_single_table(self):
         self._setup(Table)
-        out = table.cstack(self.t1)
+        out = table.dstack(self.t1)
         assert np.all(out == self.t1)
 
 

--- a/docs/table/operations.rst
+++ b/docs/table/operations.rst
@@ -595,14 +595,14 @@ Stack depth-wise
 ----------------
 
 The |Table| class supports stacking columns within tables depth-wise using
-the `~astropy.table.cstack` function. It corresponds roughly
+the `~astropy.table.dstack` function. It corresponds roughly
 to running the `numpy.dstack` function on the individual columns matched
 by name.
 
 For example, suppose one has tables of data for sources giving information on the enclosed
 source counts for different PSF fractions::
 
-  >>> from astropy.table import Table, cstack
+  >>> from astropy.table import Table, dstack
   >>> src1 = Table.read("""psf_frac  counts
   ...                      0.10        45
   ...                      0.50        90
@@ -618,7 +618,7 @@ source counts for different PSF fractions::
 Now we can stack these two tables depth-wise to get a single table with the
 characteristics of both sources::
 
-  >>> srcs = cstack([src1, src2])
+  >>> srcs = dstack([src1, src2])
   >>> print(srcs)
   psf_frac [2] counts [2]
   ------------ ----------


### PR DESCRIPTION
`Table.cstack()` is short for depth-wise stacking, by analogy to `vstack` and `hstack`.  I don't quite remember why it got named `cstack` instead of `dstack`.  I think that `table.cstack` is conceptually similar to `np.dstack` : "Stack arrays in sequence depth wise (along third axis)."

Closes #9565 