### PR TITLE
Validate type of key arguments in io.ascii read() and write()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,9 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Added type validation of key arguments in calls to ``io.ascii.read()`` and
+  ``io.ascii.write()`` functions. [#10005]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/cds.py
+++ b/astropy/io/ascii/cds.py
@@ -174,7 +174,7 @@ class CdsData(core.BaseData):
                       if x.startswith(('------', '======='))]
         if not i_sections:
             raise core.InconsistentTableError('No CDS section delimiter found')
-        return lines[i_sections[-1]+1:]
+        return lines[i_sections[-1]+1:]  # noqa
 
 
 class Cds(core.BaseReader):

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -96,12 +96,12 @@ READ_KWARG_TYPES = {
     # 'Reader'
     # 'Inputter'
     # 'Outputter'
-    'delimiter': (str, np.str_),
-    'comment': (str, np.str_),
-    'quotechar': (str, np.str_),
-    'header_start': (int, np.integer),
-    'data_start': (int, np.integer, str, np.str_),  # CDS allows 'guess'
-    'data_end': (int, np.integer),
+    'delimiter': str,
+    'comment': str,
+    'quotechar': str,
+    'header_start': int,
+    'data_start': (int, str),  # CDS allows 'guess'
+    'data_end': int,
     'converters': dict,
     # 'data_Splitter'
     # 'header_Splitter'
@@ -111,8 +111,8 @@ READ_KWARG_TYPES = {
     'fill_values': 'list-like',
     'fill_include_names': 'list-like',
     'fill_exclude_names': 'list-like',
-    'fast_reader': (bool, np.bool_, str, np.str_, dict),
-    'encoding': (str, np.str_),
+    'fast_reader': (bool, str, dict),
+    'encoding': str,
 }
 
 
@@ -170,16 +170,16 @@ WRITE_DOCSTRING = """
 WRITE_KWARG_TYPES = {
     # 'table'
     # 'output'
-    'format': (str, np.str_),
-    'delimiter': (str, np.str_),
-    'comment': (str, np.str_, bool, np.bool_),
-    'quotechar': (str, np.str_),
-    'header_start': (int, np.integer),
+    'format': str,
+    'delimiter': str,
+    'comment': (str, bool),
+    'quotechar': str,
+    'header_start': int,
     'formats': dict,
-    'strip_whitespace': (bool, np.bool_),
+    'strip_whitespace': (bool),
     'names': 'list-like',
     'include_names': 'list-like',
     'exclude_names': 'list-like',
-    'fast_writer': (bool, np.bool_, str, np.str_),
-    'overwrite': (bool, np.bool_),
+    'fast_writer': (bool, str),
+    'overwrite': (bool),
 }

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -86,9 +86,11 @@ READ_DOCSTRING = """
 
     """
 
-# Specify allowed types for core read() keyword arguments.
-#   The commented-out kwargs are too flexible for a useful check
-#   'list-list' is basically an iterable that is not a string.
+# Specify allowed types for core write() keyword arguments.  Each entry
+# corresponds to the name of an argument and either a type (e.g. int) or a
+# list of types.  These get used in io.ascii.ui._validate_read_write_kwargs().
+# -  The commented-out kwargs are too flexible for a useful check
+# -  'list-list' is a special case for an iterable that is not a string.
 READ_KWARG_TYPES = {
     # 'table'
     'guess': bool,
@@ -164,9 +166,11 @@ WRITE_DOCSTRING = """
         (e.g., a file object).
 
     """
-# Specify allowed types for core write() keyword arguments.
-#   The commented-out kwargs are too flexible for a useful check
-#   'list-list' is basically an iterable that is not a string.
+# Specify allowed types for core write() keyword arguments.  Each entry
+# corresponds to the name of an argument and either a type (e.g. int) or a
+# list of types.  These get used in io.ascii.ui._validate_read_write_kwargs().
+# -  The commented-out kwargs are too flexible for a useful check
+# -  'list-list' is a special case for an iterable that is not a string.
 WRITE_KWARG_TYPES = {
     # 'table'
     # 'output'

--- a/astropy/io/ascii/docs.py
+++ b/astropy/io/ascii/docs.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 READ_DOCSTRING = """
     Read the input ``table`` and return the table.  Most of
     the default behavior for various parameters is determined by the Reader
@@ -48,13 +50,13 @@ READ_DOCSTRING = """
         List of names to include in output.
     exclude_names : list
         List of names to exclude from output (applied after ``include_names``)
-    fill_values : dict
+    fill_values : tuple, list of tuple
         specification of fill values for bad or missing table values
     fill_include_names : list
         List of names to include in fill_values.
     fill_exclude_names : list
         List of names to exclude from fill_values (applied after ``fill_include_names``)
-    fast_reader : bool or dict
+    fast_reader : bool, str or dict
         Whether to use the C engine, can also be a dict with options which
         defaults to `False`; parameters for options dict:
 
@@ -84,6 +86,36 @@ READ_DOCSTRING = """
 
     """
 
+# Specify allowed types for core read() keyword arguments.
+#   The commented-out kwargs are too flexible for a useful check
+#   'list-list' is basically an iterable that is not a string.
+READ_KWARG_TYPES = {
+    # 'table'
+    'guess': bool,
+    # 'format'
+    # 'Reader'
+    # 'Inputter'
+    # 'Outputter'
+    'delimiter': (str, np.str_),
+    'comment': (str, np.str_),
+    'quotechar': (str, np.str_),
+    'header_start': (int, np.integer),
+    'data_start': (int, np.integer, str, np.str_),  # CDS allows 'guess'
+    'data_end': (int, np.integer),
+    'converters': dict,
+    # 'data_Splitter'
+    # 'header_Splitter'
+    'names': 'list-like',
+    'include_names': 'list-like',
+    'exclude_names': 'list-like',
+    'fill_values': 'list-like',
+    'fill_include_names': 'list-like',
+    'fill_exclude_names': 'list-like',
+    'fast_reader': (bool, np.bool_, str, np.str_, dict),
+    'encoding': (str, np.str_),
+}
+
+
 WRITE_DOCSTRING = """
     Write the input ``table`` to ``filename``.  Most of the default behavior
     for various parameters is determined by the Writer class.
@@ -104,8 +136,9 @@ WRITE_DOCSTRING = """
         Output table format. Defaults to 'basic'.
     delimiter : str
         Column delimiter string
-    comment : str
-        String defining a comment line in table
+    comment : str, bool
+        String defining a comment line in table.  If `False` then comments
+        are not written out.
     quotechar : str
         One-character string to quote fields containing special characters
     formats : dict
@@ -118,8 +151,10 @@ WRITE_DOCSTRING = """
         List of names to include in output.
     exclude_names : list
         List of names to exclude from output (applied after ``include_names``)
-    fast_writer : bool
-        Whether to use the fast Cython writer.
+    fast_writer : bool, str
+        Whether to use the fast Cython writer.  Can be `True` (use fast writer
+        if available), `False` (do not use fast writer), or ``'force'`` (use
+        fast writer and fail if not available, mostly for testing).
     overwrite : bool
         If ``overwrite=None`` (default) and the file exists, then a
         warning will be issued. In a future release this will instead
@@ -129,3 +164,22 @@ WRITE_DOCSTRING = """
         (e.g., a file object).
 
     """
+# Specify allowed types for core write() keyword arguments.
+#   The commented-out kwargs are too flexible for a useful check
+#   'list-list' is basically an iterable that is not a string.
+WRITE_KWARG_TYPES = {
+    # 'table'
+    # 'output'
+    'format': (str, np.str_),
+    'delimiter': (str, np.str_),
+    'comment': (str, np.str_, bool, np.bool_),
+    'quotechar': (str, np.str_),
+    'header_start': (int, np.integer),
+    'formats': dict,
+    'strip_whitespace': (bool, np.bool_),
+    'names': 'list-like',
+    'include_names': 'list-like',
+    'exclude_names': 'list-like',
+    'fast_writer': (bool, np.bool_, str, np.str_),
+    'overwrite': (bool, np.bool_),
+}

--- a/astropy/io/ascii/fastbasic.py
+++ b/astropy/io/ascii/fastbasic.py
@@ -266,7 +266,7 @@ class FastCommentedHeader(FastBasic):
             idx = self.header_start
             if idx < 0:
                 idx = len(comments) + idx
-            meta['comments'] = comments[:idx] + comments[idx+1:]
+            meta['comments'] = comments[:idx] + comments[idx+1:]  # noqa
             if not meta['comments']:
                 del meta['comments']
 

--- a/astropy/io/ascii/tests/test_ecsv.py
+++ b/astropy/io/ascii/tests/test_ecsv.py
@@ -281,7 +281,7 @@ mixin_cols = {
                     obstime=['J1990.5'] * 2),
     'q': [1, 2] * u.m,
     'qdb': [10, 20] * u.dB(u.mW),
-    'qdex': [4.5, 5.5] * u.dex(u.cm/u.s**2),
+    'qdex': [4.5, 5.5] * u.dex(u.cm / u.s**2),
     'qmag': [21, 22] * u.ABmag,
     'lat': Latitude([1, 2] * u.deg),
     'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -255,7 +255,7 @@ def test_validate_read_kwargs():
     assert np.all(out['a'] == [3])
 
     with pytest.raises(TypeError, match=r"read\(\) argument 'data_end' must be a "
-                       r"\(<class 'int'>, <class 'numpy.integer'>\) object, "
+                       r"<class 'int'> object, "
                        r"got <class 'str'> instead"):
         ascii.read(lines, data_end='needs integer')
 

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -19,7 +19,7 @@ from astropy import table
 from astropy.units import Unit
 from astropy.table.table_helpers import simple_table
 
-from .common import (raises, assert_equal, assert_almost_equal,
+from .common import (assert_equal, assert_almost_equal,
                      assert_true)
 from astropy.io.ascii import core
 from astropy.io.ascii.ui import _probably_html, get_read_trace
@@ -246,6 +246,22 @@ def test_guess_all_files():
             assert_equal(table.dtype.names, testfile['cols'])
             for colname in table.dtype.names:
                 assert_equal(len(table[colname]), testfile['nrows'])
+
+
+def test_validate_read_kwargs():
+    lines = ['a b', '1 2', '3 4']
+    # Check that numpy integers are allowed
+    out = ascii.read(lines, data_start=np.int16(2))
+    assert np.all(out['a'] == [3])
+
+    with pytest.raises(TypeError, match=r"read\(\) argument 'data_end' must be a "
+                       r"\(<class 'int'>, <class 'numpy.integer'>\) object, "
+                       r"got <class 'str'> instead"):
+        ascii.read(lines, data_end='needs integer')
+
+    with pytest.raises(TypeError, match=r"read\(\) argument 'fill_include_names' must "
+                       r"be a list-like object, got <class 'str'> instead"):
+        ascii.read(lines, fill_include_names='ID')
 
 
 def test_daophot_indef():

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -789,7 +789,6 @@ def test_validate_write_kwargs():
     t = table.QTable([[1, 2], [1, 2]], names=['a', 'b'])
 
     with pytest.raises(TypeError, match=r"write\(\) argument 'fast_writer' must be a "
-                       r"\(<class 'bool'>, <class 'numpy.bool_'>, "
-                       r"<class 'str'>, <class 'numpy.str_'>\) object, "
+                       r"\(<class 'bool'>, <class 'str'>\) object, "
                        r"got <class 'int'> instead"):
         ascii.write(t, out, fast_writer=12)

--- a/astropy/io/ascii/tests/test_write.py
+++ b/astropy/io/ascii/tests/test_write.py
@@ -782,3 +782,14 @@ def test_write_formatted_mixin(fast_writer):
     assert out.getvalue().splitlines() == ['a b',
                                            '01 1.00',
                                            '02 2.00']
+
+
+def test_validate_write_kwargs():
+    out = StringIO()
+    t = table.QTable([[1, 2], [1, 2]], names=['a', 'b'])
+
+    with pytest.raises(TypeError, match=r"write\(\) argument 'fast_writer' must be a "
+                       r"\(<class 'bool'>, <class 'numpy.bool_'>, "
+                       r"<class 'str'>, <class 'numpy.str_'>\) object, "
+                       r"got <class 'int'> instead"):
+        ascii.write(t, out, fast_writer=12)

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -120,14 +120,16 @@ Parameters for ``read()``
   for more information and examples. The default is that any blank table
   values are treated as missing.
 
-**fill_include_names** : list of column names affected by ``fill_values``.
-  From the list of column names found from the header or the ``names``
-  parameter, select for filling only columns within this list. If not supplied,
-  then apply ``fill_values`` to all columns.
+**fill_include_names** : list of column names affected by ``fill_values``
+  This is a list of column names (found from the header or the ``names``
+  parameter) for all columns where values will be filled. `None` (the default) will
+  apply ``fill_values`` to all columns.
 
-**fill_exclude_names** : list of column names not affected by ``fill_values``.
-  Exclude these names from the list of columns for filling. This is applied *after*
-  the ``fill_include_names`` filtering. If not specified then no columns are excluded.
+**fill_exclude_names** : list of column names not affected by ``fill_values``
+  This is a list of column names (found from the header or the ``names``
+  parameter) for all columns where values will be **not** be filled.
+  This parameter takes precedence over ``fill_include_names``.  A value
+  of `None` (default) does not exclude any columns.
 
 **Outputter** : Outputter class
   This converts the raw data tables value into the

--- a/docs/io/ascii/read.rst
+++ b/docs/io/ascii/read.rst
@@ -120,11 +120,14 @@ Parameters for ``read()``
   for more information and examples. The default is that any blank table
   values are treated as missing.
 
-**fill_include_names** : list of column names, which are affected by ``fill_values``.
-  If not supplied, then ``fill_values`` can affect all columns.
+**fill_include_names** : list of column names affected by ``fill_values``.
+  From the list of column names found from the header or the ``names``
+  parameter, select for filling only columns within this list. If not supplied,
+  then apply ``fill_values`` to all columns.
 
-**fill_exclude_names** : list of column names, which are not affected by ``fill_values``.
-  If not supplied, then ``fill_values`` can affect all columns.
+**fill_exclude_names** : list of column names not affected by ``fill_values``.
+  Exclude these names from the list of columns for filling. This is applied *after*
+  the ``fill_include_names`` filtering. If not specified then no columns are excluded.
 
 **Outputter** : Outputter class
   This converts the raw data tables value into the


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Inspired by #10000, where the Python interpretation of a string input as a iterable of characters caused confusion, this PR adds explicit up-front type validation for many of the arguments to `io.ascii.read()` and `io.ascii.write()`.

This passes tests locally, and in getting there I uncovered variations in argument types that had been undocumented.  That was fixed and some elaboration on argument usages added.

I do have a worry that this explicit approach to argument types might break some custom classes or break for usages that are legal but not tested.  Comments welcome.
[EDIT] - the current implementation is more robust and more in the line of duck typing, basically asking if the object can be converted to the required type.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

