### PR TITLE
Ensure we do not fail when CI leap second file is expired.

### DIFF
--- a/astropy/utils/iers/data/Leap_Second.dat
+++ b/astropy/utils/iers/data/Leap_Second.dat
@@ -1,10 +1,10 @@
 #  Value of TAI-UTC in second valid beetween the initial value until
 #  the epoch given on the next line. The last line reads that NO
 #  leap second was introduced since the corresponding date
-#  Updated through IERS Bulletin 58 issued in July 2019
+#  Updated through IERS Bulletin 59 issued in January 2020
 #
 #
-#  File expires on 28 June 2020
+#  File expires on 28 December 2020
 #
 #
 #    MJD        Date        TAI-UTC (s)


### PR DESCRIPTION
We are getting failures because travis does not quite keep its distribution up to date enough for leap second tests. So, this PR changes the test such that on CI if the leap second file is expired, the test is simply skipped. But if it is not expired, it checks that it is used.

cc @bsipocz, as it is something that should make your life that little bit easier!