### PR TITLE
Fix bug in locking mechanism

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1423,13 +1423,7 @@ def clear_download_cache(hashorurl=None, pkgname='astropy'):
             try:
                 dldir, url2hash = stack.enter_context(
                     _cache(pkgname, write=True))
-            except OSError as e:
-                # Problem arose when trying to open the cache
-                msg = 'Not clearing data cache - cache inaccessible due to '
-                estr = '' if len(e.args) < 1 else (': ' + str(e))
-                warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
-                return
-            except RuntimeError:  # Couldn't get lock
+            except (RuntimeError, WrongDBMModule):  # Couldn't get lock
                 if hashorurl is None:
                     # Release lock by blowing away cache
                     # Need to get locations
@@ -1437,6 +1431,12 @@ def clear_download_cache(hashorurl=None, pkgname='astropy'):
                 else:
                     # Can't do specific deletion without the lock
                     raise
+            except OSError as e:
+                # Problem arose when trying to open the cache
+                msg = 'Not clearing data cache - cache inaccessible due to '
+                estr = '' if len(e.args) < 1 else (': ' + str(e))
+                warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+                return
             if hashorurl is None:
                 if os.path.exists(dldir):
                     shutil.rmtree(dldir)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1889,12 +1889,13 @@ def test_lock_unavailable_raises_runtimeerror_and_clear_frees_lock(
             with pytest.raises(RuntimeError):
                 with _cache_lock("astropy", need_write=True):
                     pass
-            # Download
+            # Trying to do anything should raise an exception
             with pytest.raises(RuntimeError):
-                is_url_in_cache(u), "if locked, act like cache empty"
+                is_url_in_cache(u)
             with pytest.raises(RuntimeError):
                 download_file(u, cache=True, sources=[])
             with pytest.raises(RuntimeError):
                 download_file(u, cache=True)
             clear_download_cache()  # breaks lock
-            is_url_in_cache(u)
+            is_url_in_cache(u)  # False but doesn't raise an exception
+    # Exiting the lock should succeed even though it was broken open


### PR DESCRIPTION
Should fix #9642

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a bug where if the cache lock could not be acquired the failure path would incorrectly release the lock.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9642 
