### PR TITLE
Default plot labels to wcsapi world_axis_names property

### DIFF
--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -81,7 +81,7 @@ class CoordinateHelper:
 
     def __init__(self, parent_axes=None, parent_map=None, transform=None,
                  coord_index=None, coord_type='scalar', coord_unit=None,
-                 coord_wrap=None, frame=None, format_unit=None, name=None):
+                 coord_wrap=None, frame=None, format_unit=None, default_label=None):
 
         # Keep a reference to the parent axes and the transform
         self.parent_axes = parent_axes
@@ -91,7 +91,7 @@ class CoordinateHelper:
         self.coord_unit = coord_unit
         self._format_unit = format_unit
         self.frame = frame
-        self.name = name[0] if isinstance(name, (tuple, list)) else name
+        self.default_label = default_label or ''
         self._auto_axislabel = True
         # Disable auto label for elliptical frames as it puts labels in
         # annoying places.
@@ -514,9 +514,9 @@ class CoordinateHelper:
         unit = self.get_format_unit() or self.coord_unit
 
         if not unit or unit is u.one or self.coord_type in ('longitude', 'latitude'):
-            return f"{self.name}"
+            return f"{self.default_label}"
         else:
-            return f"{self.name} [{unit:latex}]"
+            return f"{self.default_label} [{unit:latex}]"
 
     def set_axislabel_position(self, position):
         """

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -65,21 +65,22 @@ class CoordinatesMap:
             coord_unit = coord_meta['unit'][index]
             name = coord_meta['name'][index]
 
+            visible = True
             if 'visible' in coord_meta:
                 visible = coord_meta['visible'][index]
-            else:
-                visible = True
 
+            format_unit = None
             if 'format_unit' in coord_meta:
                 format_unit = coord_meta['format_unit'][index]
-            else:
-                format_unit = None
 
+            default_label = None
+            if 'default_axis_label' in coord_meta:
+                default_label = coord_meta['default_axis_label'][index]
+
+            coord_index = None
             if visible:
                 visible_count += 1
                 coord_index = visible_count - 1
-            else:
-                coord_index = None
 
             self._coords.append(CoordinateHelper(parent_axes=axes,
                                                  parent_map=self,
@@ -90,7 +91,7 @@ class CoordinatesMap:
                                                  coord_unit=coord_unit,
                                                  format_unit=format_unit,
                                                  frame=self.frame,
-                                                 name=name))
+                                                 default_label=default_label))
 
             # Set up aliases for coordinates
             if isinstance(name, tuple):

--- a/astropy/visualization/wcsaxes/coordinates_map.py
+++ b/astropy/visualization/wcsaxes/coordinates_map.py
@@ -73,7 +73,7 @@ class CoordinatesMap:
             if 'format_unit' in coord_meta:
                 format_unit = coord_meta['format_unit'][index]
 
-            default_label = None
+            default_label = name[0] if isinstance(name, (tuple, list)) else name
             if 'default_axis_label' in coord_meta:
                 default_label = coord_meta['default_axis_label'][index]
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -13,6 +13,7 @@ from matplotlib.transforms import Affine2D, Bbox, Transform
 import astropy.units as u
 from astropy.coordinates import SkyCoord, BaseCoordinateFrame
 from astropy.wcs import WCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS
 
 from .transforms import CoordinateTransform
 from .coordinates_map import CoordinatesMap
@@ -346,6 +347,9 @@ class WCSAxes(Axes):
                 # wcs.set() method
                 if isinstance(wcs, WCS):
                     wcs.wcs.set()
+
+                if isinstance(wcs, BaseHighLevelWCS):
+                    wcs = wcs.low_level_wcs
 
             self.wcs = wcs
 

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -147,6 +147,7 @@ def test_coord_type_from_ctype(cube_wcs):
     wcs.wcs.crpix = [256.0] * 2
     wcs.wcs.cdelt = [-0.05] * 2
     wcs.wcs.crval = [50.0] * 2
+    wcs.wcs.cname = ['Longitude', '']
     wcs.wcs.set()
 
     _, coord_meta = transform_coord_meta_from_wcs(wcs, RectangularFrame)
@@ -154,6 +155,7 @@ def test_coord_type_from_ctype(cube_wcs):
     assert coord_meta['type'] == ['longitude', 'latitude']
     assert coord_meta['format_unit'] == [u.deg, u.deg]
     assert coord_meta['wrap'] == [None, None]
+    assert coord_meta['default_axis_label'] == ['Longitude', 'pos.galactic.lat']
 
     wcs = WCS(naxis=2)
     wcs.wcs.ctype = ['HPLN-TAN', 'HPLT-TAN']

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -125,8 +125,8 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
     coord_meta['default_ticklabel_position'] = [''] * wcs.world_n_dim
     coord_meta['default_ticks_position'] = [''] * wcs.world_n_dim
     # If the world axis has a name use it, else display the world axis physical type.
-    fallback_label = name[0] if isinstance(name, (list, tuple)) else name
-    coord_meta['default_axis_label'] = [wcs.world_axis_names[i] or fallback_label for i, name in enumerate(coord_meta['name'])]
+    fallback_labels = [name[0] if isinstance(name, (list, tuple)) else name for name in coord_meta['name']]
+    coord_meta['default_axis_label'] = [wcs.world_axis_names[i] or fallback_label for i, fallback_label in enumerate(fallback_labels)]
 
     transform_wcs, invert_xy, world_map = apply_slices(wcs, slices)
 

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -124,6 +124,9 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
     coord_meta['default_axislabel_position'] = [''] * wcs.world_n_dim
     coord_meta['default_ticklabel_position'] = [''] * wcs.world_n_dim
     coord_meta['default_ticks_position'] = [''] * wcs.world_n_dim
+    # If the world axis has a name use it, else display the world axis physical type.
+    fallback_label = name[0] if isinstance(name, list) else name
+    coord_meta['default_axis_label'] = [wcs.world_axis_names[i] or fallback_label for i, name in enumerate(coord_meta['name'])]
 
     transform_wcs, invert_xy, world_map = apply_slices(wcs, slices)
 

--- a/astropy/visualization/wcsaxes/wcsapi.py
+++ b/astropy/visualization/wcsaxes/wcsapi.py
@@ -125,7 +125,7 @@ def transform_coord_meta_from_wcs(wcs, frame_class, slices=None):
     coord_meta['default_ticklabel_position'] = [''] * wcs.world_n_dim
     coord_meta['default_ticks_position'] = [''] * wcs.world_n_dim
     # If the world axis has a name use it, else display the world axis physical type.
-    fallback_label = name[0] if isinstance(name, list) else name
+    fallback_label = name[0] if isinstance(name, (list, tuple)) else name
     coord_meta['default_axis_label'] = [wcs.world_axis_names[i] or fallback_label for i, name in enumerate(coord_meta['name'])]
 
     transform_wcs, invert_xy, world_map = apply_slices(wcs, slices)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR makes WCSAxes use the new `world_axis_names` property added to the APE 14 API in #9156
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
