### PR TITLE
Fix bug in masking of invalid coordinates returned by WCSLIB

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1154,6 +1154,13 @@ astropy.wcs
 - ``FITSWCSAPIMixin`` now returns tuples not lists from ``pixel_to_world`` and
   ``world_to_pixel``. [#9678]
 
+- Fix NaN-masking of world coordinates when some but not all of the coordinates
+  were flagged as invalid by WCSLIB. This occurred for example with WCS with >2
+  dimensions where two of the dimensions were celestial coordinates and pixel
+  coordinates ouside of the 'sky' were converted to world coordinates -
+  previously all world coordinates were masked even if uncorrelated with the
+  celestial axes, but this is no longer the case. [#9688]
+
 Other Changes and Additions
 ---------------------------
 

--- a/astropy/wcs/src/util.c
+++ b/astropy/wcs/src/util.c
@@ -20,7 +20,6 @@ void set_invalid_to_nan(
   const int* s = stat;
   const int* s_end = stat + ncoord;
   double n;
-  int bit;
 
   #ifndef NAN
     #define INF (DBL_MAX+DBL_MAX)
@@ -34,14 +33,14 @@ void set_invalid_to_nan(
 
   for ( ; s != s_end; ++s) {
     if (*s) {
-      bit = 1;
+      int bit = 1;
       for (i = 0; i < nelem; ++i) {
-        if ((*s & bit) == bit) {
+        if (*s & bit) {
           *d++ = n;
         } else {
           d++;
         }
-        bit *= 2;
+        bit <<= 1;
       }
     } else {
       d += nelem;

--- a/astropy/wcs/src/util.c
+++ b/astropy/wcs/src/util.c
@@ -20,18 +20,28 @@ void set_invalid_to_nan(
   const int* s = stat;
   const int* s_end = stat + ncoord;
   double n;
+  int bit;
 
   #ifndef NAN
     #define INF (DBL_MAX+DBL_MAX)
     #define NAN (INF-INF)
   #endif
 
+  // Note that stat is a bit mask, so we need to mask only some of
+  // the coordinates depending on the bit mask values.
+
   n = NAN;
 
   for ( ; s != s_end; ++s) {
     if (*s) {
+      bit = 1;
       for (i = 0; i < nelem; ++i) {
-        *d++ = n;
+        if ((*s & bit) == bit) {
+          *d++ = n;
+        } else {
+          d++;
+        }
+        bit *= 2;
       }
     } else {
       d += nelem;

--- a/astropy/wcs/src/util.c
+++ b/astropy/wcs/src/util.c
@@ -36,10 +36,12 @@ void set_invalid_to_nan(
       int bit = 1;
       for (i = 0; i < nelem; ++i) {
         if (*s & bit) {
-          *d++ = n;
-        } else {
-          d++;
+          *d = n;
         }
+        d++;
+        // We don't need to worry about overflow here because the WCS
+        // class cannot be used for naxis > 15 so nelem will always
+        // be <=15.
         bit <<= 1;
       }
     } else {


### PR DESCRIPTION
Previously, the masking did not respect the exact bit mask returned by WCSLIB but masked all values if the bit mask had any bit set. This caused issues with e.g. all sky spectral cubes where even if one converts pixel coordinates outside of the sky, the spectral coordinate should always return a valid coordinate if the spectral axis is uncorrelated.

I'd like to get this into 4.0 if possible since it's a pretty frustrating bug for some use cases I work on.

And for a blast from the past, this is a bug in the original implementation of the masking from https://github.com/astropy/astropy/pull/107 - unless WCSLIB changed stat from 1 to a bit mask in the mean time.