### PR TITLE
Fix problems with structured Masked Columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -546,8 +546,8 @@ astropy.table
 - Ensured that inserting ``np.ma.masked`` (or any other value with a mask) into
   a ``MaskedColumn`` causes a masked entry to be inserted. [#9623]
 
-- Ensured that one can initialize a ``MaskedColumn`` with another ``MaskedColumn``
-  also if it has a structured dtype. [#9651]
+- Fixed a bug that caused an exception when initializing a ``MaskedColumn`` from
+  another ``MaskedColumn`` that has a structured dtype. [#9651]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -546,6 +546,9 @@ astropy.table
 - Ensured that inserting ``np.ma.masked`` (or any other value with a mask) into
   a ``MaskedColumn`` causes a masked entry to be inserted. [#9623]
 
+- Ensured that one can initialize a ``MaskedColumn`` with another ``MaskedColumn``
+  also if it has a structured dtype. [#9651]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -1262,7 +1262,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
         if fill_value is None and getattr(data, 'fill_value', None) is not None:
             # Coerce the fill_value to the correct type since `data` may be a
             # different dtype than self.
-            fill_value = self.dtype.type(data.fill_value)
+            fill_value = np.array(data.fill_value, self.dtype)[()]
         self.fill_value = fill_value
 
         self.parent_table = None

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -961,7 +961,8 @@ class Table:
 
         # Structured ndarray gets viewed as a mixin unless already a valid
         # mixin class
-        if isinstance(data, np.ndarray) and len(data.dtype) > 1 and not data_is_mixin:
+        if (not isinstance(data, Column) and not data_is_mixin and
+                isinstance(data, np.ndarray) and len(data.dtype) > 1):
             data = data.view(NdarrayMixin)
             data_is_mixin = True
 

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -5,6 +5,7 @@ import operator
 
 import pytest
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from astropy.tests.helper import assert_follows_unicode_guidelines, catch_warnings
 from astropy import table
@@ -898,3 +899,11 @@ def test_unicode_sandwich_masked_compare():
 
     # Note: comparisons <, >, >=, <= fail to return a masked array entirely,
     # see https://github.com/numpy/numpy/issues/10092.
+
+
+def test_structured_masked_column_roundtrip():
+    mc = table.MaskedColumn([(1., 2.), (3., 4.)],
+                            mask=[(False, False), (False, False)], dtype='f8,f8')
+    assert len(mc.dtype.fields) == 2
+    mc2 = table.MaskedColumn(mc)
+    assert_array_equal(mc2, mc)

--- a/astropy/table/tests/test_masked.py
+++ b/astropy/table/tests/test_masked.py
@@ -23,6 +23,8 @@ class SetupData:
         self.d = MaskedColumn(name='d', data=[7, 8, 7], mask=self.d_mask)
         self.t = Table([self.a, self.b], masked=True)
         self.ca = Column(name='ca', data=[1, 2, 3])
+        self.sc = MaskedColumn(name='sc', data=[(1, 1.), (2, 2.), (3, 3.)],
+                               dtype='i8,f8', fill_value=(0, -1.))
 
 
 class TestPprint(SetupData):
@@ -121,6 +123,15 @@ class TestFillValue(SetupData):
         assert np.all(c.filled() == ['ABCD', 'yyyy'])
         assert np.all(c.filled('XY') == ['XY', 'yyyy'])
 
+    def test_set_get_fill_value_for_structured_column(self):
+        assert self.sc.fill_value == np.array((0, -1.), self.sc.dtype)
+        sc = self.sc.copy()
+        assert sc.fill_value.item() == (0, -1.)
+        sc.fill_value = (-1, np.inf)
+        assert sc.fill_value == np.array((-1, np.inf), self.sc.dtype)
+        sc2 = MaskedColumn(sc, fill_value=(-2, -np.inf))
+        assert sc2.fill_value == np.array((-2, -np.inf), sc2.dtype)
+
     def test_table_column_mask_not_ref(self):
         """Table column mask is not ref of original column mask"""
         self.b.fill_value = -999
@@ -173,6 +184,38 @@ class TestMaskedColumnInit(SetupData):
 
 class TestTableInit(SetupData):
     """Initializing a table"""
+    def test_initialization_with_all_columns(self):
+        t1 = Table([self.a, self.b, self.c, self.d, self.ca, self.sc])
+        assert t1.colnames == ['a', 'b', 'c', 'd', 'ca', 'sc']
+        # Check we get the same result by passing in as list of dict.
+        # (Regression test for error uncovered by scintillometry package.)
+        lofd = [{k: row[k] for k in t1.colnames} for row in t1]
+        t2 = Table(lofd)
+        for k in t1.colnames:
+            assert np.all(t1[k] == t2[k]) in (True, np.ma.masked)
+            assert np.all(getattr(t1[k], 'mask', False) ==
+                          getattr(t2[k], 'mask', False))
+
+    # Filter warnings since these are set to lead to exceptions,
+    # which changes behaviour in Table._convert_data_to_col
+    # (causing conversion of columns with masked elements to object dtype).
+    @pytest.mark.filterwarnings('ignore:.*converting a masked element.*')
+    def test_initialization_with_all_columns(self):
+        t1 = Table([self.a, self.b, self.c, self.d, self.ca, self.sc])
+        assert t1.colnames == ['a', 'b', 'c', 'd', 'ca', 'sc']
+        # Check we get the same result by passing in as list of dict.
+        # (Regression test for error uncovered by scintillometry package.)
+        lofd = [{k: row[k] for k in t1.colnames} for row in t1]
+        t2 = Table(lofd)
+        for k in t1.colnames:
+            # TODO: the final dtype should not depend on the presence of
+            # masked elements, but unfortunately np.ma.MaskedArray does take
+            # it into account.
+            if k not in ('b', 'd'):
+                assert t1[k].dtype == t2[k].dtype
+            assert np.all(t1[k] == t2[k]) in (True, np.ma.masked)
+            assert np.all(getattr(t1[k], 'mask', False) ==
+                          getattr(t2[k], 'mask', False))
 
     def test_mask_false_if_input_mask_not_true(self):
         """Masking is always False if initial masked arg is not True"""


### PR DESCRIPTION
fixes #9649 

Also fix overkeen viewing as `NdarrayMixin`, which could lose a column's name.

Spent a long time trying to understand what went wrong in table creation from list of dict, only to realize in part it was that in testing we now turn all warnings into exceptions, which changes the behaviour. Sigh.

EDIT:
fixes https://github.com/mhvk/scintillometry/issues/130