### PR TITLE
Fix CircleCI build by making sure we apt update before installing C++ compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,9 @@ jobs:
       - checkout
       - run:
           name: Install C++ compiler
-          command: apt install -y g++
+          command: |
+            apt update
+            apt install -y g++
       - run:
           name: Install Python dependencies, including developer version of Matplotlib
           command: pip3 install pytest pytest-mpl pytest-astropy numpy scipy git+https://github.com/matplotlib/matplotlib.git


### PR DESCRIPTION
This should hopefully fix the failing mpldev build

Fixes https://github.com/astropy/astropy/issues/9551