### PR TITLE
BUG: Fix deprecated_renamed_argument not issuing warning when deprecated keyword with no new_name called as positional argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -437,6 +437,9 @@ astropy.utils
 
 - Fixed ``deprecated_renamed_argument`` not passing in user value to
   deprecated keyword when the keyword has no new name. [#9981]
+- Fixed ``deprecated_renamed_argument`` not issuing a deprecation warning when
+  deprecated keyword without new name is passed in as positional argument.
+  [#9985]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/decorators.py
+++ b/astropy/utils/decorators.py
@@ -440,7 +440,7 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 pass
             else:
                 if new_name[i] is None:
-                    continue
+                    param = arguments[old_name[i]]
                 elif new_name[i] in arguments:
                     param = arguments[new_name[i]]
                 # In case the argument is not found in the list of arguments
@@ -449,16 +449,19 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # This case has to be explicitly specified, otherwise throw
                 # an exception!
                 else:
-                    raise TypeError('"{}" was not specified in the function '
-                                    'signature. If it was meant to be part of '
-                                    '"**kwargs" then set "arg_in_kwargs" to "True"'
-                                    '.'.format(new_name[i]))
+                    raise TypeError(
+                        f'"{new_name[i]}" was not specified in the function '
+                        'signature. If it was meant to be part of '
+                        '"**kwargs" then set "arg_in_kwargs" to "True"')
 
                 # There are several possibilities now:
 
                 # 1.) Positional or keyword argument:
                 if param.kind == param.POSITIONAL_OR_KEYWORD:
-                    position[i] = keys.index(new_name[i])
+                    if new_name[i] is None:
+                        position[i] = keys.index(old_name[i])
+                    else:
+                        position[i] = keys.index(new_name[i])
 
                 # 2.) Keyword only argument:
                 elif param.kind == param.KEYWORD_ONLY:
@@ -468,12 +471,16 @@ def deprecated_renamed_argument(old_name, new_name, since,
                 # 3.) positional-only argument, varargs, varkwargs or some
                 #     unknown type:
                 else:
-                    raise TypeError('cannot replace argument "{}" of kind '
-                                    '{!r}.'.format(new_name[i], param.kind))
+                    raise TypeError(f'cannot replace argument "{new_name[i]}" '
+                                    f'of kind {repr(param.kind)}.')
 
         @functools.wraps(function)
         def wrapper(*args, **kwargs):
             for i in range(n):
+                message = (f'"{old_name[i]}" was deprecated in version '
+                           f'{since[i]} and will be removed in a future '
+                           'version. ')
+
                 # The only way to have oldkeyword inside the function is
                 # that it is passed as kwarg because the oldkeyword
                 # parameter was renamed to newkeyword.
@@ -482,15 +489,10 @@ def deprecated_renamed_argument(old_name, new_name, since,
                     # Display the deprecation warning only when it's not
                     # pending.
                     if not pending[i]:
-                        message = ('"{}" was deprecated in version {} '
-                                   'and will be removed in a future version. '
-                                   .format(old_name[i], since[i]))
                         if new_name[i] is not None:
-                            message += ('Use argument "{}" instead.'
-                                        .format(new_name[i]))
+                            message += f'Use argument "{new_name[i]}" instead.'
                         elif alternative:
-                            message += ('\n        Use {} instead.'
-                                        .format(alternative))
+                            message += f'\n        Use {alternative} instead.'
                         warnings.warn(message, warning_type, stacklevel=2)
 
                     # Check if the newkeyword was given as well.
@@ -504,14 +506,14 @@ def deprecated_renamed_argument(old_name, new_name, since,
                             # True or raise an Exception is relax is False.
                             if relax[i]:
                                 warnings.warn(
-                                    '"{0}" and "{1}" keywords were set. '
-                                    'Using the value of "{1}".'
-                                    ''.format(old_name[i], new_name[i]),
+                                    f'"{old_name[i]}" and "{new_name[i]}" '
+                                    'keywords were set. '
+                                    f'Using the value of "{new_name[i]}".',
                                     AstropyUserWarning)
                             else:
                                 raise TypeError(
-                                    'cannot specify both "{}" and "{}"'
-                                    '.'.format(old_name[i], new_name[i]))
+                                    f'cannot specify both "{old_name[i]}" and '
+                                    f'"{new_name[i]}".')
                     else:
                         # Pass the value of the old argument with the
                         # name of the new argument to the function
@@ -521,6 +523,14 @@ def deprecated_renamed_argument(old_name, new_name, since,
                         # https://github.com/astropy/astropy/issues/9914
                         else:
                             kwargs[old_name[i]] = value
+
+                # Deprecated keyword without replacement is given as
+                # positional argument.
+                elif (not pending[i] and not new_name[i] and position[i] and
+                      len(args) > position[i]):
+                    if alternative:
+                        message += f'\n        Use {alternative} instead.'
+                    warnings.warn(message, warning_type, stacklevel=2)
 
             return function(*args, **kwargs)
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -478,6 +478,20 @@ def test_deprecated_argument_remove():
         assert len(w) == 1
 
     assert test() == (11, 3)
+    assert test(121) == (121, 3)
+    assert test(dummy=121) == (121, 3)
+
+
+# Put this back in test_deprecated_argument_remove() when fixed.
+@pytest.mark.xfail(reason='Issue 9914')
+def test_deprecated_argument_remove_called_as_pos_arg():
+    @deprecated_renamed_argument('x', None, '2.0', alternative='astropy.y')
+    def test(dummy=11, x=3):
+        return dummy, x
+
+    with pytest.warns(AstropyDeprecationWarning,
+                      match=r'Use astropy.y instead'):
+        test(121, 1) == (121, 1)
 
 
 def test_sharedmethod_reuse_on_subclasses():

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -477,21 +477,15 @@ def test_deprecated_argument_remove():
         assert test(x=1, dummy=10) == (10, 1)
         assert len(w) == 1
 
-    assert test() == (11, 3)
-    assert test(121) == (121, 3)
-    assert test(dummy=121) == (121, 3)
-
-
-# Put this back in test_deprecated_argument_remove() when fixed.
-@pytest.mark.xfail(reason='Issue 9914')
-def test_deprecated_argument_remove_called_as_pos_arg():
-    @deprecated_renamed_argument('x', None, '2.0', alternative='astropy.y')
-    def test(dummy=11, x=3):
-        return dummy, x
-
     with pytest.warns(AstropyDeprecationWarning,
                       match=r'Use astropy.y instead'):
         test(121, 1) == (121, 1)
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test() == (11, 3)
+        assert test(121) == (121, 3)
+        assert test(dummy=121) == (121, 3)
+        assert len(w) == 0
 
 
 def test_sharedmethod_reuse_on_subclasses():


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the remaining bug where if a keyword is deprecated using `deprecated_renamed_argument` without a replacement (`new_name=None`) and then it is *called* as a positional argument instead, no deprecation warning would show.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9914 
