### PR TITLE
TST: Remove deprecated doctest test

### DIFF
--- a/astropy/tests/tests/test_run_tests.py
+++ b/astropy/tests/tests/test_run_tests.py
@@ -2,13 +2,6 @@
 
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
-import doctest
-
-from textwrap import dedent
-
-import pytest
-
 # test helper.run_tests function
 from astropy import test as run_tests
 
@@ -27,41 +20,5 @@ def test_pastebin_keyword():
         run_tests(pastebin='not_an_option')
 
 
-# TODO: Temporarily disabled, as this seems to non-deterministically fail
-# def test_deprecation_warning():
-#     with pytest.raises(DeprecationWarning):
-#         warnings.warn('test warning', DeprecationWarning)
-
-
 def test_unicode_literal_conversion():
     assert isinstance('ångström', str)
-
-
-def test_doctest_float_replacement(tmpdir):
-    test1 = dedent("""
-        This will demonstrate a doctest that fails due to a few extra decimal
-        places::
-
-            >>> 1.0 / 3.0
-            0.333333333333333311
-    """)
-
-    test2 = dedent("""
-        This is the same test, but it should pass with use of
-        +FLOAT_CMP::
-
-            >>> 1.0 / 3.0  # doctest: +FLOAT_CMP
-            0.333333333333333311
-    """)
-
-    test1_rst = tmpdir.join('test1.rst')
-    test2_rst = tmpdir.join('test2.rst')
-    test1_rst.write(test1)
-    test2_rst.write(test2)
-
-    with pytest.raises(doctest.DocTestFailure):
-        doctest.testfile(str(test1_rst), module_relative=False,
-                         raise_on_error=True, verbose=False, encoding='utf-8')
-
-    doctest.testfile(str(test2_rst), module_relative=False,
-                     raise_on_error=True, verbose=False, encoding='utf-8')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to remove `pytest-doctestplus` test that is moved to astropy/pytest-doctestplus#88 .

Also removed a commented test that makes no sense to me.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9629 
