### PR TITLE
Fix doctest race condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: python setup.py egg_info
 
-  32bit:
+  32bit-and-parallel:
     docker:
       - image: quay.io/pypa/manylinux1_i686
     steps:
@@ -160,7 +160,7 @@ workflows:
     jobs:
       - egg-info-37
       - html-docs
-      - 32bit
+      - 32bit-and-parallel
       - image-tests-mpl212
       - image-tests-mpl222
       - image-tests-mpl302

--- a/docs/io/ascii/index.rst
+++ b/docs/io/ascii/index.rst
@@ -154,7 +154,7 @@ The following writes a table as a simple space-delimited file::
   >>> x = np.array([1, 2, 3])
   >>> y = x ** 2
   >>> data = Table([x, y], names=['x', 'y'])
-  >>> ascii.write(data, 'values.dat')
+  >>> ascii.write(data, 'values.dat', overwrite=True)
 
 The ``values.dat`` file will then contain::
 


### PR DESCRIPTION
I've seen a failure happen in the 32-bit parallel build which is due to two doctests both needing to write to a file called ``values.dat``. I think until recently the tests were always run such that the one with ``overwrite=True`` came second but now things have flipped so an error is happening.

Ideally we should run doctests in an isolated way that prevents this from happening, but for now this is a quick fix. I'm also renaming the CircleCI build for 32-bit to mention it is also a parallel build since this is often a source of confusion.

Fixes #9796 