### PR TITLE
Use asdf pytest plugin automatically

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,16 +15,6 @@ except ImportError:
 
 import astropy
 
-if find_spec('asdf') is not None:
-    from asdf import __version__ as asdf_version
-    if asdf_version >= astropy.__minimum_asdf_version__:
-        entry_points = []
-        for entry_point in pkg_resources.iter_entry_points('pytest11'):
-            entry_points.append(entry_point.name)
-        if "asdf_schema_tester" not in entry_points:
-            pytest_plugins += ['asdf.tests.schema_tester']
-        PYTEST_HEADER_MODULES['Asdf'] = 'asdf'
-
 # Make sure we use temporary directories for the config and cache
 # so that the tests are insensitive to local configuration.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,7 @@ open_files_ignore = "astropy.log" "/etc/hosts" "*.ttf"
 remote_data_strict = true
 addopts = --doctest-rst
 asdf_schema_root = astropy/io/misc/asdf/data/schemas
+asdf_schema_tests_enabled = true
 xfail_strict = true
 qt_no_exception_capture = 1
 filterwarnings =


### PR DESCRIPTION
It looks like the asdf schema tester now has a proper pytest entry point, so I think we can just to it as in this PR. On old versions of asdf, nothing will happen, and on recent versions, ``asdf_schema_tests_enabled`` will get picked up and the schema tests will run.