### PR TITLE
Add tags for Gaussian1D and Gaussian2D models. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ astropy.io.ascii
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
+- Added 'functional_models.py' to asdf/tags/transform. Added tags for Gaussian1D and Gaussian2D models to allow serialization. [#9959]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -22,6 +22,7 @@ from .tags.time.time import *
 from .tags.time.timedelta import *
 from .tags.transform.basic import *
 from .tags.transform.compound import *
+from .tags.transform.functional_models import *
 from .tags.transform.math import *
 from .tags.transform.polynomial import *
 from .tags.transform.projections import *

--- a/astropy/io/misc/asdf/tags/transform/functional_models.py
+++ b/astropy/io/misc/asdf/tags/transform/functional_models.py
@@ -1,0 +1,82 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+
+from numpy.testing import assert_array_equal
+
+from asdf import yamlutil
+
+from astropy.modeling import functional_models
+from .basic import TransformType
+from . import _parameter_to_value
+
+
+__all__ = ['Gaussian1DType', 'Gaussian2DType']
+
+
+class Gaussian1DType(TransformType):
+    name = "transform/gaussian1d"
+    version = '1.0.0'
+    types = ['astropy.modeling.functional_models.Gaussian1D']
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return functional_models.Gaussian1D(amplitude=node['amplitude'],
+                                            mean=node['mean'],
+                                            stddev=node['stddev'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'amplitude': _parameter_to_value(model.amplitude),
+                'mean': _parameter_to_value(model.mean),
+                'stddev': _parameter_to_value(model.stddev)}
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+    @classmethod
+    def assert_equal(cls, a, b):
+        # TODO: If models become comparable themselves, remove this.
+        TransformType.assert_equal(a, b)
+        assert (isinstance(a, functional_models.Gaussian1D) and
+                isinstance(b, functional_models.Gaussian1D))
+        assert_array_equal(a.amplitude, b.amplitude)
+        assert_array_equal(a.mean, b.mean)
+        assert_array_equal(a.stddev, b.stddev)
+
+
+class Gaussian2DType(TransformType):
+    name = "transform/gaussian2d"
+    version = '1.0.0'
+    types = ['astropy.modeling.functional_models.Gaussian2D']
+
+    @classmethod
+    def from_tree_transform(cls, node, ctx):
+        return functional_models.Gaussian2D(amplitude=node['amplitude'],
+                                            x_mean=node['x_mean'],
+                                            y_mean=node['y_mean'],
+                                            x_stddev=node['x_stddev'],
+                                            y_stddev=node['y_stddev'],
+                                            theta=node['theta'])
+
+    @classmethod
+    def to_tree_transform(cls, model, ctx):
+        node = {'amplitude': _parameter_to_value(model.amplitude),
+                'x_mean': _parameter_to_value(model.x_mean),
+                'y_mean': _parameter_to_value(model.y_mean),
+                'x_stddev': _parameter_to_value(model.x_stddev),
+                'y_stddev': _parameter_to_value(model.y_stddev),
+                'theta': _parameter_to_value(model.theta)
+                }
+
+        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+
+    @classmethod
+    def assert_equal(cls, a, b):
+        # TODO: If models become comparable themselves, remove this.
+        TransformType.assert_equal(a, b)
+        assert (isinstance(a, functional_models.Gaussian2D) and
+                isinstance(b, functional_models.Gaussian2D))
+        assert_array_equal(a.amplitude, b.amplitude)
+        assert_array_equal(a.x_mean, b.x_mean)
+        assert_array_equal(a.y_mean, b.y_mean)
+        assert_array_equal(a.x_stddev, b.x_stddev)
+        assert_array_equal(a.y_stddev, b.y_stddev)
+        assert_array_equal(a.theta, b.theta)

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -52,6 +52,8 @@ test_models = [
     astmodels.RotateCelestial2Native(5.63*u.deg, -72.5*u.deg, 180*u.deg),
     astmodels.RotationSequence3D([1.2, 2.3, 3.4, .3], 'xyzx'),
     astmodels.SphericalRotationSequence([1.2, 2.3, 3.4, .3], 'xyzy'),
+    astmodels.Gaussian1D(10., 5., 3.),
+    astmodels.Gaussian2D(10., 5., 5., 3., 3., 0.),
     custom_and_analytical_inverse(),
 ]
 


### PR DESCRIPTION
This creates a new file functional_models.py in io/misc/asdf/tags/transform, in which all the functional models in modeling will eventually have tags. It also contains tags for Gaussian1D and Gaussian2D models, so they are serializable. I submitted a separate PR to asdf-standard for the schemas. 

A few notes:  

1. You have the option to initialize the Gaussian2D model with the ‘cov_matrix’ parameter, which is used to calculate and set (x_stddev, y_stddev, theta), or you can omit cov_matrix and set those values individually (or not at all to retain the defaults). You can’t simultaneously create a model with any of those parameters AND cov_matrix. For that reason, even though cov_matrix is a parameter that can be used to initialize, only amplitude, x_mean, y_mean, x_stddev, y_stddev, and theta determine the behavior of the model and so cov_matrix is not included in the schema or tag. I did consider and try to do this, but interestingly even if you initialize the model with cov_matrix instead of (x_stddev, y_stddev, theta), model.cov_matrix is not an available attribute. Another this I found (that may warrant an issue?) is that if you initialize with cov_matrix, you can’t use units/quantites since some math with non-quantities is done to calculate (x_stddev, y_stddev, theta). 

2.  None of the serializable models currently retain any of the fitting constraints (fixed/tied/bounds). This needs to be fixed inside of TransformType I believe, but for now I am following the current convention that other writeable models use and not implementing this. 

3. I could roll Gaussian1DType and Gaussian2DType into a GaussianType if that would be preferable, but for now they are separate. 