### PR TITLE
Increase minimum asdf version to 2.5.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -463,6 +463,7 @@ Other Changes and Additions
 
 - Updated wcslib to v7.1. [#9829]
 
+- Increase minimum asdf version to 2.5.2. [#9996]
 
 
 4.0 (2019-12-16)

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -16,7 +16,7 @@ __minimum_python_version__ = '3.6'
 __minimum_numpy_version__ = '1.16.0'
 # ASDF is an optional dependency, but this is the minimum version that is
 # compatible with Astropy when it is installed.
-__minimum_asdf_version__ = '2.5.0'
+__minimum_asdf_version__ = '2.5.2'
 
 
 class UnsupportedPythonError(Exception):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request updates the minimum asdf version to 2.5.2, which adds schemas that were missing from ASDF Standard 1.4.0.  See #9956 for discussion.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
