### PR TITLE
Add get_constellation edge tests

### DIFF
--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -32,6 +32,7 @@ def test_sun():
     assert np.all(np.abs(gcrs2.dec - [23.5, 0, -23.5]*u.deg) < 1*u.deg)
 
 
+@pytest.mark.xfail
 def test_constellations(recwarn):
     from astropy.coordinates import ICRS, FK5, SkyCoord
     from astropy.coordinates.funcs import get_constellation

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -62,6 +62,23 @@ def test_constellations(recwarn):
     assert boores == 'Boötes'
     assert isinstance(boores, str) or getattr(boores, 'shape', None) == tuple()
 
+    # Test edge cases close to borders, using B1875.0 coordinates
+    # Look for HMS / DMS roundoff-to-decimal issues from Roman (1987) data
+    # as documented in https://github.com/astropy/astropy/issues/9855
+    # The actual boundary on the west side of Orion at Dec +3.0 is
+    # 06h14m30 == 6.2416666666666...
+    ras = [6.24100, 6.24160, 6.24166, 6.24168]
+    # aka ['6h14m27.6s' '6h14m29.76s' '6h14m29.976s' '6h14m30.048s']
+    decs = [3.0, 3.0, 3.0, 3.0]
+    shortnames = ['Ori', 'Ori', 'Ori', 'Mon']
+
+    testcoos = FK5(ras*u.hour, decs*u.deg, equinox='B1875')
+    npt.assert_equal(get_constellation(testcoos, short_name=True), shortnames,
+      "get_constellation() uses Roman approximations, not IAU boundaries from Delporte")
+
+    # When that's fixed, add other tests with coords that are in different constellations
+    # depending on equinox
+
 
 def test_concatenate():
     from astropy.coordinates import FK5, SkyCoord, ICRS

--- a/astropy/coordinates/tests/test_funcs.py
+++ b/astropy/coordinates/tests/test_funcs.py
@@ -67,22 +67,34 @@ def test_constellations(recwarn):
 def test_constellation_edge_cases():
     from astropy.coordinates import FK5
     from astropy.coordinates.funcs import get_constellation
-    # Test edge cases close to borders, using B1875.0 coordinates
-    # Look for HMS / DMS roundoff-to-decimal issues from Roman (1987) data
-    # as documented in https://github.com/astropy/astropy/issues/9855
-    # The actual boundary on the west side of Orion at Dec +3.0 is
-    # 06h14m30 == 6.2416666666666...
-    ras = [6.24100, 6.24160, 6.24166, 6.24168]
 
-    # aka ['6h14m27.6s' '6h14m29.76s' '6h14m29.976s' '6h14m30.048s']
+    # Test edge cases close to borders, using B1875.0 coordinates
+    # Look for HMS / DMS roundoff-to-decimal issues from Roman (1987) data,
+    # and misuse of PrecessedGeocentric, as documented in
+    # https://github.com/astropy/astropy/issues/9855
+
+    # Define eight test points.
+    # The first four cross the boundary at 06h14m30 == 6.2416666666666... hours
+    # with Monoceros on the west side of Orion at Dec +3.0.
+    ras = [6.24100, 6.24160, 6.24166, 6.24171]
+    # aka ['6h14m27.6s' '6h14m29.76s' '6h14m29.976s' '6h14m30.156s']
+
     decs = [3.0, 3.0, 3.0, 3.0]
+
+    # Correct constellations for given RA/Dec coordinates
     shortnames = ['Ori', 'Ori', 'Ori', 'Mon']
+
+    # The second four sample northward along RA 22 hours, crossing the boundary
+    # at 86° 10' == 86.1666... degrees between Cepheus and Ursa Minor
+    decs += [86.16, 86.1666, 86.16668, 86.1668]
+    ras += [22.0, 22.0, 22.0, 22.0]
+    shortnames += ['Cep', 'Cep', 'Umi', 'Umi']
 
     testcoos = FK5(ras*u.hour, decs*u.deg, equinox='B1875')
     npt.assert_equal(get_constellation(testcoos, short_name=True), shortnames,
-      "get_constellation() uses Roman approximations, not IAU boundaries from Delporte")
+      "get_constellation() error: misusing Roman approximations, vs IAU boundaries from Delporte?")
 
-    # When that's fixed, add other tests with coords that are in different constellations
+    # TODO: When that's fixed, add other tests with coords that are in different constellations
     # depending on equinox
 
 


### PR DESCRIPTION
<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

WIP!

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

The new tests expose two problems in original get_constellation code:
Next step: fix them....

- [x] Add test case near rounded-off constellation edge
- [ ] Fix decimal rounding errors in boundaries from Roman's data
- [ ] Fix improper (?) use of PrecessedGeocentric(equinox='B1875') to precess to equinox of 1875

See also: #9855

EDIT: Fix #9855 