### PR TITLE
Fix technically correct, but non-sensical example in docstring

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -124,7 +124,7 @@ class SkyCoord(ShapedLikeNDArray):
       >>> c = SkyCoord([1, 2, 3], [-30, 45, 8], frame="icrs", unit="deg")  # 3 coords
 
       >>> coords = ["1:12:43.2 +1:12:43", "1 12 43.2 +1 12 43"]
-      >>> c = SkyCoord(coords, frame=FK4, unit=(u.deg, u.hourangle), obstime="J1992.21")
+      >>> c = SkyCoord(coords, frame=FK4, unit=(u.hourangle, u.deg), obstime="J1992.21")
 
       >>> c = SkyCoord("1h12m43.2s +1d12m43s", frame=Galactic)  # Units from string
       >>> c = SkyCoord(frame="galactic", l="1h12m43.2s", b="+1d12m43s")


### PR DESCRIPTION
In astronomical coordinates, we put in RA, DEC and typically RA is given
as hourangle and DEC in degrees. The example did te opposite.
While in principle, the math allows us to specify the RA
in degrees and the DEC in hourangle, that's never ever done.

Thus the example should also give units in (hourangle, deg)
and not the other way around.
Note that the example as give would fail, if DEC was > 24, so
just to make sure, I also changed a number.