### PR TITLE
Change ascii.read with converters and names both specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,12 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Changed the behavior when reading a table where both the ``names`` argument
+  is provided (to specify the output column names) and the ``converters``
+  argument is provided (to specify column conversion functions). Previously the
+  ``converters`` dict names referred to the *input* table column names, but now
+  they refer to the *output* table column names. [#9739]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -53,6 +53,28 @@ def test_convert_overflow(fast_reader):
     assert dat['a'].dtype.kind == expected_kind
 
 
+def test_read_specify_converters_with_names():
+    """
+    Exact example from #9701: When using ascii.read with both the names and
+    converters arguments, the converters dictionary ignores the user-supplied
+    names and requires that you know the guessed names.
+    """
+    csv_text = '''a,b,c
+    1,2,3
+    4,5,6'''
+    names = ['A', 'B', 'C']
+
+    converters = {
+        'A': [ascii.convert_numpy(float)],
+        'B': [ascii.convert_numpy(int)],
+        'C': [ascii.convert_numpy(str)]
+    }
+    t = ascii.read(csv_text, format='csv', names=names, converters=converters)
+    assert t['A'].dtype.kind == 'f'
+    assert t['B'].dtype.kind == 'i'
+    assert t['C'].dtype.kind == 'U'
+
+
 def test_guess_with_names_arg():
     """
     Make sure reading a table with guess=True gives the expected result when

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -59,9 +59,7 @@ def test_read_specify_converters_with_names():
     converters arguments, the converters dictionary ignores the user-supplied
     names and requires that you know the guessed names.
     """
-    csv_text = '''a,b,c
-    1,2,3
-    4,5,6'''
+    csv_text = ['a,b,c', '1,2,3', '4,5,6']
     names = ['A', 'B', 'C']
 
     converters = {
@@ -73,6 +71,24 @@ def test_read_specify_converters_with_names():
     assert t['A'].dtype.kind == 'f'
     assert t['B'].dtype.kind == 'i'
     assert t['C'].dtype.kind == 'U'
+
+
+def test_read_remove_and_rename_columns():
+    csv_text = ['a,b,c', '1,2,3', '4,5,6']
+    reader = ascii.get_reader(Reader=ascii.Csv)
+    data = reader.read(csv_text)
+    header = reader.header
+    with pytest.raises(KeyError, match='Column NOT-EXIST does not exist'):
+        header.remove_columns(['NOT-EXIST'])
+
+    header.remove_columns(['c'])
+    assert header.colnames == ('a', 'b')
+
+    header.rename_column('a', 'aa')
+    assert header.colnames == ('aa', 'b')
+
+    with pytest.raises(KeyError, match='Column NOT-EXIST does not exist'):
+        header.rename_column('NOT-EXIST', 'aa')
 
 
 def test_guess_with_names_arg():

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -1087,7 +1087,7 @@ class LeapSeconds(QTable):
         # 32-bit systems without the np.int64 converter.
         self = cls._read_leap_seconds(
             file, names=names, include_names=names[:2],
-            converters={'col1': [convert_numpy(np.int64)]})
+            converters={'ntp_seconds': [convert_numpy(np.int64)]})
         self['mjd'] = (self['ntp_seconds']/86400 + 15020).round()
         # Note: cannot use Time.ymdhms, since that might require leap seconds.
         isot = Time(self['mjd'], format='mjd', scale='tai').isot


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Change the behavior when reading a table where both the ``names`` argument is provided (to specify the output column names) and the ``converters``  argument is provided (to specify column conversion functions). Previously the ``converters`` dict names referred to the *input* table column names, but now
  they refer to the *output* table column names.
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9701
