### PR TITLE
Use ftp w/ TLS for default IERS download (CDDIS)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -326,6 +326,9 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- The default IERS server has been updated to use the FTPS server hosted by
+  CDDIS. [#9964]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -363,6 +366,15 @@ Other Changes and Additions
 ==================
 
 Bug Fixes
+New Features
+------------
+
+astropy.utils
+^^^^^^^^^^^^^
+
+- ``astropy.utils.data.download_file` now supports FTPS/FTP over TLS. [#9964]
+
+Bug fixes
 ---------
 
 astropy.config

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -326,9 +326,6 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- The default IERS server has been updated to use the FTPS server hosted by
-  CDDIS. [#9964]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -481,6 +478,9 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
+
+- The default IERS server has been updated to use the FTPS server hosted by
+  CDDIS. [#9964]
 
 - Fixed memory allocation on 64-bit systems within ``xml.iterparse`` [#10076]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -362,14 +362,13 @@ Other Changes and Additions
 4.0.2 (unreleased)
 ==================
 
-Bug Fixes
 New Features
 ------------
 
 astropy.utils
 ^^^^^^^^^^^^^
 
-- ``astropy.utils.data.download_file` now supports FTPS/FTP over TLS. [#9964]
+- ``astropy.utils.data.download_file`` now supports FTPS/FTP over TLS. [#9964]
 
 Bug fixes
 ---------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -974,6 +974,7 @@ class _ftptlswrapper(urllib.request.ftpwrapper):
         _target = '/'.join(self.dirs)
         self.ftp.cwd(_target)
 
+
 class _FTPTLSHandler(urllib.request.FTPHandler):
     def connect_ftp(self, user, passwd, host, port, dirs, timeout):
         return _ftptlswrapper(user, passwd, host, port, dirs, timeout,

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -45,7 +45,7 @@ __all__ = ['Conf', 'conf', 'earth_orientation_table',
 
 # IERS-A default file name, URL, and ReadMe with content description
 IERS_A_FILE = 'finals2000A.all'
-IERS_A_URL = 'ftp://cddis.gsfc.nasa.gov/pub/products/iers/finals2000A.all'
+IERS_A_URL = 'ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all'
 IERS_A_URL_MIRROR = 'https://datacenter.iers.org/data/9/finals2000A.all'
 IERS_A_README = get_pkg_data_filename('data/ReadMe.finals2000A')
 
@@ -92,6 +92,7 @@ def download_file(*args, **kwargs):
     """
     kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
                                        'Accept': '*/*'})
+    kwarg.setdefault('ftp_tls', True)
 
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -92,7 +92,7 @@ def download_file(*args, **kwargs):
     """
     kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
                                        'Accept': '*/*'})
-    kwarg.setdefault('ftp_tls', True)
+    kwargs.setdefault('ftp_tls', True)
 
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -1621,6 +1621,11 @@ def test_download_file_wrong_size(monkeypatch):
     def mockurl(remote_url, timeout=None):
         yield MockURL()
 
+    def mockurl_builder(tlscontext=None):
+        mock_opener = type('MockOpener', (object,), {})()
+        mock_opener.open = mockurl
+        return mock_opener
+
     class MockURL:
         def __init__(self):
             self.reader = io.BytesIO(b"a" * real_length)
@@ -1631,7 +1636,7 @@ def test_download_file_wrong_size(monkeypatch):
         def read(self, length=None):
             return self.reader.read(length)
 
-    monkeypatch.setattr(urllib.request, "urlopen", mockurl)
+    monkeypatch.setattr(urllib.request, "build_opener", mockurl_builder)
 
     with pytest.raises(urllib.error.ContentTooShortError):
         report_length = 1024


### PR DESCRIPTION
This is an attempt to address #9963.  It is quite a bit hackier that I would like, but I don't really see an obvious way to do any better without circumventing the caching machinery.  I'm also very curious to see if the tests pass - it worked for me locally, but some of these remote tests behave quite differently on the CI...

One subtle side-effect of this implementation is that *any* ftp IERS URLs now use TLS with no way to turn it off.  There are some ways I can imagine to avoid that if we think it is important (e.g. use "ftps" instead of "ftp" to indicate the tls version), but I'm not really sure how/if it's important at all.