### PR TITLE
Update docstring & keywords for isclose and allclose in units

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,6 +82,9 @@ astropy.units
 
 - Added ``torr`` pressure unit. [#9787]
 
+- Added the ``equal_nan`` keyword argument to ``isclose`` and ``allclose``, and
+  updated the docstrings. [#9849]
+
 astropy.utils
 ^^^^^^^^^^^^^
 
@@ -264,7 +267,6 @@ Other Changes and Additions
   ``ASTROPY_USE_SYSTEM_EXPAT``, ``ASTROPY_USE_SYSTEM_WCSLIB``, and
   ``ASTROPY_USE_SYSTEM_ALL``. These should be set to ``1`` to build
   against the system libraries. [#9730]
-
 
 4.0.1 (unreleased)
 ==================

--- a/astropy/tests/tests/test_quantity_helpers.py
+++ b/astropy/tests/tests/test_quantity_helpers.py
@@ -36,4 +36,4 @@ def test_assert_quantity_allclose():
 
     with pytest.raises(u.UnitsError) as exc:
         assert_quantity_allclose([1, 2], [1, 2], rtol=0.3 * u.m)
-    assert exc.value.args[0] == "`rtol` should be dimensionless"
+    assert exc.value.args[0] == "'rtol' should be dimensionless"

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1738,7 +1738,7 @@ class SpecificTypeQuantity(Quantity):
 
 def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     """
-    Returns a boolean array where two arrays are element-wise equal
+    Return a boolean array where two arrays are element-wise equal
     within a tolerance.
 
     Parameters
@@ -1777,10 +1777,9 @@ def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     return np.isclose(*unquantified_args, equal_nan=equal_nan, **kwargs)
 
 
-def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
+def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs) -> bool:
     """
-    Return `True` if two arrays are element-wise equal within a
-    tolerance, and `False` otherwise.
+    Whether two arrays are element-wise equal within a tolerance.
 
     Parameters
     ----------
@@ -1826,7 +1825,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         desired = desired.to(actual.unit)
     except UnitsError:
         raise UnitsError(
-            f"Units for `desired` ({desired.unit}) and `actual` "
+            f"Units for 'desired' ({desired.unit}) and 'actual' "
             f"({actual.unit}) are not convertible"
         )
 
@@ -1841,7 +1840,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
             atol = atol.to(actual.unit)
         except UnitsError:
             raise UnitsError(
-                f"Units for `atol` ({atol.unit} and `actual` "
+                f"Units for 'atol' ({atol.unit} and 'actual' "
                 f"({actual.unit}) are not convertible"
             )
 
@@ -1849,6 +1848,6 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
     try:
         rtol = rtol.to(dimensionless_unscaled)
     except Exception:
-        raise UnitsError("`rtol` should be dimensionless")
+        raise UnitsError("'rtol' should be dimensionless")
 
     return actual.value, desired.value, rtol.value, atol.value

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1830,9 +1830,10 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         )
 
     if atol is None:
-        # By default, we assume an absolute tolerance of 0.  The default
-        # value of None for atol is needed because the units of atol
-        # must be consistent with the units for a and b.
+        # By default, we assume an absolute tolerance of zero in the
+        # appropriate units.  The default value of None for atol is
+        # needed because the units of atol must be consistent with the
+        # units for a and b.
         atol = Quantity(0)
     else:
         atol = Quantity(atol, subok=True, copy=False)
@@ -1840,7 +1841,7 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
             atol = atol.to(actual.unit)
         except UnitsError:
             raise UnitsError(
-                f"Units for 'atol' ({atol.unit} and 'actual' "
+                f"Units for 'atol' ({atol.unit}) and 'actual' "
                 f"({actual.unit}) are not convertible"
             )
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1736,7 +1736,48 @@ class SpecificTypeQuantity(Quantity):
         super()._set_unit(unit)
 
 
-def allclose(a, b, rtol=1.e-5, atol=0, equal_nan=False, **kwargs):
+def isclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
+    """
+    Returns a boolean array where two arrays are element-wise equal
+    within a tolerance.
+
+    Parameters
+    ----------
+    a, b : array_like or :class:`~astropy.units.Quantity`
+        Input values or arrays to compare
+    rtol : array_like or dimensionless :class:`~astropy.units.Quantity`
+        The relative tolerance for the comparison, which defaults to
+        ``1e-5``.  If ``rtol`` is a :class:`~astropy.units.Quantity`,
+        then it must be dimensionless.
+    atol : number or :class:`~astropy.units.Quantity`
+        The absolute tolerance for the comparison.  The units (or lack
+        thereof) of ``a``, ``b``, and ``atol`` must be consistent with
+        each other.  If `None`, ``atol`` defaults to zero in the
+        appropriate units.
+    equal_nan : `bool`
+        Whether to compare NaN’s as equal. If `True`, NaNs in ``a`` will
+        be considered equal to NaN’s in ``b``.
+
+    Notes
+    -----
+    This is a :class:`~astropy.units.Quantity`-aware version of
+    :func:`numpy.isclose`.
+
+    Raises
+    ------
+    UnitsError
+        If the dimensions of ``a``, ``b``, or ``atol`` are incompatible,
+        or if ``rtol`` is not dimensionless.
+
+    See also
+    --------
+    allclose
+    """
+    unquantified_args = _unquantify_allclose_arguments(a, b, rtol, atol)
+    return np.isclose(*unquantified_args, equal_nan=equal_nan, **kwargs)
+
+
+def allclose(a, b, rtol=1.e-5, atol=None, equal_nan=False, **kwargs):
     """
     Return `True` if two arrays are element-wise equal within a
     tolerance, and `False` otherwise.
@@ -1752,7 +1793,8 @@ def allclose(a, b, rtol=1.e-5, atol=0, equal_nan=False, **kwargs):
     atol : number or :class:`~astropy.units.Quantity`
         The absolute tolerance for the comparison.  The units (or lack
         thereof) of ``a``, ``b``, and ``atol`` must be consistent with
-        each other.  If `None`, ``atol`` defaults to zero.
+        each other.  If `None`, ``atol`` defaults to zero in the
+        appropriate units.
     equal_nan : `bool`
         Whether to compare NaN’s as equal. If `True`, NaNs in ``a`` will
         be considered equal to NaN’s in ``b``.
@@ -1789,7 +1831,9 @@ def _unquantify_allclose_arguments(actual, desired, rtol, atol):
         )
 
     if atol is None:
-        # by default, we assume an absolute tolerance of 0
+        # By default, we assume an absolute tolerance of 0.  The default
+        # value of None for atol is needed because the units of atol
+        # must be consistent with the units for a and b.
         atol = Quantity(0)
     else:
         atol = Quantity(atol, subok=True, copy=False)


### PR DESCRIPTION
I corrected the one-liner at the top of the docstring for `astropy.units.isclose`, since it was the one-liner that was meant for `np.allclose`.  While I was at it, I expanded the docstrings to list the parameters, describe the requirements on the units of `rtol` and `atol`, and add a section on what exceptions are raised.

I made the `equal_nan` keyword argument explicit since it has been in numpy for several years now (I think).  Since `isclose` and `allclose` both took `**kwargs` already, I don't think it changes anything.

I set the default value of `atol` to zero instead of `None` in order to be more explicit about what the defaults are.  I updated the error messages to f-strings because they are awesome.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->
