### PR TITLE
Add mass-energy equivalency docs

### DIFF
--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -418,6 +418,16 @@ between the Celsius, Fahrenheit, and Kelvin. For example::
 
 .. note:: You can also use ``u.deg_C`` instead of ``u.Celsius``.
 
+Mass-energy Equivalency
+-----------------------
+
+In a special relativity context, mass and energy can be equivalent units. For
+example::
+
+    >>> import astropy.units as u
+    >>> (1*u.g).to(u.eV, u.mass_energy())  # doctest: +FLOAT_CMP
+    <Quantity 5.60958865e+32 eV>
+
 
 Writing new equivalencies
 =========================

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -418,14 +418,14 @@ between the Celsius, Fahrenheit, and Kelvin. For example::
 
 .. note:: You can also use ``u.deg_C`` instead of ``u.Celsius``.
 
-Mass-energy Equivalency
+Mass-Energy Equivalency
 -----------------------
 
 In a special relativity context, mass and energy can be equivalent units. For
 example::
 
     >>> import astropy.units as u
-    >>> (1*u.g).to(u.eV, u.mass_energy())  # doctest: +FLOAT_CMP
+    >>> (1 * u.g).to(u.eV, u.mass_energy())  # doctest: +FLOAT_CMP
     <Quantity 5.60958865e+32 eV>
 
 


### PR DESCRIPTION
It turns out as far as I can fine there's no explicit mention of the `mass_energy` equivalency in the equivalency part of the narrative docs.  This just adds a short example of it for completeness