### PR TITLE
Make IERS parsing more resilient to failed downloads, etc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,6 +267,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- ``astropy.utils.data.download_file`` now provides an `http_headers` keyword to
+  pass in specific request headers for the download. [#9508]
+
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial
   array. [#9209]
@@ -351,7 +354,7 @@ astropy.wcs
 - ``SlicedLowLevelWCS`` now raises ``IndexError`` rather than ``ValueError`` on
   an invalid slice. [#9067]
 
-- Added ``fit_wcs_from_points`` function to ``astropy.wcs.utils``. Fits a WCS 
+- Added ``fit_wcs_from_points`` function to ``astropy.wcs.utils``. Fits a WCS
   object to set of matched detector/sky coordinates. [#9469]
 
 API Changes
@@ -763,7 +766,7 @@ Other Changes and Additions
   automatically. [#9365]
 
 - The default server for the IERS data files has been updated to reflect
-  long-term downtime of the canonical USNO server. [#9443, #9487]
+  long-term downtime of the canonical USNO server. [#9443, #9487, #9508]
 
 
 3.2.3 (2019-10-27)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,7 +267,7 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``astropy.utils.data.download_file`` now provides an `http_headers` keyword to
+- ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
   pass in specific request headers for the download. [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -268,7 +268,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
-  pass in specific request headers for the download. [#9508]
+  pass in specific request headers for the download. It also now defaults to
+  providing ``User-Agent: Astropy`` and ``Accept: */*`` headers.  [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -267,9 +267,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``astropy.utils.data.download_file`` now provides an ``http_headers`` keyword to
-  pass in specific request headers for the download. It also now defaults to
-  providing ``User-Agent: Astropy`` and ``Accept: */*`` headers.  [#9508]
+- ``astropy.utils.data.download_file`` and
+  ``astropy.utils.data.get_readable_fileobj`` now provides an ``http_headers``
+  keyword to pass in specific request headers for the download. It also now
+  defaults to providing ``User-Agent: Astropy`` and ``Accept: */*``
+  headers. [#9508]
 
 - Added a new ``astropy.utils.misc.unbroadcast`` function which can be used
   to return the smallest array that can be broadcasted back to the initial

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -766,7 +766,7 @@ Other Changes and Additions
   automatically. [#9365]
 
 - The default server for the IERS data files has been updated to reflect
-  long-term downtime of the canonical USNO server. [#9443, #9487, #9508]
+  long-term downtime of the canonical USNO server. [#9487, #9508]
 
 
 3.2.3 (2019-10-27)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -953,12 +953,13 @@ def check_free_space_in_dir(path, size):
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
-                               http_headers={'User-Agent': 'astropy',
-                                             'Accept': '*/*'}):
+                               http_headers=None):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
         remote_url = source_url
+    if http_headers is None:
+        http_headers = {}
 
     req = urllib.request.Request(source_url, headers=http_headers)
     with urllib.request.urlopen(req, timeout=timeout) as remote:
@@ -1019,7 +1020,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
-                  sources=None, pkgname='astropy', http_headers={}):
+                  sources=None, pkgname='astropy', http_headers=None):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1075,7 +1076,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
 
     http_headers : dict
         HTTP request headers to pass into ``urlopen`` if needed. (These headers
-        are ignored if the ``remote_url`` is not http.)
+        are ignored if the protocol for the ``remote_url``/``sources`` entry
+        is not http.)
 
     Returns
     -------
@@ -1097,6 +1099,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         timeout = conf.remote_timeout
     if sources is None:
         sources = [remote_url]
+    if http_headers is None:
+        http_headers = {'User-Agent': 'astropy','Accept': '*/*'}
 
     missing_cache = ""
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -952,12 +952,15 @@ def check_free_space_in_dir(path, size):
 
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
-                               remote_url=None, cache=False, pkgname='astropy'):
+                               remote_url=None, cache=False, pkgname='astropy',
+                               http_headers={}):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
         remote_url = source_url
-    with urllib.request.urlopen(source_url, timeout=timeout) as remote:
+
+    req = urllib.request.Request(source_url, headers=http_headers)
+    with urllib.request.urlopen(req, timeout=timeout) as remote:
         # keep a hash to rename the local file to the hashed name
         hasher = hashlib.md5()
 
@@ -1015,7 +1018,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
-                  sources=None, pkgname='astropy'):
+                  sources=None, pkgname='astropy', http_headers={}):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1069,6 +1072,9 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``pkgname='astropy'`` the default cache location is
         ``~/.astropy/cache``.
 
+    http_headers : dict
+        Headers to pass into ``urlopen`` if needed.
+
     Returns
     -------
     local_path : str
@@ -1114,7 +1120,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
                     show_progress=show_progress,
                     cache=cache,
                     remote_url=remote_url,
-                    pkgname=pkgname)
+                    pkgname=pkgname,
+                    http_headers=http_headers)
             # Success!
             break
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -126,7 +126,7 @@ def _is_inside(path, parent_path):
 @contextlib.contextmanager
 def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
                          show_progress=True, remote_timeout=None,
-                         sources=None):
+                         sources=None, http_headers=None):
     """Yield a readable, seekable file-like object from a file or URL.
 
     This supports passing filenames, URLs, and readable file-like objects,
@@ -190,6 +190,11 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         long waits for a primary server that is known to be inaccessible
         at the moment.
 
+    http_headers : dict
+        HTTP request headers to pass into ``urlopen`` if needed. (These headers
+        are ignored if the protocol for the ``name_or_obj``/``sources`` entry
+        is not a remote http URL.)
+
     Returns
     -------
     file : readable file-like object
@@ -219,7 +224,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         if is_url:
             name_or_obj = download_file(
                 name_or_obj, cache=cache, show_progress=show_progress,
-                timeout=remote_timeout, sources=sources)
+                timeout=remote_timeout, sources=sources,
+                http_headers=http_headers)
         fileobj = io.FileIO(name_or_obj, 'r')
         if is_url and not cache:
             delete_fds.append(fileobj)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -953,7 +953,8 @@ def check_free_space_in_dir(path, size):
 
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
-                               http_headers={}):
+                               http_headers={'User-Agent': 'astropy',
+                                             'Accept': '*/*'}):
     from astropy.utils.console import ProgressBarOrSpinner
 
     if remote_url is None:
@@ -1073,7 +1074,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``~/.astropy/cache``.
 
     http_headers : dict
-        HTTP request headers to pass into ``urlopen`` if needed.
+        HTTP request headers to pass into ``urlopen`` if needed. (These headers
+        are ignored if the ``remote_url`` is not http.)
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1073,7 +1073,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         ``~/.astropy/cache``.
 
     http_headers : dict
-        Headers to pass into ``urlopen`` if needed.
+        HTTP request headers to pass into ``urlopen`` if needed.
 
     Returns
     -------

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -43,16 +43,10 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
            'LeapSeconds', 'IERS_LEAP_SECOND_FILE', 'IERS_LEAP_SECOND_URL',
            'IETF_LEAP_SECOND_URL']
 
-# maps specific download urls to the additional http headers needed for them -
-# populated where specific urls are given below.
-SPECIAL_HTTP_HEADERS_NEEDED = {}
-
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
 IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
-SPECIAL_HTTP_HEADERS_NEEDED[IERS_A_URL_MIRROR] = {'User-Agent': 'astropy/iers',
-                                                  'Accept': '*/*'}
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description
@@ -97,8 +91,8 @@ def download_file(*args, **kwargs):
     the local ``iers.conf.remote_timeout`` value.
     """
     url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
-    if url in SPECIAL_HTTP_HEADERS_NEEDED:
-        kwargs['http_headers'] = SPECIAL_HTTP_HEADERS_NEEDED[url]
+    kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
+                                       'Accept': '*/*'})
 
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -96,6 +96,10 @@ def download_file(*args, **kwargs):
     ``**kwargs`` after temporarily setting the download_file remote timeout to
     the local ``iers.conf.remote_timeout`` value.
     """
+    url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
+    if url in SPECIAL_HTTP_HEADERS_NEEDED:
+        kwargs['http_headers'] = SPECIAL_HTTP_HEADERS_NEEDED[url]
+
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)
 
@@ -677,9 +681,6 @@ class IERS_Auto(IERS_A):
 
         for url in all_urls:
             try:
-                http_headers = {}
-                if url in SPECIAL_HTTP_HEADERS_NEEDED:
-                    http_headers.update(SPECIAL_HTTP_HEADERS_NEEDED[url])
                 filename = download_file(url, cache=True)
             except Exception as err:
                 err_list.append(str(err))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -43,10 +43,16 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
            'LeapSeconds', 'IERS_LEAP_SECOND_FILE', 'IERS_LEAP_SECOND_URL',
            'IETF_LEAP_SECOND_URL']
 
+# maps specific download urls to the additional http headers needed for them -
+# populated where specific urls are given below.
+SPECIAL_HTTP_HEADERS_NEEDED = {}
+
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
 IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
+SPECIAL_HTTP_HEADERS_NEEDED[IERS_A_URL_MIRROR] = {'User-Agent': 'astropy/iers',
+                                                  'Accept': '*/*'}
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
 # IERS-B default file name, URL, and ReadMe with content description
@@ -671,6 +677,9 @@ class IERS_Auto(IERS_A):
 
         for url in all_urls:
             try:
+                http_headers = {}
+                if url in SPECIAL_HTTP_HEADERS_NEEDED:
+                    http_headers.update(SPECIAL_HTTP_HEADERS_NEEDED[url])
                 filename = download_file(url, cache=True)
             except Exception as err:
                 err_list.append(str(err))

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -90,7 +90,6 @@ def download_file(*args, **kwargs):
     ``**kwargs`` after temporarily setting the download_file remote timeout to
     the local ``iers.conf.remote_timeout`` value.
     """
-    url = kwargs.get('remote_url', args[0] if len(args) > 0 else None)
     kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
                                        'Accept': '*/*'})
 

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -330,10 +330,21 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
 @pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
 @pytest.mark.remote_data
 def test_iers_a_dl(iersa_url):
-    iers_tab = iers.IERS_A.open(iersa_url, cache=False)
+    iersa_tab = iers.IERS_A.open(iersa_url, cache=False)
     try:
         # some basic checks to ensure the format makes sense
-        assert len(iers_tab) > 0
-        assert 'UT1_UTC_A' in iers_tab.colnames
+        assert len(iersa_tab) > 0
+        assert 'UT1_UTC_A' in iersa_tab.colnames
     finally:
         iers.IERS_A.close()
+
+
+@pytest.mark.remote_data
+def test_iers_b_dl():
+    iersb_tab = iers.IERS_B.open(iers.IERS_B_URL, cache=False)
+    try:
+        # some basic checks to ensure the format makes sense
+        assert len(iersb_tab) > 0
+        assert 'UT1_UTC' in iersb_tab.colnames
+    finally:
+        iers.IERS_B.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -325,3 +325,15 @@ def test_IERS_B_parameters_loading_into_IERS_Auto():
             A[name][ok_A], B[name][i_B], rtol=1e-15,
             err_msg=("Bug #9206 IERS B parameter {} not copied over "
                      "correctly to IERS Auto".format(name)))
+
+
+@pytest.mark.parametrize('iersa_url', [iers.IERS_A_URL, iers.IERS_A_URL_MIRROR])
+@pytest.mark.remote_data
+def test_iers_a_dl(iersa_url):
+    iers_tab = iers.IERS_A.open(iersa_url, cache=False)
+    try:
+        # some basic checks to ensure the format makes sense
+        assert len(iers_tab) > 0
+        assert 'UT1_UTC_A' in iers_tab.colnames
+    finally:
+        iers.IERS_A.close()

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -159,7 +159,7 @@ class TestIERS_AExcerpt():
         assert len(iers_tab[:2]) == 2
 
 
-@pytest.mark.skipif('not HAS_IERS_A')
+@pytest.mark.skipif(not HAS_IERS_A, reason="Does not have IERS_A file")
 class TestIERS_A():
 
     def test_simple(self):
@@ -202,6 +202,7 @@ class TestIERS_Auto():
         """
         iers.IERS_Auto.close()
 
+    @pytest.mark.remote_data
     def test_interpolate_error_formatting(self):
         """Regression test: make sure the error message in
         IERS_Auto._check_interpolate_indices() is formatted correctly.
@@ -219,6 +220,7 @@ class TestIERS_Auto():
                             iers_table.ut1_utc(self.t.jd1, self.t.jd2)
         assert str(err.value) == iers.INTERPOLATE_ERROR.format(self.ame)
 
+    @pytest.mark.remote_data
     def test_auto_max_age_none(self):
         """Make sure that iers.INTERPOLATE_ERROR's advice about setting
         auto_max_age = None actually works.
@@ -231,6 +233,8 @@ class TestIERS_Auto():
         assert delta.shape == (self.N,)
         assert_quantity_allclose(delta, np.array([-0.2246227]*self.N)*u.s)
 
+
+    @pytest.mark.remote_data
     def test_auto_max_age_minimum(self):
         """Check that the minimum auto_max_age is enforced.
         """


### PR DESCRIPTION
At [Petabytes in Science](https://petabytestoscience.github.io/workshop-iii) Hack Sessions there was an attempt to, at least partially, resolve some of the issues with IERS code. Bellow follows a list of issues touched upon in discussions:

#### Reproducibility issues 

The reproducibility issue occurs when in tests one wants to assert that a particular set of computations was executed correctly. If that set of computations relies on IERS data then it is, currently, very difficult to get the same numerical values in the calculations because the underlying IERS dataset might change. 

These issues were already discussed at some details in issue https://github.com/astropy/astropy/issues/9227

#### Resiliency to network failures

There are multiple different failure modes that can occur related to various network connectivity or transfer failures:
i) network exists but connectivity is poor and IERS data gets corrupted during the download
ii) public networks with a [captive portal](https://en.wikipedia.org/wiki/Captive_portal) the portal gets downloaded instead of the IERS tables, depending on the underlying mechanism used to create the captive portal.

#### Progress made

The Resiliency to network failures was the problem that achieved more attention. The proposed solution is to calculate a checksum and compare it to the IERS provided checksum. 
To attempt the fix it was necessary to clone off of https://github.com/astropy/astropy/pull/9508 ergo the commit history mess. That should go away.

A sketch-code solution to the checksum verification is provided in the code in this draft PR. The sketch-code solution allows users to validate the data during IERS_Auto download.        
A fuller solution would be to allow users to validate both IERS_A and IERS_B too. It would also be good to be able to validate the data held by object itself at any point in time. 

The proposed complete solution to this issue would then make `validate` a part of IERS class interface. Within the `validate` functionality a checksum of the `IERS.iers_table` would be calculated and compared to the official checksum released by IERS. 
For practical purposes I propose that the checksum is downloaded from CDDIS every time. 

I am still undecided on several aspects of this:

* checksums are only hosted by CDDIS
* yet another point of network failure
* should checksum be stored in cache along with the table,  at download time?
    * This is very complicated because people can claim validation, both having different cached checksums, but see different numbers. There is a case to make that data is valid as long as its equal to the downloaded, at the time, version. Perhaps that's what we want to call validation - at download time check if hosted checksum corresponds to calculated one, one time only, and store that checksum for all future validations.
* Easier to reason about validation is just saying: "your file is equal to the hosted one". I prefer this one.

Because of additional network points of failure introduced it would be good to add functionality that more finely combs the point of failure and specifies whether it is the internet connection or the end ftp server that is not reachable. Additionally, stringifying the current `IERS.iers_table` doesn't produce the same output as the loaded table, and neither does the `write` method. These issues should be fixed before draft PR becomes a PR. 

Even though reproducibility was discussed at length at the hack sessions I don't think it should be touched by this PR and a new one would be more appropriate.