### PR TITLE
Fix CI configuration to run tests twice in the same Python session

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,22 @@ jobs:
           name: Run tests for Python 3.8
           command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python setup.py test --parallel=4 -a "--durations=50"
 
+  double-test:
+    # Check that running tests twice in a row in the same Python session works
+    # without issues. This catches cases where running the tests changes the
+    # module state permanently.
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Run tests twice
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -e .[test]
+            python -c 'import sys; from astropy import test; test(); sys.exit(test())'
+
   image-tests-mpl212:
     docker:
       - image: astropy/image-tests-py36-mpl212:1.8
@@ -160,6 +176,7 @@ workflows:
     jobs:
       - egg-info-37
       - html-docs
+      - double-test
       - 32bit-and-parallel
       - image-tests-mpl212
       - image-tests-mpl222

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
           command: |
               mkdir -p $HOME/.astropy/config/
               printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
+      # In addition to testing 32-bit, we also use the 3.6 and 3.7 builds to
+      # test the ability to run the test suite in parallel.
       - run:
           name: Install dependencies for Python 3.6
           command: /opt/python/cp36-cp36m/bin/pip install "numpy<1.17" scipy pytest pytest-astropy pytest-xdist Cython jinja2
@@ -30,28 +32,18 @@ jobs:
       - run:
           name: Run tests for Python 3.7
           command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python setup.py test --parallel=4 -a "--durations=50"
+      # We use the 3.8 build to check that running tests twice in a row in the
+      # same Python session works without issues. This catches cases where
+      # running the tests changes the module state permanently. Note that we
+      # shouldn't also test the parallel build here since that enforces a degree
+      # of isolation of tests which will interfere with what we are trying to do
+      # here.
       - run:
           name: Install dependencies for Python 3.8
           command: /opt/python/cp38-cp38/bin/pip install numpy pytest pytest-astropy pytest-xdist Cython jinja2
       - run:
           name: Run tests for Python 3.8
-          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python setup.py test --parallel=4 -a "--durations=50"
-
-  double-test:
-    # Check that running tests twice in a row in the same Python session works
-    # without issues. This catches cases where running the tests changes the
-    # module state permanently.
-    docker:
-      - image: circleci/python:3.7
-    steps:
-      - checkout
-      - run:
-          name: Run tests twice
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -e .[test]
-            python -c 'import sys; from astropy import test; test(); sys.exit(test())'
+          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python -c 'import sys; from astropy import test; test(); sys.exit(test())'
 
   image-tests-mpl212:
     docker:
@@ -176,7 +168,6 @@ workflows:
     jobs:
       - egg-info-37
       - html-docs
-      - double-test
       - 32bit-and-parallel
       - image-tests-mpl212
       - image-tests-mpl222

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,6 @@ env:
         - INSTALL_WITH_PIP=False
         - PIP_FLAGS=""
         - EXTRAS_INSTALL=""
-        # Run test suite twice in a row without cleaning
-        - DOUBLE_PLAY=False
         - USE_CI_HELPERS=True
         # Use this for the dependencies when not using ci-helpers
         - OTHER_DEPENDENCY_PREFERENCES=''
@@ -99,7 +97,6 @@ matrix:
                PIP_DEPENDENCIES="scikit-image jplephem $ASDF_PIP_DEP"
                CCOMPILER=clang
                EVENT_TYPE='cron'
-               DOUBLE_PLAY=True
 
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
@@ -237,12 +234,7 @@ install:
       fi
 
 script:
-    - if [[ $DOUBLE_PLAY == True ]]; then
-          $MAIN_CMD $SETUP_CMD;
-          $MAIN_CMD $SETUP_CMD;
-      else
-          $MAIN_CMD $SETUP_CMD;
-      fi
+    - $MAIN_CMD $SETUP_CMD;
 
 after_success:
     - if [[ $SETUP_CMD == *--coverage* ]]; then

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -17,6 +17,7 @@ from astropy.coordinates.angles import Longitude, Latitude, Angle
 from astropy.coordinates.distances import Distance
 from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
                                                 DIFFERENTIAL_CLASSES,
+                                                DUPLICATE_REPRESENTATIONS,
                                                 BaseRepresentation,
                                                 SphericalRepresentation,
                                                 UnitSphericalRepresentation,
@@ -33,11 +34,14 @@ from astropy.coordinates.representation import (REPRESENTATION_CLASSES,
 #   the test file doesn't add a persistent test subclass (LogDRepresentation)
 def setup_function(func):
     func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
+    func.DUPLICATE_REPRESENTATIONS_ORIG = deepcopy(DUPLICATE_REPRESENTATIONS)
 
 
 def teardown_function(func):
     REPRESENTATION_CLASSES.clear()
     REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
+    DUPLICATE_REPRESENTATIONS.clear()
+    DUPLICATE_REPRESENTATIONS.update(func.DUPLICATE_REPRESENTATIONS_ORIG)
 
 
 class TestSphericalRepresentation:

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1593,3 +1593,7 @@ def test_multiple_aliases():
     assert isinstance(coord.transform_to('alias_2').frame, MultipleAliasesFrame)
 
     ftrans.unregister(frame_transform_graph)
+
+    # Need to remove MultipleAliasesFrame manually from transform graph
+    assert frame_transform_graph._graph.pop(MultipleAliasesFrame) == {}
+

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1596,4 +1596,3 @@ def test_multiple_aliases():
 
     # Need to remove MultipleAliasesFrame manually from transform graph
     assert frame_transform_graph._graph.pop(MultipleAliasesFrame) == {}
-

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -7,6 +7,7 @@ test_api_ape5.py
 """
 
 import copy
+from copy import deepcopy
 
 import pytest
 import numpy as np
@@ -14,7 +15,7 @@ import numpy.testing as npt
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
-from astropy.coordinates.representation import REPRESENTATION_CLASSES
+from astropy.coordinates.representation import REPRESENTATION_CLASSES, DUPLICATE_REPRESENTATIONS
 from astropy.coordinates import (ICRS, FK4, FK5, Galactic, SkyCoord, Angle,
                                  SphericalRepresentation, CartesianRepresentation,
                                  UnitSphericalRepresentation, AltAz,
@@ -51,6 +52,18 @@ if HAS_SCIPY and minversion(scipy, '0.12.0', inclusive=False):
     OLDER_SCIPY = False
 else:
     OLDER_SCIPY = True
+
+
+def setup_function(func):
+    func.REPRESENTATION_CLASSES_ORIG = deepcopy(REPRESENTATION_CLASSES)
+    func.DUPLICATE_REPRESENTATIONS_ORIG = deepcopy(DUPLICATE_REPRESENTATIONS)
+
+
+def teardown_function(func):
+    REPRESENTATION_CLASSES.clear()
+    REPRESENTATION_CLASSES.update(func.REPRESENTATION_CLASSES_ORIG)
+    DUPLICATE_REPRESENTATIONS.clear()
+    DUPLICATE_REPRESENTATIONS.update(func.DUPLICATE_REPRESENTATIONS_ORIG)
 
 
 def test_transform_to():

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -944,6 +944,10 @@ def test_call_keyword_mappings(model):
     assert_allclose(positional, model(x0=1, x1=2))
     assert_allclose(positional, model(1, x1=2))
 
+    # We take a copy before modifying the model since otherwise this changes
+    # the instance used in the parametrize call and affects future test runs.
+    model = model.copy()
+
     model.inputs = ('r', 't')
     assert_allclose(positional, model(r=1, t=2))
     assert_allclose(positional, model(1, t=2))

--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -829,7 +829,7 @@ def test_caching_components_and_classes():
     # are updated (we use a cache internally, so we need to make sure the cache
     # is invalidated if needed)
 
-    wcs = WCS_SIMPLE_CELESTIAL
+    wcs = WCS_SIMPLE_CELESTIAL.deepcopy()
 
     assert wcs.world_axis_object_components == [('celestial', 0, 'spherical.lon.degree'),
                                                 ('celestial', 1, 'spherical.lat.degree')]
@@ -858,7 +858,7 @@ def test_sub_wcsapi_attributes():
     # incorrect when using WCS.sub or WCS.celestial (which is an alias for sub
     # with lon/lat types).
 
-    wcs = WCS_SPECTRAL_CUBE
+    wcs = WCS_SPECTRAL_CUBE.deepcopy()
     wcs.pixel_shape = (30, 40, 50)
     wcs.pixel_bounds = [(-1, 11), (-2, 18), (5, 15)]
 


### PR DESCRIPTION
In the Travis configuration, we have a ``DOUBLE_PLAY`` option which, if true, runs the tests twice. The original intent was to catch cases where the tests changed something in the global state, which would cause them to fail when run a second time. However, the implementation in the Travis configuration isn't quite right, because it runs the tests twice in two different processes. This PR changes this to instead run the ``test()`` function twice *in the same Python session*. I also moved this to CircleCI because it was easier to code up this kind of custom behavior there.

There are currently failures, which are due precisely to the state problem. I haven't had a chance to investigate yet, but if anyone fancies taking a look, feel free to push commits directly to my branch!