### PR TITLE
Fix datetime accuracy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -294,6 +294,8 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+* Fix inaccuracy when converting between TimeDelta and datetime.timedelta [#9579]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -294,7 +294,7 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
-* Fix inaccuracy when converting between TimeDelta and datetime.timedelta [#9579]
+* Fix inaccuracy when converting between TimeDelta and datetime.timedelta [#9679]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -1558,7 +1558,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
                              op_dtypes=[None, None, object])
 
         for jd1, jd2, out in iterator:
-            jd1_, jd2_ = day_frac(jd1.item(), jd2.item())
+            jd1_, jd2_ = day_frac(jd1, jd2)
             out[...] = datetime.timedelta(days=jd1_,
                                           microseconds=jd2_*86400*1e6)
 

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -201,10 +201,10 @@ def test_conversion_preserves_jd1_jd2_invariant_2():
     assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0
 
 
-def test_datetime_difference_agrees_with_timedelta_no_hypothesis():
+def test_datetime_difference_agrees_with_timedelta():
     scale = "tai"
     dt1 = datetime(1235, 1, 1, 0, 0)
     dt2 = datetime(9950, 1, 1, 0, 0, 0, 890773)
     t1 = Time(dt1, scale=scale)
     t2 = Time(dt2, scale=scale)
-    assert(abs((t2-t1) - TimeDelta(dt2-dt1, scale=scale)) < 25*u.us)
+    assert(abs((t2-t1) - TimeDelta(dt2-dt1, scale=scale)) < 1*u.us)

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -4,6 +4,7 @@ import decimal
 import pytest
 import numpy as np
 from decimal import Decimal
+from datetime import datetime
 
 import astropy.units as u
 import astropy._erfa as erfa
@@ -198,3 +199,12 @@ def test_conversion_preserves_jd1_jd2_invariant_2():
     assert t2.jd1 % 1 == 0
     assert abs(t2.jd2) <= 0.5
     assert abs(t2.jd2) < 0.5 or t2.jd1 % 2 == 0
+
+
+def test_datetime_difference_agrees_with_timedelta_no_hypothesis():
+    scale = "tai"
+    dt1 = datetime(1235, 1, 1, 0, 0)
+    dt2 = datetime(9950, 1, 1, 0, 0, 0, 890773)
+    t1 = Time(dt1, scale=scale)
+    t2 = Time(dt2, scale=scale)
+    assert(abs((t2-t1) - TimeDelta(dt2-dt1, scale=scale)) < 25*u.us)


### PR DESCRIPTION
Fixes #9579

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address accuracy limitations in datetime <-> Time conversion revealed by PR #9532 and reported in bug #9579 . 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9579 