### PR TITLE
Cache readonly improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -454,6 +454,8 @@ astropy.utils
 - Fixed ``deprecated_renamed_argument`` not passing in user value to
   deprecated keyword when the keyword has no new name. [#9981]
 
+- Fixed detection of read-only filesystems in the caching code. [#10003]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -454,7 +454,7 @@ astropy.utils
 - Fixed ``deprecated_renamed_argument`` not passing in user value to
   deprecated keyword when the keyword has no new name. [#9981]
 
-- Fixed detection of read-only filesystems in the caching code. [#10003]
+- Fixed detection of read-only filesystems in the caching code. [#10007]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -340,6 +340,7 @@ def test_download_with_sources_and_bogus_original(
         assert is_url_in_cache(u)
 
 
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #9699")
 @pytest.mark.parametrize("b", _shelve_possible_backends)
 def test_download_file_threaded_many(b, temp_cache, valid_urls):
     """Hammer download_file with multiple threaded requests.
@@ -360,6 +361,7 @@ def test_download_file_threaded_many(b, temp_cache, valid_urls):
         assert get_file_contents(r) == c
 
 
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #9699")
 def test_download_file_threaded_many_partial_success(
         temp_cache, valid_urls, invalid_urls):
     """Hammer download_file with multiple threaded requests.

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -342,7 +342,8 @@ def test_download_with_sources_and_bogus_original(
         assert is_url_in_cache(u)
 
 
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+                    reason="causes mystery segfault! possibly bug #10008")
 @pytest.mark.parametrize("b", _shelve_possible_backends)
 def test_download_file_threaded_many(b, temp_cache, valid_urls):
     """Hammer download_file with multiple threaded requests.
@@ -363,21 +364,8 @@ def test_download_file_threaded_many(b, temp_cache, valid_urls):
         assert get_file_contents(r) == c
 
 
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
-def test_download_file_threaded_many_no_cache(valid_urls):
-    """Hammer download_file with multiple threaded requests.
-
-    The goal is to see whether this triggers segfaults even without the
-    caching machinery.
-
-    """
-    urls = list(islice(valid_urls, N_THREAD_HAMMER))
-    with ThreadPoolExecutor(max_workers=len(urls)) as P:
-        list(P.map(lambda u: download_file(u, cache=False),
-                   [u for (u, c) in urls]))
-
-
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+                    reason="causes mystery segfault! possibly bug #10008")
 def test_threaded_segfault(valid_urls):
     """Demonstrate urllib's segfault."""
     def slurp_url(u):
@@ -392,7 +380,8 @@ def test_threaded_segfault(valid_urls):
                    [u for (u, c) in urls]))
 
 
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+                    reason="causes mystery segfault! possibly bug #10008")
 def test_download_file_threaded_many_partial_success(
         temp_cache, valid_urls, invalid_urls):
     """Hammer download_file with multiple threaded requests.

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -342,7 +342,7 @@ def test_download_with_sources_and_bogus_original(
         assert is_url_in_cache(u)
 
 
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #9699")
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
 @pytest.mark.parametrize("b", _shelve_possible_backends)
 def test_download_file_threaded_many(b, temp_cache, valid_urls):
     """Hammer download_file with multiple threaded requests.
@@ -363,7 +363,36 @@ def test_download_file_threaded_many(b, temp_cache, valid_urls):
         assert get_file_contents(r) == c
 
 
-@pytest.mark.skip(reason="causes mystery segfault! possibly bug #9699")
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
+def test_download_file_threaded_many_no_cache(valid_urls):
+    """Hammer download_file with multiple threaded requests.
+
+    The goal is to see whether this triggers segfaults even without the
+    caching machinery.
+
+    """
+    urls = list(islice(valid_urls, N_THREAD_HAMMER))
+    with ThreadPoolExecutor(max_workers=len(urls)) as P:
+        list(P.map(lambda u: download_file(u, cache=False),
+                   [u for (u, c) in urls]))
+
+
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
+def test_threaded_segfault(valid_urls):
+    """Demonstrate urllib's segfault."""
+    def slurp_url(u):
+        with urllib.request.urlopen(u) as remote:
+            block = True
+            while block:
+                block = remote.read(1024)
+
+    urls = list(islice(valid_urls, N_THREAD_HAMMER))
+    with ThreadPoolExecutor(max_workers=len(urls)) as P:
+        list(P.map(lambda u: slurp_url(u),
+                   [u for (u, c) in urls]))
+
+
+@pytest.mark.skip(reason="causes mystery segfault! possibly bug #10008")
 def test_download_file_threaded_many_partial_success(
         temp_cache, valid_urls, invalid_urls):
     """Hammer download_file with multiple threaded requests.

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -6,6 +6,7 @@ import os
 import dbm
 import sys
 import stat
+import errno
 import base64
 import random
 import shutil
@@ -176,7 +177,8 @@ def readonly_cache(tmpdir, valid_urls):
 @pytest.fixture
 def fake_readonly_cache(tmpdir, valid_urls, monkeypatch):
     def no_mkdir(p):
-        raise PermissionError("os.mkdir monkeypatched out")
+        raise OSError(errno.EPERM,
+                      "os.mkdir monkeypatched out")
 
     with TemporaryDirectory(dir=tmpdir) as d:
         # other fixtures use the same tmpdir so we need a subdirectory


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

Fixes #10003 

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the cache code's failure to recognize read-only filesystems as being read-only (rather than generically broken).

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
