### PR TITLE
Fix bug with undefined pkg_config in io.fits' setup_package

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -18,11 +18,12 @@ def _get_compression_extension():
 
     cfg = defaultdict(list)
     cfg['include_dirs'].append(numpy.get_include())
-    cfg['sources'].append(os.path.join(os.path.dirname(__file__), 'src', 'compressionmodule.c'))
+    cfg['sources'].append(os.path.join(os.path.dirname(__file__),
+                                       'src', 'compressionmodule.c'))
 
     if (int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or
             int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
-        cfg.update(setup_helpers.pkg_config(['cfitsio'], ['cfitsio']))
+        cfg.update(pkg_config(['cfitsio'], ['cfitsio']))
     else:
         if get_compiler() == 'msvc':
             # These come from the CFITSIO vcc makefile, except the last


### PR DESCRIPTION
Following the migration to `extension_helpers`, `setup_helpers.pkg_config` is used though this should be `pkg_config` which is imported previously at the top of the file.
~~Not sure why linux packagers did not come into this issue?~~ Forgot that this is not released yet.