### PR TITLE
Fix asdf test helper to use new resolver

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -30,7 +30,7 @@ __minimum_python_version__ = '3.6'
 __minimum_numpy_version__ = '1.16.0'
 # ASDF is an optional dependency, but this is the minimum version that is
 # compatible with Astropy when it is installed.
-__minimum_asdf_version__ = '2.3.0'
+__minimum_asdf_version__ = '2.5.0'
 
 
 class UnsupportedPythonError(Exception):

--- a/astropy/io/misc/asdf/tags/tests/helpers.py
+++ b/astropy/io/misc/asdf/tags/tests/helpers.py
@@ -11,8 +11,8 @@ def run_schema_example_test(organization, standard, name, version, check_func=No
     from asdf.schema import load_schema
 
     tag = format_tag(organization, standard, version, name)
-    uri = asdf.resolver.default_tag_to_url_mapping(tag)
-    r = asdf.AsdfFile().resolver
+    uri = asdf.extension.default_extensions.extension_list.tag_mapping(tag)
+    r = asdf.extension.get_default_resolver()
 
     examples = []
     schema = load_schema(uri, resolver=r)

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ all =
     matplotlib>=2.1
     scikit-image
     mpmath
-    asdf>=2.3
+    asdf>=2.5
     bottleneck
     ipython
     pytest


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This fixes the DeprecationWarning issue by using the new resolver machinery in `asdf 2.5.0`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9816
Closes #9818