### PR TITLE
Fix io.ascii segfault when parsing conf.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -328,7 +328,9 @@ astropy.io.ascii
   of isolated positive/negative signs as ``float`` instead of ``str``. [#9918]
 
 - Fixed a segmentation fault in the ``fast_reader`` C parsers when parsing an
-  invalid file with ``guess=True``. [#9923]
+  invalid file with ``guess=True`` and the file contains inconsistent column
+  numbers in combination with a quoted field; e.g., ``"1  2\n 3  4 '5'"``.
+  [#9923]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-- Angle parsing now supports ``cardinal direction`` in the cases 
+- Angle parsing now supports ``cardinal direction`` in the cases
   where angles are initialized as ``string`` instances. eg ``"17°53'27"W"``.[#9859]
 
 astropy.cosmology
@@ -326,6 +326,9 @@ astropy.io.ascii
 
 - Fixed a bug in the ``fast_reader`` C parsers incorrectly returning entries
   of isolated positive/negative signs as ``float`` instead of ``str``. [#9918]
+
+- Fixed a segmentation fault in the ``fast_reader`` C parsers when parsing an
+  invalid file with ``guess=True``. [#9923]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -459,6 +459,13 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
             }
             else if (c == self->quotechar) // start parsing quoted field
             {
+
+                if (col >= self->num_cols)
+                {
+                    // Avoid segfault reported in
+                    // https://github.com/astropy/astropy/issues/9922
+                    RETURN(TOO_MANY_COLS);
+                }
                 self->state = START_QUOTED_FIELD;
                 break;
             }
@@ -564,12 +571,6 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
             }
             else if (c == '\n')
                 self->state = QUOTED_FIELD_NEWLINE;
-            else if (col >= self->num_cols)
-            {
-                // Avoid segfault reported in
-                // https://github.com/astropy/astropy/issues/9922
-                RETURN(TOO_MANY_COLS);
-            }
             else
             {
                 PUSH(c);

--- a/astropy/io/ascii/src/tokenizer.c
+++ b/astropy/io/ascii/src/tokenizer.c
@@ -564,6 +564,12 @@ int tokenize(tokenizer_t *self, int end, int header, int num_cols)
             }
             else if (c == '\n')
                 self->state = QUOTED_FIELD_NEWLINE;
+            else if (col >= self->num_cols)
+            {
+                // Avoid segfault reported in
+                // https://github.com/astropy/astropy/issues/9922
+                RETURN(TOO_MANY_COLS);
+            }
             else
             {
                 PUSH(c);

--- a/astropy/io/ascii/tests/data/conf_py.txt
+++ b/astropy/io/ascii/tests/data/conf_py.txt
@@ -1,0 +1,18 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+project = 'manno'
+
+master_doc = 'index'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'numpydoc',
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+}

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -16,11 +16,12 @@ from astropy.io.ascii.core import ParameterError, FastOptionsError, Inconsistent
 from astropy.io.ascii.fastbasic import (
     FastBasic, FastCsv, FastTab, FastCommentedHeader, FastRdb, FastNoHeader)
 from astropy.tests.helper import catch_warnings
+from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import AstropyWarning
 from .common import assert_equal, assert_almost_equal, assert_true
 
 
-StringIO = lambda x: BytesIO(x.encode('ascii'))
+StringIO = lambda x: BytesIO(x.encode('ascii'))  # noqa
 TRAVIS = os.environ.get('TRAVIS', False)
 
 
@@ -443,6 +444,15 @@ aaa,bbb
 """
     with pytest.raises(InconsistentTableError) as e:
         FastCsv().read(text)
+    assert 'Number of header columns (2) ' \
+           'inconsistent with data columns in data line 0' in str(e.value)
+
+
+def test_too_many_cols4():
+    # https://github.com/astropy/astropy/issues/9922
+    with pytest.raises(InconsistentTableError) as e:
+        ascii.read(get_pkg_data_filename('data/conf_py.txt'),
+                   fast_reader=True, guess=True)
     assert 'Number of header columns (2) ' \
            'inconsistent with data columns in data line 0' in str(e.value)
 

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -453,8 +453,7 @@ def test_too_many_cols4():
     with pytest.raises(InconsistentTableError) as e:
         ascii.read(get_pkg_data_filename('data/conf_py.txt'),
                    fast_reader=True, guess=True)
-    assert 'Number of header columns (2) ' \
-           'inconsistent with data columns in data line 0' in str(e.value)
+    assert 'Unable to guess table format with the guesses listed below' in str(e.value)
 
 
 @pytest.mark.parametrize("parallel", [True, False])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a segmentation fault when parsing `conf.py`, which is an invalid input file. With this patch, at least for that particular file, `astropy` raises an exception instead of segfault. However, I am not sure if this is the acceptable fix, so someone who is very familiar with the tokenizer should look at this carefully.

With this patch, reading the `conf.py` provided in #9922 will give this error:
```
astropy.io.ascii.core.InconsistentTableError: Number of header columns (2)
    inconsistent with data columns (3) at data line 2
Header values: ['import', 'os']
Data values: ['project', '=', "'manno'"]
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9922 

**TODO**

(Once this is deemed acceptable)

- [x] Add change log
- [x] Add a test (renamed `conf.py` to `conf_py.txt` so `setup` won't be trying to collect it as real code)