### PR TITLE
add a test with ASDF master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ matrix:
           stage: Final tests
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=''
-               PIP_DEPENDENCIES=$DEV_PIP_DEP $ASDF_DEV
+               PIP_DEPENDENCIES="$DEV_PIP_DEP $ASDF_DEV"
                MATPLOTLIB_VERSION=dev
 
         # We check numpy-dev also in a job that only runs from cron, so that
@@ -176,7 +176,7 @@ matrix:
           stage: Cron tests
           env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=''
-               PIP_DEPENDENCIES=$DEV_PIP_DEP $ASDF_DEV
+               PIP_DEPENDENCIES="$DEV_PIP_DEP $ASDF_DEV"
 
         # Run documentation link check in a cron job.
         # Was originally in CircleCI doc build but links are too flaky, so
@@ -195,7 +195,7 @@ matrix:
         stage: Final tests
         env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
              CONDA_DEPENDENCIES=''
-             PIP_DEPENDENCIES=$DEV_PIP_DEP
+             PIP_DEPENDENCIES="$DEV_PIP_DEP $ASDF_DEV"
              MATPLOTLIB_VERSION=dev
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,8 +36,9 @@ env:
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='Cython jinja2'
         - CONDA_ALL_DEPENDENCIES='Cython jinja2 scipy h5py matplotlib pyyaml pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
-        - DEV_PIP_DEP='asdf>=2.3 Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
-        - ASDF_PIP_DEP='asdf>=2.3'
+        - ASDF_PIP_DEP='asdf>=2.5'
+        - ASDF_DEV='git+https://github.com/spacetelescope/asdf.git#egg=asdf'
+        - DEV_PIP_DEP='Cython jinja2 scipy h5py matplotlib pyyaml scikit-image pandas pytz html5lib beautifulsoup4 ipython mpmath bleach bottleneck'
         - SETUP_XVFB=True
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
@@ -163,7 +164,7 @@ matrix:
           stage: Final tests
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=dev SETUP_CMD='test --remote-data'
                CONDA_DEPENDENCIES=''
-               PIP_DEPENDENCIES=$DEV_PIP_DEP
+               PIP_DEPENDENCIES=$DEV_PIP_DEP $ASDF_DEV
                MATPLOTLIB_VERSION=dev
 
         # We check numpy-dev also in a job that only runs from cron, so that
@@ -175,7 +176,7 @@ matrix:
           stage: Cron tests
           env: NUMPY_VERSION=dev MATPLOTLIB_VERSION=dev EVENT_TYPE='cron'
                CONDA_DEPENDENCIES=''
-               PIP_DEPENDENCIES=$DEV_PIP_DEP
+               PIP_DEPENDENCIES=$DEV_PIP_DEP $ASDF_DEV
 
         # Run documentation link check in a cron job.
         # Was originally in CircleCI doc build but links are too flaky, so


### PR DESCRIPTION
Add an `allow-failures`  Travis test with ASDF master to the `Numpy_DEV` job. I expect it's trivial to figure out if an error is caused by numpy or asdf.

