### PR TITLE
Deprecate imshow_only_kwargs keyword in imshow_norm

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -186,6 +186,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Deprecated the ``imshow_only_kwargs`` keyword in ``imshow_norm``.
+  [#9915]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -4,6 +4,7 @@ colorbars.
 """
 
 import inspect
+import warnings
 
 import numpy as np
 from numpy import ma
@@ -12,6 +13,7 @@ from .interval import (PercentileInterval, AsymmetricPercentileInterval,
                        ManualInterval, MinMaxInterval, BaseInterval)
 from .stretch import (LinearStretch, SqrtStretch, PowerStretch, LogStretch,
                       AsinhStretch, BaseStretch)
+from ..utils.exceptions import AstropyDeprecationWarning
 
 try:
     import matplotlib  # pylint: disable=W0611
@@ -267,6 +269,9 @@ def imshow_norm(data, ax=None, imshow_only_kwargs={}, **kwargs):
         If None, use pyplot's imshow.  Otherwise, calls ``imshow`` method of the
         supplied axes.
     imshow_only_kwargs : dict, optional
+        Deprecated since Astropy v4.1.  Note that settting both ``norm``
+        and ``vmin/vmax`` is deprecated in ``matplotlib >= 3.3``.
+
         Arguments to be passed directly to `~matplotlib.pyplot.imshow` without
         first trying `ImageNormalize`.  This is only for keywords that have the
         same name in both `ImageNormalize` and `~matplotlib.pyplot.imshow` - if
@@ -307,6 +312,11 @@ def imshow_norm(data, ax=None, imshow_only_kwargs={}, **kwargs):
                                stretch=SqrtStretch())
         fig.colorbar(im)
     """
+
+    if imshow_only_kwargs:
+        warnings.warn('imshow_only_kwargs is deprecated since v4.1 and will '
+                      'be removed in a future version.',
+                      AstropyDeprecationWarning)
 
     if 'X' in kwargs:
         raise ValueError('Cannot give both ``X`` and ``data``')

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -7,6 +7,7 @@ import numpy as np
 from numpy import ma
 from numpy.testing import assert_allclose, assert_equal
 
+from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy.visualization.mpl_normalize import ImageNormalize, simple_norm, imshow_norm
 from astropy.visualization.interval import ManualInterval, PercentileInterval
 from astropy.visualization.stretch import SqrtStretch
@@ -238,14 +239,15 @@ def test_imshow_norm():
 
     imshow_norm(image, ax=ax, vmin=0, vmax=1)
 
-    # Note that the following is deprecated in Matplotlib 3.2
-    if MATPLOTLIB_LT_32:
-        # vmin/vmax "shadow" the MPL versions, so imshow_only_kwargs allows direct-setting
-        imshow_norm(image, ax=ax, imshow_only_kwargs=dict(vmin=0, vmax=1))
+    with pytest.warns(AstropyDeprecationWarning):
+        # Note that the following is deprecated in Matplotlib 3.2
+        if MATPLOTLIB_LT_32:
+            # vmin/vmax "shadow" the MPL versions, so imshow_only_kwargs allows direct-setting
+            imshow_norm(image, ax=ax, imshow_only_kwargs=dict(vmin=0, vmax=1))
 
-    # but it should fail for an argument that is not in ImageNormalize
-    with pytest.raises(ValueError):
-        imshow_norm(image, ax=ax, imshow_only_kwargs=dict(cmap='jet'))
+        # but it should fail for an argument that is not in ImageNormalize
+        with pytest.raises(ValueError):
+            imshow_norm(image, ax=ax, imshow_only_kwargs=dict(cmap='jet'))
 
     # make sure the pyplot version works
     imres, norm = imshow_norm(image, ax=None)


### PR DESCRIPTION
Closes #9861. 

Note that I didn't use `deprecated_renamed_argument` because of the bug I discovered in #9914.