### PR TITLE
Fix `fast_reader` parsing of newline as delimiters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -472,9 +472,25 @@ astropy.io.ascii
   numbers in combination with a quoted field; e.g., ``"1  2\n 3  4 '5'"``.
   [#9923]
 
-- Magnitude, decibel, and dex can now be stored in ``ecsv`` files. [#9933]
 - Fixed a bug with the C ``fast_reader`` not correctly parsing newlines when
   ``delimiter`` was also set to ``\n`` or ``\r``. [#9929]
+
+- Magnitude, decibel, and dex can now be stored in ``ecsv`` files. [#9933]
+
+astropy.io.misc
+^^^^^^^^^^^^^^^
+
+- Magnitude, decibel, and dex can now be stored in ``hdf5`` files. [#9933]
+
+- Fixed serialization of polynomial models to include non default values of
+  domain and window values. [#9956, #9961]
+
+- Fixed a bug which affected overwriting tables within ``hdf5`` files.
+  Overwriting an existing path with associated column meta data now also
+  overwrites the meta data associated with the table. [#9950]
+
+- Fixed serialization of Time objects with location under time-1.0.0
+  ASDF schema. [#9983]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -349,6 +349,10 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fixed a bug with the C ``fast_reader`` not correctly parsing newlines when
+  ``delimiter`` was also set to ``\n`` or ``\r``; ensured consistent handling
+  of input strings without newline characters. [#9929]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -471,9 +475,6 @@ astropy.io.ascii
   invalid file with ``guess=True`` and the file contains inconsistent column
   numbers in combination with a quoted field; e.g., ``"1  2\n 3  4 '5'"``.
   [#9923]
-
-- Fixed a bug with the C ``fast_reader`` not correctly parsing newlines when
-  ``delimiter`` was also set to ``\n`` or ``\r``. [#9929]
 
 - Magnitude, decibel, and dex can now be stored in ``ecsv`` files. [#9933]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -473,6 +473,8 @@ astropy.io.ascii
   [#9923]
 
 - Magnitude, decibel, and dex can now be stored in ``ecsv`` files. [#9933]
+- Fixed a bug with the C ``fast_reader`` not correctly parsing newlines when
+  ``delimiter`` was also set to ``\n`` or ``\r``. [#9929]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -315,7 +315,15 @@ class BaseInputter:
                 table[0]
                 table[0:1]
                 iter(table)
-                lines = table
+                if len(table) > 1:
+                    lines = table
+                else:
+                    # treat single entry as if string had been passed directly
+                    if newline is None:
+                        lines = table[0].splitlines()
+                    else:
+                        lines = table[0].split(newline)
+
             except TypeError:
                 raise TypeError(
                     'Input "table" must be a string (filename or data) or an iterable')

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -277,7 +277,7 @@ class BaseInputter:
     encoding = None
     """Encoding used to read the file"""
 
-    def get_lines(self, table):
+    def get_lines(self, table, newline=None):
         """
         Get the lines from the ``table`` input. The input table can be one of:
 
@@ -292,6 +292,7 @@ class BaseInputter:
             Can be either a file name, string (newline separated) with all header and data
             lines (must have at least 2 lines), a file-like object with a ``read()`` method,
             or a list of strings.
+        newline: line separator, if `None` use OS default from ``splitlines()``.
 
         Returns
         -------
@@ -304,7 +305,10 @@ class BaseInputter:
                 with get_readable_fileobj(table,
                                           encoding=self.encoding) as fileobj:
                     table = fileobj.read()
-            lines = table.splitlines()
+            if newline is None:
+                lines = table.splitlines()
+            else:
+                lines = table.split(newline)
         except TypeError:
             try:
                 # See if table supports indexing, slicing, and iteration
@@ -1206,8 +1210,17 @@ class BaseReader(metaclass=MetaBaseReader):
             if os.linesep not in table + '':
                 self.data.table_name = os.path.basename(table)
 
+        # If one of the newline chars is set as field delimiter, only
+        # accept the other one as line splitter
+        if self.header.splitter.delimiter == '\n':
+            newline = '\r'
+        elif self.header.splitter.delimiter == '\r':
+            newline = '\n'
+        else:
+            newline = None
+
         # Get a list of the lines (rows) in the table
-        self.lines = self.inputter.get_lines(table)
+        self.lines = self.inputter.get_lines(table, newline=newline)
 
         # Set self.data.data_lines to a slice of lines contain the data rows
         self.data.get_data_lines(self.lines)
@@ -1468,7 +1481,12 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
     except TypeError:  # Start line could be None or an instancemethod
         default_header_length = None
 
+    # csv.reader is hard-coded to recognise either '\r' or '\n' as end-of-line,
+    # therefore DefaultSplitter cannot handle these as delimiters.
     if 'delimiter' in kwargs:
+        if kwargs['delimiter'] in ('\n', '\r', '\r\n'):
+            reader.header.splitter = BaseSplitter()
+            reader.data.splitter = BaseSplitter()
         reader.header.splitter.delimiter = kwargs['delimiter']
         reader.data.splitter.delimiter = kwargs['delimiter']
     if 'comment' in kwargs:

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -13,8 +13,8 @@ READ_DOCSTRING = """
     Parameters
     ----------
     table : str, file-like, list, `pathlib.Path` object
-        Input table as a file name, file-like object, list of strings,
-        single newline-separated string or `pathlib.Path` object .
+        Input table as a file name, file-like object, list of string[s],
+        single newline-separated string or `pathlib.Path` object.
     guess : bool
         Try to guess the table format. Defaults to None.
     format : str, `~astropy.io.ascii.BaseReader`

--- a/astropy/io/ascii/src/tokenizer.h
+++ b/astropy/io/ascii/src/tokenizer.h
@@ -62,6 +62,7 @@ typedef struct
     char comment;          // comment character
     char quotechar;        // quote character
     char expchar;          // exponential character in scientific notation
+    char newline;          // EOL character
     char **output_cols;    // array of output strings for each column
     char **col_ptrs;       // array of pointers to current output position for each col
     size_t *output_len;    // length of each output column string

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1484,19 +1484,39 @@ def test_conversion_fast(fast_reader):
 
 
 @pytest.mark.parametrize('delimiter', ['\n', '\r'])
-@pytest.mark.parametrize('fast_reader', [False,
-                                         dict(parallel=True),
-                                         dict(parallel=False)])
+@pytest.mark.parametrize('fast_reader', [False, True, 'force'])
 def test_newline_as_delimiter(delimiter, fast_reader):
     """
-    Check that with delimiter set to a newline character, lines are still
-    correctly split along newlines. Tests the fix for #9928.
+    Check that newline characters are correctly handled as delimiters.
+    Tests the fix for #9928.
     """
-    text = "a  b c \n 1 '2'  3\r 4   5 6\r\n7  8 9 "
+    if delimiter == '\r':
+        eol = '\n'
+    else:
+        eol = '\r'
 
-    t0 = ascii.read(text, delimiter='|', fast_reader=False)
-    t1 = ascii.read(text, delimiter=delimiter, fast_reader=fast_reader)
-    assert t1.colnames == ['a  b c']
-    assert len(t1) == 3
-    assert t1['a  b c'].dtype.kind in ('S', 'U')
+    inp0 = ["a  | b | c ", " 1 | '2' | 3.00000 "]
+    inp1 = "a {0:s} b {0:s}c{1:s} 1 {0:s}'2'{0:s} 3.0".format(delimiter, eol)
+    inp2 = [f"a {delimiter} b{delimiter} c",
+            f"1{delimiter} '2' {delimiter} 3.0"]
+
+    t0 = ascii.read(inp0, delimiter='|', fast_reader=fast_reader)
+    t1 = ascii.read(inp1, delimiter=delimiter, fast_reader=fast_reader)
+    t2 = ascii.read(inp2, delimiter=delimiter, fast_reader=fast_reader)
+
+    assert t1.colnames == t2.colnames == ['a', 'b', 'c']
+    assert len(t1) == len(t2) == 1
+    assert t1['b'].dtype.kind in ('S', 'U')
+    assert t2['b'].dtype.kind in ('S', 'U')
     assert_table_equal(t1, t0)
+    assert_table_equal(t2, t0)
+
+    inp0 = 'a {0:s} b {0:s} c{1:s} 1 {0:s}"2"{0:s} 3.0'.format('|', eol)
+    inp1 = 'a {0:s} b {0:s} c{1:s} 1 {0:s}"2"{0:s} 3.0'.format(delimiter, eol)
+
+    t0 = ascii.read(inp0, delimiter='|', fast_reader=fast_reader)
+    t1 = ascii.read(inp1, delimiter=delimiter, fast_reader=fast_reader)
+
+    if not fast_reader:
+        pytest.xfail("Quoted fields are not parsed correctly by BaseSplitter")
+    assert_equal(t1['b'].dtype.kind, 'i')

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1481,3 +1481,19 @@ def test_conversion_fast(fast_reader):
     assert table['F'].dtype.kind in ('S', 'U')
     assert table['G'].dtype.kind in ('S', 'U')
     assert table['H'].dtype.kind in ('S', 'U')
+
+
+@pytest.mark.parametrize('delimiter', ['\n', '\r'])
+@pytest.mark.parametrize('fast_reader', [False,
+                                         dict(parallel=True),
+                                         dict(parallel=False)])
+def test_newline_as_delimiter(delimiter, fast_reader):
+    """
+    Check that with delimiter set to a newline character, lines are still
+    correctly split along newlines. Tests the fix for #9928.
+    """
+    text = "a  b c \n 1 '2'  3\r 4   5 6 "
+
+    t = ascii.read(text, delimiter=delimiter, fast_reader=fast_reader)
+    assert len(t) == 2
+    assert t.colnames == ['a  b c']

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1520,3 +1520,25 @@ def test_newline_as_delimiter(delimiter, fast_reader):
     if not fast_reader:
         pytest.xfail("Quoted fields are not parsed correctly by BaseSplitter")
     assert_equal(t1['b'].dtype.kind, 'i')
+
+
+@pytest.mark.parametrize('delimiter', [' ', '|', '\n', '\r'])
+@pytest.mark.parametrize('fast_reader', [False, True, 'force'])
+def test_single_line_string(delimiter, fast_reader):
+    """
+    String input without a newline character is interpreted as filename,
+    unless element of an iterable. Maybe not logical, but test that it is
+    at least treated consistently.
+    """
+    expected = Table([[1], [2], [3.00]], names=('col1', 'col2', 'col3'))
+    text = "1{0:s}2{0:s}3.0".format(delimiter)
+
+    if delimiter in ('\r', '\n'):
+        t1 = ascii.read(text, format='no_header', delimiter=delimiter, fast_reader=fast_reader)
+        assert_table_equal(t1, expected)
+    else:
+        with pytest.raises(FileNotFoundError):
+            t1 = ascii.read(text, format='no_header', delimiter=delimiter, fast_reader=fast_reader)
+
+    t2 = ascii.read([text], format='no_header', delimiter=delimiter, fast_reader=fast_reader)
+    assert_table_equal(t2, expected)

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1492,8 +1492,11 @@ def test_newline_as_delimiter(delimiter, fast_reader):
     Check that with delimiter set to a newline character, lines are still
     correctly split along newlines. Tests the fix for #9928.
     """
-    text = "a  b c \n 1 '2'  3\r 4   5 6 "
+    text = "a  b c \n 1 '2'  3\r 4   5 6\r\n7  8 9 "
 
-    t = ascii.read(text, delimiter=delimiter, fast_reader=fast_reader)
-    assert len(t) == 2
-    assert t.colnames == ['a  b c']
+    t0 = ascii.read(text, delimiter='|', fast_reader=False)
+    t1 = ascii.read(text, delimiter=delimiter, fast_reader=fast_reader)
+    assert t1.colnames == ['a  b c']
+    assert len(t1) == 3
+    assert t1['a  b c'].dtype.kind in ('S', 'U')
+    assert_table_equal(t1, t0)

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -42,14 +42,17 @@ Parameters for ``read()``
 **table** : input table
   There are four ways to specify the table to be read:
 
-  - Name of a file (string)
+  - Path to a file (string)
   - Single string containing all table lines separated by newlines
   - File-like object with a callable read() method
   - List of strings where each list element is a table line
 
   The first two options are distinguished by the presence of a newline in the
   string. This assumes that valid file names will not normally contain a
-  newline.
+  newline, and a valid table input will at least contain two rows.
+  Note that a table read in ``no_header`` format can legitimately consist
+  of a single row; in this case passing the string as a list with a single
+  item will ensure that it is not interpreted as a file name.
 
 **format** : file format (default='basic')
   This specifies the top-level format of the ASCII table; for example,


### PR DESCRIPTION
### Description
Attempts to streamline the `io.ascii` `fast_reader` code for parsing table fields in #9923 turned up inconsistent results for the even more exotic case of reading a table with one of the newline characters specified as `delimiter`. E.g. the default `fast_reader=True` would parse
```
>>> ascii.read("a  b \n 1 2 \n 3 4", delimiter='\n')
<Table length=0>
 a  b  1 2   3 4 
int64 int64 int64
----- ----- -----
```
while the Python parser always handles `\n`, `\r` as newlines first (returning a 2-rows+header table from that same input).
This PR restores consistent output when using the fast readers and continues the code cleanup discussed in #9923.

Fixes #9928

Assuming milestone 4.1, but waiting for confirmation for changelog entry.