### PR TITLE
Handle test warning from test_wcs.py

### DIFF
--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -641,6 +641,10 @@ def test_footprint_to_file(tmpdir):
         w.footprint_to_file(testfile)
 
 
+# Ignore FITSFixedWarning about keyrecords following the END keyrecord were
+# ignored, which comes from src/astropy_wcs.c . Only a blind catch like this
+# seems to work when pytest warnings are turned into exceptions.
+@pytest.mark.filterwarnings('ignore')
 def test_validate_faulty_wcs():
     """
     From github issue #2053


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the remaining warning in WCS tests. This one is tricky because it bubbled up from the deep C layers. I don't see it when I run the test code line by line in a Python session. `pytest` doesn't see it with I lay out `with pytest.warns` on the offending line, nor when I use `pytest.mark.filterwarnings` decorator on the function with explicit test class/message. Only a "blind catch" like this seems to work. 🤷‍♀ 

The warning raised as exception is as follows:
```
___________________________ test_validate_faulty_wcs ___________________________
    def test_validate_faulty_wcs():
        """
        From github issue #2053
        """
        h = fits.Header()
        # Illegal WCS:
        h['RADESYSA'] = 'ICRS'
        h['PV2_1'] = 1.0
        hdu = fits.PrimaryHDU([[0]], header=h)
        hdulist = fits.HDUList([hdu])
        # Check that this doesn't raise a NameError exception
>       wcs.validate(hdulist)
astropy/wcs/tests/test_wcs.py:655: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
astropy/wcs/wcs.py:3304: in validate
    fix=False, _do_set=False)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
header = SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                   64 / arra...                                      
PV2_1   =                  1.0                                                  
relax = 268435456, keysel = None, fix = False, translate_units = ''
_do_set = False
    def find_all_wcs(header, relax=True, keysel=None, fix=True,
                     translate_units='',
                     _do_set=True):
        """
        Find all the WCS transformations in the given header.
    
        Parameters
        ----------
        header : str or astropy.io.fits header object.
    
        relax : bool or int, optional
            Degree of permissiveness:
    
            - `True` (default): Admit all recognized informal extensions of the
              WCS standard.
    
            - `False`: Recognize only FITS keywords defined by the
              published WCS standard.
    
            - `int`: a bit field selecting specific extensions to accept.
              See :ref:`relaxread` for details.
    
        keysel : sequence of flags, optional
            A list of flags used to select the keyword types considered by
            wcslib.  When ``None``, only the standard image header
            keywords are considered (and the underlying wcspih() C
            function is called).  To use binary table image array or pixel
            list keywords, *keysel* must be set.
    
            Each element in the list should be one of the following strings:
    
                - 'image': Image header keywords
    
                - 'binary': Binary table image array keywords
    
                - 'pixel': Pixel list keywords
    
            Keywords such as ``EQUIna`` or ``RFRQna`` that are common to
            binary table image arrays and pixel lists (including
            ``WCSNna`` and ``TWCSna``) are selected by both 'binary' and
            'pixel'.
    
        fix : bool, optional
            When `True` (default), call `~astropy.wcs.Wcsprm.fix` on
            the resulting objects to fix any non-standard uses in the
            header.  `FITSFixedWarning` warnings will be emitted if any
            changes were made.
    
        translate_units : str, optional
            Specify which potentially unsafe translations of non-standard
            unit strings to perform.  By default, performs none.  See
            `WCS.fix` for more information about this parameter.  Only
            effective when ``fix`` is `True`.
    
        Returns
        -------
        wcses : list of `WCS` objects
        """
    
        if isinstance(header, (str, bytes)):
            header_string = header
        elif isinstance(header, fits.Header):
            header_string = header.tostring()
        else:
            raise TypeError(
                "header must be a string or astropy.io.fits.Header object")
    
        keysel_flags = _parse_keysel(keysel)
    
        if isinstance(header_string, str):
            header_bytes = header_string.encode('ascii')
        else:
            header_bytes = header_string
    
>       wcsprms = _wcs.find_all_wcs(header_bytes, relax, keysel_flags)
E       astropy.wcs.wcs.FITSFixedWarning: END 
E       keyrecords following the END keyrecord were ignored.
astropy/wcs/wcs.py:3204: FITSFixedWarning
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is part of #7928 