### PR TITLE
Allow reading ASCII table with duplicate column names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 - Functional Units can now be processed in CDS-tables. [#9971]
 
+- Allow reading in ASCII tables which have duplicate column names. [#9939]
+
 - Added type validation of key arguments in calls to ``io.ascii.read()`` and
   ``io.ascii.write()`` functions. [#10005]
 
@@ -278,9 +280,6 @@ astropy.extern
 
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
-
-- Allow reading in ASCII tables which have duplicate column names.  In this
-  case a warning is issued and the names are adjusted to be unique. [#9939]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,6 +279,9 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Allow reading in ASCII tables which have duplicate column names.  In this
+  case a warning is issued and the names are adjusted to be unique. [#9939]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1037,23 +1037,16 @@ def _deduplicate_names(names):
     """
     new_names = []
     existing_names = set()
-    duplicate_names = set()
 
     for name in names:
         orig_name = name
         i = 1
         while name in existing_names:
-            duplicate_names.add(orig_name)
             # Iterate until a unique name is found
             name = orig_name + '_' + str(i)
             i += 1
         new_names.append(name)
         existing_names.add(name)
-
-    if duplicate_names:
-        duplicate_names = ', '.join(f"'{name}'" for name in duplicate_names)
-        warnings.warn(f'Duplicate column name(s) {duplicate_names} found, '
-                      f'replacing with unique names', AstropyWarning)
 
     return new_names
 

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -309,7 +309,7 @@ cdef class CParser:
         self.tokenizer.source = self.source_bytes
         self.tokenizer.source_len = <size_t>len(self.source_bytes)
 
-    def read_header(self):
+    def read_header(self, deduplicate=True):
         self.tokenizer.source_pos = 0
 
         # header_start is a valid line number
@@ -334,6 +334,8 @@ cdef class CParser:
                 else:
                     name += chr(c)
             self.width = <int>len(self.header_names)
+            if deduplicate:
+                self.header_names = core._deduplicate_names(self.header_names)
 
         else:
             # Get number of columns from first data row

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -138,7 +138,9 @@ class FastBasic(metaclass=core.MetaBaseReader):
         meta = OrderedDict()
         if comments:
             meta['comments'] = comments
-        return Table(data, names=list(self.engine.get_names()), meta=meta)
+
+        names = core._deduplicate_names(self.engine.get_names())
+        return Table(data, names=names, meta=meta)
 
     def check_header(self):
         names = self.engine.get_header_names() or self.engine.get_names()
@@ -270,7 +272,8 @@ class FastCommentedHeader(FastBasic):
             if not meta['comments']:
                 del meta['comments']
 
-        return Table(data, names=list(self.engine.get_names()), meta=meta)
+        names = core._deduplicate_names(self.engine.get_names())
+        return Table(data, names=names, meta=meta)
 
     def _read_header(self):
         tmp = self.engine.source
@@ -331,7 +334,7 @@ class FastRdb(FastBasic):
         # tokenize the two header lines separately
         self.engine.setup_tokenizer([line2])
         self.engine.header_start = 0
-        self.engine.read_header()
+        self.engine.read_header(deduplicate=False)
         types = self.engine.get_names()
         self.engine.setup_tokenizer([line1])
         self.engine.set_names([])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1527,8 +1527,7 @@ def test_deduplicate_names_basic(rdb, fast_reader):
     if rdb:
         lines = ['\t'.join(line.split()) for line in lines]
 
-    with pytest.warns(AstropyWarning, match='Duplicate'):
-        dat = ascii.read(lines, fast_reader=fast_reader)
+    dat = ascii.read(lines, fast_reader=fast_reader)
     assert dat.colnames == ['a', 'a_2', 'a_1', 'a_3', 'a_4']
 
     with ExitStack() as stack:
@@ -1537,18 +1536,16 @@ def test_deduplicate_names_basic(rdb, fast_reader):
         if rdb is True and fast_reader == 'force':
             stack.enter_context(pytest.raises(AssertionError))
 
-        with pytest.warns(AstropyWarning, match='Duplicate'):
-            dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
+        dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
         assert len(dat) == 2
         assert dat.colnames == ['a', 'a_2', 'a_3']
         assert np.all(dat['a'] == [1, 10])
         assert np.all(dat['a_2'] == [2, 20])
         assert np.all(dat['a_3'] == [4, 40])
 
-        with pytest.warns(AstropyWarning, match='Duplicate'):
-            dat = ascii.read(lines, fast_reader=fast_reader,
-                             names=['b1', 'b2', 'b3', 'b4', 'b5'],
-                             include_names=['b1', 'b2', 'b4'])
+        dat = ascii.read(lines, fast_reader=fast_reader,
+                         names=['b1', 'b2', 'b3', 'b4', 'b5'],
+                         include_names=['b1', 'b2', 'b4'])
         assert len(dat) == 2
         assert dat.colnames == ['b1', 'b2', 'b4']
         assert np.all(dat['b1'] == [1, 10])

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1526,8 +1526,8 @@ def _get_lines(rdb):
 @pytest.mark.parametrize('fast_reader', [False, 'force'])
 def test_deduplicate_names_basic(rdb, fast_reader):
     """Test that duplicate column names are successfully de-duplicated for the
-    basic format.  Skip the case of rdb=True and fast_reader='force' since that
-    fails and is tested below.
+    basic format.  Skip the case of rdb=True and fast_reader='force' when selecting
+    include_names, since that fails and is tested below.
     """
     lines = _get_lines(rdb)
 
@@ -1553,9 +1553,23 @@ def test_deduplicate_names_basic(rdb, fast_reader):
         assert np.all(dat['b4'] == [4, 40])
 
 
+
+
 @pytest.mark.xfail
-def test_deduplicate_names_rdb_fast_fail1():
-    """Test that duplicate column names fail for the rdb format for fast reader.
+def test_include_names_rdb_fast_fail0():
+    """Test that selecting column names with `include_names` fails for the rdb format for fast reader.
+    This is not desired but reflects a current known limitation.
+    """
+    lines = _get_lines(True)
+    lines[0] = 'a\ta_2\ta_1\ta_3\ta_4'
+
+    dat = ascii.read(lines, fast_reader='force', include_names=['a', 'a_2', 'a_3'])
+    assert len(dat) == 2
+
+
+@pytest.mark.xfail
+def test_include_names_rdb_fast_fail1():
+    """Test that `include_names` fails with duplicate column names for the rdb format for fast reader.
     This is not desired but reflects a current known limitation.
     """
     lines = _get_lines(True)
@@ -1565,8 +1579,8 @@ def test_deduplicate_names_rdb_fast_fail1():
 
 
 @pytest.mark.xfail
-def test_deduplicate_names_rdb_fast_fail2():
-    """Test that duplicate column names fail for the rdb format for fast reader.
+def test_include_names_rdb_fast_fail2():
+    """Test that `include_names` fails with duplicate column names for the rdb format for fast reader.
     This is not desired but reflects a current known limitation.
     """
     lines = _get_lines(True)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -8,6 +8,8 @@ from collections import OrderedDict
 import locale
 import platform
 from io import StringIO
+from contextlib import ExitStack
+import warnings
 
 import pathlib
 import pytest
@@ -1509,3 +1511,46 @@ def test_kwargs_dict_guess(enable):
     for k in get_read_trace():
         if not k.get('status', 'Disabled').startswith('Disabled'):
             assert k.get('kwargs').get('fast_reader').get('enable') is enable
+
+
+@pytest.mark.parametrize('rdb', [False, True])
+@pytest.mark.parametrize('fast_reader', [False, 'force'])
+def test_deduplicate_names_basic(rdb, fast_reader):
+    """Test that duplicate column names are successfully de-duplicated for the
+    basic format.
+    """
+    lines = ['a a_2 a_1 a a']
+    if rdb:
+        lines += ['N N N N N']
+    lines += ['1 2 3 4 5', '10 20 30 40 50']
+
+    if rdb:
+        lines = ['\t'.join(line.split()) for line in lines]
+
+    with pytest.warns(AstropyWarning, match='Duplicate'):
+        dat = ascii.read(lines, fast_reader=fast_reader)
+    assert dat.colnames == ['a', 'a_2', 'a_1', 'a_3', 'a_4']
+
+    with ExitStack() as stack:
+        # include_names doesn't work for the fast_reader and RDB (even for unique
+        # colnames), so expect an exception in this case.
+        if rdb is True and fast_reader == 'force':
+            stack.enter_context(pytest.raises(AssertionError))
+
+        with pytest.warns(AstropyWarning, match='Duplicate'):
+            dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
+        assert len(dat) == 2
+        assert dat.colnames == ['a', 'a_2', 'a_3']
+        assert np.all(dat['a'] == [1, 10])
+        assert np.all(dat['a_2'] == [2, 20])
+        assert np.all(dat['a_3'] == [4, 40])
+
+        with pytest.warns(AstropyWarning, match='Duplicate'):
+            dat = ascii.read(lines, fast_reader=fast_reader,
+                             names=['b1', 'b2', 'b3', 'b4', 'b5'],
+                             include_names=['b1', 'b2', 'b4'])
+        assert len(dat) == 2
+        assert dat.colnames == ['b1', 'b2', 'b4']
+        assert np.all(dat['b1'] == [1, 10])
+        assert np.all(dat['b2'] == [2, 20])
+        assert np.all(dat['b4'] == [4, 40])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to allow reading ASCII tables with duplicate column names.  The strategy is the same s for adding a duplicate column name to a Table, namely adding `_<N>` to a duplicate name for increasing `N` until it is no longer a duplicate.

Ideally one might want to issue a warning in the case that duplicate column names were munged, and the first commit of this PR does that.  Unfortunately one runs into a situation that I can't figure out how to resolve: while guessing the file format one might end up generating a spurious warning.  This specifically happened in testing for a CDS file with a sentence at the top that had two instances of the word `of`.  During guessing this first line was interpreted as duplicate column names and emitted the warning.  So we have a choice between:

1. No warnings for duplicate column names
2. Possible spurious warnings for duplicates in some situations, in particular reading CDS files

The 2nd commit removed warnings, and that would be my preference, but this can go either way.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8471
