### PR TITLE
Add known issue about using float on complex numbers

### DIFF
--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -226,6 +226,18 @@ means that an upstream fix in ``numpy` is required in order for
 To convert a dimensionless `~astropy.units.Quantity` to an integer, it is
 therefore recommended to use ``int(...)``.
 
+Inconsistent behavior when converting complex numbers to floats
+---------------------------------------------------------------
+
+Attempting to use `float` or NumPy's ``numpy.float`` on a standard
+complex number (e.g., ``5 + 6j``) results in a `TypeError`.  In
+contrast, using `float` or ``numpy.float`` on a complex number from
+NumPy (e.g., ``numpy.complex128``) drops the imaginary component and
+issues a ``numpy.ComplexWarning``.  This inconsistency persists between
+`~astropy.units.Quantity` instances based on standard and NumPy
+complex numbers.  To get the real part of a complex number, it is
+recommended to use ``numpy.real``.
+
 Build/Installation/Test Issues
 ==============================
 


### PR DESCRIPTION
This pull request adds a known issue in NumPy that using `float` on standard complex numbers results in different behavior than using `float` on NumPy complex numbers (e.g., `numpy.complex128`).  

Related to #10010 and https://github.com/numpy/numpy/issues/13007.