### PR TITLE
Fix syntax issues in docstrings

### DIFF
--- a/astropy/_erfa/helpers.py
+++ b/astropy/_erfa/helpers.py
@@ -43,7 +43,7 @@ class leap_seconds:
 
         Parameters
         ----------
-        table : array-like
+        table : array_like
             Must have 'year', 'month', and 'tai_utc' entries.  If a 'day'
             entry is present, it will be checked that it is always 1.
             If ``table`` has an 'expires' attribute, it will be interpreted
@@ -120,7 +120,7 @@ class leap_seconds:
 
         Parameters
         ----------
-        table : array-like or `None`
+        table : array_like or `None`
             Leap-second table that should at least hold columns of 'year',
             'month', and 'tai_utc'.  Only simple validation is done before it
             is being used, so care need to be taken that entries are correct.
@@ -173,7 +173,7 @@ class leap_seconds:
 
         Parameters
         ----------
-        table : array-like or `~astropy.utils.iers.LeapSeconds`
+        table : array_like or `~astropy.utils.iers.LeapSeconds`
             Array or table with TAI-UTC from leap seconds.  Should have
             'year', 'month', and 'tai_utc' columns.
 

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -37,7 +37,7 @@
     "Set the leap second table used in ERFA.\n\n" \
     "Parameters\n" \
     "----------\n" \
-    "leap_seconds : array-like, optional\n" \
+    "leap_seconds : array_like, optional\n" \
     "    With structured dtype `~astropy._erfa.dt_eraLEAPSECOND`,\n" \
     "    containing items 'year', 'month', and 'tai_utc'.\n" \
     "    If not given, reset to the ERFA built-in table.\n\n" \

--- a/astropy/convolution/convolve.py
+++ b/astropy/convolution/convolve.py
@@ -113,7 +113,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
 
     Parameters
     ----------
-    array : `~astropy.nddata.NDData` or `numpy.ndarray` or array-like
+    array : `~astropy.nddata.NDData` or `numpy.ndarray` or array_like
         The array to convolve. This should be a 1, 2, or 3-dimensional array
         or a list or a set of nested lists representing a 1, 2, or
         3-dimensional array.  If an `~astropy.nddata.NDData`, the ``mask`` of
@@ -138,7 +138,7 @@ def convolve(array, kernel, boundary='fill', fill_value=0.,
         The value to use outside the array when using ``boundary='fill'``
     normalize_kernel : bool, optional
         Whether to normalize the kernel to have a sum of one.
-    nan_treatment : 'interpolate', 'fill'
+    nan_treatment : {'interpolate', 'fill'}
         interpolate will result in renormalization of the kernel at each
         position ignoring (pixels that are NaN in the image) in both the image
         and the kernel.
@@ -430,7 +430,7 @@ def convolve_fft(array, kernel, boundary='fill', fill_value=0.,
         convolution
     fill_value : float, optional
         The value to use outside the array when using boundary='fill'
-    nan_treatment : 'interpolate', 'fill'
+    nan_treatment : {'interpolate', 'fill'}
         ``interpolate`` will result in renormalization of the kernel at each
         position ignoring (pixels that are NaN in the image) in both the image
         and the kernel.  ``fill`` will replace the NaN pixels with a fixed

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -204,7 +204,7 @@ class EarthLocation(u.Quantity):
 
         Parameters
         ----------
-        x, y, z : `~astropy.units.Quantity` or array-like
+        x, y, z : `~astropy.units.Quantity` or array_like
             Cartesian coordinates.  If not quantities, ``unit`` should be given.
         unit : `~astropy.units.UnitBase` object or None
             Physical unit of the coordinate values.  If ``x``, ``y``, and/or
@@ -385,12 +385,12 @@ class EarthLocation(u.Quantity):
             The address to get the location for. As per the Google maps API,
             this can be a fully specified street address (e.g., 123 Main St.,
             New York, NY) or a city name (e.g., Danbury, CT), or etc.
-        get_height : bool (optional)
+        get_height : bool, optional
             This only works when using the Google API! See the ``google_api_key``
             block below. Use the retrieved location to perform a second query to
             the Google maps elevation API to retrieve the height of the input
             address [3]_.
-        google_api_key : str (optional)
+        google_api_key : str, optional
             A Google API key with the Geocoding API and (optionally) the
             elevation API enabled. See [4]_ for more information.
 

--- a/astropy/coordinates/earth_orientation.py
+++ b/astropy/coordinates/earth_orientation.py
@@ -27,7 +27,7 @@ def eccentricity(jd):
 
     Parameters
     ----------
-    jd : scalar or array-like
+    jd : scalar or array_like
         Julian date at which to compute the eccentricity
 
     returns
@@ -54,7 +54,7 @@ def mean_lon_of_perigee(jd):
 
     Parameters
     ----------
-    jd : scalar or array-like
+    jd : scalar or array_like
         Julian date at which to compute the mean longitude of perigee
 
     returns
@@ -80,7 +80,7 @@ def obliquity(jd, algorithm=2006):
 
     Parameters
     ----------
-    jd : scalar or array-like
+    jd : scalar or array_like
         Julian date at which to compute the obliquity
     algorithm : int
         Year of algorithm based on IAU adoption. Can be 2006, 2000 or 1980. The

--- a/astropy/coordinates/funcs.py
+++ b/astropy/coordinates/funcs.py
@@ -46,11 +46,11 @@ def cartesian_to_spherical(x, y, z):
 
     Parameters
     ----------
-    x : scalar, array-like, or `~astropy.units.Quantity`
+    x : scalar, array_like, or `~astropy.units.Quantity`
         The first cartesian coordinate.
-    y : scalar, array-like, or `~astropy.units.Quantity`
+    y : scalar, array_like, or `~astropy.units.Quantity`
         The second cartesian coordinate.
-    z : scalar, array-like, or `~astropy.units.Quantity`
+    z : scalar, array_like, or `~astropy.units.Quantity`
         The third cartesian coordinate.
 
     Returns
@@ -92,11 +92,11 @@ def spherical_to_cartesian(r, lat, lon):
 
     Parameters
     ----------
-    r : scalar, array-like, or `~astropy.units.Quantity`
+    r : scalar, array_like, or `~astropy.units.Quantity`
         The radial coordinate (in the same units as the inputs).
-    lat : scalar, array-like, or `~astropy.units.Quantity`
+    lat : scalar, array_like, or `~astropy.units.Quantity`
         The latitude (in radians if array or scalar)
-    lon : scalar, array-like, or `~astropy.units.Quantity`
+    lon : scalar, array_like, or `~astropy.units.Quantity`
         The longitude (in radians if array or scalar)
 
     Returns

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -46,7 +46,7 @@ def rotation_matrix(angle, axis='z', unit=None):
     ----------
     angle : convertible to `~astropy.coordinates.Angle`
         The amount of rotation the matrices should represent.  Can be an array.
-    axis : str, or array-like
+    axis : str, or array_like
         Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
         rotate about. If ``'x'``, ``'y'``, or ``'z'``, the rotation sense is
         counterclockwise looking down the + axis (e.g. positive rotations obey
@@ -104,7 +104,7 @@ def angle_axis(matrix):
 
     Parameters
     ----------
-    matrix : array-like
+    matrix : array_like
         A 3 x 3 unitary rotation matrix (or stack of matrices).
 
     Returns

--- a/astropy/coordinates/matrix_utilities.py
+++ b/astropy/coordinates/matrix_utilities.py
@@ -46,7 +46,7 @@ def rotation_matrix(angle, axis='z', unit=None):
     ----------
     angle : convertible to `~astropy.coordinates.Angle`
         The amount of rotation the matrices should represent.  Can be an array.
-    axis : str, or array_like
+    axis : str or array_like
         Either ``'x'``, ``'y'``, ``'z'``, or a (x,y,z) specifying the axis to
         rotate about. If ``'x'``, ``'y'``, or ``'z'``, the rotation sense is
         counterclockwise looking down the + axis (e.g. positive rotations obey

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -1214,7 +1214,7 @@ class StaticMatrixTransform(BaseAffineTransform):
 
     Parameters
     ----------
-    matrix : array-like or callable
+    matrix : array_like or callable
         A 3 x 3 matrix for transforming 3-vectors. In most cases will
         be unitary (although this is not strictly required). If a callable,
         will be called *with no arguments* to get the matrix.

--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -475,7 +475,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -500,7 +500,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -524,7 +524,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -550,7 +550,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -583,7 +583,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -608,7 +608,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -634,7 +634,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -653,7 +653,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -681,7 +681,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -699,7 +699,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -797,7 +797,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -847,7 +847,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -881,7 +881,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -929,7 +929,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : float or array-like
+        z : float or array_like
           Input redshift.
 
         Returns
@@ -999,7 +999,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1017,7 +1017,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1039,7 +1039,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -1061,7 +1061,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -1079,7 +1079,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -1100,7 +1100,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -1115,7 +1115,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1136,7 +1136,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1153,7 +1153,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1175,7 +1175,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1196,7 +1196,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1217,7 +1217,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1237,7 +1237,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1261,7 +1261,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1288,7 +1288,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1326,7 +1326,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1349,7 +1349,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1377,7 +1377,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts. z2 must be large than z1.
 
         Returns
@@ -1401,7 +1401,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1427,7 +1427,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1457,7 +1457,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1493,7 +1493,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1511,7 +1511,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1529,7 +1529,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1547,7 +1547,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1565,7 +1565,7 @@ class FLRW(Cosmology, metaclass=ABCMeta):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1687,7 +1687,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1714,7 +1714,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1749,7 +1749,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : array-like
+        z1, z2 : array_like
           Input redshifts.
 
         Returns
@@ -1821,7 +1821,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1850,7 +1850,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : array-like, shape (N,)
+        z1, z2 : array_like, shape (N,)
           Input redshifts.  Must be 1D or scalar.
 
         Returns
@@ -1883,7 +1883,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z1, z2 : array-like
+        z1, z2 : array_like
           Input redshifts.
 
         Returns
@@ -1926,7 +1926,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1946,7 +1946,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -1969,7 +1969,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2000,7 +2000,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -2023,7 +2023,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2048,7 +2048,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.  Must be 1D or scalar
 
         Returns
@@ -2063,7 +2063,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2095,7 +2095,7 @@ class LambdaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2204,7 +2204,7 @@ class FlatLambdaCDM(LambdaCDM):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2236,7 +2236,7 @@ class FlatLambdaCDM(LambdaCDM):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2362,7 +2362,7 @@ class wCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2389,7 +2389,7 @@ class wCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2413,7 +2413,7 @@ class wCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2443,7 +2443,7 @@ class wCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2564,7 +2564,7 @@ class FlatwCDM(wCDM):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2594,7 +2594,7 @@ class FlatwCDM(wCDM):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2733,7 +2733,7 @@ class w0waCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -2760,7 +2760,7 @@ class w0waCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -3015,7 +3015,7 @@ class wpwaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -3044,7 +3044,7 @@ class wpwaCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -3191,7 +3191,7 @@ class w0wzCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns
@@ -3218,7 +3218,7 @@ class w0wzCDM(FLRW):
 
         Parameters
         ----------
-        z : array-like
+        z : array_like
           Input redshifts.
 
         Returns

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -128,7 +128,7 @@ class _BaseDiff:
 
         Parameters
         ----------
-        fileobj : file-like object, string, or None (optional)
+        fileobj : file-like object, string, or None, optional
             If `None`, this method returns the report as a string. Otherwise it
             returns `None` and writes the report to the given file-like object
             (which must have a ``.write()`` method at a minimum), or to a new

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -414,7 +414,7 @@ class CompImageHDU(BinTableHDU):
         data : array, optional
             Uncompressed image data
 
-        header : Header instance, optional
+        header : :class:`~astropy.io.fits.Header`, optional
             Header to be associated with the image; when reading the HDU from a
             file (data=DELAYED), the header read from the file
 
@@ -717,7 +717,7 @@ class CompImageHDU(BinTableHDU):
 
         Parameters
         ----------
-        image_header : Header instance
+        image_header : :class:`~astropy.io.fits.Header`
             header to be associated with the image
 
         name : str, optional

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -414,7 +414,7 @@ class CompImageHDU(BinTableHDU):
         data : array, optional
             Uncompressed image data
 
-        header : :class:`~astropy.io.fits.Header`, optional
+        header : `~astropy.io.fits.Header`, optional
             Header to be associated with the image; when reading the HDU from a
             file (data=DELAYED), the header read from the file
 
@@ -717,7 +717,7 @@ class CompImageHDU(BinTableHDU):
 
         Parameters
         ----------
-        image_header : :class:`~astropy.io.fits.Header`
+        image_header : `~astropy.io.fits.Header`
             header to be associated with the image
 
         name : str, optional

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -952,7 +952,7 @@ class PrimaryHDU(_ImageBaseHDU):
         data : array or DELAYED, optional
             The data in the HDU.
 
-        header : :class:`~astropy.io.fits.Header`, optional
+        header : `~astropy.io.fits.Header`, optional
             The header to be used (as a template).  If ``header`` is `None`, a
             minimal header will be provided.
 
@@ -1047,7 +1047,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         data : array
             The data in the HDU.
 
-        header : :class:`~astropy.io.fits.Header`
+        header : `~astropy.io.fits.Header`
             The header to be used (as a template).  If ``header`` is
             `None`, a minimal header will be provided.
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -952,7 +952,7 @@ class PrimaryHDU(_ImageBaseHDU):
         data : array or DELAYED, optional
             The data in the HDU.
 
-        header : Header instance, optional
+        header : :class:`~astropy.io.fits.Header`, optional
             The header to be used (as a template).  If ``header`` is `None`, a
             minimal header will be provided.
 
@@ -1047,7 +1047,7 @@ class ImageHDU(_ImageBaseHDU, ExtensionHDU):
         data : array
             The data in the HDU.
 
-        header : Header instance
+        header : :class:`~astropy.io.fits.Header`
             The header to be used (as a template).  If ``header`` is
             `None`, a minimal header will be provided.
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1148,7 +1148,7 @@ class BinTableHDU(_TableBaseHDU):
             replaced with the contents of the ASCII file instead of
             just updating the current header.
 
-        header : :class:`~astropy.io.fits.Header`, optional
+        header : `~astropy.io.fits.Header`, optional
             When the cdfile and hfile are missing, use this Header object in
             the creation of the new table and HDU.  Otherwise this Header
             supersedes the keywords from hfile, which is only used to update

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -1143,12 +1143,12 @@ class BinTableHDU(_TableBaseHDU):
             `None`, the header parameter definitions are taken from
             the current values in this objects header.
 
-        replace : bool
+        replace : bool, optional
             When `True`, indicates that the entire header should be
             replaced with the contents of the ASCII file instead of
             just updating the current header.
 
-        header : Header object
+        header : :class:`~astropy.io.fits.Header`, optional
             When the cdfile and hfile are missing, use this Header object in
             the creation of the new table and HDU.  Otherwise this Header
             supersedes the keywords from hfile, which is only used to update

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -112,7 +112,7 @@ class HeaderFormatter:
             Keywords for which the value(s) should be returned.
             If not specified, then the entire header is returned.
 
-        compressed : boolean, optional
+        compressed : bool, optional
             If True, shows the header describing the compression, rather than
             the header obtained after decompression. (Affects FITS files
             containing `CompImageHDU` extensions only.)
@@ -177,7 +177,7 @@ class HeaderFormatter:
         keywords : list of str, optional
             Keywords for which the cards should be returned.
 
-        compressed : boolean, optional
+        compressed : bool, optional
             If True, shows the header describing the compression.
 
         Raises

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -75,7 +75,7 @@ def read_table_hdf5(input, path=None, character_as_bytes=True):
     path : str
         The path from which to read the table inside the HDF5 file.
         This should be relative to the input file or group.
-    character_as_bytes: boolean
+    character_as_bytes: bool
         If `True` then Table columns are left as bytes.
         If `False` then Table columns are converted to unicode.
     """

--- a/astropy/modeling/blackbody.py
+++ b/astropy/modeling/blackbody.py
@@ -189,11 +189,11 @@ def blackbody_nu(in_x, temperature):
 
     Parameters
     ----------
-    in_x : number, array-like, or `~astropy.units.Quantity`
+    in_x : number, array_like, or `~astropy.units.Quantity`
         Frequency, wavelength, or wave number.
         If not a Quantity, it is assumed to be in Hz.
 
-    temperature : number, array-like, or `~astropy.units.Quantity`
+    temperature : number, array_like, or `~astropy.units.Quantity`
         Blackbody temperature.
         If not a Quantity, it is assumed to be in Kelvin.
 
@@ -257,11 +257,11 @@ def blackbody_lambda(in_x, temperature):
 
     Parameters
     ----------
-    in_x : number, array-like, or `~astropy.units.Quantity`
+    in_x : number, array_like, or `~astropy.units.Quantity`
         Frequency, wavelength, or wave number.
         If not a Quantity, it is assumed to be in Angstrom.
 
-    temperature : number, array-like, or `~astropy.units.Quantity`
+    temperature : number, array_like, or `~astropy.units.Quantity`
         Blackbody temperature.
         If not a Quantity, it is assumed to be in Kelvin.
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1449,7 +1449,7 @@ class Model(metaclass=_ModelMeta):
         out : `numpy.ndarray`, optional
             An array that the evaluated model will be added to.  If this is not
             given (or given as ``None``), a new array will be created.
-        coords : array-like, optional
+        coords : array_like, optional
             An array to be used to translate from the model's input coordinates
             to the ``out`` array. It should have the property that
             ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
@@ -3479,7 +3479,7 @@ class CompoundModel(Model):
         out : `numpy.ndarray`, optional
             An array that the evaluated model will be added to.  If this is not
             given (or given as ``None``), a new array will be created.
-        coords : array-like, optional
+        coords : array_like, optional
             An array to be used to translate from the model's input coordinates
             to the ``out`` array. It should have the property that
             ``self(coords)`` yields the same shape as ``out``.  If ``out`` is
@@ -3820,7 +3820,7 @@ def render_model(model, arr=None, coords=None):
         Model to be evaluated.
     arr : `numpy.ndarray`, optional
         Array on which the model is evaluated.
-    coords : array-like, optional
+    coords : array_like, optional
         Coordinate arrays mapping to ``arr``, such that
         ``arr[coords] == arr``.
 

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -322,9 +322,9 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             model to fit to x, y, z
         x : array
             Input coordinates
-        y : array-like
+        y : array_like
             Input coordinates
-        z : array-like (optional)
+        z : array_like, optional
             Input coordinates.
             If the dependent (``y`` or ``z``) co-ordinate values are provided
             as a `numpy.ma.MaskedArray`, any masked points are ignored when
@@ -332,7 +332,7 @@ class LinearLSQFitter(metaclass=_FitterMeta):
             there are masked points (not just an empty mask), as the matrix
             equation has to be solved for each model separately when their
             co-ordinate grids differ.
-        weights : array (optional)
+        weights : array, optional
             Weights for fitting.
             For data with Gaussian uncertainties, the weights should be
             1/sigma.
@@ -570,9 +570,9 @@ class FittingWithOutlierRemoval:
         sets (unless overridden in ``outlier_kwargs``), to find outliers for
         each model separately; otherwise, the same filtering must be performed
         in a loop over models, which is almost an order of magnitude slower.
-    niter : int (optional)
+    niter : int, optional
         Number of iterations.
-    outlier_kwargs : dict (optional)
+    outlier_kwargs : dict, optional
         Keyword arguments for outlier_func.
     """
 
@@ -605,15 +605,15 @@ class FittingWithOutlierRemoval:
             An analytic model which will be fit to the provided data.
             This also contains the initial guess for an optimization
             algorithm.
-        x : array-like
+        x : array_like
             Input coordinates.
-        y : array-like
+        y : array_like
             Data measurements (1D case) or input coordinates (2D case).
-        z : array-like (optional)
+        z : array_like, optional
             Data measurements (2D case).
-        weights : array-like (optional)
+        weights : array_like, optional
             Weights to be passed to the fitter.
-        kwargs : dict (optional)
+        kwargs : dict, optional
             Keyword arguments to be passed to the fitter.
 
         Returns
@@ -840,9 +840,9 @@ class LevMarLSQFitter(metaclass=_FitterMeta):
            input coordinates
         y : array
            input coordinates
-        z : array (optional)
+        z : array, optional
            input coordinates
-        weights : array (optional)
+        weights : array, optional
             Weights for fitting.
             For data with Gaussian uncertainties, the weights should be
             1/sigma.
@@ -990,9 +990,9 @@ class SLSQPLSQFitter(Fitter):
             input coordinates
         y : array
             input coordinates
-        z : array (optional)
+        z : array, optional
             input coordinates
-        weights : array (optional)
+        weights : array, optional
             Weights for fitting.
             For data with Gaussian uncertainties, the weights should be
             1/sigma.
@@ -1061,9 +1061,9 @@ class SimplexLSQFitter(Fitter):
             input coordinates
         y : array
             input coordinates
-        z : array (optional)
+        z : array, optional
             input coordinates
-        weights : array (optional)
+        weights : array, optional
             Weights for fitting.
             For data with Gaussian uncertainties, the weights should be
             1/sigma.

--- a/astropy/modeling/rotations.py
+++ b/astropy/modeling/rotations.py
@@ -68,7 +68,7 @@ class RotationSequence3D(Model):
 
     Parameters
     ----------
-    angles : array-like
+    angles : array_like
         Angles of rotation in deg in the order of axes_order.
     axes_order : str
         A sequence of 'x', 'y', 'z' corresponding to axis of rotation.
@@ -456,7 +456,7 @@ class Rotation2D(Model):
 
         Parameters
         ----------
-        x, y : ndarray-like
+        x, y : array_like
             Input quantities
         angle : float (deg) or `~astropy.units.Quantity`
             Angle of rotations.

--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -47,7 +47,7 @@ class _Tabular(Model):
     ----------
     points : tuple of ndarray of float, with shapes (m1, ), ..., (mn, ), optional
         The points defining the regular grid in n dimensions.
-    lookup_table : array-like, shape (m1, ..., mn, ...)
+    lookup_table : array_like, shape (m1, ..., mn, ...)
         The data on a regular grid in n dimensions.
     method : str, optional
         The method of interpolation to perform. Supported are "linear" and
@@ -355,9 +355,9 @@ Tabular1D.__doc__ = """
 
     Parameters
     ----------
-    points : array-like of float of ndim=1.
+    points : array_like of float of ndim=1.
         The points defining the regular grid in n dimensions.
-    lookup_table : array-like, of ndim=1.
+    lookup_table : array_like, of ndim=1.
         The data in one dimensions.
 """ + _tab_docs
 
@@ -369,7 +369,7 @@ Tabular2D.__doc__ = """
     ----------
     points : tuple of ndarray of float, with shapes (m1, m2), optional
         The points defining the regular grid in n dimensions.
-    lookup_table : array-like, shape (m1, m2)
+    lookup_table : array_like, shape (m1, m2)
         The data on a regular grid in 2 dimensions.
 
 """ + _tab_docs

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -174,7 +174,7 @@ def extract_array(array_large, shape, position, mode='partial',
         small array that do not overlap with the input ``array_large``.
         ``fill_value`` must have the same ``dtype`` as the
         ``array_large`` array.
-    return_position : boolean, optional
+    return_position : bool, optional
         If `True`, return the coordinates of ``position`` in the
         coordinate system of the returned array.
 
@@ -296,7 +296,7 @@ def subpixel_indices(position, subsampling):
 
     Parameters
     ----------
-    position : `~numpy.ndarray` or array-like
+    position : `~numpy.ndarray` or array_like
         Positions in pixels.
     subsampling : int
         Subsampling factor per pixel.
@@ -356,7 +356,7 @@ def block_reduce(data, block_size, func=np.sum):
 
     Returns
     -------
-    output : array-like
+    output : array_like
         The resampled data.
 
     Examples
@@ -494,7 +494,7 @@ class Cutout2D:
         `~astropy.coordinates.SkyCoord`, in which case ``wcs`` is a
         required input.
 
-    size : int, array-like, `~astropy.units.Quantity`
+    size : int, array_like, `~astropy.units.Quantity`
         The size of the cutout array along each axis.  If ``size``
         is a scalar number or a scalar `~astropy.units.Quantity`,
         then a square cutout of ``size`` will be created.  If

--- a/astropy/nddata/utils.py
+++ b/astropy/nddata/utils.py
@@ -494,7 +494,7 @@ class Cutout2D:
         `~astropy.coordinates.SkyCoord`, in which case ``wcs`` is a
         required input.
 
-    size : int, array_like, `~astropy.units.Quantity`
+    size : int, array_like, or `~astropy.units.Quantity`
         The size of the cutout array along each axis.  If ``size``
         is a scalar number or a scalar `~astropy.units.Quantity`,
         then a square cutout of ``size`` will be created.  If

--- a/astropy/stats/bayesian_blocks.py
+++ b/astropy/stats/bayesian_blocks.py
@@ -61,9 +61,9 @@ def bayesian_blocks(t, x=None, sigma=None,
     ----------
     t : array_like
         data times (one dimensional, length N)
-    x : array_like (optional)
+    x : array_like, optional
         data values
-    sigma : array_like or float (optional)
+    sigma : array_like or float, optional
         data errors
     fitness : str or object
         the fitness function to use for the model.
@@ -206,9 +206,9 @@ class FitnessFunc:
         ----------
         t : array_like
             times of observations
-        x : array_like (optional)
+        x : array_like, optional
             values observed at each time
-        sigma : float or array_like (optional)
+        sigma : float or array_like, optional
             errors in values x
 
         Returns
@@ -306,9 +306,9 @@ class FitnessFunc:
         ----------
         t : array_like
             data times (one dimensional, length N)
-        x : array_like (optional)
+        x : array_like, optional
             data values
-        sigma : array_like or float (optional)
+        sigma : array_like or float, optional
             data errors
 
         Returns
@@ -404,7 +404,7 @@ class Events(FitnessFunc):
 
     Parameters
     ----------
-    p0 : float (optional)
+    p0 : float, optional
         False alarm probability, used to compute the prior on
         :math:`N_{\rm blocks}` (see eq. 21 of Scargle 2012). For the Events
         type data, ``p0`` does not seem to be an accurate representation of the
@@ -413,11 +413,11 @@ class Events(FitnessFunc):
         statistical trials on signal-free noise to determine an appropriate
         value of ``gamma`` or ``ncp_prior`` to use for a desired false alarm
         rate.
-    gamma : float (optional)
+    gamma : float, optional
         If specified, then use this gamma to compute the general prior form,
         :math:`p \sim {\tt gamma}^{N_{\rm blocks}}`.  If gamma is specified, p0
         is ignored.
-    ncp_prior : float (optional)
+    ncp_prior : float, optional
         If specified, use the value of ``ncp_prior`` to compute the prior as
         above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
         gamma})`.
@@ -446,11 +446,11 @@ class RegularEvents(FitnessFunc):
     ----------
     dt : float
         tick rate for data
-    p0 : float (optional)
+    p0 : float, optional
         False alarm probability, used to compute the prior on :math:`N_{\rm
         blocks}` (see eq. 21 of Scargle 2012). If gamma is specified, p0 is
         ignored.
-    ncp_prior : float (optional)
+    ncp_prior : float, optional
         If specified, use the value of ``ncp_prior`` to compute the prior as
         above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
         gamma})`.  If ``ncp_prior`` is specified, ``gamma`` and ``p0`` are
@@ -488,11 +488,11 @@ class PointMeasures(FitnessFunc):
 
     Parameters
     ----------
-    p0 : float (optional)
+    p0 : float, optional
         False alarm probability, used to compute the prior on :math:`N_{\rm
         blocks}` (see eq. 21 of Scargle 2012). If gamma is specified, p0 is
         ignored.
-    ncp_prior : float (optional)
+    ncp_prior : float, optional
         If specified, use the value of ``ncp_prior`` to compute the prior as
         above, using the definition :math:`{\tt ncp\_prior} = -\ln({\tt
         gamma})`.  If ``ncp_prior`` is specified, ``gamma`` and ``p0`` are

--- a/astropy/stats/biweight.py
+++ b/astropy/stats/biweight.py
@@ -53,12 +53,12 @@ def biweight_location(data, c=6.0, M=None, axis=None, *, ignore_nan=False):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Input array or object that can be converted to an array.
         ``data`` can be a `~numpy.ma.MaskedArray`.
     c : float, optional
         Tuning constant for the biweight estimator (default = 6.0).
-    M : float or array-like, optional
+    M : float or array_like, optional
         Initial guess for the location.  If ``M`` is a scalar value,
         then its value will be used for the entire array (or along each
         ``axis``, if specified).  If ``M`` is an array, then its must be
@@ -193,12 +193,12 @@ def biweight_scale(data, c=9.0, M=None, axis=None, modify_sample_size=False,
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Input array or object that can be converted to an array.
         ``data`` can be a `~numpy.ma.MaskedArray`.
     c : float, optional
         Tuning constant for the biweight estimator (default = 9.0).
-    M : float or array-like, optional
+    M : float or array_like, optional
         The location estimate.  If ``M`` is a scalar value, then its
         value will be used for the entire array (or along each ``axis``,
         if specified).  If ``M`` is an array, then its must be an array
@@ -304,12 +304,12 @@ def biweight_midvariance(data, c=9.0, M=None, axis=None,
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Input array or object that can be converted to an array.
         ``data`` can be a `~numpy.ma.MaskedArray`.
     c : float, optional
         Tuning constant for the biweight estimator (default = 9.0).
-    M : float or array-like, optional
+    M : float or array_like, optional
         The location estimate.  If ``M`` is a scalar value, then its
         value will be used for the entire array (or along each ``axis``,
         if specified).  If ``M`` is an array, then its must be an array
@@ -507,7 +507,7 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
 
     Parameters
     ----------
-    data : 2D or 1D array-like
+    data : 2D or 1D array_like
         Input data either as a 2D or 1D array.  For a 2D array, it
         should have a shape (N_variables, N_observations).  A 1D array
         may be input for observations of a single variable, in which
@@ -519,7 +519,7 @@ def biweight_midcovariance(data, c=9.0, M=None, modify_sample_size=False):
     c : float, optional
         Tuning constant for the biweight estimator (default = 9.0).
 
-    M : float or 1D array-like, optional
+    M : float or 1D array_like, optional
         The location estimate of each variable, either as a scalar or
         array.  If ``M`` is an array, then its must be a 1D array
         containing the location estimate of each row (i.e. ``a.ndim``
@@ -641,13 +641,13 @@ def biweight_midcorrelation(x, y, c=9.0, M=None, modify_sample_size=False):
 
     Parameters
     ----------
-    x, y : 1D array-like
+    x, y : 1D array_like
         Input arrays for the two variables.  ``x`` and ``y`` must be 1D
         arrays and have the same number of elements.
     c : float, optional
         Tuning constant for the biweight estimator (default = 9.0).  See
         `biweight_midcovariance` for more details.
-    M : float or array-like, optional
+    M : float or array_like, optional
         The location estimate.  If ``M`` is a scalar value, then its
         value will be used for the entire array (or along each ``axis``,
         if specified).  If ``M`` is an array, then its must be an array

--- a/astropy/stats/circstats.py
+++ b/astropy/stats/circstats.py
@@ -160,7 +160,7 @@ def circmoment(data, p=1.0, centered=False, axis=None, weights=None):
         radians whenever ``data`` is ``numpy.ndarray``.
     p : float, optional
         Order of the circular moment.
-    centered : Boolean, optional
+    centered : bool, optional
         If ``True``, central circular moments are computed. Default value is
         ``False``.
     axis : int, optional

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -767,7 +767,7 @@ def median_absolute_deviation(data, axis=None, func=None, ignore_nan=False):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Input array or object that can be converted to an array.
     axis : `None`, int, or tuple of ints, optional
         The axis or axes along which the MADs are computed.  The default
@@ -865,7 +865,7 @@ def mad_std(data, axis=None, func=None, ignore_nan=False):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         Data array or object that can be converted to an array.
     axis : `None`, int, or tuple of ints, optional
         The axis or axes along which the robust standard deviations are
@@ -1366,7 +1366,7 @@ def kuiper(data, cdf=lambda x: x, args=()):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         The data values.
     cdf : callable
         A callable to evaluate the CDF of the distribution being tested
@@ -1432,9 +1432,9 @@ def kuiper_two(data1, data2):
 
     Parameters
     ----------
-    data1 : array-like
+    data1 : array_like
         The first set of data values.
-    data2 : array-like
+    data2 : array_like
         The second set of data values.
 
     Returns

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -23,7 +23,7 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
     a : array_like
         Input data. The bin edges are calculated over the flattened array.
 
-    bins : int or list or str, optional
+    bins : int, list, or str, optional
         If ``bins`` is an int, it is the number of bins. If it is a list
         it is taken to be the bin edges. If it is a string, it must be one
         of  'blocks', 'knuth', 'scott' or 'freedman'. See
@@ -96,7 +96,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     a : array_like
         array of data to be histogrammed
 
-    bins : int or list or str, optional
+    bins : int, list, or str, optional
         If bins is a string, then it must be one of:
 
         - 'blocks' : use bayesian blocks for dynamic bin widths

--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -23,13 +23,13 @@ def calculate_bin_edges(a, bins=10, range=None, weights=None):
     a : array_like
         Input data. The bin edges are calculated over the flattened array.
 
-    bins : int or list or str (optional)
+    bins : int or list or str, optional
         If ``bins`` is an int, it is the number of bins. If it is a list
         it is taken to be the bin edges. If it is a string, it must be one
         of  'blocks', 'knuth', 'scott' or 'freedman'. See
         `~astropy.stats.histogram` for a description of each method.
 
-    range : tuple or None (optional)
+    range : tuple or None, optional
         The minimum and maximum range for the histogram.  If not specified,
         it will be (a.min(), a.max()). However, if bins is a list it is
         returned unmodified regardless of the range argument.
@@ -96,7 +96,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
     a : array_like
         array of data to be histogrammed
 
-    bins : int or list or str (optional)
+    bins : int or list or str, optional
         If bins is a string, then it must be one of:
 
         - 'blocks' : use bayesian blocks for dynamic bin widths
@@ -107,7 +107,7 @@ def histogram(a, bins=10, range=None, weights=None, **kwargs):
 
         - 'freedman' : use the Freedman-Diaconis rule to determine bins
 
-    range : tuple or None (optional)
+    range : tuple or None, optional
         the minimum and maximum range for the histogram.  If not specified,
         it will be (x.min(), x.max())
 
@@ -146,9 +146,9 @@ def scott_bin_width(data, return_bins=False):
 
     Parameters
     ----------
-    data : array-like, ndim=1
+    data : array_like, ndim=1
         observed (one-dimensional) data
-    return_bins : bool (optional)
+    return_bins : bool, optional
         if True, then return the bin edges
 
     Returns
@@ -207,9 +207,9 @@ def freedman_bin_width(data, return_bins=False):
 
     Parameters
     ----------
-    data : array-like, ndim=1
+    data : array_like, ndim=1
         observed (one-dimensional) data
-    return_bins : bool (optional)
+    return_bins : bool, optional
         if True, then return the bin edges
 
     Returns
@@ -280,11 +280,11 @@ def knuth_bin_width(data, return_bins=False, quiet=True):
 
     Parameters
     ----------
-    data : array-like, ndim=1
+    data : array_like, ndim=1
         observed (one-dimensional) data
-    return_bins : bool (optional)
+    return_bins : bool, optional
         if True, then return the bin edges
-    quiet : bool (optional)
+    quiet : bool, optional
         if True (default) then suppress stdout output from scipy.optimize
 
     Returns
@@ -340,7 +340,7 @@ class _KnuthF:
 
     Parameters
     ----------
-    data : array-like, one dimension
+    data : array_like, one dimension
         data to be histogrammed
 
     Notes

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -400,7 +400,7 @@ class SigmaClip:
 
         Parameters
         ----------
-        data : array-like or `~numpy.ma.MaskedArray`
+        data : array_like or `~numpy.ma.MaskedArray`
             The data to be sigma clipped.
 
         axis : `None` or int or tuple of int, optional
@@ -509,7 +509,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
     Parameters
     ----------
-    data : array-like or `~numpy.ma.MaskedArray`
+    data : array_like or `~numpy.ma.MaskedArray`
         The data to be sigma clipped.
 
     sigma : float, optional
@@ -657,7 +657,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
 
     Parameters
     ----------
-    data : array-like or `~numpy.ma.MaskedArray`
+    data : array_like or `~numpy.ma.MaskedArray`
         Data array or object that can be converted to an array.
 
     mask : `numpy.ndarray` (bool), optional

--- a/astropy/table/column.py
+++ b/astropy/table/column.py
@@ -134,7 +134,7 @@ def _expand_string_array_for_values(arr, values):
     ----------
     arr : np.ndarray
         Input array
-    values : scalar or array-like
+    values : scalar or array_like
         Values for width comparison for string arrays
 
     Returns
@@ -511,7 +511,7 @@ class BaseColumn(_ColumnGetitemShim, np.ndarray):
 
         Returns
         -------
-        equal : boolean
+        equal : bool
             True if all attributes are equal
         """
         if not isinstance(col, BaseColumn):
@@ -1352,7 +1352,7 @@ class MaskedColumn(Column, _MaskedColumnGetitemShim, ma.MaskedArray):
             Value(s) to insert.  If the type of ``values`` is different from
             that of the column, ``values`` is converted to the matching type.
             ``values`` should be shaped so that it can be broadcast appropriately.
-        mask : boolean array_like
+        mask : bool or array_like
             Mask value(s) to insert.  If not supplied, and values does not have
             a mask either, then False is used.
         axis : int, optional

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -475,7 +475,7 @@ def unique(input_table, keys=None, silent=False, keep='first'):
         removed, leaving only rows that are already unique in
         the input.
         Default is 'first'.
-    silent : boolean
+    silent : bool
         If `True`, masked value column(s) are silently removed from
         ``keys``. If `False`, an exception is raised when ``keys``
         contains masked value column(s).

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1420,7 +1420,7 @@ class Table:
             table classes may make use of bootstrap, as this is loaded with the
             notebook.  See `this page <https://getbootstrap.com/css/#tables>`_
             for the list of classes.
-        css : string
+        css : str
             A valid CSS string declaring the formatting for the table. Defaults
             to ``astropy.table.jsviewer.DEFAULT_CSS_NB``.
         display_length : int, optional
@@ -1499,7 +1499,7 @@ class Table:
             A string with a list of HTML classes used to style the table.
             Default is "display compact", and other possible values can be
             found in https://www.datatables.net/manual/styling/classes
-        css : string
+        css : str
             A valid CSS string declaring the formatting for the table. Defaults
             to ``astropy.table.jsviewer.DEFAULT_CSS``.
         show_row_index : str or False

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -586,7 +586,7 @@ class Time(ShapedLikeNDArray):
 
         Parameters
         ----------
-        time_string : str, sequence, ndarray
+        time_string : str, sequence, or ndarray
             Objects containing time data of type string
         format_string : str
             String specifying format of time_string.
@@ -715,7 +715,7 @@ class Time(ShapedLikeNDArray):
 
         Returns
         -------
-        formatted : str, numpy.array
+        formatted : str or numpy.array
             String or numpy.array of strings formatted according to the given
             format string.
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -586,9 +586,9 @@ class Time(ShapedLikeNDArray):
 
         Parameters
         ----------
-        time_string : string, sequence, ndarray
+        time_string : str, sequence, ndarray
             Objects containing time data of type string
-        format_string : string
+        format_string : str
             String specifying format of time_string.
         kwargs : dict
             Any keyword arguments for ``Time``.  If the ``format`` keyword
@@ -710,12 +710,12 @@ class Time(ShapedLikeNDArray):
 
         Parameters
         ----------
-        format_spec : string
+        format_spec : str
             Format definition of return string.
 
         Returns
         -------
-        formatted : string, numpy.array
+        formatted : str, numpy.array
             String or numpy.array of strings formatted according to the given
             format string.
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -781,7 +781,7 @@ class TimeDatetime(TimeUnique):
 
         Parameters
         ----------
-        timezone : {`~datetime.tzinfo`, None} (optional)
+        timezone : {`~datetime.tzinfo`, None}, optional
             If not `None`, return timezone-aware datetime.
 
         Returns
@@ -975,12 +975,12 @@ class TimezoneInfo(datetime.tzinfo):
         """
         Parameters
         ----------
-        utc_offset : `~astropy.units.Quantity` (optional)
+        utc_offset : `~astropy.units.Quantity`, optional
             Offset from UTC in days. Defaults to zero.
-        dst : `~astropy.units.Quantity` (optional)
+        dst : `~astropy.units.Quantity`, optional
             Daylight Savings Time offset in days. Defaults to zero
             (no daylight savings).
-        tzname : string, `None` (optional)
+        tzname : str, `None`, optional
             Name of timezone
 
         Examples

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -980,7 +980,7 @@ class TimezoneInfo(datetime.tzinfo):
         dst : `~astropy.units.Quantity`, optional
             Daylight Savings Time offset in days. Defaults to zero
             (no daylight savings).
-        tzname : str, `None`, optional
+        tzname : str or `None`, optional
             Name of timezone
 
         Examples

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -37,7 +37,7 @@ class BoxLeastSquares(BasePeriodogram):
         Sequence of observation times.
     y : array_like or `~astropy.units.Quantity`
         Sequence of observations associated with times ``t``.
-    dy : float, array_like or `~astropy.units.Quantity`, optional
+    dy : float, array_like, or `~astropy.units.Quantity`, optional
         Error or sequence of observational errors associated with times ``t``.
 
     Examples
@@ -123,7 +123,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        duration : float, array_like or `~astropy.units.Quantity`
+        duration : float, array_like, or `~astropy.units.Quantity`
             The set of durations that will be considered.
         minimum_period, maximum_period : float or `~astropy.units.Quantity`, optional
             The minimum/maximum periods to search. If not provided, these will
@@ -239,7 +239,7 @@ class BoxLeastSquares(BasePeriodogram):
         ----------
         period : array_like or `~astropy.units.Quantity`
             The periods where the power should be computed
-        duration : float, array_like or `~astropy.units.Quantity`
+        duration : float, array_like, or `~astropy.units.Quantity`
             The set of durations to test
         objective : {'likelihood', 'snr'}, optional
             The scalar that should be optimized to find the best fit phase,
@@ -377,7 +377,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t_model : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
+        t_model : array_like, `~astropy.units.Quantity`, or `~astropy.time.Time`
             Times at which to compute the model.
         period : float or `~astropy.units.Quantity`
             The period of the transits.
@@ -611,12 +611,12 @@ class BoxLeastSquares(BasePeriodogram):
             Sequence of observation times.
         y : array_like or `~astropy.units.Quantity`
             Sequence of observations associated with times t.
-        dy : float, array_like or `~astropy.units.Quantity`
+        dy : float, array_like, or `~astropy.units.Quantity`
             Error or sequence of observational errors associated with times t.
 
         Returns
         -------
-        t, y, dy : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
+        t, y, dy : array_like, `~astropy.units.Quantity`, or `~astropy.time.Time`
             The inputs with consistent shapes and units.
         Raises
         ------
@@ -645,7 +645,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        duration : float, array_like or `~astropy.units.Quantity`
+        duration : float, array_like, or `~astropy.units.Quantity`
             The set of durations that will be considered.
 
         Returns
@@ -669,9 +669,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : float, array_like or `~astropy.units.Quantity`
+        period : float, array_like, or `~astropy.units.Quantity`
             The set of test periods.
-        duration : float, array_like or `~astropy.units.Quantity`
+        duration : float, array_like, or `~astropy.units.Quantity`
             The set of durations that will be considered.
 
         Returns
@@ -779,7 +779,7 @@ class BoxLeastSquaresResults(dict):
         The 1-sigma uncertainty on ``depth``.
     duration : array_like or `~astropy.units.Quantity`
         The maximum power duration at each period.
-    transit_time : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
+    transit_time : array_like, `~astropy.units.Quantity`, or `~astropy.time.Time`
         The maximum power phase of the transit in units of time. This
         indicates the mid-transit time and it will always be in the range
         (0, period).

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -33,11 +33,11 @@ class BoxLeastSquares(BasePeriodogram):
 
     Parameters
     ----------
-    t : array-like, `~astropy.units.Quantity`, `~astropy.time.Time`, or `~astropy.time.TimeDelta`
+    t : array_like, `~astropy.units.Quantity`, `~astropy.time.Time`, or `~astropy.time.TimeDelta`
         Sequence of observation times.
-    y : array-like or `~astropy.units.Quantity`
+    y : array_like or `~astropy.units.Quantity`
         Sequence of observations associated with times ``t``.
-    dy : float, array-like or `~astropy.units.Quantity`, optional
+    dy : float, array_like or `~astropy.units.Quantity`, optional
         Error or sequence of observational errors associated with times ``t``.
 
     Examples
@@ -123,7 +123,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        duration : float, array-like or `~astropy.units.Quantity`
+        duration : float, array_like or `~astropy.units.Quantity`
             The set of durations that will be considered.
         minimum_period, maximum_period : float or `~astropy.units.Quantity`, optional
             The minimum/maximum periods to search. If not provided, these will
@@ -141,7 +141,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Returns
         -------
-        period : array-like or `~astropy.units.Quantity`
+        period : array_like or `~astropy.units.Quantity`
             The set of periods computed using these heuristics with the same
             units as ``t``.
 
@@ -237,9 +237,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : array-like or `~astropy.units.Quantity`
+        period : array_like or `~astropy.units.Quantity`
             The periods where the power should be computed
-        duration : float, array-like or `~astropy.units.Quantity`
+        duration : float, array_like or `~astropy.units.Quantity`
             The set of durations to test
         objective : {'likelihood', 'snr'}, optional
             The scalar that should be optimized to find the best fit phase,
@@ -377,7 +377,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t_model : array-like or `~astropy.units.Quantity` or `~astropy.time.Time`
+        t_model : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
             Times at which to compute the model.
         period : float or `~astropy.units.Quantity`
             The period of the transits.
@@ -388,7 +388,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Returns
         -------
-        y_model : array-like or `~astropy.units.Quantity`
+        y_model : array_like or `~astropy.units.Quantity`
             The model evaluated at the times ``t_model`` with units of ``y``.
 
         """
@@ -574,7 +574,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t_model : array-like or `~astropy.units.Quantity`
+        t_model : array_like or `~astropy.units.Quantity`
             Times where the mask should be evaluated.
         period : float or `~astropy.units.Quantity`
             The period of the transits.
@@ -585,7 +585,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         Returns
         -------
-        transit_mask : array-like
+        transit_mask : array_like
             A boolean array where ``True`` indicates and in transit point and
             ``False`` indicates and out-of-transit point.
 
@@ -607,16 +607,16 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        t : array-like, `~astropy.units.Quantity`, `~astropy.time.Time`, or `~astropy.time.TimeDelta`
+        t : array_like, `~astropy.units.Quantity`, `~astropy.time.Time`, or `~astropy.time.TimeDelta`
             Sequence of observation times.
-        y : array-like or `~astropy.units.Quantity`
+        y : array_like or `~astropy.units.Quantity`
             Sequence of observations associated with times t.
-        dy : float, array-like or `~astropy.units.Quantity`
+        dy : float, array_like or `~astropy.units.Quantity`
             Error or sequence of observational errors associated with times t.
 
         Returns
         -------
-        t, y, dy : array-like or `~astropy.units.Quantity` or `~astropy.time.Time`
+        t, y, dy : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
             The inputs with consistent shapes and units.
         Raises
         ------
@@ -645,12 +645,12 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        duration : float, array-like or `~astropy.units.Quantity`
+        duration : float, array_like or `~astropy.units.Quantity`
             The set of durations that will be considered.
 
         Returns
         -------
-        duration : array-like or `~astropy.units.Quantity`
+        duration : array_like or `~astropy.units.Quantity`
             The input reformatted with the correct shape and units.
 
         Raises
@@ -669,14 +669,14 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        period : float, array-like or `~astropy.units.Quantity`
+        period : float, array_like or `~astropy.units.Quantity`
             The set of test periods.
-        duration : float, array-like or `~astropy.units.Quantity`
+        duration : float, array_like or `~astropy.units.Quantity`
             The set of durations that will be considered.
 
         Returns
         -------
-        period, duration : array-like or `~astropy.units.Quantity`
+        period, duration : array_like or `~astropy.units.Quantity`
             The inputs reformatted with the correct shapes and units.
 
         Raises
@@ -703,9 +703,9 @@ class BoxLeastSquares(BasePeriodogram):
 
         Parameters
         ----------
-        objective : string
+        objective : str
             The name of the objective used in the optimization.
-        period : array-like or `~astropy.units.Quantity`
+        period : array_like or `~astropy.units.Quantity`
             The set of trial periods.
         results : tuple
             The output of one of the periodogram implementations.
@@ -758,12 +758,12 @@ class BoxLeastSquaresResults(dict):
 
     Attributes
     ----------
-    objective : string
+    objective : str
         The scalar used to optimize to find the best fit phase, duration, and
         depth. See :func:`BoxLeastSquares.power` for more information.
-    period : array-like or `~astropy.units.Quantity`
+    period : array_like or `~astropy.units.Quantity`
         The set of test periods.
-    power : array-like or `~astropy.units.Quantity`
+    power : array_like or `~astropy.units.Quantity`
         The periodogram evaluated at the periods in ``period``. If
         ``objective`` is:
 
@@ -773,19 +773,19 @@ class BoxLeastSquaresResults(dict):
           which the depth is measured maximized over phase, depth, and
           duration.
 
-    depth : array-like or `~astropy.units.Quantity`
+    depth : array_like or `~astropy.units.Quantity`
         The estimated depth of the maximum power model at each period.
-    depth_err : array-like or `~astropy.units.Quantity`
+    depth_err : array_like or `~astropy.units.Quantity`
         The 1-sigma uncertainty on ``depth``.
-    duration : array-like or `~astropy.units.Quantity`
+    duration : array_like or `~astropy.units.Quantity`
         The maximum power duration at each period.
-    transit_time : array-like or `~astropy.units.Quantity` or `~astropy.time.Time`
+    transit_time : array_like or `~astropy.units.Quantity` or `~astropy.time.Time`
         The maximum power phase of the transit in units of time. This
         indicates the mid-transit time and it will always be in the range
         (0, period).
-    depth_snr : array-like or `~astropy.units.Quantity`
+    depth_snr : array_like or `~astropy.units.Quantity`
         The signal-to-noise with which the depth is measured at maximum power.
-    log_likelihood : array-like or `~astropy.units.Quantity`
+    log_likelihood : array_like or `~astropy.units.Quantity`
         The log likelihood of the maximum power model.
 
     """

--- a/astropy/timeseries/periodograms/bls/methods.py
+++ b/astropy/timeseries/periodograms/bls/methods.py
@@ -12,15 +12,15 @@ from ._impl import bls_impl
 def bls_slow(t, y, ivar, period, duration, oversample, use_likelihood):
     """Compute the periodogram using a brute force reference method
 
-    t : array-like
+    t : array_like
         Sequence of observation times.
-    y : array-like
+    y : array_like
         Sequence of observations associated with times t.
-    ivar : array-like
+    ivar : array_like
         The inverse variance of ``y``.
-    period : array-like
+    period : array_like
         The trial periods where the periodogram should be computed.
-    duration : array-like
+    duration : array_like
         The durations that should be tested.
     oversample :
         The resolution of the phase grid in units of durations.
@@ -29,21 +29,21 @@ def bls_slow(t, y, ivar, period, duration, oversample, use_likelihood):
 
     Returns
     -------
-    power : array-like
+    power : array_like
         The periodogram evaluated at the periods in ``period``.
-    depth : array-like
+    depth : array_like
         The estimated depth of the maximum power model at each period.
-    depth_err : array-like
+    depth_err : array_like
         The 1-sigma uncertainty on ``depth``.
-    duration : array-like
+    duration : array_like
         The maximum power duration at each period.
-    transit_time : array-like
+    transit_time : array_like
         The maximum power phase of the transit in units of time. This
         indicates the mid-transit time and it will always be in the range
         (0, period).
-    depth_snr : array-like
+    depth_snr : array_like
         The signal-to-noise with which the depth is measured at maximum power.
-    log_likelihood : array-like
+    log_likelihood : array_like
         The log likelihood of the maximum power model.
 
     """
@@ -55,15 +55,15 @@ def bls_slow(t, y, ivar, period, duration, oversample, use_likelihood):
 def bls_fast(t, y, ivar, period, duration, oversample, use_likelihood):
     """Compute the periodogram using an optimized Cython implementation
 
-    t : array-like
+    t : array_like
         Sequence of observation times.
-    y : array-like
+    y : array_like
         Sequence of observations associated with times t.
-    ivar : array-like
+    ivar : array_like
         The inverse variance of ``y``.
-    period : array-like
+    period : array_like
         The trial periods where the periodogram should be computed.
-    duration : array-like
+    duration : array_like
         The durations that should be tested.
     oversample :
         The resolution of the phase grid in units of durations.
@@ -72,21 +72,21 @@ def bls_fast(t, y, ivar, period, duration, oversample, use_likelihood):
 
     Returns
     -------
-    power : array-like
+    power : array_like
         The periodogram evaluated at the periods in ``period``.
-    depth : array-like
+    depth : array_like
         The estimated depth of the maximum power model at each period.
-    depth_err : array-like
+    depth_err : array_like
         The 1-sigma uncertainty on ``depth``.
-    duration : array-like
+    duration : array_like
         The maximum power duration at each period.
-    transit_time : array-like
+    transit_time : array_like
         The maximum power phase of the transit in units of time. This
         indicates the mid-transit time and it will always be in the range
         (0, period).
-    depth_snr : array-like
+    depth_snr : array_like
         The signal-to-noise with which the depth is measured at maximum power.
-    log_likelihood : array-like
+    log_likelihood : array_like
         The log likelihood of the maximum power model.
 
     """

--- a/astropy/timeseries/periodograms/lombscargle/_statistics.py
+++ b/astropy/timeseries/periodograms/lombscargle/_statistics.py
@@ -54,7 +54,7 @@ def pdf_single(z, N, normalization, dH=1, dK=3):
 
     Parameters
     ----------
-    z : array-like
+    z : array_like
         The periodogram value.
     N : int
         The number of data points from which the periodogram was computed.
@@ -105,7 +105,7 @@ def fap_single(z, N, normalization, dH=1, dK=3):
 
     Parameters
     ----------
-    z : array-like
+    z : array_like
         The periodogram value.
     N : int
         The number of data points from which the periodogram was computed.
@@ -156,7 +156,7 @@ def inv_fap_single(fap, N, normalization, dH=1, dK=3):
 
     Parameters
     ----------
-    fap : array-like
+    fap : array_like
         The false alarm probability.
     N : int
         The number of data points from which the periodogram was computed.
@@ -209,7 +209,7 @@ def cdf_single(z, N, normalization, dH=1, dK=3):
 
     Parameters
     ----------
-    z : array-like
+    z : array_like
         The periodogram value.
     N : int
         The number of data points from which the periodogram was computed.
@@ -395,11 +395,11 @@ def false_alarm_probability(Z, fmax, t, y, dy, normalization='standard',
 
     Parameters
     ----------
-    Z : array-like
+    Z : array_like
         The periodogram value.
     fmax : float
         The maximum frequency of the periodogram.
-    t, y, dy : array-like
+    t, y, dy : array_like
         The data times, values, and errors.
     normalization : {'standard', 'model', 'log', 'psd'}, optional
         The periodogram normalization.
@@ -455,7 +455,7 @@ def false_alarm_level(p, fmax, t, y, dy, normalization,
 
     Parameters
     ----------
-    p : array-like
+    p : array_like
         The false alarm probability (0 < p < 1).
     fmax : float
         The maximum frequency of the periodogram.

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -40,7 +40,7 @@ class LombScargle(BasePeriodogram):
         sequence of observation times
     y : array_like or Quantity
         sequence of observations associated with times t
-    dy : float, array_like or Quantity, optional
+    dy : float, array_like, or Quantity, optional
         error or sequence of observational errors associated with times t
     fit_mean : bool, optional
         if True, include a constant offset as part of the model at each

--- a/astropy/timeseries/periodograms/lombscargle/core.py
+++ b/astropy/timeseries/periodograms/lombscargle/core.py
@@ -40,16 +40,16 @@ class LombScargle(BasePeriodogram):
         sequence of observation times
     y : array_like or Quantity
         sequence of observations associated with times t
-    dy : float, array_like or Quantity (optional)
+    dy : float, array_like or Quantity, optional
         error or sequence of observational errors associated with times t
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if fit_mean = False
-    nterms : int (optional, default=1)
+    nterms : int, optional
         number of terms to use in the Fourier fit
     normalization : {'standard', 'model', 'log', 'psd'}, optional
         Normalization to use for the periodogram.
@@ -206,18 +206,18 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        samples_per_peak : float (optional, default=5)
+        samples_per_peak : float, optional
             The approximate number of desired samples across the typical peak
-        nyquist_factor : float (optional, default=5)
+        nyquist_factor : float, optional
             The multiple of the average nyquist frequency used to choose the
             maximum frequency if maximum_frequency is not provided.
-        minimum_frequency : float (optional)
+        minimum_frequency : float, optional
             If specified, then use this minimum frequency rather than one
             chosen based on the size of the baseline.
-        maximum_frequency : float (optional)
+        maximum_frequency : float, optional
             If specified, then use this maximum frequency rather than one
             chosen based on the average nyquist frequency.
-        return_freq_limits : bool (optional)
+        return_freq_limits : bool, optional
             if True, return only the frequency limits rather than the full
             frequency grid.
 
@@ -253,7 +253,7 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        method : string (optional)
+        method : str, optional
             specify the lomb scargle implementation to use. Options are:
 
             - 'auto': choose the best method based on the input
@@ -271,19 +271,19 @@ class LombScargle(BasePeriodogram):
               implementation written in C. Note that this does not support
               heteroskedastic errors.
 
-        method_kwds : dict (optional)
+        method_kwds : dict, optional
             additional keywords to pass to the lomb-scargle method
         normalization : {'standard', 'model', 'log', 'psd'}, optional
             If specified, override the normalization specified at instantiation.
-        samples_per_peak : float (optional, default=5)
+        samples_per_peak : float, optional
             The approximate number of desired samples across the typical peak
-        nyquist_factor : float (optional, default=5)
+        nyquist_factor : float, optional
             The multiple of the average nyquist frequency used to choose the
             maximum frequency if maximum_frequency is not provided.
-        minimum_frequency : float (optional)
+        minimum_frequency : float, optional
             If specified, then use this minimum frequency rather than one
             chosen based on the size of the baseline.
-        maximum_frequency : float (optional)
+        maximum_frequency : float, optional
             If specified, then use this maximum frequency rather than one
             chosen based on the average nyquist frequency.
 
@@ -312,7 +312,7 @@ class LombScargle(BasePeriodogram):
             frequencies (not angular frequencies) at which to evaluate the
             periodogram. Note that in order to use method='fast', frequencies
             must be regularly-spaced.
-        method : string (optional)
+        method : str, optional
             specify the lomb scargle implementation to use. Options are:
 
             - 'auto': choose the best method based on the input
@@ -330,20 +330,20 @@ class LombScargle(BasePeriodogram):
               implementation written in C. Note that this does not support
               heteroskedastic errors.
 
-        assume_regular_frequency : bool (optional)
+        assume_regular_frequency : bool, optional
             if True, assume that the input frequency is of the form
             freq = f0 + df * np.arange(N). Only referenced if method is 'auto'
             or 'fast'.
         normalization : {'standard', 'model', 'log', 'psd'}, optional
             If specified, override the normalization specified at instantiation.
-        fit_mean : bool (optional, default=True)
+        fit_mean : bool, optional
             If True, include a constant offset as part of the model at each
             frequency. This can lead to more accurate results, especially in
             the case of incomplete phase coverage.
-        center_data : bool (optional, default=True)
+        center_data : bool, optional
             If True, pre-center the data by subtracting the weighted mean of
             the input data. This is especially important if fit_mean = False.
-        method_kwds : dict (optional)
+        method_kwds : dict, optional
             additional keywords to pass to the lomb-scargle method
 
         Returns
@@ -536,7 +536,7 @@ class LombScargle(BasePeriodogram):
         ----------
         power : array_like
             The periodogram power at which to compute the distribution.
-        cumulative : bool (optional)
+        cumulative : bool, optional
             If True, then return the cumulative distribution.
 
         See Also
@@ -567,13 +567,13 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        power : array-like
+        power : array_like
             The periodogram value.
         method : {'baluev', 'davies', 'naive', 'bootstrap'}, optional
             The approximation method to use.
         maximum_frequency : float
             The maximum frequency of the periodogram.
-        method_kwds : dict (optional)
+        method_kwds : dict, optional
             Additional method-specific keywords.
 
         Returns
@@ -638,7 +638,7 @@ class LombScargle(BasePeriodogram):
 
         Parameters
         ----------
-        false_alarm_probability : array-like
+        false_alarm_probability : array_like
             The false alarm probability (0 < fap < 1).
         maximum_frequency : float
             The maximum frequency of the periodogram.

--- a/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/chi2_impl.py
@@ -18,17 +18,17 @@ def lombscargle_chi2(t, y, dy, frequency, normalization='standard',
         broadcastable to the same shape.
     frequency : array_like
         frequencies (not angular frequencies) at which to calculate periodogram
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
-    nterms : int (optional, default=1)
+    nterms : int, optional
         Number of Fourier terms in the fit
 
     Returns

--- a/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/cython_impl.pyx
@@ -31,14 +31,14 @@ def lombscargle_cython(t, y, dy, frequency, normalization='standard',
         broadcastable to the same shape.
     frequency : array_like
         frequencies (not angular frequencies) at which to calculate periodogram
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fast_impl.py
@@ -24,13 +24,13 @@ def lombscargle_fast(t, y, dy, f0, df, Nf,
     fit_mean : bool (default=True)
         If True, then compute the floating-mean periodogram; i.e. let the mean
         vary with the fit.
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
     use_fft : bool (default=True)
         If True, then use the Press & Rybicki O[NlogN] algorithm to compute
         the result. Otherwise, use a slower O[N^2] algorithm
-    trig_sum_kwds : dict or None (optional)
+    trig_sum_kwds : dict or None, optional
         extra keyword arguments to pass to the ``trig_sum`` utility.
         Options are ``oversampling`` and ``Mfft``. See documentation
         of ``trig_sum`` for details.

--- a/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/fastchi2_impl.py
@@ -21,17 +21,17 @@ def lombscargle_fastchi2(t, y, dy, f0, df, Nf, normalization='standard',
         broadcastable to the same shape.
     f0, df, Nf : (float, float, int)
         parameters describing the frequency grid, f = f0 + df * arange(Nf).
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
-    nterms : int (optional, default=1)
+    nterms : int, optional
         Number of Fourier terms in the fit
 
     Returns

--- a/astropy/timeseries/periodograms/lombscargle/implementations/main.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/main.py
@@ -124,7 +124,7 @@ def lombscargle(t, y, dy=None,
         sequence of observation times
     y : array_like
         sequence of observations associated with times t
-    dy : float or array_like (optional)
+    dy : float or array_like, optional
         error or sequence of observational errors associated with times t
     frequency : array_like
         frequencies (not angular frequencies) at which to evaluate the
@@ -132,7 +132,7 @@ def lombscargle(t, y, dy=None,
         a heuristic which will attempt to provide sufficient frequency range
         and sampling so that peaks will not be missed. Note that in order to
         use method='fast', frequencies must be regularly spaced.
-    method : string (optional)
+    method : str, optional
         specify the lomb scargle implementation to use. Options are:
 
         - 'auto': choose the best method based on the input
@@ -148,23 +148,23 @@ def lombscargle(t, y, dy=None,
           implementation written in C. Note that this does not support
           heteroskedastic errors.
 
-    assume_regular_frequency : bool (optional)
+    assume_regular_frequency : bool, optional
         if True, assume that the input frequency is of the form
         freq = f0 + df * np.arange(N). Only referenced if method is 'auto'
         or 'fast'.
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard' or 'psd'.
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if `fit_mean = False`
-    method_kwds : dict (optional)
+    method_kwds : dict, optional
         additional keywords to pass to the lomb-scargle method
-    nterms : int (default=1)
+    nterms : int, optional
         number of Fourier terms to use in the periodogram.
         Not supported with every method.
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/mle.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/mle.py
@@ -14,7 +14,7 @@ def design_matrix(t, frequency, dy=None, bias=True, nterms=1):
         times at which to compute the design matrix
     frequency : float
         frequency for the design matrix
-    dy : float or array_like (optional)
+    dy : float or array_like, optional
         data uncertainties: should be broadcastable with `t`
     bias : bool (default=True)
         If true, include a bias column in the matrix

--- a/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/scipy_impl.py
@@ -17,10 +17,10 @@ def lombscargle_scipy(t, y, frequency, normalization='standard',
         broadcastable to the same shape.
     frequency : array_like
         frequencies (not angular frequencies) at which to calculate periodogram
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data.
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/slow_impl.py
@@ -16,14 +16,14 @@ def lombscargle_slow(t, y, dy, frequency, normalization='standard',
         broadcastable to the same shape.
     frequency : array_like
         frequencies (not angular frequencies) at which to calculate periodogram
-    normalization : string (optional, default='standard')
+    normalization : str, optional
         Normalization to use for the periodogram.
         Options are 'standard', 'model', 'log', or 'psd'.
-    fit_mean : bool (optional, default=True)
+    fit_mean : bool, optional
         if True, include a constant offset as part of the model at each
         frequency. This can lead to more accurate results, especially in the
         case of incomplete phase coverage.
-    center_data : bool (optional, default=True)
+    center_data : bool, optional
         if True, pre-center the data by subtracting the weighted mean
         of the input data. This is especially important if ``fit_mean = False``
 

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -97,9 +97,9 @@ def trig_sum(t, h, df, N, f0=0, freq_factor=1,
         frequency spacing
     N : int
         number of frequency bins to return
-    f0 : float (optional, default=0)
+    f0 : float, optional
         The low frequency to use
-    freq_factor : float (optional, default=1)
+    freq_factor : float, optional
         Factor which multiplies the frequency
     use_fft : bool
         if True, use the approximate FFT algorithm to compute the result.

--- a/astropy/timeseries/periodograms/lombscargle/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/utils.py
@@ -13,11 +13,11 @@ def compute_chi2_ref(y, dy=None, center_data=True, fit_mean=True):
     ----------
     y : array_like
         data values
-    dy : float, array, or None (optional)
+    dy : float, array, or None, optional
         data uncertainties
-    center_data : boolean
+    center_data : bool
         specify whether data should be pre-centered
-    fit_mean : boolean
+    fit_mean : bool
         specify whether model should fit the mean of the data
 
     Returns
@@ -49,7 +49,7 @@ def convert_normalization(Z, N, from_normalization, to_normalization,
         the periodogram output
     N : integer
         the number of data points
-    from_normalization, to_normalization : strings
+    from_normalization, to_normalization : str
         the normalization to convert from and to. Options are
         ['standard', 'model', 'log', 'psd']
     chi2_ref : float

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -31,7 +31,7 @@ class Distribution:
 
     Parameters
     ----------
-    samples : array-like
+    samples : array_like
         The distribution, with sampling along the *leading* axis. If 1D, the
         sole dimension is used as the sampling axis (i.e., it is a scalar
         distribution).
@@ -304,7 +304,7 @@ class _DistributionRepr:
             reprarr = reprarr[firstspace+1:-1]  # :-1] removes the ending '>'
             return '<{} {} with n_samples={}>'.format(self.__class__.__name__,
                                                       reprarr, self.n_samples)
-        else:  # numpy array-like
+        else:  # numpy array_like
             firstparen = reprarr.find('(')
             reprarr = reprarr[firstparen:]
             return '{}{} with n_samples={}'.format(self.__class__.__name__,

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -304,7 +304,7 @@ class _DistributionRepr:
             reprarr = reprarr[firstspace+1:-1]  # :-1] removes the ending '>'
             return '<{} {} with n_samples={}>'.format(self.__class__.__name__,
                                                       reprarr, self.n_samples)
-        else:  # numpy array_like
+        else:  # numpy array-like
             firstparen = reprarr.find('(')
             reprarr = reprarr[firstparen:]
             return '{}{} with n_samples={}'.format(self.__class__.__name__,

--- a/astropy/uncertainty/distributions.py
+++ b/astropy/uncertainty/distributions.py
@@ -129,16 +129,16 @@ def uniform(*, lower=None, upper=None, center=None, width=None, n_samples,
 
     Parameters
     ----------
-    lower : array-like
+    lower : array_like
         The lower edge of this distribution. If a `~astropy.units.Quantity`, the
         distribution will have the same units as ``lower``.
     upper : `~astropy.units.Quantity`
         The upper edge of this distribution. Must match shape and if a
         `~astropy.units.Quantity` must have compatible units with ``lower``.
-    center : array-like
+    center : array_like
         The center value of the distribution. Cannot be provided at the same
         time as ``lower``/``upper``.
-    width : array-like
+    width : array_like
         The width of the distribution.  Must have the same shape and compatible
         units with ``center`` (if any).
     n_samples : int

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -431,7 +431,7 @@ class FunctionQuantity(Quantity):
         converted to the function unit, after, if necessary, converting it to
         the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
         For an `~astropy.units.function.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.

--- a/astropy/units/function/core.py
+++ b/astropy/units/function/core.py
@@ -431,7 +431,7 @@ class FunctionQuantity(Quantity):
         converted to the function unit, after, if necessary, converting it to
         the physical unit inferred from ``unit``.
 
-    unit : string, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
+    unit : str, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
         For an `~astropy.units.function.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -187,7 +187,7 @@ class LogQuantity(FunctionQuantity):
         it will converted to the logarithmic unit, after, if necessary,
         converting it to the physical unit inferred from ``unit``.
 
-    unit : string, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
+    unit : str, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
         For an `~astropy.units.function.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.

--- a/astropy/units/function/logarithmic.py
+++ b/astropy/units/function/logarithmic.py
@@ -187,7 +187,7 @@ class LogQuantity(FunctionQuantity):
         it will converted to the logarithmic unit, after, if necessary,
         converting it to the physical unit inferred from ``unit``.
 
-    unit : str, `~astropy.units.UnitBase` or `~astropy.units.function.FunctionUnitBase` instance, optional
+    unit : str, `~astropy.units.UnitBase`, or `~astropy.units.function.FunctionUnitBase`, optional
         For an `~astropy.units.function.FunctionUnitBase` instance, the
         physical unit will be taken from it; for other input, it will be
         inferred from ``value``. By default, ``unit`` is set by the subclass.

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1656,7 +1656,7 @@ class Quantity(np.ndarray):
         obj : int, slice or sequence of ints
             Object that defines the index or indices before which ``values`` is
             inserted.
-        values : array-like
+        values : array_like
             Values to insert.  If the type of ``values`` is different
             from that of quantity, ``values`` is converted to the matching type.
             ``values`` should be shaped so that it can be broadcast appropriately

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1212,7 +1212,7 @@ def is_url_in_cache(url_key, pkgname='astropy'):
 
     Parameters
     ----------
-    url_key : string
+    url_key : str
         The URL retrieved
     pkgname : `str`, optional
         The package name to use to locate the download cache. i.e. for

--- a/astropy/utils/timer.py
+++ b/astropy/utils/timer.py
@@ -238,7 +238,7 @@ class RunTimePredictor:
 
         Returns
         -------
-        a : array-like
+        a : array_like
             Fitted `~astropy.modeling.FittableModel` parameters.
 
         Raises

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -20,7 +20,7 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     x : array_like
         array of data to be histogrammed
 
-    bins : int or list or str, optional
+    bins : int, list, or str, optional
         If bins is a string, then it must be one of:
 
         - 'blocks' : use bayesian blocks for dynamic bin widths

--- a/astropy/visualization/hist.py
+++ b/astropy/visualization/hist.py
@@ -20,7 +20,7 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
     x : array_like
         array of data to be histogrammed
 
-    bins : int or list or str (optional)
+    bins : int or list or str, optional
         If bins is a string, then it must be one of:
 
         - 'blocks' : use bayesian blocks for dynamic bin widths
@@ -31,11 +31,11 @@ def hist(x, bins=10, ax=None, max_bins=1e5, **kwargs):
 
         - 'freedman' : use the Freedman-Diaconis rule to determine bins
 
-    ax : Axes instance (optional)
+    ax : Axes instance, optional
         specify the Axes on which to draw the histogram.  If not specified,
         then the current active axes will be used.
 
-    max_bins : int (optional)
+    max_bins : int, optional
         Maximum number of bins allowed. With more than a few thousand bins
         the performance of matplotlib will not be great. If the number of
         bins is large *and* the number of input data points is large then

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -48,7 +48,7 @@ class BaseInterval(BaseTransform):
 
         Parameters
         ----------
-        values : array-like
+        values : array_like
             The input values.
         clip : bool, optional
             If `True` (default), values outside the [0:1] range are

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -243,7 +243,7 @@ def imshow_norm(data, ax=None, imshow_only_kwargs={}, **kwargs):
 
     Parameters
     ----------
-    data : 2D or 3D array-like - see `~matplotlib.pyplot.imshow`
+    data : 2D or 3D array_like - see `~matplotlib.pyplot.imshow`
         The data to show. Can be whatever `~matplotlib.pyplot.imshow` and
         `ImageNormalize` both accept.
     ax : None or `~matplotlib.axes.Axes`, optional

--- a/astropy/visualization/scripts/fits2bitmap.py
+++ b/astropy/visualization/scripts/fits2bitmap.py
@@ -28,7 +28,7 @@ def fits2bitmap(filename, ext=0, out_fn=None, stretch='linear',
         The filename of the output bitmap image.  The type of bitmap
         is determined by the filename extension (e.g. '.jpg', '.png').
         The default is a PNG file with the same name as the FITS file.
-    stretch : {{'linear', 'sqrt', 'power', log', 'asinh'}}
+    stretch : {'linear', 'sqrt', 'power', log', 'asinh'}
         The stretching function to apply to the image.  The default is
         'linear'.
     power : float, optional

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -60,7 +60,7 @@ class BaseStretch(BaseTransform):
 
         Parameters
         ----------
-        values : array-like
+        values : array_like
             The input values, which should already be normalized to the
             [0:1] range.
         clip : bool, optional
@@ -399,9 +399,9 @@ class HistEqStretch(BaseStretch):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         The data defining the equalization.
-    values : array-like, optional
+    values : array_like, optional
         The input image values, which should already be normalized to
         the [0:1] range.
     """
@@ -437,9 +437,9 @@ class InvertedHistEqStretch(BaseStretch):
 
     Parameters
     ----------
-    data : array-like
+    data : array_like
         The data defining the equalization.
-    values : array-like, optional
+    values : array_like, optional
         The input image values, which should already be normalized to
         the [0:1] range.
     """

--- a/astropy/visualization/wcsaxes/coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/coordinate_helpers.py
@@ -1021,7 +1021,7 @@ class CoordinateHelper:
             Transparency of grid lines: 0 (transparent) to 1 (opaque).
         grid_linewidth : float, optional
             Width of grid lines in points.
-        grid_linestyle : string, optional
+        grid_linestyle : str, optional
             The style of the grid lines (accepts any valid Matplotlib line
             style).
         """

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -709,7 +709,7 @@ class WCSAxes(Axes):
             Transparency of grid lines: 0 (transparent) to 1 (opaque).
         grid_linewidth : float, optional
             Width of grid lines in points.
-        grid_linestyle : string, optional
+        grid_linestyle : str, optional
             The style of the grid lines (accepts any valid Matplotlib line
             style).
         """

--- a/astropy/visualization/wcsaxes/frame.py
+++ b/astropy/visualization/wcsaxes/frame.py
@@ -213,7 +213,7 @@ class BaseFrame(OrderedDict, metaclass=abc.ABCMeta):
 
         Parameters
         ----------
-        color : string
+        color : str
             The color of the frame.
         """
         self._color = color

--- a/docs/development/docrules.rst
+++ b/docs/development/docrules.rst
@@ -217,7 +217,7 @@ The sections of the docstring are:
    When two or more input parameters have exactly the same type, shape and
    description, they can be combined::
 
-     x1, x2 : array-like
+     x1, x2 : array_like
          Input arrays, description of `x1`, `x2`.
 
 5. **Returns**
@@ -530,10 +530,10 @@ Other points to keep in mind
   and are not often necessary. One situation in which a warning can
   be useful is for marking a known bug that is not yet fixed.
 
-* ``array-like`` : For functions that take arguments which can have not only
+* ``array_like`` : For functions that take arguments which can have not only
   a type ``ndarray``, but also types that can be converted to an ndarray
   (i.e. scalar types, sequence types), those arguments can be documented
-  with type ``array-like``.
+  with type ``array_like``.
 
 Common reST concepts
 ====================

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -80,7 +80,7 @@ def rv_to_gsr(c, v_sun=None):
     c : `~astropy.coordinates.BaseCoordinateFrame` subclass instance
         The radial velocity, associated with a sky coordinates, to be
         transformed.
-    v_sun : `~astropy.units.Quantity` (optional)
+    v_sun : `~astropy.units.Quantity`, optional
         The 3D velocity of the solar system barycenter in the GSR frame.
         Defaults to the same solar motion as in the
         `~astropy.coordinates.Galactocentric` frame.


### PR DESCRIPTION
While trying to use sphinx.ext.napoleon for docstrings, I found a bunch of issues with existing docstrings, where these are not quite numpydoc compliant. There are still >1000 warnings, but the fixes here are a start for some of the most common issues.

Note that array-like has been changed to array_like for consistency with the [latest numpydoc spec](https://numpydoc.readthedocs.io/en/latest/format.html#other-points-to-keep-in-mind)