### PR TITLE
Fixes for changes in how object arrays are created in numpy-dev

### DIFF
--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-
+from contextlib import ExitStack
 
 import pytest
 import numpy as np
@@ -9,9 +9,10 @@ from numpy import testing as npt
 from astropy import units as u
 from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
+from astropy.utils.compat import NUMPY_LT_1_18
 
 from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
-                CartesianRepresentation)
+                                 CartesianRepresentation)
 from astropy.coordinates.angle_utilities import dms_to_degrees, hms_to_hours
 
 
@@ -41,10 +42,16 @@ def test_angle_arrays():
     npt.assert_almost_equal(a6.value, 945.0)
     assert a6.unit is u.degree
 
-    with pytest.raises(TypeError):
+    with ExitStack() as stack:
+        stack.enter_context(pytest.raises(TypeError))
         # Arrays where the elements are Angle objects are not supported -- it's
         # really tricky to do correctly, if at all, due to the possibility of
         # nesting.
+        if not NUMPY_LT_1_18:
+            stack.enter_context(
+                pytest.warns(DeprecationWarning,
+                             match='automatic object dtype is deprecated'))
+
         a7 = Angle([a1, a2, a3], unit=u.degree)
 
     a8 = Angle(["04:02:02", "03:02:01", "06:02:01"], unit=u.degree)

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -9,7 +9,7 @@ from numpy import testing as npt
 from astropy import units as u
 from astropy.time import Time
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.utils.compat import NUMPY_LT_1_18
+from astropy.utils.compat import NUMPY_LT_1_19
 
 from astropy.coordinates import (Angle, ICRS, FK4, FK5, Galactic, SkyCoord,
                                  CartesianRepresentation)
@@ -47,7 +47,7 @@ def test_angle_arrays():
         # Arrays where the elements are Angle objects are not supported -- it's
         # really tricky to do correctly, if at all, due to the possibility of
         # nesting.
-        if not NUMPY_LT_1_18:
+        if not NUMPY_LT_1_19:
             stack.enter_context(
                 pytest.warns(DeprecationWarning,
                              match='automatic object dtype is deprecated'))

--- a/astropy/table/tests/test_column.py
+++ b/astropy/table/tests/test_column.py
@@ -370,7 +370,8 @@ class TestColumn():
 
         # Basic insert
         c1 = c.insert(1, [100, 200])
-        assert np.all(c1 == ['a', [100, 200], 1, None])
+        assert np.all(c1 == np.array(['a', [100, 200], 1, None],
+                                     dtype=object))
 
     def test_insert_masked(self):
         c = table.MaskedColumn([0, 1, 2], name='a', fill_value=9999,

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -2449,7 +2449,12 @@ def _make_array(val, copy=False):
     val : ndarray
         Array version of ``val``.
     """
-    val = np.array(val, copy=copy, subok=True)
+    if isinstance(val, (tuple, list)) and len(val) > 0 and isinstance(val[0], Time):
+        dtype = object
+    else:
+        dtype = None
+
+    val = np.array(val, copy=copy, subok=True, dtype=dtype)
 
     # Allow only float64, string or object arrays as input
     # (object is for datetime, maybe add more specific test later?)

--- a/astropy/utils/compat/numpycompat.py
+++ b/astropy/utils/compat/numpycompat.py
@@ -6,10 +6,11 @@ earlier versions of Numpy.
 from astropy.utils import minversion
 
 
-__all__ = ['NUMPY_LT_1_17', 'NUMPY_LT_1_18']
+__all__ = ['NUMPY_LT_1_17', 'NUMPY_LT_1_18', 'NUMPY_LT_1_19']
 
 # TODO: It might also be nice to have aliases to these named for specific
 # features/bugs we're checking for (ex:
 # astropy.table.table._BROKEN_UNICODE_TABLE_SORT)
 NUMPY_LT_1_17 = not minversion('numpy', '1.17')
 NUMPY_LT_1_18 = not minversion('numpy', '1.18')
+NUMPY_LT_1_19 = not minversion('numpy', '1.19')


### PR DESCRIPTION
Fixes #9716. **Do need to check numpy-dev travis run before merging!!** ~Locally, I saw some failures still, but those are not related to this PR, but rather to #9672 (would be good to merge that...)~ EDIT: rebased after #9762 was merged: now should give an all-green numpy-dev.

The changes for `coordinates.Angle` (cc @astrofrog) and `table` (@taldcroft) are trivial (just adjustments to how the test is done), but that to `time` a bit less so, as it involves more than wanted special-casing of a list of times. My sense would be that it would be better to move this check earlier, before the general `_init_from_vals` is run, but that is somewhat out of scope here. @taldcroft, what do you think?

EDIT: Fix #9879