### PR TITLE
Fix generation of units parser/lexer tables.

### DIFF
--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -161,7 +161,7 @@ class Generic(Base):
             return t
 
         def t_UNIT(t):
-            "%|([YZEPTGMkhdcmu\N{MICRO SIGN}npfazy]?"+r"'((?!\d)\w)+')|((?!\d)\w)+"
+            "%|([YZEPTGMkhdcmu\N{MICRO SIGN}npfazy]?'((?!\\d)\\w)+')|((?!\\d)\\w)+"
             t.value = cls._get_unit(t)
             return t
 


### PR DESCRIPTION
Somehow our testing missed that that the addition of strings in a docstring doesn't always work properly (actually, don't know why it seemed to work at all, but it ~did~ (EDIT) seems to have - at least, correct tables were generated at some point, and those were propagated...).

Anyway, with this change, the lextab/parsetab get properly generated again. I'll see if I can also device a test in our travis setup that captures this, but since that may be tricky, for now just the fix.
 
fixes #9659 