### PR TITLE
Add arm64 CI run to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,14 @@ matrix:
           stage: Cron tests
           env: APT_DEPENDENCIES="python3-pip python3-dev python3-venv python3-setuptools cython3 ipython3 python3-jinja2 python3-numpy python3-pytest-astropy python3-pytest-cov python3-pytest-xdist python3-pytest-filter-subpackage python3-objgraph python3-coverage tzdata"
 
+        # And with an arm64 processor, again with apt for convenience.
+        - name: arm64 architecture with apt
+          arch: arm64
+          language: c
+          dist: bionic
+          stage: Final tests
+          env: APT_DEPENDENCIES="python3-pip python3-dev python3-venv python3-setuptools cython3 ipython3 python3-jinja2 python3-numpy python3-pytest-astropy python3-pytest-cov python3-pytest-xdist python3-pytest-filter-subpackage python3-objgraph python3-coverage tzdata"
+
     allow_failures:
         - language: python
           python: 3.7


### PR DESCRIPTION
Following #9663, this ~tries also adding~ adds an `arm64` run that does not use `pip` and hence may avoid some of the probems in #9407.