### PR TITLE
Fix error in example usage of z_at_value()

### DIFF
--- a/astropy/cosmology/funcs.py
+++ b/astropy/cosmology/funcs.py
@@ -85,7 +85,7 @@ def z_at_value(func, fval, zmin=1e-8, zmax=1000, ztol=1e-8, maxfun=500):
 
     Finally interpolate to find the redshift at each distance modulus:
 
-    >>> zvals = np.interp(Dvals.value, zgrid, Dgrid.value)
+    >>> zvals = np.interp(Dvals.value, Dgrid.value, zgrid)
 
     Examples
     --------


### PR DESCRIPTION
Call to np.interp() passes arguments in wrong order, the grid data points for the dependent variable were mixed up with the grid data points for the independent variable

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address an incorrect code example present in the z_at_value() documentation. The call to numpy's interpolate function mixes up the order of the two grids that need to be passed in. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
