### PR TITLE
fix problem with fitting with tied constraints

### DIFF
--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1336,6 +1336,9 @@ def _fitter_to_model_params(model, fps):
         parameters[slice_] = values
         offset += size
 
+    # Update model parameters before calling ``tied`` constraints.
+    model._array_to_parameters()
+
     # This has to be done in a separate loop due to how tied parameters are
     # currently evaluated (the fitted parameters need to actually be *set* on
     # the model first, for use in evaluating the "tied" expression--it might be
@@ -1345,8 +1348,10 @@ def _fitter_to_model_params(model, fps):
             if model.tied[name]:
                 value = model.tied[name](model)
                 slice_ = param_metrics[name]['slice']
-                parameters[slice_] = value
-    model._array_to_parameters()
+                model.parameters[slice_] = value
+                # To handle multiple tied constraints, model parameters
+                # need to be updated after each iterration.
+                model._array_to_parameters()
 
 
 def _model_to_fit_params(model):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a bug in fitting with tied constraints. 
I can't come up with a simple failing test but found the problem while writing up an example.
The example is coming in a separate documentation PR and can serve as a test.

