### PR TITLE
BUG: Ensure |jd2|<=0.5 

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -787,10 +787,10 @@ class Time(ShapedLikeNDArray):
             conv_func = getattr(erfa, sys1 + sys2)
             jd1, jd2 = conv_func(*args)
 
+        jd1, jd2 = day_frac(jd1, jd2)
         if self.masked:
             jd2[self.mask] = np.nan
 
-        jd1, jd2 = day_frac(jd1, jd2)
         self._time = self.FORMATS[self.format](jd1, jd2, scale, self.precision,
                                                self.in_subfmt, self.out_subfmt,
                                                from_jd=True)

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -790,6 +790,7 @@ class Time(ShapedLikeNDArray):
         if self.masked:
             jd2[self.mask] = np.nan
 
+        jd1, jd2 = day_frac(jd1, jd2)
         self._time = self.FORMATS[self.format](jd1, jd2, scale, self.precision,
                                                self.in_subfmt, self.out_subfmt,
                                                from_jd=True)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -170,3 +170,27 @@ def test_mjd_initialization_precise():
     jd1, jd2 = day_frac(i + erfa.DJM0, f)
     jd1_t, jd2_t = day_frac(t.jd1, t.jd2)
     assert (abs((jd1-jd1_t) + (jd2-jd2_t))*u.day).to(u.ns) < 1*u.ns
+
+
+def test_conversion_preserves_jd1_jd2_invariant():
+    """Conversion can leave jd1 not an integer"""
+    scale1 = 'tai'
+    scale2 = 'tcb'
+    jd1, jd2 = 0., 0.
+    t = Time(jd1, jd2, scale=scale1, format="jd")
+    t2 = getattr(t, scale2)
+    assert t2.jd1 % 1 == 0
+    assert abs(t2.jd2) <= 0.5
+    assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0
+
+
+def test_conversion_preserves_jd1_jd2_invariant_2():
+    """Conversion can leave abs(jd2)>0.5"""
+    scale1 = 'tai'
+    scale2 = 'tcb'
+    jd1, jd2 = (2441316.5, 0.0)
+    t = Time(jd1, jd2, scale=scale1, format="jd")
+    t2 = getattr(t, scale2)
+    assert t2.jd1 % 1 == 0
+    assert abs(t2.jd2) <= 0.5
+    assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -31,7 +31,8 @@ class TestERFATestCases:
     # reproduce this exactly. Now it does not really matter,
     # but may as well fake this (and avoid IERS table lookup here)
     time_ut1.delta_ut1_utc = 0.
-    time_ut1.delta_ut1_utc = 24*3600*(((time_ut1.tt.jd2-time_tt.jd2)+0.5)%1-0.5)
+    time_ut1.delta_ut1_utc = 24*3600*(
+        (time_ut1.tt.jd1-time_tt.jd1) + (time_ut1.tt.jd2-time_tt.jd2))
     assert np.allclose(time_ut1.tt.jd2 - time_tt.jd2, 0., atol=1.e-14)
 
     @pytest.mark.parametrize('erfa_test_input',

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -33,7 +33,9 @@ class TestERFATestCases:
     time_ut1.delta_ut1_utc = 0.
     time_ut1.delta_ut1_utc = 24*3600*(
         (time_ut1.tt.jd1-time_tt.jd1) + (time_ut1.tt.jd2-time_tt.jd2))
-    assert np.allclose(time_ut1.tt.jd2 - time_tt.jd2, 0., atol=1.e-14)
+    assert np.allclose((time_ut1.tt.jd1-time_tt.jd1)
+                       + (time_ut1.tt.jd2 - time_tt.jd2),
+                       0., atol=1.e-14)
 
     @pytest.mark.parametrize('erfa_test_input',
                              ((1.754174972210740592, 1e-12, "eraGmst00"),

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -31,7 +31,7 @@ class TestERFATestCases:
     # reproduce this exactly. Now it does not really matter,
     # but may as well fake this (and avoid IERS table lookup here)
     time_ut1.delta_ut1_utc = 0.
-    time_ut1.delta_ut1_utc = 24*3600*(time_ut1.tt.jd2-time_tt.jd2)
+    time_ut1.delta_ut1_utc = 24*3600*(((time_ut1.tt.jd2-time_tt.jd2)+0.5)%1-0.5)
     assert np.allclose(time_ut1.tt.jd2 - time_tt.jd2, 0., atol=1.e-14)
 
     @pytest.mark.parametrize('erfa_test_input',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Ensures format conversion leaves abs(jd2)<=0.5

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

EDIT: Fix #9533 