### PR TITLE
Changed OverflowError condition of fast ascii converter to >= |HUGE_VAL|

### DIFF
--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -1003,7 +1003,7 @@ double xstrtod(const char *str, char **endptr, char decimal,
         else if (exponent < 0)
             number /= e[-exponent];
 
-        if (number == HUGE_VAL || number == -HUGE_VAL)
+        if (number >= HUGE_VAL || number <= -HUGE_VAL)
             errno = ERANGE;
     }
 


### PR DESCRIPTION
Addressing #9694 - if we are right about the fast C converter internally calculating in 80 bit on some architectures like x86_64/gcc 9.2 (see discussion there), this will still raise an `OverflowError` when the returned value exceeds `np.float64` range (and becomes `inf`).

Fix #9694 