### PR TITLE
Remove 'astropy' substitution from rst_epilog

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,6 @@ rst_epilog += """
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 
 .. Astropy
-.. _Astropy: http://astropy.org
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy
 .. _`astropy-dev mailing list`: http://groups.google.com/group/astropy-dev
 """.format(astropy)


### PR DESCRIPTION
This substitution is already defined in sphinx-astropy's rst_epilog which is inherited by astropy. This used to not be a problem but the rst_epilog in sphinx-astropy dev now points to a different URL which is causing sphinx warnings. The correct fix is to simply remove the substitution here.

If the CI passes, then this should hopefully be uncontroversial.