### PR TITLE
Fix bug in table Index.insert_row()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -427,6 +427,9 @@ astropy.table
 - Tables containing Magnitude, decibel, and dex columns can now be saved to
   ``ecsv`` files. [#9933]
 
+- Fixed bug where adding or inserting a row fails on a table with an index
+  defined on a column that is not the first one. [#10027]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/index.py
+++ b/astropy/table/index.py
@@ -182,7 +182,7 @@ class Index:
         key = [None] * len(self.columns)
         for i, col in enumerate(columns):
             try:
-                key[i] = vals[self.col_position(col.info.name)]
+                key[self.col_position(col.info.name)] = vals[i]
             except ValueError:  # not a member of index
                 continue
         num_rows = len(self.columns[0])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a bug in `table.index.Index.insert_row()`.  It appears the original implementation from long ago had a simple swap in two index variables in one line in `insert_row()`.  This was accidentally working as long as the table indices were on the first column or first N columns in order.  Testing used the first column and the first two columns, so always worked.

I did not add any new tests, but changed the existing ones to cover the case of indexing a column or columns that are not the first ones.  I also confirmed that the example in #10025 now gives the expected result of adding a row of zeros.
```
from astropy import table
t = table.Table({'f': [1,2,3]})
t['a'] = [3,4,5]
t.add_index("a")
t.add_row()
```


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10025.
