### PR TITLE
Revert CCData to use old WCS slicing

### DIFF
--- a/astropy/nddata/ccddata.py
+++ b/astropy/nddata/ccddata.py
@@ -199,6 +199,19 @@ class CCDData(NDDataArray):
         if _config_ccd_requires_unit and self.unit is None:
             raise ValueError("a unit for CCDData must be specified.")
 
+    def _slice_wcs(self, item):
+        """
+        Override the WCS slicing behaviour so that the wcs attribute continues
+        to be an `astropy.wcs.WCS`.
+        """
+        if self.wcs is None:
+            return None
+
+        try:
+            return self.wcs[item]
+        except Exception as err:
+            self._handle_wcs_slicing_error(err, item)
+
     @property
     def data(self):
         return self._data

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1021,3 +1021,13 @@ def test_read_returns_image(tmpdir):
     ccd = CCDData.read(filename, unit='adu')
     # Expecting to get (5, 5), the size of the image
     assert ccd.data.shape == (5, 5)
+
+
+# https://github.com/astropy/astropy/issues/9664
+def test_sliced_ccdata_to_hdu():
+    wcs = WCS(naxis=2)
+    wcs.crpix = 10, 10
+    ccd = CCDData(np.ones((10, 10)), wcs=wcs, unit='pixel')
+    trimmed = ccd[2:-2, 2:-2]
+    hdu = trimmed.to_hdu()
+    assert isinstance(hdu, fits.HDUList)

--- a/astropy/nddata/tests/test_ccddata.py
+++ b/astropy/nddata/tests/test_ccddata.py
@@ -1026,8 +1026,10 @@ def test_read_returns_image(tmpdir):
 # https://github.com/astropy/astropy/issues/9664
 def test_sliced_ccdata_to_hdu():
     wcs = WCS(naxis=2)
-    wcs.crpix = 10, 10
+    wcs.wcs.crpix = 10, 10
     ccd = CCDData(np.ones((10, 10)), wcs=wcs, unit='pixel')
     trimmed = ccd[2:-2, 2:-2]
-    hdu = trimmed.to_hdu()
-    assert isinstance(hdu, fits.HDUList)
+    hdul = trimmed.to_hdu()
+    assert isinstance(hdul, fits.HDUList)
+    assert hdul[0].header['CRPIX1'] == 8
+    assert hdul[0].header['CRPIX2'] == 8


### PR DESCRIPTION
fixes #9664

~It seemed that from within `CCData` itself this was the only place that was requiring a `wcs.WCS` object so I moved the type check to there. I don't know if this is going to break things downstream though. Perhaps we should also throw a warning in the constructor?~

ping @MSeifert04 @mwcraig 