### PR TITLE
Fix HighLevelWCSWrapper to take into account return type of pixel_to_world_values

### DIFF
--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -3,6 +3,7 @@ from collections import defaultdict, OrderedDict
 
 import numpy as np
 
+from astropy.utils import isiterable
 from .utils import deserialize_class
 
 __all__ = ['BaseHighLevelWCS', 'HighLevelWCSMixin']
@@ -214,7 +215,7 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
         # Compute the world coordinate values
         world = self.low_level_wcs.pixel_to_world_values(*pixel_arrays)
 
-        if self.world_n_dim == 1:
+        if self.world_n_dim == 1 and not (isiterable(world) and len(world) == 1):
             world = (world,)
 
         # Cache the classes and components since this may be expensive


### PR DESCRIPTION
I managed to construct a situation where we were putting a len 1 tuple inside a len 1 tuple, which then proceeded to break gWCS.

(affects dev bugfix I think)

tests etc tomorrow.