### PR TITLE
Fix error with default parameters of 2D orthonormal polynomials in model sets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -357,6 +357,7 @@ astropy.io.misc
 
 - Fixed serialization of polynomial models to include non default values of
   domain and window values. [#9956, #9961]
+
 - Fixed a bug which affected overwriting tables within ``hdf5`` files.
   Overwriting an existing path with associated column meta data now also
   overwrites the meta data associated with the table. [#9950]
@@ -383,6 +384,9 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+
+- Fixed a bug in setting default values of parameters of orthonormal
+  polynomials when constructing a model set. [#9987]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -178,9 +178,16 @@ class OrthoPolynomialBase(PolynomialBase):
         self.x_window = x_window
         self.y_window = y_window
         self._param_names = self._generate_coeff_names()
+        if n_models:
+            if model_set_axis is None:
+                model_set_axis = 0
+             minshape = (1,) * model_set_axis + (n_models,)
+         else:
+             minshape = ()
+
         for param_name in self._param_names:
             self._parameters_[param_name] = \
-                Parameter(param_name, default=0.0)
+                Parameter(param_name, default=np.zeros(minshape))
         super().__init__(
             n_models=n_models, model_set_axis=model_set_axis,
             name=name, meta=meta, **params)

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -181,9 +181,9 @@ class OrthoPolynomialBase(PolynomialBase):
         if n_models:
             if model_set_axis is None:
                 model_set_axis = 0
-             minshape = (1,) * model_set_axis + (n_models,)
-         else:
-             minshape = ()
+            minshape = (1,) * model_set_axis + (n_models,)
+        else:
+            minshape = ()
 
         for param_name in self._param_names:
             self._parameters_[param_name] = \

--- a/astropy/modeling/tests/test_model_sets.py
+++ b/astropy/modeling/tests/test_model_sets.py
@@ -7,7 +7,8 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 
-from astropy.modeling.models import Polynomial1D, Polynomial2D
+from astropy.modeling.models import (Polynomial1D, Polynomial2D,
+                                     Chebyshev2D)
 from astropy.modeling.fitting import LinearLSQFitter
 from astropy.modeling.core import Model
 from astropy.modeling.parameters import Parameter
@@ -107,6 +108,13 @@ def test_model_axis_2():
     assert_allclose(y[:, :, 0].flatten(), t1(x, x))
     assert_allclose(y[:, :, 1].flatten(), t2(x, x))
     assert_allclose(y[:, :, 2].flatten(), t3(x, x))
+
+    cheb = Chebyshev2D(1, 1, c0_0=[[[0, 1, 2]]], c0_1=[[[3, 4, 5]]],
+                      c1_0=[[[5, 6, 7]]], c1_1=[[[1,1,1]]],
+                      n_models=3, model_set_axis=2)
+    assert cheb.c0_0.shape == (1, 1, 3)
+    y = cheb(x, x, model_set_axis=False)
+    assert y.shape == (1, 4, 3)
 
 
 def test_axis_0():


### PR DESCRIPTION
When a model set is created using polynomials the default values are populated automatically taking into account `n_models` and `model_set_axis`. This is true only for polynomials, not all models. This PR fixes a bug in 2D orthonormal polynomials where `n_models` is not taken into account when setting parameter default values for model sets. The bug was first reported in [this comment](https://github.com/astropy/astropy/pull/9941#issuecomment-586440559).