### PR TITLE
Fixed tests with latest developer version of Matplotlib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
   image-tests-mpl212:
     docker:
-      - image: astropy/image-tests-py36-mpl212:1.8
+      - image: astropy/image-tests-py36-mpl212:1.10
     steps:
       - checkout
       - run:
@@ -58,7 +58,7 @@ jobs:
 
   image-tests-mpl222:
     docker:
-      - image: astropy/image-tests-py36-mpl222:1.8
+      - image: astropy/image-tests-py36-mpl222:1.10
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
 
   image-tests-mpl302:
     docker:
-      - image: astropy/image-tests-py37-mpl302:1.8
+      - image: astropy/image-tests-py37-mpl302:1.10
     steps:
       - checkout
       - run:
@@ -80,7 +80,7 @@ jobs:
 
   image-tests-mpl310:
     docker:
-      - image: astropy/image-tests-py37-mpl311:1.8
+      - image: astropy/image-tests-py37-mpl311:1.10
     steps:
       - checkout
       - run:
@@ -91,7 +91,7 @@ jobs:
 
   image-tests-mpldev:
     docker:
-      - image: astropy/image-tests-py37-base:1.2
+      - image: astropy/image-tests-py37-base:1.4
     steps:
       - checkout
       - run:

--- a/astropy/tests/image_tests.py
+++ b/astropy/tests/image_tests.py
@@ -5,10 +5,10 @@ from astropy.utils.decorators import wraps
 
 MPL_VERSION = matplotlib.__version__
 
-# The developer versions of the form 3.1.x+... contain changes that will only
-# be included in the 3.2.x release, so we update this here.
-if MPL_VERSION[:3] == '3.1' and '+' in MPL_VERSION:
-    MPL_VERSION = '3.2'
+# The developer versions of the form 3.2.x+... contain changes that will only
+# be included in the 3.3.x release, so we update this here.
+if MPL_VERSION[:3] == '3.2' and '+' in MPL_VERSION:
+    MPL_VERSION = '3.3'
 
 ROOT = "http://{server}/testing/astropy/2019-08-02T11:38:58.288466/{mpl_version}/"
 IMAGE_REFERENCE_DIR = (ROOT.format(server='data.astropy.org', mpl_version=MPL_VERSION[:3] + '.x') + ',' +

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -15,10 +15,9 @@ try:
     import matplotlib    # pylint: disable=W0611
     from matplotlib import pyplot as plt
     HAS_MATPLOTLIB = True
+    MATPLOTLIB_LT_32 = LooseVersion(matplotlib.__version__) < '3.2'
 except ImportError:
     HAS_MATPLOTLIB = False
-
-MATPLOTLIB_LT_32 = LooseVersion(matplotlib.__version__) < '3.2'
 
 DATA = np.linspace(0., 15., 6)
 DATA2 = np.arange(3)

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -1,5 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from distutils.version import LooseVersion
+
 import pytest
 import numpy as np
 from numpy import ma
@@ -16,6 +18,7 @@ try:
 except ImportError:
     HAS_MATPLOTLIB = False
 
+MATPLOTLIB_LT_32 = LooseVersion(matplotlib.__version__) < '3.2'
 
 DATA = np.linspace(0., 15., 6)
 DATA2 = np.arange(3)
@@ -235,8 +238,12 @@ def test_imshow_norm():
         imshow_norm(image, ax=ax, norm=ImageNormalize())
 
     imshow_norm(image, ax=ax, vmin=0, vmax=1)
-    # vmin/vmax "shadow" the MPL versions, so imshow_only_kwargs allows direct-setting
-    imshow_norm(image, ax=ax, imshow_only_kwargs=dict(vmin=0, vmax=1))
+
+    # Note that the following is deprecated in Matplotlib 3.2
+    if MATPLOTLIB_LT_32:
+        # vmin/vmax "shadow" the MPL versions, so imshow_only_kwargs allows direct-setting
+        imshow_norm(image, ax=ax, imshow_only_kwargs=dict(vmin=0, vmax=1))
+
     # but it should fail for an argument that is not in ImageNormalize
     with pytest.raises(ValueError):
         imshow_norm(image, ax=ax, imshow_only_kwargs=dict(cmap='jet'))


### PR DESCRIPTION
The latest developer version of Matplotlib is still called 3.1....+... so it's currently not possible to know from the version strings if the developer version is actually 3.2 or 3.3 (normally it's just the next version). I decided to try and fix this by simply treating both 3.1+ and 3.2+ as meaning 3.3. I think the number of users who are likely to want to test with an old developer version of Matplotlib is close to zero, so I think this is the best approach for now and should fix the CI.