### PR TITLE
Update linux instructions for installing from source

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -202,7 +202,7 @@ Prerequisites for Linux
 
 On Linux, using the package manager for your distribution will usually be the
 easiest route to making sure you have the prerequisites to build ``astropy``. In
-order to build from source, you will need the Python and numpy development
+order to build from source, you will need the Python and Numpy development
 package for your Linux distribution, as well as a number of helper packages.
 
 For Debian/Ubuntu::
@@ -211,7 +211,14 @@ For Debian/Ubuntu::
 
 For Fedora/RHEL::
 
-    sudo yum install python-devel
+    sudo yum install python3-devel python3-numpy python3-setuptools python3-Cython python3-jinja2 python3-pytest-astropy
+
+.. note:: Building the developer version of ``astropy`` may require
+          newer versions of the above packages than are available in
+          your distribution's repository.  If so, you could either try
+          a more up to date version (such as Debian ``testing``), or
+          install more up-to-date versions using ``pip`` or ``conda``
+          in a virtual environment.
 
 Prerequisites for Mac OS X
 --------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -202,12 +202,12 @@ Prerequisites for Linux
 
 On Linux, using the package manager for your distribution will usually be the
 easiest route to making sure you have the prerequisites to build ``astropy``. In
-order to build from source, you will need the Python development package for
-your Linux distribution.
+order to build from source, you will need the Python and numpy development
+package for your Linux distribution, as well as a number of helper packages.
 
 For Debian/Ubuntu::
 
-    sudo apt-get install python-dev
+    sudo apt-get install python3-dev python3-numpy-dev python3-setuptools cython3 python3-jinja2 python3-pytest-astropy
 
 For Fedora/RHEL::
 


### PR DESCRIPTION
While trying to add the `s390` distribution to travis in #9663, I noticed that quite a bit more was needed to install astropy than just `python3-dev` - which is what is listed in the documentation. So, an update.

cc @olebole, @sergiopasra - do these packages make sense? For debian, there is a bit of ground truth in #9663, but for redhat, I made the list just by searching the package manager...