### PR TITLE
Added bin width rules; Doane, Rice and Sturges rule to calc bins

### DIFF
--- a/astropy/stats/histogram.py
+++ b/astropy/stats/histogram.py
@@ -404,7 +404,6 @@ def doane_bin_width(data, return_bins=False):
     root_b = abs(((data - avg)**3).sum() / sigma**3)
     sigma_root_b = ((6*(n-2)) / ((n+1)*(n+3)))**(1/2)
 
-
     dx = (data.max() - data.min()) / \
          (1 + np.log2(n) + np.log2(1 + root_b/sigma_root_b))
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to add three rules for choosing bin widths for a histogram; Sturges' rule, Doane's rule (which is an extension of Sturges' rule) and The Rice rule. Methods doane_bin_width, sturges_bin_width and rice_bin_width in [astropy/stats/histogram.py](https://github.com/astropy/astropy/blob/master/astropy/stats/histogram.py)

Created methods to calculate bin widths. Updated methods histogram and calculate_bin_edges to support the three new methods, updated docstrings where applicable. Also created tests for the three new methods.

Docstrings include references. See also [wikipedia article on histogram bins and width](https://en.wikipedia.org/wiki/Histogram#Number_of_bins_and_width)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
