### PR TITLE
Allow in-place modification of coordinate BaseFrame and SkyCoord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,8 @@ astropy.table
 
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
+- Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
+``insert_row`` functions. [#9857]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,10 @@ astropy.coordinates
 - Angle parsing now supports ``cardinal direction`` in the cases
   where angles are initialized as ``string`` instances. eg ``"17°53'27"W"``.[#9859]
 
+- Allow in-place modification of array-valued ``Frame`` and ``SkyCoord`` objects.
+  This provides limited support for updating coordinate data values from another
+  coordinate object of the same class and equivalent frame attributes. [#9857]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -105,6 +109,8 @@ astropy.table
 
 - Added capability to add custom table attributes to a ``Table`` subclass.
   These attributes are persistent and can be set during table creation. [#10097]
+- Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
+``insert_row`` functions. [#9857]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,7 +113,7 @@ astropy.table
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
-``insert_row`` functions. [#9857]
+  ``insert_row`` functions. [#9857]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,7 +110,7 @@ astropy.table
 - Added capability to add custom table attributes to a ``Table`` subclass.
   These attributes are persistent and can be set during table creation. [#10097]
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
-``insert_row`` functions. [#9857]
+  ``insert_row`` functions. [#9857]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -113,6 +113,7 @@ astropy.table
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
+- Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 
 astropy.tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -110,6 +110,7 @@ astropy.table
 - Added capability to add custom table attributes to a ``Table`` subclass.
   These attributes are persistent and can be set during table creation. [#10097]
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
+- Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 
 astropy.tests

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,9 +112,6 @@ astropy.table
 
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
-- Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
-- Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
-  ``insert_row`` functions. [#9857]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,7 +109,7 @@ astropy.table
 
 - Added capability to add custom table attributes to a ``Table`` subclass.
   These attributes are persistent and can be set during table creation. [#10097]
-- Added support for ``SkyCoord`` mixin columns in ``dstack``, `vstack`` and
+
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1519,14 +1519,18 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         if not self.is_equivalent_frame(value):
             raise ValueError('can only set frame item from an equivalent frame')
 
+        if value._data is None:
+            raise ValueError('can only set frame with value that has data')
+
+        if self._data is None:
+            raise ValueError('cannot set frame which has no data')
+
         if self.shape == ():
-            raise TypeError('cannot set item on scalar frame')
+            raise TypeError(f"scalar '{self.__class__.__name__}' frame object "
+                            f"does not support item assignment")
 
         if self._data is None:
             raise ValueError('can only set frame if it has data')
-
-        if value._data is None:
-            raise ValueError('can only set frame with value that has data')
 
         # Set representation data
         self._data._setitem(item, value._data)

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1511,6 +1511,31 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         return new
 
+    def __setitem__(self, item, value):
+        if self.__class__ is not value.__class__:
+            raise TypeError(f'can only set frame to object of same class '
+                            f'{self.__class__.__name__}')
+
+        if not self.is_equivalent_frame(value):
+            raise ValueError('can only set frame item from an equivalent frame')
+
+        if self.shape == ():
+            raise TypeError('cannot set item on scalar frame')
+
+        if self._data is None:
+            raise ValueError('can only set frame if it has data')
+
+        if value._data is None:
+            raise ValueError('can only set frame with value that has data')
+
+        # Set representation data
+        self._data._setitem(item, value._data)
+
+        # Frame attributes required to be identical by is_equivalent_frame,
+        # no need to set them here.
+
+        self.cache.clear()
+
     @override__dir__
     def __dir__(self):
         """

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1513,8 +1513,9 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     def __setitem__(self, item, value):
         if self.__class__ is not value.__class__:
-            raise TypeError(f'can only set frame to object of same class '
-                            f'{self.__class__.__name__}')
+            raise TypeError(f'can only set from object of same class: '
+                            f'{self.__class__.__name__} vs. '
+                            f'{value.__class__.__name__}')
 
         if not self.is_equivalent_frame(value):
             raise ValueError('can only set frame item from an equivalent frame')

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -114,7 +114,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         The components of the 3D point or differential.  The names are the
         keys and the subclasses the values of the ``attr_classes`` attribute.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied; if `False`, they will be
+        broadcast together but not use new memory.
     """
 
     # Ensure multiplication/division with ndarray or Quantity doesn't lead to
@@ -147,7 +148,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             raise TypeError(f'unexpected keyword arguments: {kwargs}')
 
         # Pass attributes through the required initializing classes.
-        attrs = [self.attr_classes[component](attr, copy=copy)
+        attrs = [self.attr_classes[component](attr, copy=False)
                  for component, attr in zip(components, attrs)]
         try:
             attrs = np.broadcast_arrays(*attrs, subok=True)
@@ -158,6 +159,10 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 c_str = ', '.join(components[:2]) + ', and ' + components[2]
             raise ValueError("Input parameters {} cannot be broadcast"
                              .format(c_str))
+
+        if copy:
+            attrs = [attr.copy() for attr in attrs]
+
         # Set private attributes for the attributes. (If not defined explicitly
         # on the class, the metaclass will define properties to access these.)
         for component, attr in zip(components, attrs):
@@ -493,7 +498,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
         representation, the key would be ``'s'`` for seconds, indicating that
         the derivative is a time derivative.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
 
     Notes
     -----
@@ -1028,7 +1034,8 @@ class CartesianRepresentation(BaseRepresentation):
         time derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('x', u.Quantity),
@@ -1312,7 +1319,8 @@ class UnitSphericalRepresentation(BaseRepresentation):
         the derivative is a time derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('lon', Longitude),
@@ -1511,7 +1519,8 @@ class RadialRepresentation(BaseRepresentation):
         the derivative is a time derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('distance', u.Quantity)])
@@ -1596,7 +1605,8 @@ class SphericalRepresentation(BaseRepresentation):
         the derivative is a time derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('lon', Longitude),
@@ -1758,7 +1768,8 @@ class PhysicsSphericalRepresentation(BaseRepresentation):
         derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('phi', Angle),
@@ -1913,7 +1924,8 @@ class CylindricalRepresentation(BaseRepresentation):
         derivative.
 
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
 
     attr_classes = OrderedDict([('rho', u.Quantity),
@@ -2042,7 +2054,8 @@ class BaseDifferential(BaseRepresentationOrDifferential,
         The components of the 3D differentials.  The names are the keys and the
         subclasses the values of the ``attr_classes`` attribute.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
 
     Notes
     -----
@@ -2293,7 +2306,8 @@ class CartesianDifferential(BaseDifferential):
         The axis along which the coordinates are stored when a single array is
         provided instead of distinct ``d_x``, ``d_y``, and ``d_z`` (default: 0).
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = CartesianRepresentation
     _d_xyz = None
@@ -2446,7 +2460,8 @@ class UnitSphericalDifferential(BaseSphericalDifferential):
     d_lon, d_lat : `~astropy.units.Quantity`
         The longitude and latitude of the differentials.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = UnitSphericalRepresentation
 
@@ -2503,7 +2518,8 @@ class SphericalDifferential(BaseSphericalDifferential):
     d_distance : `~astropy.units.Quantity`
         The differential distance.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = SphericalRepresentation
     _unit_differential = UnitSphericalDifferential
@@ -2642,7 +2658,8 @@ class UnitSphericalCosLatDifferential(BaseSphericalCosLatDifferential):
     d_lon_coslat, d_lat : `~astropy.units.Quantity`
         The longitude and latitude of the differentials.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = UnitSphericalRepresentation
     attr_classes = OrderedDict([('d_lon_coslat', u.Quantity),
@@ -2703,7 +2720,8 @@ class SphericalCosLatDifferential(BaseSphericalCosLatDifferential):
     d_distance : `~astropy.units.Quantity`
         The differential distance.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = SphericalRepresentation
     _unit_differential = UnitSphericalCosLatDifferential
@@ -2757,7 +2775,8 @@ class RadialDifferential(BaseDifferential):
     d_distance : `~astropy.units.Quantity`
         The differential distance.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = RadialRepresentation
 
@@ -2809,7 +2828,8 @@ class PhysicsSphericalDifferential(BaseDifferential):
     d_r : `~astropy.units.Quantity`
         The differential radial distance.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = PhysicsSphericalRepresentation
 
@@ -2868,7 +2888,8 @@ class CylindricalDifferential(BaseDifferential):
     d_z : `~astropy.units.Quantity`
         The differential height.
     copy : bool, optional
-        If `True` (default), arrays will be copied rather than referenced.
+        If `True` (default), arrays will be copied. If `False`, arrays will
+        be references, though possibly broadcast to ensure matching shapes.
     """
     base_representation = CylindricalRepresentation
 

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -262,8 +262,9 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
         frame representation data (frame.data) without clearing the frame cache.
         """
         if self.__class__ is not value.__class__:
-            raise TypeError(f'can only set to object of same class '
-                            f'{self.__class__.__name__}')
+            raise TypeError(f'can only set from object of same class: '
+                            f'{self.__class__.__name__} vs. '
+                            f'{value.__class__.__name__}')
 
         for component in self.components:
             getattr(self, '_' + component)[item] = getattr(value, '_' + component)
@@ -811,9 +812,12 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
         frame representation data (frame.data) without clearing the frame cache.
         """
         if self.__class__ is not value.__class__:
-            raise TypeError(f'can only set to object of same class '
-                            f'{self.__class__.__name__}')
+            raise TypeError(f'can only set from object of same class: '
+                            f'{self.__class__.__name__} vs. '
+                            f'{value.__class__.__name__}')
 
+        # Can this ever occur? (Same class but different differential keys).
+        # This exception is not tested since it is not clear how to generate it.
         if self._differentials.keys() != value._differentials.keys():
             raise ValueError(f'setitem value must have same differentials')
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -487,8 +487,10 @@ class SkyCoord(ShapedLikeNDArray):
           self.frame.data[item] = value.frame.data
         """
         if self.__class__ is not value.__class__:
-            raise TypeError(f'can only set item from object of same class '
-                            f'{self.__class__.__name__}')
+            raise TypeError(f'can only set from object of same class: '
+                            f'{self.__class__.__name__} vs. '
+                            f'{value.__class__.__name__}')
+
 
         # Make sure that any extra frame attribute names are equivalent.
         for attr in self._extra_frameattr_names | value._extra_frameattr_names:

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -85,14 +85,15 @@ class SkyCoordInfo(MixinInfo):
 
         return out
 
-    def new_like(self, cols, length, metadata_conflicts='warn', name=None):
+    def new_like(self, skycoords, length, metadata_conflicts='warn', name=None):
         """
         Return a new SkyCoord instance which is consistent with the input
-        SkyCoord objects ``cols`` and has ``length`` rows.
+        SkyCoord objects ``skycoords`` and has ``length`` rows.  Being
+        "consistent" is defined as being able to set an item from one to each of
+        the rest without any exception being raised.
 
-        This is intended for creating a new SkyCoord instance whose elements
-        can be set in-place for table operations like join or vstack.  It checks
-        that the input locations and attributes are consistent.  This is used
+        This is intended for creating a new SkyCoord instance whose elements can
+        be set in-place for table operations like join or vstack.  This is used
         when a SkyCoord object is used as a mixin column in an astropy Table.
 
         The data values are not predictable and it is expected that the consumer
@@ -100,39 +101,39 @@ class SkyCoordInfo(MixinInfo):
 
         Parameters
         ----------
-        cols : list
-            List of input columns (SkyCoord objects)
+        skycoords : list
+            List of input SkyCoord objects
         length : int
-            Length of the output column object
+            Length of the output skycoord object
         metadata_conflicts : str ('warn'|'error'|'silent')
             How to handle metadata conflicts
         name : str
-            Output column name
+            Output name (sets output skycoord.info.name)
 
         Returns
         -------
-        col : SkyCoord (or subclass)
-            Instance of this class consistent with ``cols``
+        skycoord : SkyCoord (or subclass)
+            Instance of this class consistent with ``skycoords``
 
         """
         # Get merged info attributes like shape, dtype, format, description, etc.
-        attrs = self.merge_cols_attributes(cols, metadata_conflicts, name,
+        attrs = self.merge_cols_attributes(skycoords, metadata_conflicts, name,
                                            ('meta', 'description'))
-        col0 = cols[0]
+        skycoord0 = skycoords[0]
 
         # Make a new SkyCoord object with the desired length and attributes
         # by using the _apply / __getitem__ machinery to effectively return
-        # col0[[0, 0, ..., 0, 0]]. This will have the all the right frame
+        # skycoord0[[0, 0, ..., 0, 0]]. This will have the all the right frame
         # attributes with the right shape.
         indexes = np.zeros(length, dtype=np.int64)
-        out = col0[indexes]
+        out = skycoord0[indexes]
 
-        # Use __setitem__ machinery to check for consistency of all cols
-        for col in cols[1:]:
+        # Use __setitem__ machinery to check for consistency of all skycoords
+        for skycoord in skycoords[1:]:
             try:
-                out[0] = col[0]
+                out[0] = skycoord[0]
             except Exception as err:
-                raise ValueError(f'input columns are inconsistent: {err}')
+                raise ValueError(f'input skycoords are inconsistent: {err}')
 
         # Set (merged) info attributes
         for attr in ('name', 'meta', 'description'):

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -29,63 +29,6 @@ from .sky_coordinate_parsers import (_get_frame_class, _get_frame_without_data,
 __all__ = ['SkyCoord', 'SkyCoordInfo']
 
 
-@contextlib.contextmanager
-def _set_time_writeable_true(obj):
-    """Context manager to allow __setitem__ to operate on frame attributes.
-
-    Not used in current implementation which just insists that they are
-    equivalent but see commit 4e3f99943.
-    """
-    is_time = isinstance(obj, Time)
-    try:
-        if is_time:
-            writeable = obj.writeable
-            obj.writeable = True
-        yield
-    finally:
-        if is_time:
-            obj.writeable = writeable
-
-
-def _frame_attribute_setitem(frame, attr, item, value):
-    """Set a frame attribute ``frame.attr[item] = value```
-
-    This is not used in the current implementation of __setitem__ but here in
-    the WIP for reference of what might be possible.
-
-    The trick is that frame attributes can be scalars and they might need to be
-    broadcast to the SkyCoord shape.  For example if a SkyCoord ``sc1`` has
-    shape=(3,) with scalar equinox='B1999', and ``sc2`` has equinox='B2015',
-    then setting ``sc1[1] = sc2[2]`` needs to make sc1.equinox into shape=(3,)
-    and result in ['B1999', 'B2015', 'B1999'].
-
-    It isn't obvious if this can cause problems, so don't do that without
-    some discussion.
-    """
-    _attr = '_' + attr
-    frame_attr = getattr(frame, _attr)
-    value_attr = getattr(value, _attr)
-    frame_attr_shape = getattr(frame_attr, 'shape', ())
-
-    # If all the same then do nothing
-    if np.all(frame_attr == value_attr):
-        return
-
-    # At this point we need to ensure frame_attr has the same shape as frame
-    # because ``item`` is referenced to frame shape and we will set frame_attr[item].
-    if frame_attr_shape == ():
-        frame_attr = frame_attr.take(np.zeros(frame.shape))
-        setattr(frame, _attr, frame_attr)
-
-    elif frame_attr_shape != frame.shape:
-        # How to broadcast a ShapedLikeNDArray subclass like Time. E.g.
-        # an obstime attribute with shape (3,) and the frame has shape (10, 3).
-        raise NotImplementedError('help me @mhvk!')
-
-    # Finally do the setting
-    frame_attr[item] = value_attr
-
-
 class SkyCoordInfo(MixinInfo):
     """
     Container for meta information like name, description, format.  This is

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -515,25 +515,25 @@ def test_setitem_no_velocity():
     assert sc1.cache == {}
     assert repr(sc2) != sc1_repr
 
-    assert np.allclose(sc1.ra, [1, 10] * u.deg)
-    assert np.allclose(sc1.dec, [3, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [1, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [3, 30])
     assert sc1.obstime == sc2.obstime
     assert sc1.name == 'fk4'
 
     sc1 = sc0.copy()
     sc1[:] = sc2[0]
-    assert np.allclose(sc1.ra, [10, 10] * u.deg)
-    assert np.allclose(sc1.dec, [30, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 30])
 
     sc1 = sc0.copy()
     sc1[:] = sc2[:]
-    assert np.allclose(sc1.ra, [10, 20] * u.deg)
-    assert np.allclose(sc1.dec, [30, 40] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 20])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 40])
 
     sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
-    assert np.allclose(sc1.ra, [20, 10] * u.deg)
-    assert np.allclose(sc1.dec, [40, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [20, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [40, 30])
 
     # Works for array-valued obstime so long as they are considered equivalent
     sc1 = FK4(sc0.ra, sc0.dec, obstime=[obstime, obstime])
@@ -543,8 +543,8 @@ def test_setitem_no_velocity():
     sc1 = FK4([[1, 2], [3, 4]] * u.deg, [[5, 6], [7, 8]] * u.deg)
     sc2 = FK4([[10, 20], [30, 40]] * u.deg, [[50, 60], [70, 80]] * u.deg)
     sc1[0] = sc2[0]
-    assert np.allclose(sc1.ra, [[10, 20], [3, 4]] * u.deg)
-    assert np.allclose(sc1.dec, [[50, 60], [7, 8]] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [[10, 20], [3, 4]])
+    assert np.allclose(sc1.dec.to_value(u.deg), [[50, 60], [7, 8]])
 
 
 def test_setitem_velocities():
@@ -559,29 +559,29 @@ def test_setitem_velocities():
 
     sc1 = sc0.copy()
     sc1[1] = sc2[0]
-    assert np.allclose(sc1.ra, [1, 10] * u.deg)
-    assert np.allclose(sc1.dec, [3, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [1, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [1, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [3, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [1, 10])
     assert sc1.obstime == sc2.obstime
     assert sc1.name == 'fk4'
 
     sc1 = sc0.copy()
     sc1[:] = sc2[0]
-    assert np.allclose(sc1.ra, [10, 10] * u.deg)
-    assert np.allclose(sc1.dec, [30, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [10, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [10, 10])
 
     sc1 = sc0.copy()
     sc1[:] = sc2[:]
-    assert np.allclose(sc1.ra, [10, 20] * u.deg)
-    assert np.allclose(sc1.dec, [30, 40] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [10, 20] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 20])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 40])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [10, 20])
 
     sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
-    assert np.allclose(sc1.ra, [20, 10] * u.deg)
-    assert np.allclose(sc1.dec, [40, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [20, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [20, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [40, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [20, 10])
 
 
 def test_setitem_exceptions():

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -539,6 +539,13 @@ def test_setitem_no_velocity():
     sc1 = FK4(sc0.ra, sc0.dec, obstime=[obstime, obstime])
     sc1[0] = sc2[0]
 
+    # Multidimensional coordinates
+    sc1 = FK4([[1, 2], [3, 4]] * u.deg, [[5, 6], [7, 8]] * u.deg)
+    sc2 = FK4([[10, 20], [30, 40]] * u.deg, [[50, 60], [70, 80]] * u.deg)
+    sc1[0] = sc2[0]
+    assert np.allclose(sc1.ra, [[10, 20], [3, 4]] * u.deg)
+    assert np.allclose(sc1.dec, [[50, 60], [7, 8]] * u.deg)
+
 
 def test_setitem_velocities():
     """Test different flavors of item setting for a Frame with a velocity.
@@ -585,7 +592,8 @@ def test_setitem_exceptions():
     sc2 = FK4([10, 20]*u.deg, [30, 40]*u.deg, obstime=obstime)
 
     sc1 = Galactic(sc0.ra, sc0.dec)
-    with pytest.raises(TypeError, match='can only set frame to object of same class Galactic'):
+    with pytest.raises(TypeError, match='can only set from object of same class: '
+                       'Galactic vs. FK4'):
         sc1[0] = sc2[0]
 
     sc1 = FK4(sc0.ra, sc0.dec, obstime='B2001')
@@ -602,6 +610,11 @@ def test_setitem_exceptions():
         sc1[0] = sc2[0]
 
     sc1 = FK4(sc0.ra, sc0.dec, obstime=[obstime, 'B1980'])
+    with pytest.raises(ValueError, match='can only set frame item from an equivalent frame'):
+        sc1[0] = sc2[0]
+
+    # Wrong shape
+    sc1 = FK4([sc0.ra], [sc0.dec], obstime=[obstime, 'B1980'])
     with pytest.raises(ValueError, match='can only set frame item from an equivalent frame'):
         sc1[0] = sc2[0]
 

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -18,6 +18,8 @@ class TestManipulation():
     """
 
     def setup(self):
+        # We set up some representations with, on purpose, copy=False,
+        # so we can check that broadcasting is handled correctly.
         lon = Longitude(np.arange(0, 24, 4), u.hourangle)
         lat = Latitude(np.arange(-90, 91, 30), u.deg)
 
@@ -25,17 +27,19 @@ class TestManipulation():
         self.s0 = SphericalRepresentation(
             lon[:, np.newaxis] * np.ones(lat.shape),
             lat * np.ones(lon.shape)[:, np.newaxis],
-            np.ones(lon.shape + lat.shape) * u.kpc)
+            np.ones(lon.shape + lat.shape) * u.kpc,
+            copy=False)
 
         self.diff = SphericalDifferential(
             d_lon=np.ones(self.s0.shape)*u.mas/u.yr,
             d_lat=np.ones(self.s0.shape)*u.mas/u.yr,
-            d_distance=np.ones(self.s0.shape)*u.km/u.s)
+            d_distance=np.ones(self.s0.shape)*u.km/u.s,
+            copy=False)
         self.s0 = self.s0.with_differentials(self.diff)
 
         # With unequal arrays -> these will be broadcasted.
         self.s1 = SphericalRepresentation(lon[:, np.newaxis], lat, 1. * u.kpc,
-                                          differentials=self.diff)
+                                          differentials=self.diff, copy=False)
 
         # For completeness on some tests, also a cartesian one
         self.c0 = self.s0.to_cartesian()

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -392,25 +392,25 @@ def test_setitem_no_velocity(frame):
 
     sc1 = sc0.copy()
     sc1[1] = sc2[0]
-    assert np.allclose(sc1.ra, [1, 10] * u.deg)
-    assert np.allclose(sc1.dec, [3, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [1, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [3, 30])
     assert sc1.obstime == Time('B1955')
     assert sc1.frame.name == frame
 
     sc1 = sc0.copy()
     sc1[:] = sc2[0]
-    assert np.allclose(sc1.ra, [10, 10] * u.deg)
-    assert np.allclose(sc1.dec, [30, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 30])
 
     sc1 = sc0.copy()
     sc1[:] = sc2[:]
-    assert np.allclose(sc1.ra, [10, 20] * u.deg)
-    assert np.allclose(sc1.dec, [30, 40] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 20])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 40])
 
     sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
-    assert np.allclose(sc1.ra, [20, 10] * u.deg)
-    assert np.allclose(sc1.dec, [40, 30] * u.deg)
+    assert np.allclose(sc1.ra.to_value(u.deg), [20, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [40, 30])
 
 
 def test_setitem_velocities():
@@ -423,29 +423,29 @@ def test_setitem_velocities():
 
     sc1 = sc0.copy()
     sc1[1] = sc2[0]
-    assert np.allclose(sc1.ra, [1, 10] * u.deg)
-    assert np.allclose(sc1.dec, [3, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [1, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [1, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [3, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [1, 10])
     assert sc1.obstime == Time('B1950')
     assert sc1.frame.name == 'fk4'
 
     sc1 = sc0.copy()
     sc1[:] = sc2[0]
-    assert np.allclose(sc1.ra, [10, 10] * u.deg)
-    assert np.allclose(sc1.dec, [30, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [10, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [10, 10])
 
     sc1 = sc0.copy()
     sc1[:] = sc2[:]
-    assert np.allclose(sc1.ra, [10, 20] * u.deg)
-    assert np.allclose(sc1.dec, [30, 40] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [10, 20] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [10, 20])
+    assert np.allclose(sc1.dec.to_value(u.deg), [30, 40])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [10, 20])
 
     sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
-    assert np.allclose(sc1.ra, [20, 10] * u.deg)
-    assert np.allclose(sc1.dec, [40, 30] * u.deg)
-    assert np.allclose(sc1.radial_velocity, [20, 10] * u.km / u.s)
+    assert np.allclose(sc1.ra.to_value(u.deg), [20, 10])
+    assert np.allclose(sc1.dec.to_value(u.deg), [40, 30])
+    assert np.allclose(sc1.radial_velocity.to_value(u.km / u.s), [20, 10])
 
 
 def test_setitem_exceptions():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -414,6 +414,15 @@ def test_setitem_no_velocity(frame):
     assert np.allclose(sc1.dec.to_value(u.deg), [40, 30])
 
 
+def test_setitem_initially_broadcast():
+    sc = SkyCoord(np.ones((2, 1))*u.deg, np.ones((1, 3))*u.deg)
+    sc[1, 1] = SkyCoord(0*u.deg, 0*u.deg)
+    expected = np.ones((2, 3))*u.deg
+    expected[1, 1] = 0.
+    assert np.all(sc.ra == expected)
+    assert np.all(sc.dec == expected)
+
+
 def test_setitem_velocities():
     """Test different flavors of item setting for a SkyCoord with a velocity.
     """

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -390,24 +390,24 @@ def test_setitem_no_velocity(frame):
     sc0 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime='B1955', frame=frame)
     sc2 = SkyCoord([10, 20]*u.deg, [30, 40]*u.deg, obstime='B1955', frame=frame)
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[1] = sc2[0]
     assert np.allclose(sc1.ra, [1, 10] * u.deg)
     assert np.allclose(sc1.dec, [3, 30] * u.deg)
     assert sc1.obstime == Time('B1955')
     assert sc1.frame.name == frame
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[:] = sc2[0]
     assert np.allclose(sc1.ra, [10, 10] * u.deg)
     assert np.allclose(sc1.dec, [30, 30] * u.deg)
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[:] = sc2[:]
     assert np.allclose(sc1.ra, [10, 20] * u.deg)
     assert np.allclose(sc1.dec, [30, 40] * u.deg)
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
     assert np.allclose(sc1.ra, [20, 10] * u.deg)
     assert np.allclose(sc1.dec, [40, 30] * u.deg)
@@ -421,7 +421,7 @@ def test_setitem_velocities():
     sc2 = SkyCoord([10, 20]*u.deg, [30, 40]*u.deg, radial_velocity=[10, 20]*u.km/u.s,
                    obstime='B1950', frame='fk4')
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[1] = sc2[0]
     assert np.allclose(sc1.ra, [1, 10] * u.deg)
     assert np.allclose(sc1.dec, [3, 30] * u.deg)
@@ -429,19 +429,19 @@ def test_setitem_velocities():
     assert sc1.obstime == Time('B1950')
     assert sc1.frame.name == 'fk4'
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[:] = sc2[0]
     assert np.allclose(sc1.ra, [10, 10] * u.deg)
     assert np.allclose(sc1.dec, [30, 30] * u.deg)
     assert np.allclose(sc1.radial_velocity, [10, 10] * u.km / u.s)
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[:] = sc2[:]
     assert np.allclose(sc1.ra, [10, 20] * u.deg)
     assert np.allclose(sc1.dec, [30, 40] * u.deg)
     assert np.allclose(sc1.radial_velocity, [10, 20] * u.km / u.s)
 
-    sc1 = SkyCoord(sc0)
+    sc1 = sc0.copy()
     sc1[[1, 0]] = sc2[:]
     assert np.allclose(sc1.ra, [20, 10] * u.deg)
     assert np.allclose(sc1.dec, [40, 30] * u.deg)
@@ -457,7 +457,8 @@ def test_setitem_exceptions():
     sc2 = SkyCoord([10, 20]*u.deg, [30, 40]*u.deg, frame='fk4', obstime=obstime)
 
     sc1 = SkyCoordSub(sc0)
-    with pytest.raises(TypeError, match='can only set item from object of same class'):
+    with pytest.raises(TypeError, match='an only set from object of same class: '
+                       'SkyCoordSub vs. SkyCoord'):
         sc1[0] = sc2[0]
 
     sc1 = SkyCoord(sc0.ra, sc0.dec, frame='fk4', obstime='B2001')
@@ -467,6 +468,14 @@ def test_setitem_exceptions():
     sc1 = SkyCoord(sc0.ra[0], sc0.dec[0], frame='fk4', obstime=obstime)
     with pytest.raises(TypeError, match="scalar 'FK4' frame object does not support "
                        'item assignment'):
+        sc1[0] = sc2[0]
+
+    # Different differentials
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg,
+                   pm_ra_cosdec=[1, 2]*u.mas/u.yr, pm_dec=[3, 4]*u.mas/u.yr)
+    sc2 = SkyCoord([10, 20]*u.deg, [30, 40]*u.deg, radial_velocity=[10, 20]*u.km/u.s)
+    with pytest.raises(TypeError, match='can only set from object of same class: '
+                       'UnitSphericalCosLatDifferential vs. RadialDifferential'):
         sc1[0] = sc2[0]
 
 

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -304,7 +304,11 @@ def dstack(tables, join_type='outer', metadata_conflicts='warn'):
         # are just carried along.
         # [x x x y y y] => [[x x x],
         #                   [y y y]]
-        col.shape = (len(tables), n_row) + col.shape[1:]
+        new_shape = (len(tables), n_row) + col.shape[1:]
+        try:
+            col.shape = (len(tables), n_row) + col.shape[1:]
+        except AttributeError:
+            col = col.reshape(new_shape)
 
         # Transpose the table and row axes to get to
         # [[x, y],

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -978,13 +978,18 @@ class TestVStack():
 
         # Vstack works for these classes:
         implemented_mixin_classes = ['Quantity', 'Angle', 'Time',
-                                     'Latitude', 'Longitude',
+                                     'Latitude', 'Longitude', 'SkyCoord',
                                      'EarthLocation']
         if cls_name in implemented_mixin_classes:
             out = table.vstack([t, t])
             assert len(out) == len_col * 2
-            assert np.all(out['a'][:len_col] == col)
-            assert np.all(out['a'][len_col:] == col)
+            if cls_name == 'SkyCoord':
+                # Argh, SkyCoord needs __eq__!!
+                assert skycoord_equal(out['a'][len_col:], col)
+                assert skycoord_equal(out['a'][:len_col], col)
+            else:
+                assert np.all(out['a'][:len_col] == col)
+                assert np.all(out['a'][len_col:] == col)
         else:
             with pytest.raises(NotImplementedError) as err:
                 table.vstack([t, t])

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1133,6 +1133,15 @@ class TestDStack():
         out = table.dstack(self.t1)
         assert np.all(out == self.t1)
 
+    def test_dstack_skycoord(self):
+        sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
+        sc2 = SkyCoord([10, 20]*u.deg, [30, 40]*u.deg)
+        t1 = Table([sc1])
+        t2 = Table([sc2])
+        t12 = table.dstack([t1, t2])
+        assert skycoord_equal(sc1, t12['col0'][:, 0])
+        assert skycoord_equal(sc2, t12['col0'][:, 1])
+
 
 class TestHStack():
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -277,7 +277,7 @@ take a different lower-level approach which is described in the section
 
   You may be tempted to try an apparently obvious way of modifying a frame
   object in place by updating the component attributes directly, for example
-  `coo1.ra[1] = 40 * u.deg`. However, while this will *appear* to give a correct
+  ``coo1.ra[1] = 40 * u.deg``. However, while this will *appear* to give a correct
   result it does not actually modify the underlying representation data. This
   is related to the current implementation of performance-based caching.
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -267,6 +267,20 @@ To modify an array of coordinates use the same syntax for a numpy array::
   <ICRS Coordinate: (ra, dec) in deg
       [(10., 20.), ( 2.,  4.)]>
 
+This method is relatively slow because it requires setting from an
+existing frame object and it performs extensive validation to ensure
+that the operation is valid. For some applications it may be necessary to
+take a different lower-level approach which is described in the section
+:ref:`astropy-coordinates-fast-in-place`.
+
+.. warning::
+
+  You may be tempted to try an apparently obvious way of modifying a frame
+  object in place by updating the component attributes directly, for example
+  `coo1.ra[1] = 40 * u.deg`. However, while this will *appear* to give a correct
+  result it does not actually modify the underlying representation data. This
+  is related to the current implementation of performance-based caching.
+
 Transforming between Frames
 ===========================
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -252,6 +252,21 @@ set of coordinates, you will need to make sure that the shapes allow this::
    any non-scalar attributes are broadcast to have matching shapes
    (as can be seen for ``obstime`` in the last line above).
 
+Coordinate values in a array-valued frame object can be modified in-place
+(added in astropy 4.1). This requires that the new values be set from an
+another frame object that is equivalent in all ways except for the actual
+coordinate data values. In this way, no frame transformations are required and
+the item setting operation is extremely robust.
+
+To modify an array of coordinates use the same syntax for a numpy array::
+
+  >>> coo1 = ICRS([1, 2] * u.deg, [3, 4] * u.deg)
+  >>> coo2 = ICRS(10 * u.deg, 20 * u.deg)
+  >>> coo1[0] = coo2
+  >>> coo1
+  <ICRS Coordinate: (ra, dec) in deg
+      [(10., 20.), ( 2.,  4.)]>
+
 Transforming between Frames
 ===========================
 

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -1,43 +1,53 @@
-In-Place Modification of Coordinates
-************************************
+.. _astropy-coordinates-fast-in-place:
 
-Coordinates are generally considered to be immutable. If you want to create
-another coordinate frame with different data you should use
-`~astropy.coordinates.BaseCoordinateFrame.realize_frame`. This is the safest
-way to change the data in a frame as it creates a new frame with that data.
-Creating a new frame can be relatively slow, however, particularly for scalar
-coordinates. Hence some situations may require that data be changed in-place in
-an already existing frame object. This modification can be done by
-modifying the values of the representation data as follows::
+Fast In-Place Modification of Coordinates
+*****************************************
+
+For some applications the recommended method of
+:ref:`astropy-coordinates-modifying-in-place` may not be fast enough due to the
+extensive validation performed in that process to ensure correctness.  Likewise,
+you may find that creating another coordinate frame with different data using
+`~astropy.coordinates.BaseCoordinateFrame.realize_frame` does not meet your
+performance requirements.
+
+For these high-performance situations, you can directly modify in-place the
+representation data in the frame object as shown in this example::
 
     >>> import astropy.units as u
     >>> from astropy.coordinates import SkyCoord
-    >>> c = SkyCoord([1,2],[3,4], unit='deg')
-    >>> c.data.lon[()] = [10, 20] * u.deg
-    >>> c  # doctest: +FLOAT_CMP
+    >>> sc = SkyCoord([1,2],[3,4], unit='deg')
+    >>> sc.data.lon[()] = [10, 20] * u.deg
+    >>> sc.data.lat[1] = 40 * u.deg
+
+    >>> sc.cache.clear()  # IMPORTANT TO DO THIS!
+
+    >>> sc  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        [(10., 3.), (20., 4.)]>
+        [(10., 3.), (20., 40.)]>
 
+Notice that the ``.data`` representation object uses different names for the
+components than in the coordinate object.  If you wish to inspect the
+mapping between frame attributes (e.g., ``.ra``) and representation attributes
+(e.g., ``.lon``) you can look at the following dictionary::
 
-This changes the longitude values of the frame. Unfortunately, doing this alone
-introduces problems: `~astropy.coordinates.SkyCoord` and
-`~astropy.coordinates.BaseCoordinateFrame` cache various kinds of information to
-speed up some repeated operations. So we need to tell the cache that it should
-be cleared so that it can be recalculated from the new data. This can be
-achieved by doing::
-
-    >>> c.cache.clear()
-
-It should be noted that the only way to modify the data in a frame is by using
-the ``.data`` attribute directly and not the aliases for components on the
-frame (*i.e.*, the following will not work)::
-
-    >>> c.ra[()] = 20 * u.deg
-
-This is because a different representation object is used when accessing the
-aliased component names. If you wish to inspect the mapping between frame
-attributes (e.g., ``.ra`` and representation attributes ``.lon``) you can look
-at the following dictionary::
-
-    >>> c.representation_component_names
+    >>> sc.representation_component_names
     OrderedDict([('ra', 'lon'), ('dec', 'lat'), ('distance', 'distance')])
+
+.. warning::
+
+   You *must* include the step to clear the cache as shown. Failing to do so
+   will cause the object to be inconsistent and likely result in incorrect
+   results. `~astropy.coordinates.SkyCoord`
+   and `~astropy.coordinates.BaseCoordinateFrame` cache various kinds of
+   information for performance reasons, so you need clear the cache so that
+   the new representation values are used when required.
+
+You should note that the only way to modify the data in a frame is by using
+the ``.data`` attribute directly and not the aliases for components on the
+frame.  For example the following will *appear* to give a correct
+result but it does not actually modify the underlying representation data::
+
+    >>> c.ra[1] = 20 * u.deg  # THIS IS WRONG
+
+This problem is related to the current implementation of performance-based
+caching and cannot be easily resolved.

--- a/docs/coordinates/inplace.rst
+++ b/docs/coordinates/inplace.rst
@@ -47,7 +47,7 @@ the ``.data`` attribute directly and not the aliases for components on the
 frame.  For example the following will *appear* to give a correct
 result but it does not actually modify the underlying representation data::
 
-    >>> c.ra[1] = 20 * u.deg  # THIS IS WRONG
+    >>> sc.ra[1] = 20 * u.deg  # THIS IS WRONG
 
 This problem is related to the current implementation of performance-based
 caching and cannot be easily resolved.

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -425,7 +425,7 @@ take a different lower-level approach which is described in the section
 
   You may be tempted to try an apparently obvious way of modifying a coordinate
   object in place by updating the component attributes directly, for example
-  `sc1.ra[1] = 40 * u.deg`. However, while this will *appear* to give a correct
+  ``sc1.ra[1] = 40 * u.deg``. However, while this will *appear* to give a correct
   result it does not actually modify the underlying representation data. This
   is related to the current implementation of performance-based caching.
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -357,6 +357,52 @@ use new views of the data, with the data copied only if that is impossible
 ..
   EXAMPLE END
 
+Modifying items in-place
+------------------------
+
+Coordinate values in a array-valued |SkyCoord| object can be modified in-place
+(added in astropy 4.1). This requires that the new values be set from an
+another |SkyCoord| object that is equivalent in all ways except for the actual
+coordinate data values. In this way, no frame transformations are required and
+the item setting operation is extremely robust.
+
+..
+  EXAMPLE START
+  Modifying an Array of Coordinates in a SkyCoord Object
+
+To modify an array of coordinates in a |SkyCoord| object use the same
+syntax for a numpy array::
+
+  >>> sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+  >>> sc2 = SkyCoord(10 * u.deg, 20 * u.deg)
+  >>> sc1[0] = sc2
+  >>> sc1
+  <SkyCoord (ICRS): (ra, dec) in deg
+      [(10., 20.), ( 2.,  4.)]>
+
+..
+  EXAMPLE END
+
+..
+  EXAMPLE START
+  Inserting Coordinates into a SkyCoord Object
+
+You can insert a scalar or array-valued |SkyCoord| object into another
+compatible |SkyCooord| object::
+
+  >>> sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
+  >>> sc2 = SkyCoord(10 * u.deg, 20 * u.deg)
+  >>> sc1.insert(1, sc2)
+  <SkyCoord (ICRS): (ra, dec) in deg
+      [( 1.,  3.), (10., 20.), ( 2.,  4.)]>
+
+..
+  EXAMPLE END
+
+With the ability to modify a |SkyCoord| object in-place, all of the
+:ref:`table_operations`_ such as joining, stacking, and inserting are
+functional with |SkyCoord| mixin columns (so long as no masking is required).
+
 Attributes
 ==========
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -357,14 +357,26 @@ use new views of the data, with the data copied only if that is impossible
 ..
   EXAMPLE END
 
-Modifying items in-place
-------------------------
+.. _astropy-coordinates-modifying-in-place:
+
+Modifying Coordinate Objects In-place
+-------------------------------------
 
 Coordinate values in a array-valued |SkyCoord| object can be modified in-place
 (added in astropy 4.1). This requires that the new values be set from an
 another |SkyCoord| object that is equivalent in all ways except for the actual
 coordinate data values. In this way, no frame transformations are required and
 the item setting operation is extremely robust.
+
+Specifically, the right hand ``value`` must be strictly consistent with the
+object being modified:
+
+- Identical class
+- Equivalent frames (`~astropy.coordinates.BaseCoordinateFrame.is_equivalent_frame`)
+- Identical representation_types
+- Identical representation differentials keys
+- Identical frame attributes
+- Identical "extra" frame attributes (e.g., ``obstime`` for an ICRS coord)
 
 ..
   EXAMPLE START
@@ -388,7 +400,7 @@ syntax for a numpy array::
   Inserting Coordinates into a SkyCoord Object
 
 You can insert a scalar or array-valued |SkyCoord| object into another
-compatible |SkyCooord| object::
+compatible |SkyCoord| object::
 
   >>> sc1 = SkyCoord([1, 2] * u.deg, [3, 4] * u.deg)
   >>> sc2 = SkyCoord(10 * u.deg, 20 * u.deg)
@@ -400,8 +412,22 @@ compatible |SkyCooord| object::
   EXAMPLE END
 
 With the ability to modify a |SkyCoord| object in-place, all of the
-:ref:`table_operations`_ such as joining, stacking, and inserting are
+:ref:`table_operations` such as joining, stacking, and inserting are
 functional with |SkyCoord| mixin columns (so long as no masking is required).
+
+These methods are relatively slow because they require setting from an
+existing |SkyCoord| object and they perform extensive validation to ensure
+that the operation is valid. For some applications it may be necessary to
+take a different lower-level approach which is described in the section
+:ref:`astropy-coordinates-fast-in-place`.
+
+.. warning::
+
+  You may be tempted to try an apparently obvious way of modifying a coordinate
+  object in place by updating the component attributes directly, for example
+  `sc1.ra[1] = 40 * u.deg`. However, while this will *appear* to give a correct
+  result it does not actually modify the underlying representation data. This
+  is related to the current implementation of performance-based caching.
 
 Attributes
 ==========


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address #6394, #5745 and #6348 by adding `__setitem__` to the `SkyCoord` and `BaseCoordinateFrame` classes to allow setting values in array-valued instances.

It also adds an `insert()` method and `SkyCoordInfo.new_like()` method to support table operations with coordinates (`vstack`, `dstack`, `insert`). With this update, `SkyCoord` is fully supported in `Table` for non-masked operations. With one small exception, the changes to the `table` package in this PR are only in testing. The table change was needed because `SkyCoord` does not allow reshaping by setting the `shape` attribute.

Key points:
- This is intentionally a limited implementation that requires the right hand side value to be entirely equivalent to the left side except for the actual representation data.  This includes strict class equality and all frame attributes being equivalent.
- This is the minimal requirement to support Table operations.
- Setting values in `Representation` objects is done by a private `_setitem` method so prevent updating representation data without clearing the parent frame cache.
- The key assumption here is that clearing the frame `cache` is always sufficient to prevent any inconsistencies after updating representation data. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Closes #6394
Closes #5745
Closes #6348