### PR TITLE
Fix compilation warnings for astropy.convolution

### DIFF
--- a/astropy/convolution/src/convolve.h
+++ b/astropy/convolution/src/convolve.h
@@ -39,6 +39,8 @@ typedef size_t omp_iter_var;
 void PyInit__convolve(void);
 #endif
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#define NO_IMPORT_ARRAY
 #include "numpy/ndarrayobject.h"
 #define DTYPE npy_float64
 


### PR DESCRIPTION
This is to avoid the following warnings when compiling the convolution C code:

```
In file included from astropy/convolution/src/convolve.c:34:
In file included from astropy/convolution/src/convolve.h:42:
In file included from /Users/tom/python/dev/lib/python3.8/site-packages/numpy/core/include/numpy/ndarrayobject.h:12:
In file included from /Users/tom/python/dev/lib/python3.8/site-packages/numpy/core/include/numpy/ndarraytypes.h:1830:
/Users/tom/python/dev/lib/python3.8/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: "Using deprecated NumPy API, disable it with "          "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
#warning "Using deprecated NumPy API, disable it with " \
 ^
In file included from astropy/convolution/src/convolve.c:34:
In file included from astropy/convolution/src/convolve.h:42:
In file included from /Users/tom/python/dev/lib/python3.8/site-packages/numpy/core/include/numpy/ndarrayobject.h:21:
/Users/tom/python/dev/lib/python3.8/site-packages/numpy/core/include/numpy/__multiarray_api.h:1463:1: warning: unused function '_import_array' [-Wunused-function]
_import_array(void)
^
2 warnings generated.
```

Someone like @mhvk should review this as while I think this is the right approach, I'm not 100% certain.