### PR TITLE
added dimensionless on headers ,#9588

### DIFF
--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -2100,7 +2100,7 @@ class CompositeUnit(UnitBase):
                 return 'Unit(dimensionless with a scale of {})'.format(
                     self._scale)
             else:
-                return 'Unit(dimensionless)'
+                return super().__repr__()
 
     @property
     def scale(self):

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -61,7 +61,7 @@ def _to_string(cls, unit):
                 else:
                     parts.append(f'({unit_list})')
 
-        return ' '.join(parts)
+        return ' '.join(parts)if ' '.join(parts)=='" "' else 'dimensionless'
     elif isinstance(unit, core.NamedUnit):
         return cls._get_unit_name(unit)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

this PR enables the feature to show 'dimensionless' units on header  
i added dimensioless property in the unit row but there was a confusion when there is a dimensionless quantity with scale != 1.0 .In the code it speacifies an output
`if self._scale != 1.0: return 'Unit(dimensionless with a scale of {})'.format(self._scale).`
So i decided to keep that as it is because i thought it was an important message and putting it into the table header will generally make the plaintext render of the table useless. If you like to suggest any other way for that kindly let me know.
here in wrote a PR

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9588 
