### PR TITLE
Get scipy (optional) version last; fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ command. -->
 
 ### Steps to Reproduce
 <!-- Ideally a code example could be provided so we can run it ourselves. -->
-<!-- If you are pasting code, use tripe backticks (```) around
+<!-- If you are pasting code, use triple backticks (```) around
 your code snippet. -->
 <!-- If necessary, sanitize your screen output to be pasted so you do not
 reveal secrets like tokens and passwords. -->
@@ -53,6 +53,6 @@ Please run the following snippet and paste the output below:
 import platform; print(platform.platform())
 import sys; print("Python", sys.version)
 import numpy; print("Numpy", numpy.__version__)
-import scipy; print("Scipy", scipy.__version__)
 import astropy; print("astropy", astropy.__version__)
+import scipy; print("Scipy", scipy.__version__)
 -->


### PR DESCRIPTION
### Description

This  fixes two problems in the GitHub ISSUE_TEMPLATE comments.

1. For those who copy-paste the code snippet to generate the System Details, put the optional packages (i.e. scipy) last. Otherwise if scipy is not installed, it fails before providing the astropy version.
(Might also want to put astropy first on general principles?)

1. Fix typo in "tripe backticks". I actually searched for that ;)
