### PR TITLE
Fix bug in the frame attributes references for Galactocentric frame

### DIFF
--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -337,12 +337,13 @@ class Galactocentric(BaseCoordinateFrame):
 
         warn = False
         for k in default_params:
-            # If a frame attribute is set by the user, remove its reference
-            self.frame_attribute_references.pop(k, None)
+            if k in kwargs:
+                # If a frame attribute is set by the user, remove its reference
+                self.frame_attribute_references.pop(k, None)
 
-            # If a parameter is read from the defaults, we might want to warn
-            # the user that the defaults will change (see below)
-            if k not in kwargs:
+            else:
+                # If a parameter is read from the defaults, we might want to
+                # warn the user that the defaults will change (see below)
                 warn = True
 
             # Keep the frame attribute if it is set by the user, otherwise use

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1141,14 +1141,19 @@ def test_component_names_repr():
     assert repr(frame).count("JUSTONCE") == 1
 
 
+@pytest.fixture
 def reset_galactocentric_defaults():
     # TODO: this can be removed, along with the "warning" test below, once we
     # switch the default to 'latest' in v4.1
     from astropy.coordinates import galactocentric_frame_defaults
+
+    # Resets before each test, and after (the yield is pytest magic)
+    galactocentric_frame_defaults._value = 'pre-v4.0'
+    yield
     galactocentric_frame_defaults._value = 'pre-v4.0'
 
 
-def test_galactocentric_defaults():
+def test_galactocentric_defaults(reset_galactocentric_defaults):
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults,
                                      BaseCoordinateFrame,
@@ -1178,16 +1183,14 @@ def test_galactocentric_defaults():
         else:
             assert getattr(galcen_40, k) == getattr(galcen_latest, k)
 
-    reset_galactocentric_defaults()
 
-
-def test_galactocentric_default_warning():
+def test_galactocentric_default_warning(reset_galactocentric_defaults):
     from astropy.coordinates import (Galactocentric,
                                      galactocentric_frame_defaults)
 
     # Note: this is necessary because the doctests may alter the state of the
     # class globally and simultaneously when the tests are run in parallel
-    reset_galactocentric_defaults()
+    # reset_galactocentric_defaults()
 
     # Make sure a warning is thrown if the frame is created with no args
     with pytest.warns(AstropyDeprecationWarning,
@@ -1203,10 +1206,8 @@ def test_galactocentric_default_warning():
     with galactocentric_frame_defaults.set('latest'):
         Galactocentric()
 
-    reset_galactocentric_defaults()
 
-
-def test_galactocentric_references():
+def test_galactocentric_references(reset_galactocentric_defaults):
     # references in the "scientific paper"-sense
 
     from astropy.coordinates import (Galactocentric,
@@ -1243,5 +1244,3 @@ def test_galactocentric_references():
                 assert k not in galcen_custom.frame_attribute_references
             else:
                 assert k in galcen_custom.frame_attribute_references
-
-    reset_galactocentric_defaults()

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1204,3 +1204,44 @@ def test_galactocentric_default_warning():
         Galactocentric()
 
     reset_galactocentric_defaults()
+
+
+def test_galactocentric_references():
+    # references in the "scientific paper"-sense
+
+    from astropy.coordinates import (Galactocentric,
+                                     galactocentric_frame_defaults,
+                                     BaseCoordinateFrame,
+                                     CartesianDifferential)
+
+    with galactocentric_frame_defaults.set('pre-v4.0'):
+        galcen_pre40 = Galactocentric()
+
+        for k in galcen_pre40.get_frame_attr_names():
+            if k == 'roll':  # no reference for this parameter
+                continue
+
+            assert k in galcen_pre40.frame_attribute_references
+
+    with galactocentric_frame_defaults.set('v4.0'):
+        galcen_40 = Galactocentric()
+
+        for k in galcen_40.get_frame_attr_names():
+            if k == 'roll':  # no reference for this parameter
+                continue
+
+            assert k in galcen_40.frame_attribute_references
+
+    with galactocentric_frame_defaults.set('v4.0'):
+        galcen_custom = Galactocentric(z_sun=15*u.pc)
+
+        for k in galcen_custom.get_frame_attr_names():
+            if k == 'roll':  # no reference for this parameter
+                continue
+
+            if k == 'z_sun':
+                assert k not in galcen_custom.frame_attribute_references
+            else:
+                assert k in galcen_custom.frame_attribute_references
+
+    reset_galactocentric_defaults()


### PR DESCRIPTION
### Description
 
While working on astrofrog/astropy#91 to write a what's new entry for the changes to `Galactocentric`, I noticed that the dictionary of references (i.e. scientific papers that the parameter values come from) was not being properly handled. This adjusts the logic to fix how references are stored, and adds a test. 