### PR TITLE
Prevent NaNs from emitting a warning in Latitude

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -523,7 +523,10 @@ class Latitude(Angle):
             angles = self
         lower = u.degree.to(angles.unit, -90.0)
         upper = u.degree.to(angles.unit, 90.0)
-        if np.any(angles.value < lower) or np.any(angles.value > upper):
+        with np.errstate(invalid='ignore'):
+            invalid_angles = (np.any(angles.value < lower) or
+                              np.any(angles.value > upper))
+        if invalid_angles:
             raise ValueError('Latitude angle(s) must be within -90 deg <= angle <= 90 deg, '
                              'got {}'.format(angles.to(u.degree)))
 

--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -42,7 +42,7 @@ class Angle(u.SpecificTypeQuantity):
       Angle('1°2′3″N')
       Angle('1d2m3.4s')
       Angle('1d2m3.4sS')
-      Angle('-1h2m3s') 
+      Angle('-1h2m3s')
       Angle('-1h2m3sE')
       Angle('-1h2.5m')
       Angle('-1h2.5mW')
@@ -523,6 +523,8 @@ class Latitude(Angle):
             angles = self
         lower = u.degree.to(angles.unit, -90.0)
         upper = u.degree.to(angles.unit, 90.0)
+        # This invalid catch block can be removed when the minimum numpy
+        # version is >= 1.19 (NUMPY_LT_1_19)
         with np.errstate(invalid='ignore'):
             invalid_angles = (np.any(angles.value < lower) or
                               np.any(angles.value > upper))
@@ -639,6 +641,9 @@ class Longitude(Angle):
         wrap_angle_floor = wrap_angle - a360
         self_angle = self.value
         # Do the wrapping, but only if any angles need to be wrapped
+        #
+        # This invalid catch block can be removed when the minimum numpy
+        # version is >= 1.19 (NUMPY_LT_1_19)
         with np.errstate(invalid='ignore'):
             wraps = (self_angle - wrap_angle_floor) // a360
         if np.any(wraps != 0):

--- a/astropy/coordinates/distances.py
+++ b/astropy/coordinates/distances.py
@@ -178,7 +178,8 @@ class Distance(u.SpecificTypeQuantity):
             cls, value, unit, dtype=dtype, copy=copy, order=order,
             subok=subok, ndmin=ndmin)
 
-        # Make sure NaNs don't emit a warning
+        # This invalid catch block can be removed when the minimum numpy
+        # version is >= 1.19 (NUMPY_LT_1_19)
         with np.errstate(invalid='ignore'):
             any_negative = np.any(distance.value < 0)
 

--- a/astropy/coordinates/tests/test_angles.py
+++ b/astropy/coordinates/tests/test_angles.py
@@ -1004,3 +1004,8 @@ def test_angle_with_cds_units_enabled():
 def test_longitude_nan():
     # Check that passing a NaN to Longitude doesn't raise a warning
     Longitude([0, np.nan, 1] * u.deg)
+
+
+def test_latitude_nan():
+    # Check that passing a NaN to Latitude doesn't raise a warning
+    Latitude([0, np.nan, 1] * u.deg)


### PR DESCRIPTION
In a similar vein to #9644 and #9598, this prevents a "invalid value" warning being thrown by numpy when a `Nan` is given to `astropy.coordinates.Latitude`.