### PR TITLE
TST: Use context manager in asdf test

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -244,6 +244,5 @@ def test_custom_and_analytical(model, tmpdir):
     fa.tree['model'] = model
     file_path = str(tmpdir.join('custom_and_analytical_inverse.asdf'))
     fa.write_to(file_path)
-    f = asdf.open(file_path)
-    assert f.tree['model'].inverse is not None
-    f.close()
+    with asdf.open(file_path) as f:
+        assert f.tree['model'].inverse is not None


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a belated comment of #9706 . I feel that using a context manager (if it works) is cleaner, so that the `close` method is called even when `assert` fails.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

@bsipocz , I am not sure if this is worth backporting or not, so I'll let you set the milestone.