### PR TITLE
Use type hints to verify APE 14 implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
-        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
+        - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck typeguard'
         - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
         - ASDF_PIP_DEP='asdf>=2.3'
         - SETUP_XVFB=True

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1143,6 +1143,9 @@ astropy.wcs
 - Fix incorrect value returned by ``wcsapi.HighLevelWCSWrapper.axis_correlation_matrix``.
   [#9554]
 
+- ``FITSWCSAPIMixin`` now returns tuples not lists from ``pixel_to_world`` and
+  ``world_to_pixel``. [#9678]
+
 Other Changes and Additions
 ---------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,12 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+``BaseLowLevelWCS`` now has a full description of the return types as part of
+the API using type hinting. In addition to this a helper function
+``astropy.wcs.wcsapi.tests.utils.validate_low_level_wcs_types`` has been added
+which can be used to test APE 14 compatible implementations against these type
+annotations. [#9677]
+
 API Changes
 -----------
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -247,15 +247,15 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     def pixel_to_world_values(self, *pixel_arrays):
         world = self.all_pix2world(*pixel_arrays, 0)
-        return world[0] if self.world_n_dim == 1 else world
+        return world[0] if self.world_n_dim == 1 else tuple(world)
 
     def array_index_to_world_values(self, *indices):
         world = self.all_pix2world(*indices[::-1], 0)
-        return world[0] if self.world_n_dim == 1 else world
+        return world[0] if self.world_n_dim == 1 else tuple(world)
 
     def world_to_pixel_values(self, *world_arrays):
         pixel = self.all_world2pix(*world_arrays, 0)
-        return pixel[0] if self.pixel_n_dim == 1 else pixel
+        return pixel[0] if self.pixel_n_dim == 1 else tuple(pixel)
 
     def world_to_array_index_values(self, *world_arrays):
         pixel_arrays = self.all_world2pix(*world_arrays, 0)[::-1]

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -168,7 +168,10 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def pixel_bounds(self):
-        return self._pixel_bounds
+        pb = self._pixel_bounds
+        if pb is not None:
+            pb = tuple(pb)
+        return pb
 
     @pixel_bounds.setter
     def pixel_bounds(self, value):
@@ -196,7 +199,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                         break
                 else:
                     types.append(CTYPE_TO_UCD1.get(ctype_name, None))
-        return types
+        return tuple(types)
 
     @property
     def world_axis_units(self):
@@ -212,11 +215,11 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                 except u.UnitsError:
                     unit = ''
             units.append(unit)
-        return units
+        return tuple(units)
 
     @property
     def world_axis_names(self):
-        return list(self.wcs.cname)
+        return tuple(self.wcs.cname)
 
     @property
     def axis_correlation_matrix(self):

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -1,9 +1,15 @@
 import os
 import abc
+from typing import List, Tuple, Union, Optional, Callable, Mapping
 
 import numpy as np
 
+
 __all__ = ['BaseLowLevelWCS', 'validate_physical_types']
+
+
+scalar_or_array = Union[float, np.ndarray]
+scalar_or_array_or_tuple = Union[scalar_or_array, Tuple[scalar_or_array, ...]]
 
 
 class BaseLowLevelWCS(metaclass=abc.ABCMeta):
@@ -16,21 +22,21 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def pixel_n_dim(self):
+    def pixel_n_dim(self) -> int:
         """
         The number of axes in the pixel coordinate system.
         """
 
     @property
     @abc.abstractmethod
-    def world_n_dim(self):
+    def world_n_dim(self) -> int:
         """
         The number of axes in the world coordinate system.
         """
 
     @property
     @abc.abstractmethod
-    def world_axis_physical_types(self):
+    def world_axis_physical_types(self) -> List[Union[str, None]]:
         """
         An iterable of strings describing the physical type for each world axis.
 
@@ -43,7 +49,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_units(self):
+    def world_axis_units(self) -> List[str]:
         """
         An iterable of strings given the units of the world coordinates for each
         axis.
@@ -55,7 +61,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def pixel_to_world_values(self, *pixel_arrays):
+    def pixel_to_world_values(self, *pixel_arrays: scalar_or_array) -> scalar_or_array_or_tuple:
         """
         Convert pixel coordinates to world coordinates.
 
@@ -75,7 +81,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def array_index_to_world_values(self, *index_arrays):
+    def array_index_to_world_values(self, *index_arrays: scalar_or_array) -> scalar_or_array_or_tuple:
         """
         Convert array indices to world coordinates.
 
@@ -90,7 +96,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def world_to_pixel_values(self, *world_arrays):
+    def world_to_pixel_values(self, *world_arrays: scalar_or_array) -> scalar_or_array_or_tuple:
         """
         Convert world coordinates to pixel coordinates.
 
@@ -109,7 +115,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def world_to_array_index_values(self, *world_arrays):
+    def world_to_array_index_values(self, *world_arrays: scalar_or_array) -> scalar_or_array_or_tuple:
         """
         Convert world coordinates to array indices.
 
@@ -126,7 +132,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_object_components(self):
+    def world_axis_object_components(self) -> List[Tuple[str, Union[str, int], Union[str, Callable]]]:
         """
         A list with `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim` elements giving information
         on constructing high-level objects for the world coordinates.
@@ -159,7 +165,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_object_classes(self):
+    def world_axis_object_classes(self) -> Mapping[str, Tuple[Union[str, type], tuple, dict, Optional[Callable]]]:
         """
         A dictionary giving information on constructing high-level objects for
         the world coordinates.
@@ -217,7 +223,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
     # they are not abstract.
 
     @property
-    def array_shape(self):
+    def array_shape(self) -> Optional[Tuple[int, ...]]:
         """
         The shape of the data that the WCS applies to as a tuple of length
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` in ``(row, column)``
@@ -232,7 +238,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return None
 
     @property
-    def pixel_shape(self):
+    def pixel_shape(self) -> Optional[Tuple[int, ...]]:
         """
         The shape of the data that the WCS applies to as a tuple of length
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim` in ``(x, y)``
@@ -252,7 +258,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return None
 
     @property
-    def pixel_bounds(self):
+    def pixel_bounds(self) -> Optional[Tuple[Tuple[float, float], ...]]:
         """
         The bounds (in pixel coordinates) inside which the WCS is defined,
         as a list with `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`
@@ -267,7 +273,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return None
 
     @property
-    def pixel_axis_names(self):
+    def pixel_axis_names(self) -> List[str]:
         """
         An iterable of strings describing the name for each pixel axis.
 
@@ -279,7 +285,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return [''] * self.pixel_n_dim
 
     @property
-    def world_axis_names(self):
+    def world_axis_names(self) -> List[str]:
         """
         An iterable of strings describing the name for each world axis.
 
@@ -292,7 +298,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return [''] * self.world_n_dim
 
     @property
-    def axis_correlation_matrix(self):
+    def axis_correlation_matrix(self) -> np.ndarray:
         """
         Returns an (`~astropy.wcs.wcsapi.BaseLowLevelWCS.world_n_dim`,
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.pixel_n_dim`) matrix that
@@ -306,7 +312,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return np.ones((self.world_n_dim, self.pixel_n_dim), dtype=bool)
 
     @property
-    def serialized_classes(self):
+    def serialized_classes(self) -> bool:
         """
         Indicates whether Python objects are given in serialized form or as
         actual Python objects.

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -11,6 +11,10 @@ __all__ = ['BaseLowLevelWCS', 'validate_physical_types']
 scalar_or_array = Union[float, np.ndarray]
 scalar_or_array_or_tuple = Union[scalar_or_array, Tuple[scalar_or_array, ...]]
 
+# World axis object classes
+waoc_no_callable = Mapping[str, Tuple[Union[str, type], tuple, dict]]
+waoc_with_callable = Mapping[str, Tuple[Union[str, type], tuple, dict, Optional[Callable]]]
+
 
 class BaseLowLevelWCS(metaclass=abc.ABCMeta):
     """
@@ -36,7 +40,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_physical_types(self) -> List[Union[str, None]]:
+    def world_axis_physical_types(self) -> Tuple[Union[str, None], ...]:
         """
         An iterable of strings describing the physical type for each world axis.
 
@@ -49,7 +53,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_units(self) -> List[str]:
+    def world_axis_units(self) -> Tuple[str, ...]:
         """
         An iterable of strings given the units of the world coordinates for each
         axis.
@@ -165,7 +169,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def world_axis_object_classes(self) -> Mapping[str, Tuple[Union[str, type], tuple, dict, Optional[Callable]]]:
+    def world_axis_object_classes(self) -> Union[waoc_no_callable, waoc_with_callable]:
         """
         A dictionary giving information on constructing high-level objects for
         the world coordinates.
@@ -273,7 +277,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         return None
 
     @property
-    def pixel_axis_names(self) -> List[str]:
+    def pixel_axis_names(self) -> Tuple[str, ...]:
         """
         An iterable of strings describing the name for each pixel axis.
 
@@ -282,10 +286,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         override this property). Note that these names are just for display
         purposes and are not standardized.
         """
-        return [''] * self.pixel_n_dim
+        return tuple([''] * self.pixel_n_dim)
 
     @property
-    def world_axis_names(self) -> List[str]:
+    def world_axis_names(self) -> Tuple[str, ...]:
         """
         An iterable of strings describing the name for each world axis.
 
@@ -295,7 +299,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         purposes and are not standardized. For standardized axis types, see
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.world_axis_physical_types`.
         """
-        return [''] * self.world_n_dim
+        return tuple([''] * self.world_n_dim)
 
     @property
     def axis_correlation_matrix(self) -> np.ndarray:

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -168,7 +168,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
         # Detect the case of a length 0 array
         if isinstance(world_arrays, np.ndarray) and not world_arrays.shape:
             return world_arrays
-        world = [world_arrays[iw] for iw in self._world_keep]
+        world = tuple(world_arrays[iw] for iw in self._world_keep)
         if self.world_n_dim == 1 and self._wcs.world_n_dim > 1:
             world = world[0]
         return world
@@ -196,7 +196,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
         # Detect the case of a length 0 array
         if isinstance(pixel_arrays, np.ndarray) and not pixel_arrays.shape:
             return pixel_arrays
-        pixel = [pixel_arrays[ip] for ip in self._pixel_keep]
+        pixel = tuple(pixel_arrays[ip] for ip in self._pixel_keep)
         if self.pixel_n_dim == 1 and self._wcs.pixel_n_dim > 1:
             pixel = pixel[0]
         return pixel
@@ -240,7 +240,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
                 start = self._slices_pixel[idx].start
                 bounds.append((imin - start, imax - start))
 
-        return bounds
+        return tuple(bounds)
 
     @property
     def axis_correlation_matrix(self):

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -136,19 +136,19 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_physical_types(self):
-        return [self._wcs.world_axis_physical_types[i] for i in self._world_keep]
+        return tuple(self._wcs.world_axis_physical_types[i] for i in self._world_keep)
 
     @property
     def world_axis_units(self):
-        return [self._wcs.world_axis_units[i] for i in self._world_keep]
+        return tuple(self._wcs.world_axis_units[i] for i in self._world_keep)
 
     @property
     def pixel_axis_names(self):
-        return [self._wcs.pixel_axis_names[i] for i in self._pixel_keep]
+        return tuple(self._wcs.pixel_axis_names[i] for i in self._pixel_keep)
 
     @property
     def world_axis_names(self):
-        return [self._wcs.world_axis_names[i] for i in self._world_keep]
+        return tuple(self._wcs.world_axis_names[i] for i in self._world_keep)
 
     def pixel_to_world_values(self, *pixel_arrays):
         pixel_arrays_new = []

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -20,6 +20,8 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs.wcs import WCS, FITSFixedWarning
 from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
 
+from .utils import validate_low_level_wcs_types
+
 ###############################################################################
 # The following example is the simplest WCS with default values
 ###############################################################################
@@ -914,3 +916,16 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub4.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
     assert wcs_sub4.world_axis_units == ['deg', 'deg']
     assert wcs_sub4.world_axis_names == ['', '']
+
+
+def test_low_level_types(header_time_1d):
+    # TODO: make all these fixtures
+
+    wcses = [WCS_TIME_CUBE, WCS_EMPTY, WCS_SIMPLE_CELESTIAL]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', FITSFixedWarning)
+        wcses.append(WCS(header_time_1d))
+
+    for wcs in wcses:
+        validate_low_level_wcs_types(wcs)

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -40,10 +40,10 @@ def test_empty():
     assert wcs.world_n_dim == 1
     assert wcs.array_shape is None
     assert wcs.pixel_shape is None
-    assert wcs.world_axis_physical_types == [None]
-    assert wcs.world_axis_units == ['']
-    assert wcs.pixel_axis_names == ['']
-    assert wcs.world_axis_names == ['']
+    assert wcs.world_axis_physical_types == (None,)
+    assert wcs.world_axis_units == ('',)
+    assert wcs.pixel_axis_names == ('',)
+    assert wcs.world_axis_names == ('',)
 
     assert_equal(wcs.axis_correlation_matrix, True)
 
@@ -121,10 +121,10 @@ def test_simple_celestial():
     assert wcs.world_n_dim == 2
     assert wcs.array_shape is None
     assert wcs.pixel_shape is None
-    assert wcs.world_axis_physical_types == ['pos.eq.ra', 'pos.eq.dec']
-    assert wcs.world_axis_units == ['deg', 'deg']
-    assert wcs.pixel_axis_names == ['', '']
-    assert wcs.world_axis_names == ['', '']
+    assert wcs.world_axis_physical_types == ('pos.eq.ra', 'pos.eq.dec')
+    assert wcs.world_axis_units == ('deg', 'deg')
+    assert wcs.pixel_axis_names == ('', '')
+    assert wcs.world_axis_names == ('', '')
 
     assert_equal(wcs.axis_correlation_matrix, True)
 
@@ -235,10 +235,10 @@ def test_spectral_cube():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape is None
     assert wcs.pixel_shape is None
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
                                                [False, True, False],
@@ -325,10 +325,10 @@ def test_spectral_cube_nonaligned():
 
     wcs = WCS_SPECTRAL_CUBE_NONALIGNED
 
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, True],
                                                [False, True, True],
@@ -422,10 +422,10 @@ def test_time_cube():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (11, 2048, 2048)
     assert wcs.pixel_shape == (2048, 2048, 11)
-    assert wcs.world_axis_physical_types == ['pos.eq.dec', 'pos.eq.ra', 'time']
-    assert wcs.world_axis_units == ['deg', 'deg', 's']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['', '', '']
+    assert wcs.world_axis_physical_types == ('pos.eq.dec', 'pos.eq.ra', 'time')
+    assert wcs.world_axis_units == ('deg', 'deg', 's')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('', '', '')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True, False],
                                                [True, True, False],
@@ -755,7 +755,7 @@ def test_unrecognized_unit():
     wcs = WCS(naxis=1)
     with pytest.warns(UnitsWarning):
         wcs.wcs.cunit = ['bananas // sekonds']
-        assert wcs.world_axis_units == ['bananas // sekonds']
+        assert wcs.world_axis_units == ('bananas // sekonds', )
 
 
 def test_distortion_correlations():
@@ -793,35 +793,35 @@ def test_custom_ctype_to_ucd_mappings():
     wcs = WCS(naxis=1)
     wcs.wcs.ctype = ['SPAM']
 
-    assert wcs.world_axis_physical_types == [None]
+    assert wcs.world_axis_physical_types == (None, )
 
     # Check simple behavior
 
     with custom_ctype_to_ucd_mapping({'APPLE': 'food.fruit'}):
-        assert wcs.world_axis_physical_types == [None]
+        assert wcs.world_axis_physical_types == (None, )
 
     with custom_ctype_to_ucd_mapping({'APPLE': 'food.fruit', 'SPAM': 'food.spam'}):
-        assert wcs.world_axis_physical_types == ['food.spam']
+        assert wcs.world_axis_physical_types == ('food.spam', )
 
     # Check nesting
 
     with custom_ctype_to_ucd_mapping({'SPAM': 'food.spam'}):
         with custom_ctype_to_ucd_mapping({'APPLE': 'food.fruit'}):
-            assert wcs.world_axis_physical_types == ['food.spam']
+            assert wcs.world_axis_physical_types == ('food.spam', )
 
     with custom_ctype_to_ucd_mapping({'APPLE': 'food.fruit'}):
         with custom_ctype_to_ucd_mapping({'SPAM': 'food.spam'}):
-            assert wcs.world_axis_physical_types == ['food.spam']
+            assert wcs.world_axis_physical_types == ('food.spam', )
 
     # Check priority in nesting
 
     with custom_ctype_to_ucd_mapping({'SPAM': 'notfood'}):
         with custom_ctype_to_ucd_mapping({'SPAM': 'food.spam'}):
-            assert wcs.world_axis_physical_types == ['food.spam']
+            assert wcs.world_axis_physical_types == ('food.spam', )
 
     with custom_ctype_to_ucd_mapping({'SPAM': 'food.spam'}):
         with custom_ctype_to_ucd_mapping({'SPAM': 'notfood'}):
-            assert wcs.world_axis_physical_types == ['notfood']
+            assert wcs.world_axis_physical_types == ('notfood', )
 
 
 def test_caching_components_and_classes():
@@ -871,10 +871,10 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub1.world_n_dim == 2
     assert wcs_sub1.array_shape == (50, 30)
     assert wcs_sub1.pixel_shape == (30, 50)
-    assert wcs_sub1.pixel_bounds == [(-1, 11), (5, 15)]
-    assert wcs_sub1.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
-    assert wcs_sub1.world_axis_units == ['deg', 'deg']
-    assert wcs_sub1.world_axis_names == ['Latitude', 'Longitude']
+    assert wcs_sub1.pixel_bounds == ((-1, 11), (5, 15))
+    assert wcs_sub1.world_axis_physical_types == ('pos.galactic.lat', 'pos.galactic.lon')
+    assert wcs_sub1.world_axis_units == ('deg', 'deg')
+    assert wcs_sub1.world_axis_names == ('Latitude', 'Longitude')
 
     # Try adding axes
 
@@ -884,10 +884,10 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub2.world_n_dim == 3
     assert wcs_sub2.array_shape == (None, 40, None)
     assert wcs_sub2.pixel_shape == (None, 40, None)
-    assert wcs_sub2.pixel_bounds == [None, (-2, 18), None]
-    assert wcs_sub2.world_axis_physical_types == [None, 'em.freq', None]
-    assert wcs_sub2.world_axis_units == ['', 'Hz', '']
-    assert wcs_sub2.world_axis_names == ['', 'Frequency', '']
+    assert wcs_sub2.pixel_bounds == (None, (-2, 18), None)
+    assert wcs_sub2.world_axis_physical_types == (None, 'em.freq', None)
+    assert wcs_sub2.world_axis_units == ('', 'Hz', '')
+    assert wcs_sub2.world_axis_names == ('', 'Frequency', '')
 
     # Use strings
 
@@ -897,10 +897,10 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub3.world_n_dim == 2
     assert wcs_sub3.array_shape == (30, 50)
     assert wcs_sub3.pixel_shape == (50, 30)
-    assert wcs_sub3.pixel_bounds == [(5, 15), (-1, 11)]
-    assert wcs_sub3.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
-    assert wcs_sub3.world_axis_units == ['deg', 'deg']
-    assert wcs_sub3.world_axis_names == ['Longitude', 'Latitude']
+    assert wcs_sub3.pixel_bounds == ((5, 15), (-1, 11))
+    assert wcs_sub3.world_axis_physical_types == ('pos.galactic.lon', 'pos.galactic.lat')
+    assert wcs_sub3.world_axis_units == ('deg', 'deg')
+    assert wcs_sub3.world_axis_names == ('Longitude', 'Latitude')
 
     # Now try without CNAME set
 
@@ -911,10 +911,10 @@ def test_sub_wcsapi_attributes():
     assert wcs_sub4.world_n_dim == 2
     assert wcs_sub4.array_shape == (30, 50)
     assert wcs_sub4.pixel_shape == (50, 30)
-    assert wcs_sub4.pixel_bounds == [(5, 15), (-1, 11)]
-    assert wcs_sub4.world_axis_physical_types == ['pos.galactic.lon', 'pos.galactic.lat']
-    assert wcs_sub4.world_axis_units == ['deg', 'deg']
-    assert wcs_sub4.world_axis_names == ['', '']
+    assert wcs_sub4.pixel_bounds == ((5, 15), (-1, 11))
+    assert wcs_sub4.world_axis_physical_types == ('pos.galactic.lon', 'pos.galactic.lat')
+    assert wcs_sub4.world_axis_units == ('deg', 'deg')
+    assert wcs_sub4.world_axis_names == ('', '')
 
 
 def test_low_level_types(header_time_1d):

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -20,7 +20,6 @@ from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs.wcs import WCS, FITSFixedWarning
 from astropy.wcs.wcsapi.fitswcs import custom_ctype_to_ucd_mapping
 
-from .utils import validate_low_level_wcs_types
 
 ###############################################################################
 # The following example is the simplest WCS with default values
@@ -919,8 +918,10 @@ def test_sub_wcsapi_attributes():
 
 
 def test_low_level_types(header_time_1d):
-    # TODO: make all these fixtures
+    pytest.importorskip("typeguard")
+    from .utils import validate_low_level_wcs_types
 
+    # TODO: make all these fixtures
     wcses = [WCS_TIME_CUBE, WCS_EMPTY, WCS_SIMPLE_CELESTIAL]
 
     with warnings.catch_warnings():

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -122,16 +122,16 @@ def test_ellipsis():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 20, 10)
     assert wcs.pixel_shape == (10, 20, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
     assert wcs.world_axis_object_components == [('celestial', 1, 'spherical.lat.degree'),
-                                                  ('freq', 0, 'value'),
-                                                  ('celestial', 0, 'spherical.lon.degree')]
+                                                ('freq', 0, 'value'),
+                                                ('celestial', 0, 'spherical.lon.degree')]
 
     assert wcs.world_axis_object_classes['celestial'][0] is SkyCoord
     assert wcs.world_axis_object_classes['celestial'][1] == ()
@@ -198,10 +198,10 @@ def test_spectral_slice():
     assert wcs.world_n_dim == 2
     assert wcs.array_shape == (30, 10)
     assert wcs.pixel_shape == (10, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'deg']
-    assert wcs.pixel_axis_names == ['', '']
-    assert wcs.world_axis_names == ['Latitude', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'deg')
+    assert wcs.pixel_axis_names == ('', '')
+    assert wcs.world_axis_names == ('Latitude', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, True], [True, True]])
 
@@ -260,10 +260,10 @@ def test_spectral_range():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 6, 10)
     assert wcs.pixel_shape == (10, 6, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -326,10 +326,10 @@ def test_celestial_slice():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 20)
     assert wcs.pixel_shape == (20, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[False, True], [True, False], [False, True]])
 
@@ -393,10 +393,10 @@ def test_celestial_range():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 20, 5)
     assert wcs.pixel_shape == (5, 20, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -470,10 +470,10 @@ def test_celestial_range_rot():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 20, 5)
     assert wcs.pixel_shape == (5, 20, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
-    assert wcs.pixel_axis_names == ['', '', '']
-    assert wcs.world_axis_names == ['Latitude', 'Frequency', 'Longitude']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
+    assert wcs.pixel_axis_names == ('', '', '')
+    assert wcs.world_axis_names == ('Latitude', 'Frequency', 'Longitude')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -560,8 +560,8 @@ def test_no_array_shape():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape is None
     assert wcs.pixel_shape is None
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', 'em.freq', 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', 'em.freq', 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True], [False, True, False], [True, False, True]])
 
@@ -649,8 +649,8 @@ def test_ellipsis_none_types():
     assert wcs.world_n_dim == 3
     assert wcs.array_shape == (30, 20, 10)
     assert wcs.pixel_shape == (10, 20, 30)
-    assert wcs.world_axis_physical_types == ['pos.galactic.lat', None, 'pos.galactic.lon']
-    assert wcs.world_axis_units == ['deg', 'Hz', 'deg']
+    assert wcs.world_axis_physical_types == ('pos.galactic.lat', None, 'pos.galactic.lon')
+    assert wcs.world_axis_units == ('deg', 'Hz', 'deg')
 
     assert_equal(wcs.axis_correlation_matrix, [[True, False, True],
                                                [False, True, False], [True, False, True]])

--- a/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/tests/test_sliced_low_level_wcs.py
@@ -11,6 +11,19 @@ from astropy.units import Quantity
 from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
 import astropy.units as u
 
+
+def validate_types_or_skip(wcs):
+    """
+    Validate the types if we can import typeguard otherwise noop.
+    """
+    try:
+        from astropy.wcs.wcsapi.tests.utils import validate_low_level_wcs_types
+    except ImportError:
+        return
+
+    validate_low_level_wcs_types(wcs)
+
+
 # To test the slicing we start off from standard FITS WCS
 # objects since those implement the low-level API. We create
 # a WCS for a spectral cube with axes in non-standard order
@@ -103,6 +116,7 @@ World Dim    0    1    2
 def test_ellipsis():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, Ellipsis)
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -178,6 +192,7 @@ World Dim    0    1
 def test_spectral_slice():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [slice(None), 10])
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 2
     assert wcs.world_n_dim == 2
@@ -239,6 +254,7 @@ World Dim    0    1    2
 def test_spectral_range():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [slice(None), slice(4, 10)])
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -304,6 +320,7 @@ World Dim    0    1
 def test_celestial_slice():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [Ellipsis, 5])
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 2
     assert wcs.world_n_dim == 3
@@ -370,6 +387,7 @@ World Dim    0    1    2
 def test_celestial_range():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE, [Ellipsis, slice(5, 10)])
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -446,6 +464,7 @@ World Dim    0    1    2
 def test_celestial_range_rot():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE_ROT, [Ellipsis, slice(5, 10)])
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -535,6 +554,7 @@ World Dim    0    1    2
 def test_no_array_shape():
 
     wcs = SlicedLowLevelWCS(WCS_NO_SHAPE_CUBE, Ellipsis)
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -623,6 +643,7 @@ World Dim    0    1    2
 def test_ellipsis_none_types():
 
     wcs = SlicedLowLevelWCS(WCS_SPECTRAL_CUBE_NONE_TYPES, Ellipsis)
+    validate_types_or_skip(wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
@@ -690,7 +711,9 @@ def test_nested_slicing():
                     SlicedLowLevelWCS(wcs, [slice(None), slice(1, 10), slice(None)]),
                     [3, slice(2, None)]),
                 [slice(None), slice(2, 8)])
+    validate_types_or_skip(sub1)
     sub2 = wcs[3, 3:10, 2:8]
+    validate_types_or_skip(sub2)
     assert_allclose(sub1.pixel_to_world_values(3, 5),
                     sub2.pixel_to_world_values(3, 5))
     assert not isinstance(sub1._wcs, SlicedLowLevelWCS)

--- a/astropy/wcs/wcsapi/tests/utils.py
+++ b/astropy/wcs/wcsapi/tests/utils.py
@@ -1,0 +1,83 @@
+import inspect
+
+import numpy as np
+from typeguard import check_type
+
+from astropy.wcs.wcsapi import BaseLowLevelWCS
+
+
+__all__ = ['validate_low_level_wcs_types']
+
+
+def isproperty(obj):
+    return isinstance(obj, property)
+
+
+def validate_low_level_wcs_types(wcs):
+    """
+    Compare the return values from ``wcs`` with the type annotations on
+    `astropy.wcs.wcsapi.BaseLowLevelWCS`.
+    """
+
+    if not isinstance(wcs, BaseLowLevelWCS):
+        raise TypeError("wcs argument must be an instance of BaseLowLevelWCS")
+
+    # Get a list of all the properties on BaseLowLevelWCS
+    properties = [name for name, _ in inspect.getmembers(BaseLowLevelWCS, isproperty)]
+
+    # Compare the return value of that property with the type annotations
+    for prop_name in properties:
+        check_type(prop_name,
+                   getattr(wcs, prop_name),
+                   getattr(BaseLowLevelWCS, prop_name).fget.__annotations__['return'])
+
+    # Validate the return types of the pixel <> world functions
+
+    # Set up valid but meaningless inputs, the idea here is just to validate
+    # the *types* of the returns
+    scalar_pixel_default_call = tuple([0]*wcs.pixel_n_dim)
+    scalar_pixel_call = [b[0] for b in wcs.pixel_bounds] if wcs.pixel_bounds is not None else scalar_pixel_default_call
+    array_pixel_call = np.broadcast_to(scalar_pixel_call, (10, len(scalar_pixel_call))).T
+    scalar_world_call = wcs.pixel_to_world_values(*scalar_pixel_call)
+    array_world_call = wcs.pixel_to_world_values(*array_pixel_call)
+    if wcs.world_n_dim == 1:
+        scalar_world_call = (scalar_world_call,)
+        array_world_call = (array_world_call,)
+
+    for pixel_call in (scalar_pixel_call, array_pixel_call):
+        return_value = wcs.pixel_to_world_values(*pixel_call)
+        check_type("pixel_to_world_values",
+                   return_value,
+                   BaseLowLevelWCS.pixel_to_world_values.__annotations__['return'])
+
+        # The return type should not be a tuple if there is only one world dimension
+        if wcs.world_n_dim == 1:
+            assert not isinstance(return_value, tuple)
+
+        return_value = wcs.array_index_to_world_values(*pixel_call[::-1])
+        check_type("array_index_to_world_values",
+                   return_value,
+                   BaseLowLevelWCS.pixel_to_world_values.__annotations__['return'])
+
+        # The return type should not be a tuple if there is only one world dimension
+        if wcs.world_n_dim == 1:
+            assert not isinstance(return_value, tuple)
+
+    for world_call in (scalar_world_call, array_world_call):
+        return_value = wcs.world_to_pixel_values(*world_call)
+        check_type("world_to_pixel_values",
+                   return_value,
+                   BaseLowLevelWCS.world_to_pixel_values.__annotations__['return'])
+
+        # The return type should not be a tuple if there is only one pixel dimension
+        if wcs.pixel_n_dim == 1:
+            assert not isinstance(return_value, tuple)
+
+        return_value = wcs.world_to_array_index_values(*world_call[::-1])
+        check_type("world_to_array_index_values",
+                   return_value,
+                   BaseLowLevelWCS.world_to_array_index_values.__annotations__['return'])
+
+        # The return type should not be a tuple if there is only one pixel dimension
+        if wcs.pixel_n_dim == 1:
+            assert not isinstance(return_value, tuple)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ test =
     ipython
     coverage
     skyfield
+    typeguard
 all =
     scipy
     h5py


### PR DESCRIPTION
#9647 made me think that the return types of the APE 14 API are critical to interactions with things expecting that API. Therefore I thought it would be good to formally document what is allowed by using type hinting.

Having done that I wrote a function which using [typeguard](https://github.com/agronholm/typeguard) validates the types returned from the properties and the pixel <> world calls.

~This currently contains one commit which fixes the return types from `WCS` to be tuples rather than lists, I need to extract this and get it into 4.0~ (#9678)

TODO:

- [x] Validate `SlicedLowLevelWCS` using this helper.
- [x] Test `gwcs` against this as well. (spacetelescope/gwcs#261)