### PR TITLE
Fix Time init problems for location

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -407,6 +407,8 @@ astropy.time
 - Fixed exceptions in ``Time.to_value()``: when supplying any ``subfmt`` argument
   for string-based formats like 'iso', and for ``subfmt='long'`` for the formats
   'byear', 'jyear', and 'decimalyear'. [#9812]
+- Fixed bug where the location attribute was lost when creating a new ``Time``
+  object from an existing ``Time`` or list of ``Time`` objects. [#9969]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -407,6 +407,7 @@ astropy.time
 - Fixed exceptions in ``Time.to_value()``: when supplying any ``subfmt`` argument
   for string-based formats like 'iso', and for ``subfmt='long'`` for the formats
   'byear', 'jyear', and 'decimalyear'. [#9812]
+  
 - Fixed bug where the location attribute was lost when creating a new ``Time``
   object from an existing ``Time`` or list of ``Time`` objects. [#9969]
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -486,6 +486,9 @@ class Time(ShapedLikeNDArray):
                                         precision, in_subfmt, out_subfmt)
         self._format = self._time.name
 
+        # Hack from #9969 to allow passing the location value that has been
+        # collected by the TimeAstropyTime format class up to the Time level.
+        # TODO: find a nicer way.
         if hasattr(self._time, '_location'):
             self.location = self._time._location
             del self._time._location

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -403,6 +403,18 @@ class Time(ShapedLikeNDArray):
                  precision=None, in_subfmt=None, out_subfmt=None,
                  location=None, copy=False):
 
+        if location is not None:
+            from astropy.coordinates import EarthLocation
+            if isinstance(location, EarthLocation):
+                self.location = location
+            else:
+                self.location = EarthLocation(*location)
+            if self.location.size == 1:
+                self.location = self.location.squeeze()
+        else:
+            if not hasattr(self, 'location'):
+                self.location = None
+
         if isinstance(val, self.__class__):
             # Update _time formatting parameters if explicitly specified
             if precision is not None:
@@ -415,17 +427,6 @@ class Time(ShapedLikeNDArray):
             if scale is not None:
                 self._set_scale(scale)
         else:
-            if location is not None:
-                from astropy.coordinates import EarthLocation
-                if isinstance(location, EarthLocation):
-                    self.location = location
-                else:
-                    self.location = EarthLocation(*location)
-                if self.location.size == 1:
-                    self.location = self.location.squeeze()
-            else:
-                self.location = None
-
             self._init_from_vals(val, val2, format, scale, copy,
                                  precision, in_subfmt, out_subfmt)
             self.SCALES = TIME_TYPES[self.scale]

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -403,17 +403,6 @@ class Time(ShapedLikeNDArray):
                  precision=None, in_subfmt=None, out_subfmt=None,
                  location=None, copy=False):
 
-        if location is not None:
-            from astropy.coordinates import EarthLocation
-            if isinstance(location, EarthLocation):
-                self.location = location
-            else:
-                self.location = EarthLocation(*location)
-            if self.location.size == 1:
-                self.location = self.location.squeeze()
-        else:
-            self.location = None
-
         if isinstance(val, self.__class__):
             # Update _time formatting parameters if explicitly specified
             if precision is not None:
@@ -426,6 +415,17 @@ class Time(ShapedLikeNDArray):
             if scale is not None:
                 self._set_scale(scale)
         else:
+            if location is not None:
+                from astropy.coordinates import EarthLocation
+                if isinstance(location, EarthLocation):
+                    self.location = location
+                else:
+                    self.location = EarthLocation(*location)
+                if self.location.size == 1:
+                    self.location = self.location.squeeze()
+            else:
+                self.location = None
+
             self._init_from_vals(val, val2, format, scale, copy,
                                  precision, in_subfmt, out_subfmt)
             self.SCALES = TIME_TYPES[self.scale]
@@ -484,6 +484,10 @@ class Time(ShapedLikeNDArray):
         self._time = self._get_time_fmt(val, val2, format, scale,
                                         precision, in_subfmt, out_subfmt)
         self._format = self._time.name
+
+        if hasattr(self._time, '_location'):
+            self.location = self._time._location
+            del self._time._location
 
         # If any inputs were masked then masked jd2 accordingly.  From above
         # routine ``mask`` must be either Python bool False or an bool ndarray

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -743,6 +743,8 @@ class TimeAstropyTime(TimeUnique):
             vals = [getattr(val, scale)._time for val in val1]
             jd1 = np.concatenate([np.atleast_1d(val.jd1) for val in vals])
             jd2 = np.concatenate([np.atleast_1d(val.jd2) for val in vals])
+
+            # Collect individual location values and merge into a single location.
             if any(tm.location is not None for tm in val1):
                 if any(tm.location is None for tm in val1):
                     raise ValueError('cannot concatenate times unless all locations '

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -752,6 +752,8 @@ class TimeAstropyTime(TimeUnique):
                     location = np.broadcast_to(tm.location, tm._time.jd1.shape)
                     locations.append(np.atleast_1d(location))
                 location = np.concatenate(locations)
+            else:
+                location = None
         else:
             val = getattr(val1_0, scale)._time
             jd1, jd2 = val.jd1, val.jd2

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -754,7 +754,16 @@ class TimeAstropyTime(TimeUnique):
                     location = np.broadcast_to(tm.location, tm._time.jd1.shape,
                                                subok=True)
                     locations.append(np.atleast_1d(location))
-                location = np.concatenate(locations)
+
+                # Once we no longer have to support NUMPY_LT_1_17, we can
+                # just write np.concatenate(locations).  Right now, we
+                # effectively do what __array_function__ does directly.
+                location0 = locations[0]
+                unit = location0.unit
+                location = np.concatenate([location.to_value(unit)
+                                           for location in locations])
+                location = location0._new_view(location)
+
             else:
                 location = None
         else:

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -749,7 +749,8 @@ class TimeAstropyTime(TimeUnique):
                                      'are set or no locations are set')
                 locations = []
                 for tm in val1:
-                    location = np.broadcast_to(tm.location, tm._time.jd1.shape)
+                    location = np.broadcast_to(tm.location, tm._time.jd1.shape,
+                                               subok=True)
                     locations.append(np.atleast_1d(location))
                 location = np.concatenate(locations)
             else:

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2160,13 +2160,13 @@ def test_to_value_with_subfmt_for_every_format(fmt_name, fmt_class):
         t.to_value(fmt_name, subfmt)
 
 
-def test_location_init():
+@pytest.mark.parametrize('location', [None, (45, 45)])
+def test_location_init(location):
     """Test fix in #9969 for issue #9962 where the location attribute is
     lost when initializing Time from an existing Time instance of list of
     Time instances.
     """
-    tm = Time('J2010', location=(45, 45))
-    # (3194419.14506057, 3194419.14506057, 4487348.40886592) m
+    tm = Time('J2010', location=location)
 
     # Init from a scalar Time
     tm2 = Time(tm)
@@ -2175,13 +2175,32 @@ def test_location_init():
 
     # From a list of Times
     tm2 = Time([tm, tm])
-    for loc in tm2.location:
-        assert np.all(tm.location == loc)
+    if location is None:
+        assert tm2.location is None
+    else:
+        for loc in tm2.location:
+            assert loc == tm.location
     assert type(tm.location) is type(tm2.location)
 
     # Effectively the same as a list of Times, but just to be sure that
     # Table mixin inititialization is working as expected.
     tm2 = Table([[tm, tm]])['col0']
-    for loc in tm2.location:
-        assert np.all(tm.location == loc)
+    if location is None:
+        assert tm2.location is None
+    else:
+        for loc in tm2.location:
+            assert loc == tm.location
     assert type(tm.location) is type(tm2.location)
+
+
+def test_location_init_fail():
+    """Test fix in #9969 for issue #9962 where the location attribute is
+    lost when initializing Time from an existing Time instance of list of
+    Time instances.  Make sure exception is correct.
+    """
+    tm = Time('J2010', location=(45, 45))
+    tm2 = Time('J2010')
+
+    with pytest.raises(ValueError,
+                       match='cannot concatenate times unless all locations'):
+        Time([tm, tm2])

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -2158,3 +2158,30 @@ def test_to_value_with_subfmt_for_every_format(fmt_name, fmt_class):
     subfmts = list(subfmt[0] for subfmt in fmt_class.subfmts) + [None, '*']
     for subfmt in subfmts:
         t.to_value(fmt_name, subfmt)
+
+
+def test_location_init():
+    """Test fix in #9969 for issue #9962 where the location attribute is
+    lost when initializing Time from an existing Time instance of list of
+    Time instances.
+    """
+    tm = Time('J2010', location=(45, 45))
+    # (3194419.14506057, 3194419.14506057, 4487348.40886592) m
+
+    # Init from a scalar Time
+    tm2 = Time(tm)
+    assert np.all(tm.location == tm2.location)
+    assert type(tm.location) is type(tm2.location)
+
+    # From a list of Times
+    tm2 = Time([tm, tm])
+    for loc in tm2.location:
+        assert np.all(tm.location == loc)
+    assert type(tm.location) is type(tm2.location)
+
+    # Effectively the same as a list of Times, but just to be sure that
+    # Table mixin inititialization is working as expected.
+    tm2 = Table([[tm, tm]])['col0']
+    for loc in tm2.location:
+        assert np.all(tm.location == loc)
+    assert type(tm.location) is type(tm2.location)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request fixes some problems in losing the `location` when creating a `Time` object from one or more existing `Time` objects, as noted in #9962.

This is presently a work in progress with no tests, but it does address the specific examples:
```
In [7]: from astropy.time import Time 
   ...: from astropy.table import Table 
   ...: t = Time('J2010', location=(45, 45)) 
   ...: print(t.location) 
   ...: # (3194419.14506057, 3194419.14506057, 4487348.40886592) m 
   ...: print(Table([[t]])['col0'][0].location) 
   ...: # None 
   ...: print(Time(t).location) 
   ...: # None                                                                                                                                                  
(3194419.14506057, 3194419.14506057, 4487348.40886592) m
[(3194419.14506057, 3194419.14506057, 4487348.40886592)]
(3194419.14506057, 3194419.14506057, 4487348.40886592) m
```

This implementation may not be the most general path forward, and does rely on a somewhat unseemly trick of putting a (temporary) hidden `_location` attribute on the `TimeFormat` object to pass the locations back up to the `Time` object.  Just putting it up as a first quick idea for discussion.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9962
