### PR TITLE
Fixing issue with reference times in BoxLeastSquares

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -437,6 +437,11 @@ astropy.time
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 
+- Fixed issue with reference time for the ``transit_time`` parameter returned by
+  the ``BoxLeastSquares`` periodogram. Now, the ``transit_time`` will be within
+  the range of the input data and arbitrary time offsets/zero points no longer
+  affect results. [#10013]
+
 astropy.uncertainty
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/timeseries/periodograms/bls/core.py
+++ b/astropy/timeseries/periodograms/bls/core.py
@@ -303,6 +303,7 @@ class BoxLeastSquares(BasePeriodogram):
 
         # Format and check the input arrays
         t = np.ascontiguousarray(strip_units(self._trel), dtype=np.float64)
+        t_ref = np.min(t)
         y = np.ascontiguousarray(strip_units(self.y), dtype=np.float64)
         if self.dy is None:
             ivar = np.ones_like(y)
@@ -324,10 +325,10 @@ class BoxLeastSquares(BasePeriodogram):
 
         # Run the implementation
         results = bls(
-            t, y - np.median(y), ivar, period_fmt, duration,
+            t - t_ref, y - np.median(y), ivar, period_fmt, duration,
             oversample, use_likelihood)
 
-        return self._format_results(objective, period, results)
+        return self._format_results(t_ref, objective, period, results)
 
     def _as_relative_time(self, name, times):
         """
@@ -699,11 +700,13 @@ class BoxLeastSquares(BasePeriodogram):
 
         return period, duration
 
-    def _format_results(self, objective, period, results):
+    def _format_results(self, t_ref, objective, period, results):
         """A private method used to wrap and add units to the periodogram
 
         Parameters
         ----------
+        t_ref : float
+            The minimum time in the time series (a reference time).
         objective : str
             The name of the objective used in the optimization.
         period : array_like or `~astropy.units.Quantity`
@@ -714,6 +717,7 @@ class BoxLeastSquares(BasePeriodogram):
         """
         (power, depth, depth_err, duration, transit_time, depth_snr,
          log_likelihood) = results
+        transit_time += t_ref
 
         if has_units(self._trel):
             transit_time = units.Quantity(transit_time, unit=self._trel.unit)

--- a/astropy/timeseries/periodograms/bls/tests/test_bls.py
+++ b/astropy/timeseries/periodograms/bls/tests/test_bls.py
@@ -359,13 +359,6 @@ def test_absolute_times(data, timedelta):
     # The example data uses relative times
     t, y, dy, params = data
 
-    # FIXME: There seems to be a numerical stability issue in that if we run
-    # the algorithm with the same values but offset in time, the transit_time
-    # is not offset by a fixed amount. To avoid this issue in this test, we
-    # make sure the first time is also the smallest so that internally the
-    # values of the relative time should be the same.
-    t[0] = 0.
-
     # Add units
     t = t * u.day
     y = y * u.mag
@@ -487,3 +480,21 @@ def test_absolute_times(data, timedelta):
     assert exc.value.args[0] == ('t was provided as an absolute time '
                                  'but the BoxLeastSquares class was initialized '
                                  'with relative times.')
+
+
+def test_transit_time_in_range(data):
+    t, y, dy, params = data
+
+    t_ref = 10230.0
+    t2 = t + t_ref
+    bls1 = BoxLeastSquares(t, y, dy)
+    bls2 = BoxLeastSquares(t2, y, dy)
+
+    results1 = bls1.autopower(0.16)
+    results2 = bls2.autopower(0.16)
+
+    assert np.allclose(results1.transit_time, results2.transit_time - t_ref)
+    assert np.all(results1.transit_time >= t.min())
+    assert np.all(results1.transit_time <= t.max())
+    assert np.all(results2.transit_time >= t2.min())
+    assert np.all(results2.transit_time <= t2.max())


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a much requested (by me, @mrtommyb, and I'm sure others) fix to the `BoxLeastSquares` implementation. In the existing implementation, the `transit_time` column in the results will always be within one `period` of zero, but in practice it is much more useful to have this normalized so that the `transit_time` is always within the baseline of the observations. In other words, the results of:

```python
results1 = BoxLeastSquares(t + 100.0, y).autopower(0.1)
# and
results2 = BoxLeastSquares(t, y).autopower(0.1)
```

should differ *only* in the `transit_time` column and that should satisfy:

```python
np.allclose(results1.transit_time - 100.0, results2.transit_time)
```

This pull request satisfies this goal and fixes an existing `FIXME` in the code that was the result of the same issue. It's possible that there is a cleverer way to do this using the `timeseries` API so I'm definitely happy to have feedback! But I normally use this feature directly with `numpy` arrays so it should work properly there too.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
