### PR TITLE
BUG: Fix config generating package..cfg file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -299,6 +299,10 @@ Bug fixes
 astropy.config
 ^^^^^^^^^^^^^^
 
+- Fixed a bug where importing a development version of a package that uses
+  ``astropy`` configuration system can result in a
+  ``~/.astropy/config/package..cfg``file. [#9975]
+
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,7 +301,7 @@ astropy.config
 
 - Fixed a bug where importing a development version of a package that uses
   ``astropy`` configuration system can result in a
-  ``~/.astropy/config/package..cfg``file. [#9975]
+  ``~/.astropy/config/package..cfg`` file. [#9975]
 
 astropy.constants
 ^^^^^^^^^^^^^^^^^

--- a/astropy/config/configuration.py
+++ b/astropy/config/configuration.py
@@ -714,7 +714,7 @@ def update_default_config(pkg, default_cfg_dir_or_fn, version=None, rootname='as
 
     # Don't install template files for dev versions, or we'll end up
     # spamming `~/.astropy/config`.
-    if 'dev' not in version and cfgfn is not None:
+    if version and 'dev' not in version and cfgfn is not None:
         template_path = path.join(
             get_config_dir(rootname=rootname), f'{pkg}.{version}.cfg')
         needs_template = not path.exists(template_path)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the problem of `astropy.config` creating an unsolicited `~/.astropy/config/package..cfg` when the package uses `astropy.config` and has `version == ''` during active development. The package already uses `setuptools_scm` as recommended by APE 17.

Example problem:
```
>>> import synphot                                       
WARNING: ConfigurationChangedWarning: The configuration options in synphot  may have changed,
your configuration file was not updated in order to preserve local changes. 
A new configuration template has been saved to '/home/user/.astropy/config/synphot..cfg'.
[astropy.config.configuration]
```

p.s. I am not sure how to test this. I don't see similar existing tests that I can expand upon.

p.p.s. I cannot find who is the maintainer of `astropy.config`.