### PR TITLE
Handle test warning in test_precision.py

### DIFF
--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -10,6 +10,7 @@ import astropy._erfa as erfa
 from astropy.time import Time, TimeDelta
 from astropy.time.utils import day_frac, two_sum
 from astropy.utils import iers
+from astropy.utils.exceptions import ErfaWarning
 
 allclose_jd = functools.partial(np.allclose, rtol=2. ** -52, atol=0)
 allclose_jd2 = functools.partial(np.allclose, rtol=2. ** -52,
@@ -178,7 +179,10 @@ def test_conversion_preserves_jd1_jd2_invariant():
     scale2 = 'tcb'
     jd1, jd2 = 0., 0.
     t = Time(jd1, jd2, scale=scale1, format="jd")
-    t2 = getattr(t, scale2)
+    with pytest.warns(
+            ErfaWarning,
+            match=r'ERFA function "taiutc" yielded 1 of "dubious year'):
+        t2 = getattr(t, scale2)
     assert t2.jd1 % 1 == 0
     assert abs(t2.jd2) <= 0.5
     assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address test warning from a test added in #9577 . cc @aarchiba 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This is part of #7928 
