### PR TITLE
DOC: Add back units history

### DIFF
--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -168,6 +168,14 @@ Using `astropy.units`
    constants_versions
    conversion
 
+Acknowledgments
+===============
+
+This code is adapted from the `pynbody
+<https://github.com/pynbody/pynbody>`__ units module written by Andrew
+Pontzen, who has granted the Astropy Project permission to use the code
+under a BSD license.
+
 See Also
 ========
 
@@ -228,11 +236,3 @@ Reference/API
 .. automodapi:: astropy.units.deprecated
 
 .. automodapi:: astropy.units.required_by_vounit
-
-Acknowledgments
-===============
-
-This code is adapted from the `pynbody
-<https://github.com/pynbody/pynbody>`__ units module written by Andrew
-Pontzen, who has granted the Astropy Project permission to use the code
-under a BSD license.

--- a/docs/units/index.rst
+++ b/docs/units/index.rst
@@ -171,7 +171,7 @@ Using `astropy.units`
 Acknowledgments
 ===============
 
-This code is adapted from the `pynbody
+This code was originally based on the `pynbody
 <https://github.com/pynbody/pynbody>`__ units module written by Andrew
 Pontzen, who has granted the Astropy Project permission to use the code
 under a BSD license.


### PR DESCRIPTION
Back in https://docs.astropy.org/en/older-docs-archive/v1.0/stability.html , there is a note about this. But then it was removed to avoid confusion. I think this note is better off in the main doc, not in the sub-package status table anyway.