### PR TITLE
Set units and descriptions in Table init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -549,6 +549,11 @@ astropy.table
 - Fixed a bug that caused an exception when initializing a ``MaskedColumn`` from
   another ``MaskedColumn`` that has a structured dtype. [#9651]
 
+- Added ``units`` and ``descriptions`` keyword arguments to the Table object
+  initialization and ``Table.read()`` methods.  This allows directly setting
+  the ``unit`` and ``description`` for the table columns at the time of
+  creating or reading the table. [#9673]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,11 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Added ``units`` and ``descriptions`` keyword arguments to the Table object
+  initialization and ``Table.read()`` methods.  This allows directly setting
+  the ``unit`` and ``description`` for the table columns at the time of
+  creating or reading the table. [#9671]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -548,11 +553,6 @@ astropy.table
 
 - Fixed a bug that caused an exception when initializing a ``MaskedColumn`` from
   another ``MaskedColumn`` that has a structured dtype. [#9651]
-
-- Added ``units`` and ``descriptions`` keyword arguments to the Table object
-  initialization and ``Table.read()`` methods.  This allows directly setting
-  the ``unit`` and ``description`` for the table columns at the time of
-  creating or reading the table. [#9673]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -33,6 +33,10 @@ class TableRead(registry.UnifiedReadWrite):
         first argument is typically the input filename.
     format : str
         File format specifier.
+    units : list, dict, optional
+        List or dict of units to apply to columns
+    descriptions : list, dict, optional
+        List or dict of descriptions to apply to columns
     **kwargs : dict, optional
         Keyword arguments passed through to data reader.
 
@@ -49,6 +53,9 @@ class TableRead(registry.UnifiedReadWrite):
 
     def __call__(self, *args, **kwargs):
         cls = self._cls
+        units = kwargs.pop('units', None)
+        descriptions = kwargs.pop('descriptions', None)
+
         out = registry.read(cls, *args, **kwargs)
 
         # For some readers (e.g., ascii.ecsv), the returned `out` class is not
@@ -62,6 +69,10 @@ class TableRead(registry.UnifiedReadWrite):
             except Exception:
                 raise TypeError('could not convert reader output to {} '
                                 'class.'.format(cls.__name__))
+
+        out._set_column_attribute('unit', units)
+        out._set_column_attribute('description', descriptions)
+
         return out
 
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -636,14 +636,14 @@ class Table:
         if isinstance(values, dict):
             for name, value in values.items():
                 if name not in self.columns:
-                    raise ValueError(f'invalid olumn name {name} for setting {attr} attribute')
-                setattr(self[name], attr, value)
+                    raise ValueError(f'invalid column name {name} for setting {attr} attribute')
+                setattr(self[name].info, attr, value)
         else:
             if len(values) != len(self.columns):
                 raise ValueError(f'sequence of {attr} values must match number of columns')
             for col, value in zip(self.itercols(), values):
                 if value is not None:
-                    setattr(col, attr, value)
+                    setattr(col.info, attr, value)
 
     def __getstate__(self):
         columns = OrderedDict((key, col if isinstance(col, BaseColumn) else col_copy(col))

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -375,9 +375,9 @@ class Table:
     copy_indices : bool, optional
         Copy any indices in the input data. Default is True.
     units : list, dict, optional
-        List or dict of units to apply to columns
+        List or dict of units to apply to columns.
     descriptions : list, dict, optional
-        List or dict of descriptions to apply to columns
+        List or dict of descriptions to apply to columns.
     **kwargs : dict, optional
         Additional keyword args when converting table-like object.
     """

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2409,13 +2409,15 @@ def test_set_units_fail():
 
 
 def test_set_units():
-    dat = [[1.0, 2.0], ['aa', 'bb']]
-    exp_units = (u.m, None)
+    dat = [[1.0, 2.0], ['aa', 'bb'], [3, 4]]
+    exp_units = (u.m, None, None)
     for cls in Table, QTable:
-        for units in ({'a': u.m}, exp_units):
-            qt = cls(dat, units=units, names=['a', 'b'])
+        for units in ({'a': u.m, 'c': ''}, exp_units):
+            qt = cls(dat, units=units, names=['a', 'b', 'c'])
             if cls is QTable:
                 assert isinstance(qt['a'], u.Quantity)
+                assert isinstance(qt['b'], table.Column)
+                assert isinstance(qt['c'], table.Column)
             for col, unit in zip(qt.itercols(), exp_units):
                 assert col.info.unit is unit
 
@@ -2428,6 +2430,18 @@ def test_set_descriptions():
             qt = cls(dat, descriptions=descriptions, names=['a', 'b'])
             for col, description in zip(qt.itercols(), exp_descriptions):
                 assert col.info.description == description
+
+
+def test_set_units_from_row():
+    text = ['a,b',
+            ',s',
+            '1,2',
+            '3,4']
+    units = Table.read(text, format='ascii', data_start=1, data_end=2)[0]
+    t = Table.read(text, format='ascii', data_start=2, units=units)
+    assert isinstance(units, table.Row)
+    assert t['a'].info.unit is None
+    assert t['b'].info.unit is u.s
 
 
 def test_set_units_descriptions_read():

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2449,9 +2449,9 @@ def test_set_units_descriptions_read():
     is less comprehensive because the implementation is exactly the same
     as for Table.__init__ (calling Table._set_column_attribute) """
     for cls in Table, QTable:
-        t = cls.read(['a b', '1 2'], 
-                     format='ascii', 
-                     units=[u.m, u.s], 
+        t = cls.read(['a b', '1 2'],
+                     format='ascii',
+                     units=[u.m, u.s],
                      descriptions=['hi', 'there'])
         assert t['a'].info.unit is u.m
         assert t['b'].info.unit is u.s

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -558,7 +558,7 @@ object with the following arguments, all of which are optional:
 ``descriptions`` : list, dict, optional
     List or dict of descriptions to apply to columns
 ``**kwargs`` : dict, optional
-    Additional keyword args when converting table-like object.    
+    Additional keyword args when converting table-like object.
 
 The following subsections provide further detail on the values and options for
 each of the keyword arguments that can be used to create a new |Table| object.
@@ -684,7 +684,7 @@ rows
 
 This argument allows providing data as a sequence of rows, in contrast
 to the ``data`` keyword which generally assumes data are a sequence of columns.
-The `Row data` section provides details.
+The `Row data`_ section provides details.
 
 copy_indices
 ------------

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -535,16 +535,30 @@ Initialization Details
 A table object is created by initializing a |Table| class
 object with the following arguments, all of which are optional:
 
-``data`` : numpy ndarray, dict, list, or Table
+``data`` : numpy ndarray, dict, list, Table, or table-like object, optional
     Data to initialize table.
-``names`` : list
-    Specify column names
-``dtype`` : list
-    Specify column data types
-``meta`` : dict-like
-    Meta-Data associated with the table
-``copy`` : boolean
-    Copy the input data (default=True).
+``masked`` : bool, optional
+    Specify whether the table is masked.
+``names`` : list, optional
+    Specify column names.
+``dtype`` : list, optional
+    Specify column data types.
+``meta`` : dict, optional
+    Metadata associated with the table.
+``copy`` : bool, optional
+    Copy the input data. If the input is a Table the ``meta`` is always
+    copied regardless of the ``copy`` parameter.
+    Default is True.
+``rows`` : numpy ndarray, list of lists, optional
+    Row-oriented data for table instead of ``data`` argument.
+``copy_indices`` : bool, optional
+    Copy any indices in the input data. Default is True.
+``units`` : list, dict, optional
+    List or dict of units to apply to columns
+``descriptions`` : list, dict, optional
+    List or dict of descriptions to apply to columns
+``**kwargs`` : dict, optional
+    Additional keyword args when converting table-like object.    
 
 The following subsections provide further detail on the values and options for
 each of the keyword arguments that can be used to create a new |Table| object.
@@ -664,6 +678,43 @@ advantage of reducing memory use and being faster.  However one should take
 care because any modifications to the new Table data will also be seen in the
 original input data.  See the `Copy versus Reference`_ section for more
 information.
+
+rows
+----
+
+This argument allows providing data as a sequence of rows, in contrast
+to the ``data`` keyword which generally assumes data are a sequence of columns.
+The `Row data` section provides details.
+
+copy_indices
+------------
+
+If you are initializing a table from another table that has table
+indices defined, then this option allows copying that table *without* copying
+the indices by setting ``copy_indices=False``.  By default the indices are
+copied.
+
+units
+-----
+
+This allows setting the unit for one or more columns at the time of creating the
+table.  The input can be either a list of unit values corresponding to each of
+the columns in the table (using ``None`` for no unit), or a ``dict`` that
+provides the unit for specified column names.  For example::
+
+  >>> from astropy.table import QTable
+  >>> dat = [[1, 2] * u.m, ['hello', 'world']]
+  >>> qt = QTable(dat, names=['a', 'b'], units=(u.m, None))
+  >>> qt = QTable(dat, names=['a', 'b'], units={'a': u.m})
+
+descriptions
+------------
+
+This allows setting the description for one or more columns at the time of
+creating the table.  The input can be either a list of description values
+corresponding to each of the columns in the table (using ``None`` for no
+description), or a ``dict`` that provides the description for specified column
+names.  This works the same as the ``units`` example above.
 
 
 .. _copy_versus_reference:

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -699,11 +699,11 @@ units
 
 This allows setting the unit for one or more columns at the time of creating the
 table.  The input can be either a list of unit values corresponding to each of
-the columns in the table (using ``None`` for no unit), or a ``dict`` that
-provides the unit for specified column names.  For example::
+the columns in the table (using ``None`` or ``''`` for no unit), or a ``dict``
+that provides the unit for specified column names.  For example::
 
   >>> from astropy.table import QTable
-  >>> dat = [[1, 2] * u.m, ['hello', 'world']]
+  >>> dat = [[1, 2], ['hello', 'world']]
   >>> qt = QTable(dat, names=['a', 'b'], units=(u.m, None))
   >>> qt = QTable(dat, names=['a', 'b'], units={'a': u.m})
 


### PR DESCRIPTION
This allows explicitly setting both the `units` and `descriptions` of specified table columns from the `Table.__init__()` and `Table.read()` methods.

Closes #9639 

It provides some mitigation for #9665 (read units row from ASCII table) by making it easier to do that:
```
    text = ['a,b',
            ',s',
            '1,2',
            '3,4']
    units = Table.read(text, format='ascii', data_start=1, data_end=2)[0]
    t = Table.read(text, format='ascii', data_start=2, units=units)
```
