### PR TITLE
Add back in major minor version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,12 +74,7 @@ except Exception:
     version = '{version}'
 
 from distutils.version import LooseVersion
-
-version_info = LooseVersion(version).version
-major = version_info[0]
-minor = version_info[1]
-bugfix = version_info[2]
-
+major, minor, bugfix = LooseVersion(version).version[:3]
 del LooseVersion  # clean up the namespace
 
 release = 'dev' not in version

--- a/setup.py
+++ b/setup.py
@@ -75,11 +75,14 @@ except Exception:
 
 from distutils.version import LooseVersion
 
-v_tuple = LooseVersion(version).version
-major = v_tuple[0]
-minor = v_tuple[1]
-bugfix = v_tuple[2]
-del v_tuple
+version_info = LooseVersion(version).version
+major = version_info[0]
+minor = version_info[1]
+bugfix = version_info[2]
+
+del LooseVersion  # clean up the namespace
+
+release = 'dev' not in version
 """.lstrip()
 
 setup(use_scm_version={'write_to': os.path.join('astropy', 'version.py'),

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,14 @@ try:
     version = get_version(root='..', relative_to=__file__)
 except Exception:
     version = '{version}'
+
+from distutils.version import LooseVersion
+
+v_tuple = LooseVersion(version).version
+major = v_tuple[0]
+minor = v_tuple[1]
+bugfix = v_tuple[2]
+del v_tuple
 """.lstrip()
 
 setup(use_scm_version={'write_to': os.path.join('astropy', 'version.py'),

--- a/setup.py
+++ b/setup.py
@@ -72,13 +72,29 @@ try:
     version = get_version(root='..', relative_to=__file__)
 except Exception:
     version = '{version}'
+else:
+    del get_version  # clean up namespace
 
-# We use parse_version and the base_version attribute here since we need to
-# ignore any e.g. .dev suffix. We also need to be careful about cases where
-# there is no bugfix number (e.g. 4.1.dev1231)
-from pkg_resources import parse_version
-major, minor, bugfix = ([int(x) for x in parse_version(version).base_version.split('.')] + [0])[:3]
-del parse_version  # clean up the namespace
+
+# We use LooseVersion to define major, minor, micro, but ignore any suffixes.
+def split_version(version):
+    pieces = [0, 0, 0]
+
+    try:
+        from distutils.version import LooseVersion
+
+        for j, piece in enumerate(LooseVersion(version).version[:3]):
+            pieces[j] = int(piece)
+
+    except Exception:
+        pass
+
+    return pieces
+
+
+major, minor, bugfix = split_version(version)
+
+del split_version  # clean up namespace.
 
 release = 'dev' not in version
 """.lstrip()

--- a/setup.py
+++ b/setup.py
@@ -73,9 +73,12 @@ try:
 except Exception:
     version = '{version}'
 
-from distutils.version import LooseVersion
-major, minor, bugfix = LooseVersion(version).version[:3]
-del LooseVersion  # clean up the namespace
+# We use parse_version and the base_version attribute here since we need to
+# ignore any e.g. .dev suffix. We also need to be careful about cases where
+# there is no bugfix number (e.g. 4.1.dev1231)
+from pkg_resources import parse_version
+major, minor, bugfix = ([int(x) for x in parse_version(version).base_version.split('.')] + [0])[:3]
+del parse_version  # clean up the namespace
 
 release = 'dev' not in version
 """.lstrip()


### PR DESCRIPTION
I think this fixes #9907 by putting back in the "extra" attributes in the `astropy.version` module.

One caveat: the "bugfix" isn't quite the same as before - it will be "dev" for development on master. Probably not a serious issue or anything because I don't really know of any reason one would use `bugfix` explicitly for a `master` build, but there it is anyway.

I opted to not try to deprecate these somehow, as that seems like it would make the `version` module a lot more complicated.  But if others think we want to get rid of these extra attributes I can try to figure out how that might be done.