### PR TITLE
MNT: Fix broken Sphinx doc links

### DIFF
--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -112,7 +112,7 @@ install sphinx-astropy_ and all its dependencies automatically.
 .. _numpydoc: https://pypi.org/project/numpydoc/
 .. _Matplotlib: https://matplotlib.org/
 .. _SciPy: https://www.scipy.org/
-.. _Sphinx: http://sphinx.pocoo.org
+.. _Sphinx: http://www.sphinx-doc.org/
 .. _sphinx-automodapi: https://github.com/astropy/sphinx-automodapi
 .. _astropy-sphinx-theme: https://github.com/astropy/astropy-sphinx-theme
 .. _sphinx-astropy: https://github.com/astropy/sphinx-astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -404,7 +404,7 @@ In addition to providing configuration common to packages in the Astropy
 ecosystem, this package also serves as a way to automatically get the main
 dependencies, including:
 
-* `Sphinx <http://sphinx.pocoo.org>`_ - the main package we use to build
+* `Sphinx <http://www.sphinx-doc.org/>`_ - the main package we use to build
   the documentation
 * `astropy-sphinx-theme <https://github.com/astropy/astropy-sphinx-theme>`_ -
   the default 'bootstrap' theme used by ``astropy`` and a number of affiliated


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

I think Sphinx moved their docs. Old link is reportedly broken by cron job.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
