### PR TITLE
TST: Fix broken giles URL in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,4 +177,4 @@ workflows:
 
 notify:
   webhooks:
-    - url: https://giles.cadair.com/circleci
+    - url: https://giles.cadair.dev/circleci


### PR DESCRIPTION
This fixes the error `webhook returned http status 404, connecting to https://giles.cadair.com/circleci` seen in CircleCI.