### PR TITLE
Add verification of disp (TDISP) keyword to fits.column and tests for TFORM

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -373,6 +373,9 @@ astropy.io.fits
 
 - Fix writing noncontiguous data to a compressed HDU. [#9958]
 
+- Added verification of ``disp`` (``TDISP``) keyword to ``fits.Column`` and
+  extended tests for ``TFORM`` and ``TDISP`` validation. [#9978]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -963,8 +963,22 @@ class Column(NotifierMixin):
         valid = {}
         invalid = {}
 
-        format, recformat = cls._determine_formats(format, start, dim, ascii)
-        valid.update(format=format, recformat=recformat)
+        try:
+            format, recformat = cls._determine_formats(format, start, dim, ascii)
+            valid.update(format=format, recformat=recformat)
+        except (ValueError, VerifyError) as err:
+            msg = (
+                f'Column format option (TFORMn) failed verification: {err!s} '
+                'The invalid value will be ignored for the purpose of '
+                'formatting the data in this column.')
+            invalid['format'] = (format, msg)
+        except AttributeError as err:
+            msg = (
+                f'Column format option (TFORMn) must be a string with a valid '
+                f'FITS table format (got {format!s}: {err!s}). '
+                'The invalid value will be ignored for the purpose of '
+                'formatting the data in this column.')
+            invalid['format'] = (format, msg)
 
         # Currently we don't have any validation for name, unit, bscale, or
         # bzero so include those by default

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3080,11 +3080,12 @@ class TestColumnFunctions(FitsTestCase):
         assert 'Column name must be a string able to fit' in str(err.value)
 
         with pytest.raises(VerifyError) as err:
-            _ = fits.Column('col', format='I', null='Nan', disp=1, coord_type=1,
-                            coord_unit=2, coord_ref_point='1', coord_ref_value='1',
-                            coord_inc='1', time_ref_pos=1)
-        err_msgs = ['keyword arguments to Column were invalid', 'TNULL', 'TDISP',
-                    'TCTYP', 'TCUNI', 'TCRPX', 'TCRVL', 'TCDLT', 'TRPOS']
+            _ = fits.Column('col', format=0, null='Nan', disp=1, coord_type=1,
+                            coord_unit=2, coord_inc='1', time_ref_pos=1,
+                            coord_ref_point='1', coord_ref_value='1')
+        err_msgs = ['keyword arguments to Column were invalid',
+                    'TFORM', 'TNULL', 'TDISP', 'TCTYP', 'TCUNI', 'TCRPX',
+                    'TCRVL', 'TCDLT', 'TRPOS']
         for msg in err_msgs:
             assert msg in str(err.value)
 
@@ -3109,6 +3110,24 @@ class TestColumnFunctions(FitsTestCase):
         with pytest.raises(VerifyError) as err:
             _ = fits.Column('a', format='I', start='-56', array=[1, 2, 3])
         assert "start option (TBCOLn) must be a positive integer (got -56)." in str(err.value)
+
+    @pytest.mark.parametrize('keys',
+                             [{'TFORM': 'Z', 'TDISP': 'E'},
+                              {'TFORM': '2', 'TDISP': '2E'},
+                              {'TFORM': 3, 'TDISP': 6.3},
+                              {'TFORM': float, 'TDISP': np.float64},
+                              {'TFORM': '', 'TDISP': 'E.5'}])
+    def test_column_verify_formats(self, keys):
+        """
+        Additional tests for verification of 'TFORM' and 'TDISP' keyword
+        arguments used to initialize a Column.
+        """
+        with pytest.raises(VerifyError) as err:
+            _ = fits.Column('col', format=keys['TFORM'], disp=keys['TDISP'])
+
+        for key in keys.keys():
+            assert key in str(err.value)
+            assert str(keys[key]) in str(err.value)
 
 
 def test_regression_5383():


### PR DESCRIPTION
### Description
`fits.Column._verify_keywords` checks its `disp` kwarg for type `str` but not much else, allowing just about any string to be quietly written as the `TDISPn` key to the FITS file header. Conversely, reading in a table per #7226 parses that key and raises an exception if not conforming to the FITS standard (case in question: I have produced lots of files lazily copying `TDISP2=E` from the corresponding `TFORM2` value, which are now rejected by `io.fits`).

This pull request is adding the same verification of the `disp` argument done on reading by calling `_parse_tdisp_format(disp)`.

Additional notes:

1. On adding the tests I found that the `format` (`TFORMn`) argument is implicitly checked, but not handled by the `_verify_keywords` framework and thus could not be tested in the same way as the other keywords. The second commit adds a failed `format` verification to the `invalid_kwargs` list.

2. `_parse_tdisp_format` actually only tests the beginning of the string for a conforming format specifier, therefore kwargs like `format='Exponential', disp='E14.6D+02'` are still accepted for writing - not conforming to the FITS standard specifications, but just as readily accepted on reading. Reading them might be OK, since they are unambiguous, but perhaps the writer should implement a stricter validation.

3. The `_verify_keywords` error messages generally state "The invalid keyword will be ignored for the purpose of formatting this column", sounding like the `Column` will still be created without optional kwargs or with default values – in that case treating `format` differently would be justified, since it is a required argument. But in fact any `invalid_kwargs` raise an exception, so currently there seems no need to discriminate between mandatory and optional arguments.