### PR TITLE
Change import Exception for missing bz2/lzma to ModuleNotFoundError

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -160,6 +160,10 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Changed the exception raised by ``get_readable_fileobj`` on missing
+  compression modules (for ``bz2`` or ``lzma``/``xz`` support) to
+  ``ModuleNotFoundError``, consistent with ``io.fits`` file handlers. [#9761]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -280,9 +280,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ValueError(
-                ".bz2 format files are not supported since the Python "
-                "interpreter does not include the bz2 module")
+            raise ModuleNotFoundError(
+                "This Python installation does not provide the bz2 module.")
         try:
             # bz2.BZ2File does not support file objects, only filenames, so we
             # need to write the data to a temporary file
@@ -307,9 +306,8 @@ def get_readable_fileobj(name_or_obj, encoding=None, cache=False,
         except ImportError:
             for fd in close_fds:
                 fd.close()
-            raise ValueError(
-                ".xz format files are not supported since the Python "
-                "interpreter does not include the lzma module.")
+            raise ModuleNotFoundError(
+                "This Python installation does not provide the lzma module.")
         except (OSError, EOFError):  # invalid xz file
             fileobj.seek(0)
             fileobj_new.close()

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -825,10 +825,10 @@ def test_local_data_obj_invalid(bad_compressed):
     # created by pytest. However, we can still use get_readable_fileobj for the
     # test.
     if (not HAS_BZ2 and is_bz2) or (not HAS_XZ and is_xz):
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ModuleNotFoundError,
+                           match=r'does not provide the [lb]z[2m]a? module\.'):
             with get_readable_fileobj(bad_compressed, encoding="binary") as f:
                 f.read()
-        assert " format files are not supported" in str(e.value)
     else:
         with get_readable_fileobj(bad_compressed, encoding="binary") as f:
             assert f.read().rstrip().endswith(b"invalid")


### PR DESCRIPTION
Fixes #9713 - test adapted accordingly, though the `not HAS_BZ2`/`not HAS_XZ` branches are probably rarely ever run.
