### PR TITLE
Add pep8speaks configuration file

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,47 @@
+scanner:
+    diff_only: True
+    linter: flake8
+
+flake8:
+    max-line-length: 100
+    select:
+        - E101 # mix of tabs and spaces
+        - W191 # use of tabs
+        - W291 # trailing whitespace
+        - W292 # no newline at end of file
+        - W293 # trailing whitespace
+        - W391 # blank line at end of file
+        - E111 # 4 spaces per indentation level
+        - E112 # 4 spaces per indentation level
+        - E113 # 4 spaces per indentation level
+        - E301 # expected 1 blank line, found 0
+        - E302 # expected 2 blank lines, found 0
+        - E303 # too many blank lines (3)
+        - E304 # blank lines found after function decorator
+        - E305 # expected 2 blank lines after class or function definition
+        - E306 # expected 1 blank line before a nested definition
+        - E502 # the backslash is redundant between brackets
+        - E722 # do not use bare except
+        - E901 # SyntaxError or IndentationError
+        - E902 # IOError
+        - E999 # SyntaxError -- failed to compile a file into an Abstract Syntax Tree
+        - F822 # undefined name in __all__
+        - F823 # local variable name referenced before assignment
+
+no_blank_comment: True
+descending_issues_order: False
+
+message:
+    opened:
+        header: >
+          Hello @{name} :wave:! Thanks for opening this pull request, we are
+          very grateful for your contribution! I'm a friendly :robot: that
+          checks for style issues in this pull request, since this project
+          follows the [PEP8](https://www.python.org/dev/peps/pep-0008/) style
+          guidelines. I've listed some small issues I found below, but please
+          don't hesitate to ask if any of them are unclear!
+    updated:
+        header: >
+          Hello @{name} :wave:! It looks like you've made some changes in your
+          pull request, so I've checked the code again for style.
+    no_errors: "There are no PEP8 style issues with this pull request - thanks! :tada:"


### PR DESCRIPTION
Before we enable pep8speaks, I wanted to add a configuration file to customize the warnings to ignore/select, and to customize the messages. Currently here are examples of what this looks like:

**First time a PR is opened, with issues**

<img width="823" alt="Screenshot 2019-12-11 at 09 47 15" src="https://user-images.githubusercontent.com/314716/70642480-81b43180-1bfc-11ea-8b46-43b0861d09b7.png">

**First time a PR is opened, with no issues**

No message is shown

**When PR is updated, with issues**

<img width="832" alt="Screenshot 2019-12-11 at 09 53 41" src="https://user-images.githubusercontent.com/314716/70642579-af997600-1bfc-11ea-8e05-248f0302f48a.png">

**When PR is updated, with no issues**

<img width="821" alt="Screenshot 2019-12-11 at 09 54 19" src="https://user-images.githubusercontent.com/314716/70642593-b45e2a00-1bfc-11ea-8370-6c11044afe88.png">

One thing that is missing is a command to show how to run the PEP8 fixes locally, but I think that command is a bit scary for now, so I'd suggest we first try and fix a bunch of PEP8 issues that don't happen too often and then switch to ignoring instead of selecting error codes, which will allow the command to be shorter.
