### PR TITLE
DOC: Clarify IAU year inconsistencies

### DIFF
--- a/astropy/constants/iau2012.py
+++ b/astropy/constants/iau2012.py
@@ -35,7 +35,7 @@ kpc = IAU2012('kpc', "Kiloparsec",
               1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
               "Derived from au", system='si')
 
-# Luminosity
+# Luminosity not defined till 2015 (https://arxiv.org/abs/1510.06262)
 L_bol0 = IAU2012('L_bol0', "Luminosity for absolute bolometric magnitude 0",
                  3.0128e28, "W", 0.0, "IAU 2015 Resolution B 2", system='si')
 

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -20,7 +20,7 @@ class IAU2015(Constant):
 
 # DISTANCE
 
-# Astronomical Unit
+# Astronomical Unit (did not change from 2012)
 au = IAU2015('au', "Astronomical Unit", 1.49597870700e11, 'm', 0.0,
              "IAU 2012 Resolution B2", system='si')
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address potential year typos in IAU constant descriptions. They were both added in #6083 .

I really don't know if these are typo or intentional. Someone familiar with how IAU update their stuff need to review. However, it does seem weird that `IAU2012` somehow would know about "IAU 2015" (3 years into the future).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->