### PR TITLE
Remove inframe keyword from wcsaxes

### DIFF
--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -432,7 +432,7 @@ class WCSAxes(Axes):
 
         self.coords.frame.draw(renderer)
 
-    def draw(self, renderer, inframe=False):
+    def draw(self, renderer, **kwargs):
 
         # In Axes.draw, the following code can result in the xlim and ylim
         # values changing, so we need to force call this here to make sure that
@@ -455,7 +455,7 @@ class WCSAxes(Axes):
         # We need to make sure that that frame path is up to date
         self.coords.frame._update_patch_path()
 
-        super().draw(renderer, inframe=inframe)
+        super().draw(renderer, **kwargs)
 
         self._drawn = True
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the `mpldev` test failures caused by matplotlib/matplotlib#16063 that deprecated `inframe` keyword. ~Can we straight up remove it here or do we need to deprecate it as well? Please advise.~

Example error: https://circleci.com/gh/astropy/astropy/61262
```
E       matplotlib.cbook.deprecation.MatplotlibDeprecationWarning: 
E       The 'inframe' parameter of draw() was deprecated in Matplotlib 3.3 and will be removed two minor releases later. Use Axes.redraw_in_frame() instead. If any parameter follows 'inframe', they should be passed as keyword, not positionally.

.../matplotlib/cbook/__init__.py:2031: MatplotlibDeprecationWarning
```

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

