### PR TITLE
ENH: spectral_density equivalency now handles integrated flux

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -100,6 +100,9 @@ astropy.units
 
 - Added ``Rankine`` temperature unit. [#9916]
 
+- Added integrated flux unit conversion to ``spectral_density`` equivalency.
+  [#10015]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/units/equivalencies.py
+++ b/astropy/units/equivalencies.py
@@ -173,6 +173,7 @@ def spectral_density(wav, factor=None):
     la_f_la = nu_f_nu
     phot_f_la = astrophys.photon / (si.cm ** 2 * si.s * si.AA)
     phot_f_nu = astrophys.photon / (si.cm ** 2 * si.s * si.Hz)
+    la_phot_f_la = astrophys.photon / (si.cm ** 2 * si.s)
 
     # luminosity density
     L_nu = cgs.erg / si.s / si.Hz
@@ -270,6 +271,8 @@ def spectral_density(wav, factor=None):
         (phot_f_la, phot_f_nu, converter_phot_f_la_phot_f_nu, iconverter_phot_f_la_phot_f_nu),
         (phot_f_nu, f_nu, converter_phot_f_nu_to_f_nu, iconverter_phot_f_nu_to_f_nu),
         (phot_f_nu, f_la, converter_phot_f_nu_to_f_la, iconverter_phot_f_nu_to_f_la),
+        # integrated flux
+        (la_phot_f_la, la_f_la, converter_phot_f_la_to_f_la, iconverter_phot_f_la_to_f_la),
         # luminosity
         (L_la, L_nu, converter, iconverter),
         (L_nu, nu_L_nu, converter_L_nu_to_nu_L_nu, iconverter_L_nu_to_nu_L_nu),

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -498,7 +498,7 @@ def test_spectraldensity6():
      (u.erg / u.cm ** 2 / u.s, (u.cm * u.cm * u.s) ** -1),
      (u.erg / u.cm ** 2 / u.s, u.erg / (u.cm * u.cm * u.s * u.keV))])
 def test_spectraldensity_not_allowed(from_unit, to_unit):
-    """Now allowed to succeed as
+    """Not allowed to succeed as
     per https://github.com/astropy/astropy/pull/10015
     """
     with pytest.raises(u.UnitConversionError, match='not convertible'):

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -307,6 +307,16 @@ def test_spectraldensity2():
     a = flambda.to(fnu, 1, u.spectral_density(u.Quantity(3500, u.AA)))
     assert_allclose(a, 4.086160166177361e-12)
 
+    # integrated flux
+    f_int = u.erg / u.cm ** 2 / u.s
+    phot_int = u.ph / u.cm ** 2 / u.s
+
+    a = f_int.to(phot_int, 1, u.spectral_density(u.Quantity(3500, u.AA)))
+    assert_allclose(a, 1.7619408e+11)
+
+    a = phot_int.to(f_int, 1, u.spectral_density(u.Quantity(3500, u.AA)))
+    assert_allclose(a, 5.67555959e-12)
+
     # luminosity density
     llambda = u.erg / u.angstrom / u.s
     lnu = u.erg / u.Hz / u.s

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -173,8 +173,8 @@ These three conventions are implemented in
 Spectral Flux / Luminosity Density Units
 ----------------------------------------
 
-There is also support for spectral flux and luminosity density units
-and their equivalent surface brightness units. Their use
+There is also support for spectral flux and luminosity density units,
+their equivalent surface brightness units, and integrated flux units. Their use
 is more complex, since it is necessary to also supply the location in the
 spectrum for which the conversions will be done, and the units of those spectral
 locations.  The function that handles these unit conversions is
@@ -187,10 +187,17 @@ its arguments the |quantity| for the spectral location. For example::
     >>> (1.5 * u.Jy).to(u.photon / u.cm**2 / u.s / u.micron,
     ...                 equivalencies=u.spectral_density(3500 * u.AA))  # doctest: +FLOAT_CMP
     <Quantity 6467.9584789120845 ph / (cm2 micron s)>
-    >>> a = 1. * u.photon / u.s / u.angstrom
+    >>> a = 1. * (u.photon / u.s / u.angstrom)
     >>> a.to(u.erg / u.s / u.Hz,
-    ...      equivalencies=u.spectral_density(5500 * u.AA)) # doctest: +FLOAT_CMP
+    ...      equivalencies=u.spectral_density(5500 * u.AA))  # doctest: +FLOAT_CMP
     <Quantity 3.6443382634999996e-23 erg / (Hz s)>
+    >>> w = 5000 * u.AA
+    >>> a = 1. * (u.erg / u.cm**2 / u.s)
+    >>> b = a.to(u.photon / u.cm**2 / u.s, u.spectral_density(w))
+    >>> b  # doctest: +FLOAT_CMP
+    <Quantity 2.51705828e+11 ph / (cm2 s)>
+    >>> b.to(a.unit, u.spectral_density(w))  # doctest: +FLOAT_CMP
+    <Quantity 1. erg / (cm2 s)>
 
 Brightness Temperature / Surface Brightness Equivalency
 -------------------------------------------------------


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to add handling of integrated flux units to `spectral_density` equivalency.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #7593 
