### PR TITLE
minor docstring edits for reStructuredText (RST) validation

### DIFF
--- a/astropy/cosmology/core.py
+++ b/astropy/cosmology/core.py
@@ -1742,8 +1742,7 @@ class LambdaCDM(FLRW):
 
         For Omega_rad = 0 the comoving distance can be directly calculated
         as an elliptic integral.
-        Equation here taken from
-            Kantowski, Kao, and Thomas, arXiv:0002334
+        Equation here taken from Kantowski, Kao, and Thomas, arXiv:0002334
 
         Not valid or appropriate for flat cosmologies (Ok0=0).
 
@@ -1878,8 +1877,8 @@ class LambdaCDM(FLRW):
 
         For Omega_radiation = 0 the comoving distance can be directly calculated
         as a hypergeometric function.
-        Equation here taken from
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+
+        Equation here taken from Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
 
         Parameters
         ----------
@@ -1911,8 +1910,7 @@ class LambdaCDM(FLRW):
 
         Note:
         The scipy.special.hyp2f1 code already implements the hypergeometric
-        transformation suggested by
-            Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
+        transformation suggested by Baes, Camps, Van De Putte, 2017, MNRAS, 468, 927.
         for use in actual numerical evaulations.
 
         """
@@ -1941,8 +1939,7 @@ class LambdaCDM(FLRW):
 
         For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
         the age can be directly calculated as an elliptic integral.
-        See, e.g.,
-            Thomas and Kantowski, arXiv:0003463
+        See, e.g., Thomas and Kantowski, arXiv:0003463
 
         Parameters
         ----------
@@ -1964,8 +1961,7 @@ class LambdaCDM(FLRW):
 
         For Omega_radiation = 0 (T_CMB = 0; massless neutrinos)
         the age can be directly calculated as an elliptic integral.
-        See, e.g.,
-            Thomas and Kantowski, arXiv:0003463
+        See, e.g., Thomas and Kantowski, arXiv:0003463
 
         Parameters
         ----------

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -71,7 +71,7 @@ class HTMLInputter(core.BaseInputter):
     Input lines of HTML in a valid form.
 
     This requires `BeautifulSoup
-        <http://www.crummy.com/software/BeautifulSoup/>`_ to be installed.
+    <http://www.crummy.com/software/BeautifulSoup/>`_ to be installed.
     """
 
     def process_lines(self, lines):

--- a/astropy/io/ascii/misc.py
+++ b/astropy/io/ascii/misc.py
@@ -48,7 +48,7 @@ def sortmore(*args, **kw):
         Sort by evaluated value for all items in the lists
         (call signature of this function needs to be such that it accepts an
         argument tuple of items from each list.
-        eg.: globalkey = lambda *l: sum(l) will order all the lists by the
+        eg.: ``globalkey = lambda *l: sum(l)`` will order all the lists by the
         sum of the items from each list
 
     if key: None
@@ -69,7 +69,8 @@ def sortmore(*args, **kw):
 
     Examples
     --------
-    Capture sorting indeces:
+    Capture sorting indices::
+
         l = list('CharacterS')
         In [1]: sortmore( l, range(len(l)) )
         Out[1]: (['C', 'S', 'a', 'a', 'c', 'e', 'h', 'r', 'r', 't'],

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -310,6 +310,7 @@ class TestFitsTime(FitsTestCase):
         Test that FITS table with time columns (standard compliant)
         can be read by io.fits as a table with Time columns.
         This tests the following:
+
         1. The special-case where a column has the name 'TIME' and a
            time unit
         2. Time from Epoch (Reference time) is appropriately converted.

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -1442,6 +1442,7 @@ def populate_entry_points(entry_points):
                   entry_points are objects which encapsulate
                   importable objects and are defined on the
                   installation of a package.
+
     Notes
     -----
     An explanation of entry points can be found `here <http://setuptools.readthedocs.io/en/latest/setuptools.html#dynamic-discovery-of-services-and-plugins>`

--- a/astropy/modeling/utils.py
+++ b/astropy/modeling/utils.py
@@ -328,14 +328,14 @@ class AliasDict(MutableMapping):
     3
 
     Keys in the original parent dict are not visible if they were not
-    aliased::
+    aliased:
 
     >>> alias_dict['b']
     Traceback (most recent call last):
     ...
     KeyError: 'b'
 
-    Likewise, updates to aliased keys are reflected back in the parent dict::
+    Likewise, updates to aliased keys are reflected back in the parent dict:
 
     >>> alias_dict['foo'] = 42
     >>> alias_dict['foo']
@@ -344,7 +344,7 @@ class AliasDict(MutableMapping):
     42
 
     However, updates/insertions to keys that are *not* aliased are not
-    reflected in the parent dict::
+    reflected in the parent dict:
 
     >>> alias_dict['qux'] = 99
     >>> alias_dict['qux']
@@ -356,7 +356,7 @@ class AliasDict(MutableMapping):
     one of the aliased keys in the parent dict does *not* update the parent
     dict.  For example, ``alias_dict`` aliases ``'foo'`` to ``'a'``.  But
     assigning to a key ``'a'`` on the `AliasDict` does not impact the
-    parent::
+    parent:
 
     >>> alias_dict['a'] = 'nope'
     >>> alias_dict['a']

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -618,6 +618,7 @@ class BoxLeastSquares(BasePeriodogram):
         -------
         t, y, dy : array_like, `~astropy.units.Quantity`, or `~astropy.time.Time`
             The inputs with consistent shapes and units.
+
         Raises
         ------
         ValueError

--- a/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
+++ b/astropy/timeseries/periodograms/lombscargle/implementations/utils.py
@@ -15,6 +15,7 @@ def extirpolate(x, y, N=None, M=4):
     """
     Extirpolate the values (x, y) onto an integer grid range(N),
     using lagrange polynomial weights on the M nearest points.
+
     Parameters
     ----------
     x : array_like
@@ -80,9 +81,11 @@ def extirpolate(x, y, N=None, M=4):
 def trig_sum(t, h, df, N, f0=0, freq_factor=1,
              oversampling=5, use_fft=True, Mfft=4):
     """Compute (approximate) trigonometric sums for a number of frequencies
-    This routine computes weighted sine and cosine sums:
+    This routine computes weighted sine and cosine sums::
+
         S_j = sum_i { h_i * sin(2 pi * f_j * t_i) }
         C_j = sum_i { h_i * cos(2 pi * f_j * t_i) }
+
     Where f_j = freq_factor * (f0 + j * df) for the values j in 1 ... N.
     The sums can be computed either by a brute force O[N^2] method, or
     by an FFT-based O[Nlog(N)] method.

--- a/astropy/utils/compat/misc.py
+++ b/astropy/utils/compat/misc.py
@@ -46,9 +46,11 @@ def override__dir__(f):
     Example
     -------
 
-    @override__dir__
-    def __dir__(self):
-        return ['special_method1', 'special_method2']
+    Your class could define __dir__ as follows::
+
+        @override__dir__
+        def __dir__(self):
+            return ['special_method1', 'special_method2']
     """
     # http://bugs.python.org/issue12166
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -224,6 +224,7 @@ class IERS(QTable):
         jd2 : float or array, optional
             second part of two-part JD.
             Default is 0., ignored if jd1 is `~astropy.time.Time`.
+
         Returns
         -------
         mjd : float or array

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -898,8 +898,9 @@ def _linear_wcs_fit(params, lon, lat, x, y, w_obj):
 def _sip_fit(params, lon, lat, u, v, w_obj, order, coeff_names):
 
     """ Objective function for fitting SIP.
-     Parameters
-    -----------
+
+    Parameters
+    ----------
     params : array
         Fittable parameters. First 4 elements are PC matrix, last 2 are CRPIX.
     lon, lat: array


### PR DESCRIPTION
I assume since AstroPy uses Sphinx for its documentation on http://docs.astropy.org/ which includes many (if not all?) of the API docstrings, that you would like all the API docstrings to be valid eStructuredText (RST).

My main motivation here is using this as a large test case for my flake8 plugin https://github.com/peterjc/flake8-rst-docstrings which uses ``docutils`` to valid docstrings as RST. This has highlighted some potential false positives for me to look at (indentation within parameter documentation, and widespread use of ``*arg`` and ``**kwargs`` with unbalanced ``*`` and ``**``).

This pull request is hopefully all the low hanging fruit - minor issues which the plugin caught which will hopefully slightly improve the rendering of your documentation.

WARNING: I have not attempted to build your documentation locally to check the output visually.

