### PR TITLE
Add IERS updates to the release procedure

### DIFF
--- a/astropy/utils/iers/data/update_builtin_iers.sh
+++ b/astropy/utils/iers/data/update_builtin_iers.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -euv
+
+# This script should be run every time an astropy release is made.
+# It downloads up-to-date versions of the earth rotation and leap
+# second tables.
+
+rm Leap_Second.dat
+rm eopc04_IAU2000.62-now
+
+# iers.IERS_B_URL
+wget http://hpiers.obspm.fr/iers/eop/eopc04/eopc04_IAU2000.62-now
+# iers.IERS_LEAP_SECOND_URL
+wget https://hpiers.obspm.fr/iers/bul/bulc/Leap_Second.dat

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -63,6 +63,13 @@ packages that use the full bugfix/maintenance branch approach.)
    step is only required on major releases, but can be done for bugfix releases
    as time allows.)
 
+#. (astropy specific) Ensure the built-in IERS earth rotation parameter and
+   leap second tables are up to date by changing directory to
+   ``astropy/utils/iers/data`` and executing ``update_builtin_iers.sh``.
+   Check the result with ``git diff`` (do not be surprised to find many lines
+   in the ``eopc04_IAU2000.62-now`` file change; those data are reanalyzed
+   periodically), and committing.
+
 #. To build the source distribution in an isolated environment and make sure you
    have all the dependencies required for it, install the `pep517
    <https://pypi.org/project/pep517/>`_ package::

--- a/docs/development/releasing.rst
+++ b/docs/development/releasing.rst
@@ -68,7 +68,7 @@ packages that use the full bugfix/maintenance branch approach.)
    ``astropy/utils/iers/data`` and executing ``update_builtin_iers.sh``.
    Check the result with ``git diff`` (do not be surprised to find many lines
    in the ``eopc04_IAU2000.62-now`` file change; those data are reanalyzed
-   periodically), and committing.
+   periodically) and committing.
 
 #. To build the source distribution in an isolated environment and make sure you
    have all the dependencies required for it, install the `pep517


### PR DESCRIPTION
Following the [suggestion of @pllim](https://github.com/astropy/astropy/issues/1697#issuecomment-548051032), this adds a step to the release procedure about how to update the IERS files. I also added a small script that may be useful (if only to remind one what needs to be done).

Ideally, of course, we would automate it... but since we haven't in the 6.5 years since #1697 was raised, perhaps this is better than nothing.

@bsipocz - does this make any sense? I'm happy to adjust!