### PR TITLE
Fixed two bugs with removing transforms from the graph

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -284,6 +284,13 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug where a vestigal trace of a frame class could persist in the
+  transformation graph even after the removal of all transformations involving
+  that frame class. [#9815]
+
+- Fixed a bug with ``TransformGraph.remove_transform()`` when the "from" and
+  "to" frame classes are not explicitly specified. [#9815]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -1593,6 +1593,3 @@ def test_multiple_aliases():
     assert isinstance(coord.transform_to('alias_2').frame, MultipleAliasesFrame)
 
     ftrans.unregister(frame_transform_graph)
-
-    # Need to remove MultipleAliasesFrame manually from transform graph
-    assert frame_transform_graph._graph.pop(MultipleAliasesFrame) == {}

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -233,9 +233,14 @@ class TransformGraph:
             for a in self._graph:
                 agraph = self._graph[a]
                 for b in agraph:
-                    if b is transform:
+                    if agraph[b] is transform:
                         del agraph[b]
+                        fromsys = a
                         break
+
+                # If the transform was found, need to break out of the outer for loop too
+                if fromsys:
+                    break
             else:
                 raise ValueError('Could not find transform {} in the '
                                  'graph'.format(transform))
@@ -250,6 +255,11 @@ class TransformGraph:
                 else:
                     raise ValueError('Current transform from {} to {} is not '
                                      '{}'.format(fromsys, tosys, transform))
+
+        # Remove the subgraph if it is now empty
+        if self._graph[fromsys] == {}:
+            self._graph.pop(fromsys)
+
         self.invalidate_cache()
 
     def find_shortest_path(self, fromsys, tosys):


### PR DESCRIPTION
The bugs:

- Removing a transform when it was the last transform with that "from" frame class would not remove the now-empty dictionary from the graph, which could lead there to be vestigial traces of that frame class even when no transforms remain that actually involve that frame class.  (context: https://github.com/astropy/astropy/pull/9805#issuecomment-567988201 cc @astrofrog )
- The brute-force search to remove a transform `ftrans` by calling `TransformGraph(None, None, ftrans)` wasn't working properly (and wasn't being tested).