### PR TITLE
Fix wcsapi doctest failure with remote data

### DIFF
--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -146,7 +146,7 @@ Galactic coordinates and these will automatically be converted::
     >>> coord = SkyCoord('00h00m00s +00d00m00s', frame='galactic')
     >>> pixels = wcs.world_to_pixel(coord)  # doctest: +REMOTE_DATA
     >>> pixels  # doctest: +REMOTE_DATA
-    [array(356.85179997), array(357.45340331)]
+    (array(356.85179997), array(357.45340331))
 
 If you are looking to index the original data using these pixel coordinates,
 be sure to instead use
@@ -211,7 +211,7 @@ and back::
     >>> coord = SkyCoord('03h26m36.4901s +30d45m22.2012s')
     >>> pixels = wcs.world_to_pixel(coord, 3000 * u.m / u.s)  # doctest: +REMOTE_DATA
     >>> pixels  # doctest: +REMOTE_DATA
-    [array(8.11341207), array(71.0956641), array(7.10297292)]
+    (array(8.11341207), array(71.0956641), array(7.10297292))
 
 And as before we can index array values using::
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address doctest failure in `wcsapi` as follows:

```
________________________ [doctest] docs/wcs/wcsapi.rst _________________________
139     <SkyCoord (FK5: equinox=2000.0): (ra, dec) in deg
140         [(266.97242993, -29.42584415), (266.97084321, -29.42723968)]>
141 
142 Similarly, we can transform astropy objects back - we can test this by creating
143 Galactic coordinates and these will automatically be converted::
144 
145     >>> from astropy.coordinates import SkyCoord
146     >>> coord = SkyCoord('00h00m00s +00d00m00s', frame='galactic')
147     >>> pixels = wcs.world_to_pixel(coord)  # doctest: +REMOTE_DATA
148     >>> pixels  # doctest: +REMOTE_DATA
Expected:
    [array(356.85179997), array(357.45340331)]
Got:
    (array(356.85179997), array(357.45340331))
.../docs/wcs/wcsapi.rst:148: DocTestFailure
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Probably caused by #9678

**Note to reviewer: Check remote data test job that is allowed to fail.**