### PR TITLE
Add several convenience APE 14 WCS wrappers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -139,6 +139,9 @@ astropy.wcs
 - Implemented support for the ``-TAB`` algorithm (WCS Paper III). [#9641]
 
 - Added an ``_as_mpl_axes`` method to the ``HightLevelWCSWrapper`` class. [#10138]
+- Added wrappers in ``astropy.wcs.wcsapi`` for combining
+  (``CompoundLowLevelWCS``), reordering (``ReorderedLowLevelWCS``), and
+  resampling (``ResampledLowLevelWCS``) APE 14-compliant WCS classes. [#9736]
 
 API Changes
 -----------

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -381,15 +381,9 @@ class LowLevelWCS5D(BaseLowLevelWCS):
         pixel_arrays = (list(pixel_arrays) * 3)[:-1]  # make list have 5 elements
         return [np.asarray(pix) * scale for pix, scale in zip(pixel_arrays, [10, 0.2, 0.4, 0.39, 2])]
 
-    def array_index_to_world_values(self, *index_arrays):
-        return self.pixel_to_world_values(index_arrays[::-1])[::-1]
-
     def world_to_pixel_values(self, *world_arrays):
         world_arrays = world_arrays[:2]  # make list have 2 elements
         return [np.asarray(world) / scale for world, scale in zip(world_arrays, [10, 0.2])]
-
-    def world_to_array_index_values(self, *world_arrays):
-        return np.round(self.world_to_array_index_values(world_arrays[::-1])[::-1]).astype(int)
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/__init__.py
+++ b/astropy/wcs/wcsapi/__init__.py
@@ -1,5 +1,5 @@
-from .low_level_api import *
-from .high_level_api import *
-from .high_level_wcs_wrapper import *
-from .utils import *
-from .sliced_low_level_wcs import *
+from .low_level_api import *  # noqa
+from .high_level_api import *  # noqa
+from .high_level_wcs_wrapper import *  # noqa
+from .utils import *  # noqa
+from .wrappers import *  # noqa

--- a/astropy/wcs/wcsapi/compound_wcs.py
+++ b/astropy/wcs/wcsapi/compound_wcs.py
@@ -1,0 +1,127 @@
+import numpy as np
+from .low_level_api import BaseLowLevelWCS
+
+__all__ = ['CompoundLowLevelWCS']
+
+
+from functools import reduce
+
+def listsum(lists):
+    return reduce(list.__add__, map(list, lists))
+
+
+class CompoundLowLevelWCS(BaseLowLevelWCS):
+    """
+    A wrapper that takes multiple low level WCS objects and makes a compound
+    WCS that combines them.
+
+    Parameters
+    ----------
+    *wcs : `~astropy.wcs.wcsapi.BaseLowLevelWCS`
+        The WCSes to combine
+    """
+    def __init__(self, *wcs):
+        self._wcs = wcs
+
+    @property
+    def pixel_n_dim(self):
+        return sum([w.pixel_n_dim for w in self._wcs])
+
+    @property
+    def world_n_dim(self):
+        return sum([w.pixel_n_dim for w in self._wcs])
+
+    @property
+    def world_axis_physical_types(self):
+        return listsum([w.world_axis_physical_types for w in self._wcs])
+
+    @property
+    def world_axis_units(self):
+        return listsum([w.world_axis_units for w in self._wcs])
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        world_arrays = []
+        for w in self._wcs:
+            pixel_arrays_sub = pixel_arrays[:w.pixel_n_dim]
+            pixel_arrays = pixel_arrays[w.pixel_n_dim:]
+            world_arrays_sub = w.pixel_to_world_values(*pixel_arrays_sub)
+            if w.world_n_dim > 1:
+                world_arrays.extend(world_arrays_sub)
+            else:
+                world_arrays.append(world_arrays_sub)
+        return tuple(world_arrays)
+
+    def array_index_to_world_values(self, *index_arrays):
+        return self.pixel_to_world_values(*index_arrays[-1])
+
+    def world_to_pixel_values(self, *world_arrays):
+        pixel_arrays = []
+        for w in self._wcs:
+            world_arrays_sub = world_arrays[:w.world_n_dim]
+            world_arrays = world_arrays[w.world_n_dim:]
+            pixel_arrays_sub = w.world_to_pixel_values(*world_arrays_sub)
+            if w.pixel_n_dim > 1:
+                pixel_arrays.extend(pixel_arrays_sub)
+            else:
+                pixel_arrays.append(pixel_arrays_sub)
+        return tuple(world_arrays)
+
+    def world_to_array_index_values(self, *world_arrays):
+        pixel_arrays = self.world_to_pixel_values(*world_arrays)
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
+        return array_indices
+
+    @property
+    def world_axis_object_components(self):
+        return listsum([w.world_axis_object_components for w in self._wcs])
+
+    @property
+    def world_axis_object_classes(self):
+        # TODO: deal with name conflicts
+        all_classes = {}
+        for w in self._wcs:
+            all_classes.update(w.world_axis_object_components)
+        return all_classes
+
+    @property
+    def array_shape(self):
+        if any(w.array_shape is None for w in self._wcs):
+            return None
+        else:
+            return listsum(w.array_shape for w in self._wcs)
+
+    @property
+    def pixel_shape(self):
+        if self.array_shape is None:
+            return None
+        else:
+            return self.array_shape[::-1]
+
+    @property
+    def pixel_bounds(self):
+        if any(w.pixel_bounds is None for w in self._wcs):
+            return None
+        else:
+            return listsum(w.pixel_bounds for w in self._wcs)
+
+    @property
+    def pixel_axis_names(self):
+        return listsum(w.pixel_axis_names for w in self._wcs)
+
+    @property
+    def world_axis_names(self):
+        return listsum(w.world_axis_names for w in self._wcs)
+
+    @property
+    def axis_correlation_matrix(self):
+        matrix = np.zeros((self.world_n_dim, self.pixel_n_dim), dtype=bool)
+        iw = ip = 0
+        for w in self._wcs:
+            matrix[iw:iw+w.world_n_dim,ip:ip+w.pixel_n_dim] = w.axis_correlation_matrix
+            iw += w.world_n_dim
+            ip += w.pixel_n_dim
+        return matrix
+
+    @property
+    def serialized_classes(self):
+        return any([w.serialized_classes for w in self._wcs])

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -1,0 +1,117 @@
+import pytest
+import numpy as np
+
+from astropy.coordinates import SkyCoord
+from astropy.units import Quantity
+from astropy.wcs import WCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS
+
+
+@pytest.fixture
+def spectral_1d_fitswcs():
+    wcs = WCS(naxis=1)
+    wcs.wcs.ctype = 'FREQ',
+    wcs.wcs.cunit = 'GHz',
+    wcs.wcs.crval = 3.,
+    wcs.wcs.crpix = 10.,
+    wcs.wcs.cname == 'Frequency',
+    return wcs
+
+
+@pytest.fixture
+def time_1d_fitswcs():
+    wcs = WCS(naxis=1)
+    wcs.wcs.ctype = 'TIME',
+    wcs.wcs.mjdref = 'GHz',
+    wcs.wcs.crval = 3.,
+    wcs.wcs.crpix = 10.,
+    wcs.wcs.cname == 'Frequency',
+    return wcs
+
+
+@pytest.fixture
+def celestial_2d_fitswcs():
+    wcs = WCS(naxis=2)
+    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN'
+    wcs.wcs.cunit = 'deg', 'deg'
+    wcs.wcs.crval = 4., 5.
+    wcs.wcs.crpix = 5., 6.
+    wcs.wcs.cname == 'Right Ascension', 'Declination'
+    return wcs
+
+
+class Spectral1DLowLevelWCS(BaseLowLevelWCS):
+
+    @property
+    def pixel_n_dim(self):
+        return 1
+
+    @property
+    def world_n_dim(self):
+        return 1
+
+    @property
+    def world_axis_physical_types(self):
+        return ['em.freq']
+
+    @property
+    def world_axis_units(self):
+        return ['GHz']
+
+    def pixel_to_world_values(self, pixel_array):
+        return np.asarray(pixel_array) * 3
+
+    def world_to_pixel_values(self, world_array):
+        return np.asarray(world_array) / 3
+
+    @property
+    def world_axis_object_components(self):
+        return [('test', 0, 'value')]
+
+    @property
+    def world_axis_object_classes(self):
+        return {'test': (Quantity, (), {'unit': 'GHz'})}
+
+
+@pytest.fixture
+def spectral_1d_ape14_wcs():
+    return Spectral1DLowLevelWCS()
+
+
+class Celestial2DLowLevelWCS(BaseLowLevelWCS):
+
+    @property
+    def pixel_n_dim(self):
+        return 2
+
+    @property
+    def world_n_dim(self):
+        return 2
+
+    @property
+    def world_axis_physical_types(self):
+        return ['pos.eq.ra', 'pos.eq.dec']
+
+    @property
+    def world_axis_units(self):
+        return ['deg', 'deg']
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        return [np.asarray(pix) * 2 for pix in pixel_arrays]
+
+    def world_to_pixel_values(self, *world_arrays):
+        return [np.asarray(world) / 2 for world in world_arrays]
+
+    @property
+    def world_axis_object_components(self):
+        return [('test', 0, 'spherical.lon.degree'),
+                ('test', 1, 'spherical.lat.degree')]
+
+    @property
+    def world_axis_object_classes(self):
+        return {'test': (SkyCoord, (), {'unit': 'deg'})}
+
+
+@pytest.fixture
+def celestial_2d_ape14_wcs():
+    return Celestial2DLowLevelWCS()

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -15,7 +15,7 @@ def spectral_1d_fitswcs():
     wcs.wcs.cdelt = 3.e9,
     wcs.wcs.crval = 4.e9,
     wcs.wcs.crpix = 11.,
-    wcs.wcs.cname == 'Frequency',
+    wcs.wcs.cname = 'Frequency',
     return wcs
 
 
@@ -26,7 +26,7 @@ def time_1d_fitswcs():
     wcs.wcs.mjdref = 30042,
     wcs.wcs.crval = 3.,
     wcs.wcs.crpix = 11.,
-    wcs.wcs.cname == 'Frequency',
+    wcs.wcs.cname = 'Frequency',
     return wcs
 
 
@@ -38,7 +38,9 @@ def celestial_2d_fitswcs():
     wcs.wcs.cdelt = -2., 2.
     wcs.wcs.crval = 4., 0.
     wcs.wcs.crpix = 6., 7.
-    wcs.wcs.cname == 'Right Ascension', 'Declination'
+    wcs.wcs.cname = 'Right Ascension', 'Declination'
+    wcs.pixel_shape = (6, 7)
+    wcs.pixel_bounds = [(-1, 5), (1, 7)]
     return wcs
 
 
@@ -54,11 +56,35 @@ class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_physical_types(self):
-        return ['em.freq']
+        return 'em.freq',
 
     @property
     def world_axis_units(self):
-        return ['Hz']
+        return 'Hz',
+
+    @property
+    def world_axis_names(self):
+        return 'Frequency',
+
+    _pixel_shape = None
+
+    @property
+    def pixel_shape(self):
+        return self._pixel_shape
+
+    @pixel_shape.setter
+    def pixel_shape(self, value):
+        self._pixel_shape = value
+
+    _pixel_bounds = None
+
+    @property
+    def pixel_bounds(self):
+        return self._pixel_bounds
+
+    @pixel_bounds.setter
+    def pixel_bounds(self, value):
+        self._pixel_bounds = value
 
     def pixel_to_world_values(self, pixel_array):
         return np.asarray(pixel_array - 10) * 3e9 + 4e9
@@ -68,11 +94,12 @@ class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_object_components(self):
-        return [('test', 0, 'value')]
+        return ('test', 0, 'value'),
 
     @property
     def world_axis_object_classes(self):
         return {'test': (Quantity, (), {'unit': 'Hz'})}
+
 
 
 @pytest.fixture
@@ -92,11 +119,23 @@ class Celestial2DLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_physical_types(self):
-        return ['pos.eq.ra', 'pos.eq.dec']
+        return 'pos.eq.ra', 'pos.eq.dec'
 
     @property
     def world_axis_units(self):
-        return ['deg', 'deg']
+        return 'deg', 'deg'
+
+    @property
+    def world_axis_names(self):
+        return 'Right Ascension', 'Declination'
+
+    @property
+    def pixel_shape(self):
+        return (6, 7)
+
+    @property
+    def pixel_bounds(self):
+        return (-1, 5), (1, 7)
 
     def pixel_to_world_values(self, px, py):
         return (-(np.asarray(px) - 5.) * 2 + 4.,

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -44,6 +44,21 @@ def celestial_2d_fitswcs():
     return wcs
 
 
+@pytest.fixture
+def spectral_cube_3d_fitswcs():
+    wcs = WCS(naxis=3)
+    wcs.wcs.ctype = 'RA---CAR', 'DEC--CAR', 'FREQ'
+    wcs.wcs.cunit = 'deg', 'deg', 'Hz'
+    wcs.wcs.cdelt = -2., 2., 3.e9
+    wcs.wcs.crval = 4., 0., 4.e9
+    wcs.wcs.crpix = 6., 7., 11.
+    wcs.wcs.cname = 'Right Ascension', 'Declination', 'Frequency'
+    wcs.pixel_shape = (6, 7, 3)
+    wcs.pixel_bounds = [(-1, 5), (1, 7), (1, 2.5)]
+    return wcs
+
+
+
 class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -11,9 +11,10 @@ from astropy.wcs.wcsapi import BaseLowLevelWCS
 def spectral_1d_fitswcs():
     wcs = WCS(naxis=1)
     wcs.wcs.ctype = 'FREQ',
-    wcs.wcs.cunit = 'GHz',
-    wcs.wcs.crval = 3.,
-    wcs.wcs.crpix = 10.,
+    wcs.wcs.cunit = 'Hz',
+    wcs.wcs.cdelt = 3.e9,
+    wcs.wcs.crval = 4.e9,
+    wcs.wcs.crpix = 11.,
     wcs.wcs.cname == 'Frequency',
     return wcs
 
@@ -22,9 +23,9 @@ def spectral_1d_fitswcs():
 def time_1d_fitswcs():
     wcs = WCS(naxis=1)
     wcs.wcs.ctype = 'TIME',
-    wcs.wcs.mjdref = 'GHz',
+    wcs.wcs.mjdref = 30042,
     wcs.wcs.crval = 3.,
-    wcs.wcs.crpix = 10.,
+    wcs.wcs.crpix = 11.,
     wcs.wcs.cname == 'Frequency',
     return wcs
 
@@ -32,10 +33,11 @@ def time_1d_fitswcs():
 @pytest.fixture
 def celestial_2d_fitswcs():
     wcs = WCS(naxis=2)
-    wcs.wcs.ctype = 'RA---TAN', 'DEC--TAN'
+    wcs.wcs.ctype = 'RA---CAR', 'DEC--CAR'
     wcs.wcs.cunit = 'deg', 'deg'
-    wcs.wcs.crval = 4., 5.
-    wcs.wcs.crpix = 5., 6.
+    wcs.wcs.cdelt = -2., 2.
+    wcs.wcs.crval = 4., 0.
+    wcs.wcs.crpix = 6., 7.
     wcs.wcs.cname == 'Right Ascension', 'Declination'
     return wcs
 
@@ -56,13 +58,13 @@ class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_units(self):
-        return ['GHz']
+        return ['Hz']
 
     def pixel_to_world_values(self, pixel_array):
-        return np.asarray(pixel_array) * 3
+        return np.asarray(pixel_array - 10) * 3e9 + 4e9
 
     def world_to_pixel_values(self, world_array):
-        return np.asarray(world_array) / 3
+        return np.asarray(world_array - 4e9) / 3e9 + 10
 
     @property
     def world_axis_object_components(self):
@@ -70,7 +72,7 @@ class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_object_classes(self):
-        return {'test': (Quantity, (), {'unit': 'GHz'})}
+        return {'test': (Quantity, (), {'unit': 'Hz'})}
 
 
 @pytest.fixture
@@ -96,11 +98,13 @@ class Celestial2DLowLevelWCS(BaseLowLevelWCS):
     def world_axis_units(self):
         return ['deg', 'deg']
 
-    def pixel_to_world_values(self, *pixel_arrays):
-        return [np.asarray(pix) * 2 for pix in pixel_arrays]
+    def pixel_to_world_values(self, px, py):
+        return (-(np.asarray(px) - 5.) * 2 + 4.,
+                (np.asarray(py) - 6.) * 2)
 
-    def world_to_pixel_values(self, *world_arrays):
-        return [np.asarray(world) / 2 for world in world_arrays]
+    def world_to_pixel_values(self, wx, wy):
+        return (-(np.asarray(wx) - 4.) / 2 + 5.,
+                np.asarray(wy) / 2 + 6.)
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -132,21 +132,17 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
 
     @property
     def array_shape(self):
-        if self._naxis == [0, 0]:
+        if self.pixel_shape is None:
             return None
         else:
-            return tuple(self._naxis[::-1])
+            return self.pixel_shape[::-1]
 
     @array_shape.setter
     def array_shape(self, value):
         if value is None:
-            self._naxis = [0, 0]
+            self.pixel_shape = None
         else:
-            if len(value) != self.naxis:
-                raise ValueError("The number of data axes, "
-                                 "{}, does not equal the "
-                                 "shape {}.".format(self.naxis, len(value)))
-            self._naxis = list(value)[::-1]
+            self.pixel_shape = value[::-1]
 
     @property
     def pixel_shape(self):

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -11,7 +11,7 @@ from astropy import units as u
 
 from .low_level_api import BaseLowLevelWCS
 from .high_level_api import HighLevelWCSMixin
-from .sliced_low_level_wcs import SlicedLowLevelWCS
+from .wrappers import SlicedLowLevelWCS
 
 __all__ = ['custom_ctype_to_ucd_mapping', 'SlicedFITSWCS', 'FITSWCSAPIMixin']
 
@@ -249,18 +249,9 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         world = self.all_pix2world(*pixel_arrays, 0)
         return world[0] if self.world_n_dim == 1 else tuple(world)
 
-    def array_index_to_world_values(self, *indices):
-        world = self.all_pix2world(*indices[::-1], 0)
-        return world[0] if self.world_n_dim == 1 else tuple(world)
-
     def world_to_pixel_values(self, *world_arrays):
         pixel = self.all_world2pix(*world_arrays, 0)
         return pixel[0] if self.pixel_n_dim == 1 else tuple(pixel)
-
-    def world_to_array_index_values(self, *world_arrays):
-        pixel_arrays = self.all_world2pix(*world_arrays, 0)[::-1]
-        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
-        return array_indices[0] if self.pixel_n_dim == 1 else array_indices
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -51,7 +51,6 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         indexing and ordering conventions.
         """
 
-    @abc.abstractmethod
     def array_index_to_world(self, *index_arrays):
         """
         Convert array indices to world coordinates (represented by Astropy
@@ -64,6 +63,7 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         `~astropy.wcs.wcsapi.BaseLowLevelWCS.array_index_to_world_values` for
         pixel indexing and ordering conventions.
         """
+        return self.pixel_to_world(*index_arrays[::-1])
 
     @abc.abstractmethod
     def world_to_pixel(self, *world_objects):
@@ -78,7 +78,6 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         indexing and ordering conventions.
         """
 
-    @abc.abstractmethod
     def world_to_array_index(self, *world_objects):
         """
         Convert world coordinates (represented by Astropy objects) to array
@@ -91,6 +90,10 @@ class BaseHighLevelWCS(metaclass=abc.ABCMeta):
         pixel indexing and ordering conventions. The indices should be returned
         as rounded integers.
         """
+        if self.pixel_n_dim == 1:
+            return np.round(self.world_to_pixel(*world_objects)).astype(int)
+        else:
+            return tuple(np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int).tolist())
 
 
 class HighLevelWCSMixin(BaseHighLevelWCS):
@@ -255,12 +258,3 @@ class HighLevelWCSMixin(BaseHighLevelWCS):
             return result[0]
         else:
             return result
-
-    def array_index_to_world(self, *index_arrays):
-        return self.pixel_to_world(*index_arrays[::-1])
-
-    def world_to_array_index(self, *world_objects):
-        if self.pixel_n_dim == 1:
-            return np.round(self.world_to_pixel(*world_objects)).astype(int)
-        else:
-            return tuple(np.round(self.world_to_pixel(*world_objects)[::-1]).astype(int).tolist())

--- a/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/high_level_wcs_wrapper.py
@@ -1,6 +1,6 @@
 from .high_level_api import HighLevelWCSMixin
-
-from . import BaseLowLevelWCS
+from .low_level_api import BaseLowLevelWCS
+from .utils import wcs_info_str
 
 __all__ = ['HighLevelWCSWrapper']
 
@@ -75,3 +75,9 @@ class HighLevelWCSWrapper(HighLevelWCSMixin):
         See `~astropy.wcs.wcsapi.BaseLowLevelWCS._as_mpl_axes`
         """
         return self.low_level_wcs._as_mpl_axes()
+
+    def __str__(self):
+        return wcs_info_str(self.low_level_wcs)
+
+    def __repr__(self):
+        return f"{object.__repr__(self)}\n{str(self)}"

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -235,7 +235,10 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         objects. This is an optional property, and it should return `None`
         if a shape is not known or relevant.
         """
-        return None
+        if self.pixel_shape is None:
+            return None
+        else:
+            return self.pixel_shape[::-1]
 
     @property
     def pixel_shape(self):

--- a/astropy/wcs/wcsapi/low_level_api.py
+++ b/astropy/wcs/wcsapi/low_level_api.py
@@ -74,7 +74,6 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         arrays is returned.
         """
 
-    @abc.abstractmethod
     def array_index_to_world_values(self, *index_arrays):
         """
         Convert array indices to world coordinates.
@@ -88,6 +87,7 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         method returns a single scalar or array, otherwise a tuple of scalars or
         arrays is returned.
         """
+        return self.pixel_to_world_values(*index_arrays[::-1])
 
     @abc.abstractmethod
     def world_to_pixel_values(self, *world_arrays):
@@ -108,7 +108,6 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         arrays is returned.
         """
 
-    @abc.abstractmethod
     def world_to_array_index_values(self, *world_arrays):
         """
         Convert world coordinates to array indices.
@@ -123,6 +122,13 @@ class BaseLowLevelWCS(metaclass=abc.ABCMeta):
         method returns a single scalar or array, otherwise a tuple of scalars or
         arrays is returned.
         """
+        pixel_arrays = self.world_to_pixel_values(*world_arrays)
+        if self.pixel_n_dim == 1:
+            pixel_arrays = (pixel_arrays,)
+        else:
+            pixel_arrays = pixel_arrays[::-1]
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
+        return array_indices[0] if self.pixel_n_dim == 1 else array_indices
 
     @property
     @abc.abstractmethod

--- a/astropy/wcs/wcsapi/reordered_wcs.py
+++ b/astropy/wcs/wcsapi/reordered_wcs.py
@@ -1,0 +1,29 @@
+from .sliced_low_level_wcs import SlicedLowLevelWCS
+
+__all__ = ['ReorderedLowLevelWCS']
+
+
+class ReorderedLowLevelWCS(SlicedLowLevelWCS):
+    """
+    A wrapper for a low-level WCS object that has re-ordered
+    pixel and/or world axes.
+
+    Parameters
+    ----------
+    wcs : `~astropy.wcs.wcsapi.BaseLowLevelWCS`
+        The original WCS for which to reorder axes
+    pixel_keep : iterable
+        The indices of the original axes in the order of the
+        new WCS.
+    world_keep : iterable
+        The indices of the original axes in the order of the
+        new WCS.
+    """
+    def __init__(self, wcs, pixel_keep, world_keep):
+        super().__init__(wcs, Ellipsis)
+        self._pixel_keep = pixel_keep
+        self._world_keep = world_keep
+
+    @property
+    def array_shape(self):
+        return [self._wcs.array_shape[i] for i in self._pixel_keep[::-1]]

--- a/astropy/wcs/wcsapi/resampled_wcs.py
+++ b/astropy/wcs/wcsapi/resampled_wcs.py
@@ -1,0 +1,98 @@
+import numpy as np
+from .low_level_api import BaseLowLevelWCS
+
+__all__ = ['ResampledLowLevelWCS']
+
+
+class ResampledLowLevelWCS(BaseLowLevelWCS):
+    """
+    A wrapper for a low-level WCS object that has down- or
+    up-sampled pixel axes.
+
+    Parameters
+    ----------
+    wcs : `~astropy.wcs.wcsapi.BaseLowLevelWCS`
+        The original WCS for which to reorder axes
+    factor : int or float or iterable
+        The factor by which to increase the pixel size for each pixel
+        axis. If a scalar, the same factor is used for all axes.
+    """
+    def __init__(self, wcs, factor):
+        self._wcs = wcs
+        if np.isscalar(factor):
+            factor = [factor] * self.pixel_n_dim
+        self._factor = factor
+
+    @property
+    def pixel_n_dim(self):
+        return self._wcs.pixel_n_dim
+
+    @property
+    def world_n_dim(self):
+        return self._wcs.world_n_dim
+
+    @property
+    def world_axis_physical_types(self):
+        return self._wcs.world_axis_physical_types
+
+    @property
+    def world_axis_units(self):
+        return self._wcs.world_axis_units
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        pixel_arrays = [np.asarray(pixel_arrays[i]) * self._factor[i]
+                        for i in range(self.pixel_n_dim)]
+        return self._wcs.pixel_to_world_values(*pixel_arrays)
+
+    def array_index_to_world_values(self, *index_arrays):
+        return self.pixel_to_world_values(*index_arrays[-1])
+
+    def world_to_pixel_values(self, *world_arrays):
+        pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays)
+        pixel_arrays = [np.asarray(pixel_arrays[i]) / self._factor[i]
+                        for i in range(self.pixel_n_dim)]
+        return pixel_arrays
+
+    def world_to_array_index_values(self, *world_arrays):
+        pixel_arrays = self.world_to_pixel_values(*world_arrays)
+        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
+        return array_indices
+
+    @property
+    def world_axis_object_components(self):
+        return self._wcs.world_axis_object_components
+
+    @property
+    def world_axis_object_classes(self):
+        return self._wcs.world_axis_object_components
+
+    @property
+    def array_shape(self):
+        return self.pixel_shape[::-1]
+
+    @property
+    def pixel_shape(self):
+        return tuple(self._wcs.pixel_shape[i] / self._factor[i]
+                     for i in range(self.pixel_n_dim))
+
+    @property
+    def pixel_bounds(self):
+        return tuple((self._wcs.pixel_bounds[i][0] / self._factor[i],
+                      self._wcs.pixel_bounds[i][1] / self._factor[i])
+                     for i in range(self.pixel_n_dim))
+
+    @property
+    def pixel_axis_names(self):
+        return self._wcs.pixel_axis_names
+
+    @property
+    def world_axis_names(self):
+        return self._wcs.world_axis_names
+
+    @property
+    def axis_correlation_matrix(self):
+        return self._wcs.axis_correlation_matrix
+
+    @property
+    def serialized_classes(self):
+        return self._wcs.serialized_classes

--- a/astropy/wcs/wcsapi/tests/test_high_level_api.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_api.py
@@ -16,13 +16,7 @@ class DoubleLowLevelWCS(BaseLowLevelWCS):
     def pixel_to_world_values(self, *pixel_arrays):
         return [np.asarray(pix) * 2 for pix in pixel_arrays]
 
-    def array_index_to_world_values(self, *index_arrays):
-        return [np.asarray(pix) * 2 for pix in index_arrays]
-
     def world_to_pixel_values(self, *world_arrays):
-        return [np.asarray(world) / 2 for world in world_arrays]
-
-    def world_to_array_index_values(self, *world_arrays):
         return [np.asarray(world) / 2 for world in world_arrays]
 
 

--- a/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
+++ b/astropy/wcs/wcsapi/tests/test_high_level_wcs_wrapper.py
@@ -29,13 +29,7 @@ class CustomLowLevelWCS(BaseLowLevelWCS):
     def pixel_to_world_values(self, *pixel_arrays):
         return [np.asarray(pix) * 2 for pix in pixel_arrays]
 
-    def array_index_to_world_values(self, *index_arrays):
-        return [np.asarray(pix) * 2 for pix in index_arrays]
-
     def world_to_pixel_values(self, *world_arrays):
-        return [np.asarray(world) / 2 for world in world_arrays]
-
-    def world_to_array_index_values(self, *world_arrays):
         return [np.asarray(world) / 2 for world in world_arrays]
 
     @property

--- a/astropy/wcs/wcsapi/utils.py
+++ b/astropy/wcs/wcsapi/utils.py
@@ -53,10 +53,10 @@ def wcs_info_str(wcs):
             'Bounds\n')
 
     for ipix in range(wcs.pixel_n_dim):
-        s += (('{0:' + str(pixel_dim_width) + 'd}').format(ipix) + '  ' +
+        s += (('{0:' + str(pixel_dim_width) + 'g}').format(ipix) + '  ' +
                 ('{0:' + str(pixel_nam_width) + 's}').format(wcs.pixel_axis_names[ipix] or 'None') + '  ' +
                 (" " * 5 + str(None) if pixel_shape[ipix] is None else
-                ('{0:' + str(pixel_siz_width) + 'd}').format(pixel_shape[ipix])) + '  ' +
+                ('{0:' + str(pixel_siz_width) + 'g}').format(pixel_shape[ipix])) + '  ' +
                 '{:s}'.format(str(None if wcs.pixel_bounds is None else wcs.pixel_bounds[ipix]) + '\n'))
 
     s += '\n'

--- a/astropy/wcs/wcsapi/wrappers/__init__.py
+++ b/astropy/wcs/wcsapi/wrappers/__init__.py
@@ -1,0 +1,4 @@
+from .compound_wcs import *  # noqa
+from .reordered_wcs import *  # noqa
+from .resampled_wcs import *  # noqa
+from .sliced_wcs import *  # noqa

--- a/astropy/wcs/wcsapi/wrappers/__init__.py
+++ b/astropy/wcs/wcsapi/wrappers/__init__.py
@@ -2,3 +2,4 @@ from .compound_wcs import *  # noqa
 from .reordered_wcs import *  # noqa
 from .resampled_wcs import *  # noqa
 from .sliced_wcs import *  # noqa
+from .base import BaseWCSWrapper

--- a/astropy/wcs/wcsapi/wrappers/base.py
+++ b/astropy/wcs/wcsapi/wrappers/base.py
@@ -1,0 +1,77 @@
+import abc
+
+from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+
+
+class BaseWCSWrapper(BaseLowLevelWCS, metaclass=abc.ABCMeta):
+    """
+    A base wrapper class for things that modify Low Level WCSes.
+
+    This wrapper implements a transparent wrapper to many of the properties,
+    with the idea that not all of them would need to be overridden in your
+    wrapper, but some probably will.
+    """
+    def __init__(self, wcs, *args, **kwargs):
+        self._wcs = wcs
+
+    @property
+    def pixel_n_dim(self):
+        return self._wcs.pixel_n_dim
+
+    @property
+    def world_n_dim(self):
+        return self._wcs.world_n_dim
+
+    @property
+    def world_axis_physical_types(self):
+        return self._wcs.world_axis_physical_types
+
+    @property
+    def world_axis_units(self):
+        return self._wcs.world_axis_units
+
+    @property
+    def world_axis_object_components(self):
+        return self._wcs.world_axis_object_components
+
+    @property
+    def world_axis_object_classes(self):
+        return self._wcs.world_axis_object_classes
+
+    @property
+    def pixel_shape(self):
+        return self._wcs.pixel_shape
+
+    @property
+    def pixel_bounds(self):
+        return self._wcs.pixel_bounds
+
+    @property
+    def pixel_axis_names(self):
+        return self._wcs.pixel_axis_names
+
+    @property
+    def world_axis_names(self):
+        return self._wcs.world_axis_names
+
+    @property
+    def axis_correlation_matrix(self):
+        return self._wcs.axis_correlation_matrix
+
+    @property
+    def serialized_classes(self):
+        return self._wcs.serialized_classes
+
+    @abc.abstractmethod
+    def pixel_to_world_values(self, *pixel_arrays):
+        pass
+
+    @abc.abstractmethod
+    def world_to_pixel_values(self, *world_arrays):
+        pass
+
+    def __repr__(self):
+        return f"{object.__repr__(self)}\n{str(self)}"
+
+    def __str__(self):
+        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/compound_wcs.py
@@ -82,18 +82,11 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
         return all_classes
 
     @property
-    def array_shape(self):
+    def pixel_shape(self):
         if any(w.array_shape is None for w in self._wcs):
             return None
         else:
-            return tuplesum(w.array_shape for w in self._wcs)
-
-    @property
-    def pixel_shape(self):
-        if self.array_shape is None:
-            return None
-        else:
-            return self.array_shape[::-1]
+            return tuplesum(w.pixel_shape for w in self._wcs)
 
     @property
     def pixel_bounds(self):

--- a/astropy/wcs/wcsapi/wrappers/compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/compound_wcs.py
@@ -2,7 +2,7 @@ from functools import reduce
 
 import numpy as np
 
-from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+from .base import BaseWCSWrapper
 
 __all__ = ['CompoundLowLevelWCS']
 
@@ -11,7 +11,7 @@ def tuplesum(lists):
     return reduce(tuple.__add__, map(tuple, lists))
 
 
-class CompoundLowLevelWCS(BaseLowLevelWCS):
+class CompoundLowLevelWCS(BaseWCSWrapper):
     """
     A wrapper that takes multiple low level WCS objects and makes a compound
     WCS that combines them.
@@ -83,16 +83,12 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def pixel_shape(self):
-        if any(w.array_shape is None for w in self._wcs):
-            return None
-        else:
+        if not any(w.array_shape is None for w in self._wcs):
             return tuplesum(w.pixel_shape for w in self._wcs)
 
     @property
     def pixel_bounds(self):
-        if any(w.pixel_bounds is None for w in self._wcs):
-            return None
-        else:
+        if not any(w.pixel_bounds is None for w in self._wcs):
             return tuplesum(w.pixel_bounds for w in self._wcs)
 
     @property
@@ -108,7 +104,7 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
         matrix = np.zeros((self.world_n_dim, self.pixel_n_dim), dtype=bool)
         iw = ip = 0
         for w in self._wcs:
-            matrix[iw:iw+w.world_n_dim,ip:ip+w.pixel_n_dim] = w.axis_correlation_matrix
+            matrix[iw:iw + w.world_n_dim, ip:ip + w.pixel_n_dim] = w.axis_correlation_matrix
             iw += w.world_n_dim
             ip += w.pixel_n_dim
         return matrix
@@ -116,9 +112,3 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
     @property
     def serialized_classes(self):
         return any([w.serialized_classes for w in self._wcs])
-
-    def __repr__(self):
-        return wcs_info_str(self)
-
-    def __str__(self):
-        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/compound_wcs.py
@@ -7,9 +7,8 @@ from ..low_level_api import BaseLowLevelWCS
 __all__ = ['CompoundLowLevelWCS']
 
 
-
-def listsum(lists):
-    return reduce(list.__add__, map(list, lists))
+def tuplesum(lists):
+    return reduce(tuple.__add__, map(tuple, lists))
 
 
 class CompoundLowLevelWCS(BaseLowLevelWCS):
@@ -35,11 +34,11 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_physical_types(self):
-        return listsum([w.world_axis_physical_types for w in self._wcs])
+        return tuplesum([w.world_axis_physical_types for w in self._wcs])
 
     @property
     def world_axis_units(self):
-        return listsum([w.world_axis_units for w in self._wcs])
+        return tuplesum([w.world_axis_units for w in self._wcs])
 
     def pixel_to_world_values(self, *pixel_arrays):
         world_arrays = []
@@ -87,7 +86,7 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
         if any(w.array_shape is None for w in self._wcs):
             return None
         else:
-            return listsum(w.array_shape for w in self._wcs)
+            return tuplesum(w.array_shape for w in self._wcs)
 
     @property
     def pixel_shape(self):
@@ -101,15 +100,15 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
         if any(w.pixel_bounds is None for w in self._wcs):
             return None
         else:
-            return listsum(w.pixel_bounds for w in self._wcs)
+            return tuplesum(w.pixel_bounds for w in self._wcs)
 
     @property
     def pixel_axis_names(self):
-        return listsum(w.pixel_axis_names for w in self._wcs)
+        return tuplesum(w.pixel_axis_names for w in self._wcs)
 
     @property
     def world_axis_names(self):
-        return listsum(w.world_axis_names for w in self._wcs)
+        return tuplesum(w.world_axis_names for w in self._wcs)
 
     @property
     def axis_correlation_matrix(self):

--- a/astropy/wcs/wcsapi/wrappers/compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/compound_wcs.py
@@ -2,7 +2,7 @@ from functools import reduce
 
 import numpy as np
 
-from ..low_level_api import BaseLowLevelWCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
 
 __all__ = ['CompoundLowLevelWCS']
 
@@ -116,3 +116,9 @@ class CompoundLowLevelWCS(BaseLowLevelWCS):
     @property
     def serialized_classes(self):
         return any([w.serialized_classes for w in self._wcs])
+
+    def __repr__(self):
+        return wcs_info_str(self)
+
+    def __str__(self):
+        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
@@ -3,13 +3,13 @@ import numbers
 
 import numpy as np
 
-from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+from .base import BaseWCSWrapper
 from astropy.utils import isiterable
 
 __all__ = ['ReorderedLowLevelWCS']
 
 
-class ReorderedLowLevelWCS(BaseLowLevelWCS):
+class ReorderedLowLevelWCS(BaseWCSWrapper):
     """
     A wrapper for a low-level WCS object that has re-ordered
     pixel and/or world axes.
@@ -35,14 +35,6 @@ class ReorderedLowLevelWCS(BaseLowLevelWCS):
         self._world_order = world_order
         self._pixel_order_inv = np.argsort(pixel_order)
         self._world_order_inv = np.argsort(world_order)
-
-    @property
-    def pixel_n_dim(self):
-        return self._wcs.pixel_n_dim
-
-    @property
-    def world_n_dim(self):
-        return self._wcs.world_n_dim
 
     @property
     def world_axis_physical_types(self):
@@ -77,15 +69,6 @@ class ReorderedLowLevelWCS(BaseLowLevelWCS):
         return [self._wcs.world_axis_object_components[idx] for idx in self._world_order]
 
     @property
-    def world_axis_object_classes(self):
-        return self._wcs.world_axis_object_classes
-
-    @property
-    def array_shape(self):
-        if self.pixel_shape:
-            return self.pixel_shape[::-1]
-
-    @property
     def pixel_shape(self):
         if self._wcs.pixel_shape:
             return tuple([self._wcs.pixel_shape[idx] for idx in self._pixel_order])
@@ -98,9 +81,3 @@ class ReorderedLowLevelWCS(BaseLowLevelWCS):
     @property
     def axis_correlation_matrix(self):
         return self._wcs.axis_correlation_matrix[self._world_order][:, self._pixel_order]
-
-    def __repr__(self):
-        return wcs_info_str(self)
-
-    def __str__(self):
-        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
@@ -1,9 +1,15 @@
-from .sliced_wcs import SlicedLowLevelWCS
+
+import numbers
+
+import numpy as np
+
+from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+from astropy.utils import isiterable
 
 __all__ = ['ReorderedLowLevelWCS']
 
 
-class ReorderedLowLevelWCS(SlicedLowLevelWCS):
+class ReorderedLowLevelWCS(BaseLowLevelWCS):
     """
     A wrapper for a low-level WCS object that has re-ordered
     pixel and/or world axes.
@@ -12,18 +18,85 @@ class ReorderedLowLevelWCS(SlicedLowLevelWCS):
     ----------
     wcs : `~astropy.wcs.wcsapi.BaseLowLevelWCS`
         The original WCS for which to reorder axes
-    pixel_keep : iterable
+    pixel_order : iterable
         The indices of the original axes in the order of the
         new WCS.
-    world_keep : iterable
+    world_order : iterable
         The indices of the original axes in the order of the
         new WCS.
     """
-    def __init__(self, wcs, pixel_keep, world_keep):
-        super().__init__(wcs, Ellipsis)
-        self._pixel_keep = pixel_keep
-        self._world_keep = world_keep
+    def __init__(self, wcs, pixel_order, world_order):
+        self._wcs = wcs
+        self._pixel_order = pixel_order
+        self._world_order = world_order
+        self._pixel_order_inv = np.argsort(pixel_order)
+        self._world_order_inv = np.argsort(world_order)
+
+    @property
+    def pixel_n_dim(self):
+        return self._wcs.pixel_n_dim
+
+    @property
+    def world_n_dim(self):
+        return self._wcs.world_n_dim
+
+    @property
+    def world_axis_physical_types(self):
+        return [self._wcs.world_axis_physical_types[idx] for idx in self._world_order]
+
+    @property
+    def world_axis_units(self):
+        return [self._wcs.world_axis_units[idx] for idx in self._world_order]
+
+    @property
+    def pixel_axis_names(self):
+        return [self._wcs.pixel_axis_names[idx] for idx in self._pixel_order]
+
+    @property
+    def world_axis_names(self):
+        return [self._wcs.world_axis_names[idx] for idx in self._world_order]
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        pixel_arrays = [pixel_arrays[idx] for idx in self._pixel_order_inv]
+        world_arrays = self._wcs.pixel_to_world_values(*pixel_arrays)
+        world_arrays = [world_arrays[idx] for idx in self._world_order]
+        return world_arrays
+
+    def world_to_pixel_values(self, *world_arrays):
+        world_arrays = [world_arrays[idx] for idx in self._world_order_inv]
+        pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays)
+        pixel_arrays = [pixel_arrays[idx] for idx in self._pixel_order]
+        return pixel_arrays
+
+    @property
+    def world_axis_object_components(self):
+        return [self._wcs.world_axis_object_components[idx] for idx in self._world_order]
+
+    @property
+    def world_axis_object_classes(self):
+        return self._wcs.world_axis_object_classes
 
     @property
     def array_shape(self):
-        return [self._wcs.array_shape[i] for i in self._pixel_keep[::-1]]
+        if self.pixel_shape:
+            return self.pixel_shape[::-1]
+
+    @property
+    def pixel_shape(self):
+        if self._wcs.pixel_shape:
+            return tuple([self._wcs.pixel_shape[idx] for idx in self._pixel_order])
+
+    @property
+    def pixel_bounds(self):
+        if self._wcs.pixel_bounds:
+            return tuple([self._wcs.pixel_bounds[idx] for idx in self._pixel_order])
+
+    @property
+    def axis_correlation_matrix(self):
+        return self._wcs.axis_correlation_matrix[self._world_order][:, self._pixel_order]
+
+    def __repr__(self):
+        return wcs_info_str(self)
+
+    def __str__(self):
+        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
@@ -26,6 +26,10 @@ class ReorderedLowLevelWCS(BaseLowLevelWCS):
         new WCS.
     """
     def __init__(self, wcs, pixel_order, world_order):
+        if sorted(pixel_order) != list(range(wcs.pixel_n_dim)):
+            raise ValueError(f'pixel_order should be a permutation of {list(range(wcs.pixel_n_dim))}')
+        if sorted(world_order) != list(range(wcs.world_n_dim)):
+            raise ValueError(f'world_order should be a permutation of {list(range(wcs.world_n_dim))}')
         self._wcs = wcs
         self._pixel_order = pixel_order
         self._world_order = world_order

--- a/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/reordered_wcs.py
@@ -1,4 +1,4 @@
-from .sliced_low_level_wcs import SlicedLowLevelWCS
+from .sliced_wcs import SlicedLowLevelWCS
 
 __all__ = ['ReorderedLowLevelWCS']
 

--- a/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
@@ -1,5 +1,6 @@
 import numpy as np
-from .low_level_api import BaseLowLevelWCS
+
+from ..low_level_api import BaseLowLevelWCS
 
 __all__ = ['ResampledLowLevelWCS']
 
@@ -44,19 +45,11 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
                         for i in range(self.pixel_n_dim)]
         return self._wcs.pixel_to_world_values(*pixel_arrays)
 
-    def array_index_to_world_values(self, *index_arrays):
-        return self.pixel_to_world_values(*index_arrays[-1])
-
     def world_to_pixel_values(self, *world_arrays):
         pixel_arrays = self._wcs.world_to_pixel_values(*world_arrays)
         pixel_arrays = [np.asarray(pixel_arrays[i]) / self._factor[i]
                         for i in range(self.pixel_n_dim)]
         return pixel_arrays
-
-    def world_to_array_index_values(self, *world_arrays):
-        pixel_arrays = self.world_to_pixel_values(*world_arrays)
-        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
-        return array_indices
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+from .base import BaseWCSWrapper
 
 __all__ = ['ResampledLowLevelWCS']
 
 
-class ResampledLowLevelWCS(BaseLowLevelWCS):
+class ResampledLowLevelWCS(BaseWCSWrapper):
     """
     A wrapper for a low-level WCS object that has down- or
     up-sampled pixel axes.
@@ -24,22 +24,6 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
             factor = [factor] * self.pixel_n_dim
         self._factor = factor
 
-    @property
-    def pixel_n_dim(self):
-        return self._wcs.pixel_n_dim
-
-    @property
-    def world_n_dim(self):
-        return self._wcs.world_n_dim
-
-    @property
-    def world_axis_physical_types(self):
-        return self._wcs.world_axis_physical_types
-
-    @property
-    def world_axis_units(self):
-        return self._wcs.world_axis_units
-
     def pixel_to_world_values(self, *pixel_arrays):
         pixel_arrays = [np.asarray(pixel_arrays[i]) * self._factor[i]
                         for i in range(self.pixel_n_dim)]
@@ -52,14 +36,6 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
         return pixel_arrays
 
     @property
-    def world_axis_object_components(self):
-        return self._wcs.world_axis_object_components
-
-    @property
-    def world_axis_object_classes(self):
-        return self._wcs.world_axis_object_classes
-
-    @property
     def pixel_shape(self):
         return tuple(self._wcs.pixel_shape[i] / self._factor[i]
                      for i in range(self.pixel_n_dim))
@@ -69,25 +45,3 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
         return tuple((self._wcs.pixel_bounds[i][0] / self._factor[i],
                       self._wcs.pixel_bounds[i][1] / self._factor[i])
                      for i in range(self.pixel_n_dim))
-
-    @property
-    def pixel_axis_names(self):
-        return self._wcs.pixel_axis_names
-
-    @property
-    def world_axis_names(self):
-        return self._wcs.world_axis_names
-
-    @property
-    def axis_correlation_matrix(self):
-        return self._wcs.axis_correlation_matrix
-
-    @property
-    def serialized_classes(self):
-        return self._wcs.serialized_classes
-
-    def __repr__(self):
-        return wcs_info_str(self)
-
-    def __str__(self):
-        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
@@ -60,10 +60,6 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
         return self._wcs.world_axis_object_components
 
     @property
-    def array_shape(self):
-        return self.pixel_shape[::-1]
-
-    @property
     def pixel_shape(self):
         return tuple(self._wcs.pixel_shape[i] / self._factor[i]
                      for i in range(self.pixel_n_dim))

--- a/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/resampled_wcs.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ..low_level_api import BaseLowLevelWCS
+from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
 
 __all__ = ['ResampledLowLevelWCS']
 
@@ -57,7 +57,7 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def world_axis_object_classes(self):
-        return self._wcs.world_axis_object_components
+        return self._wcs.world_axis_object_classes
 
     @property
     def pixel_shape(self):
@@ -85,3 +85,9 @@ class ResampledLowLevelWCS(BaseLowLevelWCS):
     @property
     def serialized_classes(self):
         return self._wcs.serialized_classes
+
+    def __repr__(self):
+        return wcs_info_str(self)
+
+    def __str__(self):
+        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -2,7 +2,7 @@ import numbers
 
 import numpy as np
 
-from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
+from .base import BaseWCSWrapper
 from astropy.utils import isiterable
 
 __all__ = ['sanitize_slices', 'SlicedLowLevelWCS']
@@ -96,7 +96,7 @@ def combine_slices(slice1, slice2):
     return slice(start, stop)
 
 
-class SlicedLowLevelWCS(BaseLowLevelWCS):
+class SlicedLowLevelWCS(BaseWCSWrapper):
 
     def __init__(self, wcs, slices):
 
@@ -233,9 +233,8 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
     @property
     def pixel_bounds(self):
-
         if self._wcs.pixel_bounds is None:
-            return None
+            return
 
         bounds = []
         for idx in self._pixel_keep:
@@ -251,9 +250,3 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     @property
     def axis_correlation_matrix(self):
         return self._wcs.axis_correlation_matrix[self._world_keep][:, self._pixel_keep]
-
-    def __repr__(self):
-        return wcs_info_str(self)
-
-    def __str__(self):
-        return wcs_info_str(self)

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -229,7 +229,7 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
     @property
     def pixel_shape(self):
         if self.array_shape:
-            return self.array_shape[::-1]
+            return tuple(self.array_shape[::-1])
 
     @property
     def pixel_bounds(self):

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -1,5 +1,7 @@
 import numbers
+
 import numpy as np
+
 from astropy.wcs.wcsapi import BaseLowLevelWCS, wcs_info_str
 from astropy.utils import isiterable
 
@@ -184,9 +186,6 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
 
         return world_arrays
 
-    def array_index_to_world_values(self, *index_arrays):
-        return self.pixel_to_world_values(*index_arrays[::-1])
-
     def world_to_pixel_values(self, *world_arrays):
         world_arrays = tuple(map(np.asanyarray, world_arrays))
         world_arrays_new = []
@@ -212,11 +211,6 @@ class SlicedLowLevelWCS(BaseLowLevelWCS):
         if self.pixel_n_dim == 1 and self._wcs.pixel_n_dim > 1:
             pixel = pixel[0]
         return pixel
-
-    def world_to_array_index_values(self, *world_arrays):
-        pixel_arrays = self.world_to_pixel_values(*world_arrays, 0)[::-1]
-        array_indices = tuple(np.asarray(np.floor(pixel + 0.5), dtype=np.int_) for pixel in pixel_arrays)
-        return array_indices
 
     @property
     def world_axis_object_components(self):

--- a/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
@@ -1,0 +1,48 @@
+import pytest
+
+import numpy as np
+from numpy.testing import assert_allclose
+
+from astropy.units import Quantity
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.wcs.wcsapi import CompoundLowLevelWCS, HighLevelWCSWrapper
+from astropy.tests.helper import assert_quantity_allclose
+
+
+def test_celestial_spectral_ape14(spectral_1d_ape14_wcs,
+                                  celestial_2d_ape14_wcs):
+
+    wcs = CompoundLowLevelWCS(spectral_1d_ape14_wcs, celestial_2d_ape14_wcs)
+
+    assert wcs.pixel_n_dim == 3
+    assert wcs.world_n_dim == 3
+    assert tuple(wcs.world_axis_physical_types) == ('em.freq', 'pos.eq.ra', 'pos.eq.dec')
+    assert tuple(wcs.world_axis_units) == ('GHz', 'deg', 'deg')
+
+    pix_scalar = (2.3, 4.3, 1.3)
+    wrl_scalar = (6.9, 8.6, 2.6)
+    assert_allclose(wcs.pixel_to_world_values(*pix_scalar), wrl_scalar)
+    assert_allclose(wcs.array_index_to_world_values(*pix_scalar[::-1]), wrl_scalar)
+    assert_allclose(wcs.world_to_pixel_values(*wrl_scalar), pix_scalar)
+    assert_allclose(wcs.world_to_array_index_values(*wrl_scalar), [1, 4, 2])
+
+    pix_array = (np.array([2.3, 2.4]),
+                 np.array([4.3, 4.4]),
+                 np.array([1.3, 1.4]))
+    wrl_array = (np.array([6.9, 7.2]),
+                 np.array([8.6, 8.8]),
+                 np.array([2.6, 2.8]))
+    assert_allclose(wcs.pixel_to_world_values(*pix_array), wrl_array)
+    assert_allclose(wcs.array_index_to_world_values(*pix_array[::-1]), wrl_array)
+    assert_allclose(wcs.world_to_pixel_values(*wrl_array), pix_array)
+    assert_allclose(wcs.world_to_array_index_values(*wrl_array),
+                    [[1, 1], [4, 4], [2, 2]])
+
+    wcs_hl = HighLevelWCSWrapper(wcs)
+    spectral, celestial = wcs_hl.pixel_to_world(*pix_scalar)
+    assert isinstance(spectral, Quantity)
+    assert_quantity_allclose(spectral, 6.9 * u.GHz)
+    assert isinstance(celestial, SkyCoord)
+    assert_quantity_allclose(celestial.ra, 8.6 * u.deg)
+    assert_quantity_allclose(celestial.dec, 2.6 * u.deg)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
@@ -3,7 +3,7 @@ from itertools import product
 import pytest
 
 import numpy as np
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_equal
 
 from astropy.units import Quantity
 from astropy import units as u
@@ -34,6 +34,25 @@ def test_celestial_spectral_ape14(spectral_wcs, celestial_wcs):
     assert wcs.world_n_dim == 3
     assert tuple(wcs.world_axis_physical_types) == ('em.freq', 'pos.eq.ra', 'pos.eq.dec')
     assert tuple(wcs.world_axis_units) == ('Hz', 'deg', 'deg')
+    assert tuple(wcs.pixel_axis_names) == ('', '', '')
+    assert tuple(wcs.world_axis_names) == ('Frequency',
+                                           'Right Ascension',
+                                           'Declination')
+    assert_equal(wcs.axis_correlation_matrix, np.array([[1, 0, 0],
+                                                        [0, 1, 1],
+                                                        [0, 1, 1]]))
+
+    # If any of the individual shapes are None, return None overall
+    assert wcs.pixel_shape is None
+    assert wcs.array_shape is None
+    assert wcs.pixel_bounds is None
+
+    # Set the shape and bounds on the spectrum and test again
+    spectral_wcs.pixel_shape = (3,)
+    spectral_wcs.pixel_bounds = [(1, 2)]
+    assert wcs.pixel_shape == (3, 6, 7)
+    assert wcs.array_shape == (7, 6, 3)
+    assert wcs.pixel_bounds == ((1, 2), (-1, 5), (1, 7))
 
     pixel_scalar = (2.3, 4.3, 1.3)
     world_scalar = (-1.91e10, 5.4, -9.4)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
@@ -117,4 +117,4 @@ def test_celestial_spectral_ape14(spectral_wcs, celestial_wcs):
     assert_quantity_allclose(celestial.dec, world_array[2] * u.deg)
 
     assert str(wcs) == EXPECTED_CELESTIAL_SPECTRAL_APE14_REPR
-    assert repr(wcs) == EXPECTED_CELESTIAL_SPECTRAL_APE14_REPR
+    assert EXPECTED_CELESTIAL_SPECTRAL_APE14_REPR in repr(wcs)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_compound_wcs.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import pytest
 
 import numpy as np
@@ -10,39 +12,60 @@ from astropy.wcs.wcsapi import CompoundLowLevelWCS, HighLevelWCSWrapper
 from astropy.tests.helper import assert_quantity_allclose
 
 
-def test_celestial_spectral_ape14(spectral_1d_ape14_wcs,
-                                  celestial_2d_ape14_wcs):
+@pytest.fixture
+def spectral_wcs(request):
+    return request.getfixturevalue(request.param)
 
-    wcs = CompoundLowLevelWCS(spectral_1d_ape14_wcs, celestial_2d_ape14_wcs)
+
+@pytest.fixture
+def celestial_wcs(request):
+    return request.getfixturevalue(request.param)
+
+
+@pytest.mark.parametrize(('spectral_wcs', 'celestial_wcs'),
+                         product(['spectral_1d_ape14_wcs', 'spectral_1d_fitswcs'],
+                                 ['celestial_2d_ape14_wcs', 'celestial_2d_fitswcs']),
+                         indirect=True)
+def test_celestial_spectral_ape14(spectral_wcs, celestial_wcs):
+
+    wcs = CompoundLowLevelWCS(spectral_wcs, celestial_wcs)
 
     assert wcs.pixel_n_dim == 3
     assert wcs.world_n_dim == 3
     assert tuple(wcs.world_axis_physical_types) == ('em.freq', 'pos.eq.ra', 'pos.eq.dec')
-    assert tuple(wcs.world_axis_units) == ('GHz', 'deg', 'deg')
+    assert tuple(wcs.world_axis_units) == ('Hz', 'deg', 'deg')
 
-    pix_scalar = (2.3, 4.3, 1.3)
-    wrl_scalar = (6.9, 8.6, 2.6)
-    assert_allclose(wcs.pixel_to_world_values(*pix_scalar), wrl_scalar)
-    assert_allclose(wcs.array_index_to_world_values(*pix_scalar[::-1]), wrl_scalar)
-    assert_allclose(wcs.world_to_pixel_values(*wrl_scalar), pix_scalar)
-    assert_allclose(wcs.world_to_array_index_values(*wrl_scalar), [1, 4, 2])
+    pixel_scalar = (2.3, 4.3, 1.3)
+    world_scalar = (-1.91e10, 5.4, -9.4)
+    assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
+    assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
+    assert_allclose(wcs.world_to_array_index_values(*world_scalar), [1, 4, 2])
 
-    pix_array = (np.array([2.3, 2.4]),
+    pixel_array = (np.array([2.3, 2.4]),
                  np.array([4.3, 4.4]),
                  np.array([1.3, 1.4]))
-    wrl_array = (np.array([6.9, 7.2]),
-                 np.array([8.6, 8.8]),
-                 np.array([2.6, 2.8]))
-    assert_allclose(wcs.pixel_to_world_values(*pix_array), wrl_array)
-    assert_allclose(wcs.array_index_to_world_values(*pix_array[::-1]), wrl_array)
-    assert_allclose(wcs.world_to_pixel_values(*wrl_array), pix_array)
-    assert_allclose(wcs.world_to_array_index_values(*wrl_array),
+    world_array = (np.array([-1.91e10, -1.88e10]),
+                 np.array([5.4, 5.2]),
+                 np.array([-9.4, -9.2]))
+    assert_allclose(wcs.pixel_to_world_values(*pixel_array), world_array)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_array[::-1]), world_array)
+    assert_allclose(wcs.world_to_pixel_values(*world_array), pixel_array)
+    assert_allclose(wcs.world_to_array_index_values(*world_array),
                     [[1, 1], [4, 4], [2, 2]])
 
     wcs_hl = HighLevelWCSWrapper(wcs)
-    spectral, celestial = wcs_hl.pixel_to_world(*pix_scalar)
+
+    spectral, celestial = wcs_hl.pixel_to_world(*pixel_scalar)
     assert isinstance(spectral, Quantity)
-    assert_quantity_allclose(spectral, 6.9 * u.GHz)
+    assert_quantity_allclose(spectral, world_scalar[0] * u.Hz)
     assert isinstance(celestial, SkyCoord)
-    assert_quantity_allclose(celestial.ra, 8.6 * u.deg)
-    assert_quantity_allclose(celestial.dec, 2.6 * u.deg)
+    assert_quantity_allclose(celestial.ra, world_scalar[1] * u.deg)
+    assert_quantity_allclose(celestial.dec, world_scalar[2] * u.deg)
+
+    spectral, celestial = wcs_hl.pixel_to_world(*pixel_array)
+    assert isinstance(spectral, Quantity)
+    assert_quantity_allclose(spectral, world_array[0] * u.Hz)
+    assert isinstance(celestial, SkyCoord)
+    assert_quantity_allclose(celestial.ra, world_array[1] * u.deg)
+    assert_quantity_allclose(celestial.dec, world_array[2] * u.deg)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_reordered_wcs.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import numpy as np
@@ -106,3 +108,17 @@ def test_spectral_cube(spectral_cube_3d_fitswcs):
 
     assert str(wcs) == EXPECTED_SPECTRAL_CUBE_REPR
     assert repr(wcs) == EXPECTED_SPECTRAL_CUBE_REPR
+
+
+@pytest.mark.parametrize('order', [(1,), (1, 2, 2), (0, 1, 2, 3)])
+def test_invalid(spectral_cube_3d_fitswcs, order):
+
+    with pytest.raises(ValueError, match=re.escape('pixel_order should be a permutation of [0, 1, 2]')):
+        ReorderedLowLevelWCS(spectral_cube_3d_fitswcs,
+                             pixel_order=order,
+                             world_order=[2, 0, 1])
+
+    with pytest.raises(ValueError, match=re.escape('world_order should be a permutation of [0, 1, 2]')):
+        ReorderedLowLevelWCS(spectral_cube_3d_fitswcs,
+                             pixel_order=[1, 2, 0],
+                             world_order=order)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_reordered_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_reordered_wcs.py
@@ -107,7 +107,7 @@ def test_spectral_cube(spectral_cube_3d_fitswcs):
     assert_quantity_allclose(celestial.dec, world_array[2] * u.deg)
 
     assert str(wcs) == EXPECTED_SPECTRAL_CUBE_REPR
-    assert repr(wcs) == EXPECTED_SPECTRAL_CUBE_REPR
+    assert EXPECTED_SPECTRAL_CUBE_REPR in repr(wcs)
 
 
 @pytest.mark.parametrize('order', [(1,), (1, 2, 2), (0, 1, 2, 3)])

--- a/astropy/wcs/wcsapi/wrappers/tests/test_resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_resampled_wcs.py
@@ -92,7 +92,7 @@ def test_2d(celestial_wcs):
     assert_quantity_allclose(celestial.dec, world_array[1] * u.deg)
 
     assert str(wcs) == EXPECTED_2D_REPR
-    assert repr(wcs) == EXPECTED_2D_REPR
+    assert EXPECTED_2D_REPR in repr(wcs)
 
 
 @pytest.mark.parametrize('celestial_wcs',

--- a/astropy/wcs/wcsapi/wrappers/tests/test_resampled_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_resampled_wcs.py
@@ -1,0 +1,110 @@
+import pytest
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.wcs.wcsapi import ResampledLowLevelWCS, HighLevelWCSWrapper
+from astropy.tests.helper import assert_quantity_allclose
+
+
+@pytest.fixture
+def celestial_wcs(request):
+    return request.getfixturevalue(request.param)
+
+
+EXPECTED_2D_REPR = """
+ResampledLowLevelWCS Transformation
+
+This transformation has 2 pixel and 2 world dimensions
+
+Array shape (Numpy order): (2.3333333333333335, 15.0)
+
+Pixel Dim  Axis Name  Data size  Bounds
+        0  None              15  (-2.5, 12.5)
+        1  None         2.33333  (0.3333333333333333, 2.3333333333333335)
+
+World Dim  Axis Name        Physical Type  Units
+        0  Right Ascension  pos.eq.ra      deg
+        1  Declination      pos.eq.dec     deg
+
+Correlation between pixel and world axes:
+
+           Pixel Dim
+World Dim    0    1
+        0  yes  yes
+        1  yes  yes
+""".strip()
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs', 'celestial_2d_fitswcs'],
+                         indirect=True)
+def test_2d(celestial_wcs):
+
+    # Upsample along the first pixel dimension and downsample along the second
+    # pixel dimension.
+    wcs = ResampledLowLevelWCS(celestial_wcs, [0.4, 3])
+
+    # The following shouldn't change compared to the original WCS
+    assert wcs.pixel_n_dim == 2
+    assert wcs.world_n_dim == 2
+    assert tuple(wcs.world_axis_physical_types) == ('pos.eq.ra', 'pos.eq.dec')
+    assert tuple(wcs.world_axis_units) == ('deg', 'deg')
+    assert tuple(wcs.pixel_axis_names) == ('', '')
+    assert tuple(wcs.world_axis_names) == ('Right Ascension',
+                                           'Declination')
+    assert_equal(wcs.axis_correlation_matrix, np.ones((2,2)))
+
+    # Shapes and bounds should be floating-point if needed
+    assert_allclose(wcs.pixel_shape, (15, 7/3))
+    assert_allclose(wcs.array_shape, (7/3, 15))
+    assert_allclose(wcs.pixel_bounds, ((-2.5, 12.5), (1/3, 7/3)))
+
+    pixel_scalar = (2.3, 4.3)
+    world_scalar = (12.16, 13.8)
+    assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
+    assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
+    assert_allclose(wcs.world_to_array_index_values(*world_scalar), [4, 2])
+
+    pixel_array = (np.array([2.3, 2.4]),
+                   np.array([4.3, 4.4]))
+    world_array = (np.array([12.16, 12.08]),
+                   np.array([13.8, 14.4]))
+    assert_allclose(wcs.pixel_to_world_values(*pixel_array), world_array)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_array[::-1]), world_array)
+    assert_allclose(wcs.world_to_pixel_values(*world_array), pixel_array)
+    assert_allclose(wcs.world_to_array_index_values(*world_array),
+                    [[4, 4], [2, 2]])
+
+    wcs_hl = HighLevelWCSWrapper(wcs)
+
+    celestial = wcs_hl.pixel_to_world(*pixel_scalar)
+    assert isinstance(celestial, SkyCoord)
+    assert_quantity_allclose(celestial.ra, world_scalar[0] * u.deg)
+    assert_quantity_allclose(celestial.dec, world_scalar[1] * u.deg)
+
+    celestial = wcs_hl.pixel_to_world(*pixel_array)
+    assert isinstance(celestial, SkyCoord)
+    assert_quantity_allclose(celestial.ra, world_array[0] * u.deg)
+    assert_quantity_allclose(celestial.dec, world_array[1] * u.deg)
+
+    assert str(wcs) == EXPECTED_2D_REPR
+    assert repr(wcs) == EXPECTED_2D_REPR
+
+
+@pytest.mark.parametrize('celestial_wcs',
+                         ['celestial_2d_ape14_wcs', 'celestial_2d_fitswcs'],
+                         indirect=True)
+def test_scalar_factor(celestial_wcs):
+
+    wcs = ResampledLowLevelWCS(celestial_wcs, 2)
+
+    pixel_scalar = (2.3, 4.3)
+    world_scalar = (4.8, 5.2)
+    assert_allclose(wcs.pixel_to_world_values(*pixel_scalar), world_scalar)
+    assert_allclose(wcs.array_index_to_world_values(*pixel_scalar[::-1]), world_scalar)
+    assert_allclose(wcs.world_to_pixel_values(*world_scalar), pixel_scalar)
+    assert_allclose(wcs.world_to_array_index_values(*world_scalar), [4, 2])

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -10,7 +10,7 @@ from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
 from astropy.coordinates import SkyCoord, Galactic
 from astropy.units import Quantity
-from astropy.wcs.wcsapi.sliced_low_level_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
+from astropy.wcs.wcsapi.wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
 import astropy.units as u
 
 # To test the slicing we start off from standard FITS WCS

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -138,7 +138,8 @@ def test_ellipsis():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
+    assert str(wcs) == EXPECTED_ELLIPSIS_REPR.strip()
+    assert EXPECTED_ELLIPSIS_REPR.strip() in repr(wcs)
 
 
 def test_pixel_to_world_broadcasting():
@@ -208,7 +209,8 @@ def test_spectral_slice():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
+    assert str(wcs) == EXPECTED_SPECTRAL_SLICE_REPR.strip()
+    assert EXPECTED_SPECTRAL_SLICE_REPR.strip() in repr(wcs)
 
 
 EXPECTED_SPECTRAL_RANGE_REPR = """
@@ -274,7 +276,8 @@ def test_spectral_range():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-6, 14), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
+    assert str(wcs) == EXPECTED_SPECTRAL_RANGE_REPR.strip()
+    assert EXPECTED_SPECTRAL_RANGE_REPR.strip() in repr(wcs)
 
 
 EXPECTED_CELESTIAL_SLICE_REPR = """
@@ -339,7 +342,8 @@ def test_celestial_slice():
 
     assert_equal(wcs.pixel_bounds, [(-2, 18), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
+    assert str(wcs) == EXPECTED_CELESTIAL_SLICE_REPR.strip()
+    assert EXPECTED_CELESTIAL_SLICE_REPR.strip() in repr(wcs)
 
 
 EXPECTED_CELESTIAL_RANGE_REPR = """
@@ -405,7 +409,8 @@ def test_celestial_range():
 
     assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
+    assert str(wcs) == EXPECTED_CELESTIAL_RANGE_REPR.strip()
+    assert EXPECTED_CELESTIAL_RANGE_REPR.strip() in repr(wcs)
 
 
 # Now try with a 90 degree rotation
@@ -481,7 +486,8 @@ def test_celestial_range_rot():
 
     assert_equal(wcs.pixel_bounds, [(-6, 6), (-2, 18), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip()
+    assert str(wcs) == EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip()
+    assert EXPECTED_CELESTIAL_RANGE_ROT_REPR.strip() in repr(wcs)
 
 
 HEADER_NO_SHAPE_CUBE = """
@@ -566,7 +572,8 @@ def test_no_array_shape():
     assert_allclose(wcs.world_to_pixel_values(10, 20, 25), (29., 39., 44.))
     assert_equal(wcs.world_to_array_index_values(10, 20, 25), (44, 39, 29))
 
-    assert str(wcs) == repr(wcs) == EXPECTED_NO_SHAPE_REPR.strip()
+    assert str(wcs) == EXPECTED_NO_SHAPE_REPR.strip()
+    assert EXPECTED_NO_SHAPE_REPR.strip() in repr(wcs)
 
 
 # Testing the WCS object having some physical types as None/Unknown
@@ -653,7 +660,8 @@ def test_ellipsis_none_types():
 
     assert_equal(wcs.pixel_bounds, [(-1, 11), (-2, 18), (5, 15)])
 
-    assert str(wcs) == repr(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
+    assert str(wcs) == EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip()
+    assert EXPECTED_ELLIPSIS_REPR_NONE_TYPES.strip() in repr(wcs)
 
 
 CASES = [(slice(None), slice(None), slice(None)),


### PR DESCRIPTION
These APE 14 wrapper classes came out of discussions with @keflavich and @Cadair:

* A class to reorder pixel and world dimensions in an APE 14-compliant WCS
* A class to scale/resample pixel dimensions in an APE 14-compliant WCS
* A class to combine multiple APE 14-compliant WCSes, for example two spatial dimensions from a FITS WCS with a spectral dimension from a GWCS

One unrelated but significant change here is changing ``array_index_to_world_values`` and ``world_to_array_index_values`` to have a default implementation, since there's really no reason those need to be defined every time (we end up copy/pasting a lot of code) and instead can just always use the equivalent 'pixel' methods as a starting point.

We still need add a way for these classes to call out to implementation-specific alternatives (i.e. FITS WCS can implement these as pure FITS WCS modifications).