### PR TITLE
BUG: Fix deprecated_renamed_argument bug when no new name given

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -414,7 +414,7 @@ astropy.time
 - Fixed exceptions in ``Time.to_value()``: when supplying any ``subfmt`` argument
   for string-based formats like 'iso', and for ``subfmt='long'`` for the formats
   'byear', 'jyear', and 'decimalyear'. [#9812]
-  
+
 - Fixed bug where the location attribute was lost when creating a new ``Time``
   object from an existing ``Time`` or list of ``Time`` objects. [#9969]
 
@@ -434,6 +434,9 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
+
+- Fixed ``deprecated_renamed_argument`` not passing in user value to
+  deprecated keyword when the keyword has no new name. [#9981]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -517,6 +517,10 @@ def deprecated_renamed_argument(old_name, new_name, since,
                         # name of the new argument to the function
                         if new_name[i] is not None:
                             kwargs[new_name[i]] = value
+                        # If old argument has no replacement, cast it back.
+                        # https://github.com/astropy/astropy/issues/9914
+                        else:
+                            kwargs[old_name[i]] = value
 
             return function(*args, **kwargs)
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-import functools
 import inspect
 import pickle
 
@@ -466,19 +465,19 @@ def test_deprecated_argument_not_allowed_use():
 
 def test_deprecated_argument_remove():
     @deprecated_renamed_argument('x', None, '2.0', alternative='astropy.y')
-    def test(dummy=11):
-        return dummy
+    def test(dummy=11, x=3):
+        return dummy, x
 
     with catch_warnings(AstropyDeprecationWarning) as w:
-        assert test(x=1) == 11
+        assert test(x=1) == (11, 1)
         assert len(w) == 1
         assert 'Use astropy.y instead' in str(w[0].message)
 
     with catch_warnings(AstropyDeprecationWarning) as w:
-        assert test(x=1, dummy=10) == 10
+        assert test(x=1, dummy=10) == (10, 1)
         assert len(w) == 1
 
-    assert test() == 11
+    assert test() == (11, 3)
 
 
 def test_sharedmethod_reuse_on_subclasses():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a bug in `deprecated_renamed_argument` when a keyword is deprecated without replacement, the user value is ignored and default value is kept regardless.

The feature of deprecating a keyword without replacement was introduced in #8324 (v2.0.12).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Address part of #9914

p.s. With this patch, maybe a follow-up PR for #9915 can be made to use this decorator again. I did not do this here because that PR is milestoned for v4.1.