### PR TITLE
Allow table row to interact like a dict, e.g., making it splattable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,9 +57,9 @@ astropy.table
   the ``unit`` and ``description`` for the table columns at the time of
   creating or reading the table. [#9671]
 
-- Make table ``Row`` work as mappings, by adding ``.keys()``, ``.values()`` and
-  ``.items()`` methods. With this ``**row`` becomes possible, as does, more
-  simply, turning a ``Row`` into a dictionary with ``dict(row)``. [#9712]
+- Make table ``Row`` work as mappings, by adding ``.keys()`` and ``.values()``
+  methods. With this ``**row`` becomes possible, as does, more simply, turning
+  a ``Row`` into a dictionary with ``dict(row)``. [#9712]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,10 @@ astropy.table
   the ``unit`` and ``description`` for the table columns at the time of
   creating or reading the table. [#9671]
 
+- Make table ``Row`` work as mappings, by adding ``.keys()``, ``.values()`` and
+  ``.items()`` methods. With this ``**row`` becomes possible, as does, more
+  simply, turning a ``Row`` into a dictionary with ``dict(row)``. [#9712]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -107,11 +107,6 @@ class Row:
     def values(self):
         return self.__iter__()
 
-    def items(self):
-        index = self._index
-        for name, col in self._table.columns.items():
-            yield name, col[index]
-
     @property
     def table(self):
         return self._table

--- a/astropy/table/row.py
+++ b/astropy/table/row.py
@@ -101,6 +101,17 @@ class Row:
         for col in self._table.columns.values():
             yield col[index]
 
+    def keys(self):
+        return self._table.columns.keys()
+
+    def values(self):
+        return self.__iter__()
+
+    def items(self):
+        index = self._index
+        for name, col in self._table.columns.items():
+            yield name, col[index]
+
     @property
     def table(self):
         return self._table

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -208,7 +208,7 @@ class TestRow():
                                  names=orig_tab.dtype.names)
         assert np.all(orig_tab == new_tab)
 
-    def test_row_keys_values_items(self, table_types):
+    def test_row_keys_values(self, table_types):
         self._setup(table_types)
         row = self.t[0]
         for row_key, col_key in zip(row.keys(), self.t.columns.keys()):
@@ -216,10 +216,6 @@ class TestRow():
 
         for row_value, col in zip(row.values(), self.t.columns.values()):
             assert row_value == col[0]
-
-        for row_item, col_item in zip(row.items(), self.t.columns.items()):
-            assert row_item[0] == col_item[0]
-            assert row_item[1] == col_item[1][0]
 
     def test_row_as_mapping(self, table_types):
         self._setup(table_types)

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -208,6 +208,48 @@ class TestRow():
                                  names=orig_tab.dtype.names)
         assert np.all(orig_tab == new_tab)
 
+    def test_row_keys_values_items(self, table_types):
+        self._setup(table_types)
+        row = self.t[0]
+        for row_key, col_key in zip(row.keys(), self.t.columns.keys()):
+            assert row_key == col_key
+
+        for row_value, col in zip(row.values(), self.t.columns.values()):
+            assert row_value == col[0]
+
+        for row_item, col_item in zip(row.items(), self.t.columns.items()):
+            assert row_item[0] == col_item[0]
+            assert row_item[1] == col_item[1][0]
+
+    def test_row_as_mapping(self, table_types):
+        self._setup(table_types)
+        row = self.t[0]
+        row_dict = dict(row)
+        for key, value in row_dict.items():
+            assert row[key] == value
+
+        def f(**kwargs):
+            return kwargs
+
+        row_splatted = f(**row)
+        for key, value in row_splatted.items():
+            assert row[key] == value
+
+    def test_row_as_sequence(self, table_types):
+        self._setup(table_types)
+        row = self.t[0]
+        row_tuple = tuple(row)
+        keys = tuple(row.keys())
+        for key, value in zip(keys, row_tuple):
+            assert row[key] == value
+
+        def f(*args):
+            return args
+
+        row_splatted = f(*row)
+        for key, value in zip(keys, row_splatted):
+            assert row[key] == value
+
 
 def test_row_tuple_column_slice():
     """


### PR DESCRIPTION
Fixes #9687.

With this:
```
from astropy.table import QTable

qt = QTable([[1., 2.], [3., 4.]], names=['a', 'b'])
dict(qt[0])
# {'a': 1.0, 'b': 3.0}
```
Using a row for keyword arguments, as in `f(**row)`, works too.

This is nicely symmetric with what already works for a `Table`.

Questions/notes:
- `Table.items()` does not exist - I could add that as well, or remove it from `Row` - it does not influence the main functionality (which only requires `.keys()`).
- I could also register `Row` as a mapping, via `collections.abc.Mapping.register(Row)` (right now, it is registered only as a sequence). Not quite sure what the (dis)advantages are.