### PR TITLE
Change pdf_* properties of Distribution to methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -592,6 +592,12 @@ astropy.uncertainty
   yielding new distributions of the kind expected for the starting distribution,
   and ``to_value`` yielding ``NdarrayDistribution`` instances. [#9429, #9442]
 
+- The ``pdf_*`` properties that were used to calculate statistical properties
+  of ``Distrubution`` instances were changed into methods. This allows one
+  to pass parameters such as ``ddof`` to ``pdf_std`` and ``pdf_var`` (which
+  generally should equal 1 instead of the default 0), and reflects that these
+  are fairly involved calcuations, not just "properties". [#9613]
+
 astropy.units
 ^^^^^^^^^^^^^
 

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -124,48 +124,74 @@ class Distribution:
         """
         return self.dtype['samples'].shape[0]
 
-    @property
-    def pdf_mean(self):
+    def pdf_mean(self, dtype=None, out=None):
         """
         The mean of this distribution.
-        """
-        return self.distribution.mean(axis=-1)
 
-    @property
-    def pdf_std(self):
+        Arguments are as for `numpy.mean`.
+        """
+        return self.distribution.mean(axis=-1, dtype=dtype, out=out)
+
+    def pdf_std(self, dtype=None, out=None, ddof=0):
         """
         The standard deviation of this distribution.
-        """
-        return self.distribution.std(axis=-1)
 
-    @property
-    def pdf_var(self):
+        Arguments are as for `numpy.std`.
+        """
+        return self.distribution.std(axis=-1, dtype=dtype, out=out, ddof=ddof)
+
+    def pdf_var(self, dtype=None, out=None, ddof=0):
         """
         The variance of this distribution.
-        """
-        return self.distribution.var(axis=-1)
 
-    @property
-    def pdf_median(self):
+        Arguments are as for `numpy.var`.
+        """
+        return self.distribution.var(axis=-1, dtype=dtype, out=out, ddof=ddof)
+
+    def pdf_median(self, out=None):
         """
         The median of this distribution.
-        """
-        return np.median(self.distribution, axis=-1)
 
-    @property
-    def pdf_mad(self):
+        Parameters
+        ----------
+        out : array, optional
+            Alternative output array in which to place the result. It must
+            have the same shape and buffer length as the expected output,
+            but the type (of the output) will be cast if necessary.
+        """
+        return np.median(self.distribution, axis=-1, out=out)
+
+    def pdf_mad(self, out=None):
         """
         The median absolute deviation of this distribution.
-        """
-        return np.abs(self - self.pdf_median).pdf_median
 
-    @property
-    def pdf_smad(self):
+        Parameters
+        ----------
+        out : array, optional
+            Alternative output array in which to place the result. It must
+            have the same shape and buffer length as the expected output,
+            but the type (of the output) will be cast if necessary.
+        """
+        median = self.pdf_median(out=out)
+        absdiff = np.abs(self - median)
+        return np.median(absdiff.distribution, axis=-1, out=median,
+                         overwrite_input=True)
+
+    def pdf_smad(self, out=None):
         """
         The median absolute deviation of this distribution rescaled to match the
         standard deviation for a normal distribution.
+
+        Parameters
+        ----------
+        out : array, optional
+            Alternative output array in which to place the result. It must
+            have the same shape and buffer length as the expected output,
+            but the type (of the output) will be cast if necessary.
         """
-        return self.pdf_mad * SMAD_SCALE_FACTOR
+        result = self.pdf_mad(out=out)
+        result *= SMAD_SCALE_FACTOR
+        return result
 
     def pdf_percentiles(self, percentile, **kwargs):
         """

--- a/astropy/uncertainty/tests/test_distribution.py
+++ b/astropy/uncertainty/tests/test_distribution.py
@@ -82,62 +82,100 @@ class TestDistributionStatistics():
     def test_pdf_mean(self):
         # Mean of each PDF
         expected = np.mean(self.data, axis=-1) * self.distr.unit
-        assert_quantity_allclose(self.distr.pdf_mean, expected)
-        assert_quantity_allclose(self.distr.pdf_mean, [1, 2, 3, 4] * self.distr.unit, rtol=0.05)
+        pdf_mean = self.distr.pdf_mean()
+        assert_quantity_allclose(pdf_mean, expected)
+        assert_quantity_allclose(pdf_mean, [1, 2, 3, 4] * self.distr.unit, rtol=0.05)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
-        assert not isinstance(self.distr.pdf_mean, Distribution)
-        assert isinstance(self.distr.pdf_mean, u.Quantity)
+        assert not isinstance(pdf_mean, Distribution)
+        assert isinstance(pdf_mean, u.Quantity)
+
+        # Check with out argument.
+        out = pdf_mean * 0.
+        pdf_mean2 = self.distr.pdf_mean(out=out)
+        assert pdf_mean2 is out
+        assert np.all(pdf_mean2 == pdf_mean)
 
     def test_pdf_std(self):
         # Standard deviation of each PDF
         expected = np.std(self.data, axis=-1) * self.distr.unit
-        assert_quantity_allclose(self.distr.pdf_std, expected)
-        assert_quantity_allclose(self.distr.pdf_std, [3, 2, 4, 5] * self.distr.unit, rtol=0.05)
+        pdf_std = self.distr.pdf_std()
+        assert_quantity_allclose(pdf_std, expected)
+        assert_quantity_allclose(pdf_std, [3, 2, 4, 5] * self.distr.unit, rtol=0.05)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
-        assert not isinstance(self.distr.pdf_std, Distribution)
-        assert isinstance(self.distr.pdf_std, u.Quantity)
+        assert not isinstance(pdf_std, Distribution)
+        assert isinstance(pdf_std, u.Quantity)
+
+        # Check with proper ddof, using out argument.
+        out = pdf_std * 0.
+        expected = np.std(self.data, axis=-1, ddof=1) * self.distr.unit
+        pdf_std2 = self.distr.pdf_std(ddof=1, out=out)
+        assert pdf_std2 is out
+        assert np.all(pdf_std2 == expected)
 
     def test_pdf_var(self):
         # Variance of each PDF
         expected = np.var(self.data, axis=-1) * self.distr.unit**2
-        assert_quantity_allclose(self.distr.pdf_var, expected)
-        assert_quantity_allclose(self.distr.pdf_var, [9, 4, 16, 25] * self.distr.unit**2, rtol=0.1)
+        pdf_var = self.distr.pdf_var()
+        assert_quantity_allclose(pdf_var, expected)
+        assert_quantity_allclose(pdf_var, [9, 4, 16, 25] * self.distr.unit**2, rtol=0.1)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
-        assert not isinstance(self.distr.pdf_var, Distribution)
-        assert isinstance(self.distr.pdf_var, u.Quantity)
+        assert not isinstance(pdf_var, Distribution)
+        assert isinstance(pdf_var, u.Quantity)
+
+        # Check with proper ddof, using out argument.
+        out = pdf_var * 0.
+        expected = np.var(self.data, axis=-1, ddof=1) * self.distr.unit**2
+        pdf_var2 = self.distr.pdf_var(ddof=1, out=out)
+        assert pdf_var2 is out
+        assert np.all(pdf_var2 == expected)
 
     def test_pdf_median(self):
         # Median of each PDF
         expected = np.median(self.data, axis=-1) * self.distr.unit
-        assert_quantity_allclose(self.distr.pdf_median, expected)
-        assert_quantity_allclose(self.distr.pdf_median, [1, 2, 3, 4] * self.distr.unit, rtol=0.1)
+        pdf_median = self.distr.pdf_median()
+        assert_quantity_allclose(pdf_median, expected)
+        assert_quantity_allclose(pdf_median, [1, 2, 3, 4] * self.distr.unit, rtol=0.1)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
-        assert not isinstance(self.distr.pdf_median, Distribution)
-        assert isinstance(self.distr.pdf_median, u.Quantity)
+        assert not isinstance(pdf_median, Distribution)
+        assert isinstance(pdf_median, u.Quantity)
+
+        # Check with out argument.
+        out = pdf_median * 0.
+        pdf_median2 = self.distr.pdf_median(out=out)
+        assert pdf_median2 is out
+        assert np.all(pdf_median2 == expected)
 
     @pytest.mark.skipif(not HAS_SCIPY, reason='no scipy')
     def test_pdf_mad_smad(self):
         # Median absolute deviation of each PDF
         median = np.median(self.data, axis=-1, keepdims=True)
         expected = np.median(np.abs(self.data - median), axis=-1) * self.distr.unit
-        assert_quantity_allclose(self.distr.pdf_mad, expected)
-        assert_quantity_allclose(self.distr.pdf_smad, self.distr.pdf_mad * SMAD_FACTOR, rtol=1e-5)
-        assert_quantity_allclose(self.distr.pdf_smad, [3, 2, 4, 5] * self.distr.unit, rtol=0.05)
+        pdf_mad = self.distr.pdf_mad()
+        assert_quantity_allclose(pdf_mad, expected)
+        pdf_smad = self.distr.pdf_smad()
+        assert_quantity_allclose(pdf_smad, pdf_mad * SMAD_FACTOR, rtol=1e-5)
+        assert_quantity_allclose(pdf_smad, [3, 2, 4, 5] * self.distr.unit, rtol=0.05)
 
         # make sure the right type comes out - should be a Quantity because it's
         # now a summary statistic
-        assert not isinstance(self.distr.pdf_mad, Distribution)
-        assert isinstance(self.distr.pdf_mad, u.Quantity)
-        assert not isinstance(self.distr.pdf_smad, Distribution)
-        assert isinstance(self.distr.pdf_smad, u.Quantity)
+        assert not isinstance(pdf_mad, Distribution)
+        assert isinstance(pdf_mad, u.Quantity)
+        assert not isinstance(pdf_smad, Distribution)
+        assert isinstance(pdf_smad, u.Quantity)
+
+        # Check out argument for smad (which checks mad too).
+        out = pdf_smad * 0.
+        pdf_smad2 = self.distr.pdf_smad(out=out)
+        assert pdf_smad2 is out
+        assert np.all(pdf_smad2 == pdf_smad)
 
     def test_percentile(self):
         expected = np.percentile(self.data, [10, 50, 90], axis=-1) * self.distr.unit
@@ -153,9 +191,9 @@ class TestDistributionStatistics():
     def test_add_quantity(self):
         distrplus = self.distr + [2000, 0, 0, 500] * u.pc
         expected = (np.median(self.data, axis=-1) + np.array([2, 0, 0, 0.5])) * self.distr.unit
-        assert_quantity_allclose(distrplus.pdf_median, expected)
+        assert_quantity_allclose(distrplus.pdf_median(), expected)
         expected = np.var(self.data, axis=-1) * self.distr.unit**2
-        assert_quantity_allclose(distrplus.pdf_var, expected)
+        assert_quantity_allclose(distrplus.pdf_var(), expected)
 
     def test_add_distribution(self):
         another_data = (np.random.randn(4, 10000)
@@ -167,10 +205,10 @@ class TestDistributionStatistics():
 
         expected = np.median(self.data + another_data/1000,
                              axis=-1) * self.distr.unit
-        assert_quantity_allclose(combined_distr.pdf_median, expected)
+        assert_quantity_allclose(combined_distr.pdf_median(), expected)
 
         expected = np.var(self.data + another_data/1000, axis=-1) * self.distr.unit**2
-        assert_quantity_allclose(combined_distr.pdf_var, expected)
+        assert_quantity_allclose(combined_distr.pdf_var(), expected)
 
 
 def test_helper_normal_samples():
@@ -181,13 +219,13 @@ def test_helper_normal_samples():
         assert n_dist.distribution.shape == (4, 100)
         assert n_dist.shape == (4, )
         assert n_dist.unit == u.kpc
-        assert np.all(n_dist.pdf_std > 100*u.pc)
+        assert np.all(n_dist.pdf_std() > 100*u.pc)
 
         n_dist2 = ds.normal(centerq, std=[0.2, 1.5, 4, 1]*u.pc, n_samples=20000)
         assert n_dist2.distribution.shape == (4, 20000)
         assert n_dist2.shape == (4, )
         assert n_dist2.unit == u.kpc
-        assert np.all(n_dist2.pdf_std < 100*u.pc)
+        assert np.all(n_dist2.pdf_std() < 100*u.pc)
 
 
 def test_helper_poisson_samples():
@@ -202,7 +240,7 @@ def test_helper_poisson_samples():
         assert isinstance(p_min, Distribution)
         assert p_min.shape == ()
         assert np.all(p_min >= 0)
-        assert np.all(np.abs(p_dist.pdf_mean - centerqcounts) < centerqcounts)
+        assert np.all(np.abs(p_dist.pdf_mean() - centerqcounts) < centerqcounts)
 
 
 def test_helper_uniform_samples():
@@ -320,7 +358,7 @@ def test_array_repr_latex():
 def test_distr_to():
     distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
     todistr = distr.to(u.m)
-    assert_quantity_allclose(distr.pdf_mean.to(u.m), todistr.pdf_mean)
+    assert_quantity_allclose(distr.pdf_mean().to(u.m), todistr.pdf_mean())
 
 
 def test_distr_noq_to():
@@ -333,7 +371,7 @@ def test_distr_noq_to():
 def test_distr_to_value():
     distr = ds.normal(10*u.cm, n_samples=100, std=1*u.cm)
     tovdistr = distr.to_value(u.m)
-    assert np.allclose(distr.pdf_mean.to_value(u.m), tovdistr.pdf_mean)
+    assert np.allclose(distr.pdf_mean().to_value(u.m), tovdistr.pdf_mean())
 
 
 def test_distr_noq_to_value():

--- a/docs/uncertainty/index.rst
+++ b/docs/uncertainty/index.rst
@@ -62,9 +62,9 @@ Monte Carlo sampling) trivially with |distribution| arithmetic and attributes::
   >>> c = a + b
   >>> c # doctest: +ELLIPSIS
   <QuantityDistribution [...] kpc with n_samples=10000>
-  >>> c.pdf_mean # doctest: +FLOAT_CMP
+  >>> c.pdf_mean() # doctest: +FLOAT_CMP
   <Quantity 2.99970555 kpc>
-  >>> c.pdf_std.to(u.pc) # doctest: +FLOAT_CMP
+  >>> c.pdf_std().to(u.pc) # doctest: +FLOAT_CMP
   <Quantity 50.07120457 pc>
 
 Indeed these are close to the expectations. While this may seem unnecessary for
@@ -75,9 +75,9 @@ through::
   >>> d = unc.uniform(center=3*u.kpc, width=800*u.pc, n_samples=10000)
   >>> e = unc.Distribution(((np.random.beta(2,5, 10000)-(2/7))/2 + 3)*u.kpc)
   >>> f = (c * d * e) ** (1/3)
-  >>> f.pdf_mean # doctest: +FLOAT_CMP
+  >>> f.pdf_mean() # doctest: +FLOAT_CMP
   <Quantity 2.99786227 kpc>
-  >>> f.pdf_std # doctest: +FLOAT_CMP
+  >>> f.pdf_std() # doctest: +FLOAT_CMP
   <Quantity 0.08330476 kpc>
   >>> from matplotlib import pyplot as plt # doctest: +SKIP
   >>> from astropy.visualization import quantity_support # doctest: +SKIP
@@ -185,17 +185,17 @@ the sampled distributions::
   Unit("ct")
   >>> distr.n_samples
   1000
-  >>> distr.pdf_mean # doctest: +FLOAT_CMP
+  >>> distr.pdf_mean() # doctest: +FLOAT_CMP
   <Quantity [  0.998,   5.017,  30.085, 400.345] ct>
-  >>> distr.pdf_std # doctest: +FLOAT_CMP
+  >>> distr.pdf_std() # doctest: +FLOAT_CMP
   <Quantity [ 0.97262326,  2.32222114,  5.47629208, 20.6328373 ] ct>
-  >>> distr.pdf_var # doctest: +FLOAT_CMP
+  >>> distr.pdf_var() # doctest: +FLOAT_CMP
   <Quantity [  0.945996,   5.392711,  29.989775, 425.713975] ct2>
-  >>> distr.pdf_median
+  >>> distr.pdf_median()
   <Quantity [   1.,   5.,  30., 400.] ct>
-  >>> distr.pdf_mad  # Median absolute deviation # doctest: +FLOAT_CMP
+  >>> distr.pdf_mad()  # Median absolute deviation # doctest: +FLOAT_CMP
   <Quantity [ 1.,  2.,  4., 14.] ct>
-  >>> distr.pdf_smad  # Median absolute deviation, rescaled to match std for normal # doctest: +FLOAT_CMP
+  >>> distr.pdf_smad()  # Median absolute deviation, rescaled to match std for normal # doctest: +FLOAT_CMP
   <Quantity [ 1.48260222,  2.96520444,  5.93040887, 20.75643106] ct>
   >>> distr.pdf_percentiles([10, 50, 90])
   <Quantity [[  0. ,   2. ,  23. , 374. ],
@@ -222,9 +222,9 @@ essentially assuming the |quantity| is a Dirac delta distribution::
 
   >>> distr_in_kpc = distr * u.kpc/u.count  # for the sake of round numbers in examples
   >>> distrplus = distr_in_kpc + [2000,0,0,500]*u.pc
-  >>> distrplus.pdf_median
+  >>> distrplus.pdf_median()
   <Quantity [   3. ,   5. ,  30. , 400.5] kpc>
-  >>> distrplus.pdf_var # doctest: +FLOAT_CMP
+  >>> distrplus.pdf_var() # doctest: +FLOAT_CMP
   <Quantity [  0.945996,   5.392711,  29.989775, 425.713975] kpc2>
 
 It also operates as expected with other distributions  (But see below for a
@@ -232,9 +232,9 @@ discussion of covariances)::
 
   >>> another_distr = unc.Distribution((np.random.randn(1000,4)*[1000,.01 , 3000, 10] + [2000, 0, 0, 500]).T * u.pc)
   >>> combined_distr = distr_in_kpc + another_distr
-  >>> combined_distr.pdf_median # doctest: +FLOAT_CMP
+  >>> combined_distr.pdf_median()  # doctest: +FLOAT_CMP
   <Quantity [  3.01847755,   4.99999576,  29.60559788, 400.49176321] kpc>
-  >>> combined_distr.pdf_var # doctest: +FLOAT_CMP
+  >>> combined_distr.pdf_var()  # doctest: +FLOAT_CMP
   <Quantity [  1.8427705 ,   5.39271147,  39.5343726 , 425.71324244] kpc2>
 
 


### PR DESCRIPTION
This is to allow them to take arguments, some of which (like ``ddof`` are important to get the right statistical behaviour). As noted in #9447, this is likely the last opportunity we have to make such a drastic change.

fixes #9447.

p.s. Apologies for leaving it so late, but in my defense, I did raise #9447 almost a month ago.
