### PR TITLE
deprecate modeling.utils.ExpressionTree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -473,6 +473,8 @@ astropy.modeling
 - Deprecated and renamed ``MexicanHat1D`` and ``MexicanHat2D``
   to ``RickerWavelet1D`` and ``RickerWavelet2D``. [#9445]
 
+- Deprecated ``modeling.utils.ExpressionTree``. [#9576]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/tests/test_utils.py
+++ b/astropy/modeling/tests/test_utils.py
@@ -1,10 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import operator
 
 import numpy as np
 
+from astropy.tests.helper import catch_warnings
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.modeling.utils import ExpressionTree as ET, ellipse_extent
 from astropy.modeling.models import Ellipse2D
 
@@ -15,9 +16,9 @@ def test_traverse_postorder_duplicate_subtrees():
     where given an expression like ``(1 + 2) + (1 + 2)`` where the two proper
     subtrees are actually the same object.
     """
-
-    subtree = ET('+', ET(1), ET(2))
-    tree = ET('+', subtree, subtree)
+    with catch_warnings(AstropyDeprecationWarning):
+        subtree = ET('+', ET(1), ET(2))
+        tree = ET('+', subtree, subtree)
     traversal = [n.value for n in tree.traverse_postorder()]
     assert traversal == [1, 2, '+', 1, 2, '+', '+']
 
@@ -31,9 +32,10 @@ def test_tree_evaluate_subexpression():
                  '/': operator.truediv, '**': operator.pow}
     # The full expression represented by this tree is:
     # 1.0 + 2 - 3 * 4 / 5 ** 6 (= 2.999232 if you must know)
-    tree = ET('+', ET(1.0), ET('-', ET(2.0),
-                   ET('*', ET(3.0), ET('/', ET(4.0),
-                   ET('**', ET(5.0), ET(6.0))))))
+    with catch_warnings(AstropyDeprecationWarning):
+        tree = ET('+', ET(1.0), ET('-', ET(2.0),
+                                   ET('*', ET(3.0), ET('/', ET(4.0),
+                                                       ET('**', ET(5.0), ET(6.0))))))
 
     def test_slice(start, stop, expected):
         assert np.allclose(tree.evaluate(operators, start=start, stop=stop),

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -9,9 +9,8 @@ from collections.abc import MutableMapping
 from inspect import signature
 
 import numpy as np
-
+from astropy.utils.decorators import deprecated
 from astropy.utils import isiterable, check_broadcast
-from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy import units as u
 
@@ -19,12 +18,11 @@ __all__ = ['ExpressionTree', 'AliasDict', 'check_broadcast',
            'poly_map_domain', 'comb', 'ellipse_extent']
 
 
+@deprecated('4.0')
 class ExpressionTree:
     __slots__ = ['left', 'right', 'value', 'inputs', 'outputs']
 
     def __init__(self, value, left=None, right=None, inputs=None, outputs=None):
-        raise AstropyDeprecationWarning('The "ExpressionTree" class has been '
-                                        'deprecated and will be removed in v 4.1.')
         self.value = value
         self.inputs = inputs
         self.outputs = outputs
@@ -514,7 +512,7 @@ class _BoundingBox(tuple):
                 valid_shape = False
 
             if not isiterable(bounding_box) or not valid_shape:
-                    raise ValueError(MESSAGE)
+                raise ValueError(MESSAGE)
 
             return cls(tuple(bounds) for bounds in bounding_box)
 

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -11,6 +11,7 @@ from inspect import signature
 import numpy as np
 
 from astropy.utils import isiterable, check_broadcast
+from astropy.utils.exceptions import AstropyDeprecationWarning
 
 from astropy import units as u
 
@@ -22,6 +23,8 @@ class ExpressionTree:
     __slots__ = ['left', 'right', 'value', 'inputs', 'outputs']
 
     def __init__(self, value, left=None, right=None, inputs=None, outputs=None):
+        raise AstropyDeprecationWarning('The "ExpressionTree" class has been '
+                                        'deprecated and will be removed in v 4.1.')
         self.value = value
         self.inputs = inputs
         self.outputs = outputs


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request deprecates the public class `modeling.utils.ExpressionTree`.
It is not used in modeling or any other subpackage any more. Is there a reason to keep it?

EDIT: Close #4077 