### PR TITLE
Make io.ascii fast_reader promote isolated +/- sign to `str` dtype

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -315,14 +315,17 @@ astropy.cosmology
 astropy.extern
 ^^^^^^^^^^^^^^
 
-astropy.io.ascii
-^^^^^^^^^^^^^^^^
-
 astropy.io
 ^^^^^^^^^^
 
 - Fixed a bug that prevented the unified I/O infrastructure from working with
   datasets that are represented by directories rather than files. [#9866]
+
+astropy.io.ascii
+^^^^^^^^^^^^^^^^
+
+- Fixed a bug in the ``fast_reader`` C parsers incorrectly returning entries
+  of isolated positive/negative signs as ``float`` instead of ``str``. [#9918]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -845,9 +845,10 @@ double xstrtod(const char *str, char **endptr, char decimal,
     case '+': p++;
     }
 
-    // No data following sign - make no conversion and return zero,
+    // No numerical value following sign - make no conversion and return zero,
     // resetting endptr to beginning of str (consistent with strtod behaviour)
-    if (!isdigit(*p) && *p != decimal)
+    // E.g. -1.e0 and -.0e1 are valid, -.e0 is not!
+    if (!(isdigit(*p) || (*p == decimal && isdigit(*(p + 1)))))
     {
         if (endptr) *endptr = (char *) str;
         return 0e0;

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -649,7 +649,7 @@ double str_to_double(tokenizer_t *self, char *str)
     {
         val = xstrtod(str, &tmp, '.', self->expchar, ',', 1);
 
-        if (*tmp)
+        if (errno == EINVAL || tmp == str || *tmp != '\0')
         {
             goto conversion_error;
         }
@@ -716,9 +716,9 @@ conversion_error:
         }
         val *= INFINITY;
     }
-
-    if (tmp == str || *tmp != '\0')
+    else
     {
+       // Original (tmp == str || *tmp != '\0') case, no NaN or inf found
         self->code = CONVERSION_ERROR;
         val = 0;
     }
@@ -843,6 +843,14 @@ double xstrtod(const char *str, char **endptr, char decimal,
     {
     case '-': negative = 1; // Fall through to increment position
     case '+': p++;
+    }
+
+    // No data following sign - make no conversion and return zero,
+    // resetting endptr to beginning of str (consistent with strtod behaviour)
+    if (!isdigit(*p) && *p != decimal)
+    {
+        if (endptr) *endptr = (char *) str;
+        return 0e0;
     }
 
     number = 0.;

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -244,10 +244,10 @@ def test_conversion(parallel, read_basic):
     to strings.
     """
     text = """
-A B C D E
-1 a 3 4 5
-2. 1 9 10 -5.3e4
-4 2 -12 .4 six
+A B C D E F G
+1 a 3 4 5 6 7
+2. 1 9 10 8.7 6 -5.3e4
+4 2 -12 .4 - + six
 """
     table = read_basic(text, parallel=parallel)
     assert_equal(table['A'].dtype.kind, 'f')
@@ -255,6 +255,8 @@ A B C D E
     assert_equal(table['C'].dtype.kind, 'i')
     assert_equal(table['D'].dtype.kind, 'f')
     assert table['E'].dtype.kind in ('S', 'U')
+    assert table['F'].dtype.kind in ('S', 'U')
+    assert table['G'].dtype.kind in ('S', 'U')
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -1442,3 +1444,27 @@ def test_read_empty_basic_table_with_comments(fast_reader):
     assert t.meta['comments'] == ['comment 1', 'comment 2']
     assert len(t) == 0
     assert t.colnames == ['col1', 'col2']
+
+
+@pytest.mark.parametrize('fast_reader', [dict(use_fast_converter=True),
+                                         dict(exponent_style='A')])
+def test_conversion_fast(fast_reader):
+    """
+    The reader should try to convert each column to ints. If this fails, the
+    reader should try to convert to floats. Failing this, it should fall back
+    to strings.
+    """
+    text = """
+    A B C D E F G
+    1 a 3 4 5 6 7
+    2. 1 9 10 8.7 6 -5.3e4
+    4 2 -12 .4 - + six
+    """
+    table = ascii.read(text, fast_reader=fast_reader)
+    assert_equal(table['A'].dtype.kind, 'f')
+    assert table['B'].dtype.kind in ('S', 'U')
+    assert_equal(table['C'].dtype.kind, 'i')
+    assert_equal(table['D'].dtype.kind, 'f')
+    assert table['E'].dtype.kind in ('S', 'U')
+    assert table['F'].dtype.kind in ('S', 'U')
+    assert table['G'].dtype.kind in ('S', 'U')

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -240,14 +240,15 @@ def test_rstrip_whitespace(parallel, read_basic):
 def test_conversion(parallel, read_basic):
     """
     The reader should try to convert each column to ints. If this fails, the
-    reader should try to convert to floats. Failing this, it should fall back
-    to strings.
+    reader should try to convert to floats. Failing this, i.e. on parsing
+    non-numeric input including isolated positive/negative signs, it should
+    fall back to strings.
     """
     text = """
-A B C D E F G
-1 a 3 4 5 6 7
-2. 1 9 10 8.7 6 -5.3e4
-4 2 -12 .4 - + six
+A B C D E F G H
+1 a 3 4 5 6 7 8
+2. 1 9 -.1e1 10.0 8.7 6 -5.3e4
+4 2 -12 .4 +.e1 - + six
 """
     table = read_basic(text, parallel=parallel)
     assert_equal(table['A'].dtype.kind, 'f')
@@ -257,6 +258,7 @@ A B C D E F G
     assert table['E'].dtype.kind in ('S', 'U')
     assert table['F'].dtype.kind in ('S', 'U')
     assert table['G'].dtype.kind in ('S', 'U')
+    assert table['H'].dtype.kind in ('S', 'U')
 
 
 @pytest.mark.parametrize("parallel", [True, False])
@@ -1451,14 +1453,15 @@ def test_read_empty_basic_table_with_comments(fast_reader):
 def test_conversion_fast(fast_reader):
     """
     The reader should try to convert each column to ints. If this fails, the
-    reader should try to convert to floats. Failing this, it should fall back
-    to strings.
+    reader should try to convert to floats. Failing this, i.e. on parsing
+    non-numeric input including isolated positive/negative signs, it should
+    fall back to strings.
     """
     text = """
-    A B C D E F G
-    1 a 3 4 5 6 7
-    2. 1 9 10 8.7 6 -5.3e4
-    4 2 -12 .4 - + six
+    A B C D E F G H
+    1 a 3 4 5 6 7 8
+    2. 1 9 -.1e1 10.0 8.7 6 -5.3e4
+    4 2 -12 .4 +.e1 - + six
     """
     table = ascii.read(text, fast_reader=fast_reader)
     assert_equal(table['A'].dtype.kind, 'f')
@@ -1468,3 +1471,4 @@ def test_conversion_fast(fast_reader):
     assert table['E'].dtype.kind in ('S', 'U')
     assert table['F'].dtype.kind in ('S', 'U')
     assert table['G'].dtype.kind in ('S', 'U')
+    assert table['H'].dtype.kind in ('S', 'U')


### PR DESCRIPTION
Co-authored-by: Harshil-C@users.noreply.github.com

### Description
`ascii.read` using the (default) `fast_reader` failed to raise a `CONVERSION_ERROR` upon reading an isolated `-` or `+` sign, instead returning a float of value `1.0` or `0.0` (with `use_fast_converter`), thus incorrectly parsing the entry as `float` instead of a `str` column.

This PR has the tokenizer return 0 and set the `CONVERSION_ERROR` flag when `strtod` or `xstrtod` return a "no-conversion" result, which is triggering the conversion as `str` instead.

Fixes #9886