### PR TITLE
Add ability to pass kwargs to writer in jsviewer writing to disk

### DIFF
--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -172,7 +172,7 @@ class JSViewer:
 
 def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
                          table_class="display compact", jskwargs=None,
-                         css=DEFAULT_CSS, htmldict=None):
+                         css=DEFAULT_CSS, htmldict=None, **kwargs):
     if table_id is None:
         table_id = 'table{id}'.format(id=id(table))
 
@@ -194,7 +194,7 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
 
     if max_lines < len(table):
         table = table[:max_lines]
-    table.write(filename, format='html', htmldict=html_options)
+    table.write(filename, format='html', htmldict=html_options, **kwargs)
 
 
 io_registry.register_writer('jsviewer', Table, write_table_jsviewer)

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -161,6 +161,37 @@ def test_write_jsviewer_local(tmpdir):
         assert f.read().strip() == ref.strip()
 
 
+
+def test_write_jsviewer_local_passformatskwarg(tmpdir):
+    # separate test that formats get passed to writer
+    t = Table()
+    t['a'] = [1, 2, 3, 4, 5]
+    t['b'] = ['a', 'b', 'c', 'd', 'e']
+    t['a'].unit = 'm'
+
+    tmpfile = tmpdir.join('test.html').strpath
+
+    # crappy formatter but a reasonable test...
+    formatter = lambda x: f'a{x}'
+
+    formats = {'a': formatter}
+    t.write(tmpfile, format='jsviewer', table_id='test',
+            formats=formats,
+            jskwargs={'use_local_files': True})
+    ref = REFERENCE % dict(
+        lines=format_lines(map(formatter, t['a']), t['b']),
+        table_class='display compact',
+        table_id='test',
+        length='50',
+        display_length='10, 25, 50, 100, 500, 1000',
+        datatables_css_url='file://' + join(EXTERN_DIR, 'css', 'jquery.dataTables.css'),
+        datatables_js_url='file://' + join(EXTERN_DIR, 'js', 'jquery.dataTables.min.js'),
+        jquery_url='file://' + join(EXTERN_DIR, 'js', 'jquery-3.1.1.min.js')
+    )
+    with open(tmpfile) as f:
+        assert f.read().strip() == ref.strip()
+
+
 @pytest.mark.skipif('not HAS_IPYTHON')
 def test_show_in_notebook():
     t = Table()


### PR DESCRIPTION
The jsviewer writer doesn't pass keyword arguments onto the table writer
class, so you can't specify formatters and any other keyword arguments.

This is my attempt to get a nicely-formatted javascript table out of a
table write, but so far the attempted fix doesn't seem to work... I
might be barking up the wrong tree, so if this proves fruitless I'll
close the PR and open an issue.