### PR TITLE
Test for warnings when writing read-only cache

### DIFF
--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1289,8 +1289,9 @@ def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
             # as far as that is possible?
         with pytest.warns(CacheMissingWarning):
             assert not is_url_in_cache(u)
-        with pytest.raises(OSError):
-            check_download_cache()
+        with pytest.warns(CacheMissingWarning):
+            with pytest.raises(OSError):
+                check_download_cache()
 
     # set_temp_cache acts weird if it is pointed at a file (see below)
     # but we want to see what happens when the cache is pointed
@@ -1584,14 +1585,16 @@ def test_download_file_cache_readonly(readonly_cache):
 
 def test_download_file_cache_readonly_cache_miss(readonly_cache, valid_urls):
     u, c = next(valid_urls)
-    f = download_file(u, cache=True)
+    with pytest.warns(CacheMissingWarning):
+        f = download_file(u, cache=True)
     assert get_file_contents(f) == c
     assert not is_url_in_cache(u)
 
 
 def test_download_file_cache_readonly_update(readonly_cache):
     for u in readonly_cache:
-        f = download_file(u, cache="update")
+        with pytest.warns(CacheMissingWarning):
+            f = download_file(u, cache="update")
         assert f != readonly_cache[u]
         assert compute_hash(f) == os.path.basename(readonly_cache[u])
 
@@ -1621,14 +1624,16 @@ def test_download_file_cache_fake_readonly(fake_readonly_cache):
 
 def test_download_file_cache_fake_readonly_cache_miss(fake_readonly_cache, valid_urls):
     u, c = next(valid_urls)
-    f = download_file(u, cache=True)
+    with pytest.warns(CacheMissingWarning):
+        f = download_file(u, cache=True)
     assert get_file_contents(f) == c
     assert not is_url_in_cache(u)
 
 
 def test_download_file_cache_fake_readonly_update(fake_readonly_cache):
     for u in fake_readonly_cache:
-        f = download_file(u, cache="update")
+        with pytest.warns(CacheMissingWarning):
+            f = download_file(u, cache="update")
         assert f != fake_readonly_cache[u]
         assert compute_hash(f) == os.path.basename(fake_readonly_cache[u])
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is part of #7928 and addresses the problem more directly than #9569 . In particular this version tries to ensure that CacheMissingWarnings are raised if and only if the user's intended operation needs to write to a read-only cache. (Or if the user needs to read from a non-existent cache.)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
