### PR TITLE
Flake8 compliance --ignore=W503,E402,E721,E731

### DIFF
--- a/astropy/io/ascii/__init__.py
+++ b/astropy/io/ascii/__init__.py
@@ -2,7 +2,7 @@
 """ An extensible ASCII table reader and writer.
 
 """
-
+# flake8: noqa
 
 from .core import (InconsistentTableError,
                    ParameterError,

--- a/astropy/io/ascii/basic.py
+++ b/astropy/io/ascii/basic.py
@@ -159,7 +159,7 @@ class CommentedHeader(Basic):
             idx = self.header.start_line
             if idx < 0:
                 idx = len(out.meta['comments']) + idx
-            out.meta['comments'] = out.meta['comments'][:idx] + out.meta['comments'][idx+1:]
+            out.meta['comments'] = out.meta['comments'][:idx] + out.meta['comments'][idx + 1:]
             if not out.meta['comments']:
                 del out.meta['comments']
 
@@ -337,10 +337,12 @@ class RdbHeader(TabHeader):
         self.names, raw_types = header_vals_list
 
         if len(self.names) != len(raw_types):
-            raise core.InconsistentTableError('RDB header mismatch between number of column names and column types.')
+            raise core.InconsistentTableError(
+                'RDB header mismatch between number of column names and column types.')
 
         if any(not re.match(r'\d*(N|S)$', x, re.IGNORECASE) for x in raw_types):
-            raise core.InconsistentTableError(f'RDB types definitions do not all match [num](N|S): {raw_types}')
+            raise core.InconsistentTableError(
+                f'RDB types definitions do not all match [num](N|S): {raw_types}')
 
         self._set_cols_from_names()
         for col, raw_type in zip(self.cols, raw_types):

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -174,7 +174,7 @@ class CdsData(core.BaseData):
                       if x.startswith(('------', '======='))]
         if not i_sections:
             raise core.InconsistentTableError('No CDS section delimiter found')
-        return lines[i_sections[-1] + 1:]
+        return lines[i_sections[-1]+1:]
 
 
 class Cds(core.BaseReader):

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -107,7 +107,7 @@ class CdsHeader(core.BaseHeader):
                                 re.VERBOSE)
 
         cols = []
-        for line in itertools.islice(lines, i_col_def+4, None):
+        for line in itertools.islice(lines, i_col_def + 4, None):
             if line.startswith(('------', '=======')):
                 break
             match = re_col_def.match(line)
@@ -126,7 +126,8 @@ class CdsHeader(core.BaseHeader):
                 col.type = self.get_col_type(col)
 
                 match = re.match(
-                    r'\? (?P<equal> =)? (?P<nullval> \S*) (\s+ (?P<descriptiontext> \S.*))?', col.description, re.VERBOSE)
+                    r'\? (?P<equal> =)? (?P<nullval> \S*) (\s+ (?P<descriptiontext> \S.*))?',
+                    col.description, re.VERBOSE)
                 if match:
                     col.description = (match.group('descriptiontext') or '').strip()
                     if issubclass(col.type, core.FloatType):
@@ -139,7 +140,7 @@ class CdsHeader(core.BaseHeader):
                         # CDS tables can use -, --, ---, or ---- to mark missing values
                         # see https://github.com/astropy/astropy/issues/1335
                         for i in [1, 2, 3, 4]:
-                            self.data.fill_values.append(('-'*i, fillval, col.name))
+                            self.data.fill_values.append(('-' * i, fillval, col.name))
                     else:
                         col.null = match.group('nullval')
                         self.data.fill_values.append((col.null, fillval, col.name))
@@ -173,7 +174,7 @@ class CdsData(core.BaseData):
                       if x.startswith(('------', '======='))]
         if not i_sections:
             raise core.InconsistentTableError('No CDS section delimiter found')
-        return lines[i_sections[-1]+1:]
+        return lines[i_sections[-1] + 1:]
 
 
 class Cds(core.BaseReader):

--- a/astropy/io/ascii/connect.py
+++ b/astropy/io/ascii/connect.py
@@ -3,9 +3,8 @@
 
 
 import re
-import functools
 
-from astropy.io import registry as io_registry
+from astropy.io import registry as io_registry  # noqa
 from astropy.table import Table
 
 __all__ = []

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -299,8 +299,8 @@ class BaseInputter:
             List of lines
         """
         try:
-            if (hasattr(table, 'read') or
-                    ('\n' not in table + '' and '\r' not in table + '')):
+            if (hasattr(table, 'read')
+                    or ('\n' not in table + '' and '\r' not in table + '')):
                 with get_readable_fileobj(table,
                                           encoding=self.encoding) as fileobj:
                     table = fileobj.read()
@@ -695,16 +695,18 @@ class BaseHeader:
             for name in self.colnames:
                 if (_is_number(name) or len(name) == 0
                         or name[0] in bads or name[-1] in bads):
-                    raise InconsistentTableError('Column name {!r} does not meet strict name requirements'
-                                                 .format(name))
+                    raise InconsistentTableError(
+                        'Column name {!r} does not meet strict name requirements'
+                        .format(name))
         # When guessing require at least two columns
         if guessing and len(self.colnames) <= 1:
             raise ValueError('Table format guessing requires at least two columns, got {}'
                              .format(list(self.colnames)))
 
         if names is not None and len(names) != len(self.colnames):
-            raise InconsistentTableError('Length of names argument ({}) does not match number'
-                             ' of table columns ({})'.format(len(names), len(self.colnames)))
+            raise InconsistentTableError(
+                'Length of names argument ({}) does not match number'
+                ' of table columns ({})'.format(len(names), len(self.colnames)))
 
 
 class BaseData:
@@ -1003,10 +1005,12 @@ class BaseOutputter:
                     col.converters.pop(0)
                     last_err = err
                 except OverflowError as err:
-                    # Overflow during conversion (most likely an int that doesn't fit in native C long).
-                    # Put string at the top of the converters list for the next while iteration.
-                    warnings.warn("OverflowError converting to {} in column {}, reverting to String."
-                                  .format(converter_type.__name__, col.name), AstropyWarning)
+                    # Overflow during conversion (most likely an int that
+                    # doesn't fit in native C long). Put string at the top of
+                    # the converters list for the next while iteration.
+                    warnings.warn(
+                        "OverflowError converting to {} in column {}, reverting to String."
+                        .format(converter_type.__name__, col.name), AstropyWarning)
                     col.converters.insert(0, convert_numpy(numpy.str))
                     last_err = err
                 except IndexError:
@@ -1065,16 +1069,16 @@ class MetaBaseReader(type):
         for io_format in io_formats:
             func = functools.partial(connect.io_read, io_format)
             header = f"ASCII reader '{io_format}' details\n"
-            func.__doc__ = (inspect.cleandoc(READ_DOCSTRING).strip() + '\n\n' +
-                            header + re.sub('.', '=', header) + '\n')
+            func.__doc__ = (inspect.cleandoc(READ_DOCSTRING).strip() + '\n\n'
+                            + header + re.sub('.', '=', header) + '\n')
             func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
             connect.io_registry.register_reader(io_format, Table, func)
 
             if dct.get('_io_registry_can_write', True):
                 func = functools.partial(connect.io_write, io_format)
                 header = f"ASCII writer '{io_format}' details\n"
-                func.__doc__ = (inspect.cleandoc(WRITE_DOCSTRING).strip() + '\n\n' +
-                                header + re.sub('.', '=', header) + '\n')
+                func.__doc__ = (inspect.cleandoc(WRITE_DOCSTRING).strip() + '\n\n'
+                                + header + re.sub('.', '=', header) + '\n')
                 func.__doc__ += inspect.cleandoc(cls.__doc__).strip()
                 connect.io_registry.register_writer(io_format, Table, func)
 
@@ -1247,7 +1251,8 @@ class BaseReader(metaclass=MetaBaseReader):
         if hasattr(self.header, 'table_meta'):
             self.meta['table'].update(self.header.table_meta)
 
-        _apply_include_exclude_names(self.header, self.names, self.include_names, self.exclude_names)
+        _apply_include_exclude_names(self.header, self.names,
+                                     self.include_names, self.exclude_names)
 
         table = self.outputter(self.header.cols, self.meta)
         self.cols = self.header.cols
@@ -1406,8 +1411,8 @@ class WhitespaceSplitter(DefaultSplitter):
         in_quote = False
         lastchar = None
         for char in line:
-            if char == self.quotechar and (self.escapechar is None or
-                                           lastchar != self.escapechar):
+            if char == self.quotechar and (self.escapechar is None
+                                           or lastchar != self.escapechar):
                 in_quote = not in_quote
             if char == '\t' and not in_quote:
                 char = ' '
@@ -1441,8 +1446,8 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     # (e.g. by passing non-default options), raise an error for slow readers
     if 'fast_reader' in kwargs:
         if kwargs['fast_reader']['enable'] == 'force':
-            raise ParameterError('fast_reader required with ' +
-                                 '{}, but this is not a fast C reader: {}'
+            raise ParameterError('fast_reader required with '
+                                 + '{}, but this is not a fast C reader: {}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
             del kwargs['fast_reader']  # Otherwise ignore fast_reader parameter

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1447,7 +1447,7 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     if 'fast_reader' in kwargs:
         if kwargs['fast_reader']['enable'] == 'force':
             raise ParameterError('fast_reader required with '
-                                 + '{}, but this is not a fast C reader: {}'
+                                 '{}, but this is not a fast C reader: {}'
                                  .format(kwargs['fast_reader'], Reader))
         else:
             del kwargs['fast_reader']  # Otherwise ignore fast_reader parameter

--- a/astropy/io/ascii/daophot.py
+++ b/astropy/io/ascii/daophot.py
@@ -307,7 +307,7 @@ class DaophotInputter(core.ContinuationLinesInputter):
                     parts = []
             else:
                 raise core.InconsistentTableError('multiline re could not match line '
-                                 '{}: {}'.format(i, line))
+                                                  '{}: {}'.format(i, line))
 
         return outlines
 

--- a/astropy/io/ascii/ecsv.py
+++ b/astropy/io/ascii/ecsv.py
@@ -6,7 +6,6 @@ writing all the meta data associated with an astropy Table object.
 
 import re
 from collections import OrderedDict
-import contextlib
 import warnings
 
 from . import core, basic
@@ -24,6 +23,7 @@ class EcsvHeader(basic.BasicHeader):
     """Header class for which the column definition line starts with the
     comment character.  See the :class:`CommentedHeader` class  for an example.
     """
+
     def process_lines(self, lines):
         """Return only non-blank lines that start with the comment regexp.  For these
         lines strip out the matching characters and leading/trailing whitespace."""
@@ -160,8 +160,8 @@ class EcsvHeader(basic.BasicHeader):
         # Check for consistency of the ECSV vs. CSV header column names
         if header_names != self.names:
             raise core.InconsistentTableError('column names from ECSV header {} do not '
-                             'match names from header line of CSV data {}'
-                             .format(self.names, header_names))
+                                              'match names from header line of CSV data {}'
+                                              .format(self.names, header_names))
 
         # BaseHeader method to create self.cols, which is a list of
         # io.ascii.core.Column objects (*not* Table Column objects).
@@ -230,8 +230,8 @@ class EcsvData(basic.BasicData):
         # as a MaskedColumn.  Without 'data_mask', MaskedColumn objects are
         # stored to ECSV as normal columns.
         for col in cols:
-            if (col.dtype == 'str' and col.name in scs and
-                    scs[col.name]['__class__'] == 'astropy.table.column.MaskedColumn'):
+            if (col.dtype == 'str' and col.name in scs
+                    and scs[col.name]['__class__'] == 'astropy.table.column.MaskedColumn'):
                 col.fill_values = {}  # No data value replacement
 
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -266,7 +266,7 @@ class FastCommentedHeader(FastBasic):
             idx = self.header_start
             if idx < 0:
                 idx = len(comments) + idx
-            meta['comments'] = comments[:idx] + comments[idx + 1:]
+            meta['comments'] = comments[:idx] + comments[idx+1:]
             if not meta['comments']:
                 del meta['comments']
 

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -29,8 +29,8 @@ class FastBasic(metaclass=core.MetaBaseReader):
         # Make sure user does not set header_start to None for a reader
         # that expects a non-None value (i.e. a number >= 0).  This mimics
         # what happens in the Basic reader.
-        if (default_kwargs.get('header_start', 0) is not None and
-                user_kwargs.get('header_start', 0) is None):
+        if (default_kwargs.get('header_start', 0) is not None
+                and user_kwargs.get('header_start', 0) is None):
             raise ValueError('header_start cannot be set to None for this Reader')
 
         # Set up kwargs and copy any user kwargs.  Use deepcopy user kwargs
@@ -50,8 +50,8 @@ class FastBasic(metaclass=core.MetaBaseReader):
         self.header_start = kwargs.pop('header_start', 0)
         # If data_start is not specified, start reading
         # data right after the header line
-        data_start_default = user_kwargs.get('data_start', self.header_start +
-                                    1 if self.header_start is not None else 1)
+        data_start_default = user_kwargs.get('data_start', self.header_start
+                                             + 1 if self.header_start is not None else 1)
         self.data_start = kwargs.pop('data_start', data_start_default)
         self.kwargs = kwargs
         self.strip_whitespace_lines = True
@@ -72,7 +72,7 @@ class FastBasic(metaclass=core.MetaBaseReader):
         elif self.data_start is None:
             raise core.ParameterError("The C reader does not allow data_start to be None")
         elif self.header_start is not None and self.header_start < 0 and \
-             not isinstance(self, FastCommentedHeader):
+                not isinstance(self, FastCommentedHeader):
             raise core.ParameterError("The C reader does not allow header_start to be "
                                       "negative except for commented-header files")
         elif self.data_start < 0:
@@ -146,10 +146,10 @@ class FastBasic(metaclass=core.MetaBaseReader):
             # Impose strict requirements on column names (normally used in guessing)
             bads = [" ", ",", "|", "\t", "'", '"']
             for name in names:
-                if (core._is_number(name) or
-                    len(name) == 0 or
-                    name[0] in bads or
-                    name[-1] in bads):
+                if (core._is_number(name)
+                    or len(name) == 0
+                    or name[0] in bads
+                        or name[-1] in bads):
                     raise ValueError('Column name {!r} does not meet strict name requirements'
                                      .format(name))
         # When guessing require at least two columns
@@ -168,10 +168,10 @@ class FastBasic(metaclass=core.MetaBaseReader):
                header_output=True, output_types=False):
 
         write_kwargs = {'delimiter': self.delimiter,
-                         'quotechar': self.quotechar,
-                         'strip_whitespace': self.strip_whitespace_fields,
-                         'comment': self.write_comment
-                         }
+                        'quotechar': self.quotechar,
+                        'strip_whitespace': self.strip_whitespace_fields,
+                        'comment': self.write_comment
+                        }
         write_kwargs.update(default_kwargs)
         # user kwargs take precedence over default kwargs
         write_kwargs.update(self.kwargs)
@@ -266,7 +266,7 @@ class FastCommentedHeader(FastBasic):
             idx = self.header_start
             if idx < 0:
                 idx = len(comments) + idx
-            meta['comments'] = comments[:idx] + comments[idx+1:]
+            meta['comments'] = comments[:idx] + comments[idx + 1:]
             if not meta['comments']:
                 del meta['comments']
 
@@ -339,11 +339,11 @@ class FastRdb(FastBasic):
 
         if len(self.engine.get_names()) != len(types):
             raise core.InconsistentTableError('RDB header mismatch between number of '
-                             'column names and column types')
+                                              'column names and column types')
 
         if any(not re.match(r'\d*(N|S)$', x, re.IGNORECASE) for x in types):
             raise core.InconsistentTableError('RDB type definitions do not all match '
-                             '[num](N|S): {}'.format(types))
+                                              '[num](N|S): {}'.format(types))
 
         try_int = {}
         try_float = {}

--- a/astropy/io/ascii/fixedwidth.py
+++ b/astropy/io/ascii/fixedwidth.py
@@ -133,15 +133,19 @@ class FixedWidthHeader(basic.BasicHeader):
                 # more intuitive user interface).
                 line = self.get_line(lines, position_line)
                 if len(set(line) - set([self.splitter.delimiter, ' '])) != 1:
-                    raise InconsistentTableError('Position line should only contain delimiters and one other character, e.g. "--- ------- ---".')
+                    raise InconsistentTableError(
+                        'Position line should only contain delimiters and '
+                        'one other character, e.g. "--- ------- ---".')
                     # The line above lies. It accepts white space as well.
                     # We don't want to encourage using three different
                     # characters, because that can cause ambiguities, but white
                     # spaces are so common everywhere that practicality beats
                     # purity here.
-                charset = self.set_of_position_line_characters.union(set([self.splitter.delimiter, ' ']))
+                charset = self.set_of_position_line_characters.union(
+                    set([self.splitter.delimiter, ' ']))
                 if not set(line).issubset(charset):
-                    raise InconsistentTableError(f'Characters in position line must be part of {charset}')
+                    raise InconsistentTableError(
+                        f'Characters in position line must be part of {charset}')
                 vals, self.col_starts, col_ends = self.get_fixedwidth_params(line)
                 self.col_ends = [x - 1 if x is not None else None for x in col_ends]
 
@@ -189,7 +193,8 @@ class FixedWidthHeader(basic.BasicHeader):
         # been given, so figure out whichever wasn't given.
         if self.col_starts is not None and self.col_ends is not None:
             starts = list(self.col_starts)  # could be any iterable, e.g. np.array
-            ends = [x + 1 if x is not None else None for x in self.col_ends]  # user supplies inclusive endpoint
+            # user supplies inclusive endpoint
+            ends = [x + 1 if x is not None else None for x in self.col_ends]
             if len(starts) != len(ends):
                 raise ValueError('Fixed width col_starts and col_ends must have the same length')
             vals = [line[start:end].strip() for start, end in zip(starts, ends)]

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -84,7 +84,7 @@ class HTMLInputter(core.BaseInputter):
             from bs4 import BeautifulSoup
         except ImportError:
             raise core.OptionalTableImportError('BeautifulSoup must be '
-                                        'installed to read HTML tables')
+                                                'installed to read HTML tables')
 
         if 'parser' not in self.html:
             with warnings.catch_warnings():
@@ -129,7 +129,7 @@ class HTMLSplitter(core.BaseSplitter):
             if header_elements:
                 # Return multicolumns as tuples for HTMLHeader handling
                 yield [(el.text.strip(), el['colspan']) if el.has_attr('colspan')
-                        else el.text.strip() for el in header_elements]
+                       else el.text.strip() for el in header_elements]
             data_elements = soup.find_all('td')
             if data_elements:
                 yield [el.text.strip() for el in data_elements]
@@ -232,7 +232,7 @@ class HTMLData(core.BaseData):
             if soup.td is not None:
                 if soup.th is not None:
                     raise core.InconsistentTableError('HTML tables cannot '
-                                'have headings and data in the same row')
+                                                      'have headings and data in the same row')
                 return i
 
         raise core.InconsistentTableError('No start line found for HTML data')
@@ -374,7 +374,7 @@ class HTML(core.BaseReader):
                 with w.tag('meta', attrib={'charset': 'utf-8'}):
                     pass
                 with w.tag('meta', attrib={'http-equiv': 'Content-type',
-                                    'content': 'text/html;charset=UTF-8'}):
+                                           'content': 'text/html;charset=UTF-8'}):
                     pass
                 if 'css' in self.html:
                     with w.tag('style'):
@@ -429,7 +429,8 @@ class HTML(core.BaseReader):
                                     # Split up multicolumns into separate columns
                                     new_col = Column([el[i] for el in col])
 
-                                    new_col_iter_str_vals = self.fill_values(col, new_col.info.iter_str_vals())
+                                    new_col_iter_str_vals = self.fill_values(
+                                        col, new_col.info.iter_str_vals())
                                     col_str_iters.append(new_col_iter_str_vals)
                                     new_cols_escaped.append(col_escaped)
                                     new_cols.append(new_col)

--- a/astropy/io/ascii/ipac.py
+++ b/astropy/io/ascii/ipac.py
@@ -423,7 +423,8 @@ class Ipac(basic.Basic):
 
     DBMS : bool, optional
         If true, this verifies that written tables adhere (semantically)
-        to the `IPAC/DBMS <https://irsa.ipac.caltech.edu/applications/DDGEN/Doc/DBMSrestriction.html>`_
+        to the `IPAC/DBMS
+        <https://irsa.ipac.caltech.edu/applications/DDGEN/Doc/DBMSrestriction.html>`_
         definition of IPAC tables. If 'False' it only checks for the (less strict)
         `IPAC <https://irsa.ipac.caltech.edu/applications/DDGEN/Doc/ipac_tbl.html>`_
         definition.
@@ -506,7 +507,7 @@ class Ipac(basic.Basic):
                  "IPAC metadata must be in the form {{'keywords':"
                  "{{'keyword': {{'value': value}} }}".format(ignored_keys),
                  AstropyUserWarning
-                )
+                 )
 
         # Usually, this is done in data.write, but since the header is written
         # first, we need that here.

--- a/astropy/io/ascii/latex.py
+++ b/astropy/io/ascii/latex.py
@@ -310,7 +310,9 @@ class Latex(core.BaseReader):
     data_class = LatexData
     inputter_class = LatexInputter
 
-    def __init__(self, ignore_latex_commands=['hline', 'vspace', 'tableline', 'toprule', 'midrule', 'bottomrule'],
+    def __init__(self,
+                 ignore_latex_commands=['hline', 'vspace', 'tableline',
+                                        'toprule', 'midrule', 'bottomrule'],
                  latexdict={}, caption='', col_align=None):
 
         super().__init__()

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -34,13 +34,15 @@ class SExtractorHeader(core.BaseHeader):
         # header comment string of the format: "# 1 ID short description [unit]"
         # However, some may be missing and must be inferred from skipped column numbers
         columns = {}
-        # E.g. '# 1 ID identification number' (without units) or '# 2 MAGERR magnitude of error [mag]'
+        # E.g. '# 1 ID identification number' (no units) or '# 2 MAGERR magnitude of error [mag]'
         # Updated along with issue #4603, for more robust parsing of unit
         re_name_def = re.compile(r"""^\s* \# \s*             # possible whitespace around #
                                  (?P<colnumber> [0-9]+)\s+   # number of the column in table
                                  (?P<colname> [-\w]+)        # name of the column
-                                 (?:\s+(?P<coldescr> \w .+)  # column description, match any character until...
-                                 (?:(?<!(\]))$|(?=(?:(?<=\S)\s+\[.+\]))))?  # ...until [non-space][space][unit] or [not-right-bracket][end]
+                                 # column description, match any character until...
+                                 (?:\s+(?P<coldescr> \w .+)
+                                 # ...until [non-space][space][unit] or [not-right-bracket][end]
+                                 (?:(?<!(\]))$|(?=(?:(?<=\S)\s+\[.+\]))))?
                                  (?:\s*\[(?P<colunit>.+)\])?.* # match units in brackets
                                  """, re.VERBOSE)
         dataline = None
@@ -65,7 +67,8 @@ class SExtractorHeader(core.BaseHeader):
         if dataline is not None:
             n_data_cols = len(dataline.split())
         else:
-            n_data_cols = colnumbers[-1]  # handles no data, where we have to rely on the last column number
+            # handles no data, where we have to rely on the last column number
+            n_data_cols = colnumbers[-1]
         # sextractor column number start at 1.
         columns[n_data_cols + 1] = (None, None, None)
         colnumbers.append(n_data_cols + 1)
@@ -73,8 +76,9 @@ class SExtractorHeader(core.BaseHeader):
             previous_column = 0
             for n in colnumbers:
                 if n != previous_column + 1:
-                    for c in range(previous_column+1, n):
-                        column_name = columns[previous_column][0]+"_{}".format(c-previous_column)
+                    for c in range(previous_column + 1, n):
+                        column_name = columns[previous_column][0] + \
+                            "_{}".format(c - previous_column)
                         column_descr = columns[previous_column][1]
                         column_unit = columns[previous_column][2]
                         columns[c] = (column_name, column_descr, column_unit)

--- a/astropy/io/ascii/sextractor.py
+++ b/astropy/io/ascii/sextractor.py
@@ -77,8 +77,8 @@ class SExtractorHeader(core.BaseHeader):
             for n in colnumbers:
                 if n != previous_column + 1:
                     for c in range(previous_column + 1, n):
-                        column_name = columns[previous_column][0] + \
-                            "_{}".format(c - previous_column)
+                        column_name = (columns[previous_column][0]
+                                       + "_{}".format(c - previous_column))
                         column_descr = columns[previous_column][1]
                         column_unit = columns[previous_column][2]
                         columns[c] = (column_name, column_descr, column_unit)

--- a/astropy/io/ascii/tests/common.py
+++ b/astropy/io/ascii/tests/common.py
@@ -16,10 +16,10 @@ TEST_DIR = os.path.dirname(__file__)
 
 has_isnan = True
 try:
-    from math import isnan  # pylint: disable=W0611
+    from math import isnan  # noqa
 except ImportError:
     try:
-        from numpy import isnan  # pylint: disable=W0611
+        from numpy import isnan  # noqa
     except ImportError:
         has_isnan = False
         print('Tests requiring isnan will fail')

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -13,7 +13,6 @@ from numpy import ma
 from astropy.table import Table, MaskedColumn
 from astropy.io import ascii
 from astropy.io.ascii.core import ParameterError, FastOptionsError, InconsistentTableError
-from astropy.io.ascii.cparser import CParserError
 from astropy.io.ascii.fastbasic import (
     FastBasic, FastCsv, FastTab, FastCommentedHeader, FastRdb, FastNoHeader)
 from astropy.tests.helper import catch_warnings
@@ -173,7 +172,8 @@ def test_no_header(parallel, read_basic, read_no_header):
         read_basic("A B C\n1 2 3\n4 5 6", header_start=None, data_start=0, parallel=parallel)
 
     t2 = read_no_header("A B C\n1 2 3\n4 5 6", parallel=parallel)
-    expected = Table([['A', '1', '4'], ['B', '2', '5'], ['C', '3', '6']], names=('col1', 'col2', 'col3'))
+    expected = Table([['A', '1', '4'], ['B', '2', '5'], ['C', '3', '6']],
+                     names=('col1', 'col2', 'col3'))
     assert_table_equal(t2, expected)
 
 
@@ -344,7 +344,7 @@ def test_doubled_quotes_segv():
     tbl = dedent("""
     "ID","TIMESTAMP","addendum_id","bib_reference","bib_reference_url","client_application","client_category","client_sort_key","color","coordsys","creator","creator_did","data_pixel_bitpix","dataproduct_subtype","dataproduct_type","em_max","em_min","format","hips_builder","hips_copyright","hips_creation_date","hips_creation_date_1","hips_creator","hips_data_range","hips_estsize","hips_frame","hips_glu_tag","hips_hierarchy","hips_initial_dec","hips_initial_fov","hips_initial_ra","hips_lon_asc","hips_master_url","hips_order","hips_order_1","hips_order_4","hips_order_min","hips_overlay","hips_pixel_bitpix","hips_pixel_cut","hips_pixel_scale","hips_progenitor_url","hips_publisher","hips_release_date","hips_release_date_1","hips_rgb_blue","hips_rgb_green","hips_rgb_red","hips_sampling","hips_service_url","hips_service_url_1","hips_service_url_2","hips_service_url_3","hips_service_url_4","hips_service_url_5","hips_service_url_6","hips_service_url_7","hips_service_url_8","hips_skyval","hips_skyval_method","hips_skyval_value","hips_status","hips_status_1","hips_status_2","hips_status_3","hips_status_4","hips_status_5","hips_status_6","hips_status_7","hips_status_8","hips_tile_format","hips_tile_format_1","hips_tile_format_4","hips_tile_width","hips_version","hipsgen_date","hipsgen_date_1","hipsgen_date_10","hipsgen_date_11","hipsgen_date_12","hipsgen_date_2","hipsgen_date_3","hipsgen_date_4","hipsgen_date_5","hipsgen_date_6","hipsgen_date_7","hipsgen_date_8","hipsgen_date_9","hipsgen_params","hipsgen_params_1","hipsgen_params_10","hipsgen_params_11","hipsgen_params_12","hipsgen_params_2","hipsgen_params_3","hipsgen_params_4","hipsgen_params_5","hipsgen_params_6","hipsgen_params_7","hipsgen_params_8","hipsgen_params_9","label","maxOrder","moc_access_url","moc_order","moc_release_date","moc_sky_fraction","obs_ack","obs_collection","obs_copyrigh_url","obs_copyright","obs_copyright_1","obs_copyright_url","obs_copyright_url_1","obs_description","obs_description_url","obs_descrition_url","obs_id","obs_initial_dec","obs_initial_fov","obs_initial_ra","obs_provenance","obs_regime","obs_title","ohips_frame","pixelCut","pixelRange","prov_did","prov_progenitor","prov_progenitor_url","publisher_did","publisher_id","s_pixel_scale","t_max","t_min"
     "CDS/P/2MASS/H","1524123841000","","2006AJ....131.1163S","http://cdsbib.u-strasbg.fr/cgi-bin/cdsbib?2006AJ....131.1163S","AladinDesktop","Image/Infrared/2MASS","04-001-03","","","","ivo://CDS/P/2MASS/H","","","image","1.798E-6","1.525E-6","","Aladin/HipsGen v9.017","CNRS/Unistra","2013-05-06T20:36Z","","CDS (A.Oberto)","","","equatorial","","mean","","","","","","9","","","","","","0 60","2.236E-4","","","2016-04-22T13:48Z","","","","","","http://alasky.u-strasbg.fr/2MASS/H","https://irsa.ipac.caltech.edu/data/hips/CDS/2MASS/H","http://alaskybis.u-strasbg.fr/2MASS/H","https://alaskybis.u-strasbg.fr/2MASS/H","","","","","","","","","public master clonableOnce","public mirror unclonable","public mirror clonableOnce","public mirror clonableOnce","","","","","","jpeg fits","","","512","1.31","","","","","","","","","","","","","","","","","","","","","","","","","","","","","http://alasky.u-strasbg.fr/2MASS/H/Moc.fits","9","","1","University of Massachusetts & IPAC/Caltech","The Two Micron All Sky Survey - H band (2MASS H)","","University of Massachusetts & IPAC/Caltech","","http://www.ipac.caltech.edu/2mass/","","2MASS has uniformly scanned the entire sky in three near-infrared bands to detect and characterize point sources brighter than about 1 mJy in each band, with signal-to-noise ratio (SNR) greater than 10, using a pixel size of 2.0"". This has achieved an 80,000-fold improvement in sensitivity relative to earlier surveys. 2MASS used two highly-automated 1.3-m telescopes, one at Mt. Hopkins, AZ, and one at CTIO, Chile. Each telescope was equipped with a three-channel camera, each channel consisting of a 256x256 array of HgCdTe detectors, capable of observing the sky simultaneously at J (1.25 microns), H (1.65 microns), and Ks (2.17 microns). The University of Massachusetts (UMass) was responsible for the overall management of the project, and for developing the infrared cameras and on-site computing systems at both facilities. The Infrared Processing and Analysis Center (IPAC) is responsible for all data processing through the Production Pipeline, and construction and distribution of the data products. Funding is provided primarily by NASA and the NSF","","","","+0","0.11451621372724685","0","","Infrared","2MASS H (1.66um)","","","","","IPAC/NASA","","","","","51941","50600"
-    """)
+    """)  # noqa
     ascii.read(tbl, format='csv', fast_reader=True, guess=False)
 
 
@@ -376,7 +376,8 @@ def test_quoted_fields(parallel, read_basic):
     ('data_start', -1),  # data_start negative
     ('quotechar', '##'),  # multi-char quote signifier
     ('header_start', -1),  # negative header_start
-    ('converters', dict((i + 1, ascii.convert_numpy(np.uint)) for i in range(3))),  # passing converters
+    ('converters', dict((i + 1, ascii.convert_numpy(np.uint))
+                        for i in range(3))),  # passing converters
     ('Inputter', ascii.ContinuationLinesInputter),  # passing Inputter
     ('header_Splitter', ascii.DefaultSplitter),  # passing Splitter
     ('data_Splitter', ascii.DefaultSplitter)])
@@ -413,7 +414,7 @@ def test_too_many_cols1():
     11 12 13
     """)
     with pytest.raises(InconsistentTableError) as e:
-        table = FastBasic().read(text)
+        FastBasic().read(text)
     assert 'Number of header columns (3) ' \
            'inconsistent with data columns in data line 2' in str(e.value)
 
@@ -425,7 +426,7 @@ aaa,bbb
 3,4,
 """
     with pytest.raises(InconsistentTableError) as e:
-        table = FastCsv().read(text)
+        FastCsv().read(text)
     assert 'Number of header columns (2) ' \
            'inconsistent with data columns in data line 0' in str(e.value)
 
@@ -437,7 +438,7 @@ aaa,bbb
 3,4,
 """
     with pytest.raises(InconsistentTableError) as e:
-        table = FastCsv().read(text)
+        FastCsv().read(text)
     assert 'Number of header columns (2) ' \
            'inconsistent with data columns in data line 0' in str(e.value)
 
@@ -458,7 +459,7 @@ A,B,C
     assert table['B'][1] is not ma.masked
     assert table['C'][1] is ma.masked
 
-    with pytest.raises(InconsistentTableError) as e:
+    with pytest.raises(InconsistentTableError):
         table = FastBasic(delimiter=',').read(text)
 
 
@@ -570,8 +571,9 @@ nan, 5, -9999
     for name in 'ABC':
         assert not isinstance(table[name], MaskedColumn)
 
-    table = read_basic(text, delimiter=',', fill_values=[('', '0', 'A'),
-                                ('nan', '999', 'A', 'C')], parallel=parallel)
+    table = read_basic(text, delimiter=',',
+                       fill_values=[('', '0', 'A'),
+                                    ('nan', '999', 'A', 'C')], parallel=parallel)
     assert np.isnan(table['B'][3])  # nan filling skips column B
     assert table['B'][3] is not ma.masked  # should skip masking as well as replacing nan
     assert table['A'][0] is ma.masked
@@ -605,7 +607,8 @@ A, B, C
     assert table['A'][0] is not ma.masked
     assert table['B'][1] is not ma.masked  # A and B excluded from fill handling
 
-    table = read_csv(text, fill_include_names=['A', 'B'], fill_exclude_names=['B'], parallel=parallel)
+    table = read_csv(text, fill_include_names=['A', 'B'],
+                     fill_exclude_names=['B'], parallel=parallel)
     assert table['A'][0] is ma.masked
     assert table['B'][1] is not ma.masked  # fill_exclude_names applies after fill_include_names
     assert table['C'][2] is not ma.masked
@@ -720,7 +723,8 @@ def test_commented_header(parallel, read_commented_header):
     text = '# first commented line\n # second commented line\n\n' + text
     t2 = read_commented_header(text, header_start=2, data_start=0, parallel=parallel)
     assert_table_equal(t2, expected)
-    t3 = read_commented_header(text, header_start=-1, data_start=0, parallel=parallel)  # negative indexing allowed
+    t3 = read_commented_header(text, header_start=-1, data_start=0,
+                               parallel=parallel)  # negative indexing allowed
     assert_table_equal(t3, expected)
 
     text += '7 8 9'
@@ -729,7 +733,8 @@ def test_commented_header(parallel, read_commented_header):
     assert_table_equal(t4, expected)
 
     with pytest.raises(ParameterError):
-        read_commented_header(text, header_start=-1, data_start=-1, parallel=parallel)  # data_start cannot be negative
+        read_commented_header(text, header_start=-1, data_start=-1,
+                              parallel=parallel)  # data_start cannot be negative
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -958,10 +963,9 @@ def test_fast_tab_with_names(parallel, read_tab):
     """
     content = """#
 \tdecDeg\tRate_pn_offAxis\tRate_mos2_offAxis\tObsID\tSourceID\tRADeg\tversion\tCounts_pn\tRate_pn\trun\tRate_mos1\tRate_mos2\tInserted_pn\tInserted_mos2\tbeta\tRate_mos1_offAxis\trcArcsec\tname\tInserted\tCounts_mos1\tInserted_mos1\tCounts_mos2\ty\tx\tCounts\toffAxis\tRot
--3.007559\t0.0000\t0.0010\t0013140201\t0\t213.462574\t0\t2\t0.0002\t0\t0.0001\t0.0001\t0\t1\t0.66\t0.0217\t3.0\tfakeXMMXCS J1413.8-0300\t3\t1\t2\t1\t398.000\t127.000\t5\t13.9\t72.3\t"""
+-3.007559\t0.0000\t0.0010\t0013140201\t0\t213.462574\t0\t2\t0.0002\t0\t0.0001\t0.0001\t0\t1\t0.66\t0.0217\t3.0\tfakeXMMXCS J1413.8-0300\t3\t1\t2\t1\t398.000\t127.000\t5\t13.9\t72.3\t"""  # noqa
     head = [f'A{i}' for i in range(28)]
-    table = read_tab(content, data_start=1,
-                     parallel=parallel, names=head)
+    read_tab(content, data_start=1, parallel=parallel, names=head)
 
 
 @pytest.mark.skipif(not os.getenv('TEST_READ_HUGE_FILE'),
@@ -982,7 +986,7 @@ def test_read_big_table(tmpdir):
 
     print(f"Creating a {NB_ROWS} rows table ({NB_COLS} columns).")
     data = np.random.random(NB_ROWS)
-    t = Table(data=[data]*NB_COLS, names=[str(i) for i in range(NB_COLS)])
+    t = Table(data=[data] * NB_COLS, names=[str(i) for i in range(NB_COLS)])
     data = None
 
     print(f"Saving the table to {filename}")
@@ -1136,16 +1140,16 @@ def test_data_at_range_limit(parallel, fast_reader, guess):
 
     # Test very long fixed-format strings (to strtod range limit w/o Overflow)
     for D in 99, 202, 305:
-        t = ascii.read(StringIO(99*'0' + '.' + D*'0' + '1'), format='no_header',
+        t = ascii.read(StringIO(99 * '0' + '.' + D * '0' + '1'), format='no_header',
                        guess=guess, fast_reader=fast_reader)
-        assert_almost_equal(t['col1'][0], 10.**-(D+1), rtol=rtol, atol=1.e-324)
+        assert_almost_equal(t['col1'][0], 10.**-(D + 1), rtol=rtol, atol=1.e-324)
     for D in 99, 202, 308:
-        t = ascii.read(StringIO('1' + D*'0' + '.0'), format='no_header',
+        t = ascii.read(StringIO('1' + D * '0' + '.0'), format='no_header',
                        guess=guess, fast_reader=fast_reader)
         assert_almost_equal(t['col1'][0], 10.**D, rtol=rtol, atol=1.e-324)
 
     # 0.0 is always exact (no Overflow warning)!
-    for s in '0.0', '0.0e+0', 399*'0'+'.'+365*'0':
+    for s in '0.0', '0.0e+0', 399 * '0' + '.' + 365 * '0':
         with pytest.warns(None) as w:
             t = ascii.read(StringIO(s), format='no_header',
                            guess=guess, fast_reader=fast_reader)
@@ -1160,7 +1164,7 @@ def test_data_at_range_limit(parallel, fast_reader, guess):
     with pytest.warns(AstropyWarning, match=r'OverflowError converting to '
                       r'FloatType in column col1, possibly resulting in '
                       r'degraded precision'):
-        t = ascii.read(StringIO('0.' + 314*'0' + '1'), format='no_header',
+        t = ascii.read(StringIO('0.' + 314 * '0' + '1'), format='no_header',
                        guess=guess, fast_reader=fast_reader)
     assert_almost_equal(t['col1'][0], 1.e-315, rtol=1.e-10, atol=1.e-324)
 
@@ -1172,8 +1176,8 @@ def test_int_out_of_range(parallel, guess):
     Integer numbers outside int range shall be returned as string columns
     consistent with the standard (Python) parser (no 'upcasting' to float).
     """
-    imin = np.iinfo(int).min+1
-    imax = np.iinfo(int).max-1
+    imin = np.iinfo(int).min + 1
+    imax = np.iinfo(int).max - 1
     huge = f'{imax+2:d}'
 
     text = f'P M S\n {imax:d} {imin:d} {huge:s}'
@@ -1189,7 +1193,7 @@ def test_int_out_of_range(parallel, guess):
 
     # Check with leading zeroes to make sure strtol does not read them as octal
     text = f'P M S\n000{imax:d} -0{-imin:d} 00{huge:s}'
-    expected = Table([[imax], [imin], ['00'+huge]], names=('P', 'M', 'S'))
+    expected = Table([[imax], [imin], ['00' + huge]], names=('P', 'M', 'S'))
     with catch_warnings(AstropyWarning) as w:
         table = ascii.read(text, format='basic', guess=guess,
                            fast_reader={'parallel': parallel})
@@ -1207,9 +1211,9 @@ def test_int_out_of_order(guess):
     shows up first, it will produce a string column - with both readers.
     Broken with the parallel fast_reader.
     """
-    imax = np.iinfo(int).max-1
+    imax = np.iinfo(int).max - 1
     text = f'A B\n 12.3 {imax:d}0\n {imax:d}0 45.6e7'
-    expected = Table([[12.3, 10.*imax], [f'{imax:d}0', '45.6e7']],
+    expected = Table([[12.3, 10. * imax], [f'{imax:d}0', '45.6e7']],
                      names=('A', 'B'))
 
     with pytest.warns(AstropyWarning, match=r'OverflowError converting to '
@@ -1238,14 +1242,14 @@ def test_fortran_reader(parallel, guess):
     expc = Table([[1.0001e101, 0.42], [2, 0.5], [2.e-103, 6.e3], [3, 1.7e307]],
                  names=('A', 'B', 'C', 'D'))
 
-    expstyles = {'e': 6*('E'),
+    expstyles = {'e': 6 * ('E'),
                  'D': ('D', 'd', 'd', 'D', 'd', 'D'),
-                 'Q': 3*('q', 'Q'),
-                  'Fortran': ('E', '0', 'D', 'Q', 'd', '0')}
+                 'Q': 3 * ('q', 'Q'),
+                 'Fortran': ('E', '0', 'D', 'Q', 'd', '0')}
 
     # C strtod (not-fast converter) can't handle Fortran exp
     with pytest.raises(FastOptionsError) as e:
-        ascii.read(text.format(*(6*('D'))), format='basic', guess=guess,
+        ascii.read(text.format(*(6 * ('D'))), format='basic', guess=guess,
                    fast_reader={'use_fast_converter': False,
                                 'parallel': parallel, 'exponent_style': 'D'})
     assert 'fast_reader: exponent_style requires use_fast_converter' in str(e.value)
@@ -1283,18 +1287,18 @@ def test_fortran_invalid_exp(parallel, guess):
     # then for different specified exponents
     fields = ['1.0001+1', '.42d1', '2.3+10', '0.5', '3+1001', '3000.',
               '2', '4.56e-2.3', '8000', '4.2-022', '.00000145e314']
-    vals_e = ['1.0001+1', '.42d1', '2.3+10',   0.5, '3+1001',  3.e3,
-              2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308]
-    vals_d = ['1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-              2, '4.56e-2.3',    8000,  '4.2-022', '.00000145e314']
-    vals_a = ['1.0001+1',     4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-              2, '4.56e-2.3',    8000,   4.2e-22,  1.45e308]
-    vals_v = ['1.0001+1', 4.2, '2.3+10',   0.5, '3+1001',  3.e3,
-               2, '4.56e-2.3',    8000,  '4.2-022', 1.45e308]
+    vals_e = ['1.0001+1', '.42d1', '2.3+10', 0.5, '3+1001', 3.e3,
+              2, '4.56e-2.3', 8000, '4.2-022', 1.45e308]
+    vals_d = ['1.0001+1', 4.2, '2.3+10', 0.5, '3+1001', 3.e3,
+              2, '4.56e-2.3', 8000, '4.2-022', '.00000145e314']
+    vals_a = ['1.0001+1', 4.2, '2.3+10', 0.5, '3+1001', 3.e3,
+              2, '4.56e-2.3', 8000, 4.2e-22, 1.45e308]
+    vals_v = ['1.0001+1', 4.2, '2.3+10', 0.5, '3+1001', 3.e3,
+              2, '4.56e-2.3', 8000, '4.2-022', 1.45e308]
 
     # Iterate over supported format types and separators
     for f, s in formats.items():
-        t1 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)),
+        t1 = ascii.read(StringIO(s.join(header) + '\n' + s.join(fields)),
                         format=f, guess=guess,
                         fast_reader={'parallel': parallel, 'exponent_style': 'A'})
         assert_table_equal(t1, Table([[col] for col in vals_a], names=header))
@@ -1306,29 +1310,29 @@ def test_fortran_invalid_exp(parallel, guess):
         formats = {'basic': ' '}
 
     for s in formats.values():
-        t2 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
-                fast_reader={'parallel': parallel, 'exponent_style': 'a'})
+        t2 = ascii.read(StringIO(s.join(header) + '\n' + s.join(fields)), guess=guess,
+                        fast_reader={'parallel': parallel, 'exponent_style': 'a'})
 
         assert_table_equal(t2, Table([[col] for col in vals_a], names=header))
 
     # Iterate for (default) expchar 'E'
     for s in formats.values():
-        t3 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
-                fast_reader={'parallel': parallel, 'use_fast_converter': True})
+        t3 = ascii.read(StringIO(s.join(header) + '\n' + s.join(fields)), guess=guess,
+                        fast_reader={'parallel': parallel, 'use_fast_converter': True})
 
         assert_table_equal(t3, Table([[col] for col in vals_e], names=header))
 
     # Iterate for expchar 'D'
     for s in formats.values():
-        t4 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
-                fast_reader={'parallel': parallel, 'exponent_style': 'D'})
+        t4 = ascii.read(StringIO(s.join(header) + '\n' + s.join(fields)), guess=guess,
+                        fast_reader={'parallel': parallel, 'exponent_style': 'D'})
 
         assert_table_equal(t4, Table([[col] for col in vals_d], names=header))
 
     # Iterate for regular converter (strtod)
     for s in formats.values():
-        t5 = ascii.read(StringIO(s.join(header)+'\n'+s.join(fields)), guess=guess,
-                fast_reader={'parallel': parallel, 'use_fast_converter': False})
+        t5 = ascii.read(StringIO(s.join(header) + '\n' + s.join(fields)), guess=guess,
+                        fast_reader={'parallel': parallel, 'use_fast_converter': False})
 
         read_values = [col[0] for col in t5.itercols()]
         if os.name == 'nt':
@@ -1391,18 +1395,18 @@ def test_fortran_reader_notbasic():
     assert t5['b'].dtype.kind == 'f'
 
     with pytest.raises(ParameterError):
-        t6 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
-                        fast_reader='force')
+        ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                   fast_reader='force')
 
     with pytest.raises(ParameterError):
-        t7 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
-                        fast_reader=dict(use_fast_converter=False))
+        ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                   fast_reader=dict(use_fast_converter=False))
 
     tabrst = tabrst.replace('E', 'D')
 
     with pytest.raises(ParameterError):
-        t8 = ascii.read(tabrst.split('\n'), format='rst', guess=False,
-                        fast_reader=dict(exponent_style='D'))
+        ascii.read(tabrst.split('\n'), format='rst', guess=False,
+                   fast_reader=dict(exponent_style='D'))
 
 
 @pytest.mark.parametrize("guess", [True, False])
@@ -1416,8 +1420,8 @@ def test_dict_kwarg_integrity(fast_reader, guess):
     expstyle = fast_reader.get('exponent_style', 'E')
     fields = ['10.1D+199', '3.14d+313', '2048d+306', '0.6D-325', '-2.d345']
 
-    t = ascii.read(StringIO(' '.join(fields)), guess=guess,
-                   fast_reader=fast_reader)
+    ascii.read(StringIO(' '.join(fields)), guess=guess,
+               fast_reader=fast_reader)
     assert fast_reader.get('exponent_style', None) == expstyle
 
 

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 from astropy.io import ascii
-from .common import (assert_equal, assert_almost_equal,
-                     setup_function, teardown_function)
+from .common import (assert_equal, assert_almost_equal,  # noqa
+                     setup_function, teardown_function)  # noqa
 
 
 def read_table1(readme, data):

--- a/astropy/io/ascii/tests/test_compressed.py
+++ b/astropy/io/ascii/tests/test_compressed.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
-import sys
 
 import pytest
 import numpy as np
@@ -11,14 +10,14 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 try:
-    import bz2  # pylint: disable=W0611
+    import bz2  # noqa
 except ImportError:
     HAS_BZ2 = False
 else:
     HAS_BZ2 = True
 
 try:
-    import lzma
+    import lzma  # noqa
 except ImportError:
     HAS_XZ = False
 else:

--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -17,13 +17,13 @@ files = ['data/cds.dat', 'data/ipac.dat', 'data/daophot.dat', 'data/latex1.tex',
 # Check to see if the BeautifulSoup dependency is present.
 
 try:
-    from bs4 import BeautifulSoup  # pylint: disable=W0611
+    from bs4 import BeautifulSoup  # noqa
     HAS_BEAUTIFUL_SOUP = True
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False
 
 try:
-    import yaml
+    import yaml  # noqa
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -153,7 +153,7 @@ def test_write_csv(tmpdir):
 @pytest.mark.skipif('not HAS_YAML')
 def test_auto_identify_ecsv(tmpdir):
     tbl = simple_table()
-    tmpfile =  str(tmpdir.join('/tmpFile.ecsv'))
+    tmpfile = str(tmpdir.join('/tmpFile.ecsv'))
     tbl.write(tmpfile)
     tbl2 = Table.read(tmpfile)
     assert np.all(tbl == tbl2)

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -27,7 +27,7 @@ from astropy.io import ascii
 from astropy import units as u
 
 try:
-    import yaml  # pylint: disable=W0611
+    import yaml  # noqa
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -134,10 +134,10 @@ def test_write_read_roundtrip():
         t.write(out, format='ascii.ecsv', delimiter=delimiter)
 
         t2s = [Table.read(out.getvalue(), format='ascii.ecsv'),
-                Table.read(out.getvalue(), format='ascii'),
-                ascii.read(out.getvalue()),
-                ascii.read(out.getvalue(), format='ecsv', guess=False),
-                ascii.read(out.getvalue(), format='ecsv')]
+               Table.read(out.getvalue(), format='ascii'),
+               ascii.read(out.getvalue()),
+               ascii.read(out.getvalue(), format='ecsv', guess=False),
+               ascii.read(out.getvalue(), format='ecsv')]
         for t2 in t2s:
             assert t.meta == t2.meta
             for name in t.colnames:
@@ -227,8 +227,8 @@ def test_regression_5604():
     See https://github.com/astropy/astropy/issues/5604 for more.
     """
     t = Table()
-    t.meta = {"foo": 5*u.km, "foo2": u.s}
-    t["bar"] = [7]*u.km
+    t.meta = {"foo": 5 * u.km, "foo2": u.s}
+    t["bar"] = [7] * u.km
 
     out = StringIO()
     t.write(out, format="ascii.ecsv")
@@ -281,7 +281,7 @@ mixin_cols = {
                     obstime=['J1990.5'] * 2),
     'q': [1, 2] * u.m,
     'lat': Latitude([1, 2] * u.deg),
-    'lon': Longitude([1, 2] * u.deg, wrap_angle=180.*u.deg),
+    'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
     'ang': Angle([1, 2] * u.deg),
     'el': el,
     # 'nd': NdarrayMixin(el)  # not supported yet

--- a/astropy/io/ascii/tests/test_fixedwidth.py
+++ b/astropy/io/ascii/tests/test_fixedwidth.py
@@ -40,7 +40,7 @@ def test_read_normal_names():
 |  2.4   |'s worlds|
 """
     reader = ascii.get_reader(Reader=ascii.FixedWidth,
-                                   names=('name1', 'name2'))
+                              names=('name1', 'name2'))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['name1', 'name2'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -55,8 +55,8 @@ def test_read_normal_names_include():
 |  2.4   |'s worlds|     7 |
 """
     reader = ascii.get_reader(Reader=ascii.FixedWidth,
-                                   names=('name1', 'name2', 'name3'),
-                                   include_names=('name1', 'name3'))
+                              names=('name1', 'name2', 'name3'),
+                              include_names=('name1', 'name3'))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['name1', 'name3'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -72,7 +72,7 @@ def test_read_normal_exclude():
 |  2.4   |'s worlds|
 """
     reader = ascii.get_reader(Reader=ascii.FixedWidth,
-                                   exclude_names=('Col1',))
+                              exclude_names=('Col1',))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['Col2'])
     assert_equal(dat[1][0], "'s worlds")
@@ -117,7 +117,7 @@ def test_read_space_delimiter():
   Bob  555-4527     192.168.1.9
 """
     dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
-                          delimiter=' ')
+                     delimiter=' ')
     assert_equal(tuple(dat.dtype.names), ('Name', '--Phone-', '----TCP-----'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -132,7 +132,7 @@ def test_read_no_header_autocolumn():
 |   Bob  | 555-4527 | 192.168.1.9|
 """
     dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
-                          header_start=None, data_start=0)
+                     header_start=None, data_start=0)
     assert_equal(tuple(dat.dtype.names), ('col1', 'col2', 'col3'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -148,8 +148,8 @@ def test_read_no_header_names():
 |   Bob  | 555-4527 | 192.168.1.9|
 """
     dat = ascii.read(table, Reader=ascii.FixedWidth, guess=False,
-                          header_start=None, data_start=0,
-                          names=('Name', 'Phone', 'TCP'))
+                     header_start=None, data_start=0,
+                     names=('Name', 'Phone', 'TCP'))
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -179,7 +179,7 @@ def test_read_no_header_names_NoHeader():
 |   Bob  | 555-4527 | 192.168.1.9|
 """
     dat = ascii.read(table, Reader=ascii.FixedWidthNoHeader,
-                          names=('Name', 'Phone', 'TCP'))
+                     names=('Name', 'Phone', 'TCP'))
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
     assert_equal(dat[1][0], "Mary")
     assert_equal(dat[0][1], "555-1234")
@@ -196,10 +196,10 @@ def test_read_col_starts():
    Bob   555- 4527  192.168.1.9
 """
     dat = ascii.read(table, Reader=ascii.FixedWidthNoHeader,
-                          names=('Name', 'Phone', 'TCP'),
-                          col_starts=(0, 9, 18),
-                          col_ends=(5, 17, 28),
-                          )
+                     names=('Name', 'Phone', 'TCP'),
+                     col_starts=(0, 9, 18),
+                     col_ends=(5, 17, 28),
+                     )
     assert_equal(tuple(dat.dtype.names), ('Name', 'Phone', 'TCP'))
     assert_equal(dat[0][1], "555- 1234")
     assert_equal(dat[1][0], "Mary")
@@ -254,7 +254,7 @@ def test_write_fill_values():
     """Write a table as a normal fixed width table."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidth,
-                     fill_values=('a', 'N/A'))
+                fill_values=('a', 'N/A'))
     assert_equal_splitlines(out.getvalue(), """\
 | Col1 |      Col2 | Col3 | Col4 |
 |  1.2 |   "hello" |    1 |  N/A |
@@ -266,7 +266,7 @@ def test_write_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidth,
-                     delimiter_pad=None)
+                delimiter_pad=None)
     assert_equal_splitlines(out.getvalue(), """\
 |Col1|     Col2|Col3|Col4|
 | 1.2|  "hello"|   1|   a|
@@ -289,7 +289,7 @@ def test_write_no_delimiter():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidth, bookend=False,
-                     delimiter=None)
+                delimiter=None)
     assert_equal_splitlines(out.getvalue(), """\
 Col1       Col2  Col3  Col4
  1.2    "hello"     1     a
@@ -311,7 +311,7 @@ def test_write_noheader_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader,
-                     delimiter_pad=None)
+                delimiter_pad=None)
     assert_equal_splitlines(out.getvalue(), """\
 |1.2|  "hello"|1|a|
 |2.4|'s worlds|2|2|
@@ -322,7 +322,7 @@ def test_write_noheader_no_bookend():
     """Write a table as a fixed width table with no bookend."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader,
-                     bookend=False)
+                bookend=False)
     assert_equal_splitlines(out.getvalue(), """\
 1.2 |   "hello" | 1 | a
 2.4 | 's worlds | 2 | 2
@@ -333,7 +333,7 @@ def test_write_noheader_no_delimiter():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidthNoHeader, bookend=False,
-                     delimiter=None)
+                delimiter=None)
     assert_equal_splitlines(out.getvalue(), """\
 1.2    "hello"  1  a
 2.4  's worlds  2  2
@@ -344,7 +344,7 @@ def test_write_formats():
     """Write a table as a fixed width table with no delimiter."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidth,
-                     formats={'Col1': '%-8.3f', 'Col2': '%-15s'})
+                formats={'Col1': '%-8.3f', 'Col2': '%-15s'})
     assert_equal_splitlines(out.getvalue(), """\
 |     Col1 |            Col2 | Col3 | Col4 |
 | 1.200    | "hello"         |    1 |    a |
@@ -379,7 +379,7 @@ def test_read_twoline_ReST():
 ======= ===========
 """
     dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
-                          header_start=1, position_line=2, data_end=-1)
+                     header_start=1, position_line=2, data_end=-1)
     assert_equal(dat.dtype.names, ('Col1', 'Col2'))
     assert_almost_equal(dat[1][0], 2.4)
     assert_equal(dat[0][1], '"hello"')
@@ -398,9 +398,9 @@ def test_read_twoline_human():
 +------+----------+
 """
     dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
-                          delimiter='+',
-                          header_start=1, position_line=0,
-                          data_start=3, data_end=-1)
+                     delimiter='+',
+                     header_start=1, position_line=0,
+                     data_start=3, data_end=-1)
     assert_equal(dat.dtype.names, ('Col1', 'Col2'))
     assert_almost_equal(dat[1][0], 2.4)
     assert_equal(dat[0][1], '"hello"')
@@ -420,9 +420,10 @@ def test_read_twoline_fail():
 |  2.4 | 's worlds|
 """
     with pytest.raises(InconsistentTableError) as excinfo:
-        dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
-                         delimiter='|', guess=False)
-    assert 'Position line should only contain delimiters and one other character' in str(excinfo.value)
+        ascii.read(table, Reader=ascii.FixedWidthTwoLine,
+                   delimiter='|', guess=False)
+    assert 'Position line should only contain delimiters and one other character' in str(
+        excinfo.value)
 
 
 def test_read_twoline_wrong_marker():
@@ -438,8 +439,8 @@ def test_read_twoline_wrong_marker():
 |  2.4 | 's worlds|
 """
     with pytest.raises(InconsistentTableError) as excinfo:
-        dat = ascii.read(table, Reader=ascii.FixedWidthTwoLine,
-                         delimiter='|', guess=False)
+        ascii.read(table, Reader=ascii.FixedWidthTwoLine,
+                   delimiter='|', guess=False)
     assert 'Characters in position line must be part' in str(excinfo.value)
 
 
@@ -459,7 +460,7 @@ def test_write_twoline_no_pad():
     """Write a table as a fixed width table with no padding."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidthTwoLine,
-                     delimiter_pad=' ', position_char='=')
+                delimiter_pad=' ', position_char='=')
     assert_equal_splitlines(out.getvalue(), """\
 Col1        Col2   Col3   Col4
 ====   =========   ====   ====
@@ -472,7 +473,7 @@ def test_write_twoline_no_bookend():
     """Write a table as a fixed width table with no bookend."""
     out = StringIO()
     ascii.write(dat, out, Writer=ascii.FixedWidthTwoLine,
-                     bookend=True, delimiter='|')
+                bookend=True, delimiter='|')
     assert_equal_splitlines(out.getvalue(), """\
 |Col1|     Col2|Col3|Col4|
 |----|---------|----|----|

--- a/astropy/io/ascii/tests/test_html.py
+++ b/astropy/io/ascii/tests/test_html.py
@@ -19,7 +19,7 @@ from astropy.table import Table
 import pytest
 import numpy as np
 
-from .common import setup_function, teardown_function
+from .common import setup_function, teardown_function  # noqa
 from astropy.io import ascii
 
 try:
@@ -190,8 +190,8 @@ def test_backend_parsers():
     """
     for parser in ('lxml', 'xml', 'html.parser', 'html5lib'):
         try:
-            table = Table.read('data/html2.html', format='ascii.html',
-                               htmldict={'parser': parser}, guess=False)
+            Table.read('data/html2.html', format='ascii.html',
+                       htmldict={'parser': parser}, guess=False)
         except FeatureNotFound:
             if parser == 'html.parser':
                 raise
@@ -268,8 +268,10 @@ def test_htmlsplitter():
 
     splitter = html.HTMLSplitter()
 
-    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>', 'html.parser').tr),
-            html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>', 'html.parser').tr)]
+    lines = [html.SoupString(BeautifulSoup('<table><tr><th>Col 1</th><th>Col 2</th></tr></table>',
+                                           'html.parser').tr),
+             html.SoupString(BeautifulSoup('<table><tr><td>Data 1</td><td>Data 2</td></tr></table>',
+                                           'html.parser').tr)]
     expected_data = [['Col 1', 'Col 2'], ['Data 1', 'Data 2']]
     assert list(splitter(lines)) == expected_data
 
@@ -301,18 +303,19 @@ def test_htmlheader_start():
 
     lines = inputter.get_lines(table)
     assert str(lines[header.start_line(lines)]) == \
-           '<tr><th>Column 1</th><th>Column 2</th><th>Column 3</th></tr>'
+        '<tr><th>Column 1</th><th>Column 2</th><th>Column 3</th></tr>'
     inputter.html['table_id'] = 'second'
     lines = inputter.get_lines(table)
     assert str(lines[header.start_line(lines)]) == \
-           '<tr><th>Column A</th><th>Column B</th><th>Column C</th></tr>'
+        '<tr><th>Column A</th><th>Column B</th><th>Column C</th></tr>'
     inputter.html['table_id'] = 3
     lines = inputter.get_lines(table)
     assert str(lines[header.start_line(lines)]) == \
-           '<tr><th>C1</th><th>C2</th><th>C3</th></tr>'
+        '<tr><th>C1</th><th>C2</th><th>C3</th></tr>'
 
     # start_line should return None if no valid header is found
-    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>', 'html.parser').tr),
+    lines = [html.SoupString(BeautifulSoup('<table><tr><td>Data</td></tr></table>',
+                                           'html.parser').tr),
              html.SoupString(BeautifulSoup('<p>Text</p>', 'html.parser').p)]
     assert header.start_line(lines) is None
 
@@ -340,24 +343,24 @@ def test_htmldata():
 
     lines = inputter.get_lines(table)
     assert str(lines[data.start_line(lines)]) == \
-           '<tr><td>1</td><td>a</td><td>1.05</td></tr>'
+        '<tr><td>1</td><td>a</td><td>1.05</td></tr>'
     # end_line returns the index of the last data element + 1
     assert str(lines[data.end_line(lines) - 1]) == \
-           '<tr><td>3</td><td>c</td><td>-1.25</td></tr>'
+        '<tr><td>3</td><td>c</td><td>-1.25</td></tr>'
 
     inputter.html['table_id'] = 'second'
     lines = inputter.get_lines(table)
     assert str(lines[data.start_line(lines)]) == \
-           '<tr><td>4</td><td>d</td><td>10.5</td></tr>'
+        '<tr><td>4</td><td>d</td><td>10.5</td></tr>'
     assert str(lines[data.end_line(lines) - 1]) == \
-           '<tr><td>6</td><td>f</td><td>-12.5</td></tr>'
+        '<tr><td>6</td><td>f</td><td>-12.5</td></tr>'
 
     inputter.html['table_id'] = 3
     lines = inputter.get_lines(table)
     assert str(lines[data.start_line(lines)]) == \
-           '<tr><td>7</td><td>g</td><td>105.0</td></tr>'
+        '<tr><td>7</td><td>g</td><td>105.0</td></tr>'
     assert str(lines[data.end_line(lines) - 1]) == \
-           '<tr><td>9</td><td>i</td><td>-125.0</td></tr>'
+        '<tr><td>9</td><td>i</td><td>-125.0</td></tr>'
 
     # start_line should raise an error if no table data exists
     lines = [html.SoupString(BeautifulSoup('<div></div>', 'html.parser').div),
@@ -539,7 +542,7 @@ def test_write_no_multicols():
 </html>
     """
     assert html.HTML({'multicol': False}).write(table)[0].strip() == \
-                                                   expected.strip()
+        expected.strip()
 
 
 @pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
@@ -599,7 +602,7 @@ def test_raw_html_write_clean():
     """
     Test that columns can contain raw HTML which is not escaped.
     """
-    import bleach
+    import bleach  # noqa
 
     t = Table([['<script>x</script>'], ['<p>y</p>'], ['<em>y</em>']], names=['a', 'b', 'c'])
 
@@ -635,7 +638,7 @@ def test_write_table_html_fill_values():
     buffer_output = StringIO()
     t = Table([[1], [2]], names=('a', 'b'))
     ascii.write(t, buffer_output, fill_values=('1', 'Hello world'),
-        format='html')
+                format='html')
 
     t_expected = Table([['Hello world'], [2]], names=('a', 'b'))
     buffer_expected = StringIO()
@@ -652,7 +655,7 @@ def test_write_table_html_fill_values_optional_columns():
     buffer_output = StringIO()
     t = Table([[1], [1]], names=('a', 'b'))
     ascii.write(t, buffer_output, fill_values=('1', 'Hello world', 'b'),
-        format='html')
+                format='html')
 
     t_expected = Table([[1], ['Hello world']], names=('a', 'b'))
     buffer_expected = StringIO()
@@ -670,7 +673,7 @@ def test_write_table_html_fill_values_masked():
     t = Table([[1], [1]], names=('a', 'b'), masked=True, dtype=('i4', 'i8'))
     t['a'] = np.ma.masked
     ascii.write(t, buffer_output, fill_values=(ascii.masked, 'TEST'),
-        format='html')
+                format='html')
 
     t_expected = Table([['TEST'], [1]], names=('a', 'b'))
     buffer_expected = StringIO()
@@ -691,7 +694,7 @@ def test_multicolumn_table_html_fill_values():
     buffer_output = StringIO()
     t = Table([col1, col2, col3], names=('C1', 'C2', 'C3'))
     ascii.write(t, buffer_output, fill_values=('a', 'z'),
-        format='html')
+                format='html')
 
     col1 = [1, 2, 3]
     col2 = [(1.0, 1.0), (2.0, 2.0), (3.0, 3.0)]
@@ -714,9 +717,10 @@ def test_multi_column_write_table_html_fill_values_masked():
     t['a'][0:2] = np.ma.masked
     t['b'][0:2] = np.ma.masked
     ascii.write(t, buffer_output, fill_values=[(ascii.masked, 'MASKED')],
-        format='html')
+                format='html')
 
-    t_expected = Table([['MASKED', 'MASKED', 3, 4], ['MASKED', 'MASKED', '--', 'b']], names=('a', 'b'))
+    t_expected = Table([['MASKED', 'MASKED', 3, 4], [
+                       'MASKED', 'MASKED', '--', 'b']], names=('a', 'b'))
     buffer_expected = StringIO()
     ascii.write(t_expected, buffer_expected, format='html')
     print(buffer_expected.getvalue())

--- a/astropy/io/ascii/tests/test_ipac_definitions.py
+++ b/astropy/io/ascii/tests/test_ipac_definitions.py
@@ -66,7 +66,9 @@ def test_too_long_colname_notstrict():
         ascii.write(table, out, Writer=Ipac, DBMS=False)
 
 
-@pytest.mark.parametrize(("strict_", "Err"), [(True, IpacFormatErrorDBMS), (False, IpacFormatError)])
+@pytest.mark.parametrize(("strict_", "Err"),
+                         [(True, IpacFormatErrorDBMS),
+                          (False, IpacFormatError)])
 def test_non_alfnum_colname(strict_, Err):
     table = Table([[3]], names=['a123456789 01234'])
     out = StringIO()

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -22,14 +22,14 @@ from astropy.table.table_helpers import simple_table
 from .common import (raises, assert_equal, assert_almost_equal,
                      assert_true)
 from astropy.io.ascii import core
-from astropy.io.ascii.ui import _probably_html, get_read_trace, cparser
+from astropy.io.ascii.ui import _probably_html, get_read_trace
 from astropy.utils.exceptions import AstropyWarning
 
 # setup/teardown function to have the tests run in the correct directory
-from .common import setup_function, teardown_function
+from .common import setup_function, teardown_function  # noqa
 
 try:
-    import bz2  # pylint: disable=W0611
+    import bz2  # noqa
 except ImportError:
     HAS_BZ2 = False
 else:
@@ -76,7 +76,7 @@ def test_read_specify_converters_with_names():
 def test_read_remove_and_rename_columns():
     csv_text = ['a,b,c', '1,2,3', '4,5,6']
     reader = ascii.get_reader(Reader=ascii.Csv)
-    data = reader.read(csv_text)
+    reader.read(csv_text)
     header = reader.header
     with pytest.raises(KeyError, match='Column NOT-EXIST does not exist'):
         header.remove_columns(['NOT-EXIST'])
@@ -162,7 +162,7 @@ def test_guess_with_delimiter_arg():
     # Forcing space as delimiter produces type str columns ('10.1E+19,')
     t1 = ascii.read(asciiIO(', '.join(fields)), guess=True, delimiter=' ')
     for n, v in zip(t1.colnames[:-1], fields[:-1]):
-        assert t1[n][0] == v+','
+        assert t1[n][0] == v + ','
 
 
 def test_reading_mixed_delimiter_tabs_spaces():
@@ -529,7 +529,7 @@ def test_masking_Cds():
     f = 'data/cds.dat'
     testfile = get_testfiles(f)
     data = ascii.read(f,
-                           **testfile['opts'])
+                      **testfile['opts'])
     assert_true(data['AK'].mask[0])
     assert not hasattr(data['Fit'], 'mask')
 
@@ -873,7 +873,7 @@ def get_testfiles(name=None):
     ]
 
     try:
-        import bs4  # pylint: disable=W0611
+        import bs4  # noqa
         testfiles.append({'cols': ('Column 1', 'Column 2', 'Column 3'),
                           'name': 'data/html.html',
                           'nrows': 3,
@@ -898,7 +898,7 @@ def test_header_start_exception():
                         ascii.BaseReader, ascii.FixedWidthNoHeader,
                         ascii.Cds, ascii.Daophot]:
         with pytest.raises(ValueError):
-            reader = ascii.core._get_reader(readerclass, header_start=5)
+            ascii.core._get_reader(readerclass, header_start=5)
 
 
 def test_csv_table_read():
@@ -952,19 +952,23 @@ def test_sextractor_last_column_array():
     table = ascii.read('data/sextractor3.dat', Reader=ascii.SExtractor, guess=False)
     expected_columns = ['X_IMAGE', 'Y_IMAGE', 'ALPHA_J2000', 'DELTA_J2000',
                         'MAG_AUTO', 'MAGERR_AUTO',
-                        'MAG_APER', 'MAG_APER_1', 'MAG_APER_2', 'MAG_APER_3', 'MAG_APER_4', 'MAG_APER_5', 'MAG_APER_6',
-                        'MAGERR_APER', 'MAGERR_APER_1', 'MAGERR_APER_2', 'MAGERR_APER_3', 'MAGERR_APER_4', 'MAGERR_APER_5', 'MAGERR_APER_6']
+                        'MAG_APER', 'MAG_APER_1', 'MAG_APER_2', 'MAG_APER_3',
+                        'MAG_APER_4', 'MAG_APER_5', 'MAG_APER_6',
+                        'MAGERR_APER', 'MAGERR_APER_1', 'MAGERR_APER_2', 'MAGERR_APER_3',
+                        'MAGERR_APER_4', 'MAGERR_APER_5', 'MAGERR_APER_6']
     expected_units = [Unit('pix'), Unit('pix'), Unit('deg'), Unit('deg'),
                       Unit('mag'), Unit('mag'),
-                      Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'),
-                      Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag')]
+                      Unit('mag'), Unit('mag'), Unit('mag'),
+                      Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'),
+                      Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'), Unit('mag'),
+                      Unit('mag'), Unit('mag')]
     expected_descrs = ['Object position along x', None,
                        'Right ascension of barycenter (J2000)',
                        'Declination of barycenter (J2000)',
                        'Kron-like elliptical aperture magnitude',
                        'RMS error for AUTO magnitude', ] + [
-                       'Fixed aperture magnitude vector'] * 7 + [
-                       'RMS error vector for fixed aperture mag.'] * 7
+        'Fixed aperture magnitude vector'] * 7 + [
+        'RMS error vector for fixed aperture mag.'] * 7
     for i, colname in enumerate(table.colnames):
         assert table[colname].name == expected_columns[i]
         assert table[colname].unit == expected_units[i]
@@ -1019,7 +1023,8 @@ def test_guess_fail():
 
     # Test the case with guessing enabled but with all params specified
     with pytest.raises(ValueError) as err:
-        ascii.read('asfdasdf\n1 2 3', format='basic', quotechar='"', delimiter=' ', fast_reader=False)
+        ascii.read('asfdasdf\n1 2 3', format='basic',
+                   quotechar='"', delimiter=' ', fast_reader=False)
     assert 'Number of header columns (1) inconsistent with data columns (3)' in str(err.value)
 
 
@@ -1127,7 +1132,7 @@ def test_probably_html():
     """
     Test the routine for guessing if a table input to ascii.read is probably HTML
     """
-    for table in ('data/html.html',
+    for tabl0 in ('data/html.html',
                   'http://blah.com/table.html',
                   'https://blah.com/table.html',
                   'file://blah/table.htm',
@@ -1137,10 +1142,10 @@ def test_probably_html():
                   'junk < table baz> <tr foo > <td bar> </td> </tr> </table> junk',
                   ['junk < table baz>', ' <tr foo >', ' <td bar> ', '</td> </tr>', '</table> junk'],
                   (' <! doctype html > ', ' hello world'),
-                   ):
-        assert _probably_html(table) is True
+                  ):
+        assert _probably_html(tabl0) is True
 
-    for table in ('data/html.htms',
+    for tabl0 in ('data/html.htms',
                   'Xhttp://blah.com/table.html',
                   ' https://blah.com/table.htm',
                   'fole://blah/table.htm',
@@ -1149,8 +1154,8 @@ def test_probably_html():
                   ['junk < table baz>', ' <t foo >', ' <td bar> ', '</td> </tr>', '</table> junk'],
                   (' <! doctype htm > ', ' hello world'),
                   [[1, 2, 3]],
-                   ):
-        assert _probably_html(table) is False
+                  ):
+        assert _probably_html(tabl0) is False
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])
@@ -1164,7 +1169,7 @@ def test_data_header_start(fast_reader):
               [{'header_start': 1},
                {'header_start': 1, 'data_start': 2}
                ]
-               ),
+              ),
 
              (['# comment',
                '',
@@ -1270,7 +1275,10 @@ def test_non_C_locale_with_fast_reader():
         else:
             locale.setlocale(locale.LC_ALL, 'de_DE.utf8')
 
-        for fast_reader in (True, False, {'use_fast_converter': False}, {'use_fast_converter': True}):
+        for fast_reader in (True,
+                            False,
+                            {'use_fast_converter': False},
+                            {'use_fast_converter': True}):
             t = ascii.read(['a b', '1.5 2'], format='basic', guess=False,
                            fast_reader=fast_reader)
             assert t['a'].dtype.kind == 'f'

--- a/astropy/io/ascii/tests/test_rst.py
+++ b/astropy/io/ascii/tests/test_rst.py
@@ -41,7 +41,7 @@ def test_read_normal_names():
 ======= =========
 """
     reader = ascii.get_reader(Reader=ascii.RST,
-                                   names=('name1', 'name2'))
+                              names=('name1', 'name2'))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['name1', 'name2'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -59,8 +59,8 @@ def test_read_normal_names_include():
 =======  ========== ======
 """
     reader = ascii.get_reader(Reader=ascii.RST,
-                                   names=('name1', 'name2', 'name3'),
-                                   include_names=('name1', 'name3'))
+                              names=('name1', 'name2', 'name3'),
+                              include_names=('name1', 'name3'))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['name1', 'name3'])
     assert_almost_equal(dat[1][0], 2.4)
@@ -78,7 +78,7 @@ def test_read_normal_exclude():
 ======= ==========
 """
     reader = ascii.get_reader(Reader=ascii.RST,
-                                   exclude_names=('Col1',))
+                              exclude_names=('Col1',))
     dat = reader.read(table)
     assert_equal(dat.colnames, ['Col2'])
     assert_equal(dat[1][0], "'s worlds")

--- a/astropy/io/ascii/tests/test_types.py
+++ b/astropy/io/ascii/tests/test_types.py
@@ -3,8 +3,6 @@
 
 from io import StringIO
 
-import numpy as np
-
 from astropy.io import ascii
 
 from .common import assert_equal
@@ -43,7 +41,7 @@ def test_ipac_read_types():
    2.09708   2956        73765    2.06000   B8IVpMnHg
 """
     reader = ascii.get_reader(Reader=ascii.Ipac)
-    dat = reader.read(table)
+    reader.read(table)
     types = [ascii.FloatType,
              ascii.FloatType,
              ascii.IntType,

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -17,11 +17,11 @@ from astropy.tests.helper import catch_warnings
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 from astropy import units as u
 
-from .common import setup_function, teardown_function
+from .common import setup_function, teardown_function  # noqa
 
 # Check to see if the BeautifulSoup dependency is present.
 try:
-    from bs4 import BeautifulSoup, FeatureNotFound
+    from bs4 import BeautifulSoup, FeatureNotFound  # noqa
     HAS_BEAUTIFUL_SOUP = True
 except ImportError:
     HAS_BEAUTIFUL_SOUP = False
@@ -114,7 +114,7 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable}
-"""
+"""  # noqa
          ),
     dict(
         kwargs=dict(Writer=ascii.AASTex, caption='Mag values \\label{tab1}', latexdict={
@@ -129,15 +129,15 @@ ID & XCENTER & YCENTER & MAG & MERR & MSKY & NITER & SHARPNESS & CHI & PIER & PE
 18 & 18.114 & 280.170 & 22.329 & 0.206 & 30.12784 & 4 & -2.544 & 1.104 & 0 & No_error
 \\enddata
 \\end{deluxetable*}
-"""
+"""  # noqa
     ),
     dict(
         kwargs=dict(Writer=ascii.Latex, caption='Mag values \\label{tab1}',
                     latexdict={'preamble': '\\begin{center}', 'tablefoot': '\\end{center}',
                                'data_end': ['\\hline', '\\hline'],
                                'units':{'MAG': '[mag]', 'XCENTER': '[pixel]'},
-                    'tabletype': 'table*',
-                    'tablealign': 'h'},
+                               'tabletype': 'table*',
+                               'tablealign': 'h'},
                     col_align='|lcccccccccc|'),
         out="""\
 \\begin{table*}[h]
@@ -281,7 +281,7 @@ table,th,td{border:1px solid black;  </style>
 |     null|      null|      null|        null|          null|           null|  null|                   null|        null|  null|         null|
  14        138.538    256.405    15.461       0.003          34.85955        4      -0.032                  0.802        0      No_error
  18        18.114     280.170    22.329       0.206          30.12784        4      -2.544                  1.104        0      No_error
-"""
+"""  # noqa
          ),
 ]
 
@@ -565,7 +565,7 @@ def test_latex_units():
     **latexdict** does not specify units.
     """
     t = table.Table([table.Column(name='date', data=['a', 'b']),
-               table.Column(name='NUV exp.time', data=[1, 2])])
+                     table.Column(name='NUV exp.time', data=[1, 2])])
     latexdict = copy.deepcopy(ascii.latexdicts['AA'])
     latexdict['units'] = {'NUV exp.time': 's'}
     out = StringIO()
@@ -632,7 +632,7 @@ def test_names_with_formats(names, include_names, exclude_names, formats, issues
     with catch_warnings(AstropyWarning) as ASwarn:
         out = StringIO()
         ascii.write(t, out, names=names, include_names=include_names,
-        exclude_names=exclude_names, formats=formats)
+                    exclude_names=exclude_names, formats=formats)
     assert (issues_warning == (len(ASwarn) == 1))
 
 

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -34,14 +34,14 @@ from . import fastbasic
 from . import cparser
 from . import fixedwidth
 
-from astropy.table import Table, vstack, MaskedColumn
+from astropy.table import Table, MaskedColumn
 from astropy.utils.data import get_readable_fileobj
 from astropy.utils.exceptions import AstropyWarning, AstropyDeprecationWarning
 
 _read_trace = []
 
 try:
-    import yaml  # pylint: disable=W0611
+    import yaml  # noqa
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -67,7 +67,7 @@ def _probably_html(table, maxchars=100000):
                 size += len(line)
                 if size > maxchars:
                     break
-            table = os.linesep.join(table[:i+1])
+            table = os.linesep.join(table[:i + 1])
         except Exception:
             pass
 
@@ -317,7 +317,7 @@ def read(table, guess=None, **kwargs):
                 _read_trace.append({'kwargs': copy.deepcopy(new_kwargs),
                                     'Reader': reader.__class__,
                                     'status': 'Success with slow reader after failing'
-                                             ' with fast (no guessing)'})
+                                    ' with fast (no guessing)'})
         else:
             reader = get_reader(**new_kwargs)
             dat = reader.read(table)
@@ -366,7 +366,7 @@ def _guess(table, read_kwargs, format, fast_reader):
 
     # If a fast version of the reader is available, try that before the slow version
     if (fast_reader['enable'] and format is not None and f'fast_{format}' in
-        core.FAST_CLASSES):
+            core.FAST_CLASSES):
         fast_kwargs = copy.deepcopy(read_kwargs)
         fast_kwargs['Reader'] = core.FAST_CLASSES[f'fast_{format}']
         full_list_guess = [fast_kwargs] + full_list_guess
@@ -380,8 +380,8 @@ def _guess(table, read_kwargs, format, fast_reader):
 
     for guess_kwargs in full_list_guess:
         # If user specified slow reader then skip all fast readers
-        if (fast_reader['enable'] is False and
-                guess_kwargs['Reader'] in core.FAST_CLASSES.values()):
+        if (fast_reader['enable'] is False
+                and guess_kwargs['Reader'] in core.FAST_CLASSES.values()):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
                                 'status': 'Disabled: reader only available in fast version',
@@ -389,8 +389,8 @@ def _guess(table, read_kwargs, format, fast_reader):
             continue
 
         # If user required a fast reader then skip all non-fast readers
-        if (fast_reader['enable'] == 'force' and
-                guess_kwargs['Reader'] not in core.FAST_CLASSES.values()):
+        if (fast_reader['enable'] == 'force'
+                and guess_kwargs['Reader'] not in core.FAST_CLASSES.values()):
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'Reader': guess_kwargs['Reader'].__class__,
                                 'status': 'Disabled: no fast version of reader available',
@@ -454,7 +454,7 @@ def _guess(table, read_kwargs, format, fast_reader):
         except guess_exception_classes as err:
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'status': '{}: {}'.format(err.__class__.__name__,
-                                                            str(err)),
+                                                          str(err)),
                                 'dt': '{:.3f} ms'.format((time.time() - t0) * 1000)})
             failed_kwargs.append(guess_kwargs)
     else:
@@ -471,7 +471,7 @@ def _guess(table, read_kwargs, format, fast_reader):
         except guess_exception_classes as err:
             _read_trace.append({'kwargs': copy.deepcopy(guess_kwargs),
                                 'status': '{}: {}'.format(err.__class__.__name__,
-                                                            str(err))})
+                                                          str(err))})
             failed_kwargs.append(read_kwargs)
             lines = ['\nERROR: Unable to guess table format with the guesses listed below:']
             for kwargs in failed_kwargs:
@@ -777,7 +777,7 @@ def write(table, output=None, format=None, Writer=None, fast_writer=True, *,
 
     table0 = table[:0].copy()
     core._apply_include_exclude_names(table0, kwargs.get('names'),
-                    kwargs.get('include_names'), kwargs.get('exclude_names'))
+                                      kwargs.get('include_names'), kwargs.get('exclude_names'))
     diff_format_with_names = set(kwargs.get('formats', [])) - set(table0.colnames)
 
     if diff_format_with_names:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR makes the io.ascii subpackage pass:
```
flake8 --ignore=W503,E402,E721,E731
```
This allows much better local flake8 testing during development with an IDE or command-line run with flake8.  It may eventually allow more complete CI testing using `--ignore` instead of `--select`, but that is not in scope here.

Justification for exceptions:

- W503: *Line break occurred before a binary operator.*  Best practice is now:
```
income = (gross_wages
          + taxable_interest)
```
- E402: *Module level import not at top of file.*  There are frequently good reasons for out-of-order imports, and the `# noqa` get distracting.
- E721: *Do not compare types, use 'isinstance()'.*  In testing it is frequently necessary to do direct type comparisons.
- E731: *Do not assign a lambda expression, use a def.*  This one is controversial anyway, but IMO there are many cases where lamdba expressions provide for concise and readable code. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
