### PR TITLE
Support for units on otherwise unitless models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ astropy.modeling
 ^^^^^^^^^^^^^^^^
 - Added Plummer1D model to ``functional_models``. [#9896]
 
+- Added ``UnitsMapping`` model and ``Model.coerce_units`` to support units on otherwise
+  unitless models. [#9936]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
@@ -1,0 +1,79 @@
+%YAML 1.1
+---
+$schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
+id: "http://astropy.org/schemas/astropy/transform/units_mapping-1.0.0"
+tag: "tag:astropy.org:astropy/transform/units_mapping-1.0.0"
+
+title: |
+  Mapper that operates on the units of the input.
+
+description: |
+  This transform operates on the units of the input, first converting to
+  the expected input units, then assigning replacement output units without
+  further conversion.
+
+examples:
+  -
+    - Assign units of seconds to dimensionless input.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            units: !unit/unit-1.0.0
+        outputs:
+          - name: x
+            units: !unit/unit-1.0.0 s
+  -
+    - Convert input to meters, then assign dimensionless units.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            units: !unit/unit-1.0.0 m
+        outputs:
+          - name: x
+            units: !unit/unit-1.0.0
+
+allOf:
+  - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
+  - type: object
+    properties:
+      inputs:
+        description: |
+          Array of input configurations.
+        type: array
+        items:
+          $ref: "#/definitions/value_configuration"
+      outputs:
+        description: |
+          Array of output configurations.
+        type: array
+        items:
+          $ref: "#/definitions/value_configuration"
+    required: [inputs, outputs]
+
+definitions:
+  value_configuration:
+    description: |
+      Configuration of a single model value (input or output).
+    type: object
+    properties:
+      name:
+        description: |
+          Value name.
+        type: string
+      units:
+        description: |
+          Expected units.
+        $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
+      equivalencies:
+        description: |
+          Equivalencies to apply when converting value to expected units.
+        $ref: "http://astropy.org/schemas/astropy/units/equivalency-1.0.0"
+      allow_dimensionless:
+        description: |
+          Allow this value to receive dimensionless data.
+        type: boolean
+        default: false
+    required: [name, units]
+...

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/transform/units_mapping-1.0.0.yaml
@@ -19,20 +19,40 @@ examples:
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
         inputs:
           - name: x
-            units: !unit/unit-1.0.0
+            unit: !unit/unit-1.0.0
         outputs:
           - name: x
-            units: !unit/unit-1.0.0 s
+            unit: !unit/unit-1.0.0 s
   -
     - Convert input to meters, then assign dimensionless units.
     - |
       !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
         inputs:
           - name: x
-            units: !unit/unit-1.0.0 m
+            unit: !unit/unit-1.0.0 m
         outputs:
           - name: x
-            units: !unit/unit-1.0.0
+            unit: !unit/unit-1.0.0
+
+  -
+    - Convert input to meters, then drop units entirely.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+            unit: !unit/unit-1.0.0 m
+        outputs:
+          - name: x
+
+  -
+    - Accept any units, then replace with meters.
+    - |
+      !<tag:astropy.org:astropy/transform/units_mapping-1.0.0>
+        inputs:
+          - name: x
+        outputs:
+          - name: x
+            unit: !unit/unit-1.0.0 m
 
 allOf:
   - $ref: "http://stsci.edu/schemas/asdf/transform/transform-1.2.0"
@@ -62,18 +82,18 @@ definitions:
         description: |
           Value name.
         type: string
-      units:
+      unit:
         description: |
-          Expected units.
+          Expected unit.
         $ref: "http://stsci.edu/schemas/asdf/unit/unit-1.0.0"
       equivalencies:
         description: |
-          Equivalencies to apply when converting value to expected units.
+          Equivalencies to apply when converting value to expected unit.
         $ref: "http://astropy.org/schemas/astropy/units/equivalency-1.0.0"
       allow_dimensionless:
         description: |
           Allow this value to receive dimensionless data.
         type: boolean
         default: false
-    required: [name, units]
+    required: [name]
 ...

--- a/astropy/io/misc/asdf/tags/transform/tests/test_units_mapping.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_units_mapping.py
@@ -44,8 +44,12 @@ def test_basic(tmpdir):
 
 def test_remove_units(tmpdir):
     m = UnitsMapping(((u.m, None),))
-    with pytest.raises(ValueError, match=r"Due to a limitation in ASDF"):
-        assert_model_roundtrip(m, tmpdir)
+    assert_model_roundtrip(m, tmpdir)
+
+
+def test_accept_any_units(tmpdir):
+    m = UnitsMapping(((None, u.m),))
+    assert_model_roundtrip(m, tmpdir)
 
 
 def test_with_equivalencies(tmpdir):

--- a/astropy/io/misc/asdf/tags/transform/tests/test_units_mapping.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_units_mapping.py
@@ -1,0 +1,61 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+
+from astropy import __minimum_asdf_version__
+
+asdf = pytest.importorskip("asdf", minversion=__minimum_asdf_version__)
+from asdf.tests.helpers import assert_roundtrip_tree
+
+from astropy.modeling.models import UnitsMapping
+from astropy import units as u
+
+
+def assert_model_roundtrip(model, tmpdir):
+    tree = {"model": model}
+    assert_roundtrip_tree(tree, tmpdir, tree_match_func=assert_models_equal)
+
+
+def assert_models_equal(a, b):
+    assert a.name == b.name
+    assert a.inputs == b.inputs
+    assert a.input_units == b.input_units
+    assert a.outputs == b.outputs
+    assert a.mapping == b.mapping
+    assert a.input_units_allow_dimensionless == b.input_units_allow_dimensionless
+
+    for i in a.inputs:
+        if a.input_units_equivalencies is None:
+            a_equiv = None
+        else:
+            a_equiv = a.input_units_equivalencies.get(i)
+
+        if b.input_units_equivalencies is None:
+            b_equiv = None
+        else:
+            b_equiv = b.input_units_equivalencies.get(i, None)
+
+        assert a_equiv == b_equiv
+
+
+def test_basic(tmpdir):
+    m = UnitsMapping(((u.m, u.dimensionless_unscaled),))
+    assert_model_roundtrip(m, tmpdir)
+
+
+def test_remove_units(tmpdir):
+    m = UnitsMapping(((u.m, None),))
+    with pytest.raises(ValueError, match=r"Due to a limitation in ASDF"):
+        assert_model_roundtrip(m, tmpdir)
+
+
+def test_with_equivalencies(tmpdir):
+    m = UnitsMapping(((u.m, u.dimensionless_unscaled),), input_units_equivalencies={"x": u.equivalencies.spectral()})
+    assert_model_roundtrip(m, tmpdir)
+
+
+def test_with_allow_dimensionless(tmpdir):
+    m = UnitsMapping(((u.m, u.dimensionless_unscaled), (u.s, u.Hz)), input_units_allow_dimensionless=True)
+    assert_model_roundtrip(m, tmpdir)
+
+    m = UnitsMapping(((u.m, u.dimensionless_unscaled), (u.s, u.Hz)), input_units_allow_dimensionless={"x0": True, "x1": False})
+    assert_model_roundtrip(m, tmpdir)

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1763,6 +1763,148 @@ class Model(metaclass=_ModelMeta):
         new_model._name = name
         return new_model
 
+    def coerce_units(
+        self,
+        input_units=None,
+        return_units=None,
+        input_units_equivalencies=None,
+        input_units_allow_dimensionless=False
+    ):
+        """
+        Attach units to this (unitless) model.
+
+        Parameters
+        ----------
+        input_units : dict or tuple, optional
+            Input units to attach.  If dict, each key is the name of a model input,
+            and the value is the unit to attach.  If tuple, the elements are units
+            to attach in order corresponding to `Model.inputs`.
+        return_units : dict or tuple, optional
+            Output units to attach.  If dict, each key is the name of a model output,
+            and the value is the unit to attach.  If tuple, the elements are units
+            to attach in order corresponding to `Model.outputs`.
+        input_units_equivalencies : dict, optional
+            Default equivalencies to apply to input values.  If set, this should be a
+            dictionary where each key is a string that corresponds to one of the
+            model inputs.
+        input_units_allow_dimensionless : bool or dict, optional
+            Allow dimensionless input. If this is True, input values to evaluate will
+            gain the units specified in input_units. If this is a dictionary then it
+            should map input name to a bool to allow dimensionless numbers for that
+            input.
+
+        Returns
+        -------
+        `CompoundModel`
+            A `CompoundModel` composed of the current model plus
+            `~astropy.modeling.mappings.UnitsMapping` model(s) that attach the units.
+
+        Raises
+        ------
+        ValueError
+            If the current model already has units.
+
+        Examples
+        --------
+
+        Wrapping a unitless model to require and convert units:
+
+        >>> from astropy.modeling.models import Polynomial1D
+        >>> from astropy import units as u
+        >>> poly = Polynomial1D(1, c0=1, c1=2)
+        >>> model = poly.coerce_units((u.m,), (u.s,))
+        >>> model(u.Quantity(10, u.m))  # doctest: +FLOAT_CMP
+        <Quantity 21. s>
+        >>> model(u.Quantity(1000, u.cm))  # doctest: +FLOAT_CMP
+        <Quantity 21. s>
+        >>> model(u.Quantity(10, u.cm))  # doctest: +FLOAT_CMP
+        <Quantity 1.2 s>
+
+        Wrapping a unitless model but still permitting unitless input:
+
+        >>> from astropy.modeling.models import Polynomial1D
+        >>> from astropy import units as u
+        >>> poly = Polynomial1D(1, c0=1, c1=2)
+        >>> model = poly.coerce_units((u.m,), (u.s,), input_units_allow_dimensionless=True)
+        >>> model(u.Quantity(10, u.m))  # doctest: +FLOAT_CMP
+        <Quantity 21. s>
+        >>> model(10)  # doctest: +FLOAT_CMP
+        <Quantity 21. s>
+        """
+        from .mappings import UnitsMapping
+
+        result = self
+
+        if input_units is not None:
+            if self.input_units is not None:
+                model_units = self.input_units
+            else:
+                model_units = {}
+
+            for unit in [model_units.get(i) for i in self.inputs]:
+                if unit is not None and unit != dimensionless_unscaled:
+                    raise ValueError("Cannot specify input_units for model with existing input units")
+
+            if isinstance(input_units, dict):
+                if input_units.keys() != set(self.inputs):
+                    message = (
+                        f"""input_units keys ({", ".join(input_units.keys())}) """
+                        f"""do not match model inputs ({", ".join(self.inputs)})"""
+                    )
+                    raise ValueError(message)
+                input_units = [input_units[i] for i in self.inputs]
+
+            if len(input_units) != self.n_inputs:
+                message = (
+                    "input_units length does not match n_inputs: "
+                    f"expected {self.n_inputs}, received {len(input_units)}"
+                )
+                raise ValueError(message)
+
+            mapping = tuple((unit, model_units.get(i)) for i, unit in zip(self.inputs, input_units))
+            input_mapping = UnitsMapping(
+                mapping,
+                input_units_equivalencies=input_units_equivalencies,
+                input_units_allow_dimensionless=input_units_allow_dimensionless
+            )
+            input_mapping.inputs = self.inputs
+            input_mapping.outputs = self.inputs
+            result = input_mapping | result
+
+        if return_units is not None:
+            if self.return_units is not None:
+                model_units = self.return_units
+            else:
+                model_units = {}
+
+            for unit in [model_units.get(i) for i in self.outputs]:
+                if unit is not None and unit != dimensionless_unscaled:
+                    raise ValueError("Cannot specify return_units for model with existing output units")
+
+            if isinstance(return_units, dict):
+                if return_units.keys() != set(self.outputs):
+                    message = (
+                        f"""return_units keys ({", ".join(return_units.keys())}) """
+                        f"""do not match model outputs ({", ".join(self.outputs)})"""
+                    )
+                    raise ValueError(message)
+                return_units = [return_units[i] for i in self.outputs]
+
+            if len(return_units) != self.n_outputs:
+                message = (
+                    "return_units length does not match n_outputs: "
+                    f"expected {self.n_outputs}, received {len(return_units)}"
+                )
+                raise ValueError(message)
+
+            mapping = tuple((model_units.get(i), unit) for i, unit in zip(self.outputs, return_units))
+            return_mapping = UnitsMapping(mapping)
+            return_mapping.inputs = self.outputs
+            return_mapping.outputs = self.outputs
+            result = result | return_mapping
+
+        return result
+
     @property
     def n_submodels(self):
         """

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -478,3 +478,50 @@ def test_rename_inputs_outputs():
 
     with pytest.raises(ValueError):
         g2.outputs = ("w", "e")
+
+
+def test_coerce_units():
+    model = models.Polynomial1D(1, c0=1, c1=2)
+
+    with pytest.raises(u.UnitsError):
+        model(u.Quantity(10, u.m))
+
+    with_input_units = model.coerce_units({"x": u.m})
+    result = with_input_units(u.Quantity(10, u.m))
+    assert np.isclose(result, 21.0)
+
+    with_input_units_tuple = model.coerce_units((u.m,))
+    result = with_input_units_tuple(u.Quantity(10, u.m))
+    assert np.isclose(result, 21.0)
+
+    with_return_units = model.coerce_units(return_units={"y": u.s})
+    result = with_return_units(10)
+    assert np.isclose(result.value, 21.0)
+    assert result.unit == u.s
+
+    with_return_units_tuple = model.coerce_units(return_units=(u.s,))
+    result = with_return_units_tuple(10)
+    assert np.isclose(result.value, 21.0)
+    assert result.unit == u.s
+
+    with_both = model.coerce_units({"x": u.m}, {"y": u.s})
+
+    result = with_both(u.Quantity(10, u.m))
+    assert np.isclose(result.value, 21.0)
+    assert result.unit == u.s
+
+    with pytest.raises(ValueError, match=r"input_units keys.*do not match model inputs"):
+        model.coerce_units({"q": u.m})
+
+    with pytest.raises(ValueError, match=r"input_units length does not match n_inputs"):
+        model.coerce_units((u.m, u.s))
+
+    model_with_existing_input_units = models.BlackBody()
+    with pytest.raises(ValueError, match=r"Cannot specify input_units for model with existing input units"):
+        model_with_existing_input_units.coerce_units({"x": u.m})
+
+    with pytest.raises(ValueError, match=r"return_units keys.*do not match model outputs"):
+        model.coerce_units(return_units={"q": u.m})
+
+    with pytest.raises(ValueError, match=r"return_units length does not match n_outputs"):
+        model.coerce_units(return_units=(u.m, u.s))

--- a/astropy/modeling/tests/test_units_mapping.py
+++ b/astropy/modeling/tests/test_units_mapping.py
@@ -1,0 +1,115 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
+import numpy as np
+
+from astropy import units as u
+from astropy.units import Quantity, UnitsError, equivalencies
+from astropy.modeling.models import UnitsMapping
+
+
+def test_properties():
+    model = UnitsMapping(((u.dimensionless_unscaled, u.m), (u.dimensionless_unscaled, u.s)))
+    assert model.n_inputs == 2
+    assert model.n_outputs == 2
+    assert model.inputs == ("x0", "x1")
+    assert model.outputs == ("x0", "x1")
+    assert model.input_units == {"x0": u.dimensionless_unscaled, "x1": u.dimensionless_unscaled}
+    assert model.mapping == ((u.dimensionless_unscaled, u.m), (u.dimensionless_unscaled, u.s))
+
+
+def test_add_units():
+    model = UnitsMapping(((u.dimensionless_unscaled, u.m),))
+
+    for value in [10, Quantity(10), np.arange(10), Quantity(np.arange(10))]:
+        result = model(value)
+        assert isinstance(result, Quantity)
+        assert np.all(result.value == value)
+        assert result.unit == u.m
+
+    with pytest.raises(UnitsError):
+        model(Quantity(10, u.s))
+
+
+def test_remove_units():
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),))
+
+    result = model(Quantity(10, u.m))
+    assert isinstance(result, Quantity)
+    assert result.value == 10
+    assert result.unit == u.dimensionless_unscaled
+
+    result = model(Quantity(1000, u.cm))
+    assert isinstance(result, Quantity)
+    assert result.value == 10
+    assert result.unit == u.dimensionless_unscaled
+
+    with pytest.raises(UnitsError):
+        model(10)
+
+    with pytest.raises(UnitsError):
+        model(Quantity(10))
+
+
+def test_remove_quantity():
+    model = UnitsMapping(((u.m, None),))
+
+    result = model(Quantity(10, u.m))
+    assert result == 10
+
+    result = model(Quantity(1000, u.cm))
+    assert result == 10
+
+    with pytest.raises(UnitsError):
+        model(10)
+
+    with pytest.raises(UnitsError):
+        model(Quantity(10))
+
+    # The model shouldn't allow a mixture of None and non-None
+    # output units.
+    with pytest.raises(ValueError, match=r"If one return unit is None, then all must be None"):
+        UnitsMapping(((u.m, None), (u.s, u.dimensionless_unscaled)))
+
+
+def test_equivalencies():
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),))
+
+    with pytest.raises(UnitsError):
+        model(Quantity(100, u.Hz))
+
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),), input_units_equivalencies={"x": equivalencies.spectral()})
+
+    result = model(Quantity(100, u.Hz))
+    assert result.unit == u.dimensionless_unscaled
+
+
+def test_allow_dimensionless():
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),))
+
+    with pytest.raises(UnitsError):
+        model(10)
+
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),), input_units_allow_dimensionless=True)
+    result = model(10)
+    assert isinstance(result, Quantity)
+    assert result.value == 10
+    assert result.unit == u.dimensionless_unscaled
+
+
+def test_custom_inputs_and_outputs():
+    model = UnitsMapping(((u.m, u.dimensionless_unscaled),))
+
+    model.inputs = ("foo",)
+    model.outputs = ("bar",)
+
+    assert model.inputs == ("foo",)
+    assert model.input_units == {"foo": u.m}
+    assert model.outputs == ("bar",)
+
+
+def test_repr():
+    model = UnitsMapping(((u.m, None),))
+    assert repr(model) == """<UnitsMapping(((Unit("m"), None),))>"""
+
+    model = UnitsMapping(((u.m, None),), name="foo")
+    assert repr(model) == """<UnitsMapping(((Unit("m"), None),), name='foo')>"""

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -16,3 +16,5 @@ In particular, this release includes:
    `WCS Paper III <https://www.atnf.csiro.au/people/mcalabre/WCS/scs.pdf>`__ .
    In particular, ``astropy.wcs`` will be able to support ``-TAB`` in WCS if
    already defined in the ``astropy.io.fits.HDUList`` object.
+
+2. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

I'm opening this PR for discussion, but it isn't complete -- I'll need to write unit tests at least.

This is an idea for supporting units on unitless models, which would address #7840 and #8923.  I've introduced a `UnitsMapping` model which coerces the units of its input into the specified units (without conversion) and a `Model.coerce_units` method that adds input and return units to a unitless model by sandwiching it between `UnitsMapping` instances.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

EDIT:
Fix #7840
Fix #8923