### PR TITLE
Implement support for the -TAB algorithm in WCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,7 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Implemented support for the ``-TAB`` algorithm (WCS Paper III). [#9641]
 
 API Changes
 -----------

--- a/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_wrap.h
@@ -1,6 +1,5 @@
 /*
  Author: Michael Droettboom
-         mdroe@stsci.edu
 */
 
 #ifndef __WCSLIB_WRAP_H__
@@ -22,5 +21,9 @@ PyWcsprm_find_all_wcs(
     PyObject* self,
     PyObject* args,
     PyObject* kwds);
+
+int _update_wtbarr_from_hdulist(PyObject *hdulist, struct wtbarr *wtb);
+
+void _set_wtbarr_callback(PyObject* callback);
 
 #endif

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -288,7 +288,9 @@ def get_extensions():
         'unit_list_proxy.c',
         'util.c',
         'wcslib_wrap.c',
-        'wcslib_tabprm_wrap.c']
+        'wcslib_tabprm_wrap.c',
+        'wcslib_wtbarr_wrap.c'
+    ]
     cfg['sources'].extend(join(WCSROOT, 'src', x) for x in astropy_wcs_files)
 
     cfg['sources'] = [str(x) for x in cfg['sources']]

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -19,6 +19,9 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include <tab.h>
+#include <wtbarr.h>
+
 /***************************************************************************
  * Wcs type
  ***************************************************************************/
@@ -26,6 +29,22 @@
 static PyTypeObject WcsType;
 
 static int _setup_wcs_type(PyObject* m);
+
+
+PyObject* PyWcsprm_set_wtbarr_fitsio_callback(PyObject *dummy, PyObject *args) {
+    PyObject *callback;
+
+    if (PyArg_ParseTuple(args, "O:set_wtbarr_fitsio_callback", &callback)) {
+        if (!PyCallable_Check(callback)) {
+            PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+            return NULL;
+        }
+        _set_wtbarr_callback(callback);
+
+        Py_RETURN_NONE;
+    }
+    return NULL;
+}
 
 
 /***************************************************************************
@@ -724,6 +743,7 @@ static PyMethodDef Wcs_methods[] = {
 static PyMethodDef module_methods[] = {
   {"_sanity_check", (PyCFunction)_sanity_check, METH_NOARGS, ""},
   {"find_all_wcs", (PyCFunction)PyWcsprm_find_all_wcs, METH_VARARGS|METH_KEYWORDS, doc_find_all_wcs},
+  {"set_wtbarr_fitsio_callback", (PyCFunction)PyWcsprm_set_wtbarr_fitsio_callback, METH_VARARGS, NULL},
   {NULL}  /* Sentinel */
 };
 
@@ -837,7 +857,7 @@ PyInit__wcs(void)
       _setup_unit_list_proxy_type(m)||
       _setup_wcsprm_type(m)         ||
       _setup_tabprm_type(m)         ||
-      /* _setup_wtbarr_type(m)         || */
+      _setup_wtbarr_type(m)         ||
       _setup_distortion_type(m)     ||
       _setup_sip_type(m)            ||
       _setup_wcs_type(m)          ||

--- a/astropy/wcs/src/wcslib_tabprm_wrap.c
+++ b/astropy/wcs/src/wcslib_tabprm_wrap.c
@@ -94,6 +94,7 @@ PyTabprm*
 PyTabprm_cnew(PyObject* wcsprm, struct tabprm* x) {
   PyTabprm* self;
   self = (PyTabprm*)(&PyTabprmType)->tp_alloc(&PyTabprmType, 0);
+  if (self == NULL) return NULL;
   self->x = x;
   Py_INCREF(wcsprm);
   self->owner = wcsprm;
@@ -124,8 +125,7 @@ PyTabprm_set(
     return NULL;
   }
 
-  Py_INCREF(Py_None);
-  return Py_None;
+  Py_RETURN_NONE;
 }
 
 /*@null@*/ static PyObject*
@@ -139,13 +139,10 @@ PyTabprm_print_contents(
   /* This is not thread-safe, but since we're holding onto the GIL,
      we can assume we won't have thread conflicts */
   wcsprintf_set(NULL);
-
   tabprt(self->x);
-
   printf("%s", wcsprintf_buf());
-
-  Py_INCREF(Py_None);
-  return Py_None;
+  fflush(stdout);
+  Py_RETURN_NONE;
 }
 
 /*@null@*/ static PyObject*
@@ -413,7 +410,7 @@ PyTypeObject PyTabprmType = {
   0,                            /*tp_getattr*/
   0,                            /*tp_setattr*/
   0,                            /*tp_compare*/
-  (reprfunc)PyTabprm___str__,   /*tp_repr*/
+  0,                            /*tp_repr*/
   0,                            /*tp_as_number*/
   0,                            /*tp_as_sequence*/
   0,                            /*tp_as_mapping*/

--- a/astropy/wcs/src/wcslib_wtbarr_wrap.c
+++ b/astropy/wcs/src/wcslib_wtbarr_wrap.c
@@ -1,0 +1,239 @@
+#define NO_IMPORT_ARRAY
+
+#include "astropy_wcs/wcslib_wtbarr_wrap.h"
+
+#include <wcs.h>
+#include <wcsprintf.h>
+#include <tab.h>
+#include <wtbarr.h>
+
+/*
+ It gets to be really tedious to type long docstrings in ANSI C syntax
+ (since multi-line strings literals are not valid).  Therefore, the
+ docstrings are written in doc/docstrings.py, which are then converted
+ by setup.py into docstrings.h, which we include here.
+*/
+#include "astropy_wcs/docstrings.h"
+
+
+/***************************************************************************
+ * PyWtbarr methods                                                        *
+ ***************************************************************************/
+
+static PyObject*
+PyWtbarr_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+  PyWtbarr* self;
+  self = (PyWtbarr*)type->tp_alloc(type, 0);
+  return (PyObject*)self;
+}
+
+
+static int
+PyWtbarr_traverse(PyWtbarr* self, visitproc visit, void *arg) {
+  Py_VISIT(self->owner);
+  return 0;
+}
+
+
+static int
+PyWtbarr_clear(PyWtbarr* self) {
+  Py_CLEAR(self->owner);
+  return 0;
+}
+
+
+static void PyWtbarr_dealloc(PyWtbarr* self) {
+  PyWtbarr_clear(self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+PyWtbarr* PyWtbarr_cnew(PyObject* wcsprm, struct wtbarr* x) {
+  PyWtbarr* self;
+  self = (PyWtbarr*)(&PyWtbarrType)->tp_alloc(&PyWtbarrType, 0);
+  if (self == NULL) return NULL;
+  self->x = x;
+  Py_INCREF(wcsprm);
+  self->owner = wcsprm;
+  return self;
+}
+
+
+static void wtbarrprt(const struct wtbarr *wtb) {
+  int i, nd, ndim;
+
+  if (wtb == 0x0) return;
+
+  wcsprintf("     i: %d\n", wtb->i);
+  wcsprintf("     m: %d\n", wtb->m);
+  wcsprintf("  kind: %c\n", wtb->kind);
+  wcsprintf("extnam: %s\n", wtb->extnam);
+  wcsprintf("extver: %d\n", wtb->extver);
+  wcsprintf("extlev: %d\n", wtb->extlev);
+  wcsprintf(" ttype: %s\n", wtb->ttype);
+  wcsprintf("   row: %ld\n", wtb->row);
+  wcsprintf("  ndim: %d\n", wtb->ndim);
+  wcsprintf("dimlen: %p\n", (void *)wtb->dimlen);
+
+  ndim = wtb->ndim - (int)(wtb->kind == 'c');
+  nd = 1 + (int) log10(ndim ? ndim : 1);
+  for (i = 0; i < ndim; i++) {
+    wcsprintf("        %*d:   %d\n", nd, i, wtb->dimlen[i]);
+  }
+  wcsprintf("arrayp: %p\n", (void *)wtb->arrayp);
+
+  return;
+}
+
+
+static PyObject* PyWtbarr_print_contents(PyWtbarr* self) {
+  /* This is not thread-safe, but since we're holding onto the GIL,
+     we can assume we won't have thread conflicts */
+  wcsprintf_set(NULL);
+  wtbarrprt(self->x);
+  printf("%s", wcsprintf_buf());
+  fflush(stdout);
+  Py_RETURN_NONE;
+}
+
+
+static PyObject* PyWtbarr___str__(PyWtbarr* self) {
+  /* This is not thread-safe, but since we're holding onto the GIL,
+     we can assume we won't have thread conflicts */
+  wcsprintf_set(NULL);
+  wtbarrprt(self->x);
+  return PyUnicode_FromString(wcsprintf_buf());
+}
+
+
+/***************************************************************************
+ * Member getters/setters (properties)
+ */
+
+
+static PyObject* PyWtbarr_get_i(PyWtbarr* self, void* closure) {
+  return get_int("i", self->x->i);
+}
+
+
+static PyObject* PyWtbarr_get_m(PyWtbarr* self, void* closure) {
+  return get_int("m", self->x->m);
+}
+
+
+static PyObject* PyWtbarr_get_extver(PyWtbarr* self, void* closure) {
+  return get_int("extver", self->x->extver);
+}
+
+
+static PyObject* PyWtbarr_get_extlev(PyWtbarr* self, void* closure) {
+  return get_int("extlev", self->x->extlev);
+}
+
+
+static PyObject* PyWtbarr_get_ndim(PyWtbarr* self, void* closure) {
+  return get_int("ndim", self->x->ndim);
+}
+
+
+static PyObject* PyWtbarr_get_row(PyWtbarr* self, void* closure) {
+  return get_int("row", self->x->row);
+}
+
+
+static PyObject* PyWtbarr_get_extnam(PyWtbarr* self, void* closure) {
+  if (is_null(self->x->extnam)) return NULL;
+  return get_string("extnam", self->x->extnam);
+}
+
+
+static PyObject* PyWtbarr_get_ttype(PyWtbarr* self, void* closure) {
+  if (is_null(self->x->ttype)) return NULL;
+  return get_string("ttype", self->x->ttype);
+}
+
+
+static PyObject* PyWtbarr_get_kind(PyWtbarr* self, void* closure) {
+  return PyUnicode_FromFormat("%c", self->x->kind);
+}
+
+
+/***************************************************************************
+ * PyWtbarr definition structures
+ */
+
+static PyGetSetDef PyWtbarr_getset[] = {
+  {"i", (getter)PyWtbarr_get_i, NULL, (char *) NULL},
+  {"m", (getter)PyWtbarr_get_m, NULL, (char *) NULL},
+  {"kind", (getter)PyWtbarr_get_kind, NULL, (char *) NULL},
+  {"extnam", (getter)PyWtbarr_get_extnam, NULL, (char *) NULL},
+  {"extver", (getter)PyWtbarr_get_extver, NULL, (char *) NULL},
+  {"extlev", (getter)PyWtbarr_get_extlev, NULL, (char *) NULL},
+  {"ttype", (getter)PyWtbarr_get_ttype, NULL, (char *) NULL},
+  {"row", (getter)PyWtbarr_get_row, NULL, (char *) NULL},
+  {"ndim", (getter)PyWtbarr_get_ndim, NULL, (char *) NULL},
+/*  {"dimlen", (getter)PyWtbarr_get_dimlen, NULL, (char *) NULL}, */
+/*  {"arrayp", (getter)PyWtbarr_get_arrayp, NULL, (char *) NULL}, */
+  {NULL}
+};
+
+
+static PyMethodDef PyWtbarr_methods[] = {
+  {"print_contents", (PyCFunction)PyWtbarr_print_contents, METH_NOARGS, NULL},
+  {NULL}
+};
+
+PyTypeObject PyWtbarrType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "astropy.wcs.Wtbarr",         /*tp_name*/
+  sizeof(PyWtbarr),             /*tp_basicsize*/
+  0,                            /*tp_itemsize*/
+  (destructor)PyWtbarr_dealloc, /*tp_dealloc*/
+  0,                            /*tp_print*/
+  0,                            /*tp_getattr*/
+  0,                            /*tp_setattr*/
+  0,                            /*tp_compare*/
+  0,                            /*tp_repr*/
+  0,                            /*tp_as_number*/
+  0,                            /*tp_as_sequence*/
+  0,                            /*tp_as_mapping*/
+  0,                            /*tp_hash */
+  0,                            /*tp_call*/
+  (reprfunc)PyWtbarr___str__,   /*tp_str*/
+  0,                            /*tp_getattro*/
+  0,                            /*tp_setattro*/
+  0,                            /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+  0,                            /* tp_doc */
+  0,                            /* tp_traverse */
+  0,                            /* tp_clear */
+  0,                            /* tp_richcompare */
+  0,                            /* tp_weaklistoffset */
+  0,                            /* tp_iter */
+  0,                            /* tp_iternext */
+  PyWtbarr_methods,             /* tp_methods */
+  0,                            /* tp_members */
+  PyWtbarr_getset,              /* tp_getset */
+  0,                            /* tp_base */
+  0,                            /* tp_dict */
+  0,                            /* tp_descr_get */
+  0,                            /* tp_descr_set */
+  0,                            /* tp_dictoffset */
+  0,                            /* tp_init */
+  0,                            /* tp_alloc */
+  0,                            /* tp_new */
+};
+
+
+int
+_setup_wtbarr_type(PyObject* m) {
+  if (PyType_Ready(&PyWtbarrType) < 0) {
+    return -1;
+  }
+
+  Py_INCREF(&PyWtbarrType);
+
+  PyModule_AddObject(m, "Wtbarr", (PyObject *)&PyWtbarrType);
+
+  return 0;
+}

--- a/astropy/wcs/tests/conftest.py
+++ b/astropy/wcs/tests/conftest.py
@@ -1,0 +1,48 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+import numpy as np
+
+from astropy import wcs
+
+from . helper import SimModelTAB
+
+
+@pytest.fixture(scope='module')
+def tab_wcs_2di():
+    model = SimModelTAB(nx=150, ny=200)
+
+    # generate FITS HDU list:
+    hdulist = model.hdulist
+
+    # create WCS object:
+    w = wcs.WCS(hdulist[0].header, hdulist)
+
+    return w
+
+
+@pytest.fixture(scope='module')
+def tab_wcsh_2di():
+    model = SimModelTAB(nx=150, ny=200)
+
+    # generate FITS HDU list:
+    hdulist = model.hdulist
+
+    # create WCS object:
+    w = wcs.WCS(hdulist[0].header, hdulist)
+
+    return w, hdulist
+
+
+@pytest.fixture(scope='function')
+def tab_wcs_2di_f():
+    model = SimModelTAB(nx=150, ny=200)
+
+    # generate FITS HDU list:
+    hdulist = model.hdulist
+
+    # create WCS object:
+    w = wcs.WCS(hdulist[0].header, hdulist)
+
+    return w

--- a/astropy/wcs/tests/helper.py
+++ b/astropy/wcs/tests/helper.py
@@ -1,0 +1,112 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
+import numpy as np
+
+from astropy import wcs
+from astropy.io import fits
+
+
+class SimModelTAB:
+    def __init__(self, nx=150, ny=200, crpix=[1, 1], crval = [1, 1],
+                 cdelt = [1, 1], pc = {'PC1_1': 1, 'PC2_2': 1}):
+        """  set essential parameters of the model (coord transformations)  """
+        assert nx > 2 and ny > 1  # a limitation of this particular simulation
+        self.nx = nx
+        self.ny = ny
+        self.crpix = crpix
+        self.crval = crval
+        self.cdelt = cdelt
+        self.pc = pc
+
+    def fwd_eval(self, xy):
+        xb = 1 + self.nx // 3
+        px = np.array([1, xb, xb, self.nx + 1])
+        py = np.array([1, self.ny + 1])
+
+        xi = self.crval[0] + self.cdelt[0] * (px - self.crpix[0])
+        yi = self.crval[1] + self.cdelt[1] * (py - self.crpix[1])
+
+        cx = np.array([0.0, 0.26, 0.8, 1.0])
+        cy = np.array([-0.5, 0.5])
+
+        xy = np.atleast_2d(xy)
+        x = xy[:, 0]
+        y = xy[:, 1]
+
+        mbad = (x < px[0]) | (y < py[0]) | (x > px[-1]) | (y > py[-1])
+        mgood = np.logical_not(mbad)
+
+        i = 2 * (x > xb).astype(np.int)
+
+        psix = self.crval[0] + self.cdelt[0] * (x - self.crpix[0])
+        psiy = self.crval[1] + self.cdelt[1] * (y - self.crpix[1])
+
+        cfx = (psix - xi[i]) / (xi[i + 1] - xi[i])
+        cfy = (psiy - yi[0]) / (yi[1] - yi[0])
+
+        ra = cx[i] + cfx * (cx[i + 1] - cx[i])
+        dec = cy[0] + cfy * (cy[1] - cy[0])
+
+        return np.dstack([ra, dec])[0]
+
+    @property
+    def hdulist(self):
+        """ Simulates 2D data with a _spatial_ WCS that uses the ``-TAB``
+        algorithm with indexing.
+        """
+        # coordinate array (some "arbitrary" numbers with a "jump" along x axis):
+        x = np.array([[0.0, 0.26, 0.8, 1.0], [0.0, 0.26, 0.8, 1.0]])
+        y = np.array([[-0.5, -0.5, -0.5, -0.5], [0.5, 0.5, 0.5, 0.5]])
+        c = np.dstack([x, y])
+
+        # index arrays (skip PC matrix for simplicity - assume it is an
+        # identity matrix):
+        xb = 1 + self.nx // 3
+        px = np.array([1, xb, xb, self.nx + 1])
+        py = np.array([1, self.ny + 1])
+        xi = self.crval[0] + self.cdelt[0] * (px - self.crpix[0])
+        yi = self.crval[1] + self.cdelt[1] * (py - self.crpix[1])
+
+        # structured array (data) for binary table HDU:
+        arr = np.array(
+            [(c, xi, yi)],
+            dtype=[
+                ('wavelength', np.float64, c.shape),
+                ('xi', np.double, (xi.size,)),
+                ('yi', np.double, (yi.size,))
+            ]
+        )
+
+        # create binary table HDU:
+        bt = fits.BinTableHDU(arr);
+        bt.header['EXTNAME'] = 'WCS-TABLE'
+
+        # create primary header:
+        image_data = np.ones((self.ny, self.nx), dtype=np.float32)
+        pu = fits.PrimaryHDU(image_data)
+        pu.header['ctype1'] = 'RA---TAB'
+        pu.header['ctype2'] = 'DEC--TAB'
+        pu.header['naxis1'] = self.nx
+        pu.header['naxis2'] = self.ny
+        pu.header['PS1_0'] = 'WCS-TABLE'
+        pu.header['PS2_0'] = 'WCS-TABLE'
+        pu.header['PS1_1'] = 'wavelength'
+        pu.header['PS2_1'] = 'wavelength'
+        pu.header['PV1_3'] = 1
+        pu.header['PV2_3'] = 2
+        pu.header['CUNIT1'] = 'deg'
+        pu.header['CUNIT2'] = 'deg'
+        pu.header['CDELT1'] = self.cdelt[0]
+        pu.header['CDELT2'] = self.cdelt[1]
+        pu.header['CRPIX1'] = self.crpix[0]
+        pu.header['CRPIX2'] = self.crpix[1]
+        pu.header['CRVAL1'] = self.crval[0]
+        pu.header['CRVAL2'] = self.crval[1]
+        pu.header['PS1_2'] = 'xi'
+        pu.header['PS2_2'] = 'yi'
+        for k, v in self.pc.items():
+            pu.header[k] = v
+
+        hdulist = fits.HDUList([pu, bt])
+        return hdulist

--- a/astropy/wcs/tests/test_tab.py
+++ b/astropy/wcs/tests/test_tab.py
@@ -1,0 +1,39 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+import numpy as np
+
+from astropy import wcs
+
+from . helper import SimModelTAB
+
+
+def test_2d_spatial_tab_roundtrip(tab_wcs_2di):
+    nx, ny = tab_wcs_2di.pixel_shape
+    # generate "random" test coordinates:
+    np.random.seed(1)
+    xy = 0.51 + [nx + 0.99, ny + 0.99] * np.random.random((100, 2))
+    rd = tab_wcs_2di.wcs_pix2world(xy, 1)
+    xy_roundtripped = tab_wcs_2di.wcs_world2pix(rd, 1)
+    m = np.logical_and(*(np.isfinite(xy_roundtripped).T))
+    assert np.allclose(xy[m], xy_roundtripped[m], rtol=0, atol=1e-7)
+
+
+def test_2d_spatial_tab_vs_model():
+    nx = 150
+    ny = 200
+    model = SimModelTAB(nx=nx, ny=ny)
+
+    # generate FITS HDU list:
+    hdulist = model.hdulist
+
+    # create WCS object:
+    w = wcs.WCS(hdulist[0].header, hdulist)
+
+    # generate "random" test coordinates:
+    np.random.seed(1)
+    xy = 0.51 + [nx + 0.99, ny + 0.99] * np.random.random((100, 2))
+    rd = w.wcs_pix2world(xy, 1)
+    rd_model = model.fwd_eval(xy)
+    assert np.allclose(rd, rd_model, rtol=0, atol=1e-7)

--- a/astropy/wcs/tests/test_tabprm.py
+++ b/astropy/wcs/tests/test_tabprm.py
@@ -1,0 +1,138 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from copy import deepcopy
+
+import pytest
+
+import numpy as np
+
+from astropy import wcs
+
+from . helper import SimModelTAB
+
+
+def test_wcsprm_tab_basic(tab_wcs_2di):
+    assert len(tab_wcs_2di.wcs.tab) == 1
+    t = tab_wcs_2di.wcs.tab[0]
+    assert tab_wcs_2di.wcs.tab[0] is not t
+
+
+def test_tabprm_coord(tab_wcs_2di_f):
+    t = tab_wcs_2di_f.wcs.tab[0]
+
+    c0 = t.coord
+    c1 = np.ones_like(c0)
+    t.coord = c1
+    assert np.allclose(tab_wcs_2di_f.wcs.tab[0].coord, c1)
+
+
+def test_tabprm_crval_and_deepcopy(tab_wcs_2di_f):
+    w = deepcopy(tab_wcs_2di_f)
+
+    t = tab_wcs_2di_f.wcs.tab[0]
+
+    pix = np.array([[2, 3]], dtype=np.float32)
+
+    rd1 = tab_wcs_2di_f.wcs_pix2world(pix, 1)
+
+    c = t.crval.copy()
+    d = 0.5 * np.ones_like(c)
+    t.crval += d
+    assert np.allclose(tab_wcs_2di_f.wcs.tab[0].crval, c + d)
+
+    rd2 = tab_wcs_2di_f.wcs_pix2world(pix - d, 1)
+    assert np.allclose(rd1, rd2)
+
+    rd3 = w.wcs_pix2world(pix, 1)
+    assert np.allclose(rd1, rd3)
+
+
+def test_tabprm_delta(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert np.allclose([0.0, 0.0], t.delta)
+
+
+def test_tabprm_K(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert np.all(t.K == [4, 2])
+
+
+def test_tabprm_M(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert t.M == 2
+
+
+def test_tabprm_nc(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert t.nc == 8
+
+
+def test_tabprm_extrema(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    extrema = np.array(
+        [[[-0.0026, -0.5], [1.001, -0.5]],
+         [[-0.0026, 0.5], [1.001, 0.5]]]
+    )
+    assert np.allclose(t.extrema, extrema)
+
+
+def test_tabprm_map(tab_wcs_2di_f):
+    t = tab_wcs_2di_f.wcs.tab[0]
+    assert np.allclose(t.map, [0, 1])
+
+    t.map[1] = 5
+    assert np.all(tab_wcs_2di_f.wcs.tab[0].map == [0, 5])
+
+    t.map = [1, 4]
+    assert np.all(tab_wcs_2di_f.wcs.tab[0].map == [1, 4])
+
+
+def  test_tabprm_sense(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert np.all(t.sense == [1, 1])
+
+
+def  test_tabprm_p0(tab_wcs_2di):
+    t = tab_wcs_2di.wcs.tab[0]
+    assert np.all(t.p0 == [0, 0])
+
+
+def test_tabprm_print(tab_wcs_2di_f, capfd):
+    tab_wcs_2di_f.wcs.tab[0].print_contents()
+    captured = capfd.readouterr()
+    s = str(tab_wcs_2di_f.wcs.tab[0])
+    out = str(captured.out)
+    lout= out.split('\n')
+    assert out == s
+    assert lout[0] == '       flag: 137'
+    assert lout[1] == '          M: 2'
+
+
+def test_wcstab_copy(tab_wcs_2di_f):
+    t = tab_wcs_2di_f.wcs.tab[0]
+
+    c0 = t.coord
+    c1 = np.ones_like(c0)
+    t.coord = c1
+    assert np.allclose(tab_wcs_2di_f.wcs.tab[0].coord, c1)
+
+
+def test_tabprm_crval(tab_wcs_2di_f):
+    w = deepcopy(tab_wcs_2di_f)
+
+    t = tab_wcs_2di_f.wcs.tab[0]
+
+    pix = np.array([[2, 3]], dtype=np.float32)
+
+    rd1 = tab_wcs_2di_f.wcs_pix2world(pix, 1)
+
+    c = t.crval.copy()
+    d = 0.5 * np.ones_like(c)
+    t.crval += d
+    assert np.allclose(tab_wcs_2di_f.wcs.tab[0].crval, c + d)
+
+    rd2 = tab_wcs_2di_f.wcs_pix2world(pix - d, 1)
+    assert np.allclose(rd1, rd2)
+
+    rd3 = w.wcs_pix2world(pix, 1)
+    assert np.allclose(rd1, rd3)

--- a/astropy/wcs/tests/test_wtbarr.py
+++ b/astropy/wcs/tests/test_wtbarr.py
@@ -1,0 +1,64 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+
+import numpy as np
+
+from astropy import wcs
+
+
+def test_wtbarr_i(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].i == 1
+
+
+def test_wtbarr_m(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].m == 1
+
+
+def test_wtbarr_m(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].kind == 'c'
+
+
+def test_wtbarr_extnam(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].extnam == 'WCS-TABLE'
+
+
+def test_wtbarr_extver(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].extver == 1
+
+
+def test_wtbarr_extlev(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].extlev == 1
+
+
+def test_wtbarr_ttype(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].ttype == 'wavelength'
+
+
+def test_wtbarr_row(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].row == 1
+
+
+def test_wtbarr_ndim(tab_wcs_2di):
+    assert tab_wcs_2di.wcs.wtb[0].ndim == 3
+
+
+def test_wtbarr_print(tab_wcs_2di, capfd):
+    tab_wcs_2di.wcs.wtb[0].print_contents()
+    captured = capfd.readouterr()
+    s = str(tab_wcs_2di.wcs.wtb[0])
+    lines = s.split('\n')
+    assert captured.out == s
+    assert '     i: 1' == lines[0]
+    assert '     m: 1' == lines[1]
+    assert '  kind: c' == lines[2]
+    assert 'extnam: WCS-TABLE' == lines[3]
+    assert 'extver: 1' == lines[4]
+    assert 'extlev: 1' == lines[5]
+    assert ' ttype: wavelength' == lines[6]
+    assert '   row: 1' == lines[7]
+    assert '  ndim: 3' == lines[8]
+    assert lines[9].startswith('dimlen: ')
+    assert '        0:   4' == lines[10]
+    assert '        1:   2' == lines[11]
+    assert lines[12].startswith('arrayp: ')

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -7,7 +7,12 @@ What's New in Astropy 4.1?
 Overview
 ========
 
-Astropy 4.1 is a major release that ...  since
+Astropy 4.1 is a major release that contains bug fixes and new features since
 the 4.0.x series of releases.
 
 In particular, this release includes:
+
+1. Support for the ``-TAB`` algorithm in FITS WCS as described in
+   `WCS Paper III <https://www.atnf.csiro.au/people/mcalabre/WCS/scs.pdf>`__ .
+   In particular, ``astropy.wcs`` will be able to support ``-TAB`` in WCS if
+   already defined in the ``astropy.io.fits.HDUList`` object.


### PR DESCRIPTION
This pull request is to implement support for the `-TAB` algorithm in FITS WCS as described in [WCS Paper III](https://www.atnf.csiro.au/people/mcalabre/WCS/scs.pdf).

This PR partially addresses #2362, #5462, #7883 in the sense that `astropy.wcs` now will be able to support `-TAB` in WCS if already defined in a HDUList object. However this PR does not provide "write" support for `-TAB`: the files must be created using external scripts.
