### PR TITLE
Handle doctest warning in unified IO

### DIFF
--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -721,12 +721,15 @@ whether its unit is a FITS recognized time unit (``TUNITn`` is a time unit).
 For example, reading a Chandra event list which has the above mentioned header
 and the time coordinate column ``time`` as ``[1, 2]`` will give::
 
+    >>> import warnings
     >>> from astropy.table import Table
     >>> from astropy.time import Time, TimeDelta
     >>> from astropy.utils.data import get_pkg_data_filename
     >>> chandra_events = get_pkg_data_filename('data/chandra_time.fits',
     ...                                        package='astropy.io.fits.tests')
-    >>> native = Table.read(chandra_events, astropy_native=True)
+    >>> with warnings.catch_warnings():
+    ...     warnings.simplefilter('ignore')  # Ignore Time column warning
+    ...     native = Table.read(chandra_events, astropy_native=True)
     >>> native['time']  # doctest: +FLOAT_CMP
     <Time object: scale='tt' format='mjd' value=[57413.76033393 57413.76033393]>
     >>> non_native = Table.read(chandra_events)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the remaining doctest warning in unified I/O. Cannot skip the test and no sure how to fix the data. Warning is:

```
WARNING: Time column "time" reference position will be ignored due to
unspecified observatory position. [astropy.io.fits.fitstime]
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is part of #7928 
