### PR TITLE
TST: xfail timeouts on CI

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -1,3 +1,4 @@
+import os
 
 import pytest
 import numpy as np
@@ -50,7 +51,14 @@ def test_positions_skyfield():
     location = None
 
     # skyfield ephemeris
-    planets = load('de421.bsp')
+    try:
+        planets = load('de421.bsp')
+    except OSError as e:
+        if os.environ.get('CI', False) and 'timed out' in str(e):
+            pytest.xfail('Timed out in CI')
+        else:
+            raise
+
     ts = load.timescale()
     mercury, jupiter, moon = planets['mercury'], planets['jupiter barycenter'], planets['moon']
     earth = planets['earth']

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -1,9 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import json
-import os
-from datetime import datetime
 import locale
+import os
+import socket
+from datetime import datetime
 
 import pytest
 import numpy as np
@@ -27,8 +28,14 @@ def test_signal_number_to_name_no_failure():
 
 @pytest.mark.remote_data
 def test_api_lookup():
-    strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)
-    objurl = misc.find_api_page(misc, 'dev', False, timeout=3)
+    try:
+        strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)
+        objurl = misc.find_api_page(misc, 'dev', False, timeout=3)
+    except socket.timeout:
+        if os.environ.get('CI', False):
+            pytest.xfail('Timed out in CI')
+        else:
+            raise
 
     assert strurl == objurl
     assert strurl == 'http://devdocs.astropy.org/utils/index.html#module-astropy.utils.misc'  # noqa


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address two cases that time out a lot in CI, but I don't see the problem when testing locally. I cannot tell who is blocking what or just slower connection, so easiest is to catch the exception and `xfail` if we detect that they are running in CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

These failures are marking the `numpy-dev` job red even when they are unrelated to the PR being reviewed, which gets annoying after a while.

**Note to reviewer: Check the numpy-dev job that is allowed to fail.**