### PR TITLE
Fixed overwriting bug in HDF5 tables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -350,6 +350,10 @@ astropy.io.misc
 
 - Fixed serialization of polynomial models to include non default values of
   domain and window values. [#9956]
+- Fixed a bug which affected overwriting tables within ``hdf5`` files.
+  Overwriting an existing path with associated column meta data now also
+  overwrites the meta data associated with the table. [#9950]
+
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/misc/hdf5.py
+++ b/astropy/io/misc/hdf5.py
@@ -317,6 +317,8 @@ def write_table_hdf5(table, output, path=None, compression=False,
         if append and overwrite:
             # Delete only the dataset itself
             del output_group[name]
+            if serialize_meta and name + '.__table_column_meta__' in output_group:
+                del output_group[name + '.__table_column_meta__']
         else:
             raise OSError(f"Table {path} already exists")
 


### PR DESCRIPTION
### Description

Overwriting a table within a HDF5 file is achieved by setting `append=True` and `overwrite=True`. 
However, if the table was written with the option `serialize_meta=True`, attempting to overwrite the 
table causes an error because the node which contains the meta data is not removed.

The error is reproduced by the following example code:

    from astropy import table

    t = table.Table([[1, 2, 3]])
    t.write('test_file.hdf5', path='data', overwrite=True, serialize_meta=True)
    t.write('test_file.hdf5', path='data', overwrite=True, append=True, serialize_meta=True)

The expected behaviour is that both the table in path `data` and its meta data, which is recorded at 
the path `data.__table_column_meta__`, should be overwritten. This was achieved by adding a 
conditional, after deleting `data` from the output_group, which checks if the `serialize_meta` option 
is set to `True` and if a path with the meta data is already present. If it evaluates to `True`, then the 
column meta data is also removed from `output_group`.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
