### PR TITLE
Get --debug flag from sys.argv instead of using an astropy helpers routine

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -1,15 +1,18 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import os
+import sys
 
 from distutils.core import Extension
 from glob import glob
 
 from astropy_helpers import setup_helpers
-from astropy_helpers.distutils_helpers import get_distutils_build_option
 
 
 def _get_compression_extension():
+
+    debug = '--debug' in sys.argv
+
     # 'numpy' will be replaced with the proper path to the numpy includes
     cfg = setup_helpers.DistutilsExtensionArgs()
     cfg['include_dirs'].append('numpy')
@@ -33,7 +36,7 @@ def _get_compression_extension():
                 '-Wno-declaration-after-statement'
             ])
 
-            if not get_distutils_build_option('debug'):
+            if not debug:
                 # these switches are to silence warnings from compiling CFITSIO
                 # For full silencing, some are added that only are used in
                 # later versions of gcc (versions approximate; see #6474)

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import io
+import os
 from os.path import join
 import os.path
 import shutil
@@ -12,7 +13,6 @@ from distutils.dep_util import newer_group
 
 from astropy_helpers.utils import import_file
 from astropy_helpers import setup_helpers
-from astropy_helpers.distutils_helpers import get_distutils_build_option
 
 WCSROOT = os.path.relpath(os.path.dirname(__file__))
 WCSVERSION = "6.4.0"
@@ -175,7 +175,7 @@ MSVC, do not support string literals greater than 256 characters.
 
 def get_wcslib_cfg(cfg, wcslib_files, include_paths):
 
-    debug = import_file(os.path.join(WCSROOT, '..', 'version.py')).debug
+    debug = '--debug' in sys.argv
 
     cfg['include_dirs'].append('numpy')
     cfg['define_macros'].extend([
@@ -226,7 +226,7 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
 
     # Squelch a few compilation warnings in WCSLIB
     if setup_helpers.get_compiler_option() in ('unix', 'mingw32'):
-        if not get_distutils_build_option('debug'):
+        if not debug:
             cfg['extra_compile_args'].extend([
                 '-Wno-strict-prototypes',
                 '-Wno-unused-function',


### PR DESCRIPTION
*This is a self-contained subset of changes related to the APE [A roadmap for package infrastructure without astropy-helpers](https://github.com/astropy/astropy-APEs/pull/52). This PR as-is is ready for review, and does not actually require removing astropy-helpers to work, though I think we should maybe wait until Tuesday to merge since that's when we'll be discussing the APE in Socorro.*

Previously, the presence of the ``--debug`` flag to ``setup.py`` was used to control whether certain warnings should be shown or not when compiling the ``io.fits`` and ``wcs`` extensions. For similar reasons to #9730 it makes more sense to switch to using an environment variable to control this. Note that this is not a documented feature, hence why there are no changes to the docs.

I'm not super happy with the variable name so far, so am open to other suggestions - @mhvk?

EDIT: changed to getting `--debug` from `sys.argv`