### PR TITLE
Add initial support for saving Dask arrays to FITS files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ astropy.io.misc
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
+- Added support for writing Dask arrays to disk efficiently for ``ImageHDU`` and
+  ``PrimaryHDU``. [#9742]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -54,7 +54,7 @@ explanation of all the different formats.
     around a single format and officially deprecate the other formats.
 """
 
-
+import pathlib
 import operator
 import os
 import warnings
@@ -72,6 +72,11 @@ from .util import fileobj_closed, fileobj_name, fileobj_mode, _is_int
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
+try:
+    from dask.array import Array as DaskArray
+except ImportError:
+    class DaskArray:
+        pass
 
 __all__ = ['getheader', 'getdata', 'getval', 'setval', 'delval', 'writeto',
            'append', 'update', 'info', 'tabledump', 'tableload',
@@ -1061,7 +1066,7 @@ def _makehdu(data, header):
         if ((isinstance(data, np.ndarray) and data.dtype.fields is not None) or
                 isinstance(data, np.recarray)):
             hdu = BinTableHDU(data, header=header)
-        elif isinstance(data, np.ndarray):
+        elif isinstance(data, (np.ndarray, DaskArray)):
             hdu = ImageHDU(data, header=header)
         else:
             raise KeyError('Data must be a numpy array.')
@@ -1069,6 +1074,8 @@ def _makehdu(data, header):
 
 
 def _stat_filename_or_fileobj(filename):
+    if isinstance(filename, pathlib.Path):
+        filename = str(filename)
     closed = fileobj_closed(filename)
     name = fileobj_name(filename) or ''
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -43,7 +43,7 @@ IO_FITS_MODES = {
     'copyonwrite': 'rb',
     'update': 'rb+',
     'append': 'ab+',
-    'ostream': 'wb+',
+    'ostream': 'wb',
     'denywrite': 'rb'}
 
 # Maps OS-level file modes to the appropriate astropy.io.fits specific mode

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -35,7 +35,9 @@ else:
 
 
 # Maps astropy.io.fits-specific file mode names to the appropriate file
-# modes to use for the underlying raw files
+# modes to use for the underlying raw files. Note that we need ostream to
+# be wb+ instead of wb since when writing FITS files with dask arrays we
+# need to be able to use a writable mmap to part of the file.
 IO_FITS_MODES = {
     'readonly': 'rb',
     'copyonwrite': 'rb',

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -35,9 +35,7 @@ else:
 
 
 # Maps astropy.io.fits-specific file mode names to the appropriate file
-# modes to use for the underlying raw files. Note that we need ostream to
-# be wb+ instead of wb since when writing FITS files with dask arrays we
-# need to be able to use a writable mmap to part of the file.
+# modes to use for the underlying raw files.
 IO_FITS_MODES = {
     'readonly': 'rb',
     'copyonwrite': 'rb',

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -41,7 +41,7 @@ IO_FITS_MODES = {
     'copyonwrite': 'rb',
     'update': 'rb+',
     'append': 'ab+',
-    'ostream': 'wb',
+    'ostream': 'wb+',
     'denywrite': 'rb'}
 
 # Maps OS-level file modes to the appropriate astropy.io.fits specific mode

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -668,7 +668,7 @@ class _ImageBaseHDU(_ValidHDU):
 
         if should_swap:
             from dask.utils import M
-            # NOTE: the byteswap flag needs to be False otherwise the array is
+            # NOTE: the inplace flag to byteswap needs to be False otherwise the array is
             # byteswapped in place every time it is computed and this affects
             # the input dask array.
             output = output.map_blocks(M.byteswap, False).map_blocks(M.newbyteorder, "S")
@@ -682,7 +682,7 @@ class _ImageBaseHDU(_ValidHDU):
         fileobj.flush()
 
         outmmap = mmap.mmap(fileobj._file.fileno(),
-                            initial_position+n_bytes,
+                            initial_position + n_bytes,
                             access=mmap.ACCESS_WRITE)
 
         outarr = np.ndarray(shape=output.shape,

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -690,7 +690,7 @@ class _ImageBaseHDU(_ValidHDU):
         fileobj.flush()
 
         outmmap = mmap.mmap(fileobj._file.fileno(),
-                            initial_position + n_bytes,
+                            length=initial_position + n_bytes,
                             access=mmap.ACCESS_WRITE)
 
         outarr = np.ndarray(shape=output.shape,
@@ -701,6 +701,11 @@ class _ImageBaseHDU(_ValidHDU):
         output.store(outarr, lock=True, compute=True)
 
         outmmap.close()
+
+        # On Windows closing the memmap causes the file pointer to return to 0, so
+        # we need to go back to the end of the data (since padding may be written
+        # after)
+        fileobj.seek(initial_position + n_bytes)
 
         return n_bytes
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -700,6 +700,8 @@ class _ImageBaseHDU(_ValidHDU):
 
         output.store(outarr, lock=True, compute=True)
 
+        outmmap.close()
+
         return n_bytes
 
     def _dtype_for_bitpix(self):

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -518,13 +518,13 @@ class _ImageBaseHDU(_ValidHDU):
 
         # Do the scaling
         if _zero != 0:
-            # 0.9.6.3 to avoid out of range error for BZERO = +32768
-            # We have to explcitly cast _zero to prevent numpy from raising an
-            # error when doing self.data -= zero, and we do this instead of
-            # self.data = self.data - zero to avoid doubling memory usage.
             if isinstance(self.data, DaskArray):
                 self.data = self.data - _zero
             else:
+                # 0.9.6.3 to avoid out of range error for BZERO = +32768
+                # We have to explcitly cast _zero to prevent numpy from raising an
+                # error when doing self.data -= zero, and we do this instead of
+                # self.data = self.data - zero to avoid doubling memory usage.
                 np.add(self.data, -_zero, out=self.data, casting='unsafe')
             self._header['BZERO'] = _zero
         else:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -652,19 +652,8 @@ class _ImageBaseHDU(_ValidHDU):
 
             return size
 
-    @staticmethod
-    def _dask_byteswap(array):
-        import dask.array
-        from dask import delayed
-
-        @delayed
-        def _byteswap(arr):
-            return np.array(arr).byteswap(True).newbyteorder("S")
-
-        return dask.array.from_delayed(_byteswap(array), shape=array.shape,
-                                       dtype=array.dtype.newbyteorder("S"))
-
     def _writeinternal_dask(self, fileobj):
+
         size = 0
 
         if sys.byteorder == 'little':
@@ -680,8 +669,8 @@ class _ImageBaseHDU(_ValidHDU):
             should_swap = (byteorder in swap_types)
 
         if should_swap:
-            # output = output.map_blocks(M.byteswap, True).map_blocks(M.newbyteorder, "S")
-            output = self._dask_byteswap(output)
+            from dask.utils import M
+            output = output.map_blocks(M.byteswap, True).map_blocks(M.newbyteorder, "S")
 
         initial_position = fileobj.tell()
         n_bytes = output.nbytes

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -689,18 +689,30 @@ class _ImageBaseHDU(_ValidHDU):
         fileobj.write(b'\0')
         fileobj.flush()
 
-        outmmap = mmap.mmap(fileobj._file.fileno(),
-                            length=initial_position + n_bytes,
-                            access=mmap.ACCESS_WRITE)
+        if fileobj.fileobj_mode not in ('rb+', 'wb+', 'ab+'):
+            # Use another file handle if the current one is not in
+            # read/write mode
+            fp = open(fileobj.name, mode='rb+')
+            should_close = True
+        else:
+            fp = fileobj._file
+            should_close = False
 
-        outarr = np.ndarray(shape=output.shape,
-                            dtype=output.dtype,
-                            offset=initial_position,
-                            buffer=outmmap)
+        try:
+            outmmap = mmap.mmap(fp.fileno(),
+                                length=initial_position + n_bytes,
+                                access=mmap.ACCESS_WRITE)
 
-        output.store(outarr, lock=True, compute=True)
+            outarr = np.ndarray(shape=output.shape,
+                                dtype=output.dtype,
+                                offset=initial_position,
+                                buffer=outmmap)
 
-        outmmap.close()
+            output.store(outarr, lock=True, compute=True)
+        finally:
+            if should_close:
+                fp.close()
+            outmmap.close()
 
         # On Windows closing the memmap causes the file pointer to return to 0, so
         # we need to go back to the end of the data (since padding may be written

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -59,14 +59,20 @@ def test_save_hdulist(dask_array_in_mem, tmp_path):
 
     filename = tmp_path / 'test.fits'
 
-    hdu = PrimaryHDU(data=dask_array_in_mem)
-    hdulist = fits.HDUList([hdu])
+    hdu1 = PrimaryHDU(data=dask_array_in_mem)
+    hdu2 = ImageHDU(data=np.random.random((128, 128)))
+    hdu3 = ImageHDU(data=dask_array_in_mem * 2)
+    hdulist = fits.HDUList([hdu1, hdu2, hdu3])
     assert isinstance(hdulist[0].data, da.Array)
     hdulist.writeto(filename)
 
     with fits.open(filename) as hdulist_new:
         assert isinstance(hdulist_new[0].data, np.ndarray)
         np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+        assert isinstance(hdulist_new[1].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[1].data, hdu2.data)
+        assert isinstance(hdulist_new[2].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[2].data, dask_array_in_mem.compute() * 2)
 
 
 def test_long_header(dask_array_in_mem, tmp_path):

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -155,3 +155,22 @@ def test_append(dask_array_in_mem, tmp_path):
         np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
         assert isinstance(hdulist_new[1].data, np.ndarray)
         np.testing.assert_allclose(hdulist_new[1].data, np.arange(10))
+
+
+# @pytest.mark.parametrize('mode', ['rb+', 'ab', 'ab+', 'wb', 'wb+'])
+@pytest.mark.parametrize('mode', ['wb', 'wb+'])
+def test_file_handle(mode, dask_array_in_mem, tmp_path):
+
+    filename = tmp_path / 'test.fits'
+    hdu1 = PrimaryHDU(data=dask_array_in_mem)
+    hdu2 = ImageHDU(data=np.arange(10))
+    hdulist = fits.HDUList([hdu1, hdu2])
+
+    with filename.open(mode=mode) as fp:
+        hdulist.writeto(fp)
+
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+        assert isinstance(hdulist_new[1].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[1].data, np.arange(10))

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -139,3 +139,19 @@ def test_scaled_minmax(dask_array_in_mem, tmp_path):
     with fits.open(filename) as hdulist_new:
         assert isinstance(hdulist_new[0].data, np.ndarray)
         np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute(), atol=1e-5)
+
+
+def test_append(dask_array_in_mem, tmp_path):
+
+    # Test append mode
+
+    filename = tmp_path / 'test.fits'
+
+    fits.append(filename, dask_array_in_mem)
+    fits.append(filename, np.arange(10))
+
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+        assert isinstance(hdulist_new[1].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[1].data, np.arange(10))

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -1,41 +1,91 @@
+# Tests related to writing dask arrays to FITS files in an efficient way
+
 import pytest
 
-pytest.importorskip("dask.array")
-
 import numpy as np
-import dask.array
-dask.config.set(scheduler='synchronous')
-
 from astropy.io import fits
-from astropy.io.fits import ImageHDU
+from astropy.io.fits import ImageHDU, PrimaryHDU
+
+da = pytest.importorskip("dask.array")
 
 
 @pytest.fixture
 def dask_array_in_mem():
-    return dask.array.from_array(np.random.random((10, 10)))
+    return da.from_array(np.random.random((1322, 755))).rechunk((59, 55))
 
 
 def test_construct_image_hdu(dask_array_in_mem):
     hdu = ImageHDU(data=dask_array_in_mem)
-    assert isinstance(hdu.data, dask.array.Array)
+    assert isinstance(hdu.data, da.Array)
 
 
-def test_construct_hdul(dask_array_in_mem):
+def test_construct_hdulist(dask_array_in_mem):
     hdu = ImageHDU(data=dask_array_in_mem)
-    hdul = fits.HDUList([hdu])
-    assert isinstance(hdul[0].data, dask.array.Array)
+    hdulist = fits.HDUList([hdu])
+    assert isinstance(hdulist[0].data, da.Array)
 
 
-def test_save_hdul(dask_array_in_mem, tmp_path):
-    fname = "/tmp/test_save_hdul.fits"
+def test_save_primary_hdu(dask_array_in_mem, tmp_path):
+
+    # Saving a Primary HDU directly
+
+    filename = tmp_path / 'test.fits'
+
+    hdu = PrimaryHDU(data=dask_array_in_mem)
+    hdu.writeto(filename)
+
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+
+
+def test_save_image_hdu(dask_array_in_mem, tmp_path):
+
+    # Saving an image HDU directly
+
+    filename = tmp_path / 'test.fits'
+
     hdu = ImageHDU(data=dask_array_in_mem)
-    hdul = fits.HDUList([hdu])
-    assert isinstance(hdul[0].data, dask.array.Array)
+    hdu.writeto(filename)
 
-    with open(fname, "wb+") as fobj:
-        hdu.writeto(fobj)
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[1].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[1].data, dask_array_in_mem.compute())
 
 
-    with fits.open(fname) as newhdul:
-        assert isinstance(newhdul[1].data, np.ndarray)
-        assert np.allclose(newhdul[1].data, dask_array_in_mem.compute())
+def test_save_hdulist(dask_array_in_mem, tmp_path):
+
+    # Saving an HDUList
+
+    filename = tmp_path / 'test.fits'
+
+    hdu = PrimaryHDU(data=dask_array_in_mem)
+    hdulist = fits.HDUList([hdu])
+    assert isinstance(hdulist[0].data, da.Array)
+    hdulist.writeto(filename)
+
+    with fits.open(filename) as hdulist_new:
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())
+
+
+def test_long_header(dask_array_in_mem, tmp_path):
+
+    # Make sure things work correctly if there is a long header in the HDU.
+
+    filename = tmp_path / 'test.fits'
+
+    # NOTE: we deliberately set up a long header here rather than add the
+    # keys one by one to hdu.header as adding the header in one go used to
+    # cause issues, so this acts as a regression test.
+    header = fits.Header()
+    for index in range(2048):
+        header[f'KEY{index:x}'] = 0.
+
+    hdu = PrimaryHDU(data=dask_array_in_mem, header=header)
+    hdu.writeto(filename)
+
+    with fits.open(filename) as hdulist_new:
+        assert len(hdulist_new[0].header) == 2053
+        assert isinstance(hdulist_new[0].data, np.ndarray)
+        np.testing.assert_allclose(hdulist_new[0].data, dask_array_in_mem.compute())

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -1,0 +1,41 @@
+import pytest
+
+pytest.importorskip("dask.array")
+
+import numpy as np
+import dask.array
+dask.config.set(scheduler='synchronous')
+
+from astropy.io import fits
+from astropy.io.fits import ImageHDU
+
+
+@pytest.fixture
+def dask_array_in_mem():
+    return dask.array.from_array(np.random.random((10, 10)))
+
+
+def test_construct_image_hdu(dask_array_in_mem):
+    hdu = ImageHDU(data=dask_array_in_mem)
+    assert isinstance(hdu.data, dask.array.Array)
+
+
+def test_construct_hdul(dask_array_in_mem):
+    hdu = ImageHDU(data=dask_array_in_mem)
+    hdul = fits.HDUList([hdu])
+    assert isinstance(hdul[0].data, dask.array.Array)
+
+
+def test_save_hdul(dask_array_in_mem, tmp_path):
+    fname = "/tmp/test_save_hdul.fits"
+    hdu = ImageHDU(data=dask_array_in_mem)
+    hdul = fits.HDUList([hdu])
+    assert isinstance(hdul[0].data, dask.array.Array)
+
+    with open(fname, "wb+") as fobj:
+        hdu.writeto(fobj)
+
+
+    with fits.open(fname) as newhdul:
+        assert isinstance(newhdul[1].data, np.ndarray)
+        assert np.allclose(newhdul[1].data, dask_array_in_mem.compute())

--- a/docs/io/fits/index.rst
+++ b/docs/io/fits/index.rst
@@ -314,9 +314,9 @@ would with a dict::
 Structural Keywords
 """""""""""""""""""
 
-FITS keywords mix up both metadata and critical information about the file structure 
+FITS keywords mix up both metadata and critical information about the file structure
 that is needed to parse the file. These *structural* keywords are managed internally by
-:mod:`astropy.io.fits` and, in general, should not be touched by the user. Instead one 
+:mod:`astropy.io.fits` and, in general, should not be touched by the user. Instead one
 should use  the related attributes of the `astropy.io.fits` classes (see examples below).
 
 The specific set of structural keywords used by the FITS standard varies with HDU type.
@@ -332,10 +332,10 @@ The following table lists which keywords are associated with each HDU type:
    ":class:`GroupsHDU`", "``NAXIS1``, ``GCOUNT``, ``PCOUNT``, ``GROUPS``"
    ":class:`TableHDU`, :class:`BinTableHDU`", "``TFIELDS``, ``TFORM``, ``TBCOL``"
 
-There are many other reserved keywords, for instance for the data scaling, or for table's column 
-attributes, as described in the  `FITS Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`__. 
-Most of these are accessible via attributes of the :class:`Column` or HDU objects, for instance 
-``hdu.name`` to set ``EXTNAME``, or ``hdu.ver`` for ``EXTVER``. Structural keywords are checked 
+There are many other reserved keywords, for instance for the data scaling, or for table's column
+attributes, as described in the  `FITS Standard <https://fits.gsfc.nasa.gov/fits_standard.html>`__.
+Most of these are accessible via attributes of the :class:`Column` or HDU objects, for instance
+``hdu.name`` to set ``EXTNAME``, or ``hdu.ver`` for ``EXTVER``. Structural keywords are checked
 and/or updated as a consequence of common operations. For example, when:
 
 1. Setting the data. The ``NAXIS*`` keywords are set from the data shape (``.data.shape``), and ``BITPIX``
@@ -972,6 +972,7 @@ Other Information
 .. note that if this section gets too long, it should be moved to a separate
    doc page - see the top of performance.inc.rst for the instructions on how to do
    that
+
 .. include:: performance.inc.rst
 
 Reference/API

--- a/docs/io/fits/performance.inc.rst
+++ b/docs/io/fits/performance.inc.rst
@@ -5,6 +5,22 @@
 
 .. _astropy-io-fits-performance:
 
+Performance Tips
+================
+
+It is possible to set the data array for :class:`~astropy.io.fits.PrimaryHDU`
+and :class:`~astropy.io.fits.ImageHDU` to a `dask <https://dask.org/>`_ array.
+If this is written to disk, the dask array will be computed as it is being
+written, which will avoid using excessive memory:
+
+.. doctest-requires:: dask
+
+    >>> import dask.array as da
+    >>> array = da.random.random((1000, 1000))
+    >>> from astropy.io import fits
+    >>> hdu = fits.PrimaryHDU(data=array)
+    >>> hdu.writeto('test_dask.fits')
+
 .. TODO: determine whether the following is quantitatively true, and either
 .. uncomment or remove.
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -18,3 +18,20 @@ In particular, this release includes:
    already defined in the ``astropy.io.fits.HDUList`` object.
 
 2. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
+
+
+Support for writing Dask arrays to FITS files
+=============================================
+
+It is now possible to set the data array for :class:`~astropy.io.fits.PrimaryHDU`
+and :class:`~astropy.io.fits.ImageHDU` to a `dask <https://dask.org/>`_ array.
+If this is written to disk, the dask array will be computed as it is being
+written, which will avoid using excessive memory:
+
+.. doctest-requires:: dask
+
+    >>> import dask.array as da
+    >>> array = da.random.random((1000, 1000))
+    >>> from astropy.io import fits
+    >>> hdu = fits.PrimaryHDU(data=array)
+    >>> hdu.writeto('test_dask.fits')

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,9 +52,9 @@ test =
     ipython
     coverage
     skyfield
-    dask[array]
 all =
     scipy>=0.18
+    dask[array]
     h5py
     beautifulsoup4
     html5lib

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ test =
     ipython
     coverage
     skyfield
+    dask[array]
 all =
     scipy>=0.18
     h5py


### PR DESCRIPTION
The objective of this is to allow you to construct an `ImageHDU` object with a Dask array object as it's `data=` argument, and then not have this casted to a `np.ndarray` or have to be all loaded into memory.

We use `dask.array.store` to save the array to the memmap inside the fits file once we have allocated the block in the file. The main limitation of this is that by default when a file is opened for writing, i.e. with `HDUList.writeto` the file is opened with `wb` which isn't compatible with using mmap inside the file, so for the moment to use this you need to do:

```python
hdu = ImageHDU(data=dask.array.Array())
with open("test.fits", "wb+") as fobj:
    hdu.writeto(fobj)
```

(EDIT from @astrofrog - this PR now changes the wb mode to wb+ so that we can write things out with vanilla writeto)