### PR TITLE
Tabular1d inverse flags

### DIFF
--- a/astropy/modeling/tabular.py
+++ b/astropy/modeling/tabular.py
@@ -251,7 +251,8 @@ class _Tabular(Model):
             else:
                 # equal-valued or double-valued lookup_table
                 raise NotImplementedError
-            return Tabular1D(points=points, lookup_table=lookup_table)
+            return Tabular1D(points=points, lookup_table=lookup_table, method=self.method,
+                             bounds_error=self.bounds_error, fill_value=self.fill_value)
         else:
             raise NotImplementedError("An analytical inverse transform "
                 "has not been implemented for this model.")

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -741,6 +741,16 @@ def test_tabular1d_inverse():
     with pytest.raises(NotImplementedError):
         t3.inverse((3, 3))
 
+    # Check that it uses the same kwargs as the original model
+    points = np.arange(5)
+    values = np.array([1.5, 3.4, 6.7, 7, 32])
+    t = models.Tabular1D(points, values)
+    with pytest.raises(ValueError):
+        t.inverse(100)
+    t = models.Tabular1D(points, values, bounds_error=False, fill_value=None)
+    result = t.inverse(100)
+    assert_allclose(result, t(result))
+
 
 class classmodel(FittableModel):
     f = Parameter(default=1)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -749,7 +749,7 @@ def test_tabular1d_inverse():
         t.inverse(100)
     t = models.Tabular1D(points, values, bounds_error=False, fill_value=None)
     result = t.inverse(100)
-    assert_allclose(result, t(result))
+    assert_allclose(t(result), 100)
 
 
 class classmodel(FittableModel):


### PR DESCRIPTION
This pull request is to address an issue with `Tabular1D.inverse` which is set to use the default flags.
This change sets the inverse to reuse the flags of the original model. For example, if `bounds_error=False` in the forward model, it is also set to `False` in the inverse model. 
There's really no way to give the user the option to change he flags of the inverse. If that's desirable then they should reassign the inverse. 


@Cadair Does this solve the issue you were having? If not could you describe it?