### PR TITLE
Fix bug in temporary path setting (was: Clear up cache-related warnings on Windows)

### DIFF
--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -187,7 +187,11 @@ class _SetTempPath:
 
     def __enter__(self):
         self.__class__._temp_path = self._path
-        return self._default_path_getter('astropy')
+        try:
+            return self._default_path_getter('astropy')
+        except Exception:
+            self.__class__._temp_path = self._prev_path
+            raise
 
     def __exit__(self, *args):
         self.__class__._temp_path = self._prev_path

--- a/astropy/config/tests/test_configs.py
+++ b/astropy/config/tests/test_configs.py
@@ -74,6 +74,18 @@ def test_set_temp_cache(tmpdir, monkeypatch):
     assert not os.path.exists(temp_cache_dir)
 
 
+def test_set_temp_cache_resets_on_exception(tmpdir):
+    """Test for regression of  bug #9704"""
+    t = paths.get_cache_dir()
+    a = tmpdir / 'a'
+    with open(a, 'wt') as f:
+        f.write("not a good cache\n")
+    with pytest.raises(OSError):
+        with paths.set_temp_cache(a):
+            pass
+    assert t == paths.get_cache_dir()
+
+
 def test_config_file():
     from astropy.config.configuration import get_config, reload_config
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,9 +113,6 @@ filterwarnings =
     ignore:The timefunc function is deprecated
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:Using or importing the ABCs from 'collections':DeprecationWarning
-    ignore:Remote data cache could not be accessed due to NotADirectoryError
-    ignore:Remote data cache could not be accessed due to FileNotFoundError
-    ignore:.*Cache directory cannot be read or created
     ignore:can't resolve package from __spec__
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

#9634 suppressed a certain number of warning from the cache module. This PR is meant to track them down and test for them as appropriate so that they can be left enabled.

It turns out they all stemmed from a single bug, which was that if an error occurred at a particular moment, the command that temporarily resets the cache location fails to reset it.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9704
Fixes #9620 