### PR TITLE
Fix memory corruption bugs in WCSLIB/wcscopy for WCS-TAB

### DIFF
--- a/cextern/wcslib/C/wcs.c
+++ b/cextern/wcslib/C/wcs.c
@@ -1260,7 +1260,7 @@ int wcssub(
     for (m = 0; m < wcssrc->tab[itab].M; m++) {
       i = wcssrc->tab[itab].map[m];
 
-      if (map[i-1]) {
+      if (map[i]) { /* temporary bug fix - mcara */
         wcsdst->ntab++;
         break;
       }
@@ -1284,7 +1284,7 @@ int wcssub(
     for (m = 0; m < wcssrc->tab[itab].M; m++) {
       i = wcssrc->tab[itab].map[m];
 
-      if (map[i-1]) {
+      if (map[i]) { /* temporary bug fix - mcara */
         if ((status = tabcpy(1, wcssrc->tab + itab, tab))) {
           wcserr_set(WCS_ERRMSG(wcs_taberr[status]));
           goto cleanup;


### PR DESCRIPTION
This PR implements bug fixes in WCSLIB that lead to memory corruption in wcscopy when a WCS has -TAB. This should fix memory corruption issues in https://github.com/astropy/astropy/pull/9641 PR. No unit tests added in this PR but the affected code gets invoked *only when* -TAB is present in the WCS so it should not affect existing functionality.