### PR TITLE
add extension-helpers to setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,9 @@ packages = find:
 requires = numpy
 zip_safe = False
 tests_require = pytest-astropy
-setup_requires = setuptools_scm
+setup_requires = 
+    setuptools_scm
+    extension-helpers
 install_requires = numpy>=1.16
 python_requires = >=3.6
 


### PR DESCRIPTION
This does a fairly trivial thing of adding the extension-helpers package to be part of setup_requires in the `setup.cfg`.

*However*: this doesn't really solve what I thought it would solve: that if I do ``python setup.py build`` on the current master with `extension-helpers` not installed, I get:
```
ModuleNotFoundError: No module named 'extension_helpers'
```
which is not a surprise since it's high up in the `setup.py` file... But it seems like a pretty serious impediment that the user has no way to know where they're supposed to be getting this from.  @astrofrog or @cadair, any idea how best to address this beyond what I'm already doing in this PR?