### PR TITLE
Add torr unit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Added ``torr`` pressure unit. [#9787]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/astrophys.py
+++ b/astropy/units/astrophys.py
@@ -169,6 +169,14 @@ def_unit(['littleh'], namespace=_ns, prefixes=False,
          doc="Reduced/\"dimensionless\" Hubble constant",
          format={'latex': r'h_{100}'})
 
+# The torr is almost the same as mmHg but not quite.
+# See https://en.wikipedia.org/wiki/Torr
+# Define the unit here despite it not being an astrophysical unit.
+# It may be moved if more similar units are created later.
+def_unit(['Torr', 'torr'], _si.atm.value/760. * si.Pa, namespace=_ns,
+         prefixes=[(['m'], ['milli'], 1.e-3)],
+         doc="Unit of pressure based on an absolute scale, now defined as "
+             "exactly 1/760 of a standard atmosphere")
 
 ###########################################################################
 # CLEANUP


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the missing torr unit.

I support mTorr == millitorr and allow all prefixes since I have seen mention of k, m, and micro prefixes.

No unit tests since I'm not entirely sure where to put them. We don't seem to have tests for specific unit conversions. For example, I'd like to show that torr approximates mmHg and that mTorr and millitorr both parse to the same unit.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9783
