### PR TITLE
Fix broken WCS transformation from ITRS to ICRS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -312,6 +312,11 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- The default WCS to celestial frame mapping for world coordinate systems that
+  specify ``TLON`` and ``TLAT`` coordinates will now return an ITRS frame with
+  the representation class set to ``SphericalRepresentation``. This fixes a bug
+  that caused ``WCS.pixel_to_world`` to raise an error for such world
+  coordinate systems. [#9609]
 
 
 Other Changes and Additions

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1149,3 +1149,22 @@ B_DMAX  =    44.62692873032506
 
     assert dists.max() < 7e-6*u.deg
     assert np.std(dists) < 2.5e-6*u.deg
+
+
+@pytest.mark.remote_data
+@pytest.mark.parametrize('x_in,y_in', [[0, 0], [np.arange(5), np.arange(5)]])
+def test_pixel_to_world_itrs(x_in, y_in):
+    """Regression test for https://github.com/astropy/astropy/pull/9609"""
+    wcs = WCS({'NAXIS': 2,
+               'CTYPE1': 'TLON-CAR',
+               'CTYPE2': 'TLAT-CAR',
+               'RADESYS': 'ITRS ',
+               'DATE-OBS': '2017-08-17T12:41:04.444'})
+
+    # This shouldn't raise an exception.
+    coord = wcs.pixel_to_world(x_in, y_in)
+
+    # Check round trip transformation.
+    x, y = wcs.world_to_pixel(coord)
+    np.testing.assert_almost_equal(x, x_in)
+    np.testing.assert_almost_equal(y, y_in)

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -48,7 +48,8 @@ def add_stokes_axis_to_wcs(wcs, add_before_ind):
 def _wcs_to_celestial_frame_builtin(wcs):
 
     # Import astropy.coordinates here to avoid circular imports
-    from astropy.coordinates import FK4, FK4NoETerms, FK5, ICRS, ITRS, Galactic
+    from astropy.coordinates import (FK4, FK4NoETerms, FK5, ICRS, ITRS,
+                                     Galactic, SphericalRepresentation)
 
     # Import astropy.time here otherwise setup.py fails before extensions are compiled
     from astropy.time import Time
@@ -93,7 +94,10 @@ def _wcs_to_celestial_frame_builtin(wcs):
         if xcoord == 'GLON' and ycoord == 'GLAT':
             frame = Galactic()
         elif xcoord == 'TLON' and ycoord == 'TLAT':
-            frame = ITRS(obstime=wcs.wcs.dateobs or None)
+            # The default representation for ITRS is cartesian, but for WCS
+            # purposes, we need the spherical representation.
+            frame = ITRS(representation_type=SphericalRepresentation,
+                         obstime=wcs.wcs.dateobs or None)
         else:
             frame = None
 


### PR DESCRIPTION
Astropy 3.2 broke the use of the reproject package to transform from a HEALPix image in ICRS coordinates to a WCS in ITRS coordinates. I can reproduce this with astropy 3.2.3 and master.

The reason is that the default representation for ITRS frames is cartesian, but WCS transformations require spherical representation.

I don't know exactly what changed in Astropy 3.2 that caused this; perhaps something deep within the SkyCoord machinery. This patch works around the issue by having `_wcs_to_celestial_frame_builtin` set the representation to `SphericalRepresentation` for a WCS in the ITRS frame.

Here is the example that was failing:

```pycon
>>> from astropy.io.fits import Header
>>> import numpy as np
>>> from reproject.healpix import reproject_from_healpix
>>> header = Header({'NAXIS': 2,
...                  'NAXIS1': 335,
...                  'NAXIS2': 168,
...                  'CRPIX1': 168.0,
...                  'CRPIX2': 84.5,
...                  'CRVAL1': 0,
...                  'CRVAL2': 0.0,
...                  'CDELT1': -0.9675041009449499,
...                  'CDELT2': 0.9646246244540423,
...                  'CTYPE1': 'TLON-AIT',
...                  'CTYPE2': 'TLAT-AIT',
...                  'RADESYS': 'ITRS ',
...                  'DATE-OBS': '2017-08-17T12:41:04.444'})
>>> hpx = np.zeros(12288)
>>> reproject_from_healpix((hpx, 'ICRS'), header, nested=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.7/site-packages/reproject/healpix/high_level.py", line 74, in reproject_from_healpix
    order=order, nested=nested)
  File "/usr/lib/python3.7/site-packages/reproject/healpix/core.py", line 59, in healpix_to_image
    world_in = wcs_out.pixel_to_world(xinds, yinds).transform_to(coord_system_in)
  File "/usr/lib/python3.7/site-packages/astropy/wcs/wcsapi/high_level_api.py", line 227, in pixel_to_world
    result.append(klass(*args[key], *ar, **kwargs[key], **kw))
  File "/usr/lib/python3.7/site-packages/astropy/coordinates/sky_coordinate.py", line 272, in __init__
    self._sky_coord_frame = frame_cls(copy=copy, **frame_kwargs)
  File "/usr/lib/python3.7/site-packages/astropy/coordinates/baseframe.py", line 507, in __init__
    **repr_kwargs)
  File "/usr/lib/python3.7/site-packages/astropy/coordinates/representation.py", line 1028, in __init__
    .format(self.__class__.__name__))
ValueError: x, y, and z are required to instantiate CartesianRepresentation
```
