### PR TITLE
Do not attempt to do in-place changes inside the erfa python wrappers

### DIFF
--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -136,7 +136,11 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
 
     Notes
     -----
-    The ERFA documentation is below.
+    The ERFA documentation is below.  {% if func.args_by_inout('inout') -%}
+    Note that, unlike the erfa routine,
+    the python wrapper does not change {{ func.args_by_inout('inout')
+    | map(attribute='name')|join(', ') }} in-place.
+    {%- endif %}
 
 {{ func.doc }}
     """

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -454,7 +454,6 @@ class Function:
     def python_call(self):
         outnames = [arg.name for arg in self.args_by_inout('inout|out|stat|ret')]
         argnames = [arg.name for arg in self.args_by_inout('in|inout')]
-        argnames += [arg.name for arg in self.args_by_inout('inout')]
         return '{out} = {func}({args})'.format(out=', '.join(outnames),
                                                func='ufunc.' + self.pyname,
                                                args=', '.join(argnames))

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -244,6 +244,22 @@ def test_float32_input():
     np.testing.assert_allclose(out32, out64, rtol=1.e-5)
 
 
+def test_scalar_astrom_input():
+    # Regression test for gh-9799
+    mjd = 58827.15925499
+    utc2mjd = 2400000.5
+    paranal_long = -1.228798
+    paranal_lat = -0.42982
+    paranal_height = 2669.
+    apco_param = [utc2mjd, mjd, 0.0, paranal_long, paranal_lat,
+                  paranal_height, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5]
+    astrom0, eo0 = erfa.apco13(*apco_param)
+    assert type(astrom0) is np.void
+    # This caused a TypeError before, as astrom0 was a void
+    astrom = erfa.aper13(utc2mjd, mjd, astrom0)
+    assert type(astrom) is np.void
+
+
 class TestLeapSecondsBasics:
     def test_get_leap_seconds(self):
         leap_seconds = erfa.leap_seconds.get()

--- a/astropy/_erfa/tests/test_erfa.py
+++ b/astropy/_erfa/tests/test_erfa.py
@@ -244,20 +244,39 @@ def test_float32_input():
     np.testing.assert_allclose(out32, out64, rtol=1.e-5)
 
 
-def test_scalar_astrom_input():
-    # Regression test for gh-9799
-    mjd = 58827.15925499
-    utc2mjd = 2400000.5
-    paranal_long = -1.228798
-    paranal_lat = -0.42982
-    paranal_height = 2669.
-    apco_param = [utc2mjd, mjd, 0.0, paranal_long, paranal_lat,
-                  paranal_height, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5]
-    astrom0, eo0 = erfa.apco13(*apco_param)
-    assert type(astrom0) is np.void
-    # This caused a TypeError before, as astrom0 was a void
-    astrom = erfa.aper13(utc2mjd, mjd, astrom0)
-    assert type(astrom) is np.void
+class TestAstromNotInplace:
+    def setup(self):
+        self.mjd_array = np.array(
+            [58827.15925499, 58827.15925499, 58827.15925499,
+             58827.15925499, 58827.15925499])
+        self.mjd_scalar = self.mjd_array[0].item()
+        self.utc2mjd = 2400000.5
+        paranal_long = -1.228798
+        paranal_lat = -0.42982
+        paranal_height = 2669.
+        self.astrom_scalar, _ = erfa.apco13(
+            self.utc2mjd, self.mjd_scalar, 0.0, paranal_long, paranal_lat,
+            paranal_height, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5)
+        self.astrom_array, _ = erfa.apco13(
+            self.utc2mjd, self.mjd_array, 0.0, paranal_long, paranal_lat,
+            paranal_height, 0.0, 0.0, 0.0, 0.0, 0.0, 2.5)
+
+    def test_scalar_input(self):
+        # Regression test for gh-9799, where astrom0 being a void
+        # caused a TypeError, as it was trying to change it in-place.
+        assert type(self.astrom_scalar) is np.void
+        astrom = erfa.aper13(self.utc2mjd, self.mjd_scalar, self.astrom_scalar)
+        assert astrom is not self.astrom_scalar
+        assert type(astrom) is np.void
+
+    def test_array_input(self):
+        # Trying to fix gh-9799, it became clear that doing things in-place was
+        # a bad idea generally (and didn't work), so also for array input we
+        # now return a copy.
+        assert type(self.astrom_array) is np.ndarray
+        astrom = erfa.aper13(self.utc2mjd, self.mjd_array, self.astrom_array)
+        assert astrom is not self.astrom_array
+        assert type(astrom) is np.ndarray
 
 
 class TestLeapSecondsBasics:


### PR DESCRIPTION
It turns out we did not use any of those routines internally, but the implementation was broken, as became clear in looking into #9799. It seems much safer to just not do changes in-place at all in the wrapper and let experts use the `ufunc` directly if they want (which may need some fixing up, but I'm leaving that to a separate PR).  I'm not adding a change-log entry as the erfa module is private and really people shouldn't rely on it at all. (The fact that people do anyway is, of course, a reason to expose at least the ufuncs in a separate `pyerfa` package - see #9802).

fixes #9799