### PR TITLE
Fix ZScaleInterval when input array has few points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -379,6 +379,10 @@ astropy.visualization
 - Fixed bug from matplotlib >=3.1 where an empty Quantity array is
   sent for unit conversion as an empty list. [#9848]
 
+- Fix bug in ``ZScaleInterval`` to return the array minimum and
+  maximum when there are less then ``min_npixels`` in the input array.
+  [#9913]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -283,9 +283,9 @@ class ZScaleInterval(BaseInterval):
             last_ngoodpix = ngoodpix
             ngoodpix = np.sum(~badpix)
 
-        slope, intercept = fit
-
         if ngoodpix >= minpix:
+            slope, intercept = fit
+
             if self.contrast > 0:
                 slope = slope / self.contrast
             center_pixel = (npix - 1) // 2

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -260,7 +260,7 @@ class ZScaleInterval(BaseInterval):
         ngrow = max(1, int(npix * 0.01))
         kernel = np.ones(ngrow, dtype=bool)
 
-        for niter in range(self.max_iterations):
+        for _ in range(self.max_iterations):
             if ngoodpix >= last_ngoodpix or ngoodpix < minpix:
                 break
 
@@ -284,7 +284,7 @@ class ZScaleInterval(BaseInterval):
             ngoodpix = np.sum(~badpix)
 
         if ngoodpix >= minpix:
-            slope, intercept = fit
+            slope, _ = fit
 
             if self.contrast > 0:
                 slope = slope / self.contrast

--- a/astropy/visualization/interval.py
+++ b/astropy/visualization/interval.py
@@ -216,9 +216,9 @@ class ZScaleInterval(BaseInterval):
         the returned values are the minimum and maximum of the data.
         Defaults to 0.5.
     min_npixels : int, optional
-        If less than ``min_npixels`` pixels are rejected, then the
-        returned values are the minimum and maximum of the data.
-        Defaults to 5.
+        If there are less than ``min_npixels`` pixels remaining after
+        the pixel rejection, then the returned values are the minimum
+        and maximum of the data.  Defaults to 5.
     krej : float, optional
         The number of sigma used for the rejection. Defaults to 2.5.
     max_iterations : int, optional

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -86,6 +86,9 @@ class ImageNormalize(Normalize):
             self._set_limits(data)
 
     def _set_limits(self, data):
+        if self.vmin is not None and self.vmax is not None:
+            return
+
         # Define vmin and vmax from the interval class if not None
         if self.interval is None:
             if self.vmin is None:

--- a/astropy/visualization/tests/test_interval.py
+++ b/astropy/visualization/tests/test_interval.py
@@ -108,6 +108,20 @@ def test_zscale():
     np.testing.assert_allclose(vmax, 99, atol=0.1)
 
 
+def test_zscale_npoints():
+    """
+    Regression test to ensure ZScaleInterval returns the minimum and
+    maximum of the data if the number of data points is less than
+    ``min_pixels``.
+    """
+
+    data = np.arange(4).reshape((2, 2))
+    interval = ZScaleInterval(min_npixels=5)
+    vmin, vmax = interval.get_limits(data)
+    assert vmin == 0
+    assert vmax == 3
+
+
 def test_integers():
     # Need to make sure integers get cast to float
     interval = MinMaxInterval()


### PR DESCRIPTION
This PR fixes #9880, where `ZScaleInterval` was failing when the mpl `colorbar` was called.  The underlying issue is that when the input array had less than `min_npixels` values, the linear fit was not performed (good), but the non-existent fit values were still trying to be being accessed.

This PR also corrects the ``min_npixels`` parameter description.

Fix #9880