### PR TITLE
Support for InterferometricVisibility frame

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -39,6 +39,7 @@ from .itrs import ITRS
 from .hcrs import HCRS
 from .ecliptic import *  # there are a lot of these so we don't list them all explicitly
 from .skyoffset import SkyOffsetFrame
+from .intvis import InterferometricVisibility
 # need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
 from . import fk4_fk5_transforms
@@ -62,7 +63,8 @@ __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'HeliocentricTrueEcliptic',
            'SkyOffsetFrame', 'GalacticLSR', 'LSR',
            'BaseEclipticFrame', 'BaseRADecFrame', 'make_transform_graph_docs',
-           'HeliocentricEclipticIAU76', 'CustomBarycentricEcliptic']
+           'HeliocentricEclipticIAU76', 'CustomBarycentricEcliptic',
+           'InterferometricVisibility']
 
 
 def make_transform_graph_docs(transform_graph):

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -58,8 +58,9 @@ class InterferometricVisibility(BaseCoordinateFrame):
     It enables simple transformation between various other frames and the
     observers frame during the radio synthesis.
     It enables easily calculating elevation of a field with e.g.
-    >>> coord = astropy.coordinates.SkyCoord(ra=0*u.deg dec=0*u.deg)
-    >>> location = astropy.coordinates.EarthLocation(*observatory name*)
+    >>> import astropy
+    >>> coo = astropy.coordinates.SkyCoord(ra=0*u.deg, dec=0*u.deg)
+    >>> location = astropy.coordinates.EarthLocation(lon=-107.61828306, lat=34.07874917)
     >>> now = astropy.time.Time.now()
     >>> uvw_frame=astropy.coordinates.InterferometricVisibility(location=location, obstime=now)
     >>> uvw = coo.transform_to(uvw_frame) 

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -63,8 +63,7 @@ class InterferometricVisibility(BaseCoordinateFrame):
     >>> location = astropy.coordinates.EarthLocation(lon=-107.61828306, lat=34.07874917)
     >>> now = astropy.time.Time.now()
     >>> uvw_frame=astropy.coordinates.InterferometricVisibility(location=location, obstime=now)
-    >>> uvw = coo.transform_to(uvw_frame) 
-    >>> print(uvw.u, uvw.v, uvw.w)  # earth-centric distance in meters
+    >>> uvw = coo.transform_to(uvw_frame)  # uvw.u, .v, .w can be differenced to get baseline lengths in meters
     """
 
     frame_specific_representation_info = {

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -77,7 +77,7 @@ class InterferometricVisibility(BaseCoordinateFrame):
 
     obstime = TimeAttribute(default=None)
     location = EarthLocationAttribute(default=None)
-    phase = CoordinateAttribute(ICRS,default=None)
+    phase = CoordinateAttribute(ICRS, default=None)
 
     def __init__(self, *args, **kwargs):
         super(InterferometricVisibility, self).__init__(*args, **kwargs)
@@ -89,7 +89,7 @@ def itrs_to_uvw(itrs_coo, uvw_frame):
                         itrs_coo.cartesian.x.unit == u.one)
     lon, lat, height = uvw_frame.location.to_geodetic('WGS84')
     lst = uvw_frame.obstime.sidereal_time('mean',longitude=lon).to(u.radian).value
-    ha = (lst - uvw_frame.phase.ra).to(u.radian).value
+    ha = lst - uvw_frame.phase.ra.to(u.radian).value
     dec = uvw_frame.phase.dec.to(u.radian).value
     lonrad = lon.to(u.radian).value - ha
     latrad = dec

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -1,0 +1,163 @@
+from __future__ import (absolute_import, unicode_literals, division,
+                        print_function)
+import numpy as np
+
+import astropy.units as u
+
+from astropy.coordinates.baseframe import (BaseCoordinateFrame,
+                         RepresentationMapping, frame_transform_graph)
+
+from astropy.coordinates.attributes import (CoordinateAttribute,
+                         TimeAttribute, EarthLocationAttribute)
+
+from astropy.coordinates.transformations import FunctionTransform
+from astropy.coordinates.representation import (SphericalRepresentation,
+                              UnitSphericalRepresentation,CartesianRepresentation)
+from . import (ITRS,ICRS,AltAz)
+
+class InterferometricVisibility(BaseCoordinateFrame):
+    """
+    A coordinate or frame in the interferometric visibilities (a.k.a. "uvw"),
+    as is common in radio astronomy.
+    This system are the local East, North, and Up unit vectors projected
+    into the plane of the sky, whose origin is fixed to a direction ``phase``.
+    These coordinates are used to measure the interferometric baselines in 
+    in radio interferometry.
+
+    This frame has the following frame attributes, which are necessary for
+    transforming from InterferometricVisibility to some other system:
+    * ``obstime``
+        The time at which the observation is taken.  Used for determining the
+        position and orientation of the Earth.
+    * ``location``
+        The location of the center of the radio interferometer on the Earth,
+        typically the centroid of all antenna locations, though it can be
+        fixed to any particular antenna.  This can be specified either as an
+        `~astropy.coordinates.EarthLocation` object or as anything that can be
+        transformed to an `~astropy.coordinates.ITRS` frame.
+    * ``phase``
+        The phase tracking center of the frame.  This can be specified either
+        as an (ra,dec) `~astropy.units.Qunatity` or as anything that can be
+        transformed to an `~astropy.coordinates.ICRS` frame.
+
+    Parameters
+    ----------
+    representation : `BaseRepresentation` or None
+        A representation object or None to have no data (or use the other
+        keywords)
+    u : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The u coordinate for this object (``v`` and ``w`` must also be given
+        and ``representation`` must be None).
+    v : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The v coordinate for this object (``u`` and ``w`` must also be given
+        and ``representation`` must be None).
+    w : :class:`~astropy.units.Quantity`, optional, must be keyword
+        The w coordinate for this object (``u`` and ``v`` must also be given
+        and ``representation`` must be None).
+
+    Notes
+    -----
+    This is useful for radio astronomers.
+    It enables simple transformation between various other frames and the
+    observers frame during the radio synthesis.
+    It enables easily calculating elevation of a field with e.g.
+    #>>> coord = astropy.coordinates.SkyCoord(ra=..., dec=...,
+                frame=InterferometricVisibility(location=..., obstime=..., phase=...))
+    #>>> elevation = coord.transform_to(astropy.coordinates.AltAz).alt
+    The local East-North-Up frame coordinates can easily be calculated by 
+    transforming to a InterferometricVisibility with ``phase`` pointing at zenith.
+    """
+
+    frame_specific_representation_info = {
+        'cartesian': [RepresentationMapping('x', 'u'),
+                      RepresentationMapping('y', 'v'),
+                     RepresentationMapping('z','w')],
+    }
+    default_representation = CartesianRepresentation
+
+    obstime = TimeAttribute(default=None)
+    location = EarthLocationAttribute(default=None)
+    phase = CoordinateAttribute(ICRS,default=None)
+
+    def __init__(self, *args, **kwargs):
+        super(InterferometricVisibility, self).__init__(*args, **kwargs)
+
+@frame_transform_graph.transform(FunctionTransform, ITRS, InterferometricVisibility)
+def itrs_to_uvw(itrs_coo, uvw_frame):
+    '''Defines the transformation between ITRS and the InterferometricVisibility frame.'''
+    is_unitspherical = (isinstance(itrs_coo.data, UnitSphericalRepresentation) or
+                        itrs_coo.cartesian.x.unit == u.one)
+    lon, lat, height = uvw_frame.location.to_geodetic('WGS84')
+    lst = uvw_frame.obstime.sidereal_time('mean',longitude=lon).to(u.radian).value
+    ha = (lst - uvw_frame.phase.ra).to(u.radian).value
+    dec = uvw_frame.phase.dec.to(u.radian).value
+    lonrad = lon.to(u.radian).value - ha
+    latrad = dec
+    sinlat = np.sin(latrad)
+    coslat = np.cos(latrad)
+    sinlon = np.sin(lonrad)
+    coslon = np.cos(lonrad)
+    north = [-sinlat*coslon,
+                      -sinlat*sinlon,
+                      coslat]
+    east = [-sinlon,coslon,0]
+    up = [coslat*coslon,coslat*sinlon,sinlat]
+    R = np.array([east,north,up])
+    if is_unitspherical:
+        p = itrs_coo.cartesian.xyz.value
+        diff = p
+        penu = R.dot(diff)
+        rep = CartesianRepresentation(x = u.Quantity(penu[0],u.one,copy=False),
+                                     y = u.Quantity(penu[1],u.one,copy=False),
+                                     z = u.Quantity(penu[2],u.one,copy=False),
+                                     copy=False)
+    else:
+        p = itrs_coo.cartesian.xyz
+        p0 = ITRS(*uvw_frame.location.geocentric,obstime=uvw_frame.obstime).cartesian.xyz
+        diff = (p.T-p0).T
+        penu = R.dot(diff)
+        rep = CartesianRepresentation(x = penu[0],
+                y = penu[1],
+                z = penu[2],
+                copy=False)
+
+    return uvw_frame.realize_frame(rep)
+
+@frame_transform_graph.transform(FunctionTransform, InterferometricVisibility, ITRS)
+def uvw_to_itrs(uvw_coo, itrs_frame):
+    lon, lat, height = uvw_coo.location.to_geodetic('WGS84')
+    lst = uvw_coo.obstime.sidereal_time('mean',longitude=lon).to(u.radian).value
+    ha = (lst - uvw_coo.phase.ra).to(u.radian).value
+    dec = uvw_coo.phase.dec.to(u.radian).value
+    lonrad = lon.to(u.radian).value - ha
+    latrad = dec
+    sinlat = np.sin(latrad)
+    coslat = np.cos(latrad)
+    sinlon = np.sin(lonrad)
+    coslon = np.cos(lonrad)
+    north = [-sinlat*coslon,
+                      -sinlat*sinlon,
+                      coslat]
+    east = [-sinlon,coslon,0]
+    up = [coslat*coslon,coslat*sinlon,sinlat]
+    R = np.array([east,north,up])
+    if isinstance(uvw_coo.data, UnitSphericalRepresentation) or uvw_coo.cartesian.x.unit == u.one:
+        diff = R.T.dot(uvw_coo.cartesian.xyz)
+        p = diff
+        rep = CartesianRepresentation(x = u.Quantity(p[0],u.one,copy=False),
+                                     y = u.Quantity(p[1],u.one,copy=False),
+                                     z = u.Quantity(p[2],u.one,copy=False),
+                                     copy=False)
+    else:
+        diff = R.T.dot(uvw_coo.cartesian.xyz)
+        p0 = ITRS(*uvw_coo.location.geocentric,obstime=uvw_coo.obstime).cartesian.xyz
+        p = (diff.T + p0).T
+        rep = CartesianRepresentation(x = p[0],
+                y = p[1],
+                z = p[2],
+                copy=False)
+    return itrs_frame.realize_frame(rep)
+
+@frame_transform_graph.transform(FunctionTransform, InterferometricVisibility, InterferometricVisibility)
+def uvw_to_uvw(from_coo, to_frame):
+    return from_coo.transform_to(ITRS(obstime=from_coo.obstime)).transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -7,22 +7,25 @@ import astropy.units as u
 from astropy.coordinates.baseframe import (BaseCoordinateFrame,
                          RepresentationMapping, frame_transform_graph)
 
-from astropy.coordinates.attributes import (CoordinateAttribute,
-                         TimeAttribute, EarthLocationAttribute)
+from astropy.coordinates.attributes import (CoordinateAttribute, EarthLocationAttribute,
+                                            TimeAttribute, QuantityAttribute)
+
+from astropy.coordinates.earth import EarthLocation
 
 from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates.representation import (SphericalRepresentation,
                               UnitSphericalRepresentation,CartesianRepresentation)
-from . import (ITRS,ICRS,AltAz)
 
+from . import (ITRS, ICRS)
+               
 class InterferometricVisibility(BaseCoordinateFrame):
     """
     A coordinate or frame in the interferometric visibilities (a.k.a. "uvw"),
     as is common in radio astronomy.
     This system are the local East, North, and Up unit vectors projected
     into the plane of the sky, whose origin is fixed to a direction ``phase``.
-    These coordinates are used to measure the interferometric baselines in 
-    in radio interferometry.
+    These coordinates are used to measure the projected antenna position
+    that can be differenced against others for a baseline measurement.
 
     This frame has the following frame attributes, which are necessary for
     transforming from InterferometricVisibility to some other system:
@@ -37,7 +40,7 @@ class InterferometricVisibility(BaseCoordinateFrame):
         transformed to an `~astropy.coordinates.ITRS` frame.
     * ``phase``
         The phase tracking center of the frame.  This can be specified either
-        as an (ra,dec) `~astropy.units.Qunatity` or as anything that can be
+        as an (ra,dec) `~astropy.units.Quantity` or as anything that can be
         transformed to an `~astropy.coordinates.ICRS` frame.
 
     Parameters
@@ -57,7 +60,6 @@ class InterferometricVisibility(BaseCoordinateFrame):
 
     Notes
     -----
-    This is useful for radio astronomers.
     It enables simple transformation between various other frames and the
     observers frame during the radio synthesis.
     It enables easily calculating elevation of a field with e.g.
@@ -77,87 +79,35 @@ class InterferometricVisibility(BaseCoordinateFrame):
 
     obstime = TimeAttribute(default=None)
     location = EarthLocationAttribute(default=None)
-    phase = CoordinateAttribute(ICRS, default=None)
 
     def __init__(self, *args, **kwargs):
         super(InterferometricVisibility, self).__init__(*args, **kwargs)
 
-@frame_transform_graph.transform(FunctionTransform, ITRS, InterferometricVisibility)
-def itrs_to_uvw(itrs_coo, uvw_frame):
-    '''Defines the transformation between ITRS and the InterferometricVisibility frame.'''
-    is_unitspherical = (isinstance(itrs_coo.data, UnitSphericalRepresentation) or
-                        itrs_coo.cartesian.x.unit == u.one)
+@frame_transform_graph.transform(FunctionTransform, ICRS, InterferometricVisibility)
+def icrs_to_uvw(icrs_loc, uvw_frame):
+    '''Defines the transformation between ICRS and the InterferometricVisibility frame.'''
+
     lon, lat, height = uvw_frame.location.to_geodetic('WGS84')
-    lst = uvw_frame.obstime.sidereal_time('mean',longitude=lon).to(u.radian).value
-    ha = lst - uvw_frame.phase.ra.to(u.radian).value
-    dec = uvw_frame.phase.dec.to(u.radian).value
-    lonrad = lon.to(u.radian).value - ha
-    latrad = dec
-    sinlat = np.sin(latrad)
-    coslat = np.cos(latrad)
-    sinlon = np.sin(lonrad)
-    coslon = np.cos(lonrad)
-    north = [-sinlat*coslon,
-                      -sinlat*sinlon,
-                      coslat]
-    east = [-sinlon,coslon,0]
-    up = [coslat*coslon,coslat*sinlon,sinlat]
+    lst = uvw_frame.obstime.sidereal_time('mean', longitude=lon).to(u.radian).value
+    ha = lst - icrs_loc.ra.to(u.radian).value
+    dec = icrs_loc.dec.to(u.rad)
+
+    sinha = np.sin(ha)
+    cosha = np.cos(ha)
+    sindec = np.sin(dec)
+    cosdec = np.cos(dec)
+    east = [sinha, cosha, 0]
+    north = [-sindec*cosha,
+             sindec*sinha,
+             cosdec]
+    up = [cosdec*cosha, -cosdec*sinha, sindec]
     R = np.array([east,north,up])
-    if is_unitspherical:
-        p = itrs_coo.cartesian.xyz.value
-        diff = p
-        penu = R.dot(diff)
-        rep = CartesianRepresentation(x = u.Quantity(penu[0],u.one,copy=False),
-                                     y = u.Quantity(penu[1],u.one,copy=False),
-                                     z = u.Quantity(penu[2],u.one,copy=False),
-                                     copy=False)
-    else:
-        p = itrs_coo.cartesian.xyz
-        p0 = ITRS(*uvw_frame.location.geocentric,obstime=uvw_frame.obstime).cartesian.xyz
-        diff = (p.T-p0).T
-        penu = R.dot(diff)
-        rep = CartesianRepresentation(x = penu[0],
-                y = penu[1],
-                z = penu[2],
-                copy=False)
+    xyz = [uvw_frame.location.x.value, uvw_frame.location.y.value, uvw_frame.location.z.value]
+
+    uvw = R.dot(xyz)
+    rep = CartesianRepresentation(x = uvw[0],
+                                  y = uvw[1],
+                                  z = uvw[2],
+                                  copy=False)
 
     return uvw_frame.realize_frame(rep)
-
-@frame_transform_graph.transform(FunctionTransform, InterferometricVisibility, ITRS)
-def uvw_to_itrs(uvw_coo, itrs_frame):
-    lon, lat, height = uvw_coo.location.to_geodetic('WGS84')
-    lst = uvw_coo.obstime.sidereal_time('mean',longitude=lon).to(u.radian).value
-    ha = (lst - uvw_coo.phase.ra).to(u.radian).value
-    dec = uvw_coo.phase.dec.to(u.radian).value
-    lonrad = lon.to(u.radian).value - ha
-    latrad = dec
-    sinlat = np.sin(latrad)
-    coslat = np.cos(latrad)
-    sinlon = np.sin(lonrad)
-    coslon = np.cos(lonrad)
-    north = [-sinlat*coslon,
-                      -sinlat*sinlon,
-                      coslat]
-    east = [-sinlon,coslon,0]
-    up = [coslat*coslon,coslat*sinlon,sinlat]
-    R = np.array([east,north,up])
-    if isinstance(uvw_coo.data, UnitSphericalRepresentation) or uvw_coo.cartesian.x.unit == u.one:
-        diff = R.T.dot(uvw_coo.cartesian.xyz)
-        p = diff
-        rep = CartesianRepresentation(x = u.Quantity(p[0],u.one,copy=False),
-                                     y = u.Quantity(p[1],u.one,copy=False),
-                                     z = u.Quantity(p[2],u.one,copy=False),
-                                     copy=False)
-    else:
-        diff = R.T.dot(uvw_coo.cartesian.xyz)
-        p0 = ITRS(*uvw_coo.location.geocentric,obstime=uvw_coo.obstime).cartesian.xyz
-        p = (diff.T + p0).T
-        rep = CartesianRepresentation(x = p[0],
-                y = p[1],
-                z = p[2],
-                copy=False)
-    return itrs_frame.realize_frame(rep)
-
-@frame_transform_graph.transform(FunctionTransform, InterferometricVisibility, InterferometricVisibility)
-def uvw_to_uvw(from_coo, to_frame):
-    return from_coo.transform_to(ITRS(obstime=from_coo.obstime)).transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -1,5 +1,3 @@
-from __future__ import (absolute_import, unicode_literals, division,
-                        print_function)
 import numpy as np
 
 import astropy.units as u
@@ -17,7 +15,8 @@ from astropy.coordinates.representation import (SphericalRepresentation,
                               UnitSphericalRepresentation,CartesianRepresentation)
 
 from . import (ITRS, ICRS)
-               
+
+
 class InterferometricVisibility(BaseCoordinateFrame):
     """
     A coordinate or frame in the interferometric visibilities (a.k.a. "uvw"),
@@ -27,8 +26,8 @@ class InterferometricVisibility(BaseCoordinateFrame):
     These coordinates are used to measure the projected antenna position
     that can be differenced against others for a baseline measurement.
 
-    This frame has the following frame attributes, which are necessary for
-    transforming from InterferometricVisibility to some other system:
+    This frame has the following frame attributes, which are necessary 
+    to calculate uvw coords and transform between frames.
     * ``obstime``
         The time at which the observation is taken.  Used for determining the
         position and orientation of the Earth.
@@ -38,10 +37,6 @@ class InterferometricVisibility(BaseCoordinateFrame):
         fixed to any particular antenna.  This can be specified either as an
         `~astropy.coordinates.EarthLocation` object or as anything that can be
         transformed to an `~astropy.coordinates.ITRS` frame.
-    * ``phase``
-        The phase tracking center of the frame.  This can be specified either
-        as an (ra,dec) `~astropy.units.Quantity` or as anything that can be
-        transformed to an `~astropy.coordinates.ICRS` frame.
 
     Parameters
     ----------
@@ -63,11 +58,12 @@ class InterferometricVisibility(BaseCoordinateFrame):
     It enables simple transformation between various other frames and the
     observers frame during the radio synthesis.
     It enables easily calculating elevation of a field with e.g.
-    #>>> coord = astropy.coordinates.SkyCoord(ra=..., dec=...,
-                frame=InterferometricVisibility(location=..., obstime=..., phase=...))
-    #>>> elevation = coord.transform_to(astropy.coordinates.AltAz).alt
-    The local East-North-Up frame coordinates can easily be calculated by 
-    transforming to a InterferometricVisibility with ``phase`` pointing at zenith.
+    >>> coord = astropy.coordinates.SkyCoord(ra=0*u.deg dec=0*u.deg)
+    >>> location = astropy.coordinates.EarthLocation(*observatory name*)
+    >>> now = astropy.time.Time.now()
+    >>> uvw_frame=astropy.coordinates.InterferometricVisibility(location=location, obstime=now)
+    >>> uvw = coo.transform_to(uvw_frame) 
+    >>> print(uvw.u, uvw.v, uvw.w)  # earth-centric distance in meters
     """
 
     frame_specific_representation_info = {
@@ -82,6 +78,7 @@ class InterferometricVisibility(BaseCoordinateFrame):
 
     def __init__(self, *args, **kwargs):
         super(InterferometricVisibility, self).__init__(*args, **kwargs)
+
 
 @frame_transform_graph.transform(FunctionTransform, ICRS, InterferometricVisibility)
 def icrs_to_uvw(icrs_loc, uvw_frame):

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -90,7 +90,12 @@ def icrs_to_uvw(icrs_loc, uvw_frame):
     # use CIRS frame to correct for nutation-precession
     ha = lst - icrs_loc.transform_to(CIRS).ra.to(u.radian).value  
     dec = icrs_loc.transform_to(CIRS).dec.to(u.rad)
+    xyz = [uvw_frame.location.x.value, uvw_frame.location.y.value, uvw_frame.location.z.value]
 
+    # rotate ITRS xyz to telescope local frame as in TMS
+#    ...
+
+    # rotate xyz to uvw as in TMS
     sinha = np.sin(ha)
     cosha = np.cos(ha)
     sindec = np.sin(dec)
@@ -100,8 +105,7 @@ def icrs_to_uvw(icrs_loc, uvw_frame):
              sindec*sinha,
              cosdec]
     up = [cosdec*cosha, -cosdec*sinha, sindec]
-    R = np.array([east,north,up])
-    xyz = [uvw_frame.location.x.value, uvw_frame.location.y.value, uvw_frame.location.z.value]
+    R = np.array([east,north,up]) 
 
     uvw = R.dot(xyz)
     rep = CartesianRepresentation(x = uvw[0],

--- a/astropy/coordinates/builtin_frames/intvis.py
+++ b/astropy/coordinates/builtin_frames/intvis.py
@@ -14,7 +14,7 @@ from astropy.coordinates.transformations import FunctionTransform
 from astropy.coordinates.representation import (SphericalRepresentation,
                               UnitSphericalRepresentation,CartesianRepresentation)
 
-from . import (ITRS, ICRS)
+from . import (ICRS, CIRS)
 
 
 class InterferometricVisibility(BaseCoordinateFrame):
@@ -87,8 +87,9 @@ def icrs_to_uvw(icrs_loc, uvw_frame):
 
     lon, lat, height = uvw_frame.location.to_geodetic('WGS84')
     lst = uvw_frame.obstime.sidereal_time('mean', longitude=lon).to(u.radian).value
-    ha = lst - icrs_loc.ra.to(u.radian).value
-    dec = icrs_loc.dec.to(u.rad)
+    # use CIRS frame to correct for nutation-precession
+    ha = lst - icrs_loc.transform_to(CIRS).ra.to(u.radian).value  
+    dec = icrs_loc.transform_to(CIRS).dec.to(u.rad)
 
     sinha = np.sin(ha)
     cosha = np.cos(ha)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1238,6 +1238,7 @@ def test_galactocentric_references(reset_galactocentric_defaults):
             else:
                 assert k in galcen_custom.frame_attribute_references
 
+
 def test_uvw_frame():
     """Test the UVW frame by ensuring it meets the conventions defined in:
     https://casa.nrao.edu/Memos/CoordConvention.pdf
@@ -1256,10 +1257,10 @@ def test_uvw_frame():
     # with X - East, Z - NCP and Y - Down
     time = at.Time("2017-01-26T17:07:00.000",format='isot',scale='utc')
     loc = ac.EarthLocation(lon=10*u.deg,lat=10*u.deg,height=0*u.km)
-    enu = ac.ENU(location=loc,obstime=time)
+#    enu = ac.ENU(location=loc,obstime=time)
     lst = time.sidereal_time('mean',10*u.deg)
-    phase_enu = ac.ICRS(lst,10*u.deg)
-    enu = ac.UVW(location=loc,obstime=time,phase=phase_enu)
+#    phase_enu = ac.ICRS(lst,10*u.deg)
+    enu = ac.UVW(location=loc, obstime=time)#, phase=phase_enu)
     x = ac.SkyCoord(1,0,0,frame=enu)
     z = ac.SkyCoord(0,np.cos(loc.geodetic[1].rad),np.sin(loc.geodetic[1].rad),frame=enu)
     #ncp = ac.SkyCoord(0*u.one,0*u.one,1*u.one,frame='itrs').transform_to(enu)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1237,3 +1237,73 @@ def test_galactocentric_references(reset_galactocentric_defaults):
                 assert k not in galcen_custom.frame_attribute_references
             else:
                 assert k in galcen_custom.frame_attribute_references
+
+def test_uvw_frame():
+    """Test the UVW frame by ensuring it meets the conventions defined in:
+    https://casa.nrao.edu/Memos/CoordConvention.pdf
+    """
+    from ... import time as at
+    from ... import units as u
+    from ... import coordinates as ac
+
+    def compVectors(a,b):
+        a = a.cartesian.xyz.value
+        a /= np.linalg.norm(a)
+        b = b.cartesian.xyz.value
+        b /= np.linalg.norm(b)
+        h = np.linalg.norm(a-b)
+        return h < 1e-8
+    # with X - East, Z - NCP and Y - Down
+    time = at.Time("2017-01-26T17:07:00.000",format='isot',scale='utc')
+    loc = ac.EarthLocation(lon=10*u.deg,lat=10*u.deg,height=0*u.km)
+    enu = ac.ENU(location=loc,obstime=time)
+    lst = time.sidereal_time('mean',10*u.deg)
+    phase_enu = ac.ICRS(lst,10*u.deg)
+    enu = ac.UVW(location=loc,obstime=time,phase=phase_enu)
+    x = ac.SkyCoord(1,0,0,frame=enu)
+    z = ac.SkyCoord(0,np.cos(loc.geodetic[1].rad),np.sin(loc.geodetic[1].rad),frame=enu)
+    #ncp = ac.SkyCoord(0*u.one,0*u.one,1*u.one,frame='itrs').transform_to(enu)
+    y = ac.SkyCoord(0,np.sin(loc.geodetic[1].rad),-np.cos(loc.geodetic[1].rad),frame=enu)
+    lst = ac.AltAz(alt=90*u.deg,az=0*u.deg,location=loc,obstime=time).transform_to(ac.ICRS).ra
+    #ha = lst - ra
+    print("a) when ha=0,dec=90  uvw aligns with xyz")
+    ha = 0*u.deg
+    ra = lst - ha
+    dec = 90*u.deg
+    phaseTrack = ac.SkyCoord(ra,dec,frame=ac.ICRS)
+    uvw = ac.UVW(obstime=time,location=loc,phase=phaseTrack)
+    U = ac.SkyCoord(1,0,0,frame=uvw).transform_to(enu)
+    V = ac.SkyCoord(0,1,0,frame=uvw).transform_to(enu)
+    W = ac.SkyCoord(0,0,1,frame=uvw).transform_to(enu)
+    assert compVectors(U,x),"fail test a, u != x"
+    assert compVectors(V,y),"fail test a, v != y"
+    assert compVectors(W,z),"fail test a, w != z"
+    #print("passed a")
+    #print("b) v, w, z are always on great circle")
+    assert np.cross(V.cartesian.xyz.value,W.cartesian.xyz.value).dot(z.cartesian.xyz.value) < 1e-10, "Not on the great circle"
+    #print("passed b")
+    #print("c) when ha = 0 U points east")
+    ha = 0*u.deg
+    ra = lst - ha
+    dec = 35*u.deg
+    phaseTrack = ac.SkyCoord(ra,dec,frame=ac.ICRS)
+    uvw = ac.UVW(obstime=time,location=loc,phase=phaseTrack)
+    U = ac.SkyCoord(1*u.m,0*u.m,0*u.m,frame=uvw).transform_to(enu)
+    V = ac.SkyCoord(0*u.m,1*u.m,0*u.m,frame=uvw).transform_to(enu)
+    W = ac.SkyCoord(0*u.m,0*u.m,1*u.m,frame=uvw).transform_to(enu)
+    assert np.cross(V.cartesian.xyz.value,W.cartesian.xyz.value).dot(z.cartesian.xyz.value) < 1e-10, "Not on the great circle"
+    east = ac.SkyCoord(1,0,0,frame=enu)
+    assert compVectors(U,east),"fail test c, u != east"
+    #print("passed c")
+    #print("d) when dec=0 and ha = -6 w points east")
+    ha = -6*u.hourangle
+    ra = lst - ha
+    dec = 0*u.deg
+    phaseTrack = ac.SkyCoord(ra,dec,frame=ac.ICRS)
+    uvw = ac.UVW(obstime=time,location=loc,phase=phaseTrack)
+    U = ac.SkyCoord(1*u.m,0*u.m,0*u.m,frame=uvw).transform_to(enu)
+    V = ac.SkyCoord(0*u.m,1*u.m,0*u.m,frame=uvw).transform_to(enu)
+    W = ac.SkyCoord(0*u.m,0*u.m,1*u.m,frame=uvw).transform_to(enu)
+    assert np.cross(V.cartesian.xyz.value,W.cartesian.xyz.value).dot(z.cartesian.xyz.value) < 1e-10, "Not on the great circle"
+    assert compVectors(W,east),"fail test d, w != east"
+    #print("passed d")

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1238,7 +1238,7 @@ def test_galactocentric_references(reset_galactocentric_defaults):
             else:
                 assert k in galcen_custom.frame_attribute_references
 
-
+@pytest.mark.remote_data
 def test_uvw_frame():
     """Test the UVW frame by ensuring it meets the conventions defined in:
     https://casa.nrao.edu/Memos/CoordConvention.pdf


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

First step reviving this interferometric coordinate calculation, as described in Issue #7766. This work was started as AAS Hack Together Day! 🎉 This is not complete, but hopefully helps start a conversation.

I modified the original work by @joshuaalbert to use a time and earth location in the frame definition. Then a given RA, Dec can be projected into that frame to get "uvw" coordinates. An example of how to calculate a single baseline with two antennas looking at the same location and time:
```
uvw_frame0 = coordinates.InterferometricVisibility(location=coordinates.EarthLocation(lon=-u.deg*(107+37/60+6.9/3600), lat=u.deg*(33+54/60+10.3/3600)), obstime=now)
uvw_frame1 = coordinates.InterferometricVisibility(location=coordinates.EarthLocation(lon=-u.deg*(107+36/60+58.4/3600), lat=u.deg*(33+53/60+58.8/3600)), obstime=now)
uvw0 = coo.transform_to(uvw_frame0)
uvw1= coo.transform_to(uvw_frame1)
print(uvw1.u-uvw0.u, uvw1.v-uvw0.v, uvw1.w-uvw0.w)                                
--> -320.8834414416924 -294.0936500374228 356.1691571404226
```

This result was confirmed (once) by comparing to the code used by the EHT (https://github.com/achael/eht-imaging/blob/master/ehtim/observing/obs_helpers.py#L55). More checks would be helpful. For example, I tried to compare to a memo by CASA developers (https://casa.nrao.edu/Memos/CoordConvention.pdf), but could not get identical uvw values.

closes #7766
