### PR TITLE
Fix start of What's new in v4.0

### DIFF
--- a/docs/whatsnew/4.0.rst
+++ b/docs/whatsnew/4.0.rst
@@ -7,8 +7,9 @@ What's New in Astropy 4.0?
 Overview
 ========
 
-Astropy 4.0 is a major release that ...  since
-the 3.2.x series of releases.
+Astropy 4.0 is a major release that adds significant new functionality since the
+3.2.x series of releases. In addition, it is a long-term support release (LTS)
+which will be supported with bug fixes for two years.
 
 In particular, this release includes:
 


### PR DESCRIPTION
The start of the what's new in v4.0 is missing some words! 🔥 (I should have spotted that sooner, sorry!)

I also added a mention of LTS but can remove if needed. I'm opening this to v4.0.x since the what's new will be removed in master in #9789. I think ideally we should merge this and then update the stable branch to include this commit on top of v4.0?
