### PR TITLE
update docs to point to the correct docs invocation to build docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -426,7 +426,7 @@ Building
 There are two ways to build the Astropy documentation. The easiest way is to
 execute the following tox command (from the ``astropy`` source directory)::
 
-    tox -e docs
+    tox -e build_docs
 
 If you do this, you do not need to install any of the documentation dependencies
 as this will be done automatically. The documentation will be built in the


### PR DESCRIPTION
The current instructions say to use ``tox -e docs`` which doesn't work.  I think that's because it's since been changed to ``tox -e build_docs``, in which case this is an easy fix.

I might have it switched, though - if the *docs* represent the intent, then the `python setup.py build_docs` redirection message should change along with the tox file.