### PR TITLE
Use motion in rvs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -337,6 +337,9 @@ astropy.coordinates
 - Read-only longitudes can now be passed in to ``EarthLocation`` even if
   they include angles outside of the range of -180 to 180 degrees. [#9900]
 
+- ```SkyCoord.radial_velocity_correction``` no longer raises an Exception
+  when space motion information is present on the SkyCoord. [#9980]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1,5 +1,6 @@
 import re
 import copy
+import warnings
 
 import numpy as np
 
@@ -11,6 +12,7 @@ from astropy.wcs.utils import skycoord_to_pixel, pixel_to_skycoord
 from astropy.utils.data_info import MixinInfo
 from astropy.utils import ShapedLikeNDArray
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyUserWarning
 
 from .distances import Distance
 from .angles import Angle
@@ -1608,15 +1610,23 @@ class SkyCoord(ShapedLikeNDArray):
             # barycentric redshift according to eq 28 in Wright & Eastmann (2014),
             # neglecting Shapiro delay and effects of the star's own motion
             zb = gamma_obs * (1 + targcart.dot(beta_obs)) / (1 + gr/speed_of_light)
-            # try and get terms corresponding to stellar motion. If this fails
-            # then do so silently
+            # try and get terms corresponding to stellar motion.
+            # Fail silently if there are no differentials, but raise a warning if
+            # differentials exist but are not sufficient to calculate space velocity
             try:
                 beta_star = icrs_cart.differentials['s'].to_cartesian() / speed_of_light
                 ro = icrs_cart_novel/icrs_cart_novel.norm()
                 zb *= (1 + beta_star.dot(ro)) / (1 + beta_star.dot(targcart))
             except KeyError:
                 pass
+            except u.UnitConversionError:
+                warnings.warn("SkyCoord contains some velocity information, but not enough to "
+                              "calculate the full space motion of the source, and so this has "
+                              "been ignored for the purposes of calculating the radial velocity "
+                              "correction. This can lead to errors on the order of metres/second.",
+                              AstropyUserWarning)
 
+            zb = zb - 1
             return zb * speed_of_light
         else:
             # do a simpler correction ignoring time dilation and gravitational redshift

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1482,7 +1482,8 @@ class SkyCoord(ShapedLikeNDArray):
         Use barycentric corrections if m/s precision is required.
 
         The algorithm here is sufficient to perform corrections at the mm/s level, but
-        care is needed in application. Strictly speaking, the barycentric correction is
+        care is needed in application. The barycentric correction returned uses the optical
+        approximation v = z * c. Strictly speaking, the barycentric correction is
         multiplicative and should be applied as::
 
           >>> from astropy.time import Time
@@ -1493,9 +1494,6 @@ class SkyCoord(ShapedLikeNDArray):
           >>> sc = SkyCoord(1*u.deg, 2*u.deg)
           >>> vcorr = sc.radial_velocity_correction(kind='barycentric', obstime=t, location=loc)  # doctest: +REMOTE_DATA
           >>> rv = rv + vcorr + rv * vcorr / c  # doctest: +SKIP
-
-        If your target is nearby and/or has finite proper motion you may need to account
-        for terms arising from this. See Wright & Eastman (2014) for details.
 
         Also note that this method returns the correction velocity in the so-called
         *optical convention*::

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1598,7 +1598,7 @@ class SkyCoord(ShapedLikeNDArray):
         else:
             # skycoord has distances so apply parallax
             obs_icrs_cart = pos_earth + gcrs_p
-            icrs_cart = self.icrs.cartesian
+            icrs_cart = self.icrs.cartesian.without_differentials()
             targcart = icrs_cart - obs_icrs_cart
             targcart /= targcart.norm()
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1596,7 +1596,7 @@ class SkyCoord(ShapedLikeNDArray):
         icrs_cart = self.icrs.cartesian
         icrs_cart_novel = icrs_cart.without_differentials()
         if self.data.__class__ is UnitSphericalRepresentation:
-            targcart = icrs_cart
+            targcart = icrs_cart_novel
         else:
             # skycoord has distances so apply parallax
             obs_icrs_cart = pos_earth + gcrs_p

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -303,6 +303,7 @@ def test_invalid_argument_combos():
         scwattrs.radial_velocity_correction(timel)
 
 
+@pytest.mark.remote_data
 def test_regression_9645():
     sc = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc,
                   pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr, radial_velocity=0*u.km/u.s)

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -518,9 +518,11 @@ Precision of `~astropy.coordinates.SkyCoord.radial_velocity_correction`
 ------------------------------------------------------------------------
 
 The correction computed by `~astropy.coordinates.SkyCoord.radial_velocity_correction`
-can be added to any observed radial velocity to provide a correction that is
-accurate to a level of approximately 3 m/s. If you need more precise
-corrections, there are a number of subtleties of which you must be aware.
+uses the optical approximation :math:`v = zc` (see :ref:`astropy-units-dopper-equivalencies`
+for details). The corretion can be added to any observed radial velocity
+to provide a correction that is accurate to a level of approximately 3 m/s.
+If you need more precise corrections, there are a number of subtleties of
+which you must be aware.
 
 The first is that you should always use a barycentric correction, as the
 barycenter is a fixed point where gravity is constant. Since the heliocenter
@@ -534,7 +536,7 @@ surface. For these reasons, the barycentric correction in
 be used for high precision work.
 
 Other considerations necessary for radial velocity corrections at the cm/s
-level are outlined in `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.
+level are outlined in `Wright & Eastman (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.
 Most important is that the barycentric correction is, strictly speaking,
 *multiplicative*, so that you should apply it as:
 
@@ -550,9 +552,7 @@ the barycentric correction in this way leads to errors of order 3 m/s.
 The barycentric correction in `~astropy.coordinates.SkyCoord.radial_velocity_correction` is consistent
 with the `IDL implementation <http://astroutils.astronomy.ohio-state.edu/exofast/barycorr.html>`_ of
 the Wright & Eastmann (2014) paper to a level of 10 mm/s for a source at
-infinite distance. We do not include the Shapiro delay, nor any effect related
-to the finite distance or proper motion of the source. The Shapiro delay is
-unlikely to be important unless you seek mm/s precision, but the effects of the
-source's parallax and proper motion can be important at the cm/s level. These
-effects are likely to be added to future versions of Astropy along with
-velocity support for |skycoord|, but in the meantime see `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.
+infinite distance. We do not include the Shapiro delay nor the light
+travel time correction from equation 28 of that paper. The neglected terms
+are not important unless you require accuracies of better than 1 cm/s.
+If you do require that precision, see `Wright & Eastmann (2014) <http://adsabs.harvard.edu/abs/2014PASP..126..838W>`_.

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -143,6 +143,8 @@ These equivalencies even work with non-base units::
   >>> imperial.inch.to(imperial.Cal, equivalencies=u.spectral())  # doctest: +FLOAT_CMP
   1.869180759162485e-27
 
+.. _astropy-units-dopper-equivalencies:
+
 Spectral (Doppler) equivalencies
 --------------------------------
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request addresses #9645 and cheekily also clarifies the documentation to fix #9269.

If a ```SkyCoord``` has velocity information present this is now used in the calculation of the radial velocity correction in a manner consistent with [Wright & Eastman 2014](https://ui.adsabs.harvard.edu/abs/2014PASP..126..838W/abstract). If the velocity information in the ```SkyCoord``` cannot be used to calculate a physical space motion in m/s the user receives a warning.


Edit: closes #9645
