### PR TITLE
Fix a memory corruption issue in WCS due to uninitialized wcsprm.flag before wcscopy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -91,6 +91,9 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Fix a memory corruption issue in WCS due to uninitialized value of
+  ``wcsprm.flag`` before ``wcscopy``. [#9838]
+
 
 API Changes
 -----------

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -181,6 +181,7 @@ static PyWcsprm*
 PyWcsprm_cnew(void) {
   PyWcsprm* self;
   self = (PyWcsprm*)(&PyWcsprmType)->tp_alloc(&PyWcsprmType, 0);
+  memset(&self->x, 0, sizeof(struct wcsprm));
   return self;
 }
 
@@ -192,6 +193,7 @@ PyWcsprm_new(
 
   PyWcsprm* self;
   self = (PyWcsprm*)type->tp_alloc(type, 0);
+  memset(&self->x, 0, sizeof(struct wcsprm));
   return (PyObject*)self;
 }
 
@@ -257,7 +259,6 @@ PyWcsprm_init(
       return -1;
     }
 
-    note_change(self);
     self->x.flag = -1;
     status = wcsini(1, naxis, &self->x);
 
@@ -434,6 +435,7 @@ PyWcsprm_init(
       return -1;
     }
 
+    self->x.flag = -1;
     if (wcscopy(1, wcs + i, &self->x) != 0) {
       wcsvfree(&nwcs, &wcs);
       PyErr_SetString(


### PR DESCRIPTION
This PR fixes a memory corruption issue in WCS. This memory corruption might be the likely reason for unit tests failures in https://github.com/astropy/astropy/pull/9641.

Fundamentally, currently the code does not set the flag of `Wcsprm` _before_ calling `wcscopy`. The most important change in this PR is the addition of the line:

```c
self->x.flag = -1;
```

before `wcscopy()`. `memset` was added out of caution.

CC: @nden, @MSeifert04 

I will rebase https://github.com/astropy/astropy/pull/9641 after this one is merged.