### PR TITLE
Fix bug in init from list of mixins

### DIFF
--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -995,6 +995,7 @@ class Table:
             try:
                 col = data[0].__class__(data)
                 col.info.name = name
+                col.info.indices = []
                 return col
             except Exception:
                 # If that didn't work for some reason, just turn it into np.array of object


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

There was an oversight in #9165 (Allow adding a table column as a list of mixin-type objects) where the column `info.indices` was not initialized to `[]`.  This whole machinery is little fragile, but for now just doing the initialization fixes the problem noted in #9357.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9357