### PR TITLE
Fix unclosed file warning with nonstandard HDU.

### DIFF
--- a/astropy/io/fits/hdu/nonstandard.py
+++ b/astropy/io/fits/hdu/nonstandard.py
@@ -52,7 +52,10 @@ class FitsHDU(NonstandardExtHDU):
             Gzip compress the FITS file
         """
 
-        return cls.fromhdulist(HDUList.fromfile(filename), compress=compress)
+        hdulist = HDUList.fromfile(filename)
+        fitshdu = cls.fromhdulist(hdulist, compress=compress)
+        hdulist.close()
+        return fitshdu
 
     @classmethod
     def fromhdulist(cls, hdulist, compress=False):

--- a/astropy/io/fits/hdu/nonstandard.py
+++ b/astropy/io/fits/hdu/nonstandard.py
@@ -52,10 +52,8 @@ class FitsHDU(NonstandardExtHDU):
             Gzip compress the FITS file
         """
 
-        hdulist = HDUList.fromfile(filename)
-        fitshdu = cls.fromhdulist(hdulist, compress=compress)
-        hdulist.close()
-        return fitshdu
+        with HDUList.fromfile(filename) as hdulist:
+            return cls.fromhdulist(hdulist, compress=compress)
 
     @classmethod
     def fromhdulist(cls, hdulist, compress=False):


### PR DESCRIPTION
Fix another warning with `io.fits` :
```
astropy/io/fits/tests/test_nonstandard.py::TestNonstandardHdus::test_create_fitshdu_from_filename
  /home/simon/dev/astropy/astropy/io/fits/hdu/nonstandard.py:55: ResourceWarning: unclosed file <_io.FileIO name='/tmp/simon/fits-test-ulxk6ga8/test.fits' mode='rb' closefd=True>
    return cls.fromhdulist(HDUList.fromfile(filename), compress=compress)
```