### PR TITLE
Fix more warnings in test suite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -164,6 +164,10 @@ astropy.stats
 - A numpy ``MaskedArray`` can now be input to the ``biweight_location``,
   ``biweight_scale``, and ``biweight_midvariance`` functions. [#9466]
 
+- Removed the warning related to p0 in the Bayesian blocks algorithm.
+  The caveat related to p0 is described in the docstring for ``Events``.
+  [#9567]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -262,11 +262,11 @@ def test_delimiter(parallel, read_basic):
     """
     Make sure that different delimiters work as expected.
     """
-    text = """
-COL1 COL2 COL3
-1 A -1
-2 B -2
-"""
+    text = dedent("""
+    COL1 COL2 COL3
+    1 A -1
+    2 B -2
+    """)
     expected = Table([[1, 2], ['A', 'B'], [-1, -2]], names=('COL1', 'COL2', 'COL3'))
 
     for sep in ' ,\t#;':
@@ -299,11 +299,11 @@ def test_include_exclude_names(parallel, read_basic):
     """
     Make sure that include_names is applied before exclude_names if both are specified.
     """
-    text = """
-A B C D E F G H
-1 2 3 4 5 6 7 8
-9 10 11 12 13 14 15 16
-"""
+    text = dedent("""
+    A B C D E F G H
+    1 2 3 4 5 6 7 8
+    9 10 11 12 13 14 15 16
+    """)
     table = read_basic(text, include_names=['A', 'B', 'D', 'F', 'H'],
                        exclude_names=['B', 'F'], parallel=parallel)
     expected = Table([[1, 9], [4, 12], [8, 16]], names=('A', 'D', 'H'))
@@ -333,6 +333,7 @@ def test_doubled_quotes(read_csv):
         assert_table_equal(dat, expected)
 
 
+@pytest.mark.filterwarnings("ignore:OverflowError converting to IntType in column TIMESTAMP")
 def test_doubled_quotes_segv():
     """
     Test the exact example from #8281 which resulted in SEGV prior to #8283
@@ -340,10 +341,10 @@ def test_doubled_quotes_segv():
     Attempts to produce a more minimal example were unsuccessful, so the whole
     thing is included.
     """
-    tbl = """\
-"ID","TIMESTAMP","addendum_id","bib_reference","bib_reference_url","client_application","client_category","client_sort_key","color","coordsys","creator","creator_did","data_pixel_bitpix","dataproduct_subtype","dataproduct_type","em_max","em_min","format","hips_builder","hips_copyright","hips_creation_date","hips_creation_date_1","hips_creator","hips_data_range","hips_estsize","hips_frame","hips_glu_tag","hips_hierarchy","hips_initial_dec","hips_initial_fov","hips_initial_ra","hips_lon_asc","hips_master_url","hips_order","hips_order_1","hips_order_4","hips_order_min","hips_overlay","hips_pixel_bitpix","hips_pixel_cut","hips_pixel_scale","hips_progenitor_url","hips_publisher","hips_release_date","hips_release_date_1","hips_rgb_blue","hips_rgb_green","hips_rgb_red","hips_sampling","hips_service_url","hips_service_url_1","hips_service_url_2","hips_service_url_3","hips_service_url_4","hips_service_url_5","hips_service_url_6","hips_service_url_7","hips_service_url_8","hips_skyval","hips_skyval_method","hips_skyval_value","hips_status","hips_status_1","hips_status_2","hips_status_3","hips_status_4","hips_status_5","hips_status_6","hips_status_7","hips_status_8","hips_tile_format","hips_tile_format_1","hips_tile_format_4","hips_tile_width","hips_version","hipsgen_date","hipsgen_date_1","hipsgen_date_10","hipsgen_date_11","hipsgen_date_12","hipsgen_date_2","hipsgen_date_3","hipsgen_date_4","hipsgen_date_5","hipsgen_date_6","hipsgen_date_7","hipsgen_date_8","hipsgen_date_9","hipsgen_params","hipsgen_params_1","hipsgen_params_10","hipsgen_params_11","hipsgen_params_12","hipsgen_params_2","hipsgen_params_3","hipsgen_params_4","hipsgen_params_5","hipsgen_params_6","hipsgen_params_7","hipsgen_params_8","hipsgen_params_9","label","maxOrder","moc_access_url","moc_order","moc_release_date","moc_sky_fraction","obs_ack","obs_collection","obs_copyrigh_url","obs_copyright","obs_copyright_1","obs_copyright_url","obs_copyright_url_1","obs_description","obs_description_url","obs_descrition_url","obs_id","obs_initial_dec","obs_initial_fov","obs_initial_ra","obs_provenance","obs_regime","obs_title","ohips_frame","pixelCut","pixelRange","prov_did","prov_progenitor","prov_progenitor_url","publisher_did","publisher_id","s_pixel_scale","t_max","t_min"
-"CDS/P/2MASS/H","1524123841000","","2006AJ....131.1163S","http://cdsbib.u-strasbg.fr/cgi-bin/cdsbib?2006AJ....131.1163S","AladinDesktop","Image/Infrared/2MASS","04-001-03","","","","ivo://CDS/P/2MASS/H","","","image","1.798E-6","1.525E-6","","Aladin/HipsGen v9.017","CNRS/Unistra","2013-05-06T20:36Z","","CDS (A.Oberto)","","","equatorial","","mean","","","","","","9","","","","","","0 60","2.236E-4","","","2016-04-22T13:48Z","","","","","","http://alasky.u-strasbg.fr/2MASS/H","https://irsa.ipac.caltech.edu/data/hips/CDS/2MASS/H","http://alaskybis.u-strasbg.fr/2MASS/H","https://alaskybis.u-strasbg.fr/2MASS/H","","","","","","","","","public master clonableOnce","public mirror unclonable","public mirror clonableOnce","public mirror clonableOnce","","","","","","jpeg fits","","","512","1.31","","","","","","","","","","","","","","","","","","","","","","","","","","","","","http://alasky.u-strasbg.fr/2MASS/H/Moc.fits","9","","1","University of Massachusetts & IPAC/Caltech","The Two Micron All Sky Survey - H band (2MASS H)","","University of Massachusetts & IPAC/Caltech","","http://www.ipac.caltech.edu/2mass/","","2MASS has uniformly scanned the entire sky in three near-infrared bands to detect and characterize point sources brighter than about 1 mJy in each band, with signal-to-noise ratio (SNR) greater than 10, using a pixel size of 2.0"". This has achieved an 80,000-fold improvement in sensitivity relative to earlier surveys. 2MASS used two highly-automated 1.3-m telescopes, one at Mt. Hopkins, AZ, and one at CTIO, Chile. Each telescope was equipped with a three-channel camera, each channel consisting of a 256x256 array of HgCdTe detectors, capable of observing the sky simultaneously at J (1.25 microns), H (1.65 microns), and Ks (2.17 microns). The University of Massachusetts (UMass) was responsible for the overall management of the project, and for developing the infrared cameras and on-site computing systems at both facilities. The Infrared Processing and Analysis Center (IPAC) is responsible for all data processing through the Production Pipeline, and construction and distribution of the data products. Funding is provided primarily by NASA and the NSF","","","","+0","0.11451621372724685","0","","Infrared","2MASS H (1.66um)","","","","","IPAC/NASA","","","","","51941","50600"
-"""
+    tbl = dedent("""
+    "ID","TIMESTAMP","addendum_id","bib_reference","bib_reference_url","client_application","client_category","client_sort_key","color","coordsys","creator","creator_did","data_pixel_bitpix","dataproduct_subtype","dataproduct_type","em_max","em_min","format","hips_builder","hips_copyright","hips_creation_date","hips_creation_date_1","hips_creator","hips_data_range","hips_estsize","hips_frame","hips_glu_tag","hips_hierarchy","hips_initial_dec","hips_initial_fov","hips_initial_ra","hips_lon_asc","hips_master_url","hips_order","hips_order_1","hips_order_4","hips_order_min","hips_overlay","hips_pixel_bitpix","hips_pixel_cut","hips_pixel_scale","hips_progenitor_url","hips_publisher","hips_release_date","hips_release_date_1","hips_rgb_blue","hips_rgb_green","hips_rgb_red","hips_sampling","hips_service_url","hips_service_url_1","hips_service_url_2","hips_service_url_3","hips_service_url_4","hips_service_url_5","hips_service_url_6","hips_service_url_7","hips_service_url_8","hips_skyval","hips_skyval_method","hips_skyval_value","hips_status","hips_status_1","hips_status_2","hips_status_3","hips_status_4","hips_status_5","hips_status_6","hips_status_7","hips_status_8","hips_tile_format","hips_tile_format_1","hips_tile_format_4","hips_tile_width","hips_version","hipsgen_date","hipsgen_date_1","hipsgen_date_10","hipsgen_date_11","hipsgen_date_12","hipsgen_date_2","hipsgen_date_3","hipsgen_date_4","hipsgen_date_5","hipsgen_date_6","hipsgen_date_7","hipsgen_date_8","hipsgen_date_9","hipsgen_params","hipsgen_params_1","hipsgen_params_10","hipsgen_params_11","hipsgen_params_12","hipsgen_params_2","hipsgen_params_3","hipsgen_params_4","hipsgen_params_5","hipsgen_params_6","hipsgen_params_7","hipsgen_params_8","hipsgen_params_9","label","maxOrder","moc_access_url","moc_order","moc_release_date","moc_sky_fraction","obs_ack","obs_collection","obs_copyrigh_url","obs_copyright","obs_copyright_1","obs_copyright_url","obs_copyright_url_1","obs_description","obs_description_url","obs_descrition_url","obs_id","obs_initial_dec","obs_initial_fov","obs_initial_ra","obs_provenance","obs_regime","obs_title","ohips_frame","pixelCut","pixelRange","prov_did","prov_progenitor","prov_progenitor_url","publisher_did","publisher_id","s_pixel_scale","t_max","t_min"
+    "CDS/P/2MASS/H","1524123841000","","2006AJ....131.1163S","http://cdsbib.u-strasbg.fr/cgi-bin/cdsbib?2006AJ....131.1163S","AladinDesktop","Image/Infrared/2MASS","04-001-03","","","","ivo://CDS/P/2MASS/H","","","image","1.798E-6","1.525E-6","","Aladin/HipsGen v9.017","CNRS/Unistra","2013-05-06T20:36Z","","CDS (A.Oberto)","","","equatorial","","mean","","","","","","9","","","","","","0 60","2.236E-4","","","2016-04-22T13:48Z","","","","","","http://alasky.u-strasbg.fr/2MASS/H","https://irsa.ipac.caltech.edu/data/hips/CDS/2MASS/H","http://alaskybis.u-strasbg.fr/2MASS/H","https://alaskybis.u-strasbg.fr/2MASS/H","","","","","","","","","public master clonableOnce","public mirror unclonable","public mirror clonableOnce","public mirror clonableOnce","","","","","","jpeg fits","","","512","1.31","","","","","","","","","","","","","","","","","","","","","","","","","","","","","http://alasky.u-strasbg.fr/2MASS/H/Moc.fits","9","","1","University of Massachusetts & IPAC/Caltech","The Two Micron All Sky Survey - H band (2MASS H)","","University of Massachusetts & IPAC/Caltech","","http://www.ipac.caltech.edu/2mass/","","2MASS has uniformly scanned the entire sky in three near-infrared bands to detect and characterize point sources brighter than about 1 mJy in each band, with signal-to-noise ratio (SNR) greater than 10, using a pixel size of 2.0"". This has achieved an 80,000-fold improvement in sensitivity relative to earlier surveys. 2MASS used two highly-automated 1.3-m telescopes, one at Mt. Hopkins, AZ, and one at CTIO, Chile. Each telescope was equipped with a three-channel camera, each channel consisting of a 256x256 array of HgCdTe detectors, capable of observing the sky simultaneously at J (1.25 microns), H (1.65 microns), and Ks (2.17 microns). The University of Massachusetts (UMass) was responsible for the overall management of the project, and for developing the infrared cameras and on-site computing systems at both facilities. The Infrared Processing and Analysis Center (IPAC) is responsible for all data processing through the Production Pipeline, and construction and distribution of the data products. Funding is provided primarily by NASA and the NSF","","","","+0","0.11451621372724685","0","","Infrared","2MASS H (1.66um)","","","","","IPAC/NASA","","","","","51941","50600"
+    """)
     ascii.read(tbl, format='csv', fast_reader=True, guess=False)
 
 
@@ -355,12 +356,12 @@ def test_quoted_fields(parallel, read_basic):
     """
     if parallel:
         pytest.xfail("Multiprocessing can fail with quoted fields")
-    text = """
-"A B" C D
-1.5 2.1 -37.1
-a b "   c
- d"
-"""
+    text = dedent("""
+    "A B" C D
+    1.5 2.1 -37.1
+    a b "   c
+    d"
+    """)
     table = read_basic(text, parallel=parallel)
     expected = Table([['1.5', 'a'], ['2.1', 'b'], ['-37.1', 'cd']], names=('A B', 'C', 'D'))
     assert_table_equal(table, expected)
@@ -404,13 +405,13 @@ def test_too_many_cols1():
     """
     If a row contains too many columns, the C reader should raise an error.
     """
-    text = """
-A B C
-1 2 3
-4 5 6
-7 8 9 10
-11 12 13
-"""
+    text = dedent("""
+    A B C
+    1 2 3
+    4 5 6
+    7 8 9 10
+    11 12 13
+    """)
     with pytest.raises(InconsistentTableError) as e:
         table = FastBasic().read(text)
     assert 'Number of header columns (3) ' \

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -1,7 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import numpy as np
 from astropy.io import ascii
-from .common import (assert_equal, assert_almost_equal, has_isnan,
+from .common import (assert_equal, assert_almost_equal,
                      setup_function, teardown_function)
 
 
@@ -138,14 +139,12 @@ def test_header_from_readme():
          1.958,
          1.416,
          0.949]
-    if has_isnan:
-        from .common import isnan
-        for i, val in enumerate(table.field('Q')):
-            if isnan(val):
-                # text value for a missing value in that table
-                assert Q[i] == -9.999
-            else:
-                assert val == Q[i]
+    for i, val in enumerate(table.field('Q')):
+        if val is np.ma.masked:
+            # text value for a missing value in that table
+            assert Q[i] == -9.999
+        else:
+            assert val == Q[i]
 
 
 def test_cds_units():

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -43,7 +43,8 @@ def test_soupstring():
     Test to make sure the class SoupString behaves properly.
     """
 
-    soup = BeautifulSoup('<html><head></head><body><p>foo</p></body></html>')
+    soup = BeautifulSoup('<html><head></head><body><p>foo</p></body></html>',
+                         'html.parser')
     soup_str = html.SoupString(soup)
     assert isinstance(soup_str, str)
     assert isinstance(soup_str, html.SoupString)
@@ -75,12 +76,12 @@ def test_identify_table():
     """
 
     # Should return False on non-<table> tags and None
-    soup = BeautifulSoup('<html><body></body></html>')
+    soup = BeautifulSoup('<html><body></body></html>', 'html.parser')
     assert html.identify_table(soup, {}, 0) is False
     assert html.identify_table(None, {}, 0) is False
 
     soup = BeautifulSoup('<table id="foo"><tr><th>A</th></tr><tr>'
-                         '<td>B</td></tr></table>').table
+                         '<td>B</td></tr></table>', 'html.parser').table
     assert html.identify_table(soup, {}, 2) is False
     assert html.identify_table(soup, {}, 1) is True  # Default index of 1
 
@@ -267,8 +268,8 @@ def test_htmlsplitter():
 
     splitter = html.HTMLSplitter()
 
-    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>').tr),
-            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>').tr)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>', 'html.parser').tr),
+            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>', 'html.parser').tr)]
     expected_data = [['Col 1', 'Col 2'], ['Data 1', 'Data 2']]
     assert list(splitter(lines)) == expected_data
 
@@ -311,8 +312,8 @@ def test_htmlheader_start():
            '<tr><th>C1</th><th>C2</th><th>C3</th></tr>'
 
     # start_line should return None if no valid header is found
-    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>').tr),
-             html.SoupString(BeautifulSoup('<p>Text</p>').p)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>', 'html.parser').tr),
+             html.SoupString(BeautifulSoup('<p>Text</p>', 'html.parser').p)]
     assert header.start_line(lines) is None
 
     # Should raise an error if a non-SoupString is present
@@ -359,8 +360,8 @@ def test_htmldata():
            '<tr><td>9</td><td>i</td><td>-125.0</td></tr>'
 
     # start_line should raise an error if no table data exists
-    lines = [html.SoupString(BeautifulSoup('<div></div>').div),
-             html.SoupString(BeautifulSoup('<p>Text</p>').p)]
+    lines = [html.SoupString(BeautifulSoup('<div></div>', 'html.parser').div),
+             html.SoupString(BeautifulSoup('<p>Text</p>', 'html.parser').p)]
     with pytest.raises(core.InconsistentTableError):
         data.start_line(lines)
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -23,6 +23,7 @@ from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true)
 from astropy.io.ascii import core
 from astropy.io.ascii.ui import _probably_html, get_read_trace, cparser
+from astropy.utils.exceptions import AstropyWarning
 
 # setup/teardown function to have the tests run in the correct directory
 from .common import setup_function, teardown_function
@@ -46,8 +47,9 @@ def test_convert_overflow(fast_reader):
     return inf (kind 'f') for this.
     """
     expected_kind = 'U'
-    dat = ascii.read(['a', '1' * 10000], format='basic',
-                     fast_reader=fast_reader, guess=False)
+    with pytest.warns(AstropyWarning, match="OverflowError converting to IntType in column a"):
+        dat = ascii.read(['a', '1' * 10000], format='basic',
+                         fast_reader=fast_reader, guess=False)
     assert dat['a'].dtype.kind == expected_kind
 
 

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -1,6 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
+import warnings
+from distutils.version import LooseVersion
+
 import pytest
 import numpy as np
 
@@ -94,8 +97,12 @@ def test_inverse_transforms(tmpdir):
 
 @pytest.mark.parametrize(('model'), test_models)
 def test_single_model(tmpdir, model):
-    tree = {'single_model': model}
-    helpers.assert_roundtrip_tree(tree, tmpdir)
+    with warnings.catch_warnings():
+        # Some schema files are missing from asdf<=2.4.2 which causes warnings
+        if LooseVersion(asdf.__version__) <= '2.4.2':
+            warnings.filterwarnings('ignore', 'Unable to locate schema file')
+        tree = {'single_model': model}
+        helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
 def test_name(tmpdir):
@@ -195,13 +202,19 @@ def test_tabular_model_units(tmpdir):
 
 
 def test_fix_inputs(tmpdir):
-    model = astmodels.Pix2Sky_TAN() | astmodels.Rotation2D()
-    tree = {
-        'compound': fix_inputs(model, {'x': 45}),
-        'compound1': fix_inputs(model, {0: 45})
-    }
 
-    helpers.assert_roundtrip_tree(tree, tmpdir)
+    with warnings.catch_warnings():
+        # Some schema files are missing from asdf<=2.4.2 which causes warnings
+        if LooseVersion(asdf.__version__) <= '2.4.2':
+            warnings.filterwarnings('ignore', 'Unable to locate schema file')
+
+        model = astmodels.Pix2Sky_TAN() | astmodels.Rotation2D()
+        tree = {
+            'compound': fix_inputs(model, {'x': 45}),
+            'compound1': fix_inputs(model, {0: 45})
+        }
+
+        helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
 def test_fix_inputs_type():

--- a/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
@@ -16,8 +16,8 @@ def get_equivalencies():
     Return a list of example equivalencies for testing serialization.
     """
     return [eq.plate_scale(.3 * u.deg/u.mm), eq.pixel_scale(.5 * u.deg/u.pix),
-            eq.spectral_density(3500 * u.Angstrom, factor=2),
-            eq.spectral_density(3500 * u.Angstrom), eq.spectral(),
+            eq.spectral_density(350 * u.nm, factor=2),
+            eq.spectral_density(350 * u.nm), eq.spectral(),
             eq.brightness_temperature(500 * u.GHz),
             eq.brightness_temperature(500 * u.GHz, beam_area=23 * u.sr),
             eq.with_H0(), eq.temperature_energy(), eq.temperature(),

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -418,14 +418,6 @@ class Events(FitnessFunc):
         gamma})`.
         If ``ncp_prior`` is specified, ``gamma`` and ``p0`` is ignored.
     """
-    def __init__(self, p0=0.05, gamma=None, ncp_prior=None):
-        if p0 is not None and gamma is None and ncp_prior is None:
-            warnings.warn('p0 does not seem to accurately represent the false '
-                          'positive rate for event data. It is highly '
-                          'recommended that you run random trials on signal-'
-                          'free noise to calibrate ncp_prior to achieve a '
-                          'desired false positive rate.', AstropyUserWarning)
-        super().__init__(p0, gamma, ncp_prior)
 
     def fitness(self, N_k, T_k):
         # eq. 19 from Scargle 2012

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -110,13 +110,13 @@ def bayesian_blocks(t, x=None, sigma=None,
     Event data:
 
     >>> t = np.random.normal(size=100)
-    >>> edges = bayesian_blocks(t, fitness='events', gamma=1)
+    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
 
     Event data with repeats:
 
     >>> t = np.random.normal(size=100)
     >>> t[80:] = t[:20]
-    >>> edges = bayesian_blocks(t, fitness='events', gamma=1)
+    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
 
     Regular event data:
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -105,13 +105,13 @@ def bayesian_blocks(t, x=None, sigma=None,
     Event data:
 
     >>> t = np.random.normal(size=100)
-    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
+    >>> edges = bayesian_blocks(t, fitness='events', gamma=1)
 
     Event data with repeats:
 
     >>> t = np.random.normal(size=100)
     >>> t[80:] = t[:20]
-    >>> edges = bayesian_blocks(t, fitness='events', p0=0.01)
+    >>> edges = bayesian_blocks(t, fitness='events', gamma=1)
 
     Regular event data:
 

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -102,6 +102,11 @@ def bayesian_blocks(t, x=None, sigma=None,
 
     Examples
     --------
+
+    .. testsetup::
+
+        >>> np.random.seed(12345)
+
     Event data:
 
     >>> t = np.random.normal(size=100)

--- a/astropy/stats/info_theory.py
+++ b/astropy/stats/info_theory.py
@@ -364,7 +364,7 @@ def akaike_info_criterion_lsq(ssr, n_params, n_samples):
     >>> # Fit with three Gaussians
     >>> g3_init = (models.Gaussian1D(.1, 0, 0.1)
     ...            + models.Gaussian1D(.1, 0.2, 0.15)
-    ...            + models.Gaussian1D(2., .4, 0.1))
+    ...            + models.Gaussian1D(2.4, .4, 0.1))
     >>> fitter = fitting.LevMarLSQFitter()
     >>> g3_fit = fitter(g3_init, x, y)
     >>> # Fit with two Gaussians
@@ -379,7 +379,7 @@ def akaike_info_criterion_lsq(ssr, n_params, n_samples):
     >>> ssr_g2 = np.sum((g2_fit(x) - y)**2.0)
     >>> ssr_g1 = np.sum((g1_fit(x) - y)**2.0)
     >>> akaike_info_criterion_lsq(ssr_g3, 9, x.shape[0]) # doctest: +FLOAT_CMP
-    -660.41075962620482
+    -634.5257517810961
     >>> akaike_info_criterion_lsq(ssr_g2, 6, x.shape[0]) # doctest: +FLOAT_CMP
     -662.83834510232043
     >>> akaike_info_criterion_lsq(ssr_g1, 3, x.shape[0]) # doctest: +FLOAT_CMP

--- a/astropy/stats/tests/test_bayesian_blocks.py
+++ b/astropy/stats/tests/test_bayesian_blocks.py
@@ -14,9 +14,7 @@ def test_single_change_point(rseed=0):
     x = np.concatenate([rng.rand(100),
                         1 + rng.rand(200)])
 
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        bins = bayesian_blocks(x)
+    bins = bayesian_blocks(x)
 
     assert (len(bins) == 3)
     assert_allclose(bins[1], 1, rtol=0.02)
@@ -31,10 +29,8 @@ def test_duplicate_events(rseed=0):
     x = np.ones(t.shape, dtype=int)
     x[:20] += 1
 
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        bins1 = bayesian_blocks(t)
-        bins2 = bayesian_blocks(t[:80], x[:80])
+    bins1 = bayesian_blocks(t)
+    bins2 = bayesian_blocks(t[:80], x[:80])
 
     assert_allclose(bins1, bins2)
 
@@ -90,47 +86,33 @@ def test_errors():
 
     # x must be integer or None for events
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='events', x=t)
+        bayesian_blocks(t, fitness='events', x=t)
 
     # x must be binary for regular events
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='regular_events', x=10 * t, dt=1)
+        bayesian_blocks(t, fitness='regular_events', x=10 * t, dt=1)
 
     # x must be specified for measures
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='measures')
+        bayesian_blocks(t, fitness='measures')
 
     # sigma cannot be specified without x
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='events', sigma=0.5)
+        bayesian_blocks(t, fitness='events', sigma=0.5)
 
     # length of x must match length of t
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='measures', x=t[:-1])
+        bayesian_blocks(t, fitness='measures', x=t[:-1])
 
     # repeated values in t fail when x is specified
     t2 = t.copy()
     t2[1] = t2[0]
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t2, fitness='measures', x=t)
+        bayesian_blocks(t2, fitness='measures', x=t)
 
     # sigma must be broadcastable with x
     with pytest.raises(ValueError):
-        with pytest.warns(AstropyUserWarning,
-                          match=r'p0 does not seem to accurate'):
-            bayesian_blocks(t, fitness='measures', x=t, sigma=t[:-1])
+        bayesian_blocks(t, fitness='measures', x=t, sigma=t[:-1])
 
 
 def test_fitness_function_results():
@@ -139,16 +121,12 @@ def test_fitness_function_results():
 
     # Event Data
     t = rng.randn(100)
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        edges = bayesian_blocks(t, fitness='events')
+    edges = bayesian_blocks(t, fitness='events')
     assert_allclose(edges, [-2.6197451, -0.71094865, 0.36866702, 1.85227818])
 
     # Event data with repeats
     t[80:] = t[:20]
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        edges = bayesian_blocks(t, fitness='events', p0=0.01)
+    edges = bayesian_blocks(t, fitness='events', p0=0.01)
     assert_allclose(edges, [-2.6197451, -0.47432431, -0.46202823, 1.85227818])
 
     # Regular event data
@@ -196,8 +174,6 @@ def test_zero_change_points(rseed=0):
     # Using the failed edge case from
     # https://github.com/astropy/astropy/issues/8558
     values = np.array([1, 1, 1, 1, 1, 1, 1, 1, 2])
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        bins = bayesian_blocks(values)
+    bins = bayesian_blocks(values)
     assert values.min() == bins[0]
     assert values.max() == bins[-1]

--- a/astropy/stats/tests/test_biweight.py
+++ b/astropy/stats/tests/test_biweight.py
@@ -120,6 +120,7 @@ def test_biweight_location_axis_tuple():
                  biweight_location(data, axis=None))
 
 
+@pytest.mark.filterwarnings('ignore:All-NaN slice encountered')
 def test_biweight_location_ignore_nan():
     data1d = np.array([1, 3, 5, 500, 2, np.nan])
     data2d = np.array([data1d, data1d])
@@ -135,6 +136,7 @@ def test_biweight_location_ignore_nan():
                  [biw_expected, biw_expected])
 
 
+@pytest.mark.filterwarnings('ignore:All-NaN slice encountered')
 def test_biweight_location_masked():
     data1d = np.array([1, 3, 5, 500, 2, np.nan])
     data2d = np.array([data1d, data1d])
@@ -246,6 +248,7 @@ def test_biweight_midvariance_axis_3d():
         assert_allclose(bw[y], bwi)
 
 
+@pytest.mark.filterwarnings('ignore:All-NaN slice encountered')
 def test_biweight_midvariance_ignore_nan():
     data1d = np.array([1, 3, 5, 500, 2, np.nan])
     data2d = np.array([data1d, data1d])
@@ -262,6 +265,7 @@ def test_biweight_midvariance_ignore_nan():
                  [biw_var_nonan, biw_var_nonan])
 
 
+@pytest.mark.filterwarnings('ignore:All-NaN slice encountered')
 def test_biweight_midvariance_masked():
     data1d = np.array([1, 3, 5, 500, 2, np.nan])
     data2d = np.array([data1d, data1d])

--- a/astropy/stats/tests/test_histogram.py
+++ b/astropy/stats/tests/test_histogram.py
@@ -96,13 +96,7 @@ if HAS_SCIPY:
 def test_histogram(bin_type, N=1000, rseed=0):
     rng = np.random.RandomState(rseed)
     x = rng.randn(N)
-
-    # Warning is emitted for blocks
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            'ignore', message=r'.*p0 does not seem to accurate.*',
-            category=AstropyUserWarning)
-        counts, bins = histogram(x, bin_type)
+    counts, bins = histogram(x, bin_type)
     assert (counts.sum() == len(x))
     assert (len(counts) == len(bins) - 1)
 
@@ -116,12 +110,7 @@ def test_histogram_range(bin_type, N=1000, rseed=0):
     x = rng.randn(N)
     range = (0.1, 0.8)
 
-    # Warning is emitted for blocks
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            'ignore', message=r'.*p0 does not seem to accurate.*',
-            category=AstropyUserWarning)
-        bins = calculate_bin_edges(x, bin_type, range=range)
+    bins = calculate_bin_edges(x, bin_type, range=range)
     assert bins.max() == range[1]
     assert bins.min() == range[0]
 
@@ -171,9 +160,7 @@ def test_histogram_output():
                            -0.17288406, 0.42214237, 1.01716881, 1.61219525,
                            2.20722169, 2.80224813])
 
-    with pytest.warns(AstropyUserWarning,
-                      match=r'p0 does not seem to accurate'):
-        counts, bins = histogram(X, bins='blocks')
+    counts, bins = histogram(X, bins='blocks')
     assert_allclose(counts, [10, 61, 29])
     assert_allclose(bins, [-2.55298982, -1.24381059, 0.46422235, 2.26975462])
 

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -12,7 +12,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.io import fits
-from astropy.table import Table, QTable, MaskedColumn
+from astropy.table import Table, QTable, MaskedColumn, TableReplaceWarning
 from astropy.tests.helper import (assert_follows_unicode_guidelines,
                                   ignore_warnings, catch_warnings)
 from astropy.coordinates import SkyCoord
@@ -1914,7 +1914,9 @@ class TestPandas:
                        2584288728310999296]
         t['Source'].mask = [False, False, False]
 
-        d = t.to_pandas()
+        with pytest.warns(TableReplaceWarning,
+                          match="converted column 'a' from integer to float"):
+            d = t.to_pandas()
 
         t2 = table.Table.from_pandas(d)
 

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -382,9 +382,12 @@ class TestArithmetic:
         else:
             assert np.all(self.t0.argsort(axis=None) == ravel)
 
-    def test_argsort_warning(self, masked):
+    @pytest.mark.parametrize('scale', Time.SCALES)
+    def test_argsort_warning(self, masked, scale):
+        if scale == 'utc':
+            pytest.xfail()
         with warnings.catch_warnings(record=True) as wlist:
-            Time([1, 2, 3], format='jd', scale='tai').argsort()
+            Time([1, 2, 3], format='jd', scale=scale).argsort()
         assert len(wlist) == 0
 
     def test_min(self, masked):

--- a/astropy/timeseries/tests/test_sampled.py
+++ b/astropy/timeseries/tests/test_sampled.py
@@ -25,7 +25,7 @@ CSV_FILE = get_pkg_data_filename('data/sampled.csv')
 
 def test_empty_initialization():
     ts = TimeSeries()
-    ts['time'] = Time([1, 2, 3], format='mjd')
+    ts['time'] = Time([50001, 50002, 50003], format='mjd')
 
 
 def test_empty_initialization_invalid():

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -49,7 +49,6 @@ def test_hist_specify_ax(rseed=0):
 
 
 @pytest.mark.skipif('not HAS_PLT')
-@pytest.mark.filterwarnings('ignore:p0 does not seem to accurately represent')
 def test_hist_autobin(rseed=0):
     rng = np.random.RandomState(rseed)
     x = rng.randn(100)

--- a/astropy/visualization/tests/test_histogram.py
+++ b/astropy/visualization/tests/test_histogram.py
@@ -49,6 +49,7 @@ def test_hist_specify_ax(rseed=0):
 
 
 @pytest.mark.skipif('not HAS_PLT')
+@pytest.mark.filterwarnings('ignore:p0 does not seem to accurately represent')
 def test_hist_autobin(rseed=0):
     rng = np.random.RandomState(rseed)
     x = rng.randn(100)

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -190,7 +190,7 @@ class TestImageScaling:
 def test_imshow_norm():
     image = np.random.randn(10, 10)
 
-    ax = plt.subplot()
+    ax = plt.subplot(label='test_imshow_norm')
     imshow_norm(image, ax=ax)
 
     with pytest.raises(ValueError):
@@ -212,3 +212,5 @@ def test_imshow_norm():
     imres, norm = imshow_norm(image, ax=None)
 
     assert isinstance(norm, ImageNormalize)
+
+    plt.close('all')

--- a/docs/visualization/histogram.rst
+++ b/docs/visualization/histogram.rst
@@ -148,10 +148,8 @@ the results of these procedures for the above dataset:
 
     fig.subplots_adjust(left=0.1, right=0.95, bottom=0.15)
     for i, bins in enumerate(['knuth', 'blocks']):
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')  # Ignore bayesian block p0 warning
-            hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
-                 alpha=0.2, density=True)
+        hist(t, bins=bins, ax=ax[i], histtype='stepfilled',
+                alpha=0.2, density=True)
         ax[i].set_xlabel('t')
         ax[i].set_ylabel('P(t)')
         ax[i].set_title('hist(t, bins="{0}")'.format(bins),


### PR DESCRIPTION
This fixes some of the remaining warnings in ``io``, ``stats``, and ``timeseries``

@mhvk - take a look at the updated test for astropy.time's argsort - you'll notice that I had to xfail the utc case, and I'm not sure how to fix that one. Any ideas?

⚠️ note that there is a reasonably significant change here, which is the removal of the bayesian blocks warning about ``p0``, as discussed in https://github.com/astropy/astropy/issues/9568 and https://github.com/astropy/astropy/issues/4927