### PR TITLE
Fix unified I/O for dataset directories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,6 +302,12 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+astropy.io
+^^^^^^^^^^
+
+- Fixed a bug that prevented the unified I/O infrastructure from working with
+  datasets that are represented by directories rather than files. [#9866]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -506,6 +506,11 @@ def read(cls, *args, format=None, **kwargs):
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
                         fileobj = ctx.__enter__()
+                    except IsADirectoryError:
+                        # Note that we need to special case this otherwise it
+                        # gets caught by the OSError below, since IsADirectoryError
+                        # is a subclass of OSError.
+                        fileobj = None
                     except OSError:
                         raise
                     except Exception:

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -497,7 +497,7 @@ def read(cls, *args, format=None, **kwargs):
             fileobj = None
 
             if len(args):
-                if isinstance(args[0], PATH_TYPES):
+                if isinstance(args[0], PATH_TYPES) and not os.path.isdir(args[0]):
                     from astropy.utils.data import get_readable_fileobj
                     # path might be a pathlib.Path object
                     if isinstance(args[0], pathlib.Path):
@@ -506,11 +506,6 @@ def read(cls, *args, format=None, **kwargs):
                     try:
                         ctx = get_readable_fileobj(args[0], encoding='binary')
                         fileobj = ctx.__enter__()
-                    except IsADirectoryError:
-                        # Note that we need to special case this otherwise it
-                        # gets caught by the OSError below, since IsADirectoryError
-                        # is a subclass of OSError.
-                        fileobj = None
                     except OSError:
                         raise
                     except Exception:

--- a/astropy/io/tests/test_registry.py
+++ b/astropy/io/tests/test_registry.py
@@ -487,3 +487,25 @@ class TestSubclass:
             assert t['a'].description == 'hello'
         else:
             assert t['a'].description is None
+
+
+def test_directory(tmpdir):
+
+    # Regression test for a bug that caused the I/O registry infrastructure to
+    # not work correctly for datasets that are represented by folders as
+    # opposed to files, when using the descriptors to add read/write methods.
+
+    io_registry.register_identifier('test_folder_format', TestData,
+                                    lambda o, *x, **y: o == 'read')
+    io_registry.register_reader('test_folder_format', TestData,
+                                empty_reader)
+
+    filename = tmpdir.mkdir('folder_dataset').strpath
+
+    # With the format explicitly specified
+    dataset = TestData.read(filename, format='test_folder_format')
+    assert isinstance(dataset, TestData)
+
+    # With the auto-format identification
+    dataset = TestData.read(filename)
+    assert isinstance(dataset, TestData)


### PR DESCRIPTION
This fixes a bug that prevented the unified I/O infrastructure from working with datasets that are represented by directories rather than files, such as CASA ``.image`` datasets. The issue was that ``IsADirectoryError`` is a subclass of ``OSError``, and the latter type of execption is not ignored when trying to get a file handle object.