### PR TITLE
Use environment variables to select system libraries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -248,9 +248,14 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
-
-
+- The way in which users can specify whether to build astropy against
+  existing installations of C libraries rather than the bundled one
+  has changed, and should now be done via environment variables rather
+  than setup.py flags (e.g. --use-system-erfa). The available variables
+  are ``ASTROPY_USE_SYSTEM_CFITSIO``, ``ASTROPY_USE_SYSTEM_ERFA``,
+  ``ASTROPY_USE_SYSTEM_EXPAT``, ``ASTROPY_USE_SYSTEM_WCSLIB``, and
+  ``ASTROPY_USE_SYSTEM_ALL``. These should be set to ``1`` to build
+  against the system libraries. [#9730]
 
 
 4.0.1 (unreleased)

--- a/astropy/_erfa/setup_package.py
+++ b/astropy/_erfa/setup_package.py
@@ -84,7 +84,7 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
 
-    if setup_helpers.use_system_library('erfa'):
+    if int(os.environ.get('ASTROPY_USE_SYSTEM_ERFA', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
         libraries.append('erfa')
     else:
         # get all of the .c files in the cextern/erfa directory
@@ -102,7 +102,3 @@ def get_extensions():
         language="c",)
 
     return [erfa_ext]
-
-
-def get_external_libraries():
-    return ['erfa']

--- a/astropy/_erfa/setup_package.py
+++ b/astropy/_erfa/setup_package.py
@@ -84,7 +84,8 @@ def get_extensions():
     include_dirs = ['numpy']
     libraries = []
 
-    if int(os.environ.get('ASTROPY_USE_SYSTEM_ERFA', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
+    if (int(os.environ.get('ASTROPY_USE_SYSTEM_ERFA', 0)) or
+            int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
         libraries.append('erfa')
     else:
         # get all of the .c files in the cextern/erfa directory

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -19,7 +19,9 @@ def _get_compression_extension():
     cfg['sources'].append(os.path.join(os.path.dirname(__file__), 'src',
                                        'compressionmodule.c'))
 
-    if not setup_helpers.use_system_library('cfitsio'):
+    if int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
+        cfg.update(setup_helpers.pkg_config(['cfitsio'], ['cfitsio']))
+    else:
         if setup_helpers.get_compiler_option() == 'msvc':
             # These come from the CFITSIO vcc makefile, except the last
             # which ensures on windows we do not include unistd.h (in regular
@@ -57,15 +59,9 @@ def _get_compression_extension():
         cfg['include_dirs'].append(cfitsio_zlib_path)
         cfg['sources'].extend(cfitsio_files)
         cfg['sources'].extend(cfitsio_zlib_files)
-    else:
-        cfg.update(setup_helpers.pkg_config(['cfitsio'], ['cfitsio']))
 
     return Extension('astropy.io.fits.compression', **cfg)
 
 
 def get_extensions():
     return [_get_compression_extension()]
-
-
-def get_external_libraries():
-    return ['cfitsio']

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -19,7 +19,8 @@ def _get_compression_extension():
     cfg['sources'].append(os.path.join(os.path.dirname(__file__), 'src',
                                        'compressionmodule.c'))
 
-    if int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
+    if (int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or
+            int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
         cfg.update(setup_helpers.pkg_config(['cfitsio'], ['cfitsio']))
     else:
         if setup_helpers.get_compiler_option() == 'msvc':

--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+import os
 from distutils.core import Extension
 from os.path import join
 import sys
 
 from astropy_helpers import setup_helpers
-
-
-def get_external_libraries():
-    return ['expat']
 
 
 def get_extensions(build_type='release'):
@@ -18,7 +15,7 @@ def get_extensions(build_type='release'):
         'sources': [join(XML_DIR, "iterparse.c")]
         })
 
-    if setup_helpers.use_system_library('expat'):
+    if int(os.environ.get('ASTROPY_USE_SYSTEM_EXPAT', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
         cfg.update(setup_helpers.pkg_config(['expat'], ['expat']))
     else:
         EXPAT_DIR = 'cextern/expat/lib'

--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -15,7 +15,8 @@ def get_extensions(build_type='release'):
         'sources': [join(XML_DIR, "iterparse.c")]
         })
 
-    if int(os.environ.get('ASTROPY_USE_SYSTEM_EXPAT', 0)) or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)):
+    if (int(os.environ.get('ASTROPY_USE_SYSTEM_EXPAT', 0)) or
+            int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
         cfg.update(setup_helpers.pkg_config(['expat'], ['expat']))
     else:
         EXPAT_DIR = 'cextern/expat/lib'

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -184,19 +184,20 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
         ('ASTROPY_WCS_BUILD', None),
         ('_GNU_SOURCE', None)])
 
-    if (not setup_helpers.use_system_library('wcslib') or
-            sys.platform == 'win32'):
+    if ((int(os.environ.get('ASTROPY_USE_SYSTEM_WCSLIB', 0))
+            or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0)))
+            and not sys.platform == 'win32'):
+        wcsconfig_h_path = join(WCSROOT, 'include', 'wcsconfig.h')
+        if os.path.exists(wcsconfig_h_path):
+            os.unlink(wcsconfig_h_path)
+        cfg.update(setup_helpers.pkg_config(['wcslib'], ['wcs']))
+    else:
         write_wcsconfig_h(include_paths)
 
         wcslib_path = join("cextern", "wcslib")  # Path to wcslib
         wcslib_cpath = join(wcslib_path, "C")  # Path to wcslib source files
         cfg['sources'].extend(join(wcslib_cpath, x) for x in wcslib_files)
         cfg['include_dirs'].append(wcslib_cpath)
-    else:
-        wcsconfig_h_path = join(WCSROOT, 'include', 'wcsconfig.h')
-        if os.path.exists(wcsconfig_h_path):
-            os.unlink(wcsconfig_h_path)
-        cfg.update(setup_helpers.pkg_config(['wcslib'], ['wcs']))
 
     if debug:
         cfg['define_macros'].append(('DEBUG', None))
@@ -319,7 +320,3 @@ def get_extensions():
                 shutil.copy(source, dest)
 
     return [Extension('astropy.wcs._wcs', **cfg)]
-
-
-def get_external_libraries():
-    return ['wcslib']

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -312,7 +312,8 @@ def get_extensions():
         'wcsprintf.h',
     ]
 
-    if not setup_helpers.use_system_library('wcslib'):
+    if not (int(os.environ.get('ASTROPY_USE_SYSTEM_WCSLIB', 0))
+            or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
         for header in wcslib_headers:
             source = join('cextern', 'wcslib', 'C', header)
             dest = join('astropy', 'wcs', 'include', 'wcslib', header)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -299,44 +299,34 @@ External C Libraries
 The ``astropy`` source ships with the C source code of a number of
 libraries. By default, these internal copies are used to build
 ``astropy``. However, if you wish to use the system-wide installation of
-one of those libraries, you can pass one or more of the
-``--use-system-X`` flags to the ``setup.py build`` command.
+one of those libraries, you can set environment variables with the
+pattern ``ASTROPY_USE_SYSTEM_???`` to ``1`` when building/installing
+the package.
 
 For example, to build ``astropy`` using the system `libexpat
 <http://www.libexpat.org/>`_, use::
 
-    python setup.py build --use-system-expat
+    ASTROPY_USE_SYSTEM_EXPAT=1 python setup.py build
 
 To build using all of the system libraries, use::
 
-    python setup.py build --use-system-libraries
-
-To see which system libraries ``astropy`` knows how to build against, use::
-
-    python setup.py build --help
-
-As with all distutils command line options, they may also be provided in a
-``setup.cfg`` in the same directory as ``setup.py``. For example, to use
-the system `libexpat <http://www.libexpat.org/>`_, add the following to the
-``setup.cfg`` file::
-
-    [build]
-    use_system_expat=1
-
+    ASTROPY_USE_SYSTEM_ALL=1 python setup.py build
 
 The C libraries currently bundled with ``astropy`` include:
 
 - `wcslib <https://www.atnf.csiro.au/people/mcalabre/WCS/>`_ see
-  ``cextern/wcslib/README`` for the bundled version.
+  ``cextern/wcslib/README`` for the bundled version. To use the
+  system version, set ``ASTROPY_USE_SYSTEM_WCSLIB=1``.
 
 - `cfitsio <https://heasarc.gsfc.nasa.gov/fitsio/fitsio.html>`_ see
-  ``cextern/cfitsio/changes.txt`` for the bundled version.
+  ``cextern/cfitsio/changes.txt`` for the bundled version. To use the
+  system version, set ``ASTROPY_USE_SYSTEM_CFITSIO=1``.
 
 - `erfa <https://github.com/liberfa>`_ see ``cextern/erfa/README.rst`` for the
-  bundled version.
+  bundled version. To use the system version, set ``ASTROPY_USE_SYSTEM_ERFA=1``.
 
 - `expat <http://expat.sourceforge.net/>`_ see ``cextern/expat/README`` for the
-  bundled version.
+  bundled version. To use the system version, set ``ASTROPY_USE_SYSTEM_EXPAT=1``.
 
 
 Installing ``astropy`` into CASA


### PR DESCRIPTION
*This is a self-contained subset of changes related to the APE [A roadmap for package infrastructure without astropy-helpers](https://github.com/astropy/astropy-APEs/pull/52). This PR as-is is ready for review, and does not actually require removing astropy-helpers to work, though I think we should maybe wait until Tuesday to merge since that's when we'll be discussing the APE in Socorro.*

Previously, the ``--use-system-...`` command-line options required patching the setup.py commands, and these were also not easy to set when doing pip installs. The environment variable approach no longer requires patching the commands, and works regardless of whether pip or setup.py is used. This approach is described [in the APE](https://github.com/astropy/astropy-APEs/pull/52).

I checked with @olebole who confirmed this approach would not pose issues for Debian packaging.
