### PR TITLE
Fixes to ImageNormalize

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1008,6 +1008,9 @@ astropy.visualization
 - The default ``clip`` value is now ``False`` in ``ImageNormalize``.
   [#9478]
 
+- The default ``clip`` value is now ``False`` in ``simple_norm``.
+  [#9698]
+
 - Infinite values are now excluded when calculating limits in
   ``ManualInterval`` and ``MinMaxInterval``.  They were already
   excluded in all other interval classes. [#9480]
@@ -1151,6 +1154,11 @@ astropy.visualization
   handle when input coordinates are not already in spherical representations.
   [#8927]
 
+- Fixed ``ImageNormalize`` so that when it is intialized without
+  ``data`` it will still use the input ``interval`` class. [#9698]
+
+- Fixed ``ImageNormalize`` to handle input data with non-finite
+  values. [#9698]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -107,20 +107,18 @@ class ImageNormalize(Normalize):
             # copy because of in-place operations after
             values = np.array(values, copy=True, dtype=float)
 
-        # Filter out invalid values (inf, nan)
-        values = values[np.isfinite(values)]
-
         # Define vmin and vmax from the interval class if not None
-        if self.interval is not None:
+        if self.interval is None:
+            if self.vmin is None:
+                self.vmin = np.nanmin(values)
+            if self.vmax is None:
+                self.vmax = np.nanmax(values)
+        else:
             _vmin, _vmax = self.interval.get_limits(values)
             if self.vmin is None:
                 self.vmin = _vmin
             if self.vmax is None:
                 self.vmax = _vmax
-
-        # Define vmin and vmax (as the min and max of the values array)
-        # if not specified and the interval class is None
-        self.autoscale_None(values)
 
         # Normalize based on vmin and vmax
         np.subtract(values, self.vmin, out=values)

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -144,7 +144,7 @@ class ImageNormalize(Normalize):
 
 def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
                 max_cut=None, min_percent=None, max_percent=None,
-                percent=None, clip=True, log_a=1000):
+                percent=None, clip=False, log_a=1000):
     """
     Return a Normalization class that can be used for displaying images
     with Matplotlib.
@@ -207,8 +207,8 @@ def simple_norm(data, stretch='linear', power=1.0, asinh_a=0.1, min_cut=None,
         either ``min_percent`` or ``max_percent`` is input.
 
     clip : bool, optional
-        If `True` (default), data values outside the [0:1] range are
-        clipped to the [0:1] range.
+        If `True`, data values outside the [0:1] range are clipped to
+        the [0:1] range.
 
     Returns
     -------

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -46,11 +46,11 @@ class ImageNormalize(Normalize):
         ``data`` is also input.  ``data`` and ``interval`` are used to
         compute the vmin and/or vmax values only if ``vmin`` or ``vmax``
         are not input.
-    vmin, vmax : float
+    vmin, vmax : float, optional
         The minimum and maximum levels to show for the data.  The
         ``vmin`` and ``vmax`` inputs override any calculated values from
         the ``interval`` and ``data`` inputs.
-    stretch : `~astropy.visualization.BaseStretch` subclass instance, optional
+    stretch : `~astropy.visualization.BaseStretch` subclass instance
         The stretch object to apply to the data.  The default is
         `~astropy.visualization.LinearStretch`.
     clip : bool, optional
@@ -72,7 +72,9 @@ class ImageNormalize(Normalize):
             if self.vmax is None:
                 self.vmax = _vmax
 
-        if stretch is not None and not isinstance(stretch, BaseStretch):
+        if stretch is None:
+            raise ValueError('stretch must be input')
+        if not isinstance(stretch, BaseStretch):
             raise TypeError('stretch must be an instance of a BaseStretch '
                             'subclass')
         self.stretch = stretch

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -105,6 +105,9 @@ class ImageNormalize(Normalize):
             # copy because of in-place operations after
             values = np.array(values, copy=True, dtype=float)
 
+        # Filter out invalid values (inf, nan)
+        values = values[np.isfinite(values)]
+
         # Set default values for vmin and vmax if not specified
         self.autoscale_None(values)
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -108,7 +108,16 @@ class ImageNormalize(Normalize):
         # Filter out invalid values (inf, nan)
         values = values[np.isfinite(values)]
 
-        # Set default values for vmin and vmax if not specified
+        # Define vmin and vmax from the interval class if not None
+        if self.interval is not None:
+            _vmin, _vmax = self.interval.get_limits(values)
+            if self.vmin is None:
+                self.vmin = _vmin
+            if self.vmax is None:
+                self.vmax = _vmax
+
+        # Define vmin and vmax (as the min and max of the values array)
+        # if not specified and the interval class is None
         self.autoscale_None(values)
 
         # Normalize based on vmin and vmax

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -168,16 +168,16 @@ class TestImageScaling:
 
     def test_min(self):
         """Test linear scaling."""
-        norm = simple_norm(DATA2, stretch='linear', min_cut=1.)
+        norm = simple_norm(DATA2, stretch='linear', min_cut=1., clip=True)
         assert_allclose(norm(DATA2), [0., 0., 1.], atol=0, rtol=1.e-5)
 
     def test_percent(self):
         """Test percent keywords."""
-        norm = simple_norm(DATA2, stretch='linear', percent=99.)
+        norm = simple_norm(DATA2, stretch='linear', percent=99., clip=True)
         assert_allclose(norm(DATA2), DATA2SCL, atol=0, rtol=1.e-5)
 
         norm2 = simple_norm(DATA2, stretch='linear', min_percent=0.5,
-                         max_percent=99.5)
+                            max_percent=99.5, clip=True)
         assert_allclose(norm(DATA2), norm2(DATA2), atol=0, rtol=1.e-5)
 
     def test_invalid_stretch(self):

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -146,6 +146,13 @@ class TestNormalize:
         assert_allclose(norm(data), norm2(data))
         assert_allclose(norm(data), norm3(data))
 
+        norm4 = ImageNormalize()
+        norm4(data)  # sets vmin/vmax
+        assert_equal((norm4.vmin, norm4.vmax), (0, 24))
+
+        norm5 = ImageNormalize(data)
+        assert_equal((norm5.vmin, norm5.vmax), (norm4.vmin, norm4.vmax))
+
 
 @pytest.mark.skipif('not HAS_MATPLOTLIB')
 class TestImageScaling:


### PR DESCRIPTION
This PR addresses #9689.  While investigating this issue, I discovered a more significant bug.  When the `ImageNormalize` class is initialized without `data` (and without `vmin`/`vmax`), the input `interval` class was *never* used to define the `vmin`/`vmax` limits.  Instead, it was calling `matplotlib.Normalize.autoscale_None`, which simply returns the array `min()` and `max()`.  This is also the source of the `NaN` returns when the data contains `NaN`.  The `interval` classes handle NaN data fine.

```python
>>> interval = PercentileInterval(85)
>>> norm = ImageNormalize(interval=interval)
>>> norm(data)

>>> norm2 = ImageNormalize(data, interval=interval)
```
In the above example, the `norm` and `norm2` `vmin/vmax` values should be the same.  This PR fixes that, which also fixes the issue with non-finite data values reported in #9689.

I also discovered that `simple_norm` still has a default `clip=True` (that should have been updated in #9478).  I changed that here to `clip=False` to be consistent with `ImageNormalize` and `matplotlib`.

Fixes #9689 