### PR TITLE
Skip asdf tests if entry points are not installed

### DIFF
--- a/astropy/io/misc/asdf/tags/coordinates/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tags/fits/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/fits/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tags/table/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/table/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tags/time/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/time/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tags/transform/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tags/unit/tests/__init__.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/__init__.py
@@ -1,0 +1,6 @@
+import pytest
+from astropy.io.misc.asdf.tests import ASDF_ENTRY_INSTALLED
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)

--- a/astropy/io/misc/asdf/tests/__init__.py
+++ b/astropy/io/misc/asdf/tests/__init__.py
@@ -1,2 +1,17 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
+
+# Define a constant to know if the entry points are installed, since this impacts
+# whether we can run the tests.
+
+import pytest
+from pkg_resources import iter_entry_points
+
+entry_points = [entry.name for entry in iter_entry_points('asdf_extensions')]
+ASDF_ENTRY_INSTALLED = 'astropy' in entry_points and 'astropy-asdf' in entry_points
+
+del entry_points, iter_entry_points
+
+if not ASDF_ENTRY_INSTALLED:
+    pytest.skip('The astropy asdf entry points are not installed',
+                allow_module_level=True)


### PR DESCRIPTION
*As suggested by @mhvk, I've split this out from https://github.com/astropy/astropy/pull/9726*

Since we are now transitioning to running tests with pytest directly, if one runs:

```
python setup.py build_ext --inplace
pytest
```

then the entry points in astropy are not installed, so the io.misc.asdf tests fail (if ``asdf`` is installed). This PR adjusts the behavior of the test suite to skip the io.misc.asdf tests if the entry points are not detected.

Note that ideally one should use:

```
pip install -e .
pytest
```

or use ``tox``, which ensures the entry points are installed, but we've had feedback from some developers that they would prefer the first option, to avoid having to install the package into the current environment, while also wanting to preserve the ability to run things fast (whereas tox does incur some overhead).
