### PR TITLE
Make bz2 import optional for `io.fits`

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -476,9 +476,8 @@ class _File:
                 raise OSError("update and append modes are not supported "
                               "with bzip2 files")
             if not HAS_BZ2:
-                raise ValueError(
-                    ".bz2 format files are not supported since the Python "
-                    "interpreter does not include the bz2 module")
+                raise ModuleNotFoundError(
+                    "This Python installation does not provide the bz2 module.")
             # bzip2 only supports 'w' and 'r' modes
             bzip2_mode = 'w' if mode == 'ostream' else 'r'
             self._file = bz2.BZ2File(obj_or_name, mode=bzip2_mode)
@@ -582,7 +581,7 @@ class _File:
             self._file.seek(0)
 
     @classproperty(lazy=True)
-    def _mmap_available(self):
+    def _mmap_available(cls):
         """Tests that mmap, and specifically mmap.flush works.  This may
         be the case on some uncommon platforms (see
         https://github.com/astropy/astropy/issues/968).

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -582,7 +582,7 @@ class _File:
             self._file.seek(0)
 
     @classproperty(lazy=True)
-    def _mmap_available(cls):
+    def _mmap_available(self):
         """Tests that mmap, and specifically mmap.flush works.  This may
         be the case on some uncommon platforms (see
         https://github.com/astropy/astropy/issues/968).

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -16,9 +16,9 @@ from .groups import GroupsHDU
 from .image import PrimaryHDU, ImageHDU
 from astropy.io.fits.file import _File, FILE_MODES
 from astropy.io.fits.header import _pad_length
-from astropy.io.fits.util import (_is_int, _tmp_name, fileobj_closed,
-                                  ignore_sigint, _get_array_mmap,
-                                  _free_space_check, fileobj_mode, isfile)
+from astropy.io.fits.util import (_free_space_check, _get_array_mmap, _is_int,
+                                  _tmp_name, fileobj_closed, fileobj_mode,
+                                  ignore_sigint, isfile)
 from astropy.io.fits.verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning
@@ -1287,9 +1287,8 @@ class HDUList(list, _Verify):
                 new_file = gzip.GzipFile(name, mode='ab+')
             elif self._file.compression == 'bzip2':
                 if not HAS_BZ2:
-                    raise ValueError(
-                        ".bz2 format files are not supported since the Python "
-                        "interpreter does not include the bz2 module")
+                    raise ModuleNotFoundError(
+                        "This Python installation does not provide the bz2 module.")
                 new_file = bz2.BZ2File(name, mode='w')
             else:
                 new_file = name

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 
-import bz2
 import gzip
 import itertools
 import os
@@ -23,6 +22,13 @@ from astropy.io.fits.verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
+
+try:
+    import bz2
+except ImportError:
+    HAS_BZ2 = False
+else:
+    HAS_BZ2 = True
 
 
 def fitsopen(name, mode='readonly', memmap=None, save_backup=False,
@@ -1279,6 +1285,10 @@ class HDUList(list, _Verify):
             if self._file.compression == 'gzip':
                 new_file = gzip.GzipFile(name, mode='ab+')
             elif self._file.compression == 'bzip2':
+                if not HAS_BZ2:
+                    raise ValueError(
+                        ".bz2 format files are not supported since the Python "
+                        "interpreter does not include the bz2 module")
                 new_file = bz2.BZ2File(name, mode='w')
             else:
                 new_file = name

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -16,8 +16,9 @@ from .groups import GroupsHDU
 from .image import PrimaryHDU, ImageHDU
 from astropy.io.fits.file import _File, FILE_MODES
 from astropy.io.fits.header import _pad_length
-from astropy.io.fits.util import (_is_int, _tmp_name, fileobj_closed, ignore_sigint,
-                    _get_array_mmap, _free_space_check, fileobj_mode, isfile)
+from astropy.io.fits.util import (_is_int, _tmp_name, fileobj_closed,
+                                  ignore_sigint, _get_array_mmap,
+                                  _free_space_check, fileobj_mode, isfile)
 from astropy.io.fits.verify import _Verify, _ErrList, VerifyError, VerifyWarning
 from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import gzip
-import bz2
 import io
 import mmap
 import errno
@@ -26,6 +25,13 @@ from astropy.tests.helper import raises, catch_warnings, ignore_warnings
 from astropy.utils.data import conf, get_pkg_data_filename
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
+
+try:
+    import bz2  # pylint: disable=W0611
+except ImportError:
+    HAS_BZ2 = False
+else:
+    HAS_BZ2 = True
 
 
 class TestCore(FitsTestCase):
@@ -746,6 +752,7 @@ class TestFileFunctions(FitsTestCase):
             with fits.open(self._make_gzip_file('append.gz'), mode='append') as _:
                 pass
 
+    @pytest.mark.skipif(not HAS_BZ2, reason='Python built without bz2 module')
     def test_open_bzipped(self):
         bzip_file = self._make_bzip2_file()
         with ignore_warnings():
@@ -757,12 +764,14 @@ class TestFileFunctions(FitsTestCase):
                 assert fits_handle._file.compression == 'bzip2'
                 assert len(fits_handle) == 5
 
+    @pytest.mark.skipif(not HAS_BZ2, reason='Python built without bz2 module')
     def test_open_bzipped_from_handle(self):
         with open(self._make_bzip2_file(), 'rb') as handle:
             with fits.open(handle) as fits_handle:
                 assert fits_handle._file.compression == 'bzip2'
                 assert len(fits_handle) == 5
 
+    @pytest.mark.skipif(not HAS_BZ2, reason='Python built without bz2 module')
     def test_detect_bzipped(self):
         """Test detection of a bzip2 file when the extension is not .bz2."""
         with ignore_warnings():
@@ -770,6 +779,7 @@ class TestFileFunctions(FitsTestCase):
                 assert fits_handle._file.compression == 'bzip2'
                 assert len(fits_handle) == 5
 
+    @pytest.mark.skipif(not HAS_BZ2, reason='Python built without bz2 module')
     def test_writeto_bzip2_fileobj(self):
         """Test writing to a bz2.BZ2File file like object"""
         fileobj = bz2.BZ2File(self.temp('test.fits.bz2'), 'w')
@@ -782,6 +792,7 @@ class TestFileFunctions(FitsTestCase):
         with fits.open(self.temp('test.fits.bz2')) as hdul:
             assert hdul[0].header == h.header
 
+    @pytest.mark.skipif(not HAS_BZ2, reason='Python built without bz2 module')
     def test_writeto_bzip2_filename(self):
         """Test writing to a bzip2 file by name"""
         filename = self.temp('testname.fits.bz2')

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -27,7 +27,7 @@ from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
 
 try:
-    import bz2  # pylint: disable=W0611
+    import bz2
 except ImportError:
     HAS_BZ2 = False
 else:

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -280,8 +280,9 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ModuleNotFoundError(
-                "This Python installation does not provide the bz2 module.")
+            raise ValueError(
+                ".bz2 format files are not supported since the Python "
+                "interpreter does not include the bz2 module")
         try:
             # bz2.BZ2File does not support file objects, only filenames, so we
             # need to write the data to a temporary file
@@ -306,8 +307,9 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ModuleNotFoundError(
-                "This Python installation does not provide the lzma module.")
+            raise ValueError(
+                ".xz format files are not supported since the Python "
+                "interpreter does not include the lzma module.")
         except (OSError, EOFError):  # invalid xz file
             fileobj.seek(0)
             fileobj_new.close()

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -280,9 +280,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ValueError(
-                ".bz2 format files are not supported since the Python "
-                "interpreter does not include the bz2 module")
+            raise ModuleNotFoundError(
+                "This Python installation does not provide the bz2 module.")
         try:
             # bz2.BZ2File does not support file objects, only filenames, so we
             # need to write the data to a temporary file
@@ -307,9 +306,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ValueError(
-                ".xz format files are not supported since the Python "
-                "interpreter does not include the lzma module.")
+            raise ModuleNotFoundError(
+                "This Python installation does not provide the lzma module.")
         except (OSError, EOFError):  # invalid xz file
             fileobj.seek(0)
             fileobj_new.close()

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -168,8 +168,7 @@ Working with compressed files
 The :func:`open` function will seamlessly open FITS files that have been
 compressed with gzip, bzip2 or pkzip. Note that in this context we are talking
 about a FITS file that has been compressed with one of these utilities (e.g., a
-.fits.gz file). Opening bzip2-compressed files requires the :mod:`bz2` module
-to be available.
+.fits.gz file).
 
 There are some limitations when working with compressed files. For example,
 with Zip files that contain multiple compressed files, only the first file will

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -168,11 +168,12 @@ Working with compressed files
 The :func:`open` function will seamlessly open FITS files that have been
 compressed with gzip, bzip2 or pkzip. Note that in this context we are talking
 about a FITS file that has been compressed with one of these utilities (e.g., a
-.fits.gz file).
+.fits.gz file). Opening bzip2-compressed files requires the :mod:`bz2` module
+to be available.
 
 There are some limitations when working with compressed files. For example,
 with Zip files that contain multiple compressed files, only the first file will
-be accessible. Also bzip does not support the append or update access modes.
+be accessible. Also bzip2 does not support the append or update access modes.
 
 When writing a file (e.g., with the :func:`writeto` function), compression will
 be determined based on the filename extension given, or the compression used in


### PR DESCRIPTION
### Description
Addressing #5967: removed the unconditional `import bz2` from `io.fits` so the module itself can be imported in Python installations without the `bz2` module. For these systems only the autodetection of bzip2'ed FITS files based on file signature and of course their transparent decompression will be disabled.

Notes

- I do not have a Python interpreter built without bzip2 support; thus I only made some checks for this case by forcing the import to fail (misnaming the module).

- It should be possible to mark the bzip2-tests `xfail` or check for the appropriate exceptions, if the  `_make_bzip2_file` function for creating the test files was modified to fall back to an `os.system("bzip2 -k test0.fits")` call or the like. But that would probably fail on Windows, and on other systems we should perhaps not make assumptions on the availability of the command line `bzip2` either, so it did not seem worth the effort to me.

- Should this go under "API Changes" or "Bug Fixes"?