### PR TITLE
Fix auto-expansion of string columns when dealing with masked values

### DIFF
--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -142,14 +142,8 @@ def _expand_string_array_for_values(arr, values):
     arr_expanded : np.ndarray
 
     """
-    if arr.dtype.kind in ('U', 'S'):
-        # Find the length of the longest string in the new values,
-        # ignoring any masked values.
-        if hasattr(values, 'mask'):
-            if values is np.ma.masked:
-                values = ''
-            else:
-                values = values.filled('')
+    if arr.dtype.kind in ('U', 'S') and values is not np.ma.masked:
+        # Find the length of the longest string in the new values.
         values_str_len = np.char.str_len(values).max()
 
         # Determine character repeat count of arr.dtype.  Returns a positive

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -143,7 +143,13 @@ def _expand_string_array_for_values(arr, values):
 
     """
     if arr.dtype.kind in ('U', 'S'):
-        # Find the length of the longest string in the new values.
+        # Find the length of the longest string in the new values,
+        # ignoring any masked values.
+        if hasattr(values, 'mask'):
+            if values is np.ma.masked:
+                values = ''
+            else:
+                values = values.filled('')
         values_str_len = np.char.str_len(values).max()
 
         # Determine character repeat count of arr.dtype.  Returns a positive
@@ -1041,9 +1047,9 @@ class Column(BaseColumn):
             Object that defines the index or indices before which ``values`` is
             inserted.
         values : array_like
-            Value(s) to insert.  If the type of ``values`` is different
-            from that of quantity, ``values`` is converted to the matching type.
-            ``values`` should be shaped so that it can be broadcast appropriately
+            Value(s) to insert.  If the type of ``values`` is different from
+            that of the column, ``values`` is converted to the matching type.
+            ``values`` should be shaped so that it can be broadcast appropriately.
         axis : int, optional
             Axis along which to insert ``values``.  If ``axis`` is None then
             the column array is flattened before insertion.  Default is 0,
@@ -1349,11 +1355,12 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             Object that defines the index or indices before which ``values`` is
             inserted.
         values : array_like
-            Value(s) to insert.  If the type of ``values`` is different
-            from that of quantity, ``values`` is converted to the matching type.
-            ``values`` should be shaped so that it can be broadcast appropriately
+            Value(s) to insert.  If the type of ``values`` is different from
+            that of the column, ``values`` is converted to the matching type.
+            ``values`` should be shaped so that it can be broadcast appropriately.
         mask : boolean array_like
-            Mask value(s) to insert.  If not supplied then False is used.
+            Mask value(s) to insert.  If not supplied, and values does not have
+            a mask either, then False is used.
         axis : int, optional
             Axis along which to insert ``values``.  If ``axis`` is None then
             the column array is flattened before insertion.  Default is 0,
@@ -1378,10 +1385,13 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             new_data = np.insert(self_ma.data, obj, values, axis=axis)
 
         if mask is None:
-            if self.dtype.kind == 'O':
-                mask = False
-            else:
-                mask = np.zeros(np.shape(values), dtype=bool)
+            mask = getattr(values, 'mask', np.ma.nomask)
+            if mask is np.ma.nomask:
+                if self.dtype.kind == 'O':
+                    mask = False
+                else:
+                    mask = np.zeros(np.shape(values), dtype=bool)
+
         new_mask = np.insert(self_ma.mask, obj, mask, axis=axis)
         new_ma = np.ma.array(new_data, mask=new_mask, copy=False)
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -335,9 +335,9 @@ class TestColumn():
         assert np.all(c1.mask == [True, False, False])
         assert c1.dtype == 'U1'
         c2 = c.insert(1, np.ma.MaskedArray(['ccc', 'dd'], mask=[True, False]))
-        assert np.all(c2 == ['a', '', 'dd', 'b'])
+        assert np.all(c2 == ['a', 'ccc', 'dd', 'b'])
         assert np.all(c2.mask == [False, True, False, False])
-        assert c2.dtype == 'U2'
+        assert c2.dtype == 'U3'
 
     def test_insert_string_type_error(self, Column):
         c = Column([1, 2])

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -328,6 +328,17 @@ class TestColumn():
         c1 = c.insert(0, ['c', 'def'])
         assert np.all(c1 == ['c', 'def', 'a', 'b'])
 
+    def test_insert_string_masked_values(self):
+        c = table.MaskedColumn(['a', 'b'])
+        c1 = c.insert(0, np.ma.masked)
+        assert np.all(c1 == ['', 'a', 'b'])
+        assert np.all(c1.mask == [True, False, False])
+        assert c1.dtype == 'U1'
+        c2 = c.insert(1, np.ma.MaskedArray(['ccc', 'dd'], mask=[True, False]))
+        assert np.all(c2 == ['a', '', 'dd', 'b'])
+        assert np.all(c2.mask == [False, True, False, False])
+        assert c2.dtype == 'U2'
+
     def test_insert_string_type_error(self, Column):
         c = Column([1, 2])
         with pytest.raises(ValueError, match='invalid literal for int'):

--- a/astropy/utils/iers/tests/test_iers.py
+++ b/astropy/utils/iers/tests/test_iers.py
@@ -251,7 +251,6 @@ class TestIERS_Auto():
         assert type(t) is iers.IERS_B
 
     @pytest.mark.remote_data
-    @pytest.mark.xfail(reason='See issue 9600')
     def test_simple(self):
 
         with iers.conf.set_temp('iers_auto_url', self.iers_a_url_1):


### PR DESCRIPTION
When inserting masked values, #9559 caused any string column to expand to allow "N/A" to be added. But this breaks `iers`. Here, we ensure that masked values will never cause an expansion of string columns. Writing tests, it also seemed to make sense that to use the mask of whatever is inserted. I think this makes more sense (and seemingly there was no test for this).

fixes #9600 
