### PR TITLE
Avoid wrapping input longitudes to EarthLocation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -304,6 +304,9 @@ astropy.coordinates
 - Fixed a bug with ``TransformGraph.remove_transform()`` when the "from" and
   "to" frame classes are not explicitly specified. [#9815]
 
+- Read-only longitudes can now be passed in to ``EarthLocation`` even if
+  they include angles outside of the range of -180 to 180 degrees. [#9900]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -13,7 +13,7 @@ from astropy import units as u
 from astropy import constants as consts
 from astropy.units.quantity import QuantityInfoBase
 from astropy.utils.exceptions import AstropyUserWarning
-from .angles import Longitude, Latitude
+from .angles import Angle, Longitude, Latitude
 from .representation import CartesianRepresentation, CartesianDifferential
 from .errors import UnknownSiteException
 from astropy.utils import data
@@ -280,7 +280,10 @@ class EarthLocation(u.Quantity):
         ``gd2gc`` is used.  See https://github.com/liberfa/erfa
         """
         ellipsoid = _check_ellipsoid(ellipsoid, default=cls._ellipsoid)
-        lon = Longitude(lon, u.degree, wrap_angle=180*u.degree, copy=False)
+        # We use Angle here since there is no need to wrap the longitude -
+        # gd2gc will just take cos/sin anyway.  And wrapping might fail
+        # on readonly input.
+        lon = Angle(lon, u.degree, copy=False)
         lat = Latitude(lat, u.degree, copy=False)
         # don't convert to m by default, so we can use the height unit below.
         if not isinstance(height, u.Quantity):

--- a/astropy/coordinates/tests/test_earth.py
+++ b/astropy/coordinates/tests/test_earth.py
@@ -396,3 +396,11 @@ def test_gravitational_redshift():
                   'moon': 1*u.km,  # wrong units!
                   'earth': constants.G*constants.M_earth}
         someloc.gravitational_redshift(sometime, masses=masses)
+
+
+def test_read_only_input():
+    lon = np.array([80., 440.]) * u.deg
+    lat = np.array([45.]) * u.deg
+    lon.flags.writeable = lat.flags.writeable = False
+    loc = EarthLocation.from_geodetic(lon=lon, lat=lat)
+    assert quantity_allclose(loc[1].x, loc[0].x)


### PR DESCRIPTION
This follows on the report of @niess (https://github.com/astropy/astropy/issues/9898#issuecomment-579769528) that initializing `EarthLocation` with read-only arrays gives errors because the in-place wrapping of `Longitude` cannot be done. But there really is no need to wrap, since the resulting longitude is never exposed to the user, and only its sin and cos are taken. So, here we initialize an `Angle` instead.