### PR TITLE
Improve test runner error when pytest dependency is missing

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -176,7 +176,6 @@ class TestRunnerBase:
         "have a previous version installed, e.g., "
         "'pip install pytest-astropy --upgrade' or the equivalent with conda).")
 
-
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
         # Using the test runner will not work without these dependencies, but

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -170,7 +170,11 @@ class TestRunnerBase:
         """
 
     _required_dependencies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus', 'pytest_astropy_header']
-    _missing_dependancy_error = "Test dependencies are missing. You should install the 'pytest-astropy' package."
+    _missing_dependancy_error = ("Test dependencies are missing: {module}. You "
+                                 "should install the 'pytest-astropy' package "
+                                 "(you may need to run `pip install "
+                                 "pytest-astropy --upgrade` if you have a "
+                                 "previous version installed).")
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover
@@ -180,7 +184,8 @@ class TestRunnerBase:
             spec = find_spec(module)
             # Checking loader accounts for packages that were uninstalled
             if spec is None or spec.loader is None:
-                raise RuntimeError(cls._missing_dependancy_error)
+                raise RuntimeError(
+                    cls._missing_dependancy_error.format(module=module))
 
     def run_tests(self, **kwargs):
 

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -170,11 +170,12 @@ class TestRunnerBase:
         """
 
     _required_dependencies = ['pytest', 'pytest_remotedata', 'pytest_doctestplus', 'pytest_astropy_header']
-    _missing_dependancy_error = ("Test dependencies are missing: {module}. You "
-                                 "should install the 'pytest-astropy' package "
-                                 "(you may need to run `pip install "
-                                 "pytest-astropy --upgrade` if you have a "
-                                 "previous version installed).")
+    _missing_dependancy_error = (
+        "Test dependencies are missing: {module}. You should install the "
+        "'pytest-astropy' package (you may need to update the package if you "
+        "have a previous version installed, e.g., "
+        "`pip install pytest-astropy --upgrade` or the equivalent with conda).")
+
 
     @classmethod
     def _has_test_dependencies(cls):  # pragma: no cover

--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -174,7 +174,7 @@ class TestRunnerBase:
         "Test dependencies are missing: {module}. You should install the "
         "'pytest-astropy' package (you may need to update the package if you "
         "have a previous version installed, e.g., "
-        "`pip install pytest-astropy --upgrade` or the equivalent with conda).")
+        "'pip install pytest-astropy --upgrade' or the equivalent with conda).")
 
 
     @classmethod


### PR DESCRIPTION
This just adds a bit more information to the `RuntimeError` that is thrown when running tests with the Astropy test runner and a pytest dependency is missing.

As noted by @astrofrog, it might be even better to require a minimum version of `pytest-astropy`, and check for that version when executing the test runner