### PR TITLE
Fix for #9932 by checking for collections.abc.Sequence in units.quantity_decorator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -399,6 +399,11 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Fix for ``quantity_input`` annotation raising an exception on iterable
+  types that don't define a general ``__contains__`` for checking if ``None``
+  is contained (e.g. Enum as of python3.8), by instead checking for instance of
+  Sequence. [#9948]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -3,9 +3,9 @@
 
 __all__ = ['quantity_input']
 
+from collections.abc import Sequence
 import inspect
 from astropy.utils.decorators import wraps
-from astropy.utils.misc import isiterable
 
 from .core import Unit, UnitBase, UnitsError, add_enabled_equivalencies
 from .physical import _unit_physical_mapping
@@ -204,7 +204,7 @@ class QuantityInput:
                 #   were specified in the decorator/annotation, or whether a
                 #   single string (unit or physical type) or a Unit object was
                 #   specified
-                if isinstance(targets, str) or not isiterable(targets):
+                if isinstance(targets, str) or not isinstance(targets, Sequence):
                     valid_targets = [targets]
 
                 # Check for None in the supplied list of allowed units and, if

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -222,3 +222,17 @@ def test_return_annotation_none():
 
     solarx = myfunc_args(1*u.arcsec)
     assert solarx is None
+
+
+def test_enum_annotation():
+    # Regression test for gh-9932
+    from enum import Enum, auto
+
+    class BasicEnum(Enum):
+        AnOption = auto()
+
+    @u.quantity_input
+    def myfunc_args(a: BasicEnum, b: u.arcsec) -> None:
+        pass
+
+    myfunc_args(BasicEnum.AnOption, 1*u.arcsec)


### PR DESCRIPTION

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->
It is checked if an object is a Sequence rather than simply iterable. I would expect a sequence of types to be provided in a list or tuple, whereas objects like Enum are also iterable, but can't hold multiple types for checking here. Added test for Enum case.

Tested in clean venvs on 3.8 and 3.7

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9932 
