### PR TITLE
table (hdf5): pass additional kwargs through to create_dataset() in write_table_hdf5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,9 @@ astropy.table
 - Added new ``Table`` method ``.round()``, which rounds numeric columns to the
   specified number of decimals. [#9862]
 
+- The HDF5 writer, ``write_table_hdf5()``, now allows passing through
+  additional keyword arguments to the ``h5py.Group.create_dataset()``. [#9602]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -253,7 +253,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
         If ``append=True`` and ``overwrite=True`` then only the dataset will be
         replaced; the file/group will not be overwritten.
     **create_dataset_kwargs
-        Additional keyword arguments are passed to `h5py.File.create_dataset`.
+        Additional keyword arguments are passed to
+        ``h5py.File.create_dataset()`` or ``h5py.Group.create_dataset()``.
     """
 
     from astropy.table import meta

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -222,7 +222,8 @@ def _encode_mixins(tbl):
 
 
 def write_table_hdf5(table, output, path=None, compression=False,
-                     append=False, overwrite=False, serialize_meta=False):
+                     append=False, overwrite=False, serialize_meta=False,
+                     create_dataset_kwargs=None):
     """
     Write a Table object to an HDF5 file
 
@@ -251,6 +252,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
         Whether to overwrite any existing file without warning.
         If ``append=True`` and ``overwrite=True`` then only the dataset will be
         replaced; the file/group will not be overwritten.
+    create_dataset_kwargs : `dict`
+        Additional keyword arguments are passed to `h5py.File.create_dataset`.
     """
 
     from astropy.table import meta
@@ -349,9 +352,11 @@ def write_table_hdf5(table, output, path=None, compression=False,
         if compression is True:
             compression = 'gzip'
         dset = output_group.create_dataset(name, data=table.as_array(),
-                                           compression=compression)
+                                           compression=compression,
+                                           **create_dataset_kwargs)
     else:
-        dset = output_group.create_dataset(name, data=table.as_array())
+        dset = output_group.create_dataset(name, data=table.as_array(),
+                                           **create_dataset_kwargs)
 
     if serialize_meta:
         header_yaml = meta.get_yaml_from_table(table)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -223,7 +223,7 @@ def _encode_mixins(tbl):
 
 def write_table_hdf5(table, output, path=None, compression=False,
                      append=False, overwrite=False, serialize_meta=False,
-                     create_dataset_kwargs=None):
+                     **create_dataset_kwargs):
     """
     Write a Table object to an HDF5 file
 
@@ -252,7 +252,7 @@ def write_table_hdf5(table, output, path=None, compression=False,
         Whether to overwrite any existing file without warning.
         If ``append=True`` and ``overwrite=True`` then only the dataset will be
         replaced; the file/group will not be overwritten.
-    create_dataset_kwargs : `dict`
+    **create_dataset_kwargs
         Additional keyword arguments are passed to `h5py.File.create_dataset`.
     """
 
@@ -267,9 +267,6 @@ def write_table_hdf5(table, output, path=None, compression=False,
         path = '__astropy_table__'
     elif path.endswith('/'):
         raise ValueError("table path should end with table name, not /")
-
-    if create_dataset_kwargs is None:
-        create_dataset_kwargs = dict()
 
     if '/' in path:
         group, name = path.rsplit('/', 1)

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -268,6 +268,9 @@ def write_table_hdf5(table, output, path=None, compression=False,
     elif path.endswith('/'):
         raise ValueError("table path should end with table name, not /")
 
+    if create_dataset_kwargs is None:
+        create_dataset_kwargs = dict()
+
     if '/' in path:
         group, name = path.rsplit('/', 1)
     else:

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -370,7 +370,6 @@ def test_write_create_dataset_kwargs(tmpdir):
     assert np.all(t3['a'] == [1, 2, 3, 4, 5])
 
 
-
 @pytest.mark.skipif('not HAS_H5PY')
 def test_write_filobj_group(tmpdir):
 

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -346,6 +346,32 @@ def test_write_fileobj(tmpdir):
 
 
 @pytest.mark.skipif('not HAS_H5PY')
+def test_write_create_dataset_kwargs(tmpdir):
+
+    test_file = str(tmpdir.join('test.hdf5'))
+    the_path = 'the_table'
+
+    import h5py
+    with h5py.File(test_file, 'w') as output_file:
+        t1 = Table()
+        t1.add_column(Column(name='a', data=[1, 2, 3]))
+        t1.write(output_file, path=the_path,
+                 create_dataset_kwargs=dict(maxshape=(None, )))
+
+    # A roundabout way of checking this, but the table created above should be
+    # resizable if the kwarg was passed through successfully
+    t2 = Table()
+    t2.add_column(Column(name='a', data=[4, 5]))
+    with h5py.File(test_file, 'a') as output_file:
+        output_file[the_path].resize((len(t1) + len(t2), ))
+        output_file[the_path][len(t1):] = t2.as_array()
+
+    t3 = Table.read(test_file, path='the_table')
+    assert np.all(t3['a'] == [1, 2, 3, 4, 5])
+
+
+
+@pytest.mark.skipif('not HAS_H5PY')
 def test_write_filobj_group(tmpdir):
 
     test_file = str(tmpdir.join('test.hdf5'))

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -356,7 +356,7 @@ def test_write_create_dataset_kwargs(tmpdir):
         t1 = Table()
         t1.add_column(Column(name='a', data=[1, 2, 3]))
         t1.write(output_file, path=the_path,
-                 create_dataset_kwargs=dict(maxshape=(None, )))
+                 maxshape=(None, ))
 
     # A roundabout way of checking this, but the table created above should be
     # resizable if the kwarg was passed through successfully


### PR DESCRIPTION
While thinking about #3320, and looking at the HDF5 table writer, I realized that there is no way to use `Table.write()` to pass through additional arguments to `h5py.File.create_dataset()` (some of its kwargs are added as kwargs to `write_table_hdf5()` itself, like `compression`, but there are many more optional kwargs in `h5py.File.create_dataset()`). This PR adds support for passing through additional kwargs, like `maxshape` or `chunks` (both of which are relevant for the discussion in #3320). 

Needs a changelog if this is something we would like to add...