### PR TITLE
Fix issue changing format with incompatible out_subfmt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -399,8 +399,12 @@ astropy.time
 
 - Fix inaccuracy when converting between TimeDelta and datetime.timedelta. [#9679]
 
-- Fix exception when changing ``format`` in the case when ``out_subfmt`` is
+- Fixed exception when changing ``format`` in the case when ``out_subfmt`` is
   defined and is incompatible with the new format. [#9812]
+
+- Fixed exceptions in ``Time.to_value()``: when supplying any ``subfmt`` argument
+  for string-based formats like 'iso', and for ``subfmt='long'`` for the formats
+  'byear', 'jyear', and 'decimalyear'. [#9812]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -397,6 +397,11 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Fix inaccuracy when converting between TimeDelta and datetime.timedelta. [#9679]
+
+- Fix exception when changing ``format`` in the case when ``out_subfmt`` is
+  defined and is incompatible with the new format. [#9812]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1477,12 +1477,14 @@ class Time(ShapedLikeNDArray):
         tm._format = new_format
         tm.SCALES = self.SCALES
 
-        # If current output subformat does not match any subfmts in new format
-        # then replace with default '*'.
-        try:
-            tm._time._select_subfmts(tm.out_subfmt)
-        except ValueError:
-            tm.out_subfmt = '*'
+        # If format has changed and current output subformat does not match any
+        # subfmts in new format then replace with default '*'.  If format is
+        # unchanged then the original out_subfmt is by definition OK.
+        if new_format != self.format:
+            try:
+                tm._time._select_subfmts(tm.out_subfmt)
+            except ValueError:
+                tm.out_subfmt = '*'
 
         return tm
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -661,18 +661,19 @@ class Time(ShapedLikeNDArray):
                              .format(list(self.FORMATS)))
         format_cls = self.FORMATS[format]
 
-        # If current output subformat is not in the new format then replace
-        # with default '*'
-        if hasattr(format_cls, 'subfmts'):
-            subfmt_names = [subfmt[0] for subfmt in format_cls.subfmts]
-            if self.out_subfmt not in subfmt_names:
-                self.out_subfmt = '*'
-
         self._time = format_cls(self._time.jd1, self._time.jd2,
                                 self._time._scale, self.precision,
                                 in_subfmt=self.in_subfmt,
                                 out_subfmt=self.out_subfmt,
                                 from_jd=True)
+
+        # If current output subformat does not match any subfmts in new format
+        # then replace with default '*'
+        try:
+            self._time._select_subfmts(self.out_subfmt)
+        except ValueError:
+            self.out_subfmt = '*'
+
         self._format = format
 
     def __repr__(self):
@@ -1468,12 +1469,21 @@ class Time(ShapedLikeNDArray):
                              .format(list(tm.FORMATS)))
 
         NewFormat = tm.FORMATS[new_format]
+
         tm._time = NewFormat(tm._time.jd1, tm._time.jd2,
                              tm._time._scale, tm.precision,
                              tm.in_subfmt, tm.out_subfmt,
                              from_jd=True)
         tm._format = new_format
         tm.SCALES = self.SCALES
+
+        # If current output subformat does not match any subfmts in new format
+        # then replace with default '*'.
+        try:
+            tm._time._select_subfmts(tm.out_subfmt)
+        except ValueError:
+            tm.out_subfmt = '*'
+
         return tm
 
     def __copy__(self):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -129,6 +129,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
     """
 
     _default_scale = 'utc'  # As of astropy 0.4
+    subfmts = ()
 
     def __init__(self, val1, val2, scale, precision,
                  in_subfmt, out_subfmt, from_jd=False):

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2118,3 +2118,32 @@ def test_ymdhms_output():
 def test_broadcasting_writeable():
     t = Time('J2015') + np.linspace(-1, 1, 10) * u.day
     t[2] = Time(58000, format="mjd")
+
+
+def test_format_subformat_compatibility():
+    """Test that changing format with out_subfmt defined is not a problem.
+    See #9812, #9810."""
+    t = Time('2019-12-20', out_subfmt='date_??')
+    assert t.mjd == 58837.0
+    assert t.yday == '2019:354:00:00'  # Preserves out_subfmt
+
+    t2 = t.replicate(format='mjd')
+    assert t2.out_subfmt == '*'  # Changes to default
+
+    t2 = t.copy(format='mjd')
+    assert t2.out_subfmt == '*'
+
+    t2 = Time(t, format='mjd')
+    assert t2.out_subfmt == '*'
+
+    t2 = t.copy(format='yday')
+    assert t2.out_subfmt == 'date_??'
+    assert t2.value == '2019:354:00:00'
+
+    t.format = 'yday'
+    assert t.value == '2019:354:00:00'
+    assert t.out_subfmt == 'date_??'
+
+    t = Time('2019-12-20', out_subfmt='date')
+    assert t.mjd == 58837.0
+    assert t.yday == '2019:354'

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -14,7 +14,7 @@ from astropy.tests.helper import catch_warnings, pytest
 from astropy.utils.exceptions import AstropyDeprecationWarning, ErfaWarning
 from astropy.utils import isiterable, iers
 from astropy.time import (Time, TimeDelta, ScaleValueError, STANDARD_TIME_SCALES,
-                          TimeString, TimezoneInfo)
+                          TimeString, TimezoneInfo, TIME_FORMATS)
 from astropy.coordinates import EarthLocation
 from astropy import units as u
 from astropy import _erfa as erfa
@@ -2147,3 +2147,14 @@ def test_format_subformat_compatibility():
     t = Time('2019-12-20', out_subfmt='date')
     assert t.mjd == 58837.0
     assert t.yday == '2019:354'
+
+
+@pytest.mark.parametrize('fmt_name,fmt_class', TIME_FORMATS.items())
+def test_to_value_with_subfmt_for_every_format(fmt_name, fmt_class):
+    """From a starting Time value, test that every valid combination of
+    to_value(format, subfmt) works.  See #9812, #9361.
+    """
+    t = Time('2000-01-01')
+    subfmts = list(subfmt[0] for subfmt in fmt_class.subfmts) + [None, '*']
+    for subfmt in subfmts:
+        t.to_value(fmt_name, subfmt)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to fix an exception when changing Time format in the case where ``out_subfmt`` is a value that is incompatible with available `subfmts` in the new format class.  See #9810 for examples and discussion.  The fix here is within the ``_apply`` method, which is used for copy, replicate and many other ways that format can get changed.

It also fixes a bug I just discovered where `tm.to_value(fmt, subfmt='long')` fails for `fmt` in 'byear', 'jyear', or 'decimalyear'.

This also changes two minor problems in the changelog entry for #9679.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9810
Fixes #9860