### PR TITLE
Remove old erfa cruft needed for numpy < 1.16

### DIFF
--- a/astropy/_erfa/core.py.templ
+++ b/astropy/_erfa/core.py.templ
@@ -145,17 +145,6 @@ def {{ func.pyname }}({{ func.args_by_inout('in|inout')|map(attribute='name')|jo
      # Call the ufunc. Note that we pass inout twice, once as input
      # and once as output, so that changes are done in-place
      #}
-    {%- if func.d3_fix_arg %}
-    {% if func.args_by_inout('in|inout') -%}
-    ({{ func.args_by_inout('in|inout')|map(attribute='name')|join(', ') }},)
-    {%- else -%}_{%- endif -%}, {{ func.d3_fix_arg.name
-        }} = arrayify_inputs_and_create_d3_fix(
-        [{{ func.args_by_inout('in|inout')|map(attribute='name')|list()|join(', ')
-        }}], core_dims=[{{
-        func.args_by_inout('in|inout')|map(attribute='ndim')|list()|join(', ')
-        }}], out_core_shape={{ func.d3_fix_arg.shape
-        }}, out_dtype=numpy.{{ func.d3_fix_arg.ctype }})
-    {%- endif %}
     {{ func.python_call }}
     {#-
      # Check whether any warnings or errors occurred.

--- a/astropy/_erfa/erfa_generator.py
+++ b/astropy/_erfa/erfa_generator.py
@@ -450,38 +450,11 @@ class Function:
              for args in (self.args_by_inout('in|inout'),
                           self.args_by_inout('inout|out|ret|stat'))])
 
-    def _d3_fix_arg_and_index(self):
-        if not any('d3' in arg.signature_shape
-                   for arg in self.args_by_inout('in|inout')):
-            for j, arg in enumerate(self.args_by_inout('out')):
-                if 'd3' in arg.signature_shape:
-                    return j, arg
-
-        return None, None
-
-    @property
-    def d3_fix_op_index(self):
-        """Whether only output arguments have a d3 dimension."""
-        index = self._d3_fix_arg_and_index()[0]
-        if index is not None:
-            len_in = len(list(self.args_by_inout('in')))
-            len_inout = len(list(self.args_by_inout('inout')))
-            index += + len_in + 2 * len_inout
-        return index
-
-    @property
-    def d3_fix_arg(self):
-        """Whether only output arguments have a d3 dimension."""
-        return self._d3_fix_arg_and_index()[1]
-
     @property
     def python_call(self):
         outnames = [arg.name for arg in self.args_by_inout('inout|out|stat|ret')]
         argnames = [arg.name for arg in self.args_by_inout('in|inout')]
         argnames += [arg.name for arg in self.args_by_inout('inout')]
-        d3fix_index = self._d3_fix_arg_and_index()[0]
-        if d3fix_index is not None:
-            argnames += ['None'] * d3fix_index + [self.d3_fix_arg.name]
         return '{out} = {func}({args})'.format(out=', '.join(outnames),
                                                func='ufunc.' + self.pyname,
                                                args=', '.join(argnames))

--- a/astropy/_erfa/ufunc.c.templ
+++ b/astropy/_erfa/ufunc.c.templ
@@ -893,11 +893,7 @@ PyMODINIT_FUNC PyInit_ufunc(void)
         goto fail;
     }
     {%- endif %}
-    {%- if func.signature and 'd3' in func.signature and not func.d3_fix_arg %}
-    ufunc->type_resolver = &ErfaUFuncD3CheckTypeResolver;
-    {%- else %}
     ufunc->type_resolver = &ErfaUFuncTypeResolver;
-    {%- endif %}
     PyDict_SetItemString(d, "{{ func.pyname }}", (PyObject *)ufunc);
     Py_DECREF(ufunc);
     {%- endfor %}


### PR DESCRIPTION
While working on #9804, I noticed that the numpy >=1.16 cleanup had missed some stuff in `_erfa`. This removes parts of work-arounds that now never are called any more.