### PR TITLE
TST: Ignore cache warning on Windows

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ filterwarnings =
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
     ignore:Remote data cache could not be accessed due to NotADirectoryError
+    ignore:Remote data cache could not be accessed due to FileNotFoundError
     ignore:.*Cache directory cannot be read or created
     ignore:can't resolve package from __spec__
     ignore:::astropy.tests.plugins.display


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address cache warning seen on Windows testing.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Follow up of #7928 and needs to be addressed as part of #9620.

cc @aarchiba 

p.s. Not sure why Windows job on Travis CI didn't catch this, but I see it on a local Windows 10 machine.