### PR TITLE
Avoid warnings in documentation build

### DIFF
--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -67,6 +67,10 @@ class BlackBody1D(Fittable1DModel):
     .. plot::
         :include-source:
 
+        # Ignore warnings about deprecation of BlackBody1D
+        import warnings
+        warnings.simplefilter('ignore')
+
         import numpy as np
         import matplotlib.pyplot as plt
 

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -237,7 +237,6 @@ class Drude1D(Fittable1DModel):
         ax.set_xlabel('x')
         ax.set_ylabel('F(x)')
 
-        ax.legend(loc='best')
         plt.show()
     """
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,6 +225,12 @@ try:
         'abort_on_example_error': True
     }
 
+    # Filter out backend-related warnings as described in
+    # https://github.com/sphinx-gallery/sphinx-gallery/pull/564
+    warnings.filterwarnings("ignore", category=UserWarning,
+                            message='Matplotlib is currently using agg, which is a'
+                                    ' non-GUI backend, so cannot show the figure.')
+
 except ImportError:
     def setup(app):
         msg = ('The sphinx_gallery extension is not installed, so the '

--- a/docs/modeling/blackbody_deprecated.rst
+++ b/docs/modeling/blackbody_deprecated.rst
@@ -12,7 +12,17 @@ The equivalency between the
 is shown in the plot below.
 
 .. plot::
+    :nofigs:
+    :context: reset
+
+    # Ignore deprecation warnings from Blackbody1D
+    import warnings
+    warnings.simplefilter('ignore')
+
+
+.. plot::
     :include-source:
+    :context:
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -67,7 +77,17 @@ func:`~astropy.modeling.blackbody.blackbody_nu` and
 func:`~astropy.modeling.blackbody.blackbody_lambda` is shown in the plot below.
 
 .. plot::
+    :nofigs:
+    :context: reset
+
+    # Ignore deprecation warnings from Blackbody1D
+    import warnings
+    warnings.simplefilter('ignore')
+
+
+.. plot::
     :include-source:
+    :context:
 
     import numpy as np
     import matplotlib.pyplot as plt

--- a/docs/timeseries/analysis.rst
+++ b/docs/timeseries/analysis.rst
@@ -127,6 +127,13 @@ using:
 downsample using:
 
 .. plot::
+   :context:
+   :nofigs:
+
+   import warnings
+   warnings.filterwarnings('ignore', message='All-NaN slice encountered')
+
+.. plot::
    :include-source:
    :context:
    :nofigs:
@@ -205,6 +212,13 @@ sigma-clipped median value.
    example_data = get_pkg_data_filename('timeseries/kplr010666592-2009131110544_slc.fits')
    kepler = TimeSeries.read(example_data, format='kepler.fits')
    kepler_folded = kepler.fold(period=2.2 * u.day, epoch_time='2009-05-02T20:53:40')
+
+.. plot::
+   :context:
+   :nofigs:
+
+   import warnings
+   warnings.filterwarnings('ignore', message='Input data contains invalid values')
 
 .. plot::
    :include-source:

--- a/docs/timeseries/index.rst
+++ b/docs/timeseries/index.rst
@@ -260,6 +260,9 @@ the data to determine the baseline flux::
    :context:
    :nofigs:
 
+   import warnings
+   warnings.filterwarnings('ignore', message='Input data contains invalid values')
+
    from astropy.stats import sigma_clipped_stats
    mean, median, stddev = sigma_clipped_stats(ts_folded['sap_flux'])
    ts_folded['sap_flux_norm'] = ts_folded['sap_flux'] / median
@@ -296,9 +299,13 @@ time - this returns a |BinnedTimeSeries|::
      1.0577883629517035             2592.0 ... 0.9999105930328369
      1.0877883629517036 2592.0000000000095 ... 0.9998687505722046
 
+
 .. plot::
    :context:
    :nofigs:
+
+   import warnings
+   warnings.filterwarnings('ignore', message='Mean of empty slice')
 
    from astropy.timeseries import aggregate_downsample
    ts_binned = aggregate_downsample(ts_folded, time_bin_size=0.03 * u.day)

--- a/docs/visualization/matplotlib_integration.rst
+++ b/docs/visualization/matplotlib_integration.rst
@@ -110,11 +110,11 @@ can also be explicitly controlled by passing arguments to ``time_support``:
 
     time_support(format='mjd', scale='tai')
     plt.figure(figsize=(5,3))
-    plt.plot(Time([58000, 59000, 62000], format='mjd'), [1.2, 3.3, 2.3])
+    plt.plot(Time([50000, 52000, 54000], format='mjd'), [1.2, 3.3, 2.3])
 
 To make sure support for plotting times is turned off afterward, you can use
 `~astropy.visualization.time_support` as a context manager::
 
     with time_support(format='mjd', scale='tai'):
         plt.figure(figsize=(5,3))
-        plt.plot(Time([58000, 59000, 62000], format='mjd'))
+        plt.plot(Time([50000, 52000, 54000], format='mjd'))

--- a/docs/visualization/wcsaxes/index.rst
+++ b/docs/visualization/wcsaxes/index.rst
@@ -58,7 +58,7 @@ of WCSAxes.  An example of this usage is:
    :include-source:
    :align: center
 
-    ax = plt.subplot(projection=wcs)
+    ax = plt.subplot(projection=wcs, label='overlays')
 
     ax.imshow(hdu.data, vmin=-2.e-5, vmax=2.e-4, origin='lower')
 

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -29,6 +29,10 @@ import astropy.units as u
 import astropy.coordinates as coord
 
 ################################################################################
+# Use the latest convention for the Galactocentric coordinates
+coord.galactocentric_frame_defaults.set('latest')
+
+################################################################################
 # For this example, let's work with the coordinates and barycentric radial
 # velocity of the star HD 155967, as obtained from
 # `Simbad <http://simbad.harvard.edu/simbad/>`_:


### PR DESCRIPTION
This fixes a few residual warnings in the docs - these weren't being caught before because of https://github.com/matplotlib/matplotlib/issues/15715