### PR TITLE
Build documentation in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
 
   html-docs:
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
             flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
       - run:
           name: Build Docs
-          command: venv/bin/python setup.py build_docs -w
+          command: venv/bin/python setup.py build_docs -w --parallel=4
           environment:
             LC_CTYPE: C
             LC_ALL: C

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,14 +115,14 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install numpydoc matplotlib sphinx
-            pip install .[docs,all]
+            pip install numpydoc matplotlib sphinx --progress-bar off
+            pip install .[docs,all] --progress-bar off
       - run:
           name: Make sure flake8 passes
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install flake8
+            pip install flake8 --progress-bar off
             # select options should be the same as in the travis config
             flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
       - run:


### PR DESCRIPTION
This is an experimental/work in progress PR to try and build the astropy docs in parallel. I'm running into errors locally, so I wanted to open this PR to make it easier to test this in an isolated/reproducible environment. Once this works we can make the CircleCI build work in parallel for speed and to prevent any regressions in being able to build in parallel.

Build stats locally:

Serial mode:

```
real    4m6.100s
user    4m26.864s
sys     0m26.069s
```

Parallel with ``-j 2``

```
real    2m41.556s
user    4m53.928s
sys     0m31.940s
```

Parallel with ``-j 4``

```
real    2m17.576s
user    5m8.778s
sys     0m33.250s
```

Parallel with ``-j 16``

```
real    1m40.609s
user    6m42.726s
sys     0m35.352s
```

On CircleCi the HTML build part of the job goes from 8m to 2:20m (which makes sense since we only get 4x parallelization at most).

For now the writing isn't parallel so that could probably be sped up a bit more (edit: this is because of sphinx-gallery which is explicitly unsafe for parallel writing, see https://github.com/sphinx-gallery/sphinx-gallery/issues/560). In addition there are a couple of pages that seem to be dominating the time such that towards the end of the read only a couple of processes are running, so perhaps more room for optimization there.

Things that are needed before I can clean up and finalize this PR:
* [x] Fix for rst_epilog warnings (https://github.com/astropy/astropy/pull/9599)
* [x] sphinx-astropy release (to include https://github.com/astropy/sphinx-astropy/pull/26)
* [x] sphinx-gallery needs to be marked as parallel-safe (https://github.com/sphinx-gallery/sphinx-gallery/pull/561)
* [x] https://github.com/astropy/astropy/issues/9586 needs to be fixed
* [x] Expose a ``--parallel`` option in astropy-helpers that would set ``-j auto`` (https://github.com/astropy/astropy-helpers/pull/498)
* [ ] Matplotlib v3.2.0 release (which will include https://github.com/matplotlib/matplotlib/pull/14535)

For the last one we may not want to do that if astropy-helpers is going away - instead we could just set ``-j auto`` in the Makefile so that people doing manual builds benefit from this but we don't change anything for people using ``python setup.py build_docs``
