### PR TITLE
switching to check only geocentric coordinates

### DIFF
--- a/astropy/coordinates/tests/test_sites.py
+++ b/astropy/coordinates/tests/test_sites.py
@@ -152,7 +152,7 @@ def check_builtin_matches_remote(download_url=True):
     for name in builtin_registry.names:
         in_dl[name] = name in dl_registry
         if in_dl[name]:
-            matches[name] = quantity_allclose(builtin_registry[name], dl_registry[name])
+            matches[name] = quantity_allclose(builtin_registry[name].geocentric, dl_registry[name].geocentric)
         else:
             matches[name] = False
 


### PR DESCRIPTION
 as just passing EarthLocation objects to `quantity_allclose` causes a TypeError

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9988 (edited)

Fixes `check_builtin_matches_remote` in `coordinates.test_sites`. Previously, if a local .json file was specified as as source for the site registry, tests would fail here due to a type error when feeding `EarthLocation` objects into numpy's `is_close` framework. As a fix, I instead pass the geocentric coordinates of the respective `EarthLocation` objects which run through without problems.
