### PR TITLE
Silence Matplotlib deprecation warnings after pytest run

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -70,8 +70,10 @@ def pytest_unconfigure(config):
     builtins._pytest_running = False
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:
-        matplotlib.rcParams.update(matplotlibrc_cache)
-        matplotlibrc_cache.clear()
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            matplotlib.rcParams.update(matplotlibrc_cache)
+            matplotlibrc_cache.clear()
 
     if builtins._xdg_config_home_orig is None:
         os.environ.pop('XDG_CONFIG_HOME')


### PR DESCRIPTION
This silences the following warnings that get emitted at the end of the test suite:

```
/usr/local/lib/python3.7/_collections_abc.py:841: MatplotlibDeprecationWarning: 
The savefig.frameon rcparam was deprecated in Matplotlib 3.1 and will be removed in 3.3.
  self[key] = other[key]
/usr/local/lib/python3.7/_collections_abc.py:841: MatplotlibDeprecationWarning: 
The text.latex.unicode rcparam was deprecated in Matplotlib 3.0 and will be removed in 3.2.
  self[key] = other[key]
/usr/local/lib/python3.7/_collections_abc.py:841: MatplotlibDeprecationWarning: 
The verbose.fileo rcparam was deprecated in Matplotlib 3.1 and will be removed in 3.3.
  self[key] = other[key]
/usr/local/lib/python3.7/_collections_abc.py:841: MatplotlibDeprecationWarning: 
The verbose.level rcparam was deprecated in Matplotlib 3.1 and will be removed in 3.3.
  self[key] = other[key]
```