### PR TITLE
Fix serialization of polynomials; improve documentation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -503,8 +503,6 @@ astropy.io.misc
 
 - Fixed serialization of Time objects with location under time-1.0.0
   ASDF schema. [#9983]
-- Fixed serialization of polynomial models to include non default values of
-  domain and window values. [#9941]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
@@ -553,9 +551,6 @@ astropy.modeling
 
 - Fixed a bug in setting default values of parameters of orthonormal
   polynomials when constructing a model set. [#9987]
-- Improvements to documentation clearing up how domain and window attributes are
-  used for polynomials; added domain and window attributes to repr and str. Fixed
-  bug with _format_repr in core.py. [#9941]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,9 @@ astropy.modeling
 - Added ``UnitsMapping`` model and ``Model.coerce_units`` to support units on otherwise
   unitless models. [#9936]
 
+- Added ``domain`` and ``window`` attributes to ``repr`` and ``str``. Fixed bug with
+  ``_format_repr`` in core.py. [#9941]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 
@@ -500,6 +503,8 @@ astropy.io.misc
 
 - Fixed serialization of Time objects with location under time-1.0.0
   ASDF schema. [#9983]
+- Fixed serialization of polynomial models to include non default values of
+  domain and window values. [#9941]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
@@ -548,6 +553,9 @@ astropy.modeling
 
 - Fixed a bug in setting default values of parameters of orthonormal
   polynomials when constructing a model set. [#9987]
+- Improvements to documentation clearing up how domain and window attributes are
+  used for polynomials; added domain and window attributes to repr and str. Fixed
+  bug with _format_repr in core.py. [#9941]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -13,7 +13,7 @@ __all__ = ['TransformType', 'IdentityType', 'ConstantType']
 
 
 class TransformType(AstropyAsdfType):
-    version = '1.1.0'
+    version = '1.2.0'
     requires = ['astropy']
 
     @classmethod

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -145,8 +145,11 @@ def test_generic_projections(tmpdir):
             'backward': util.resolve_name(
                 f'astropy.modeling.projections.Pix2Sky_{name}')()
         }
-
-        helpers.assert_roundtrip_tree(tree, tmpdir)
+        with warnings.catch_warnings():
+            # Some schema files are missing from asdf<=2.4.2 which causes warnings
+            if LooseVersion(asdf.__version__) <= '2.5.1':
+                warnings.filterwarnings('ignore', 'Unable to locate schema file')
+            helpers.assert_roundtrip_tree(tree, tmpdir)
 
 
 def test_tabular_model(tmpdir):

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2293,7 +2293,7 @@ class Model(metaclass=_ModelMeta):
             parts.append('name={0!r}'.format(self.name))
 
         for kwarg, value in kwargs.items():
-            if kwarg in defaults and defaults[kwarg] != value:
+            if kwarg in defaults and defaults[kwarg] == value:
                 continue
             parts.append('{0}={1!r}'.format(kwarg, value))
 

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 """
 This module contains models representing polynomials and polynomial series.
+
 """
 # pylint: disable=invalid-name
 import numpy as np
@@ -332,7 +333,7 @@ class Chebyshev1D(PolynomialModel):
         degree of the series
     domain : list or None, optional
     window : list or None, optional
-        If None, it is set to [-1,1]
+        If None, it is set to [-1, 1]
         Fitters will remap the domain to this window
     **params : dict
         keyword : value pairs, representing parameter_name: value
@@ -352,13 +353,26 @@ class Chebyshev1D(PolynomialModel):
 
     _separable = True
 
-    def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
+    def __init__(self, degree, domain=None, window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
+        if window is None:
+            window = [-1, 1]
         self.window = window
         super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.degree],
+                                 kwargs={'domain': self.domain, 'window': self.window},
+                                 defaults={'domain': None, 'window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('Degree', self.degree),
+             ('Domain', self.domain),
+             ('Window', self.window)])
 
     def fit_deriv(self, x, *params):
         """
@@ -441,7 +455,7 @@ class Hermite1D(PolynomialModel):
         degree of the series
     domain : list or None, optional
     window : list or None, optional
-        If None, it is set to [-1,1]
+        If None, it is set to [-1, 1]
         Fitters will remap the domain to this window
     **params : dict
         keyword : value pairs, representing parameter_name: value
@@ -461,13 +475,27 @@ class Hermite1D(PolynomialModel):
 
     _separable = True
 
-    def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
+    def __init__(self, degree, domain=None, window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
+        if window is None:
+            window = [-1, 1]
         self.window = window
         super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.degree],
+                                 kwargs={'domain': self.domain, 'window': self.window},
+                                 defaults={'domain': None, 'window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('Degree', self.degree),
+             ('Domain', self.domain),
+             ('Window', self.window)])
+
 
     def fit_deriv(self, x, *params):
         """
@@ -555,8 +583,12 @@ class Hermite2D(OrthoPolynomialBase):
         domain of the y independent variable
     x_window : list or None, optional
         range of the x independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
     y_window : list or None, optional
         range of the y independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
     **params : dict
         keyword: value pairs, representing parameter_name: value
 
@@ -572,13 +604,38 @@ class Hermite2D(OrthoPolynomialBase):
     """
     _separable = False
 
-    def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
-                 y_domain=None, y_window=[-1, 1], n_models=None,
+    def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
+                 y_domain=None, y_window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
+        if x_window is None:
+            x_window = [-1, 1]
+        if y_window is None:
+            y_window = [-1, 1]
         super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
             model_set_axis=model_set_axis, name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.x_degree, self.y_degree],
+                                 kwargs={'x_domain': self.x_domain,
+                                         'y_domain': self.y_domain,
+                                         'x_window': self.x_window,
+                                         'y_window': self.y_window},
+                                 defaults={'x_domain': None,
+                                           'y_domain': None,
+                                           'x_window': [-1, 1],
+                                           'y_window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('X_Degree', self.x_degree),
+             ('Y_Degree', self.y_degree),
+             ('X_Domain', self.x_domain),
+             ('Y_Domain', self.y_domain),
+             ('X_Window', self.x_window),
+             ('Y_Window', self.y_window)])
+
 
     def _fcache(self, x, y):
         """
@@ -677,7 +734,7 @@ class Legendre1D(PolynomialModel):
         degree of the series
     domain : list or None, optional
     window : list or None, optional
-        If None, it is set to [-1,1]
+        If None, it is set to [-1, 1]
         Fitters will remap the domain to this window
     **params : dict
         keyword: value pairs, representing parameter_name: value
@@ -699,13 +756,27 @@ class Legendre1D(PolynomialModel):
 
     _separable = True
 
-    def __init__(self, degree, domain=None, window=[-1, 1], n_models=None,
+    def __init__(self, degree, domain=None, window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
         self.domain = domain
+        if window is None:
+            window = [-1, 1]
         self.window = window
         super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.degree],
+                                 kwargs={'domain': self.domain, 'window': self.window},
+                                 defaults={'domain': None, 'window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('Degree', self.degree),
+             ('Domain', self.domain),
+             ('Window', self.window)])
+
 
     def prepare_inputs(self, x, **kwargs):
         inputs, format_info = super().prepare_inputs(x, **kwargs)
@@ -783,6 +854,7 @@ class Polynomial1D(PolynomialModel):
     degree : int
         degree of the series
     domain : list or None, optional
+        If None, it is set to [-1, 1]
     window : list or None, optional
         If None, it is set to [-1, 1]
         Fitters will remap the domain to this window
@@ -796,13 +868,28 @@ class Polynomial1D(PolynomialModel):
 
     _separable = True
 
-    def __init__(self, degree, domain=[-1, 1], window=[-1, 1], n_models=None,
+    def __init__(self, degree, domain=None, window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
+        if domain is None:
+            domain = [-1, 1]
+        if window is None:
+            window = [-1, 1]
         self.domain = domain
         self.window = window
         super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
+
+    def __repr__(self):
+        return self._format_repr([self.degree],
+                                 kwargs={'domain': self.domain, 'window': self.window},
+                                 defaults={'domain': [-1, 1], 'window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('Degree', self.degree),
+             ('Domain', self.domain),
+             ('Window', self.window)])
 
     def prepare_inputs(self, x, **kwargs):
         inputs, format_info = super().prepare_inputs(x, **kwargs)
@@ -886,12 +973,18 @@ class Polynomial2D(PolynomialModel):
         the number of terms is degree+1
     x_domain : list or None, optional
         domain of the x independent variable
+        If None, it is set to [-1, 1]
     y_domain : list or None, optional
         domain of the y independent variable
+        If None, it is set to [-1, 1]
     x_window : list or None, optional
         range of the x independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the x_domain to x_window
     y_window : list or None, optional
         range of the y independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the y_domain to y_window
     **params : dict
         keyword: value pairs, representing parameter_name: value
     """
@@ -901,16 +994,24 @@ class Polynomial2D(PolynomialModel):
 
     _separable = False
 
-    def __init__(self, degree, x_domain=[-1, 1], y_domain=[-1, 1],
-                 x_window=[-1, 1], y_window=[-1, 1], n_models=None,
+    def __init__(self, degree, x_domain=None, y_domain=None,
+                 x_window=None, y_window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
         super().__init__(
             degree, n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)
-        self.x_domain = x_domain
-        self.y_domain = y_domain
-        self.x_window = x_window
-        self.y_window = y_window
+
+        self._default_domain_window = {
+            'x_domain': [-1, 1],
+            'y_domain': [-1, 1],
+            'x_window': [-1, 1],
+            'y_window':  [-1, 1]
+            }
+
+        self.x_domain = (x_domain or self._default_domain_window['x_domain'])
+        self.y_domain = (y_domain or self._default_domain_window['y_domain'])
+        self.x_window = (x_window or self._default_domain_window['x_window'])
+        self.y_window = (y_window or self._default_domain_window['y_window'])
 
     def prepare_inputs(self, x, y, **kwargs):
 
@@ -940,6 +1041,22 @@ class Polynomial2D(PolynomialModel):
                 result = new_result
 
         return result
+
+    def __repr__(self):
+        return self._format_repr([self.degree],
+                                 kwargs={'x_domain': self.x_domain,
+                                         'y_domain': self.y_domain,
+                                         'x_window': self.x_window,
+                                         'y_window': self.y_window},
+                                 defaults=self._default_domain_window)
+
+    def __str__(self):
+        return self._format_str(
+            [('Degree', self.degree),
+             ('X_Domain', self.x_domain),
+             ('Y_Domain', self.y_domain),
+             ('X_Window', self.x_window),
+             ('Y_Window', self.y_window)])
 
     def fit_deriv(self, x, y, *params):
         """
@@ -1062,8 +1179,13 @@ class Chebyshev2D(OrthoPolynomialBase):
         domain of the y independent variable
     x_window : list or None, optional
         range of the x independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
     y_window : list or None, optional
         range of the y independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
+
     **params : dict
         keyword: value pairs, representing parameter_name: value
 
@@ -1079,9 +1201,14 @@ class Chebyshev2D(OrthoPolynomialBase):
     """
     _separable = False
 
-    def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
-                 y_domain=None, y_window=[-1, 1], n_models=None,
+    def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
+                 y_domain=None, y_window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
+        if x_window is None:
+            x_window = [-1, 1]
+        if y_window is None:
+            y_window = [-1, 1]
+
         super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
@@ -1105,6 +1232,26 @@ class Chebyshev2D(OrthoPolynomialBase):
         for n in range(x_terms + 2, x_terms + y_terms):
             kfunc[n] = 2 * y * kfunc[n - 1] - kfunc[n - 2]
         return kfunc
+
+    def __repr__(self):
+        return self._format_repr([self.x_degree, self.y_degree],
+                                 kwargs={'x_domain': self.x_domain,
+                                         'y_domain': self.y_domain,
+                                         'x_window': self.x_window,
+                                         'y_window': self.y_window},
+                                 defaults={'x_domain': None,
+                                           'y_domain': None,
+                                           'x_window': [-1, 1],
+                                           'y_window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('X_Degree', self.x_degree),
+             ('Y_Degree', self.y_degree),
+             ('X_Domain', self.x_domain),
+             ('Y_Domain', self.y_domain),
+             ('X_Window', self.x_window),
+             ('Y_Window', self.y_window)])
 
     def fit_deriv(self, x, y, *params):
         """
@@ -1189,8 +1336,12 @@ class Legendre2D(OrthoPolynomialBase):
         domain of the y independent variable
     x_window : list or None, optional
         range of the x independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
     y_window : list or None, optional
         range of the y independent variable
+        If None, it is set to [-1, 1]
+        Fitters will remap the domain to this window
     **params : dict
         keyword: value pairs, representing parameter_name: value
 
@@ -1213,9 +1364,14 @@ class Legendre2D(OrthoPolynomialBase):
     """
     _separable = False
 
-    def __init__(self, x_degree, y_degree, x_domain=None, x_window=[-1, 1],
-                 y_domain=None, y_window=[-1, 1], n_models=None,
+    def __init__(self, x_degree, y_degree, x_domain=None, x_window=None,
+                 y_domain=None, y_window=None, n_models=None,
                  model_set_axis=None, name=None, meta=None, **params):
+        if x_window is None:
+            x_window = [-1, 1]
+        if y_window is None:
+            y_window = [-1, 1]
+
         super().__init__(
             x_degree, y_degree, x_domain=x_domain, y_domain=y_domain,
             x_window=x_window, y_window=y_window, n_models=n_models,
@@ -1241,6 +1397,26 @@ class Legendre2D(OrthoPolynomialBase):
             kfunc[n + x_terms] = ((2 * (n - 1) + 1) * y * kfunc[n + x_terms - 1] -
                                   (n - 1) * kfunc[n + x_terms - 2]) / (n)
         return kfunc
+
+    def __repr__(self):
+        return self._format_repr([self.x_degree, self.y_degree],
+                                 kwargs={'x_domain': self.x_domain,
+                                         'y_domain': self.y_domain,
+                                         'x_window': self.x_window,
+                                         'y_window': self.y_window},
+                                 defaults={'x_domain': None,
+                                           'y_domain': None,
+                                           'x_window': [-1, 1],
+                                           'y_window': [-1, 1]})
+
+    def __str__(self):
+        return self._format_str(
+            [('X_Degree', self.x_degree),
+             ('Y_Degree', self.y_degree),
+             ('X_Domain', self.x_domain),
+             ('Y_Domain', self.y_domain),
+             ('X_Window', self.x_window),
+             ('Y_Window', self.y_window)])
 
     def fit_deriv(self, x, y, *params):
         """

--- a/docs/modeling/example-fitting-model-sets.rst
+++ b/docs/modeling/example-fitting-model-sets.rst
@@ -77,6 +77,8 @@ Now inspect the model::
     Outputs: ('y',)
     Model set size: 12
     Degree: 1
+    Domain: [-1, 1]
+    Window: [-1, 1]
     Parameters:
                  c0                 c1
         ------------------- ------------------


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the fact that previously orthonormal polynomials were not serialized with necessary information about domain or window if those attributes were not the defaults

Documentation was improved to clarify the meaning of the domain and window keywords and attributes of polynomials since there is evident confusion about how they are applied.

The  repr output now includes the values for domain and window if not default values and str does as well if not None.

Previously the polynomial constructors used default lists for some of the values of domain and window, which is generally discouraged. These have been replaced with None and a check for None in the constructor is used to set the value to a list. A future PR will change the usage to tuple because it is planned to back port this PR, and making that change now would break the API for a bugfix.

This PR replaces #9906
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9809 #9795 
