### PR TITLE
Fix small problems uncovered by package updates.

### DIFF
--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -379,7 +379,7 @@ class TestBasic:
         dt = datetime.datetime(2000, 1, 2, 3, 4, 5, 123456)
         Time(dt, format='datetime', scale='tai')
         Time([dt, dt], format='datetime', scale='tai')
-        dt64 = np.datetime64('2012-06-18T02:00:05.453000000', format='datetime64')
+        dt64 = np.datetime64('2012-06-18T02:00:05.453000000')
         Time(dt64, format='datetime64', scale='tai')
         Time([dt64, dt64], format='datetime64', scale='tai')
 

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1174,7 +1174,7 @@ dynamical models). An example using the JPL ephemerides is:
     >>> ltt_bary_jpl = times.light_travel_time(ip_peg, ephemeris='jpl') # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     >>> ltt_bary_jpl # doctest: +REMOTE_DATA +FLOAT_CMP
     <TimeDelta object: scale='tdb' format='jd' value=[-0.0037715  -0.00377286]>
-    >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> (ltt_bary_jpl - ltt_bary).to(u.ms) # doctest: +REMOTE_DATA +IGNORE_OUTPUT
     <Quantity [-0.00132325, -0.00132861] ms>
 
 The difference between the builtin ephemerides and the JPL ephemerides is normally


### PR DESCRIPTION
1. Numpy now checks arguments on calls of `np.datetime64` and we gave it an argument that belonged to `Time` in one of our tests.
2. Differences between the built-in and JPL ephemerides are very small, and hence the relative precision assumed by `FLOAT_CMP` is wrong. Ignore that comparison in a doctest.

Missing is a fix for a JPL ephemeris file that consistently times out (it may just be too big). Might be best to rewrite the corresponding test, but out of scope for this PR.