### PR TITLE
Flake8 compliance --ignore=W503,E402,E721,E731

### DIFF
--- a/astropy/time/__init__.py
+++ b/astropy/time/__init__.py
@@ -1,3 +1,3 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .formats import *
-from .core import *
+from .formats import *  # noqa
+from .core import *  # noqa

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1530,10 +1530,17 @@ class Time(ShapedLikeNDArray):
 
         if keepdims and indices.ndim < self.ndim:
             indices = np.expand_dims(indices, axis)
-        return tuple([(indices if i == axis else np.arange(s).reshape(
-            (1,) * (i if keepdims or i < axis else i - 1) + (s,)
-            + (1,) * (ndim - i - (1 if keepdims or i > axis else 2))))
-            for i, s in enumerate(self.shape)])
+
+        index = [indices
+                 if i == axis
+                 else np.arange(s).reshape(
+                     (1,) * (i if keepdims or i < axis else i - 1)
+                     + (s,)
+                     + (1,) * (ndim - i - (1 if keepdims or i > axis else 2))
+                 )
+                 for i, s in enumerate(self.shape)]
+
+        return tuple(index)
 
     def argmin(self, axis=None, out=None):
         """Return indices of the minimum values along the given axis.

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -28,18 +28,19 @@ from .formats import (TIME_FORMATS, TIME_DELTA_FORMATS,
                       TimeJD, TimeUnique, TimeAstropyTime, TimeDatetime)
 # Import TimeFromEpoch to avoid breaking code that followed the old example of
 # making a custom timescale in the documentation.
-from .formats import TimeFromEpoch  # pylint: disable=W0611
+from .formats import TimeFromEpoch  # noqa
 
 from astropy.extern import _strptime
 
-__all__ = ['Time', 'TimeDelta',  'TimeInfo', 'update_leap_seconds',
+__all__ = ['Time', 'TimeDelta', 'TimeInfo', 'update_leap_seconds',
            'TIME_SCALES', 'STANDARD_TIME_SCALES', 'TIME_DELTA_SCALES',
            'ScaleValueError', 'OperandTypeError']
 
 
 STANDARD_TIME_SCALES = ('tai', 'tcb', 'tcg', 'tdb', 'tt', 'ut1', 'utc')
 LOCAL_SCALES = ('local',)
-TIME_TYPES = dict((scale, scales) for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES) for scale in scales)
+TIME_TYPES = dict((scale, scales) for scales in (STANDARD_TIME_SCALES, LOCAL_SCALES)
+                  for scale in scales)
 TIME_SCALES = STANDARD_TIME_SCALES + LOCAL_SCALES
 MULTI_HOPS = {('tai', 'tcb'): ('tt', 'tdb'),
               ('tai', 'tcg'): ('tt',),
@@ -429,8 +430,8 @@ class Time(ShapedLikeNDArray):
                                  precision, in_subfmt, out_subfmt)
             self.SCALES = TIME_TYPES[self.scale]
 
-        if self.location is not None and (self.location.size > 1 and
-                                          self.location.shape != self.shape):
+        if self.location is not None and (self.location.size > 1
+                                          and self.location.shape != self.shape):
             try:
                 # check the location can be broadcast to self's shape.
                 self.location = np.broadcast_to(self.location, self.shape,
@@ -469,11 +470,11 @@ class Time(ShapedLikeNDArray):
                                  'they cannot be broadcast together.')
 
         if scale is not None:
-            if not (isinstance(scale, str) and
-                    scale.lower() in self.SCALES):
+            if not (isinstance(scale, str)
+                    and scale.lower() in self.SCALES):
                 raise ScaleValueError("Scale {!r} is not in the allowed scales "
                                       "{}".format(scale,
-                                                   sorted(self.SCALES)))
+                                                  sorted(self.SCALES)))
 
         # If either of the input val, val2 are masked arrays then
         # find the masked elements and fill them.
@@ -503,8 +504,8 @@ class Time(ShapedLikeNDArray):
         guess available formats and stop when one matches.
         """
 
-        if (format is None and
-                (val.dtype.kind in ('S', 'U', 'O', 'M') or val.dtype.names)):
+        if (format is None
+                and (val.dtype.kind in ('S', 'U', 'O', 'M') or val.dtype.names)):
             # Input is a string, object, datetime, or a table-like ndarray
             # (structured array, recarray). These input types can be
             # uniquely identified by the format classes.
@@ -515,15 +516,15 @@ class Time(ShapedLikeNDArray):
             # but try to guess it at the end.
             formats.append(('astropy_time', TimeAstropyTime))
 
-        elif not (isinstance(format, str) and
-                  format.lower() in self.FORMATS):
+        elif not (isinstance(format, str)
+                  and format.lower() in self.FORMATS):
             if format is None:
                 raise ValueError("No time format was given, and the input is "
                                  "not unique")
             else:
                 raise ValueError("Format {!r} is not one of the allowed "
                                  "formats {}".format(format,
-                                                      sorted(self.FORMATS)))
+                                                     sorted(self.FORMATS)))
         else:
             formats = [(format, self.FORMATS[format])]
 
@@ -538,7 +539,7 @@ class Time(ShapedLikeNDArray):
                 # If ``format`` specified then there is only one possibility, so raise
                 # immediately and include the upstream exception message to make it
                 # easier for user to see what is wrong.
-                if len(formats)==1:
+                if len(formats) == 1:
                     raise ValueError(
                         f'Input values did not match the format class {format}:'
                         + os.linesep
@@ -728,7 +729,8 @@ class Time(ShapedLikeNDArray):
                               date_tuple[6], date_tuple[7], -1)
             fmtd_str = format_spec
             if '%f' in fmtd_str:
-                fmtd_str = fmtd_str.replace('%f', '{frac:0{precision}}'.format(frac=sk['fracsec'], precision=self.precision))
+                fmtd_str = fmtd_str.replace('%f', '{frac:0{precision}}'.format(
+                    frac=sk['fracsec'], precision=self.precision))
             fmtd_str = strftime(fmtd_str, datetime_tuple)
             formatted_strings.append(fmtd_str)
 
@@ -1105,8 +1107,8 @@ class Time(ShapedLikeNDArray):
             # a Location object.
             if self_location is None and value.location is None:
                 match = True
-            elif ((self_location is None and value.location is not None) or
-                  (self_location is not None and value.location is None)):
+            elif ((self_location is None and value.location is not None)
+                  or (self_location is not None and value.location is None)):
                 match = False
             else:
                 match = np.all(self_location == value.location)
@@ -1204,7 +1206,7 @@ class Time(ShapedLikeNDArray):
             location = self.location
 
         from astropy.coordinates import (UnitSphericalRepresentation, CartesianRepresentation,
-                                   HCRS, ICRS, GCRS, solar_system_ephemeris)
+                                         HCRS, ICRS, GCRS, solar_system_ephemeris)
 
         # ensure sky location is ICRS compatible
         if not skycoord.is_transformable_to(ICRS()):
@@ -1292,11 +1294,11 @@ class Time(ShapedLikeNDArray):
             longitude = self.location.lon
         elif longitude == 'greenwich':
             longitude = Longitude(0., u.degree,
-                                  wrap_angle=180.*u.degree)
+                                  wrap_angle=180. * u.degree)
         else:
             # sanity check on input
             longitude = Longitude(longitude, u.degree,
-                                  wrap_angle=180.*u.degree)
+                                  wrap_angle=180. * u.degree)
 
         gst = self._erfa_sidereal_time(available_models[model.upper()])
         return Longitude(gst + longitude, u.hourangle)
@@ -1529,9 +1531,9 @@ class Time(ShapedLikeNDArray):
         if keepdims and indices.ndim < self.ndim:
             indices = np.expand_dims(indices, axis)
         return tuple([(indices if i == axis else np.arange(s).reshape(
-            (1,)*(i if keepdims or i < axis else i-1) + (s,) +
-            (1,)*(ndim-i-(1 if keepdims or i > axis else 2))))
-                for i, s in enumerate(self.shape)])
+            (1,) * (i if keepdims or i < axis else i - 1) + (s,)
+            + (1,) * (ndim - i - (1 if keepdims or i > axis else 2))))
+            for i, s in enumerate(self.shape)])
 
     def argmin(self, axis=None, out=None):
         """Return indices of the minimum values along the given axis.
@@ -1634,8 +1636,8 @@ class Time(ShapedLikeNDArray):
         if out is not None:
             raise ValueError("Since `Time` instances are immutable, ``out`` "
                              "cannot be set to anything but ``None``.")
-        return (self.max(axis, keepdims=keepdims) -
-                self.min(axis, keepdims=keepdims))
+        return (self.max(axis, keepdims=keepdims)
+                - self.min(axis, keepdims=keepdims))
 
     def sort(self, axis=-1):
         """Return a copy sorted along the specified axis.
@@ -1993,13 +1995,13 @@ class Time(ShapedLikeNDArray):
                 # Let other have a go.
                 return NotImplemented
 
-        if(self.scale is not None and self.scale not in other.SCALES or
-           other.scale is not None and other.scale not in self.SCALES):
+        if(self.scale is not None and self.scale not in other.SCALES
+           or other.scale is not None and other.scale not in self.SCALES):
             # Other will also not be able to do it, so raise a TypeError
             # immediately, allowing us to explain why it doesn't work.
             raise TypeError("Cannot compare {} instances with scales "
                             "'{}' and '{}'".format(self.__class__.__name__,
-                                                     self.scale, other.scale))
+                                                   self.scale, other.scale))
 
         if self.scale is not None and other.scale is not None:
             other = getattr(other, self.scale)
@@ -2160,8 +2162,8 @@ class TimeDelta(Time):
                 return NotImplemented
 
         # the scales should be compatible (e.g., cannot convert TDB to TAI)
-        if(self.scale is not None and self.scale not in other.SCALES or
-           other.scale is not None and other.scale not in self.SCALES):
+        if(self.scale is not None and self.scale not in other.SCALES
+           or other.scale is not None and other.scale not in self.SCALES):
             raise TypeError("Cannot add TimeDelta instances with scales "
                             "'{}' and '{}'".format(self.scale, other.scale))
 
@@ -2192,8 +2194,8 @@ class TimeDelta(Time):
                 return NotImplemented
 
         # the scales should be compatible (e.g., cannot convert TDB to TAI)
-        if(self.scale is not None and self.scale not in other.SCALES or
-           other.scale is not None and other.scale not in self.SCALES):
+        if(self.scale is not None and self.scale not in other.SCALES
+           or other.scale is not None and other.scale not in self.SCALES):
             raise TypeError("Cannot subtract TimeDelta instances with scales "
                             "'{}' and '{}'".format(self.scale, other.scale))
 
@@ -2234,9 +2236,9 @@ class TimeDelta(Time):
         # would enter here again (via __rmul__)
         if isinstance(other, Time) and not isinstance(other, TimeDelta):
             raise OperandTypeError(self, other, '*')
-        elif ((isinstance(other, u.UnitBase) and
-               other == u.dimensionless_unscaled) or
-              (isinstance(other, str) and other == '')):
+        elif ((isinstance(other, u.UnitBase)
+               and other == u.dimensionless_unscaled)
+                or (isinstance(other, str) and other == '')):
             return self.copy()
 
         # If other is something consistent with a dimensionless quantity
@@ -2267,9 +2269,9 @@ class TimeDelta(Time):
     def __truediv__(self, other):
         """Division of `TimeDelta` objects by numbers/arrays."""
         # Cannot do __mul__(1./other) as that looses precision
-        if ((isinstance(other, u.UnitBase) and
-             other == u.dimensionless_unscaled) or
-                (isinstance(other, str) and other == '')):
+        if ((isinstance(other, u.UnitBase)
+             and other == u.dimensionless_unscaled)
+                or (isinstance(other, str) and other == '')):
             return self.copy()
 
         # If other is something consistent with a dimensionless quantity
@@ -2396,8 +2398,8 @@ class TimeDelta(Time):
         # TODO: maybe allow 'subfmt' also for units, keeping full precision
         # (effectively, by doing the reverse of quantity_day_frac)?
         # This way, only equivalencies could lead to possible precision loss.
-        if ('format' in kwargs or
-                (args != () and (args[0] is None or args[0] in self.FORMATS))):
+        if ('format' in kwargs
+                or (args != () and (args[0] is None or args[0] in self.FORMATS))):
             # Super-class will error with duplicate arguments, etc.
             return super().to_value(*args, **kwargs)
 
@@ -2522,8 +2524,8 @@ class OperandTypeError(TypeError):
         super().__init__(
             "Unsupported operand type(s){}: "
             "'{}' and '{}'".format(op_string,
-                                     left.__class__.__name__,
-                                     right.__class__.__name__))
+                                   left.__class__.__name__,
+                                   right.__class__.__name__))
 
 
 def update_leap_seconds(files=None):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -11,7 +11,7 @@ from collections import OrderedDict, defaultdict
 import numpy as np
 
 from astropy.utils.decorators import lazyproperty
-from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy import units as u
 from astropy import _erfa as erfa
 
@@ -215,8 +215,8 @@ class TimeFormat(metaclass=TimeFormatMeta):
         ok1 = (val1.dtype.kind == 'f' and val1.dtype.itemsize >= 8
                and np.all(np.isfinite(val1)) or val1.size == 0)
         ok2 = val2 is None or (
-            val2.dtype.kind == 'f' and val2.dtype.itemsize >= 8 and
-            not np.any(np.isinf(val2))) or val2.size == 0
+            val2.dtype.kind == 'f' and val2.dtype.itemsize >= 8
+            and not np.any(np.isinf(val2))) or val2.size == 0
         if not (ok1 and ok2):
             raise TypeError('Input values for {} class must be finite doubles'
                             .format(self.name))
@@ -334,10 +334,10 @@ class TimeNumeric(TimeFormat):
         """Input value validation, typically overridden by derived classes"""
         if val1.dtype.kind == 'f':
             val1, val2 = super()._check_val_type(val1, val2)
-        elif (val2 is not None or
-              not (val1.dtype.kind in 'US' or
-                   (val1.dtype.kind == 'O' and
-                    all(isinstance(v, Decimal) for v in val1.flat)))):
+        elif (val2 is not None
+              or not (val1.dtype.kind in 'US'
+                      or (val1.dtype.kind == 'O'
+                          and all(isinstance(v, Decimal) for v in val1.flat)))):
             raise TypeError(
                 'for {} class, input should be doubles, string, or Decimal, '
                 'and second values are only allowed for doubles.'
@@ -671,8 +671,8 @@ class TimeStardate(TimeFromEpoch):
     See http://trekguide.com/Stardates.htm#TNG for calculations and reference points
     """
     name = 'stardate'
-    unit = 0.397766856 # Stardate units per day
-    epoch_val = '2318-07-05 11:00:00' # Date and time of stardate 00000.00
+    unit = 0.397766856  # Stardate units per day
+    epoch_val = '2318-07-05 11:00:00'  # Date and time of stardate 00000.00
     epoch_val2 = None
     epoch_scale = 'tai'
     epoch_format = 'iso'
@@ -754,7 +754,7 @@ class TimeDatetime(TimeUnique):
         # Iterate through the datetime objects, getting year, month, etc.
         iterator = np.nditer([val1, None, None, None, None, None, None],
                              flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=[None] + 5*[np.intc] + [np.double])
+                             op_dtypes=[None] + 5 * [np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             dt = val.item()
 
@@ -805,7 +805,7 @@ class TimeDatetime(TimeUnique):
         ifracs = ihmsfs['f']
         iterator = np.nditer([iys, ims, ids, ihrs, imins, isecs, ifracs, None],
                              flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=7*[None] + [object])
+                             op_dtypes=7 * [None] + [object])
 
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if isec >= 60:
@@ -888,9 +888,9 @@ class TimeYMDHMS(TimeUnique):
             # Input was empty list [], so set to None and set_jds will handle this
             return None, None
 
-        elif (val1.dtype.kind == 'O' and
-              val1.shape == () and
-              isinstance(val1.item(), dict)):
+        elif (val1.dtype.kind == 'O'
+              and val1.shape == ()
+              and isinstance(val1.item(), dict)):
             # Code gets here for input as a dict.  The dict input
             # can be either scalar values or N-d arrays.
 
@@ -971,7 +971,7 @@ class TimezoneInfo(datetime.tzinfo):
     a workaround for users without pytz.
     """
     @u.quantity_input(utc_offset=u.day, dst=u.day)
-    def __init__(self, utc_offset=0*u.day, dst=0*u.day, tzname=None):
+    def __init__(self, utc_offset=0 * u.day, dst=0 * u.day, tzname=None):
         """
         Parameters
         ----------
@@ -1083,7 +1083,7 @@ class TimeString(TimeUnique):
                      lambda x: str(x.item(), encoding='ascii'))
         iterator = np.nditer([val1, None, None, None, None, None, None],
                              flags=['zerosize_ok'],
-                             op_dtypes=[None] + 5*[np.intc] + [np.double])
+                             op_dtypes=[None] + 5 * [np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             val = to_string(val)
             iy[...], im[...], id[...], ihr[...], imin[...], dsec[...] = (
@@ -1499,7 +1499,7 @@ class TimeDeltaNumeric(TimeDeltaFormat, TimeNumeric):
 
     def set_jds(self, val1, val2):
         self._check_scale(self._scale)  # Validate scale.
-        self.jd1, self.jd2 = day_frac(val1, val2, divisor=1./self.unit)
+        self.jd1, self.jd2 = day_frac(val1, val2, divisor=1. / self.unit)
 
     def to_value(self, **kwargs):
         # Note that 1/unit is always exactly representable, so the
@@ -1546,7 +1546,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
         day = datetime.timedelta(days=1)
         for val, jd1, jd2 in iterator:
             jd1[...], other = divmod(val.item(), day)
-            jd2[...] = other/day
+            jd2[...] = other / day
 
         self.jd1, self.jd2 = day_frac(iterator.operands[-2],
                                       iterator.operands[-1])
@@ -1560,7 +1560,7 @@ class TimeDeltaDatetime(TimeDeltaFormat, TimeUnique):
         for jd1, jd2, out in iterator:
             jd1_, jd2_ = day_frac(jd1, jd2)
             out[...] = datetime.timedelta(days=jd1_,
-                                          microseconds=jd2_*86400*1e6)
+                                          microseconds=jd2_ * 86400 * 1e6)
 
         return self.mask_if_needed(iterator.operands[-1])
 
@@ -1603,4 +1603,4 @@ def _broadcast_writeable(jd1, jd2):
     return s_jd1, s_jd2
 
 
-from .core import Time, TIME_SCALES, TIME_DELTA_SCALES, ScaleValueError
+from .core import Time, TIME_SCALES, TIME_DELTA_SCALES, ScaleValueError  # noqa

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -754,7 +754,7 @@ class TimeDatetime(TimeUnique):
         # Iterate through the datetime objects, getting year, month, etc.
         iterator = np.nditer([val1, None, None, None, None, None, None],
                              flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=[None] + 5 * [np.intc] + [np.double])
+                             op_dtypes=[None] + 5*[np.intc] + [np.double])
         for val, iy, im, id, ihr, imin, dsec in iterator:
             dt = val.item()
 
@@ -805,7 +805,7 @@ class TimeDatetime(TimeUnique):
         ifracs = ihmsfs['f']
         iterator = np.nditer([iys, ims, ids, ihrs, imins, isecs, ifracs, None],
                              flags=['refs_ok', 'zerosize_ok'],
-                             op_dtypes=7 * [None] + [object])
+                             op_dtypes=7*[None] + [object])
 
         for iy, im, id, ihr, imin, isec, ifracsec, out in iterator:
             if isec >= 60:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -54,7 +54,7 @@ class TestBasic:
         assert (repr(t) == "<Time object: scale='utc' format='iso' "
                 "value=['1999-01-01 00:00:00.123' '2010-01-01 00:00:00.000']>")
         assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
-        assert allclose_jd2(t.jd2, np.array([-0.5+1.4288980208333335e-06,
+        assert allclose_jd2(t.jd2, np.array([-0.5 + 1.4288980208333335e-06,
                                              -0.50000000e+00]))
 
         # Set scale to TAI
@@ -62,8 +62,8 @@ class TestBasic:
         assert (repr(t) == "<Time object: scale='tai' format='iso' "
                 "value=['1999-01-01 00:00:32.123' '2010-01-01 00:00:34.000']>")
         assert allclose_jd(t.jd1, np.array([2451180., 2455198.]))
-        assert allclose_jd2(t.jd2, np.array([-0.5+0.00037179926839122024,
-                                             -0.5+0.00039351851851851852]))
+        assert allclose_jd2(t.jd2, np.array([-0.5 + 0.00037179926839122024,
+                                             -0.5 + 0.00039351851851851852]))
 
         # Get a new ``Time`` object which is referenced to the TT scale
         # (internal JD1 and JD1 are now with respect to TT scale)"""
@@ -91,7 +91,7 @@ class TestBasic:
         val2 = 0.
         t3 = Time(val, val2, format='jd')
         assert t3.isscalar is False and t3.shape == val.shape
-        val2 = (np.arange(5.)/10.).reshape(5, 1)
+        val2 = (np.arange(5.) / 10.).reshape(5, 1)
         # now see if broadcasting to two-dimensional works
         t4 = Time(val, val2, format='jd')
         assert t4.isscalar is False
@@ -300,11 +300,11 @@ class TestBasic:
 
         lat = 19.48125
         lon = -155.933222
-        t = Time(['2006-01-15 21:24:37.5']*2, format='iso', scale='utc',
+        t = Time(['2006-01-15 21:24:37.5'] * 2, format='iso', scale='utc',
                  precision=6, location=(lon, lat))
         assert np.all(t.utc.iso == '2006-01-15 21:24:37.500000')
         assert np.all(t.tdb.iso[0] == '2006-01-15 21:25:42.684373')
-        t2 = Time(['2006-01-15 21:24:37.5']*2, format='iso', scale='utc',
+        t2 = Time(['2006-01-15 21:24:37.5'] * 2, format='iso', scale='utc',
                   precision=6, location=(np.array([lon, 0]),
                                          np.array([lat, 0])))
         assert np.all(t2.utc.iso == '2006-01-15 21:24:37.500000')
@@ -315,7 +315,7 @@ class TestBasic:
                  precision=6, location=(np.array([lon, 0]),
                                         np.array([lat, 0])))
         with pytest.raises(ValueError):  # 3 times, but two locations
-            Time(['2006-01-15 21:24:37.5']*3, format='iso', scale='utc',
+            Time(['2006-01-15 21:24:37.5'] * 3, format='iso', scale='utc',
                  precision=6, location=(np.array([lon, 0]),
                                         np.array([lat, 0])))
         # multidimensional
@@ -390,27 +390,27 @@ class TestBasic:
         ScalevalueError
         """
         t = Time('2006-01-15 21:24:37.5', scale='local')
-        assert_allclose(t.jd, 2453751.3921006946, atol=0.001/3600./24., rtol=0.)
-        assert_allclose(t.mjd, 53750.892100694444, atol=0.001/3600./24., rtol=0.)
-        assert_allclose(t.decimalyear, 2006.0408002758752, atol=0.001/3600./24./365., rtol=0.)
+        assert_allclose(t.jd, 2453751.3921006946, atol=0.001 / 3600. / 24., rtol=0.)
+        assert_allclose(t.mjd, 53750.892100694444, atol=0.001 / 3600. / 24., rtol=0.)
+        assert_allclose(t.decimalyear, 2006.0408002758752, atol=0.001 / 3600. / 24. / 365., rtol=0.)
         assert t.datetime == datetime.datetime(2006, 1, 15, 21, 24, 37, 500000)
         assert t.isot == '2006-01-15T21:24:37.500'
         assert t.yday == '2006:015:21:24:37.500'
         assert t.fits == '2006-01-15T21:24:37.500'
-        assert_allclose(t.byear, 2006.04217888831, atol=0.001/3600./24./365., rtol=0.)
-        assert_allclose(t.jyear, 2006.0407723496082, atol=0.001/3600./24./365., rtol=0.)
+        assert_allclose(t.byear, 2006.04217888831, atol=0.001 / 3600. / 24. / 365., rtol=0.)
+        assert_allclose(t.jyear, 2006.0407723496082, atol=0.001 / 3600. / 24. / 365., rtol=0.)
         assert t.byear_str == 'B2006.042'
         assert t.jyear_str == 'J2006.041'
 
         # epochTimeFormats
         with pytest.raises(ScaleValueError):
-            t2 = t.gps
+            t.gps
         with pytest.raises(ScaleValueError):
-            t2 = t.unix
+            t.unix
         with pytest.raises(ScaleValueError):
-            t2 = t.cxcsec
+            t.cxcsec
         with pytest.raises(ScaleValueError):
-            t2 = t.plot_date
+            t.plot_date
 
     def test_datetime(self):
         """
@@ -433,7 +433,7 @@ class TestBasic:
         assert t.datetime == datetime.datetime(2000, 1, 1, 1, 1, 1, 123457)
 
         # broadcasting
-        dt3 = (dt + (dt2-dt)*np.arange(12)).reshape(4, 3)
+        dt3 = (dt + (dt2 - dt) * np.arange(12)).reshape(4, 3)
         t3 = Time(dt3, scale='utc')
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]
@@ -467,7 +467,7 @@ class TestBasic:
         assert t.datetime64 == np.datetime64('2000-01-01T01:01:01.123456789')
 
         # broadcasting
-        dt3 = (dt64 + (dt64_2-dt64)*np.arange(12)).reshape(4, 3)
+        dt3 = (dt64 + (dt64_2 - dt64) * np.arange(12)).reshape(4, 3)
         t3 = Time(dt3, scale='utc', format='datetime64')
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]
@@ -544,7 +544,7 @@ class TestBasic:
             if month == 6:
                 yyyy_mm_dd_plus1 = f'{year:04d}-07-01'
             else:
-                yyyy_mm_dd_plus1 = '{:04d}-01-01'.format(year+1)
+                yyyy_mm_dd_plus1 = '{:04d}-01-01'.format(year + 1)
 
             with pytest.warns(ErfaWarning):
                 t1 = Time(yyyy_mm_dd + ' 23:59:61.0', scale='utc')
@@ -596,7 +596,7 @@ class TestBasic:
         # throw error when deriving local scale time
         # from non local time scale
         with pytest.raises(ValueError):
-            t6 = Time(t1, scale='local')
+            Time(t1, scale='local')
 
 
 class TestVal2:
@@ -634,7 +634,7 @@ class TestVal2:
         val = (2458000 + np.arange(3))[:, None]
         val2 = np.linspace(0, 1, 4, endpoint=False)
         t = Time(val=val, val2=val2, format="jd", scale="tai")
-        t_b = Time(val=val+0*val2, val2=0*val+val2, format="jd", scale="tai")
+        t_b = Time(val=val + 0 * val2, val2=0 * val + val2, format="jd", scale="tai")
         t_i = Time(val=57990, val2=0.3, format="jd", scale="tai")
         t_b[1, 2] = t_i
         t[1, 2] = t_i
@@ -647,7 +647,7 @@ class TestVal2:
         val = (2458000 + np.arange(3))
         val2 = np.arange(1)
         t = Time(val=val, val2=val2, format="jd", scale="tai")
-        t_b = Time(val=val+0*val2, val2=0*val+val2, format="jd", scale="tai")
+        t_b = Time(val=val + 0 * val2, val2=0 * val + val2, format="jd", scale="tai")
         t_i = Time(val=57990, val2=0.3, format="jd", scale="tai")
         t_b[1] = t_i
         t[1] = t_i
@@ -900,8 +900,8 @@ class TestNumericalSubFormat:
         assert mjd_long != i, "longdouble failure!"
         t = Time(mjd_long, format='mjd')
         expected = Time(i, f, format='mjd')
-        assert abs(t - expected) <= 20.*u.ps
-        t_float = Time(i+f, format='mjd')
+        assert abs(t - expected) <= 20. * u.ps
+        t_float = Time(i + f, format='mjd')
         assert t_float == Time(i, format='mjd')
         assert t_float != t
         assert t.value == 54321.  # Lost precision!
@@ -919,7 +919,7 @@ class TestNumericalSubFormat:
         t_fmt_long = np.longdouble(t_fmt)
         # Create a different long double (ensuring it will give a different jd2
         # even when long doubles are more precise than Time, as on arm64).
-        atol = np.finfo(float).eps * (1. if fmt == 'mjd' else 24.*3600.)
+        atol = np.finfo(float).eps * (1. if fmt == 'mjd' else 24. * 3600.)
         t_fmt_long2 = t_fmt_long + max(
             t_fmt_long * np.finfo(np.longdouble).eps * 2, atol)
         assert t_fmt_long != t_fmt_long2, "longdouble weird!"
@@ -932,7 +932,7 @@ class TestNumericalSubFormat:
     def test_subformat_input(self):
         s = '54321.01234567890123456789'
         i, f = s.split('.')  # Note, OK only for fraction < 0.5
-        t = Time(float(i), float('.'+f), format='mjd')
+        t = Time(float(i), float('.' + f), format='mjd')
         t_str = Time(s, format='mjd')
         t_bytes = Time(s.encode('ascii'), format='mjd')
         t_decimal = Time(Decimal(s), format='mjd')
@@ -1226,7 +1226,7 @@ def test_fits_year10000():
     assert t.fits == '+10000-01-01T00:00:00.000'
     t = Time(5373484.5 - 365., format='jd', scale='tai')
     assert t.fits == '9999-01-01T00:00:00.000'
-    t = Time(5373484.5, -1./24./3600., format='jd', scale='tai')
+    t = Time(5373484.5, -1. / 24. / 3600., format='jd', scale='tai')
     assert t.fits == '9999-12-31T23:59:59.000'
 
 
@@ -1407,7 +1407,7 @@ def test_isiterable():
 
 
 def test_to_datetime():
-    tz = TimezoneInfo(utc_offset=-10*u.hour, tzname='US/Hawaii')
+    tz = TimezoneInfo(utc_offset=-10 * u.hour, tzname='US/Hawaii')
     # The above lines produces a `datetime.tzinfo` object similar to:
     #     tzinfo = pytz.timezone('US/Hawaii')
     time = Time('2010-09-03 00:00:00')
@@ -1978,13 +1978,13 @@ def test_get_time_fmt_exception_messages():
 
     with pytest.raises(ValueError) as err:
         Time('200', format='iso')
-    assert ('Input values did not match the format class iso:' + os.linesep +
-            'ValueError: Time 200 does not match iso format') == str(err.value)
+    assert ('Input values did not match the format class iso:' + os.linesep
+            + 'ValueError: Time 200 does not match iso format') == str(err.value)
 
     with pytest.raises(ValueError) as err:
         Time(200, format='iso')
-    assert ('Input values did not match the format class iso:' + os.linesep +
-            'TypeError: Input values for iso class must be strings') == str(err.value)
+    assert ('Input values did not match the format class iso:' + os.linesep
+            + 'TypeError: Input values for iso class must be strings') == str(err.value)
 
 
 def test_ymdhms_defaults():
@@ -2116,5 +2116,5 @@ def test_ymdhms_output():
 # and can ensure that strange broadcasting anomalies can't happen.
 # This form of construction uses from_jd=True.
 def test_broadcasting_writeable():
-    t = Time('J2015') + np.linspace(-1, 1, 10)*u.day
+    t = Time('J2015') + np.linspace(-1, 1, 10) * u.day
     t[2] = Time(58000, format="mjd")

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -433,7 +433,7 @@ class TestBasic:
         assert t.datetime == datetime.datetime(2000, 1, 1, 1, 1, 1, 123457)
 
         # broadcasting
-        dt3 = (dt + (dt2 - dt) * np.arange(12)).reshape(4, 3)
+        dt3 = (dt + (dt2-dt) * np.arange(12)).reshape(4, 3)
         t3 = Time(dt3, scale='utc')
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]
@@ -467,7 +467,7 @@ class TestBasic:
         assert t.datetime64 == np.datetime64('2000-01-01T01:01:01.123456789')
 
         # broadcasting
-        dt3 = (dt64 + (dt64_2 - dt64) * np.arange(12)).reshape(4, 3)
+        dt3 = (dt64 + (dt64_2-dt64) * np.arange(12)).reshape(4, 3)
         t3 = Time(dt3, scale='utc', format='datetime64')
         assert t3.shape == (4, 3)
         assert t3[2, 1].value == dt3[2, 1]

--- a/astropy/time/tests/test_comparisons.py
+++ b/astropy/time/tests/test_comparisons.py
@@ -26,12 +26,12 @@ class TestTimeComparisons:
                            (operator.gt, '>'),
                            (operator.le, '<='),
                            (operator.lt, '<')):
-            with pytest.raises(TypeError) as err:
+            with pytest.raises(TypeError):
                 op(t1, None)
         # Keep == and != as they are specifically meant to test Time.__eq__
         # and Time.__ne__
-        assert (t1 == None) is False  # nopep8
-        assert (t1 != None) is True  # nopep8
+        assert (t1 == None) is False  # noqa
+        assert (t1 != None) is True  # noqa
 
     def test_time(self):
         t1_lt_t2 = self.t1 < self.t2

--- a/astropy/time/tests/test_corrs.py
+++ b/astropy/time/tests/test_corrs.py
@@ -33,7 +33,7 @@ class TestHelioBaryCentric:
         iers.conf.auto_download = cls.orig_auto_download
 
     def setup(self):
-        wht = EarthLocation(342.12*u.deg, 28.758333333333333*u.deg, 2327*u.m)
+        wht = EarthLocation(342.12 * u.deg, 28.758333333333333 * u.deg, 2327 * u.m)
         self.obstime = Time("2013-02-02T23:00", location=wht)
         self.obstime2 = Time("2013-08-02T23:00", location=wht)
         self.obstimeArr = Time(["2013-02-02T23:00", "2013-08-02T23:00"],
@@ -60,10 +60,10 @@ class TestHelioBaryCentric:
         hval1 = self.obstime.light_travel_time(self.star, 'heliocentric')
         hval2 = self.obstime2.light_travel_time(self.star, 'heliocentric')
         hval_arr = self.obstimeArr.light_travel_time(self.star, 'heliocentric')
-        assert hval_arr[0]-hval1 < 1. * u.us
-        assert hval_arr[1]-hval2 < 1. * u.us
-        assert bval_arr[0]-bval1 < 1. * u.us
-        assert bval_arr[1]-bval2 < 1. * u.us
+        assert hval_arr[0] - hval1 < 1. * u.us
+        assert hval_arr[1] - hval2 < 1. * u.us
+        assert bval_arr[0] - bval1 < 1. * u.us
+        assert bval_arr[1] - bval2 < 1. * u.us
 
     @pytest.mark.remote_data
     @pytest.mark.skipif('not HAS_JPLEPHEM')

--- a/astropy/time/tests/test_delta.py
+++ b/astropy/time/tests/test_delta.py
@@ -39,7 +39,7 @@ class TestTimeDelta:
         self.t2 = Time('2010-01-02 00:00:01', scale='utc')
         self.t3 = Time('2010-01-03 01:02:03', scale='utc', precision=9,
                        in_subfmt='date_hms', out_subfmt='date_hm',
-                       location=(-75.*u.degree, 30.*u.degree, 500*u.m))
+                       location=(-75. * u.degree, 30. * u.degree, 500 * u.m))
         self.t4 = Time('2010-01-01', scale='local')
         self.dt = TimeDelta(100.0, format='sec')
         self.dt_array = TimeDelta(np.arange(100, 1000, 100), format='sec')
@@ -297,7 +297,7 @@ class TestTimeDeltaScales:
                           '2012-07-01 00:00:00', '2012-07-01 12:00:00']
         self.t = dict((scale, Time(self.iso_times, scale=scale, precision=9))
                       for scale in TIME_SCALES)
-        self.dt = dict((scale, self.t[scale]-self.t[scale][0])
+        self.dt = dict((scale, self.t[scale] - self.t[scale][0])
                        for scale in TIME_SCALES)
 
     def test_delta_scales_definition(self):

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -170,8 +170,8 @@ class TestManipulation:
         t2_reshape_t_reshape = t2_reshape_t.reshape(10, 5)
         assert t2_reshape_t_reshape.shape == (10, 5)
         assert not np.may_share_memory(t2_reshape_t_reshape.jd1, self.t2.jd1)
-        assert (t2_reshape_t_reshape.location.shape ==
-                t2_reshape_t_reshape.shape)
+        assert (t2_reshape_t_reshape.location.shape
+                == t2_reshape_t_reshape.shape)
         assert not np.may_share_memory(t2_reshape_t_reshape.location,
                                        t2_reshape_t.location)
 
@@ -300,7 +300,7 @@ class TestArithmetic:
 
     def setup(self):
         mjd = np.arange(50000, 50100, 10).reshape(2, 5, 1)
-        frac = np.array([0.1, 0.1+1.e-15, 0.1-1.e-15, 0.9+2.e-16, 0.9])
+        frac = np.array([0.1, 0.1 + 1.e-15, 0.1 - 1.e-15, 0.9 + 2.e-16, 0.9])
         if use_masked_data:
             frac = np.ma.array(frac)
             frac[1] = np.ma.masked
@@ -423,8 +423,8 @@ class TestArithmetic:
         assert np.all(self.t0.sort(1) == self.t0)
         assert np.all(self.t0.sort(2) == self.t0[:, :, order])
         if not masked:
-            assert np.all(self.t0.sort(None) ==
-                          self.t0[:, :, order].ravel())
+            assert np.all(self.t0.sort(None)
+                          == self.t0[:, :, order].ravel())
             # Bit superfluous, but good to check.
             assert np.all(self.t0.sort(-1)[:, :, 0] == self.t0.min(-1))
             assert np.all(self.t0.sort(-1)[:, :, -1] == self.t0.max(-1))

--- a/astropy/time/tests/test_precision.py
+++ b/astropy/time/tests/test_precision.py
@@ -28,8 +28,8 @@ def test_abs_jd2_always_less_than_half():
     t1 = Time(2400000.5, [-tiny, +tiny], format='jd')
     assert np.all(t1.jd1 % 1 == 0)
     assert np.all(abs(t1.jd2) < 0.5)
-    t2 = Time(2400000., [[0.5-tiny, 0.5+tiny],
-                         [-0.5-tiny, -0.5+tiny]], format='jd')
+    t2 = Time(2400000., [[0.5 - tiny, 0.5 + tiny],
+                         [-0.5 - tiny, -0.5 + tiny]], format='jd')
     assert np.all(t2.jd1 % 1 == 0)
     assert np.all(abs(t2.jd2) < 0.5)
 
@@ -148,7 +148,7 @@ def test_two_sum_simple():
         a = Decimal(i) + Decimal(f)
         s, r = two_sum(i, f)
         b = Decimal(s) + Decimal(r)
-        assert (abs(a-b)*u.day).to(u.ns) < 1*u.ns
+        assert (abs(a - b) * u.day).to(u.ns) < 1 * u.ns
 
 
 def test_day_frac_harmless():
@@ -157,7 +157,7 @@ def test_day_frac_harmless():
         a = Decimal(i) + Decimal(f)
         i_d, f_d = day_frac(i, f)
         a_d = Decimal(i_d) + Decimal(f_d)
-        assert (abs(a-a_d)*u.day).to(u.ns) < 1*u.ns
+        assert (abs(a - a_d) * u.day).to(u.ns) < 1 * u.ns
 
 
 def test_day_frac_idempotent():
@@ -171,7 +171,7 @@ def test_mjd_initialization_precise():
     t = Time(val=i, val2=f, format="mjd", scale="tai")
     jd1, jd2 = day_frac(i + erfa.DJM0, f)
     jd1_t, jd2_t = day_frac(t.jd1, t.jd2)
-    assert (abs((jd1-jd1_t) + (jd2-jd2_t))*u.day).to(u.ns) < 1*u.ns
+    assert (abs((jd1 - jd1_t) + (jd2 - jd2_t)) * u.day).to(u.ns) < 1 * u.ns
 
 
 def test_conversion_preserves_jd1_jd2_invariant():
@@ -207,4 +207,4 @@ def test_datetime_difference_agrees_with_timedelta():
     dt2 = datetime(9950, 1, 1, 0, 0, 0, 890773)
     t1 = Time(dt1, scale=scale)
     t2 = Time(dt2, scale=scale)
-    assert(abs((t2-t1) - TimeDelta(dt2-dt1, scale=scale)) < 1*u.us)
+    assert(abs((t2 - t1) - TimeDelta(dt2 - dt1, scale=scale)) < 1 * u.us)

--- a/astropy/time/tests/test_quantity_interaction.py
+++ b/astropy/time/tests/test_quantity_interaction.py
@@ -17,42 +17,42 @@ class TestTimeQuantity:
 
     def test_valid_quantity_input(self):
         """Test Time formats that are allowed to take quantity input."""
-        q = 2450000.125*u.day
+        q = 2450000.125 * u.day
         t1 = Time(q, format='jd', scale='utc')
         assert t1.value == q.value
         q2 = q.to(u.second)
         t2 = Time(q2, format='jd', scale='utc')
         assert t2.value == q.value == q2.to_value(u.day)
-        q3 = q-2400000.5*u.day
+        q3 = q - 2400000.5 * u.day
         t3 = Time(q3, format='mjd', scale='utc')
         assert t3.value == q3.value
         # test we can deal with two quantity arguments, with different units
-        qs = 24.*36.*u.second
+        qs = 24. * 36. * u.second
         t4 = Time(q3, qs, format='mjd', scale='utc')
-        assert t4.value == (q3+qs).to_value(u.day)
+        assert t4.value == (q3 + qs).to_value(u.day)
 
-        qy = 1990.*u.yr
+        qy = 1990. * u.yr
         ty1 = Time(qy, format='jyear', scale='utc')
         assert ty1.value == qy.value
         ty2 = Time(qy.to(u.day), format='jyear', scale='utc')
         assert ty2.value == qy.value
-        qy2 = 10.*u.yr
+        qy2 = 10. * u.yr
         tcxc = Time(qy2, format='cxcsec')
         assert tcxc.value == qy2.to_value(u.second)
         tgps = Time(qy2, format='gps')
         assert tgps.value == qy2.to_value(u.second)
         tunix = Time(qy2, format='unix')
         assert tunix.value == qy2.to_value(u.second)
-        qd = 2000.*365.*u.day
+        qd = 2000. * 365. * u.day
         tplt = Time(qd, format='plot_date', scale='utc')
         assert tplt.value == qd.value
 
     def test_invalid_quantity_input(self):
         with pytest.raises(u.UnitsError):
-            Time(2450000.*u.m, format='jd', scale='utc')
+            Time(2450000. * u.m, format='jd', scale='utc')
 
         with pytest.raises(u.UnitsError):
-            Time(2450000.*u.dimensionless_unscaled, format='jd', scale='utc')
+            Time(2450000. * u.dimensionless_unscaled, format='jd', scale='utc')
 
     def test_column_with_and_without_units(self):
         """Ensure a Column without a unit is treated as an array [#3648]"""
@@ -70,7 +70,7 @@ class TestTimeQuantity:
 
     def test_no_quantity_input_allowed(self):
         """Time formats that are not allowed to take Quantity input."""
-        qy = 1990.*u.yr
+        qy = 1990. * u.yr
         for fmt in ('iso', 'yday', 'datetime', 'byear',
                     'byear_str', 'jyear_str'):
             with pytest.raises(ValueError):
@@ -79,33 +79,34 @@ class TestTimeQuantity:
     def test_valid_quantity_operations(self):
         """Check that adding a time-valued quantity to a Time gives a Time"""
         t0 = Time(100000., format='cxcsec')
-        q1 = 10.*u.second
+        q1 = 10. * u.second
         t1 = t0 + q1
         assert isinstance(t1, Time)
-        assert t1.value == t0.value+q1.to_value(u.second)
-        q2 = 1.*u.day
+        assert t1.value == t0.value + q1.to_value(u.second)
+        q2 = 1. * u.day
         t2 = t0 - q2
-        assert allclose_sec(t2.value, t0.value-q2.to_value(u.second))
+        assert allclose_sec(t2.value, t0.value - q2.to_value(u.second))
         # check broadcasting
         q3 = np.arange(15.).reshape(3, 5) * u.hour
         t3 = t0 - q3
         assert t3.shape == q3.shape
-        assert allclose_sec(t3.value, t0.value-q3.to_value(u.second))
+        assert allclose_sec(t3.value, t0.value - q3.to_value(u.second))
 
     def test_invalid_quantity_operations(self):
         """Check that comparisons of Time with quantities does not work
         (even for time-like, since we cannot compare Time to TimeDelta)"""
         with pytest.raises(TypeError):
-            Time(100000., format='cxcsec') > 10.*u.m
+            Time(100000., format='cxcsec') > 10. * u.m
         with pytest.raises(TypeError):
-            Time(100000., format='cxcsec') > 10.*u.second
+            Time(100000., format='cxcsec') > 10. * u.second
 
 
 class TestTimeDeltaQuantity:
     """Test interaction of TimeDelta with Quantities"""
+
     def test_valid_quantity_input(self):
         """Test that TimeDelta can take quantity input."""
-        q = 500.25*u.day
+        q = 500.25 * u.day
         dt1 = TimeDelta(q, format='jd')
         assert dt1.value == q.value
         dt2 = TimeDelta(q, format='sec')
@@ -115,16 +116,16 @@ class TestTimeDeltaQuantity:
 
     def test_invalid_quantity_input(self):
         with pytest.raises(u.UnitsError):
-            TimeDelta(2450000.*u.m, format='jd')
+            TimeDelta(2450000. * u.m, format='jd')
 
         with pytest.raises(u.UnitsError):
-            Time(2450000.*u.dimensionless_unscaled, format='jd', scale='utc')
+            Time(2450000. * u.dimensionless_unscaled, format='jd', scale='utc')
 
         with pytest.raises(TypeError):
-            TimeDelta(100, format='sec') > 10.*u.m
+            TimeDelta(100, format='sec') > 10. * u.m
 
     def test_quantity_output(self):
-        q = 500.25*u.day
+        q = 500.25 * u.day
         dt = TimeDelta(q)
         assert dt.to(u.day) == q
         assert dt.to_value(u.day) == q.value
@@ -156,17 +157,17 @@ class TestTimeDeltaQuantity:
         """Check adding/substracting/comparing a time-valued quantity works
         with a TimeDelta.  Addition/subtraction should give TimeDelta"""
         t0 = TimeDelta(106400., format='sec')
-        q1 = 10.*u.second
+        q1 = 10. * u.second
         t1 = t0 + q1
         assert isinstance(t1, TimeDelta)
-        assert t1.value == t0.value+q1.to_value(u.second)
-        q2 = 1.*u.day
+        assert t1.value == t0.value + q1.to_value(u.second)
+        q2 = 1. * u.day
         t2 = t0 - q2
         assert isinstance(t2, TimeDelta)
-        assert allclose_sec(t2.value, t0.value-q2.to_value(u.second))
+        assert allclose_sec(t2.value, t0.value - q2.to_value(u.second))
         # now comparisons
         assert t0 > q1
-        assert t0 < 1.*u.yr
+        assert t0 < 1. * u.yr
         # and broadcasting
         q3 = np.arange(12.).reshape(4, 3) * u.hour
         t3 = t0 + q3
@@ -177,21 +178,21 @@ class TestTimeDeltaQuantity:
     def test_valid_quantity_operations2(self):
         """Check that TimeDelta is treated as a quantity where possible."""
         t0 = TimeDelta(100000., format='sec')
-        f = 1./t0
+        f = 1. / t0
         assert isinstance(f, u.Quantity)
-        assert f.unit == 1./u.day
-        g = 10.*u.m/u.second**2
+        assert f.unit == 1. / u.day
+        g = 10. * u.m / u.second**2
         v = t0 * g
         assert isinstance(v, u.Quantity)
         assert u.allclose(v, t0.sec * g.value * u.m / u.second)
-        q = np.log10(t0/u.second)
+        q = np.log10(t0 / u.second)
         assert isinstance(q, u.Quantity)
         assert q.value == np.log10(t0.sec)
-        s = 1.*u.m
-        v = s/t0
+        s = 1. * u.m
+        v = s / t0
         assert isinstance(v, u.Quantity)
         assert u.allclose(v, 1. / t0.sec * u.m / u.s)
-        t = 1.*u.s
+        t = 1. * u.s
         t2 = t0 * t
         assert isinstance(t2, u.Quantity)
         assert u.allclose(t2, t0.sec * u.s ** 2)
@@ -262,7 +263,7 @@ class TestTimeDeltaQuantity:
     def test_invalid_quantity_operations(self):
         """Check comparisons of TimeDelta with non-time quantities fails."""
         with pytest.raises(TypeError):
-            TimeDelta(100000., format='sec') > 10.*u.m
+            TimeDelta(100000., format='sec') > 10. * u.m
 
     def test_invalid_quantity_operations2(self):
         """Check that operations with non-time/quantity fail."""
@@ -291,7 +292,7 @@ class TestDeltaAttributes:
         # Also check that a TimeDelta works.
         t.delta_ut1_utc = TimeDelta(0.3, format='sec')
         assert t.ut1.iso == '2010-01-01 00:00:00.300000'
-        t.delta_ut1_utc = TimeDelta(0.5/24./3600., format='jd')
+        t.delta_ut1_utc = TimeDelta(0.5 / 24. / 3600., format='jd')
         assert t.ut1.iso == '2010-01-01 00:00:00.500000'
 
     def test_delta_tdb_tt(self):
@@ -305,14 +306,14 @@ class TestDeltaAttributes:
         # Also check that a TimeDelta works.
         t.delta_tdb_tt = TimeDelta(40., format='sec')
         assert t.tdb.iso == '2010-01-01 00:00:40.000000'
-        t.delta_tdb_tt = TimeDelta(50./24./3600., format='jd')
+        t.delta_tdb_tt = TimeDelta(50. / 24. / 3600., format='jd')
         assert t.tdb.iso == '2010-01-01 00:00:50.000000'
 
 
-@pytest.mark.parametrize('q1, q2', ((5e8*u.s, None),
-                                    (5e17*u.ns, None),
-                                    (4e8*u.s, 1e17*u.ns),
-                                    (4e14*u.us, 1e17*u.ns)))
+@pytest.mark.parametrize('q1, q2', ((5e8 * u.s, None),
+                                    (5e17 * u.ns, None),
+                                    (4e8 * u.s, 1e17 * u.ns),
+                                    (4e14 * u.us, 1e17 * u.ns)))
 def test_quantity_conversion_rounding(q1, q2):
     """Check that no rounding errors are incurred by unit conversion.
 

--- a/astropy/time/tests/test_sidereal.py
+++ b/astropy/time/tests/test_sidereal.py
@@ -11,8 +11,8 @@ from astropy.utils import iers
 
 allclose_hours = functools.partial(np.allclose, rtol=1e-15, atol=3e-8)
 # 0.1 ms atol; IERS-B files change at that level.
-within_1_second = functools.partial(np.allclose, rtol=1., atol=1./3600.)
-within_2_seconds = functools.partial(np.allclose, rtol=1., atol=2./3600.)
+within_1_second = functools.partial(np.allclose, rtol=1., atol=1. / 3600.)
+within_2_seconds = functools.partial(np.allclose, rtol=1., atol=2. / 3600.)
 
 
 def test_doc_string_contains_models():
@@ -31,9 +31,9 @@ class TestERFATestCases:
     # reproduce this exactly. Now it does not really matter,
     # but may as well fake this (and avoid IERS table lookup here)
     time_ut1.delta_ut1_utc = 0.
-    time_ut1.delta_ut1_utc = 24*3600*(
-        (time_ut1.tt.jd1-time_tt.jd1) + (time_ut1.tt.jd2-time_tt.jd2))
-    assert np.allclose((time_ut1.tt.jd1-time_tt.jd1)
+    time_ut1.delta_ut1_utc = 24 * 3600 * (
+        (time_ut1.tt.jd1 - time_tt.jd1) + (time_ut1.tt.jd2 - time_tt.jd2))
+    assert np.allclose((time_ut1.tt.jd1 - time_tt.jd1)
                        + (time_ut1.tt.jd2 - time_tt.jd2),
                        0., atol=1.e-14)
 
@@ -50,11 +50,11 @@ class TestERFATestCases:
         if name[4] == 'm':
             kind = 'mean'
             model_name = 'IAU{:2d}{:s}'.format(20 if name[7] == '0' else 19,
-                                                 name[7:])
+                                               name[7:])
         else:
             kind = 'apparent'
             model_name = 'IAU{:2d}{:s}'.format(20 if name[6] == '0' else 19,
-                                                 name[6:].upper())
+                                               name[6:].upper())
 
         assert kind in SIDEREAL_TIME_MODELS.keys()
         assert model_name in SIDEREAL_TIME_MODELS[kind]
@@ -134,7 +134,7 @@ class TestST:
         gmst2 = self.t2.sidereal_time(kind, 'greenwich')
         lmst2 = self.t2.sidereal_time(kind)
         assert allclose_hours(lmst2.value, lst_compare[kind])
-        assert allclose_hours((lmst2-gmst2).wrap_at('12h').value,
+        assert allclose_hours((lmst2 - gmst2).wrap_at('12h').value,
                               self.t2.location.lon.to_value('hourangle'))
         # check it also works when one gives longitude explicitly
         lmst1 = self.t1.sidereal_time(kind, self.t2.location.lon)
@@ -183,8 +183,8 @@ class TestModelInterpretation:
         with pytest.raises(ValueError):
             self.t.sidereal_time(kind, 'greenwich', 'nonsense')
 
-        for model in (set(SIDEREAL_TIME_MODELS[other].keys()) -
-                      set(SIDEREAL_TIME_MODELS[kind].keys())):
+        for model in (set(SIDEREAL_TIME_MODELS[other].keys())
+                      - set(SIDEREAL_TIME_MODELS[kind].keys())):
             with pytest.raises(ValueError):
                 self.t.sidereal_time(kind, 'greenwich', model)
             with pytest.raises(ValueError):

--- a/astropy/time/tests/test_update_leap_seconds.py
+++ b/astropy/time/tests/test_update_leap_seconds.py
@@ -76,8 +76,8 @@ class TestUpdateLeapSeconds:
         # Create similarly expired file.
         expired_file = str(tmpdir.join('expired.dat'))
         with open(expired_file, 'w') as fh:
-            fh.write('\n'.join(['# File expires on 28 June 2010'] +
-                               [str(item) for item in expired]))
+            fh.write('\n'.join(['# File expires on 28 June 2010']
+                               + [str(item) for item in expired]))
 
         with pytest.warns(iers.IERSStaleWarning):
             update_leap_seconds(['erfa', expired_file])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR makes the time subpackage pass:
```
flake8 --ignore=W503,E402,E721,E731
```
This allows much better local flake8 testing during development with an IDE or command-line run with flake8.  It may eventually allow more complete CI testing using `--ignore` instead of `--select`, but that is not in scope here.

Justification for exceptions:

- W503: *Line break occurred before a binary operator.*  Best practice is now:
```
income = (gross_wages
          + taxable_interest)
```
- E402: *Module level import not at top of file.*  There are frequently good reasons for out-of-order imports, and the `# noqa` get distracting.
- E721: *Do not compare types, use 'isinstance()'.*  In testing it is frequently necessary to do direct type comparisons.  (There are around 40 instances of this in table).
- E731: *Do not assign a lambda expression, use a def.*  This one is controversial anyway, but IMO there are many cases where lamdba expressions provide for concise and readable code. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #<Issue Number>
