### PR TITLE
Update bundled erfa sources to 1.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -335,7 +335,9 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-
+- The bundled ERFA was updated to version 1.7.0.  Like 1.6.0, this is based on
+  SOFA 20190722, but includes additional routines to allow updates to the
+  leap-second table. [#9734]
 
 
 4.0 (unreleased)

--- a/cextern/erfa/erfadatextra.c
+++ b/cextern/erfa/erfadatextra.c
@@ -1,16 +1,44 @@
+/*
+** Copyright (C) 2019, NumFOCUS Foundation.
+**
+** Licensed under a 3-clause BSD style license - see LICENSE
+**
+** This file is NOT derived from SOFA sources.
+**
+** The eraGetLeapSeconds and eraSetLeapSeconds functions are used as an
+** experimental interface for getting and setting the leap second table in
+** astropy 4.0.  They will be supported as long as astropy 4.0 is supported
+** (until 2021), but not necessarily beyond.  Comments and ideas about the
+** best way to keep the leap second tables up to date for all users of erfa
+** are welcome (https://github.com/liberfa/erfa).
+**
+** The eraDatini function is used internally in dat.c; it is strictly an
+** implementation detail and should not be used elsewhere.
+*/
 #include "erfa.h"
 #include "erfaextra.h"
 
 static eraLEAPSECOND *changes;
-static int NDAT = 0;
+static int NDAT = -1;
 
 
 int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
+/*
+**  Get the current leap second table.
+**
+**  Returned:
+**     leapseconds eraLEAPSECOND*  Array of year, month, TAI minus UTC
+**
+**  Returned (function value):
+**            int  NDAT  Number of entries/status
+**                       >0 = number of entries
+**                       -1 = internal error
+*/
 {
-    if (NDAT == 0) {
+    if (NDAT <= 0) {
         double delat;
         int stat = eraDat(2000, 1, 1, 0., &delat);
-        if (stat != 0 || NDAT == 0) {
+        if (stat != 0 || NDAT <= 0) {
             return -1;
         }
     }
@@ -19,18 +47,45 @@ int eraGetLeapSeconds(eraLEAPSECOND **leapseconds)
 }
 
 void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count)
+/*
+**  Set the current leap second table.
+**
+**  Given:
+**     leapseconds eraLEAPSECOND*  Array of year, month, TAI minus UTC
+**     count       int             Number of entries.  If <= 0, causes
+**                                 a reset of the table to the built-in
+**                                 version.
+**
+**  Notes:
+**     *No* sanity checks are performed.
+*/
 {
     changes = leapseconds;
     NDAT = count;
 }
 
-/*
- * For internal use in dat.c
- */
 int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
               eraLEAPSECOND **leapseconds)
+/*
+**  Get the leap second table, initializing it to the built-in version
+**  if necessary.
+**
+**  This function is for internal use in dat.c only and should
+**  not be used elsewhere.
+**
+**  Given:
+**     builtin     eraLEAPSECOND   Array of year, month, TAI minus UTC
+**     n_builtin   int             Number of entries of the table.
+**
+**  Returned:
+**     leapseconds eraLEAPSECOND*  Current array, set to the builtin one
+**                                 if not yet initialized.
+**
+**  Returned (function value):
+**            int  NDAT  Number of entries
+*/
 {
-    if (NDAT == 0) {
+    if (NDAT <= 0) {
         eraSetLeapSeconds((eraLEAPSECOND *)builtin, n_builtin);
     }
     *leapseconds = changes;

--- a/cextern/erfa/erfadatextra.h
+++ b/cextern/erfa/erfadatextra.h
@@ -1,2 +1,18 @@
+/*
+** Copyright (C) 2019, NumFOCUS Foundation.
+**
+** Licensed under a 3-clause BSD style license - see LICENSE
+**
+** This file is NOT derived from SOFA sources.
+**
+*/
+
+/*
+**  Get the leap second table, initializing it to the built-in version
+**  if necessary.
+**
+**  This function is for internal use in dat.c only and should
+**  not be used elsewhere.
+*/
 int eraDatini(const eraLEAPSECOND *builtin, int n_builtin,
               eraLEAPSECOND **leapseconds);

--- a/cextern/erfa/erfaextra.h
+++ b/cextern/erfa/erfaextra.h
@@ -1,9 +1,20 @@
 /*
-** Copyright (C) 2016-2017, NumFOCUS Foundation.
+** Copyright (C) 2016-2019, NumFOCUS Foundation.
 **
 ** Licensed under a 3-clause BSD style license - see LICENSE
 **
-** This file is NOT derived from SOFA sources
+** This file is NOT derived from SOFA sources.
+**
+** The functions here provide an interface to ERFA and SOFA version
+** information, and for updating the leap second table.
+**
+** The eraGetLeapSeconds and eraSetLeapSeconds functions are used as an
+** experimental interface for getting and setting the leap second table in
+** astropy 4.0.  They will be supported as long as astropy 4.0 is supported
+** (until 2021), but not necessarily beyond.  Comments and ideas about the
+** best way to keep the leap second tables up to date for all users of erfa
+** are welcome (https://github.com/liberfa/erfa).
+**
 */
 
 
@@ -51,9 +62,8 @@ int eraVersionMicro(void);
 const char* eraSofaVersion(void);
 
 
-
 /*
-** Get and set leap seconds (not supported by SOFA)
+** Get and set leap seconds (not supported by SOFA; EXPERIMENTAL)
 */
 int eraGetLeapSeconds(eraLEAPSECOND **leapseconds);
 void eraSetLeapSeconds(eraLEAPSECOND *leapseconds, int count);

--- a/cextern/erfa/erfaversion.c
+++ b/cextern/erfa/erfaversion.c
@@ -1,7 +1,7 @@
 /*
 ** Copyright (C) 2016-2017, NumFOCUS Foundation.
 **
-** Licensed under a 3-clause BSD style license - see LICENSE 
+** Licensed under a 3-clause BSD style license - see LICENSE
 **
 ** This file is NOT derived from SOFA sources
 */
@@ -49,4 +49,3 @@ int eraVersionMicro(void) {
 const char* eraSofaVersion(void) {
   return SOFA_VERSION;
 }
-


### PR DESCRIPTION
fixes #9728 

Ideally still goes in 4.0, though the file differences should not affect anything.
