### PR TITLE
Fix bug when Time object is created with only masked elements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -743,6 +743,8 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Fix bug when ``Time`` object is created with only masked elements. [#9624]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -489,6 +489,7 @@ class Time(ShapedLikeNDArray):
         # with shape broadcastable to jd2.
         if mask is not False:
             mask = np.broadcast_to(mask, self._time.jd2.shape)
+            self._time.jd1[mask] = 2451544.5  # Set to JD for 2000-01-01
             self._time.jd2[mask] = np.nan
 
     def _get_time_fmt(self, val, val2, format, scale,

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -149,6 +149,15 @@ def test_masked_input():
     assert t2.masked is True
 
 
+def test_all_masked_input():
+    """Fix for #9612"""
+    # Test with jd=0 and jd=np.nan. Both triggered an exception prior to #9624
+    # due to astropy.utils.exceptions.ErfaError.
+    for val in (0, np.nan):
+        t = Time(np.ma.masked_array([val], mask=[True]), format='jd')
+        assert str(t.iso) == '[--]'
+
+
 def test_serialize_fits_masked(tmpdir):
     tm = Time([1, 2, 3], format='cxcsec')
     tm[1] = np.ma.masked


### PR DESCRIPTION
Fixes #9612

Milestoned for 4.0 so the bot is happy.