### PR TITLE
Handle non-finite position in overlap_slices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1069,6 +1069,9 @@ astropy.nddata
 - ``Cutout2D`` will now get the WCS from its first argument if that argument
   has with WCS property. [#9492]
 
+- ``overlap_slices`` will now raise a ``ValueError`` if the input
+  position contains any non-finite values (e.g. NaN or inf). [#9648]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/tests/test_utils.py
+++ b/astropy/nddata/tests/test_utils.py
@@ -37,6 +37,8 @@ test_slices = [slice(10.52, 3.12), slice(5.62, 12.97),
 subsampling = 5
 
 test_pos_bad = [(-1, -4), (-2, 0), (6, 2), (6, 6)]
+test_nonfinite_positions= [(np.nan, np.nan), (np.inf, np.inf), (1, np.nan),
+                           (np.nan, 2), (2, -np.inf), (-np.inf, 3)]
 
 
 def test_slices_different_dim():
@@ -110,6 +112,17 @@ def test_slices_overlap_wrong_mode():
     with pytest.raises(ValueError) as e:
         overlap_slices((5,), (3,), (0,), mode='full')
     assert "Mode can be only" in str(e.value)
+
+
+@pytest.mark.parametrize('position', test_nonfinite_positions)
+def test_slices_no_overlap(position):
+    """
+    A ValueError should be raised if position contains a non-finite
+    value.
+    """
+
+    with pytest.raises(ValueError):
+        overlap_slices((7, 7), (3, 3), position)
 
 
 def test_extract_array_even_shape_rounding():

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -87,6 +87,10 @@ def overlap_slices(large_array_shape, small_array_shape, position,
     if np.isscalar(position):
         position = (position, )
 
+    if any(~np.isfinite(position)):
+        raise ValueError('Input position contains invalid values (NaNs or '
+                         'infs).')
+
     if len(small_array_shape) != len(large_array_shape):
         raise ValueError('"large_array_shape" and "small_array_shape" must '
                          'have the same number of dimensions.')
@@ -207,6 +211,7 @@ def extract_array(array_large, shape, position, mode='partial',
 
     if mode not in ['partial', 'trim', 'strict']:
         raise ValueError("Valid modes are 'partial', 'trim', and 'strict'.")
+
     large_slices, small_slices = overlap_slices(array_large.shape,
                                                 shape, position, mode=mode)
     extracted_array = array_large[large_slices]


### PR DESCRIPTION
This PR raises a `ValueError` with an informative error message if the `overlap_slices` `position` contains any non-finite values (NaN or inf).

Fixes #9637.
