### PR TITLE
Test exception catching in test_missing_file

### DIFF
--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -327,9 +327,9 @@ def test_extra_data_col2(fast_reader):
         ascii.read('data/simple5.txt', delimiter='|', fast_reader=fast_reader)
 
 
-@raises(OSError)
 def test_missing_file():
-    ascii.read('does_not_exist')
+    with pytest.raises(OSError):
+        ascii.read('does_not_exist')
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, 'force'])

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -464,7 +464,7 @@ class WCSAxes(Axes):
     # xlabel). While these are meant to be a single positional argument,
     # Matplotlib internally sometimes specifies e.g. set_xlabel(xlabel=...).
 
-    def set_xlabel(self, xlabel=None, labelpad=1, **kwargs):
+    def set_xlabel(self, xlabel=None, labelpad=1, loc=None, **kwargs):
         if xlabel is None:
             xlabel = kwargs.pop('label', None)
             if xlabel is None:
@@ -474,7 +474,7 @@ class WCSAxes(Axes):
                 coord.set_axislabel(xlabel, minpad=labelpad, **kwargs)
                 break
 
-    def set_ylabel(self, ylabel=None, labelpad=1, **kwargs):
+    def set_ylabel(self, ylabel=None, labelpad=1, loc=None, **kwargs):
         if ylabel is None:
             ylabel = kwargs.pop('label', None)
             if ylabel is None:


### PR DESCRIPTION
I think this must be due to an update in pytest.

Fixes https://github.com/astropy/astropy/issues/9872