### PR TITLE
Add a counter to keep track of SkyCoord initializations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The ``SkyCoord`` class now maintains a counter to keep track of the number of
+  times it has been initialized. Once the number exceeds the config value
+  ``skycoord_init_counter_warn_threshold``, the initializer raises a warning to
+  suggest that the user use array-valued components. Set the threshold to 0 to
+  disable. [#9764]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/__init__.py
+++ b/astropy/coordinates/__init__.py
@@ -21,3 +21,22 @@ from .sky_coordinate import *
 from .funcs import *
 from .calculation import *
 from .solar_system import *
+
+
+from astropy import config as _config
+
+
+class Conf(_config.ConfigNamespace):
+    """
+    Configuration parameters for `astropy.coordinates`.
+    """
+
+    skycoord_init_counter_warn_threshold = _config.ConfigItem(
+        100,
+        'This controls the (globally-counted) number of SkyCoord '
+        'initializations that will trigger a warning to the user. To disable '
+        'this counter and warning, set this config item to 0.'
+    )
+
+
+conf = Conf()


### PR DESCRIPTION
I opted for an absolute number instead of a rate because I think this should be a very simple check.

This fixes #9744.