### PR TITLE
Enable astropy test header in partial run

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -96,6 +96,7 @@ show-response = 1
 minversion = 3.1
 testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern"
+astropy_header = true
 doctest_plus = enabled
 text_file_format = rst
 open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to enable test header even when only one file is tested with `-t` option. With this patch, `python setup.py test -t docs/whatsnew/4.0.rst` gives:
```
platform win32 -- Python 3.7.4, pytest-5.2.0, py-1.8.0, pluggy-0.13.0

Running tests with Astropy version 4.1.dev27042.
Running tests in docs\whatsnew\4.0.rst.

Date: 2019-11-26T18:07:06

Platform: Windows-10-10.0.18362-SP0

Executable: C:\...\Miniconda3\envs\py37\python.exe

Full Python Version:
3.7.4 (default, Aug  9 2019, 18:34:13) [MSC v.1915 64 bit (AMD64)]

encodings: sys: utf-8, locale: cp1252, filesystem: utf-8
byteorder: little
float info: dig: 15, mant_dig: 15

Package versions:
Numpy: 1.17.2
Scipy: 1.3.1
Matplotlib: 3.1.1
h5py: not available
Pandas: not available
astropy-helpers: 3.1rc1

Using Astropy options: remote_data: none.

rootdir: C:\...\site-packages, inifile: setup.cfg
plugins: arraydiff-0.3, astropy-header-0.1.1, doctestplus-0.5.0, openfiles-0.4.0, remotedata-0.3.2
collected 1 item

docs\whatsnew\4.0.rst .                                                  [100%]
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Prompted by astropy/pytest-astropy-header#10