### PR TITLE
Add functioning evaluate for CompoundModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Added missing logic for evaluate to compound models [#10002]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Adds a functioning evaluate method so that compound model is a Composite. 
I was working on an update to `saba` as its been falling behind and noticed this functionality was missing.

# TODO: 
- [X] handle fix_input
- [X] check handling of `|` and `&` operators 
- [X] handle parameter `kwargs` 
- [ ] ~~handle other `kwargs`~~ Other evaluates just take the model parameters
- [X] add tests
- [X] add change log

EDIT: Turn list into check list and add entry to add change log.