### PR TITLE
Immediate validation of Time and TimeFormat in_subfmt and out_subfmt properties

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -174,6 +174,11 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Require that ``in_subfmt`` and ``out_subfmt`` properties of a ``Time`` object
+  have allowed values at the time of being set, either when creating the object
+  or when setting those properties on an existing ``Time`` instance.  Previously
+  the validation of those properties was not strictly enforced. [#9868]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1073,6 +1073,16 @@ class TestNumericalSubFormat:
         with pytest.raises(ValueError, match=match):
             Time('J2000', format='jyear_str', in_subfmt='parrot')
 
+    def test_switch_to_format_with_no_out_subfmt(self):
+        t = Time('2001-01-01', out_subfmt='date_hm')
+        assert t.out_subfmt == 'date_hm'
+
+        # Now do an in-place switch to format 'jyear_str' that has no subfmts
+        # where out_subfmt is changed to '*'.
+        t.format = 'jyear_str'
+        assert t.out_subfmt == '*'
+        assert t.value == 'J2001.001'
+
 
 class TestSofaErrors:
     """Test that erfa status return values are handled correctly"""

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1043,14 +1043,35 @@ class TestNumericalSubFormat:
         with pytest.raises(ValueError, match='not among selected'):
             Time(58000., format='mjd', in_subfmt='long')
 
-    def test_wrong_out_subfmt(self):
+    def test_wrong_subfmt(self):
         t = Time(58000., format='mjd')
         with pytest.raises(ValueError, match='must match one'):
             t.to_value('mjd', subfmt='parrot')
 
-        t.out_subfmt = 'parrot'
-        with pytest.raises(ValueError):
-            t.value
+        with pytest.raises(ValueError, match='must match one'):
+            t.out_subfmt = 'parrot'
+
+        with pytest.raises(ValueError, match='must match one'):
+            t.in_subfmt = 'parrot'
+
+    def test_not_allowed_subfmt(self):
+        """Test case where format has no defined subfmts"""
+        t = Time('J2000')
+        match = 'subformat not allowed for format jyear_str'
+        with pytest.raises(ValueError, match=match):
+            t.to_value('jyear_str', subfmt='parrot')
+
+        with pytest.raises(ValueError, match=match):
+            t.out_subfmt = 'parrot'
+
+        with pytest.raises(ValueError, match=match):
+            Time('J2000', out_subfmt='parrot')
+
+        with pytest.raises(ValueError, match=match):
+            t.in_subfmt = 'parrot'
+
+        with pytest.raises(ValueError, match=match):
+            Time('J2000', format='jyear_str', in_subfmt='parrot')
 
 
 class TestSofaErrors:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Require that `in_subfmt` and `out_subfmt` properties of a `Time` object have allowed values at the time of being set, either when creating the object or when setting those properties on an existing `Time` instance.  Previously the validation of those properties was not done until they were actually used either on input or output.

This is actually done by doing the validation at the `TimeFormat` (`self._time`) level.

This is based on #9812, with a plan to merge that and rebase this PR.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
