### PR TITLE
Handle FITS doc warnings

### DIFF
--- a/docs/io/fits/usage/headers.rst
+++ b/docs/io/fits/usage/headers.rst
@@ -305,10 +305,11 @@ the example below is flagged by such verification. More about verification in
 
 ::
 
-    >>> c1 = fits.Card.fromstring('ABC = 3.456D023')
+    >>> c1 = fits.Card.fromstring('ABC     = 3.456D023')
     >>> c2 = fits.Card.fromstring("P.I. ='Hubble'")
-    >>> print(c1); print(c2)
-    ABC     =            3.456D023
+    >>> print(c1)
+    ABC     = 3.456D023
+    >>> print(c2)  # doctest: +SKIP
     P.I. ='Hubble'
     >>> c2.verify()  # doctest: +SKIP
     Output verification result:
@@ -405,8 +406,8 @@ Examples
 more than eight characters::
 
     >>> # this will result in a Warning because a HIERARCH card is implicitly created
-    >>> c = fits.Card('abcdefghi', 10)
-    >>> print(c)
+    >>> c = fits.Card('abcdefghi', 10)  # doctest: +SKIP
+    >>> print(c)  # doctest: +SKIP
     HIERARCH abcdefghi = 10
     >>> c = fits.Card('hierarch abcdefghi', 10)
     >>> print(c)
@@ -441,5 +442,5 @@ more than eight characters::
     quirks of the FITS format, ``astropy`` tries to make it so that you have to
     think about it as little as possible. If there are any areas that are left
     vague or difficult to understand about how the header is constructed, please
-    let help@stsci.edu know, as there are probably areas where this can be
+    let us know, as there are probably areas where this can be
     improved on even more.

--- a/docs/io/fits/usage/image.rst
+++ b/docs/io/fits/usage/image.rst
@@ -187,10 +187,12 @@ To write scaled data with the `~ImageHDU.scale` method::
 
     >>> # scale the data to Int16 with user specified bscale/bzero
     >>> hdu.scale('int16', bzero=32768)
-    >>> # scale the data to Int32 with the min/max of the data range
-    >>> hdu.scale('int32', 'minmax')
-    >>> # scale the data, using the original BSCALE/BZERO
-    >>> hdu.scale('int32', 'old')
+    >>> # scale the data to Int32 with the min/max of the data range, emits
+    >>> # RuntimeWarning: overflow encountered in short_scalars
+    >>> hdu.scale('int32', 'minmax')  # doctest: +SKIP
+    >>> # scale the data, using the original BSCALE/BZERO, emits
+    >>> # RuntimeWarning: invalid value encountered in add
+    >>> hdu.scale('int32', 'old')  # doctest: +SKIP
     >>> hdul.close()
 
 The first example above shows how to store an unsigned short integer array.

--- a/docs/io/fits/usage/verification.rst
+++ b/docs/io/fits/usage/verification.rst
@@ -234,8 +234,8 @@ Fixable Cards:
 6. Unparsable values will be "fixed" as a string::
 
     >>> c = fits.Card.fromstring('FIX6    = 2 10 ')
-    >>> c.verify('fix+warn')
-    >>> print(c)
+    >>> c.verify('fix+warn')  # doctest: +SKIP
+    >>> print(c)  # doctest: +SKIP
     FIX6    = '2 10    '
 
 Unfixable Cards:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the remaining warnings from FITS doctest. People do not seem to like explicit warning handling in the doctest snippet, so I opted for `# doctest: +SKIP` instead unless I can fix it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is part of #7928 