### PR TITLE
Add bullet point to code style guide to discourage automatic code formatters and encourage PEP 8 check

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -141,7 +141,7 @@ Coding Style/Conventions
 * Our testing infrastructure currently enforces a subset of the PEP8 style
   guide. You can check locally whether your changes have followed these by
   running `flake8 <https://pypi.org/project/flake8/>`_ with the following
-  command:
+  command::
 
     flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
 

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -143,6 +143,10 @@ Coding Style/Conventions
   maximum line length for different subpackages (typically either 80 or 100
   characters).  Please try to maintain the style when adding or modifying code.
 
+* The use of automatic code formatters (e.g.,
+  `Black <https://black.readthedocs.io/en/stable/>`_) is strongly discouraged in
+  contributions to Astropy.
+
 * Following PEP8's recommendation, absolute imports are to be used in general.
   The exception to this is relative imports of the form
   ``from . import modname``, best when referring to files within the same

--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -138,6 +138,13 @@ Coding Style/Conventions
   <https://www.python.org/dev/peps/pep-0008/>`_. In particular, this includes
   using only 4 spaces for indentation, and never tabs.
 
+* Our testing infrastructure currently enforces a subset of the PEP8 style
+  guide. You can check locally whether your changes have followed these by
+  running `flake8 <https://pypi.org/project/flake8/>`_ with the following
+  command:
+
+    flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823
+
 * *Follow the existing coding style* within a subpackage and avoid making
   changes that are purely stylistic.  In particular, there is variation in the
   maximum line length for different subpackages (typically either 80 or 100


### PR DESCRIPTION
This adds a bullet point to the [Coding Style/Conventions](http://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions) that explicitly discourages use of automatic code formatters.