### PR TITLE
Flake8 compliance for io.fits

### DIFF
--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -83,7 +83,7 @@ from .header import Header  # noqa
 from .verify import VerifyError  # noqa
 
 
-__all__ = (['Conf', 'conf'] + card.__all__ + column.__all__ +
-           convenience.__all__ + hdu.__all__ +
-           ['FITS_record', 'FITS_rec', 'GroupData', 'open', 'Section',
+__all__ = (['Conf', 'conf'] + card.__all__ + column.__all__
+           + convenience.__all__ + hdu.__all__
+           + ['FITS_record', 'FITS_rec', 'GroupData', 'open', 'Section',
             'Header', 'VerifyError', 'conf'])

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -86,4 +86,4 @@ from .verify import VerifyError  # noqa
 __all__ = (['Conf', 'conf'] + card.__all__ + column.__all__
            + convenience.__all__ + hdu.__all__
            + ['FITS_record', 'FITS_rec', 'GroupData', 'open', 'Section',
-            'Header', 'VerifyError', 'conf'])
+              'Header', 'VerifyError', 'conf'])

--- a/astropy/io/fits/__init__.py
+++ b/astropy/io/fits/__init__.py
@@ -65,22 +65,22 @@ conf = Conf()
 # Public API compatibility imports
 # These need to come after the global config variables, as some of the
 # submodules use them
-from . import card
-from . import column
-from . import convenience
-from . import hdu
-from .card import *
-from .column import *
-from .convenience import *
-from .diff import *
-from .fitsrec import FITS_record, FITS_rec
-from .hdu import *
+from . import card  # noqa
+from . import column  # noqa
+from . import convenience  # noqa
+from . import hdu  # noqa
+from .card import *  # noqa
+from .column import *  # noqa
+from .convenience import *  # noqa
+from .diff import *  # noqa
+from .fitsrec import FITS_record, FITS_rec  # noqa
+from .hdu import *  # noqa
 
-from .hdu.groups import GroupData
-from .hdu.hdulist import fitsopen as open
-from .hdu.image import Section
-from .header import Header
-from .verify import VerifyError
+from .hdu.groups import GroupData  # noqa
+from .hdu.hdulist import fitsopen as open  # noqa
+from .hdu.image import Section  # noqa
+from .header import Header  # noqa
+from .verify import VerifyError  # noqa
 
 
 __all__ = (['Conf', 'conf'] + card.__all__ + column.__all__ +

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -62,10 +62,10 @@ class Card(_Verify):
     # This regex helps delete leading zeros from numbers, otherwise
     # Python might evaluate them as octal values (this is not-greedy, however,
     # so it may not strip leading zeros from a float, which is fine)
-    _number_FSC_RE = re.compile(r'(?P<sign>[+-])?0*?(?P<digt>{})'.format(
-            _digits_FSC))
-    _number_NFSC_RE = re.compile(r'(?P<sign>[+-])? *0*?(?P<digt>{})'.format(
-            _digits_NFSC))
+    _number_FSC_RE = re.compile(r'(?P<sign>[+-])?0*?(?P<digt>{})'
+                                .format(_digits_FSC))
+    _number_NFSC_RE = re.compile(r'(?P<sign>[+-])? *0*?(?P<digt>{})'
+                                 .format(_digits_NFSC))
 
     # FSC commentary card string which must contain printable ASCII characters.
     # Note: \Z matches the end of the string without allowing newlines
@@ -78,7 +78,7 @@ class Card(_Verify):
     # None, meaning the keyword is undefined.  The comment field will
     # return a match if the comment separator is found, though the
     # comment maybe an empty string.
-    _value_FSC_RE = re.compile(
+    _value_FSC_RE = re.compile(  # noqa
         r'(?P<valu_field> *'
             r'(?P<valu>'
 
@@ -108,7 +108,7 @@ class Card(_Verify):
             r'(?P<comm>[!-~][ -~]*)?'
         r')?$')
 
-    _value_NFSC_RE = re.compile(
+    _value_NFSC_RE = re.compile(  # noqa
         r'(?P<valu_field> *'
             r'(?P<valu>'
                 r'\'(?P<strg>([ -~]+?|\'\'|) *?)\'(?=$|/| )|'
@@ -126,11 +126,11 @@ class Card(_Verify):
     _rvkc_identifier = r'[a-zA-Z_]\w*'
     _rvkc_field = _rvkc_identifier + r'(\.\d+)?'
     _rvkc_field_specifier_s = fr'{_rvkc_field}(\.{_rvkc_field})*'
-    _rvkc_field_specifier_val = (r'(?P<keyword>{}): (?P<val>{})'.format(
-            _rvkc_field_specifier_s, _numr_FSC))
+    _rvkc_field_specifier_val = (r'(?P<keyword>{}): (?P<val>{})'
+                                 .format(_rvkc_field_specifier_s, _numr_FSC))
     _rvkc_keyword_val = fr'\'(?P<rawval>{_rvkc_field_specifier_val})\''
-    _rvkc_keyword_val_comm = (r' *{} *(/ *(?P<comm>[ -~]*))?$'.format(
-            _rvkc_keyword_val))
+    _rvkc_keyword_val_comm = (r' *{} *(/ *(?P<comm>[ -~]*))?$'
+                              .format(_rvkc_keyword_val))
 
     _rvkc_field_specifier_val_RE = re.compile(_rvkc_field_specifier_val + '$')
 
@@ -138,8 +138,8 @@ class Card(_Verify):
     # string that is being used to index into a card list that contains
     # record value keyword cards (ex. 'DP1.AXIS.1')
     _rvkc_keyword_name_RE = (
-        re.compile(r'(?P<keyword>{})\.(?P<field_specifier>{})$'.format(
-                _rvkc_identifier, _rvkc_field_specifier_s)))
+        re.compile(r'(?P<keyword>{})\.(?P<field_specifier>{})$'
+                   .format(_rvkc_identifier, _rvkc_field_specifier_s)))
 
     # regular expression to extract the field specifier and value and comment
     # from the string value of a record value keyword card
@@ -376,7 +376,7 @@ class Card(_Verify):
                     self._value = _int_or_float(self._value)
                 except ValueError:
                     raise ValueError('value {} is not a float'.format(
-                            self._value))
+                        self._value))
 
     @value.deleter
     def value(self):
@@ -1111,7 +1111,7 @@ class Card(_Verify):
                     errs.append(self.run_option(
                         option,
                         err_text='Card keyword {!r} is not upper case.'.format(
-                                  keyword),
+                            keyword),
                         fix_text=fix_text,
                         fix=self._fix_keyword))
 
@@ -1135,7 +1135,7 @@ class Card(_Verify):
                     option,
                     err_text='Unprintable string {!r}; commentary cards may '
                              'only contain printable ASCII characters'.format(
-                             valuecomment),
+                                 valuecomment),
                     fixable=False))
         else:
             m = self._value_FSC_RE.match(valuecomment)
@@ -1175,8 +1175,8 @@ class Card(_Verify):
             card = Card.fromstring(self._image[idx:idx + Card.length])
             if idx > 0 and card.keyword.upper() != 'CONTINUE':
                 raise VerifyError(
-                        'Long card images must have CONTINUE cards after '
-                        'the first card.')
+                    'Long card images must have CONTINUE cards after '
+                    'the first card.')
 
             if not isinstance(card.value, str):
                 raise VerifyError('CONTINUE cards must have string values.')

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -183,8 +183,8 @@ class Card(_Verify):
         self._rawkeyword = None
         self._rawvalue = None
 
-        if not (keyword is not None and value is not None and
-                self._check_if_rvkc(keyword, value)):
+        if not (keyword is not None and value is not None
+                and self._check_if_rvkc(keyword, value)):
             # If _check_if_rvkc passes, it will handle setting the keyword and
             # value
             if keyword is not None:
@@ -234,8 +234,8 @@ class Card(_Verify):
             # should be strictly disallowed.
             keyword = keyword.rstrip()
             keyword_upper = keyword.upper()
-            if (len(keyword) <= KEYWORD_LENGTH and
-                    self._keywd_FSC_RE.match(keyword_upper)):
+            if (len(keyword) <= KEYWORD_LENGTH
+                    and self._keywd_FSC_RE.match(keyword_upper)):
                 # For keywords with length > 8 they will be HIERARCH cards,
                 # and can have arbitrary case keywords
                 if keyword_upper == 'END':
@@ -355,15 +355,15 @@ class Card(_Verify):
         elif isinstance(value, np.bool_):
             value = bool(value)
 
-        if (conf.strip_header_whitespace and
-                (isinstance(oldvalue, str) and isinstance(value, str))):
+        if (conf.strip_header_whitespace
+                and (isinstance(oldvalue, str) and isinstance(value, str))):
             # Ignore extra whitespace when comparing the new value to the old
             different = oldvalue.rstrip() != value.rstrip()
         elif isinstance(oldvalue, bool) or isinstance(value, bool):
             different = oldvalue is not value
         else:
-            different = (oldvalue != value or
-                         not isinstance(value, type(oldvalue)))
+            different = (oldvalue != value
+                         or not isinstance(value, type(oldvalue)))
 
         if different:
             self._value = value
@@ -540,9 +540,9 @@ class Card(_Verify):
         # If the keyword, value, and comment are all empty (for self.value
         # explicitly check that it is a string value, since a blank value is
         # returned as '')
-        return (not self.keyword and
-                (isinstance(self.value, str) and not self.value) and
-                not self.comment)
+        return (not self.keyword
+                and (isinstance(self.value, str) and not self.value)
+                and not self.comment)
 
     @classmethod
     def fromstring(cls, image):
@@ -580,8 +580,8 @@ class Card(_Verify):
 
         # Test first for the most common case: a standard FITS keyword provided
         # in standard all-caps
-        if (len(keyword) <= KEYWORD_LENGTH and
-                cls._keywd_FSC_RE.match(keyword)):
+        if (len(keyword) <= KEYWORD_LENGTH
+                and cls._keywd_FSC_RE.match(keyword)):
             return keyword
 
         # Test if this is a record-valued keyword
@@ -701,8 +701,8 @@ class Card(_Verify):
 
         if keyword_upper in self._special_keywords:
             return keyword_upper
-        elif (keyword_upper == 'HIERARCH' and self._image[8] == ' ' and
-              HIERARCH_VALUE_INDICATOR in self._image):
+        elif (keyword_upper == 'HIERARCH' and self._image[8] == ' '
+              and HIERARCH_VALUE_INDICATOR in self._image):
             # This is valid HIERARCH card as described by the HIERARCH keyword
             # convention:
             # http://fits.gsfc.nasa.gov/registry/hierarch_keyword.html
@@ -933,8 +933,8 @@ class Card(_Verify):
             # The value of a commentary card must be just a raw unprocessed
             # string
             value = str(value)
-        elif (self._valuestring and not self._valuemodified and
-              isinstance(self.value, float_types)):
+        elif (self._valuestring and not self._valuemodified
+              and isinstance(self.value, float_types)):
             # Keep the existing formatting for float/complex numbers
             value = f'{self._valuestring:>20}'
         elif self.field_specifier:
@@ -979,8 +979,8 @@ class Card(_Verify):
         # removing the space between the keyword and the equals sign; I'm
         # guessing this is part of the HIEARCH card specification
         keywordvalue_length = len(keyword) + len(delimiter) + len(value)
-        if (keywordvalue_length > self.length and
-                keyword.startswith('HIERARCH')):
+        if (keywordvalue_length > self.length
+                and keyword.startswith('HIERARCH')):
             if (keywordvalue_length == self.length + 1 and keyword[-1] == ' '):
                 output = ''.join([keyword[:-1], delimiter, value, comment])
             else:
@@ -995,8 +995,8 @@ class Card(_Verify):
             # longstring case (CONTINUE card)
             # try not to use CONTINUE if the string value can fit in one line.
             # Instead, just truncate the comment
-            if (isinstance(self.value, str) and
-                    len(value) > (self.length - 10)):
+            if (isinstance(self.value, str)
+                    and len(value) > (self.length - 10)):
                 output = self._format_long_image()
             else:
                 warnings.warn('Card is too long, comment will be truncated.',
@@ -1085,8 +1085,8 @@ class Card(_Verify):
             return errs
 
         # verify the equal sign position
-        if (self.keyword not in self._commentary_keywords and
-            (self._image and self._image[:9].upper() != 'HIERARCH ' and
+        if (self.keyword not in self._commentary_keywords
+            and (self._image and self._image[:9].upper() != 'HIERARCH ' and
              self._image.find('=') != 8)):
             errs.append(self.run_option(
                 option,
@@ -1098,8 +1098,8 @@ class Card(_Verify):
         # verify the key, it is never fixable
         # always fix silently the case where "=" is before column 9,
         # since there is no way to communicate back to the _keys.
-        if ((self._image and self._image[:8].upper() == 'HIERARCH') or
-                self._hierarch):
+        if ((self._image and self._image[:8].upper() == 'HIERARCH')
+                or self._hierarch):
             pass
         else:
             if self._image:

--- a/astropy/io/fits/card.py
+++ b/astropy/io/fits/card.py
@@ -1086,8 +1086,8 @@ class Card(_Verify):
 
         # verify the equal sign position
         if (self.keyword not in self._commentary_keywords
-            and (self._image and self._image[:9].upper() != 'HIERARCH ' and
-             self._image.find('=') != 8)):
+            and (self._image and self._image[:9].upper() != 'HIERARCH '
+                 and self._image.find('=') != 8)):
             errs.append(self.run_option(
                 option,
                 err_text='Card {!r} is not FITS standard (equal sign not '

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -2620,7 +2620,7 @@ def python_to_tdisp(format_string, logical_dtype=False):
             if width == "":
                 ascii_key = ftype if ftype != 'G' else 'F'
                 width = str(int(precision) + (ASCII_DEFAULT_WIDTHS[ascii_key][0] -
-                                     ASCII_DEFAULT_WIDTHS[ascii_key][1]))
+                                              ASCII_DEFAULT_WIDTHS[ascii_key][1]))
         # Otherwise we just have a width
         else:
             width = fmt_str

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -832,8 +832,8 @@ class Column(NotifierMixin):
 
         # This ensures that the new name can fit into a single FITS card
         # without any special extension like CONTINUE cards or the like.
-        if (not isinstance(name, str)
-                or len(str(Card('TTYPE', name))) != CARD_LENGTH):
+        if (not isinstance(name, str) or
+                len(str(Card('TTYPE', name))) != CARD_LENGTH):
             raise AssertionError(
                 'Column name must be a string able to fit in a single '
                 'FITS card--typically this means a maximum of 68 '
@@ -845,46 +845,44 @@ class Column(NotifierMixin):
         if coord_type is None:
             return
 
-        if (not isinstance(coord_type, str)
-                or len(coord_type) > 8):
+        if not isinstance(coord_type, str) or len(coord_type) > 8:
             raise AssertionError(
                 'Coordinate/axis type must be a string of atmost 8 '
                 'characters.')
 
     @ColumnAttribute('TCUNI')
     def coord_unit(col, coord_unit):
-        if (coord_unit is not None
-                and not isinstance(coord_unit, str)):
+        if coord_unit is not None and not isinstance(coord_unit, str):
             raise AssertionError(
                 'Coordinate/axis unit must be a string.')
 
     @ColumnAttribute('TCRPX')
     def coord_ref_point(col, coord_ref_point):
-        if (coord_ref_point is not None
-                and not isinstance(coord_ref_point, numbers.Real)):
+        if (coord_ref_point is not None and
+                not isinstance(coord_ref_point, numbers.Real)):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be '
                 'real floating type.')
 
     @ColumnAttribute('TCRVL')
     def coord_ref_value(col, coord_ref_value):
-        if (coord_ref_value is not None
-                and not isinstance(coord_ref_value, numbers.Real)):
+        if (coord_ref_value is not None and
+                not isinstance(coord_ref_value, numbers.Real)):
             raise AssertionError(
                 'Coordinate value at reference point must be real '
                 'floating type.')
 
     @ColumnAttribute('TCDLT')
     def coord_inc(col, coord_inc):
-        if (coord_inc is not None
-                and not isinstance(coord_inc, numbers.Real)):
+        if (coord_inc is not None and
+                not isinstance(coord_inc, numbers.Real)):
             raise AssertionError(
                 'Coordinate increment must be real floating type.')
 
     @ColumnAttribute('TRPOS')
     def time_ref_pos(col, time_ref_pos):
-        if (time_ref_pos is not None
-                and not isinstance(time_ref_pos, str)):
+        if (time_ref_pos is not None and
+                not isinstance(time_ref_pos, str)):
             raise AssertionError(
                 'Time reference position must be a string.')
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -786,8 +786,8 @@ class Column(NotifierMixin):
         # hard reference to the field like it used to.
         base = array
         while True:
-            if (hasattr(base, '_coldefs') and
-                    isinstance(base._coldefs, ColDefs)):
+            if (hasattr(base, '_coldefs')
+                    and isinstance(base._coldefs, ColDefs)):
                 for col in base._coldefs:
                     if col is self and self._parent_fits_rec is None:
                         self._parent_fits_rec = weakref.ref(base)
@@ -832,8 +832,8 @@ class Column(NotifierMixin):
 
         # This ensures that the new name can fit into a single FITS card
         # without any special extension like CONTINUE cards or the like.
-        if (not isinstance(name, str) or
-                len(str(Card('TTYPE', name))) != CARD_LENGTH):
+        if (not isinstance(name, str)
+                or len(str(Card('TTYPE', name))) != CARD_LENGTH):
             raise AssertionError(
                 'Column name must be a string able to fit in a single '
                 'FITS card--typically this means a maximum of 68 '
@@ -858,31 +858,31 @@ class Column(NotifierMixin):
 
     @ColumnAttribute('TCRPX')
     def coord_ref_point(col, coord_ref_point):
-        if (coord_ref_point is not None and
-                not isinstance(coord_ref_point, numbers.Real)):
+        if (coord_ref_point is not None
+                and not isinstance(coord_ref_point, numbers.Real)):
             raise AssertionError(
                 'Pixel coordinate of the reference point must be '
                 'real floating type.')
 
     @ColumnAttribute('TCRVL')
     def coord_ref_value(col, coord_ref_value):
-        if (coord_ref_value is not None and
-                not isinstance(coord_ref_value, numbers.Real)):
+        if (coord_ref_value is not None
+                and not isinstance(coord_ref_value, numbers.Real)):
             raise AssertionError(
                 'Coordinate value at reference point must be real '
                 'floating type.')
 
     @ColumnAttribute('TCDLT')
     def coord_inc(col, coord_inc):
-        if (coord_inc is not None and
-                not isinstance(coord_inc, numbers.Real)):
+        if (coord_inc is not None
+                and not isinstance(coord_inc, numbers.Real)):
             raise AssertionError(
                 'Coordinate increment must be real floating type.')
 
     @ColumnAttribute('TRPOS')
     def time_ref_pos(col, time_ref_pos):
-        if (time_ref_pos is not None and
-                not isinstance(time_ref_pos, str)):
+        if (time_ref_pos is not None
+                and not isinstance(time_ref_pos, str)):
             raise AssertionError(
                 'Time reference position must be a string.')
 
@@ -1010,9 +1010,9 @@ class Column(NotifierMixin):
                         'will be ignored for the purpose of formatting '
                         'the data in this column.'.format(null))
 
-                elif not (format.format in tnull_formats or
-                          (format.format in ('P', 'Q') and
-                           format.p_format in tnull_formats)):
+                elif not (format.format in tnull_formats
+                          or (format.format in ('P', 'Q')
+                           and format.p_format in tnull_formats)):
                     # TODO: We should also check that TNULLn's integer value
                     # is in the range allowed by the column's format
                     msg = (
@@ -1036,8 +1036,8 @@ class Column(NotifierMixin):
                     f'{disp!r}). The invalid value will be ignored for the '
                     'purpose of formatting the data in this column.')
 
-            elif (isinstance(format, _AsciiColumnFormat) and
-                    disp[0].upper() == 'L'):
+            elif (isinstance(format, _AsciiColumnFormat)
+                    and disp[0].upper() == 'L'):
                 # disp is at least one character long and has the 'L' format
                 # which is not recognized for ASCII tables
                 msg = (
@@ -1318,10 +1318,10 @@ class Column(NotifierMixin):
                 # pseudo-unsigned
                 bzeros = {2: np.uint16(2**15), 4: np.uint32(2**31),
                           8: np.uint64(2**63)}
-                if (array.dtype.kind == 'u' and
-                        array.dtype.itemsize in bzeros and
-                        self.bscale in (1, None, '') and
-                        self.bzero == bzeros[array.dtype.itemsize]):
+                if (array.dtype.kind == 'u'
+                        and array.dtype.itemsize in bzeros
+                        and self.bscale in (1, None, '')
+                        and self.bzero == bzeros[array.dtype.itemsize]):
                     # Basically the array is uint, has scale == 1.0, and the
                     # bzero is the appropriate value for a pseudo-unsigned
                     # integer of the input dtype, then go ahead and assume that
@@ -1353,11 +1353,11 @@ class ColDefs(NotifierMixin):
     def __new__(cls, input, ascii=False):
         klass = cls
 
-        if (hasattr(input, '_columns_type') and
-                issubclass(input._columns_type, ColDefs)):
+        if (hasattr(input, '_columns_type')
+                and issubclass(input._columns_type, ColDefs)):
             klass = input._columns_type
-        elif (hasattr(input, '_col_format_cls') and
-                issubclass(input._col_format_cls, _AsciiColumnFormat)):
+        elif (hasattr(input, '_col_format_cls')
+                and issubclass(input._col_format_cls, _AsciiColumnFormat)):
             klass = _AsciiColDefs
 
         if ascii:  # force ASCII if this has been explicitly requested
@@ -1386,8 +1386,8 @@ class ColDefs(NotifierMixin):
 
         if isinstance(input, ColDefs):
             self._init_from_coldefs(input)
-        elif (isinstance(input, FITS_rec) and hasattr(input, '_coldefs') and
-                input._coldefs):
+        elif (isinstance(input, FITS_rec) and hasattr(input, '_coldefs')
+                and input._coldefs):
             # If given a FITS_rec object we can directly copy its columns, but
             # only if its columns have already been defined, otherwise this
             # will loop back in on itself and blow up
@@ -1552,8 +1552,8 @@ class ColDefs(NotifierMixin):
             # the column is an ASCII table column...
             if new_column.null is not None:
                 new_column.null = DEFAULT_ASCII_TNULL
-            if (new_column.disp is not None and
-                    new_column.disp.upper().startswith('L')):
+            if (new_column.disp is not None
+                    and new_column.disp.upper().startswith('L')):
                 # ASCII columns may not use the logical data display format;
                 # for now just drop the TDISPn option for this column as we
                 # don't have a systematic conversion of boolean data to ASCII
@@ -2617,8 +2617,8 @@ def python_to_tdisp(format_string, logical_dtype=False):
             sep = '.'
             if width == "":
                 ascii_key = ftype if ftype != 'G' else 'F'
-                width = str(int(precision) + (ASCII_DEFAULT_WIDTHS[ascii_key][0] -
-                                              ASCII_DEFAULT_WIDTHS[ascii_key][1]))
+                width = str(int(precision) + (ASCII_DEFAULT_WIDTHS[ascii_key][0]
+                                              - ASCII_DEFAULT_WIDTHS[ascii_key][1]))
         # Otherwise we just have a width
         else:
             width = fmt_str

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1012,7 +1012,7 @@ class Column(NotifierMixin):
 
                 elif not (format.format in tnull_formats
                           or (format.format in ('P', 'Q')
-                           and format.p_format in tnull_formats)):
+                              and format.p_format in tnull_formats)):
                     # TODO: We should also check that TNULLn's integer value
                     # is in the range allowed by the column's format
                     msg = (

--- a/astropy/io/fits/connect.py
+++ b/astropy/io/fits/connect.py
@@ -318,8 +318,8 @@ def _encode_mixins(tbl):
         import yaml  # noqa
     except ImportError:
         for col in tbl.itercols():
-            if (has_info_class(col, MixinInfo) and
-                    col.__class__ not in (u.Quantity, Time)):
+            if (has_info_class(col, MixinInfo)
+                    and col.__class__ not in (u.Quantity, Time)):
                 raise TypeError("cannot write type {} column '{}' "
                                 "to FITS without PyYAML installed."
                                 .format(col.__class__.__name__, col.info.name))

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -995,8 +995,8 @@ def _getext(filename, mode, *args, ext=None, extname=None, extver=None,
     """
 
     err_msg = ('Redundant/conflicting extension arguments(s): {}'.format(
-            {'args': args, 'ext': ext, 'extname': extname,
-             'extver': extver}))
+        {'args': args, 'ext': ext, 'extname': extname,
+         'extver': extver}))
 
     # This code would be much simpler if just one way of specifying an
     # extension were picked.  But now we need to support all possible ways for

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -1086,8 +1086,8 @@ def _stat_filename_or_fileobj(filename):
 
     noexist_or_empty = ((name and
                          (not os.path.exists(name) or
-                          (os.path.getsize(name) == 0)))
-                        or (not name and loc == 0))
+                          (os.path.getsize(name) == 0))) or
+                        (not name and loc == 0))
 
     return name, closed, noexist_or_empty
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -535,7 +535,7 @@ def table_to_hdu(table, character_as_bytes=False):
                 warning = (
                     f"The unit '{unit.to_string()}' could not be saved in "
                     f"native FITS format ")
-                if any('SerializedColumn' in item and 'name: '+col.name in item
+                if any('SerializedColumn' in item and 'name: ' + col.name in item
                        for item in table.meta.get('comments', [])):
                     warning += (
                         "and hence will be lost to non-astropy fits readers. "

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -488,8 +488,8 @@ def table_to_hdu(table, character_as_bytes=False):
             # TODO: Determine a schema for handling non-integer masked columns
             # in FITS (if at all possible)
             int_formats = ('B', 'I', 'J', 'K')
-            if not (col.format in int_formats or
-                    col.format.p_format in int_formats):
+            if not (col.format in int_formats
+                    or col.format.p_format in int_formats):
                 continue
 
             # The astype is necessary because if the string column is less
@@ -1027,9 +1027,9 @@ def _getext(filename, mode, *args, ext=None, extname=None, extver=None,
     elif len(args) > 2:
         raise TypeError('Too many positional arguments.')
 
-    if (ext is not None and
-            not (_is_int(ext) or
-                 (isinstance(ext, tuple) and len(ext) == 2 and
+    if (ext is not None
+            and not (_is_int(ext)
+                 or (isinstance(ext, tuple) and len(ext) == 2 and
                   isinstance(ext[0], str) and _is_int(ext[1])))):
         raise ValueError(
             'The ext keyword must be either an extension number '
@@ -1063,8 +1063,8 @@ def _makehdu(data, header):
     if hdu.__class__ in (_BaseHDU, _ValidHDU):
         # The HDU type was unrecognized, possibly due to a
         # nonexistent/incomplete header
-        if ((isinstance(data, np.ndarray) and data.dtype.fields is not None) or
-                isinstance(data, np.recarray)):
+        if ((isinstance(data, np.ndarray) and data.dtype.fields is not None)
+                or isinstance(data, np.recarray)):
             hdu = BinTableHDU(data, header=header)
         elif isinstance(data, (np.ndarray, DaskArray)):
             hdu = ImageHDU(data, header=header)
@@ -1084,8 +1084,8 @@ def _stat_filename_or_fileobj(filename):
     except AttributeError:
         loc = 0
 
-    noexist_or_empty = ((name and
-                         (not os.path.exists(name) or
+    noexist_or_empty = ((name
+                         and (not os.path.exists(name) or
                           (os.path.getsize(name) == 0))) or
                         (not name and loc == 0))
 

--- a/astropy/io/fits/convenience.py
+++ b/astropy/io/fits/convenience.py
@@ -482,7 +482,8 @@ def table_to_hdu(table, character_as_bytes=False):
 
         # TODO: it might be better to construct the FITS table directly from
         # the Table columns, rather than go via a structured array.
-        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=True)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr,
+                                             character_as_bytes=True)
         for col in table_hdu.columns:
             # Binary FITS tables support TNULL *only* for integer data columns
             # TODO: Determine a schema for handling non-integer masked columns
@@ -499,7 +500,8 @@ def table_to_hdu(table, character_as_bytes=False):
 
             col.null = fill_value.astype(table[col.name].dtype)
     else:
-        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr, character_as_bytes=character_as_bytes)
+        table_hdu = BinTableHDU.from_columns(np.array(table.filled()), header=hdr,
+                                             character_as_bytes=character_as_bytes)
 
     # Set units and format display for output HDU
     for col in table_hdu.columns:
@@ -1029,8 +1031,8 @@ def _getext(filename, mode, *args, ext=None, extname=None, extver=None,
 
     if (ext is not None
             and not (_is_int(ext)
-                 or (isinstance(ext, tuple) and len(ext) == 2 and
-                  isinstance(ext[0], str) and _is_int(ext[1])))):
+                     or (isinstance(ext, tuple) and len(ext) == 2
+                         and isinstance(ext[0], str) and _is_int(ext[1])))):
         raise ValueError(
             'The ext keyword must be either an extension number '
             '(zero-indexed) or a (extname, extver) tuple.')
@@ -1085,9 +1087,9 @@ def _stat_filename_or_fileobj(filename):
         loc = 0
 
     noexist_or_empty = ((name
-                         and (not os.path.exists(name) or
-                          (os.path.getsize(name) == 0))) or
-                        (not name and loc == 0))
+                         and (not os.path.exists(name)
+                              or (os.path.getsize(name) == 0)))
+                        or (not name and loc == 0))
 
     return name, closed, noexist_or_empty
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -563,8 +563,8 @@ class HDUDiff(_BaseDiff):
             # be closed by .close()
             self.diff_data.a = None
             self.diff_data.b = None
-        elif (isinstance(self.a, _TableLikeHDU) and
-              isinstance(self.b, _TableLikeHDU)):
+        elif (isinstance(self.a, _TableLikeHDU)
+              and isinstance(self.b, _TableLikeHDU)):
             # TODO: Replace this if/when _BaseHDU grows a .is_table property
             self.diff_data = TableDataDiff.fromdiff(self, self.a.data,
                                                     self.b.data)
@@ -1014,8 +1014,8 @@ class ImageDataDiff(_BaseDiff):
         # Find the indices where the values are not equal
         # If neither a nor b are floating point (or complex), ignore rtol and
         # atol
-        if not (np.issubdtype(self.a.dtype, np.inexact) or
-                np.issubdtype(self.b.dtype, np.inexact)):
+        if not (np.issubdtype(self.a.dtype, np.inexact)
+                or np.issubdtype(self.b.dtype, np.inexact)):
             rtol = 0
             atol = 0
         else:
@@ -1366,8 +1366,8 @@ class TableDataDiff(_BaseDiff):
             arra = self.a[col.name]
             arrb = self.b[col.name]
 
-            if (np.issubdtype(arra.dtype, np.floating) and
-                    np.issubdtype(arrb.dtype, np.floating)):
+            if (np.issubdtype(arra.dtype, np.floating)
+                    and np.issubdtype(arrb.dtype, np.floating)):
                 diffs = where_not_allclose(arra, arrb,
                                            rtol=self.rtol,
                                            atol=self.atol)

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -274,7 +274,7 @@ class FITSDiff(_BaseDiff):
                 a = fitsopen(a)
             except Exception as exc:
                 raise OSError("error opening file a ({}): {}: {}".format(
-                        a, exc.__class__.__name__, exc.args[0]))
+                    a, exc.__class__.__name__, exc.args[0]))
             close_a = True
         else:
             close_a = False
@@ -284,7 +284,7 @@ class FITSDiff(_BaseDiff):
                 b = fitsopen(b)
             except Exception as exc:
                 raise OSError("error opening file b ({}): {}: {}".format(
-                        b, exc.__class__.__name__, exc.args[0]))
+                    b, exc.__class__.__name__, exc.args[0]))
             close_b = True
         else:
             close_b = False
@@ -888,14 +888,14 @@ class HeaderDiff(_BaseDiff):
                 else:
                     val = self.a[keyword]
                 self._writeln(' Extra keyword {!r:8} in a: {!r}'.format(
-                                keyword, val))
+                    keyword, val))
             for keyword in self.diff_keywords[1]:
                 if keyword in Card._commentary_keywords:
                     val = self.b[keyword][0]
                 else:
                     val = self.b[keyword]
                 self._writeln(' Extra keyword {!r:8} in b: {!r}'.format(
-                                keyword, val))
+                    keyword, val))
 
         if self.diff_duplicate_keywords:
             for keyword, count in sorted(self.diff_duplicate_keywords.items()):
@@ -1416,11 +1416,11 @@ class TableDataDiff(_BaseDiff):
             for name in self.diff_column_names[0]:
                 format = self.diff_columns[0][name.lower()].format
                 self._writeln(' Extra column {} of format {} in a'.format(
-                                name, format))
+                    name, format))
             for name in self.diff_column_names[1]:
                 format = self.diff_columns[1][name.lower()].format
                 self._writeln(' Extra column {} of format {} in b'.format(
-                                name, format))
+                    name, format))
 
         col_attrs = dict(_COL_ATTRS)
         # Now go through each table again and show columns with common
@@ -1428,7 +1428,7 @@ class TableDataDiff(_BaseDiff):
         for col_attr, vals in self.diff_column_attributes:
             name, attr = col_attr
             self._writeln(' Column {} has different {}:'.format(
-                    name, col_attrs[attr]))
+                name, col_attrs[attr]))
             report_diff_values(vals[0], vals[1], fileobj=self._fileobj,
                                indent_width=self._indent + 1)
 
@@ -1450,7 +1450,7 @@ class TableDataDiff(_BaseDiff):
 
         if self.diff_values and self.numdiffs < self.diff_total:
             self._writeln(' ...{} additional difference(s) found.'.format(
-                                self.diff_total - self.numdiffs))
+                self.diff_total - self.numdiffs))
 
         if self.diff_total > self.numdiffs:
             self._writeln(' ...')

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -290,10 +290,10 @@ class FITSDiff(_BaseDiff):
             close_b = False
 
         # Normalize keywords/fields to ignore to upper case
-        self.ignore_hdus = set(k.upper() for k in ignore_hdus)
-        self.ignore_keywords = set(k.upper() for k in ignore_keywords)
-        self.ignore_comments = set(k.upper() for k in ignore_comments)
-        self.ignore_fields = set(k.upper() for k in ignore_fields)
+        self.ignore_hdus = {k.upper() for k in ignore_hdus}
+        self.ignore_keywords = {k.upper() for k in ignore_keywords}
+        self.ignore_comments = {k.upper() for k in ignore_comments}
+        self.ignore_fields = {k.upper() for k in ignore_fields}
 
         self.numdiffs = numdiffs
         self.rtol = rtol

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -151,8 +151,9 @@ class _File:
             mode = 'readonly'
 
         # Handle raw URLs
-        if (isinstance(fileobj, (str, bytes)) and
-                mode not in ('ostream', 'append', 'update') and _is_url(fileobj)):
+        if (isinstance(fileobj, (str, bytes))
+                and mode not in ('ostream', 'append', 'update')
+                and _is_url(fileobj)):
             self.name = download_file(fileobj, cache=cache)
         # Handle responses from URL requests that have already been opened
         elif isinstance(fileobj, http.client.HTTPResponse):
@@ -186,17 +187,17 @@ class _File:
         elif _is_bz2file(fileobj):
             self.compression = 'bzip2'
 
-        if (mode in ('readonly', 'copyonwrite', 'denywrite') or
-                (self.compression and mode == 'update')):
+        if (mode in ('readonly', 'copyonwrite', 'denywrite')
+                or (self.compression and mode == 'update')):
             self.readonly = True
-        elif (mode == 'ostream' or
-                (self.compression and mode == 'append')):
+        elif (mode == 'ostream'
+                or (self.compression and mode == 'append')):
             self.writeonly = True
 
         # For 'ab+' mode, the pointer is at the end after the open in
         # Linux, but is at the beginning in Solaris.
-        if (mode == 'ostream' or self.compression or
-                not hasattr(self._file, 'seek')):
+        if (mode == 'ostream' or self.compression
+                or not hasattr(self._file, 'seek')):
             # For output stream start with a truncated file.
             # For compressed files we can't really guess at the size
             self.size = 0
@@ -417,8 +418,8 @@ class _File:
         This will close the mmap if there are no arrays referencing it.
         """
 
-        if (self._mmap is not None and
-                sys.getrefcount(self._mmap) == 2 + refcount_delta):
+        if (self._mmap is not None
+                and sys.getrefcount(self._mmap) == 2 + refcount_delta):
             self._mmap.close()
             self._mmap = None
 
@@ -430,8 +431,8 @@ class _File:
         """
 
         # The file will be overwritten...
-        if ((self.file_like and hasattr(fileobj, 'len') and fileobj.len > 0) or
-                (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
+        if ((self.file_like and hasattr(fileobj, 'len') and fileobj.len > 0)
+                or (os.path.exists(self.name) and os.path.getsize(self.name) != 0)):
             if overwrite:
                 if self.file_like and hasattr(fileobj, 'truncate'):
                     fileobj.truncate(0)
@@ -528,16 +529,16 @@ class _File:
 
         # If there is not seek or tell methods then set the mode to
         # output streaming.
-        if (not hasattr(self._file, 'seek') or
-                not hasattr(self._file, 'tell')):
+        if (not hasattr(self._file, 'seek')
+                or not hasattr(self._file, 'tell')):
             self.mode = mode = 'ostream'
 
         if mode == 'ostream':
             self._overwrite_existing(overwrite, fileobj, False)
 
         # Any "writeable" mode requires a write() method on the file object
-        if (self.mode in ('update', 'append', 'ostream') and
-                not hasattr(self._file, 'write')):
+        if (self.mode in ('update', 'append', 'ostream')
+                and not hasattr(self._file, 'write')):
             raise OSError("File-like object does not have a 'write' "
                           "method, required for mode '{}'.".format(self.mode))
 

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -615,8 +615,8 @@ class _File:
 
         if mode in ('update', 'append'):
             raise OSError(
-                  "Writing to zipped fits files is not currently "
-                  "supported")
+                "Writing to zipped fits files is not currently "
+                "supported")
 
         if not isinstance(fileobj, zipfile.ZipFile):
             zfile = zipfile.ZipFile(fileobj)
@@ -628,7 +628,7 @@ class _File:
         namelist = zfile.namelist()
         if len(namelist) != 1:
             raise OSError(
-              "Zip files with multiple members are not supported.")
+                "Zip files with multiple members are not supported.")
         self._file = tempfile.NamedTemporaryFile(suffix='.fits')
         self._file.write(zfile.read(namelist[0]))
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -408,8 +408,8 @@ class FITS_rec(np.recarray):
                 # TODO: Maybe this step isn't necessary at all if _scale_back
                 # will handle it?
                 inarr = np.where(inarr == np.False_, ord('F'), ord('T'))
-            elif (columns[idx]._physical_values and
-                    columns[idx]._pseudo_unsigned_ints):
+            elif (columns[idx]._physical_values
+                    and columns[idx]._pseudo_unsigned_ints):
                 # Temporary hack...
                 bzero = column.bzero
                 converted = np.zeros(field.shape, dtype=inarr.dtype)
@@ -441,9 +441,9 @@ class FITS_rec(np.recarray):
                 continue
 
             if inarr.shape != outarr.shape:
-                if (inarr.dtype.kind == outarr.dtype.kind and
-                        inarr.dtype.kind in ('U', 'S') and
-                        inarr.dtype != outarr.dtype):
+                if (inarr.dtype.kind == outarr.dtype.kind
+                        and inarr.dtype.kind in ('U', 'S')
+                        and inarr.dtype != outarr.dtype):
 
                     inarr_rowsize = inarr[0].size
                     inarr = inarr.flatten().view(outarr.dtype)
@@ -705,8 +705,8 @@ class FITS_rec(np.recarray):
         # contains a reference to the ._coldefs object of the original data;
         # this can lead to a circular reference; see ticket #49
         base = self
-        while (isinstance(base, FITS_rec) and
-                isinstance(base.base, np.recarray)):
+        while (isinstance(base, FITS_rec)
+                and isinstance(base.base, np.recarray)):
             base = base.base
         # base could still be a FITS_rec in some cases, so take care to
         # use rec.recarray.field to avoid a potential infinite
@@ -1109,8 +1109,8 @@ class FITS_rec(np.recarray):
                     npts = [len(arr) for arr in self._converted[name]]
 
                     raw_field[:len(npts), 0] = npts
-                    raw_field[1:, 1] = (np.add.accumulate(raw_field[:-1, 0]) *
-                                        dtype.itemsize)
+                    raw_field[1:, 1] = (np.add.accumulate(raw_field[:-1, 0])
+                                        * dtype.itemsize)
                     raw_field[:, 1][:] += heapsize
 
                 heapsize += raw_field[:, 0].sum() * dtype.itemsize
@@ -1264,8 +1264,8 @@ class FITS_rec(np.recarray):
         # Even if the format precision is 0, we should output a decimal point
         # as long as there is space to do so--not including a decimal point in
         # a float value is discouraged by the FITS Standard
-        trailing_decimal = (format.precision == 0 and
-                            format.format in ('F', 'E', 'D'))
+        trailing_decimal = (format.precision == 0
+                            and format.format in ('F', 'E', 'D'))
 
         # not using numarray.strings's num2char because the
         # result is not allowed to expand (as C/Python does).
@@ -1299,8 +1299,8 @@ def _get_recarray_field(array, key):
     # This is currently needed for backwards-compatibility and for
     # automatic truncation of trailing whitespace
     field = np.recarray.field(array, key)
-    if (field.dtype.char in ('S', 'U') and
-            not isinstance(field, chararray.chararray)):
+    if (field.dtype.char in ('S', 'U')
+            and not isinstance(field, chararray.chararray)):
         field = field.view(chararray.chararray)
     return field
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -1327,7 +1327,7 @@ def _ascii_encode(inarray, out=None):
     """
 
     out_dtype = np.dtype(('S{}'.format(inarray.dtype.itemsize // 4),
-                         inarray.dtype.shape))
+                          inarray.dtype.shape))
     if out is not None:
         out = out.view(out_dtype)
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -374,8 +374,8 @@ def _convert_time_column(col, column_info):
         # If reference value is 0 for JD or MJD, the column values can be
         # directly converted to Time, as they are absolute (relative
         # to a globally accepted zero point).
-        if (column_info['ref_time']['val'] == 0 and
-                column_info['ref_time']['format'] in ['jd', 'mjd']):
+        if (column_info['ref_time']['val'] == 0
+                and column_info['ref_time']['format'] in ['jd', 'mjd']):
             # (jd1, jd2) where jd = jd1 + jd2
             if col.shape[-1] == 2 and col.ndim > 1:
                 return Time(col[..., 0], col[..., 1], scale=column_info['scale'],
@@ -452,8 +452,8 @@ def fits_to_time(hdr, table):
             time_columns[int(idx)][base] = value
             hcopy.remove(key)
 
-        elif (value in ('OBSGEO-X', 'OBSGEO-Y', 'OBSGEO-Z') and
-              re.match('TTYPE[0-9]+', key)):
+        elif (value in ('OBSGEO-X', 'OBSGEO-Y', 'OBSGEO-Z')
+              and re.match('TTYPE[0-9]+', key)):
 
             global_info[value] = table[value]
 

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -576,9 +576,9 @@ def time_to_fits(table):
                 if location.size > 1:
                     for dim in ('x', 'y', 'z'):
                         newtable.add_column(Column(getattr(location, dim).to_value(u.m)),
-                                            name='OBSGEO-{}'.format(dim.upper()))
+                                            name=f'OBSGEO-{dim.upper()}')
                 else:
-                    hdr.extend([Card(keyword='OBSGEO-{}'.format(dim.upper()),
+                    hdr.extend([Card(keyword=f'OBSGEO-{dim.upper()}',
                                      value=getattr(location, dim).to_value(u.m))
                                 for dim in ('x', 'y', 'z')])
             elif location != col.location:

--- a/astropy/io/fits/fitstime.py
+++ b/astropy/io/fits/fitstime.py
@@ -580,7 +580,7 @@ def time_to_fits(table):
                 else:
                     hdr.extend([Card(keyword='OBSGEO-{}'.format(dim.upper()),
                                      value=getattr(location, dim).to_value(u.m))
-                            for dim in ('x', 'y', 'z')])
+                                for dim in ('x', 'y', 'z')])
             elif location != col.location:
                 raise ValueError('Multiple Time Columns with different geocentric '
                                  'observatory locations ({}, {}) encountered.'

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -228,10 +228,10 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
     def is_image(self):
         return (
             self.name == 'PRIMARY'
-            or ('XTENSION' in self._header and
-             (self._header['XTENSION'] == 'IMAGE' or
-              (self._header['XTENSION'] == 'BINTABLE' and
-               'ZIMAGE' in self._header and self._header['ZIMAGE'] is True))))
+            or ('XTENSION' in self._header
+                and (self._header['XTENSION'] == 'IMAGE'
+                     or (self._header['XTENSION'] == 'BINTABLE'
+                         and 'ZIMAGE' in self._header and self._header['ZIMAGE'] is True))))
 
     @property
     def _data_loaded(self):
@@ -569,10 +569,10 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             if datasum_keyword in self._header:
                 del self._header[datasum_keyword]
         elif (modified or self._new
-                or (checksum and ('CHECKSUM' not in self._header or
-                               'DATASUM' not in self._header
-                               or not self._checksum_valid
-                               or not self._datasum_valid))):
+                or (checksum and ('CHECKSUM' not in self._header
+                                  or 'DATASUM' not in self._header
+                                  or not self._checksum_valid
+                                  or not self._datasum_valid))):
             if checksum == 'datasum':
                 self.add_datasum(datasum_keyword=datasum_keyword)
             elif checksum:

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -76,8 +76,8 @@ def _hdu_class_from_header(cls, header):
             try:
                 # HDU classes built into astropy.io.fits are always considered,
                 # but extension HDUs must be explicitly registered
-                if not (c.__module__.startswith('astropy.io.fits.') or
-                        c in cls._hdu_registry):
+                if not (c.__module__.startswith('astropy.io.fits.')
+                        or c in cls._hdu_registry):
                     continue
                 if c.match_header(header):
                     klass = c
@@ -107,8 +107,8 @@ class _BaseHDUMeta(type):
         # same name on base classes
         if 'data' in members:
             data_prop = members['data']
-            if (isinstance(data_prop, (lazyproperty, property)) and
-                    data_prop.fdel is None):
+            if (isinstance(data_prop, (lazyproperty, property))
+                    and data_prop.fdel is None):
                 # Don't do anything if the class has already explicitly
                 # set the deleter for its data property
                 def data(self):
@@ -227,8 +227,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
     @property
     def is_image(self):
         return (
-            self.name == 'PRIMARY' or
-            ('XTENSION' in self._header and
+            self.name == 'PRIMARY'
+            or ('XTENSION' in self._header and
              (self._header['XTENSION'] == 'IMAGE' or
               (self._header['XTENSION'] == 'BINTABLE' and
                'ZIMAGE' in self._header and self._header['ZIMAGE'] is True))))
@@ -537,8 +537,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
         header.
         """
 
-        if (self._has_data and self._standard and
-                _is_pseudo_unsigned(self.data.dtype)):
+        if (self._has_data and self._standard
+                and _is_pseudo_unsigned(self.data.dtype)):
             # CompImageHDUs need TFIELDS immediately after GCOUNT,
             # so BSCALE has to go after TFIELDS if it exists.
             if 'TFIELDS' in self._header:
@@ -568,11 +568,11 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
 
             if datasum_keyword in self._header:
                 del self._header[datasum_keyword]
-        elif (modified or self._new or
-                (checksum and ('CHECKSUM' not in self._header or
-                               'DATASUM' not in self._header or
-                               not self._checksum_valid or
-                               not self._datasum_valid))):
+        elif (modified or self._new
+                or (checksum and ('CHECKSUM' not in self._header or
+                               'DATASUM' not in self._header
+                               or not self._checksum_valid
+                               or not self._datasum_valid))):
             if checksum == 'datasum':
                 self.add_datasum(datasum_keyword=datasum_keyword)
             elif checksum:
@@ -582,8 +582,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
     def _postwriteto(self):
         # If data is unsigned integer 16, 32 or 64, remove the
         # BSCALE/BZERO cards
-        if (self._has_data and self._standard and
-                _is_pseudo_unsigned(self.data.dtype)):
+        if (self._has_data and self._standard
+                and _is_pseudo_unsigned(self.data.dtype)):
             for keyword in ('BSCALE', 'BZERO'):
                 with suppress(KeyError):
                     del self._header[keyword]
@@ -746,8 +746,8 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
         # prevent any future access to the .data attribute if there are
         # not other references to it; if there are other references then
         # it is up to the user to clean those up
-        if (closed and self._data_loaded and
-                _get_array_mmap(self.data) is not None):
+        if (closed and self._data_loaded
+                and _get_array_mmap(self.data) is not None):
             del self.data
 
 
@@ -901,8 +901,8 @@ class _ValidHDU(_BaseHDU, _Verify):
     def __init__(self, data=None, header=None, name=None, ver=None, **kwargs):
         super().__init__(data=data, header=header)
 
-        if (header is not None and
-                not isinstance(header, (Header, _BasicHeader))):
+        if (header is not None
+                and not isinstance(header, (Header, _BasicHeader))):
             # TODO: Instead maybe try initializing a new Header object from
             # whatever is passed in as the header--there are various types
             # of objects that could work for this...
@@ -1634,8 +1634,8 @@ class NonstandardExtHDU(ExtensionHDU):
         standard_xtensions = ('IMAGE', 'TABLE', 'BINTABLE', 'A3DTABLE')
         # The check that xtension is not one of the standard types should be
         # redundant.
-        return (card.keyword == 'XTENSION' and
-                xtension not in standard_xtensions)
+        return (card.keyword == 'XTENSION'
+                and xtension not in standard_xtensions)
 
     def _summary(self):
         axes = tuple(self.data.shape)

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1228,7 +1228,7 @@ class _ValidHDU(_BaseHDU, _Verify):
         cs = self._calculate_datasum()
 
         if when is None:
-            when = 'data unit checksum updated {}'.format(self._get_timestamp())
+            when = f'data unit checksum updated {self._get_timestamp()}'
 
         self._header[datasum_keyword] = (str(cs), when)
         return cs
@@ -1275,7 +1275,7 @@ class _ValidHDU(_BaseHDU, _Verify):
             data_cs = self._calculate_datasum()
 
         if when is None:
-            when = 'HDU checksum updated {}'.format(self._get_timestamp())
+            when = f'HDU checksum updated {self._get_timestamp()}'
 
         # Add the CHECKSUM card to the header with a value of all zeros.
         if datasum_keyword in self._header:

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -15,8 +15,8 @@ from astropy.io.fits.file import _File
 from astropy.io.fits.header import (Header, _BasicHeader, _pad_length,
                                     _DelayedHeader)
 from astropy.io.fits.util import (_is_int, _is_pseudo_unsigned, _unsigned_zero,
-                    itersubclasses, decode_ascii, _get_array_mmap, first,
-                    _free_space_check, _extract_number)
+                                  itersubclasses, decode_ascii, _get_array_mmap, first,
+                                  _free_space_check, _extract_number)
 from astropy.io.fits.verify import _Verify, _ErrList
 
 from astropy.utils import lazyproperty
@@ -1159,7 +1159,7 @@ class _ValidHDU(_BaseHDU, _Verify):
                     self._header.insert(insert_pos, card)
 
             errs.append(self.run_option(option, err_text=err_text,
-                        fix_text=fix_text, fix=fix, fixable=fixable))
+                                        fix_text=fix_text, fix=fix, fixable=fixable))
         else:
             # if the supposed location is specified
             if pos is not None:
@@ -1175,23 +1175,23 @@ class _ValidHDU(_BaseHDU, _Verify):
                         self._header.insert(insert_pos, card)
 
                     errs.append(self.run_option(option, err_text=err_text,
-                                fix_text=fix_text, fix=fix))
+                                                fix_text=fix_text, fix=fix))
 
             # if value checking is specified
             if test:
                 val = self._header[keyword]
                 if not test(val):
                     err_text = ("'{}' card has invalid value '{}'.".format(
-                            keyword, val))
+                        keyword, val))
                     fix_text = ("Fixed by setting a new value '{}'.".format(
-                            fix_value))
+                        fix_value))
 
                     if fixable:
                         def fix(self=self, keyword=keyword, val=fix_value):
                             self._header[keyword] = fix_value
 
                     errs.append(self.run_option(option, err_text=err_text,
-                                fix_text=fix_text, fix=fix, fixable=fixable))
+                                                fix_text=fix_text, fix=fix, fixable=fixable))
 
         return errs
 

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -1144,7 +1144,9 @@ class _ValidHDU(_BaseHDU, _Verify):
         # lambda)
         if _is_int(pos):
             insert_pos = pos
-            pos = lambda x: x == insert_pos
+
+            def pos(x):
+                return x == insert_pos
 
         # if the card does not exist
         if index is None:

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -986,8 +986,8 @@ class CompImageHDU(BinTableHDU):
         # Set default tile dimensions for HCOMPRESS_1
 
         if compression_type == 'HCOMPRESS_1':
-            if (self._image_header['NAXIS1'] < 4 or
-                    self._image_header['NAXIS2'] < 4):
+            if (self._image_header['NAXIS1'] < 4
+                    or self._image_header['NAXIS2'] < 4):
                 raise ValueError('Hcompress minimum image dimension is '
                                  '4 pixels')
             elif tile_size:
@@ -1402,8 +1402,8 @@ class CompImageHDU(BinTableHDU):
 
     @data.setter
     def data(self, data):
-        if (data is not None) and (not isinstance(data, np.ndarray) or
-                                   data.dtype.fields is not None):
+        if (data is not None) and (not isinstance(data, np.ndarray)
+                                   or data.dtype.fields is not None):
             raise TypeError('CompImageHDU data has incorrect type:{}; '
                             'dtype.fields = {}'.format(
                                 type(data), data.dtype.fields))
@@ -1555,8 +1555,8 @@ class CompImageHDU(BinTableHDU):
 
         # Remove the EXTNAME card if the value in the table header
         # is the default value of COMPRESSED_IMAGE.
-        if ('EXTNAME' in self._header and
-                self._header['EXTNAME'] == 'COMPRESSED_IMAGE'):
+        if ('EXTNAME' in self._header
+                and self._header['EXTNAME'] == 'COMPRESSED_IMAGE'):
             del image_header['EXTNAME']
 
         # Look to see if there are any blank cards in the table
@@ -1853,8 +1853,8 @@ class CompImageHDU(BinTableHDU):
         super()._close(closed=closed)
 
         # Also make sure to close access to the compressed data mmaps
-        if (closed and self._data_loaded and
-                _get_array_mmap(self.compressed_data) is not None):
+        if (closed and self._data_loaded
+                and _get_array_mmap(self.compressed_data) is not None):
             del self.compressed_data
 
     # TODO: This was copied right out of _ImageBaseHDU; get rid of it once we
@@ -1882,8 +1882,8 @@ class CompImageHDU(BinTableHDU):
             return np.dtype('float32')
 
     def _update_header_scale_info(self, dtype=None):
-        if (not self._do_not_scale_image_data and
-                not (self._orig_bzero == 0 and self._orig_bscale == 1)):
+        if (not self._do_not_scale_image_data
+                and not (self._orig_bzero == 0 and self._orig_bscale == 1)):
             for keyword in ['BSCALE', 'BZERO']:
                 # Make sure to delete from both the image header and the table
                 # header; later this will be streamlined

--- a/astropy/io/fits/hdu/compressed.py
+++ b/astropy/io/fits/hdu/compressed.py
@@ -1252,7 +1252,7 @@ class CompImageHDU(BinTableHDU):
                     dither_seed = self._header['ZDITHER0']
                 else:
                     dither_seed = self._generate_dither_seed(
-                            DEFAULT_DITHER_SEED)
+                        DEFAULT_DITHER_SEED)
 
                 self._header.set('ZDITHER0', dither_seed,
                                  'dithering offset when quantizing floats',
@@ -1403,10 +1403,10 @@ class CompImageHDU(BinTableHDU):
     @data.setter
     def data(self, data):
         if (data is not None) and (not isinstance(data, np.ndarray) or
-                data.dtype.fields is not None):
+                                   data.dtype.fields is not None):
             raise TypeError('CompImageHDU data has incorrect type:{}; '
                             'dtype.fields = {}'.format(
-                    type(data), data.dtype.fields))
+                                type(data), data.dtype.fields))
 
     @lazyproperty
     def compressed_data(self):

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -280,8 +280,8 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
     @classmethod
     def match_header(cls, header):
         keyword = header.cards[0].keyword
-        return (keyword == 'SIMPLE' and 'GROUPS' in header and
-                header['GROUPS'] is True)
+        return (keyword == 'SIMPLE' and 'GROUPS' in header
+                and header['GROUPS'] is True)
 
     @lazyproperty
     def data(self):

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -512,7 +512,9 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                        option, errs)
 
         after = self._header['NAXIS'] + 3
-        pos = lambda x: x >= after
+
+        def pos(x):
+            return x >= after
 
         self.req_cards('GCOUNT', pos, _is_int, 1, option, errs)
         self.req_cards('PCOUNT', pos, _is_int, 0, option, errs)

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -739,8 +739,8 @@ class HDUList(list, _Verify):
             if isinstance(name, str):
                 name = name.strip().upper()
             # 'PRIMARY' should always work as a reference to the first HDU
-            if ((name == _key or (_key == 'PRIMARY' and idx == 0)) and
-                    (_ver is None or _ver == hdu.ver)):
+            if ((name == _key or (_key == 'PRIMARY' and idx == 0))
+                    and (_ver is None or _ver == hdu.ver)):
                 found = idx
                 break
 
@@ -965,8 +965,8 @@ class HDUList(list, _Verify):
         """
 
         try:
-            if (self._file and self._file.mode in ('append', 'update') and
-                    not self._file.closed):
+            if (self._file and self._file.mode in ('append', 'update')
+                    and not self._file.closed):
                 self.flush(output_verify=output_verify, verbose=verbose)
         finally:
             if self._file and closed and hasattr(self._file, 'close'):
@@ -1133,8 +1133,8 @@ class HDUList(list, _Verify):
         try:
             self._in_read_next_hdu = True
 
-            if ('disable_image_compression' in kwargs and
-                    kwargs['disable_image_compression']):
+            if ('disable_image_compression' in kwargs
+                    and kwargs['disable_image_compression']):
                 compressed.COMPRESSION_ENABLED = False
 
             # read all HDUs
@@ -1215,8 +1215,8 @@ class HDUList(list, _Verify):
                                   fix_text=fix_text, fix=fix)
             errs.append(err)
 
-        if len(self) > 1 and ('EXTEND' not in self[0].header or
-                              self[0].header['EXTEND'] is not True):
+        if len(self) > 1 and ('EXTEND' not in self[0].header
+                              or self[0].header['EXTEND'] is not True):
             err_text = ('Primary HDU does not contain an EXTEND keyword '
                         'equal to T even though there are extension HDUs.')
             fix_text = 'Fixed by inserting or updating the EXTEND keyword.'

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -965,8 +965,8 @@ class HDUList(list, _Verify):
         """
 
         try:
-            if (self._file and self._file.mode in ('append', 'update')
-                    and not self._file.closed):
+            if (self._file and self._file.mode in ('append', 'update') and
+                    not self._file.closed):
                 self.flush(output_verify=output_verify, verbose=verbose)
         finally:
             if self._file and closed and hasattr(self._file, 'close'):

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -354,7 +354,7 @@ class HDUList(list, _Verify):
             self._try_while_unread_hdus(super().__setitem__, _key, hdu)
         except IndexError:
             raise IndexError('Extension {} is out of bound or not found.'
-                            .format(key))
+                             .format(key))
 
         self._resize = True
         self._truncate = False
@@ -803,7 +803,7 @@ class HDUList(list, _Verify):
 
         if self._file.mode not in ('append', 'update', 'ostream'):
             warnings.warn("Flush for '{}' mode is not supported."
-                         .format(self._file.mode), AstropyUserWarning)
+                          .format(self._file.mode), AstropyUserWarning)
             return
 
         save_backup = self._open_kwargs.get('save_backup', False)
@@ -818,7 +818,7 @@ class HDUList(list, _Verify):
                     backup = filename + '.bak.' + str(idx)
                     idx += 1
                 warnings.warn('Saving a backup of {} to {}.'.format(
-                        filename, backup), AstropyUserWarning)
+                    filename, backup), AstropyUserWarning)
                 try:
                     shutil.copy(filename, backup)
                 except OSError as exc:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -850,7 +850,7 @@ class _ImageBaseHDU(_ValidHDU):
                 format = ''
             else:
                 format = self.data.dtype.name
-                format = format[format.rfind('.')+1:]
+                format = format[format.rfind('.') + 1:]
         else:
             if self.shape and all(self.shape):
                 # Only show the format if all the dimensions are non-zero
@@ -951,7 +951,7 @@ class Section:
             raise IndexError('too many indices for array')
         # Insert extra dimensions as needed.
         idx = next(i for i, k in enumerate(key + (Ellipsis,)) if k is Ellipsis)
-        key = key[:idx] + (slice(None),) * (naxis - len(key) + 1) + key[idx+1:]
+        key = key[:idx] + (slice(None),) * (naxis - len(key) + 1) + key[idx + 1:]
         return_0dim = (all(isinstance(k, (int, np.integer)) for k in key)
                        and len(key) == naxis)
 

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -257,8 +257,8 @@ class _ImageBaseHDU(_ValidHDU):
             try:
                 data = np.array(data)
             except Exception:
-                raise TypeError('data object {!r} could not be coerced into an '
-                                'ndarray'.format(data))
+                raise TypeError('data object {!r} could not be coerced into '
+                                'an ndarray'.format(data))
 
             if data.shape == ():
                 raise TypeError('data object {!r} should have at least one '
@@ -940,8 +940,8 @@ class Section:
         if not isinstance(key, tuple):
             key = (key,)
         naxis = len(self.hdu.shape)
-        return_scalar = (all(isinstance(k, (int, np.integer)) for k in key)
-                         and len(key) == naxis)
+        return_scalar = (all(isinstance(k, (int, np.integer)) for k in key) and
+                         len(key) == naxis)
         if not any(k is Ellipsis for k in key):
             # We can always add a ... at the end, after making note of whether
             # to return a scalar.
@@ -952,8 +952,8 @@ class Section:
         # Insert extra dimensions as needed.
         idx = next(i for i, k in enumerate(key + (Ellipsis,)) if k is Ellipsis)
         key = key[:idx] + (slice(None),) * (naxis - len(key) + 1) + key[idx + 1:]
-        return_0dim = (all(isinstance(k, (int, np.integer)) for k in key)
-                       and len(key) == naxis)
+        return_0dim = (all(isinstance(k, (int, np.integer)) for k in key) and
+                       len(key) == naxis)
 
         dims = []
         offset = 0

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -71,7 +71,7 @@ class _ImageBaseHDU(_ValidHDU):
 
             if isinstance(self, GroupsHDU):
                 cards.append(('GROUPS', True,
-                             self.standard_keyword_comments['GROUPS']))
+                              self.standard_keyword_comments['GROUPS']))
 
             if isinstance(self, (ExtensionHDU, GroupsHDU)):
                 cards.append(('PCOUNT', 0,

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -136,8 +136,8 @@ class _ImageBaseHDU(_ValidHDU):
         self._modified = False
 
         if data is DELAYED:
-            if (not do_not_scale_image_data and
-                    (self._bscale != 1 or self._bzero != 0)):
+            if (not do_not_scale_image_data
+                    and (self._bscale != 1 or self._bzero != 0)):
                 # This indicates that when the data is accessed or written out
                 # to a new file it will need to be rescaled
                 self._data_needs_rescale = True
@@ -308,8 +308,8 @@ class _ImageBaseHDU(_ValidHDU):
         Update the header keywords to agree with the data.
         """
 
-        if not (self._modified or self._header._modified or
-                (self._has_data and self.shape != self.data.shape)):
+        if not (self._modified or self._header._modified
+                or (self._has_data and self.shape != self.data.shape)):
             # Not likely that anything needs updating
             return
 
@@ -390,15 +390,15 @@ class _ImageBaseHDU(_ValidHDU):
         # else:
         #     original_was_unsigned = False
 
-        if (self._do_not_scale_image_data or
-                (self._orig_bzero == 0 and self._orig_bscale == 1)):
+        if (self._do_not_scale_image_data
+                or (self._orig_bzero == 0 and self._orig_bscale == 1)):
             return
 
         if dtype is None:
             dtype = self._dtype_for_bitpix()
 
-        if (dtype is not None and dtype.kind == 'u' and
-                (self._scale_back or self._scale_back is None)):
+        if (dtype is not None and dtype.kind == 'u'
+                and (self._scale_back or self._scale_back is None)):
             # Data is pseudo-unsigned integers, and the scale_back option
             # was not explicitly set to False, so preserve all the scale
             # factors
@@ -491,8 +491,8 @@ class _ImageBaseHDU(_ValidHDU):
         elif bzero is not None:
             _scale = 1
             _zero = bzero
-        elif (option == 'old' and self._orig_bscale is not None and
-                self._orig_bzero is not None):
+        elif (option == 'old' and self._orig_bscale is not None
+                and self._orig_bzero is not None):
             _scale = self._orig_bscale
             _zero = self._orig_bzero
         elif option == 'minmax' and not issubclass(_type, np.floating):
@@ -777,8 +777,8 @@ class _ImageBaseHDU(_ValidHDU):
         raw_data.dtype = raw_data.dtype.newbyteorder('>')
 
         if self._do_not_scale_image_data or (
-                self._orig_bzero == 0 and self._orig_bscale == 1 and
-                self._blank is None):
+                self._orig_bzero == 0 and self._orig_bscale == 1
+                and self._blank is None):
             # No further conversion of the data is necessary
             return raw_data
 
@@ -859,8 +859,8 @@ class _ImageBaseHDU(_ValidHDU):
             else:
                 format = ''
 
-            if (format and not self._do_not_scale_image_data and
-                    (self._orig_bscale != 1 or self._orig_bzero != 0)):
+            if (format and not self._do_not_scale_image_data
+                    and (self._orig_bscale != 1 or self._orig_bzero != 0)):
                 new_dtype = self._dtype_for_bitpix()
                 if new_dtype is not None:
                     format += f' (rescales to {new_dtype.name})'
@@ -940,8 +940,8 @@ class Section:
         if not isinstance(key, tuple):
             key = (key,)
         naxis = len(self.hdu.shape)
-        return_scalar = (all(isinstance(k, (int, np.integer)) for k in key) and
-                         len(key) == naxis)
+        return_scalar = (all(isinstance(k, (int, np.integer)) for k in key)
+                         and len(key) == naxis)
         if not any(k is Ellipsis for k in key):
             # We can always add a ... at the end, after making note of whether
             # to return a scalar.
@@ -952,8 +952,8 @@ class Section:
         # Insert extra dimensions as needed.
         idx = next(i for i, k in enumerate(key + (Ellipsis,)) if k is Ellipsis)
         key = key[:idx] + (slice(None),) * (naxis - len(key) + 1) + key[idx + 1:]
-        return_0dim = (all(isinstance(k, (int, np.integer)) for k in key) and
-                       len(key) == naxis)
+        return_0dim = (all(isinstance(k, (int, np.integer)) for k in key)
+                       and len(key) == naxis)
 
         dims = []
         offset = 0
@@ -1079,9 +1079,9 @@ class PrimaryHDU(_ImageBaseHDU):
         card = header.cards[0]
         # Due to problems discussed in #5808, we cannot assume the 'GROUPS'
         # keyword to be True/False, have to check the value
-        return (card.keyword == 'SIMPLE' and
-                ('GROUPS' not in header or header['GROUPS'] != True) and  # noqa
-                card.value)
+        return (card.keyword == 'SIMPLE'
+                and ('GROUPS' not in header or header['GROUPS'] != True)  # noqa
+                and card.value)
 
     def update_header(self):
         super().update_header()

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -537,7 +537,7 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
                 self._header[0].rstrip() == self._extension):
 
             err_text = 'The XTENSION keyword must match the HDU type.'
-            fix_text = 'Converted the XTENSION keyword to {}.'.format(self._extension)
+            fix_text = f'Converted the XTENSION keyword to {self._extension}.'
 
             def fix(header=self._header):
                 header[0] = (self._extension, self._ext_comment)
@@ -1303,7 +1303,7 @@ class BinTableHDU(_TableBaseHDU):
         close_file = False
 
         if isinstance(fileobj, str):
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
             close_file = True
 
         initialpos = fileobj.tell()  # We'll be returning here later
@@ -1446,7 +1446,7 @@ class BinTableHDU(_TableBaseHDU):
         close_file = False
 
         if isinstance(fileobj, str):
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
             close_file = True
 
         columns = []

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -160,8 +160,8 @@ class _TableLikeHDU(_ValidHDU):
         # specific to FITS binary tables
         if (any(type(r) in (_FormatP, _FormatQ)
                 for r in columns._recformats) and
-                self._data_size is not None and
-                self._data_size > self._theap):
+                self._data_size is not None
+                and self._data_size > self._theap):
             # We have a heap; include it in the raw_data
             raw_data = self._get_raw_data(self._data_size, np.uint8,
                                           self._data_offset)
@@ -533,8 +533,8 @@ class _TableBaseHDU(ExtensionHDU, _TableLikeHDU):
         """
 
         errs = super()._verify(option=option)
-        if not (isinstance(self._header[0], str) and
-                self._header[0].rstrip() == self._extension):
+        if not (isinstance(self._header[0], str)
+                and self._header[0].rstrip() == self._extension):
 
             err_text = 'The XTENSION keyword must match the HDU type.'
             fix_text = f'Converted the XTENSION keyword to {self._extension}.'
@@ -768,8 +768,8 @@ class TableHDU(_TableBaseHDU):
             if idx == len(columns) - 1:
                 # The last column is padded out to the value of NAXIS1
                 if self._header['NAXIS1'] > itemsize:
-                    data_type = 'S' + str(columns.spans[idx] +
-                                          self._header['NAXIS1'] - itemsize)
+                    data_type = 'S' + str(columns.spans[idx]
+                                          + self._header['NAXIS1'] - itemsize)
             dtype[columns.names[idx]] = (data_type, columns.starts[idx] - 1)
 
         raw_data = self._get_raw_data(self._nrows, dtype, self._data_offset)
@@ -864,8 +864,8 @@ class BinTableHDU(_TableBaseHDU):
         xtension = card.value
         if isinstance(xtension, str):
             xtension = xtension.rstrip()
-        return (card.keyword == 'XTENSION' and
-                xtension in (cls._extension, 'A3DTABLE'))
+        return (card.keyword == 'XTENSION'
+                and xtension in (cls._extension, 'A3DTABLE'))
 
     def _calculate_datasum_with_heap(self):
         """
@@ -1520,8 +1520,8 @@ def _binary_table_byte_swap(data):
         if isinstance(recformat, _FormatP):
             coldata = data.field(idx)
             for c in coldata:
-                if (not isinstance(c, chararray.chararray) and
-                        c.itemsize > 1 and c.dtype.str[0] in swap_types):
+                if (not isinstance(c, chararray.chararray)
+                        and c.itemsize > 1 and c.dtype.str[0] in swap_types):
                     to_swap.append(c)
 
     for arr in reversed(to_swap):

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -19,10 +19,10 @@ from .base import DELAYED, _ValidHDU, ExtensionHDU
 # astropy.io.fits.column has fewer dependencies overall, so it's easier to
 # keep table/column-related utilities in astropy.io.fits.column
 from astropy.io.fits.column import (FITS2NUMPY, KEYWORD_NAMES, KEYWORD_TO_ATTRIBUTE,
-                      ATTRIBUTE_TO_KEYWORD, TDEF_RE, Column, ColDefs,
-                      _AsciiColDefs, _FormatP, _FormatQ, _makep,
-                      _parse_tformat, _scalar_to_format, _convert_format,
-                      _cmp_recformats)
+                                    ATTRIBUTE_TO_KEYWORD, TDEF_RE, Column, ColDefs,
+                                    _AsciiColDefs, _FormatP, _FormatQ, _makep,
+                                    _parse_tformat, _scalar_to_format, _convert_format,
+                                    _cmp_recformats)
 from astropy.io.fits.fitsrec import FITS_rec, _get_recarray_field, _has_unicode_fields
 from astropy.io.fits.header import Header, _pad_length
 from astropy.io.fits.util import _is_int, _str_to_num
@@ -769,7 +769,7 @@ class TableHDU(_TableBaseHDU):
                 # The last column is padded out to the value of NAXIS1
                 if self._header['NAXIS1'] > itemsize:
                     data_type = 'S' + str(columns.spans[idx] +
-                                self._header['NAXIS1'] - itemsize)
+                                          self._header['NAXIS1'] - itemsize)
             dtype[columns.names[idx]] = (data_type, columns.starts[idx] - 1)
 
         raw_data = self._get_raw_data(self._nrows, dtype, self._data_offset)
@@ -1264,7 +1264,7 @@ class BinTableHDU(_TableBaseHDU):
                             line.append(format_value(value, array_format))
                     else:
                         line.append(format_value(row[column.name],
-                                    array_format))
+                                                 array_format))
             linewriter.writerow(line)
         if close_file:
             fileobj.close()

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -978,15 +978,15 @@ class BinTableHDU(_TableBaseHDU):
                 if field.dtype.kind == 'U':
                     # Read the field *width* by reading past the field kind.
                     i = field.dtype.str.index(field.dtype.kind)
-                    field_width = int(field.dtype.str[i+1:])
+                    field_width = int(field.dtype.str[i + 1:])
                     item = np.char.encode(item, 'ascii')
 
                 fileobj.writearray(item)
                 if field_width is not None:
                     j = item.dtype.str.index(item.dtype.kind)
-                    item_length = int(item.dtype.str[j+1:])
+                    item_length = int(item.dtype.str[j + 1:])
                     # Fix padding problem (see #5296).
-                    padding = '\x00'*(field_width - item_length)
+                    padding = '\x00' * (field_width - item_length)
                     fileobj.write(padding.encode('ascii'))
 
     _tdump_file_format = textwrap.dedent("""

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -136,8 +136,8 @@ class Header:
         elif self._haswildcard(key):
             return self.__class__([copy.copy(self._cards[idx])
                                    for idx in self._wildcardmatch(key)])
-        elif (isinstance(key, str) and
-              key.upper() in Card._commentary_keywords):
+        elif (isinstance(key, str)
+              and key.upper() in Card._commentary_keywords):
             key = key.upper()
             # Special case for commentary cards
             return _HeaderCommentaryCards(self, key)
@@ -639,8 +639,8 @@ class Header:
 
                 # Sanitize out invalid END card now that the appropriate
                 # warnings have been issued
-                block = (block[:offset] + encode_ascii(END_CARD) +
-                         block[offset + len(END_CARD):])
+                block = (block[:offset] + encode_ascii(END_CARD)
+                         + block[offset + len(END_CARD):])
 
             return True, block
 
@@ -948,16 +948,16 @@ class Header:
         # Don't try to make a temporary card though if they keyword looks like
         # it might be a HIERARCH card or is otherwise invalid--this step is
         # only for validating RVKCs.
-        if (len(keyword) <= KEYWORD_LENGTH and
-            Card._keywd_FSC_RE.match(keyword) and
-                keyword not in self._keyword_indices):
+        if (len(keyword) <= KEYWORD_LENGTH
+            and Card._keywd_FSC_RE.match(keyword)
+                and keyword not in self._keyword_indices):
             new_card = Card(keyword, value, comment)
             new_keyword = new_card.keyword
         else:
             new_keyword = keyword
 
-        if (new_keyword not in Card._commentary_keywords and
-                new_keyword in self):
+        if (new_keyword not in Card._commentary_keywords
+                and new_keyword in self):
             if comment is None:
                 comment = self.comments[keyword]
             if value is None:
@@ -1212,8 +1212,8 @@ class Header:
                 idx -= 1
 
             if not bottom and card.keyword not in Card._commentary_keywords:
-                while (idx >= 0 and
-                       self._cards[idx].keyword in Card._commentary_keywords):
+                while (idx >= 0
+                       and self._cards[idx].keyword in Card._commentary_keywords):
                     idx -= 1
 
             idx += 1
@@ -1314,8 +1314,8 @@ class Header:
                         # Dumbly update the first keyword to either SIMPLE or
                         # XTENSION as the case may be, as was in the case in
                         # Header.fromTxtFile
-                        if ((keyword == 'SIMPLE' and first == 'XTENSION') or
-                                (keyword == 'XTENSION' and first == 'SIMPLE')):
+                        if ((keyword == 'SIMPLE' and first == 'XTENSION')
+                                or (keyword == 'XTENSION' and first == 'SIMPLE')):
                             del self[0]
                             self.insert(0, card)
                         else:
@@ -1549,10 +1549,10 @@ class Header:
         if newkeyword == 'CONTINUE':
             raise ValueError('Can not rename to CONTINUE')
 
-        if (newkeyword in Card._commentary_keywords or
-                oldkeyword in Card._commentary_keywords):
-            if not (newkeyword in Card._commentary_keywords and
-                    oldkeyword in Card._commentary_keywords):
+        if (newkeyword in Card._commentary_keywords
+                or oldkeyword in Card._commentary_keywords):
+            if not (newkeyword in Card._commentary_keywords
+                    and oldkeyword in Card._commentary_keywords):
                 raise ValueError('Regular and commentary keys can not be '
                                  'renamed to each other.')
         elif not force and newkeyword in self:
@@ -1635,8 +1635,8 @@ class Header:
         if keyword.startswith('HIERARCH '):
             keyword = keyword[9:]
 
-        if (keyword not in Card._commentary_keywords and
-                keyword in self._keyword_indices):
+        if (keyword not in Card._commentary_keywords
+                and keyword in self._keyword_indices):
             # Easy; just update the value/comment
             idx = self._keyword_indices[keyword][0]
             existing_card = self._cards[idx]
@@ -1680,8 +1680,8 @@ class Header:
         elif isinstance(key, slice):
             return key
         elif isinstance(key, tuple):
-            if (len(key) != 2 or not isinstance(key[0], str) or
-                    not isinstance(key[1], int)):
+            if (len(key) != 2 or not isinstance(key[0], str)
+                    or not isinstance(key[1], int)):
                 raise ValueError(
                     'Tuple indices must be 2-tuples consisting of a '
                     'keyword string and an integer index.')
@@ -1746,8 +1746,8 @@ class Header:
             insertionkey = before
 
         def get_insertion_idx():
-            if not (isinstance(insertionkey, int) and
-                    insertionkey >= len(self._cards)):
+            if not (isinstance(insertionkey, int)
+                    and insertionkey >= len(self._cards)):
                 idx = self._cardindex(insertionkey)
             else:
                 idx = insertionkey
@@ -1765,8 +1765,8 @@ class Header:
             old_idx = self._cardindex(card.keyword)
             insertion_idx = get_insertion_idx()
 
-            if (insertion_idx >= len(self._cards) and
-                    old_idx == len(self._cards) - 1):
+            if (insertion_idx >= len(self._cards)
+                    and old_idx == len(self._cards) - 1):
                 # The card would be appended to the end, but it's already at
                 # the end
                 return
@@ -1825,8 +1825,8 @@ class Header:
     def _haswildcard(self, keyword):
         """Return `True` if the input keyword contains a wildcard pattern."""
 
-        return (isinstance(keyword, str) and
-                (keyword.endswith('...') or '*' in keyword or '?' in keyword))
+        return (isinstance(keyword, str)
+                and (keyword.endswith('...') or '*' in keyword or '?' in keyword))
 
     def _wildcardmatch(self, pattern):
         """

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -492,7 +492,7 @@ class Header:
             # Otherwise assume we are reading from an actual FITS file and open
             # in binary mode.
             if sep:
-                fileobj = open(fileobj, 'r', encoding='latin1')
+                fileobj = open(fileobj, encoding='latin1')
             else:
                 fileobj = open(fileobj, 'rb')
 
@@ -819,7 +819,7 @@ class Header:
             A new :class:`Header` instance.
         """
 
-        tmp = self.__class__((copy.copy(card) for card in self._cards))
+        tmp = self.__class__(copy.copy(card) for card in self._cards)
         if strip:
             tmp._strip()
         return tmp

--- a/astropy/io/fits/scripts/fitsdiff.py
+++ b/astropy/io/fits/scripts/fitsdiff.py
@@ -73,7 +73,7 @@ class StoreListAction(argparse.Action):
                 log.warning(f'{self.dest} argument {value} does not exist')
                 return
             try:
-                values = [v.strip() for v in open(value, 'r').readlines()]
+                values = [v.strip() for v in open(value).readlines()]
                 setattr(namespace, self.dest, values)
             except OSError as exc:
                 log.warning('reading {} for {} failed: {}; ignoring this '

--- a/astropy/io/fits/scripts/fitsheader.py
+++ b/astropy/io/fits/scripts/fitsheader.py
@@ -194,7 +194,7 @@ class HeaderFormatter:
             else:
                 header = self._hdulist[hdukey].header
         except (IndexError, KeyError):
-            message = '{}: Extension {} not found.'.format(self.filename, hdukey)
+            message = f'{self.filename}: Extension {hdukey} not found.'
             if self.verbose:
                 log.warning(message)
             raise ExtensionNotFoundException(message)

--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -21,8 +21,8 @@ def _get_compression_extension():
     cfg['sources'].append(os.path.join(os.path.dirname(__file__),
                                        'src', 'compressionmodule.c'))
 
-    if (int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or
-            int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
+    if (int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0))
+            or int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
         cfg.update(pkg_config(['cfitsio'], ['cfitsio']))
     else:
         if get_compiler() == 'msvc':

--- a/astropy/io/fits/tests/test_checksum.py
+++ b/astropy/io/fits/tests/test_checksum.py
@@ -168,7 +168,7 @@ class TestChecksumFunctions(FitsTestCase):
     def test_variable_length_table_data(self):
         c1 = fits.Column(name='var', format='PJ()',
                          array=np.array([[45.0, 56], np.array([11, 12, 13])],
-                         'O'))
+                                        'O'))
         c2 = fits.Column(name='xyz', format='2I', array=[[11, 3], [12, 4]])
         tbhdu = fits.BinTableHDU.from_columns([c1, c2])
         tbhdu.writeto(self.temp('tmp.fits'), overwrite=True, checksum=True)

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -485,7 +485,10 @@ def test_scale_error():
     t['a'].unit = '1.2'
     with pytest.raises(UnitScaleError) as exc:
         t.write('t.fits', format='fits', overwrite=True)
-    assert exc.value.args[0] == "The column 'a' could not be stored in FITS format because it has a scale '(1.2)' that is not recognized by the FITS standard. Either scale the data or change the units."
+    assert exc.value.args[0] == (
+        "The column 'a' could not be stored in FITS format because it has a "
+        "scale '(1.2)' that is not recognized by the FITS standard. Either "
+        "scale the data or change the units.")
 
 
 @pytest.mark.parametrize('tdisp_str, format_return',

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -184,7 +184,7 @@ class TestSingleTable:
         filename = str(tmpdir.join('test_masked_nan.fits'))
         data = np.array(list(zip([5.2, 8.4, 3.9, 6.3],
                                  [2.3, 4.5, 6.7, 8.9])),
-                                dtype=[('a', np.float64), ('b', np.float32)])
+                        dtype=[('a', np.float64), ('b', np.float32)])
         t1 = Table(data, masked=True)
         t1.mask['a'] = [1, 0, 1, 0]
         t1.mask['b'] = [1, 0, 0, 1]

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -88,10 +88,10 @@ class TestSingleTable:
         filename = str(tmpdir.join('test_simple.fits'))
         t1 = Table(self.data)
         t1.meta['ttype1'] = 'spam'
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t1.write(filename, overwrite=True)
-        assert len(l) == 1
-        assert str(l[0].message).startswith(
+        assert len(ww) == 1
+        assert str(ww[0].message).startswith(
             'Meta-data keyword ttype1 will be ignored since it conflicts with a FITS reserved keyword')
 
     def test_simple_noextension(self, tmpdir):
@@ -324,18 +324,18 @@ class TestMultipleHDU:
     def test_read_with_hdu_1(self, tmpdir, hdu):
         filename = str(tmpdir.join('test_read_with_hdu_1.fits'))
         self.hdus.writeto(filename)
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(filename, hdu=hdu)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data1)
 
     @pytest.mark.parametrize('hdu', [2, 'second'])
     def test_read_with_hdu_2(self, tmpdir, hdu):
         filename = str(tmpdir.join('test_read_with_hdu_2.fits'))
         self.hdus.writeto(filename)
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(filename, hdu=hdu)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data2)
 
     @pytest.mark.parametrize('hdu', [3, 'third'])
@@ -348,9 +348,9 @@ class TestMultipleHDU:
     def test_read_with_hdu_4(self, tmpdir):
         filename = str(tmpdir.join('test_read_with_hdu_4.fits'))
         self.hdus.writeto(filename)
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(filename, hdu=4)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data3)
 
     @pytest.mark.parametrize('hdu', [2, 3, '1', 'second', ''])
@@ -405,23 +405,23 @@ class TestMultipleHDU:
 
     @pytest.mark.parametrize('hdu', [1, 'first', None])
     def test_read_from_hdulist_with_single_table(self, hdu):
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(self.hdus1, hdu=hdu)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data1)
 
     @pytest.mark.parametrize('hdu', [1, 'first'])
     def test_read_from_hdulist_with_hdu_1(self, hdu):
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(self.hdus, hdu=hdu)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data1)
 
     @pytest.mark.parametrize('hdu', [2, 'second'])
     def test_read_from_hdulist_with_hdu_2(self, hdu):
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(self.hdus, hdu=hdu)
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data2)
 
     @pytest.mark.parametrize('hdu', [3, 'third'])
@@ -433,7 +433,7 @@ class TestMultipleHDU:
     def test_read_from_hdulist_with_hdu_warning(self, hdu):
         with pytest.warns(AstropyDeprecationWarning,
                           match=rf"No table found in specified hdu={hdu}, "
-                                r"reading in first available table \(hdu=1\)"):\
+                                r"reading in first available table \(hdu=1\)"):
             t2 = Table.read(self.hdus2, hdu=hdu)
         assert equal_data(t2, self.data1)
 
@@ -455,9 +455,9 @@ class TestMultipleHDU:
 
     @pytest.mark.parametrize('hdu', [None, 1, 'first'])
     def test_read_from_single_hdu(self, hdu):
-        with catch_warnings() as l:
+        with catch_warnings() as ww:
             t = Table.read(self.hdus[1])
-        assert len(l) == 0
+        assert len(ww) == 0
         assert equal_data(t, self.data1)
 
 
@@ -572,14 +572,15 @@ def test_unit_warnings_read_write(tmpdir):
     t1['a'].unit = 'm/s'
     t1['b'].unit = 'not-a-unit'
 
-    with catch_warnings() as l:
+    with catch_warnings() as ww:
         t1.write(filename, overwrite=True)
-        assert len(l) == 1
-        assert str(l[0].message).startswith("'not-a-unit' did not parse as fits unit")
+        assert len(ww) == 1
+        assert str(ww[0].message).startswith(
+            "'not-a-unit' did not parse as fits unit")
 
-    with catch_warnings() as l:
+    with catch_warnings() as ww:
         Table.read(filename, hdu=1)
-    assert len(l) == 0
+    assert len(ww) == 0
 
 
 def test_convert_comment_convention(tmpdir):

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -553,8 +553,8 @@ class TestCore(FitsTestCase):
                             if idx != 1:
                                 assert hdu.header == hdu2.header
                             else:
-                                assert (hdu2.header ==
-                                        hdu.header[:len(hdu2.header)])
+                                assert (hdu2.header
+                                        == hdu.header[:len(hdu2.header)])
                             assert np.all(hdu.data == hdu2.data)
 
 

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -49,8 +49,8 @@ class TestCore(FitsTestCase):
             assert 'NAXIS3' not in hdulist[1].header
 
     def test_byteswap(self):
-        p = fits.PrimaryHDU()
-        l = fits.HDUList()
+        phdu = fits.PrimaryHDU()
+        hdul = fits.HDUList()
 
         n = np.zeros(3, dtype='i2')
         n[0] = 1
@@ -61,13 +61,13 @@ class TestCore(FitsTestCase):
                         array=n)
         t = fits.BinTableHDU.from_columns([c])
 
-        l.append(p)
-        l.append(t)
+        hdul.append(phdu)
+        hdul.append(t)
 
-        l.writeto(self.temp('test.fits'), overwrite=True)
+        hdul.writeto(self.temp('test.fits'), overwrite=True)
 
-        with fits.open(self.temp('test.fits')) as p:
-            assert p[1].data[1]['foo'] == 60000.0
+        with fits.open(self.temp('test.fits')) as newhdul:
+            assert newhdul[1].data[1]['foo'] == 60000.0
 
     def test_fits_file_path_object(self):
         """

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -75,8 +75,8 @@ class TestDiff(FitsTestCase):
         hb.comments['C'] = 'comment 2'
         diff = HeaderDiff(ha, hb)
         assert not diff.identical
-        assert (diff.diff_keyword_comments ==
-                {'C': [('comment 1', 'comment 2')]})
+        assert (diff.diff_keyword_comments
+                == {'C': [('comment 1', 'comment 2')]})
 
     def test_different_keyword_values_with_duplicate(self):
         ha = Header([('A', 1), ('B', 2), ('C', 3)])
@@ -97,8 +97,8 @@ class TestDiff(FitsTestCase):
         diff = HeaderDiff(ha, hb)
         assert not diff.identical
         assert diff.diff_keyword_values == {}
-        assert (diff.diff_duplicate_keywords ==
-                {'A': (3, 1), 'B': (1, 2), 'C': (1, 2)})
+        assert (diff.diff_duplicate_keywords
+                == {'A': (3, 1), 'B': (1, 2), 'C': (1, 2)})
 
         report = diff.report()
         assert ("Inconsistent duplicates of keyword 'A'     :\n"
@@ -111,8 +111,8 @@ class TestDiff(FitsTestCase):
         hb['C'] = 3.000002
         diff = HeaderDiff(ha, hb)
         assert not diff.identical
-        assert (diff.diff_keyword_values ==
-                {'B': [(2.00001, 2.00002)], 'C': [(3.000001, 3.000002)]})
+        assert (diff.diff_keyword_values
+                == {'B': [(2.00001, 2.00002)], 'C': [(3.000001, 3.000002)]})
         diff = HeaderDiff(ha, hb, rtol=1e-6)
         assert not diff.identical
         assert diff.diff_keyword_values == {'B': [(2.00001, 2.00002)]}
@@ -126,20 +126,20 @@ class TestDiff(FitsTestCase):
         hb['C'] = 0.000001
         diff = HeaderDiff(ha, hb, rtol=1e-6)
         assert not diff.identical
-        assert (diff.diff_keyword_values ==
-                {'B': [(1.0, 1.00001)], 'C': [(0.0, 0.000001)]})
+        assert (diff.diff_keyword_values
+                == {'B': [(1.0, 1.00001)], 'C': [(0.0, 0.000001)]})
         diff = HeaderDiff(ha, hb, rtol=1e-5)
         assert not diff.identical
-        assert (diff.diff_keyword_values ==
-                {'C': [(0.0, 0.000001)]})
+        assert (diff.diff_keyword_values
+                == {'C': [(0.0, 0.000001)]})
         diff = HeaderDiff(ha, hb, atol=1e-6)
         assert not diff.identical
-        assert (diff.diff_keyword_values ==
-                {'B': [(1.0, 1.00001)]})
+        assert (diff.diff_keyword_values
+                == {'B': [(1.0, 1.00001)]})
         diff = HeaderDiff(ha, hb, atol=1e-5)  # strict inequality
         assert not diff.identical
-        assert (diff.diff_keyword_values ==
-                {'B': [(1.0, 1.00001)]})
+        assert (diff.diff_keyword_values
+                == {'B': [(1.0, 1.00001)]})
         diff = HeaderDiff(ha, hb, rtol=1e-5, atol=1e-5)
         assert diff.identical
         diff = HeaderDiff(ha, hb, atol=1.1e-5)
@@ -653,8 +653,8 @@ class TestDiff(FitsTestCase):
         assert isinstance(datadiff, ImageDataDiff)
         assert not datadiff.identical
         assert datadiff.diff_dimensions == ()
-        assert (datadiff.diff_pixels ==
-                [((0, y), (y, y + 1)) for y in range(10)])
+        assert (datadiff.diff_pixels
+                == [((0, y), (y, y + 1)) for y in range(10)])
         assert datadiff.diff_ratio == 1.0
         assert datadiff.diff_total == 100
 

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -372,8 +372,8 @@ class TestDiff(FitsTestCase):
         c5 = Column('E', format='A3', array=['abc', 'def'])
         c6 = Column('F', format='E', unit='m', array=[0.0, 1.0])
         c7 = Column('G', format='D', bzero=-0.1, array=[0.0, 1.0])
-        c8 = Column('H', format='C', array=[0.0+1.0j, 2.0+3.0j])
-        c9 = Column('I', format='M', array=[4.0+5.0j, 6.0+7.0j])
+        c8 = Column('H', format='C', array=[0.0 + 1.0j, 2.0 + 3.0j])
+        c9 = Column('I', format='M', array=[4.0 + 5.0j, 6.0 + 7.0j])
         c10 = Column('J', format='PI(2)', array=[[0, 1], [2, 3]])
 
         columns = [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10]
@@ -518,8 +518,8 @@ class TestDiff(FitsTestCase):
         ca5 = Column('E', format='A3', array=['abc', 'def'])
         ca6 = Column('F', format='E', unit='m', array=[0.0, 1.0])
         ca7 = Column('G', format='D', bzero=-0.1, array=[0.0, 1.0])
-        ca8 = Column('H', format='C', array=[0.0+1.0j, 2.0+3.0j])
-        ca9 = Column('I', format='M', array=[4.0+5.0j, 6.0+7.0j])
+        ca8 = Column('H', format='C', array=[0.0 + 1.0j, 2.0 + 3.0j])
+        ca9 = Column('I', format='M', array=[4.0 + 5.0j, 6.0 + 7.0j])
         ca10 = Column('J', format='PI(2)', array=[[0, 1], [2, 3]])
 
         cb1 = Column('A', format='L', array=[False, False])
@@ -530,8 +530,8 @@ class TestDiff(FitsTestCase):
         cb5 = Column('E', format='A3', array=['abc', 'ghi'])
         cb6 = Column('F', format='E', unit='m', array=[1.0, 2.0])
         cb7 = Column('G', format='D', bzero=-0.1, array=[2.0, 3.0])
-        cb8 = Column('H', format='C', array=[1.0+1.0j, 2.0+3.0j])
-        cb9 = Column('I', format='M', array=[5.0+5.0j, 6.0+7.0j])
+        cb8 = Column('H', format='C', array=[1.0 + 1.0j, 2.0 + 3.0j])
+        cb9 = Column('I', format='M', array=[5.0 + 5.0j, 6.0 + 7.0j])
         cb10 = Column('J', format='PI(2)', array=[[1, 2], [3, 4]])
 
         ta = BinTableHDU.from_columns([ca1, ca2, ca3, ca4, ca5, ca6, ca7,
@@ -554,8 +554,8 @@ class TestDiff(FitsTestCase):
         assert diff.diff_values[6] == (('F', 1), (1.0, 2.0))
         assert diff.diff_values[7] == (('G', 0), (0.0, 2.0))
         assert diff.diff_values[8] == (('G', 1), (1.0, 3.0))
-        assert diff.diff_values[9] == (('H', 0), (0.0+1.0j, 1.0+1.0j))
-        assert diff.diff_values[10] == (('I', 0), (4.0+5.0j, 5.0+5.0j))
+        assert diff.diff_values[9] == (('H', 0), (0.0 + 1.0j, 1.0 + 1.0j))
+        assert diff.diff_values[10] == (('I', 0), (4.0 + 5.0j, 5.0 + 5.0j))
         assert diff.diff_values[11][0] == ('J', 0)
         assert (diff.diff_values[11][1][0] == [0, 1]).all()
         assert (diff.diff_values[11][1][1] == [1, 2]).all()

--- a/astropy/io/fits/tests/test_fitsdiff.py
+++ b/astropy/io/fits/tests/test_fitsdiff.py
@@ -164,7 +164,7 @@ Primary HDU:\n\n   Data contains differences:
     def test_wildcard(self):
         tmp1 = self.temp("tmp_file1")
         with pytest.raises(SystemExit) as e:
-            fitsdiff.main([tmp1+"*", "ACME"])
+            fitsdiff.main([tmp1 + "*", "ACME"])
         assert e.value.code == 2
 
     def test_not_quiet(self, capsys):
@@ -236,9 +236,9 @@ No differences found.\n""".format(version, tmp_a, tmp_b)
         # globbing
         with pytest.warns(UserWarning, match=r"Field 'ORBPARM' has a repeat "
                           r"count of 0 in its format code"):
-            assert fitsdiff.main(["-q", self.data_dir+'/*.fits',
+            assert fitsdiff.main(["-q", self.data_dir + '/*.fits',
                                   self.data_dir]) == 0
-        assert fitsdiff.main(["-q", self.data_dir+'/g*.fits', tmp_d]) == 0
+        assert fitsdiff.main(["-q", self.data_dir + '/g*.fits', tmp_d]) == 0
 
         # one file and a directory
         tmp_f = self.data('tb.fits')

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -148,11 +148,11 @@ class TestFitsTime(FitsTestCase):
         t['a'] = Time(self.time, format='isot', scale='utc',
                       location=EarthLocation(-2446354,
                       4237210, 4077985, unit='m'))
-        t['b'] = Time([1,2], format='cxcsec', scale='tt')
+        t['b'] = Time([1, 2], format='cxcsec', scale='tt')
 
-        ideal_col_hdr = {'OBSGEO-X' : t['a'].location.x.value,
-                         'OBSGEO-Y' : t['a'].location.y.value,
-                         'OBSGEO-Z' : t['a'].location.z.value}
+        ideal_col_hdr = {'OBSGEO-X': t['a'].location.x.value,
+                         'OBSGEO-Y': t['a'].location.y.value,
+                         'OBSGEO-Z': t['a'].location.z.value}
 
         with pytest.warns(AstropyUserWarning, match=r'Time Column "b" has no '
                           r'specified location, but global Time Position is present'):
@@ -253,7 +253,7 @@ class TestFitsTime(FitsTestCase):
         """
         t = table_types()
         t['a'] = Time(self.time, format='isot', scale='utc',
-                      location=EarthLocation(1,2,3, unit='km'))
+                      location=EarthLocation(1, 2, 3, unit='km'))
 
         table, hdr = time_to_fits(t)
 

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -147,7 +147,7 @@ class TestFitsTime(FitsTestCase):
         t = table_types()
         t['a'] = Time(self.time, format='isot', scale='utc',
                       location=EarthLocation(-2446354,
-                      4237210, 4077985, unit='m'))
+                                             4237210, 4077985, unit='m'))
         t['b'] = Time([1, 2], format='cxcsec', scale='tt')
 
         ideal_col_hdr = {'OBSGEO-X': t['a'].location.x.value,

--- a/astropy/io/fits/tests/test_fitstime.py
+++ b/astropy/io/fits/tests/test_fitstime.py
@@ -175,7 +175,7 @@ class TestFitsTime(FitsTestCase):
             assert coord_info[colname]['coord_unit'] == 'd'
 
         assert coord_info['a']['time_ref_pos'] == 'TOPOCENTER'
-        assert coord_info['b']['time_ref_pos'] == None
+        assert coord_info['b']['time_ref_pos'] is None
 
         assert len(hdr) == 0
 

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -716,15 +716,15 @@ class TestHDUListFunctions(FitsTestCase):
                     assert hdul[idx].header == hdul2[idx].header
                     if hdul[idx].data is None or hdul2[idx].data is None:
                         assert hdul[idx].data == hdul2[idx].data
-                    elif (hdul[idx].data.dtype.fields and
-                          hdul2[idx].data.dtype.fields):
+                    elif (hdul[idx].data.dtype.fields
+                          and hdul2[idx].data.dtype.fields):
                         # Compare tables
                         for n in hdul[idx].data.names:
                             c1 = hdul[idx].data[n]
                             c2 = hdul2[idx].data[n]
                             assert (c1 == c2).all()
-                    elif (any(dim == 0 for dim in hdul[idx].data.shape) or
-                          any(dim == 0 for dim in hdul2[idx].data.shape)):
+                    elif (any(dim == 0 for dim in hdul[idx].data.shape)
+                          or any(dim == 0 for dim in hdul2[idx].data.shape)):
                         # For some reason some combinations of Python and Numpy
                         # on Windows result in MemoryErrors when trying to work
                         # on memmap arrays with more than one dimension but

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2805,9 +2805,9 @@ class TestRecordValuedKeywordCards(FitsTestCase):
             assert len(mytable) == len(fitsobj[0].header)
             # Repeat the above test when multiple HDUs are requested
             mytable = formatter.parse(extensions=['AIPS FQ', 2, "4"])
-            assert len(mytable) == (len(fitsobj['AIPS FQ'].header)
-                                    + len(fitsobj[2].header)
-                                    + len(fitsobj[4].header))
+            assert len(mytable) == (len(fitsobj['AIPS FQ'].header) +
+                                    len(fitsobj[2].header) +
+                                    len(fitsobj[4].header))
 
         # Can we recover the filename and extension name from the table?
         mytable = formatter.parse(extensions=['AIPS FQ'])

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -121,8 +121,8 @@ class TestHeaderFunctions(FitsTestCase):
 
         c = fits.Card('floatnum', -467374636747637647347374734737437.)
 
-        if (str(c) != _pad("FLOATNUM= -4.6737463674763E+32") and
-                str(c) != _pad("FLOATNUM= -4.6737463674763E+032")):
+        if (str(c) != _pad("FLOATNUM= -4.6737463674763E+32")
+                and str(c) != _pad("FLOATNUM= -4.6737463674763E+032")):
             assert str(c) == _pad("FLOATNUM= -4.6737463674763E+32")
 
     def test_complex_value_card(self):
@@ -143,8 +143,8 @@ class TestHeaderFunctions(FitsTestCase):
         # (non-string value)
         with ignore_warnings():
             c = fits.Card('abc', 9, 'abcde' * 20)
-            assert (str(c) ==
-                    "ABC     =                    9 "
+            assert (str(c)
+                    == "ABC     =                    9 "
                     "/ abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeab")
             c = fits.Card('abc', 'a' * 68, 'abcdefg')
             assert str(c) == "ABC     = '{}'".format('a' * 68)
@@ -481,15 +481,15 @@ class TestHeaderFunctions(FitsTestCase):
         # long string value via fromstring() method
         c = fits.Card.fromstring(
             _pad("abc     = 'longstring''s testing  &  ' "
-                 "/ comments in line 1") +
-            _pad("continue  'continue with long string but without the "
-                 "ampersand at the end' /") +
-            _pad("continue  'continue must have string value (with quotes)' "
+                 "/ comments in line 1")
+            + _pad("continue  'continue with long string but without the "
+                 "ampersand at the end' /")
+            + _pad("continue  'continue must have string value (with quotes)' "
                  "/ comments with ''. "))
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
-            assert (str(c) ==
-                    "ABC     = 'longstring''s testing  continue with long string but without the &'  "
+            assert (str(c)
+                    == "ABC     = 'longstring''s testing  continue with long string but without the &'  "
                     "CONTINUE  'ampersand at the endcontinue must have string value (with quotes)&'  "
                     "CONTINUE  '' / comments in line 1 comments with ''.                             ")
 
@@ -499,13 +499,13 @@ class TestHeaderFunctions(FitsTestCase):
         """
 
         c = fits.Card.fromstring(
-            _pad("EXPR    = '/grp/hst/cdbs//grid/pickles/dat_uvk/pickles_uk_10.fits * &'") +
-            _pad("CONTINUE  '5.87359e-12 * MWAvg(Av=0.12)&'") +
-            _pad("CONTINUE  '&' / pysyn expression"))
+            _pad("EXPR    = '/grp/hst/cdbs//grid/pickles/dat_uvk/pickles_uk_10.fits * &'")
+            + _pad("CONTINUE  '5.87359e-12 * MWAvg(Av=0.12)&'")
+            + _pad("CONTINUE  '&' / pysyn expression"))
 
         assert c.keyword == 'EXPR'
-        assert (c.value ==
-                '/grp/hst/cdbs//grid/pickles/dat_uvk/pickles_uk_10.fits '
+        assert (c.value
+                == '/grp/hst/cdbs//grid/pickles/dat_uvk/pickles_uk_10.fits '
                 '* 5.87359e-12 * MWAvg(Av=0.12)')
         assert c.comment == 'pysyn expression'
 
@@ -538,8 +538,8 @@ class TestHeaderFunctions(FitsTestCase):
                           'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)')
         assert len(w) == 1
         assert 'HIERARCH card will be created' in str(w[0].message)
-        assert (str(c) ==
-                "HIERARCH ESO INS SLIT2 Y1FRML= "
+        assert (str(c)
+                == "HIERARCH ESO INS SLIT2 Y1FRML= "
                 "'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)'")
 
         # Test manual creation of hierarch card
@@ -547,8 +547,8 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(c) == _pad("HIERARCH abcdefghi = 10")
         c = fits.Card('HIERARCH ESO INS SLIT2 Y1FRML',
                       'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)')
-        assert (str(c) ==
-                "HIERARCH ESO INS SLIT2 Y1FRML= "
+        assert (str(c)
+                == "HIERARCH ESO INS SLIT2 Y1FRML= "
                 "'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)'")
 
     def test_hierarch_with_abbrev_value_indicator(self):
@@ -609,8 +609,8 @@ class TestHeaderFunctions(FitsTestCase):
         hdu.writeto(self.temp('test.fits'))
         with fits.open(self.temp('test.fits')) as hdul:
             header2 = hdul[0].header
-            assert (str(header.cards[header.index('key.META_0')]) ==
-                    str(header2.cards[header2.index('key.META_0')]))
+            assert (str(header.cards[header.index('key.META_0')])
+                    == str(header2.cards[header2.index('key.META_0')]))
 
     def test_missing_keyword(self):
         """Test that accessing a non-existent keyword raises a KeyError."""
@@ -1034,8 +1034,8 @@ class TestHeaderFunctions(FitsTestCase):
 
     def test_header_keys(self):
         with fits.open(self.data('arange.fits')) as hdul:
-            assert (list(hdul[0].header) ==
-                    ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
+            assert (list(hdul[0].header)
+                    == ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
                      'EXTEND'])
 
     def test_header_list_like_pop(self):
@@ -1419,8 +1419,8 @@ class TestHeaderFunctions(FitsTestCase):
 
     def test_header_comments(self):
         header = fits.Header([('A', 'B', 'C'), ('DEF', 'G', 'H')])
-        assert (repr(header.comments) ==
-                '       A  C\n'
+        assert (repr(header.comments)
+                == '       A  C\n'
                 '     DEF  H')
 
     def test_comment_slices_and_filters(self):
@@ -1808,13 +1808,13 @@ class TestHeaderFunctions(FitsTestCase):
         # written with repaired exponent signs?
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
-            assert (str(h.cards['FOCALLEN']) ==
-                    _pad("FOCALLEN= +1.550000000000E+002"))
+            assert (str(h.cards['FOCALLEN'])
+                    == _pad("FOCALLEN= +1.550000000000E+002"))
         assert h.cards['FOCALLEN']._modified
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
-            assert (str(h.cards['APERTURE']) ==
-                    _pad("APERTURE= +0.000000000000E+000"))
+            assert (str(h.cards['APERTURE'])
+                    == _pad("APERTURE= +0.000000000000E+000"))
         assert h.cards['APERTURE']._modified
         assert h._modified
 
@@ -1824,13 +1824,13 @@ class TestHeaderFunctions(FitsTestCase):
         h = fits.Header.fromstring(hstr, sep='\n')
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
-            assert (str(h.cards['FOCALLEN']) ==
-                    _pad("FOCALLEN= +1.550000000000E+002"))
+            assert (str(h.cards['FOCALLEN'])
+                    == _pad("FOCALLEN= +1.550000000000E+002"))
         assert h.cards['FOCALLEN']._modified
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
-            assert (str(h.cards['APERTURE']) ==
-                    _pad("APERTURE= +0.000000000000E+000"))
+            assert (str(h.cards['APERTURE'])
+                    == _pad("APERTURE= +0.000000000000E+000"))
         assert h.cards['APERTURE']._modified
 
         assert h['FOCALLEN'] == 155.0
@@ -1841,10 +1841,10 @@ class TestHeaderFunctions(FitsTestCase):
         # that the newly fixed value strings are left intact
         h['FOCALLEN'] = 155.0
         h['APERTURE'] = 0.0
-        assert (str(h.cards['FOCALLEN']) ==
-                _pad("FOCALLEN= +1.550000000000E+002"))
-        assert (str(h.cards['APERTURE']) ==
-                _pad("APERTURE= +0.000000000000E+000"))
+        assert (str(h.cards['FOCALLEN'])
+                == _pad("FOCALLEN= +1.550000000000E+002"))
+        assert (str(h.cards['APERTURE'])
+                == _pad("APERTURE= +0.000000000000E+000"))
 
     def test_invalid_float_cards2(self, capsys):
         """
@@ -2601,29 +2601,29 @@ class TestRecordValuedKeywordCards(FitsTestCase):
 
         cl = self._test_header['DP1.AXIS.*']
         assert isinstance(cl, fits.Header)
-        assert ([str(c).strip() for c in cl.cards] ==
-                ["DP1     = 'AXIS.1: 1'",
+        assert ([str(c).strip() for c in cl.cards]
+                == ["DP1     = 'AXIS.1: 1'",
                  "DP1     = 'AXIS.2: 2'"])
 
         cl = self._test_header['DP1.N*']
-        assert ([str(c).strip() for c in cl.cards] ==
-                ["DP1     = 'NAXIS: 2'",
+        assert ([str(c).strip() for c in cl.cards]
+                == ["DP1     = 'NAXIS: 2'",
                  "DP1     = 'NAUX: 2'"])
 
         cl = self._test_header['DP1.AUX...']
-        assert ([str(c).strip() for c in cl.cards] ==
-                ["DP1     = 'AUX.1.COEFF.0: 0'",
+        assert ([str(c).strip() for c in cl.cards]
+                == ["DP1     = 'AUX.1.COEFF.0: 0'",
                  "DP1     = 'AUX.1.POWER.0: 1'",
                  "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
                  "DP1     = 'AUX.1.POWER.1: 1'"])
 
         cl = self._test_header['DP?.NAXIS']
-        assert ([str(c).strip() for c in cl.cards] ==
-                ["DP1     = 'NAXIS: 2'"])
+        assert ([str(c).strip() for c in cl.cards]
+                == ["DP1     = 'NAXIS: 2'"])
 
         cl = self._test_header['DP1.A*S.*']
-        assert ([str(c).strip() for c in cl.cards] ==
-                ["DP1     = 'AXIS.1: 1'",
+        assert ([str(c).strip() for c in cl.cards]
+                == ["DP1     = 'AXIS.1: 1'",
                  "DP1     = 'AXIS.2: 2'"])
 
     def test_pattern_matching_key_deletion(self):
@@ -2651,8 +2651,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
                  "DP1     = 'AUX.1.POWER.1: 1'"])
 
         cl2 = cl['*.*AUX...']
-        assert ([str(c).strip() for c in cl2.cards] ==
-                ["DP1     = 'AUX.1.COEFF.0: 0'",
+        assert ([str(c).strip() for c in cl2.cards]
+                == ["DP1     = 'AUX.1.COEFF.0: 0'",
                  "DP1     = 'AUX.1.POWER.0: 1'",
                  "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
                  "DP1     = 'AUX.1.POWER.1: 1'"])
@@ -2719,8 +2719,8 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         h = fits.Header()
         h['FOO'] = 'Date: 2012-09-19T13:58:53.756061'
         assert 'FOO.Date' not in h
-        assert (str(h.cards[0]) ==
-                _pad("FOO     = 'Date: 2012-09-19T13:58:53.756061'"))
+        assert (str(h.cards[0])
+                == _pad("FOO     = 'Date: 2012-09-19T13:58:53.756061'"))
 
     def test_overly_aggressive_rvkc_lookup(self):
         """
@@ -2804,9 +2804,9 @@ class TestRecordValuedKeywordCards(FitsTestCase):
             assert len(mytable) == len(fitsobj[0].header)
             # Repeat the above test when multiple HDUs are requested
             mytable = formatter.parse(extensions=['AIPS FQ', 2, "4"])
-            assert len(mytable) == (len(fitsobj['AIPS FQ'].header) +
-                                    len(fitsobj[2].header) +
-                                    len(fitsobj[4].header))
+            assert len(mytable) == (len(fitsobj['AIPS FQ'].header)
+                                    + len(fitsobj[2].header)
+                                    + len(fitsobj[4].header))
 
         # Can we recover the filename and extension name from the table?
         mytable = formatter.parse(extensions=['AIPS FQ'])

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -483,9 +483,9 @@ class TestHeaderFunctions(FitsTestCase):
             _pad("abc     = 'longstring''s testing  &  ' "
                  "/ comments in line 1")
             + _pad("continue  'continue with long string but without the "
-                 "ampersand at the end' /")
+                   "ampersand at the end' /")
             + _pad("continue  'continue must have string value (with quotes)' "
-                 "/ comments with ''. "))
+                   "/ comments with ''. "))
         with pytest.warns(fits.verify.VerifyWarning,
                           match=r'Verification reported errors'):
             assert (str(c)
@@ -1036,7 +1036,7 @@ class TestHeaderFunctions(FitsTestCase):
         with fits.open(self.data('arange.fits')) as hdul:
             assert (list(hdul[0].header)
                     == ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
-                     'EXTEND'])
+                        'EXTEND'])
 
     def test_header_list_like_pop(self):
         header = fits.Header([('A', 'B'), ('C', 'D'), ('E', 'F'),
@@ -2603,19 +2603,19 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         assert isinstance(cl, fits.Header)
         assert ([str(c).strip() for c in cl.cards]
                 == ["DP1     = 'AXIS.1: 1'",
-                 "DP1     = 'AXIS.2: 2'"])
+                    "DP1     = 'AXIS.2: 2'"])
 
         cl = self._test_header['DP1.N*']
         assert ([str(c).strip() for c in cl.cards]
                 == ["DP1     = 'NAXIS: 2'",
-                 "DP1     = 'NAUX: 2'"])
+                    "DP1     = 'NAUX: 2'"])
 
         cl = self._test_header['DP1.AUX...']
         assert ([str(c).strip() for c in cl.cards]
                 == ["DP1     = 'AUX.1.COEFF.0: 0'",
-                 "DP1     = 'AUX.1.POWER.0: 1'",
-                 "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
-                 "DP1     = 'AUX.1.POWER.1: 1'"])
+                    "DP1     = 'AUX.1.POWER.0: 1'",
+                    "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
+                    "DP1     = 'AUX.1.POWER.1: 1'"])
 
         cl = self._test_header['DP?.NAXIS']
         assert ([str(c).strip() for c in cl.cards]
@@ -2624,7 +2624,7 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         cl = self._test_header['DP1.A*S.*']
         assert ([str(c).strip() for c in cl.cards]
                 == ["DP1     = 'AXIS.1: 1'",
-                 "DP1     = 'AXIS.2: 2'"])
+                    "DP1     = 'AXIS.2: 2'"])
 
     def test_pattern_matching_key_deletion(self):
         """Deletion by filter strings should work."""
@@ -2653,9 +2653,9 @@ class TestRecordValuedKeywordCards(FitsTestCase):
         cl2 = cl['*.*AUX...']
         assert ([str(c).strip() for c in cl2.cards]
                 == ["DP1     = 'AUX.1.COEFF.0: 0'",
-                 "DP1     = 'AUX.1.POWER.0: 1'",
-                 "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
-                 "DP1     = 'AUX.1.POWER.1: 1'"])
+                    "DP1     = 'AUX.1.POWER.0: 1'",
+                    "DP1     = 'AUX.1.COEFF.1: 0.00048828125'",
+                    "DP1     = 'AUX.1.POWER.1: 1'"])
 
     def test_rvkc_in_cardlist_keys(self):
         """

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -2265,7 +2265,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(h).startswith('TEST    =                    1')
 
         # int -> complex
-        h['TEST'] = 1.0+0.0j
+        h['TEST'] = 1.0 + 0.0j
         assert isinstance(h['TEST'], complex)
         assert str(h).startswith('TEST    =           (1.0, 0.0)')
 
@@ -2275,7 +2275,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(h).startswith('TEST    =                  1.0')
 
         # float -> complex
-        h['TEST'] = 1.0+0.0j
+        h['TEST'] = 1.0 + 0.0j
         assert isinstance(h['TEST'], complex)
         assert str(h).startswith('TEST    =           (1.0, 0.0)')
 
@@ -2298,7 +2298,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(h).startswith('TEST    =                    0')
 
         # int -> complex
-        h['TEST'] = 0.0+0.0j
+        h['TEST'] = 0.0 + 0.0j
         assert isinstance(h['TEST'], complex)
         assert str(h).startswith('TEST    =           (0.0, 0.0)')
 
@@ -2308,7 +2308,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert str(h).startswith('TEST    =                  0.0')
 
         # float -> complex
-        h['TEST'] = 0.0+0.0j
+        h['TEST'] = 0.0 + 0.0j
         assert isinstance(h['TEST'], complex)
         assert str(h).startswith('TEST    =           (0.0, 0.0)')
 

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
 import copy

--- a/astropy/io/fits/tests/test_header.py
+++ b/astropy/io/fits/tests/test_header.py
@@ -383,12 +383,12 @@ class TestHeaderFunctions(FitsTestCase):
         # test long string value
         c = fits.Card('abc', 'long string value ' * 10, 'long comment ' * 10)
         assert (str(c) ==
-            "ABC     = 'long string value long string value long string value long string &' "
-            "CONTINUE  'value long string value long string value long string value long &'  "
-            "CONTINUE  'string value long string value long string value &'                  "
-            "CONTINUE  '&' / long comment long comment long comment long comment long        "
-            "CONTINUE  '&' / comment long comment long comment long comment long comment     "
-            "CONTINUE  '' / long comment                                                     ")
+                "ABC     = 'long string value long string value long string value long string &' "
+                "CONTINUE  'value long string value long string value long string value long &'  "
+                "CONTINUE  'string value long string value long string value &'                  "
+                "CONTINUE  '&' / long comment long comment long comment long comment long        "
+                "CONTINUE  '&' / comment long comment long comment long comment long comment     "
+                "CONTINUE  '' / long comment                                                     ")
 
     def test_long_unicode_string(self):
         """Regression test for
@@ -421,14 +421,14 @@ class TestHeaderFunctions(FitsTestCase):
         header['TEST3'] = ('Regular value', 'Regular comment')
 
         assert (repr(header).splitlines() ==
-            [str(fits.Card('TEST1', 'Regular value', 'Regular comment')),
-             "TEST2   = 'long string value long string value long string value long string &' ",
-             "CONTINUE  'value long string value long string value long string value long &'  ",
-             "CONTINUE  'string value long string value long string value &'                  ",
-             "CONTINUE  '&' / long comment long comment long comment long comment long        ",
-             "CONTINUE  '&' / comment long comment long comment long comment long comment     ",
-             "CONTINUE  '' / long comment                                                     ",
-             str(fits.Card('TEST3', 'Regular value', 'Regular comment'))])
+                [str(fits.Card('TEST1', 'Regular value', 'Regular comment')),
+                 "TEST2   = 'long string value long string value long string value long string &' ",
+                 "CONTINUE  'value long string value long string value long string value long &'  ",
+                 "CONTINUE  'string value long string value long string value &'                  ",
+                 "CONTINUE  '&' / long comment long comment long comment long comment long        ",
+                 "CONTINUE  '&' / comment long comment long comment long comment long comment     ",
+                 "CONTINUE  '' / long comment                                                     ",
+                 str(fits.Card('TEST3', 'Regular value', 'Regular comment'))])
 
     def test_blank_keyword_long_value(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/194
@@ -461,22 +461,22 @@ class TestHeaderFunctions(FitsTestCase):
         c = hdul[0].header.cards['abc']
         hdul.close()
         assert (str(c) ==
-            "ABC     = 'long string value long string value long string value long string &' "
-            "CONTINUE  'value long string value long string value long string value long &'  "
-            "CONTINUE  'string value long string value long string value &'                  "
-            "CONTINUE  '&' / long comment long comment long comment long comment long        "
-            "CONTINUE  '&' / comment long comment long comment long comment long comment     "
-            "CONTINUE  '' / long comment                                                     ")
+                "ABC     = 'long string value long string value long string value long string &' "
+                "CONTINUE  'value long string value long string value long string value long &'  "
+                "CONTINUE  'string value long string value long string value &'                  "
+                "CONTINUE  '&' / long comment long comment long comment long comment long        "
+                "CONTINUE  '&' / comment long comment long comment long comment long comment     "
+                "CONTINUE  '' / long comment                                                     ")
 
     def test_word_in_long_string_too_long(self):
         # if a word in a long string is too long, it will be cut in the middle
         c = fits.Card('abc', 'longstringvalue' * 10, 'longcomment' * 10)
         assert (str(c) ==
-            "ABC     = 'longstringvaluelongstringvaluelongstringvaluelongstringvaluelongstr&'"
-            "CONTINUE  'ingvaluelongstringvaluelongstringvaluelongstringvaluelongstringvalu&'"
-            "CONTINUE  'elongstringvalue&'                                                   "
-            "CONTINUE  '&' / longcommentlongcommentlongcommentlongcommentlongcommentlongcomme"
-            "CONTINUE  '' / ntlongcommentlongcommentlongcommentlongcomment                   ")
+                "ABC     = 'longstringvaluelongstringvaluelongstringvaluelongstringvaluelongstr&'"
+                "CONTINUE  'ingvaluelongstringvaluelongstringvaluelongstringvaluelongstringvalu&'"
+                "CONTINUE  'elongstringvalue&'                                                   "
+                "CONTINUE  '&' / longcommentlongcommentlongcommentlongcommentlongcommentlongcomme"
+                "CONTINUE  '' / ntlongcommentlongcommentlongcommentlongcomment                   ")
 
     def test_long_string_value_via_fromstring(self, capsys):
         # long string value via fromstring() method
@@ -526,11 +526,11 @@ class TestHeaderFunctions(FitsTestCase):
 
         c = fits.Card('TEST', 'long value' * 10, 'long comment &' * 10)
         assert (str(c) ==
-            "TEST    = 'long valuelong valuelong valuelong valuelong valuelong valuelong &'  "
-            "CONTINUE  'valuelong valuelong valuelong value&'                                "
-            "CONTINUE  '&' / long comment &long comment &long comment &long comment &long    "
-            "CONTINUE  '&' / comment &long comment &long comment &long comment &long comment "
-            "CONTINUE  '' / &long comment &                                                  ")
+                "TEST    = 'long valuelong valuelong valuelong valuelong valuelong valuelong &'  "
+                "CONTINUE  'valuelong valuelong valuelong value&'                                "
+                "CONTINUE  '&' / long comment &long comment &long comment &long comment &long    "
+                "CONTINUE  '&' / comment &long comment &long comment &long comment &long comment "
+                "CONTINUE  '' / &long comment &                                                  ")
 
     def test_hierarch_card_creation(self):
         # Test automatic upgrade to hierarch card
@@ -547,7 +547,7 @@ class TestHeaderFunctions(FitsTestCase):
         c = fits.Card('hierarch abcdefghi', 10)
         assert str(c) == _pad("HIERARCH abcdefghi = 10")
         c = fits.Card('HIERARCH ESO INS SLIT2 Y1FRML',
-                        'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)')
+                      'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)')
         assert (str(c) ==
                 "HIERARCH ESO INS SLIT2 Y1FRML= "
                 "'ENC=OFFSET+RESOL*acos((WID-(MAX+MIN))/(MAX-MIN)'")
@@ -572,7 +572,7 @@ class TestHeaderFunctions(FitsTestCase):
         """
 
         c = fits.Card.fromstring(
-                "HIERARCH  key.META_4    = 'calFileVersion'")
+            "HIERARCH  key.META_4    = 'calFileVersion'")
         assert c.keyword == 'key.META_4'
         assert c.value == 'calFileVersion'
         assert c.comment == ''
@@ -1037,7 +1037,7 @@ class TestHeaderFunctions(FitsTestCase):
         with fits.open(self.data('arange.fits')) as hdul:
             assert (list(hdul[0].header) ==
                     ['SIMPLE', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3',
-                    'EXTEND'])
+                     'EXTEND'])
 
     def test_header_list_like_pop(self):
         header = fits.Header([('A', 'B'), ('C', 'D'), ('E', 'F'),
@@ -1845,7 +1845,7 @@ class TestHeaderFunctions(FitsTestCase):
         assert (str(h.cards['FOCALLEN']) ==
                 _pad("FOCALLEN= +1.550000000000E+002"))
         assert (str(h.cards['APERTURE']) ==
-                     _pad("APERTURE= +0.000000000000E+000"))
+                _pad("APERTURE= +0.000000000000E+000"))
 
     def test_invalid_float_cards2(self, capsys):
         """

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -373,13 +373,13 @@ class TestImageFunctions(FitsTestCase):
         # notice that the header has the right NAXIS's since it is constructed
         # with ImageHDU
         hdu2 = fits.ImageHDU(header=r[1].header, data=np.array([1, 2],
-                             dtype='int32'))
+                                                               dtype='int32'))
 
         assert ('\n'.join(str(x) for x in hdu2.header.cards[1:5]) ==
-            "BITPIX  =                   32 / array data type                                \n"
-            "NAXIS   =                    1 / number of array dimensions                     \n"
-            "NAXIS1  =                    2                                                  \n"
-            "PCOUNT  =                    0 / number of parameters                           ")
+                "BITPIX  =                   32 / array data type                                \n"
+                "NAXIS   =                    1 / number of array dimensions                     \n"
+                "NAXIS1  =                    2                                                  \n"
+                "PCOUNT  =                    0 / number of parameters                           ")
 
     def test_memory_mapping(self):
         # memory mapping
@@ -624,7 +624,7 @@ class TestImageFunctions(FitsTestCase):
         """
 
         fits.writeto(self.temp('test_new.fits'), data=np.array([],
-                     dtype='uint8'))
+                                                               dtype='uint8'))
         d = np.zeros([100, 100]).astype('uint16')
         fits.append(self.temp('test_new.fits'), data=d)
 
@@ -1536,7 +1536,7 @@ class TestCompressedImage(FitsTestCase):
                 hdr[keyword] = value
                 assert len(w) == 1
                 assert str(w[0].message).startswith(
-                        f"Keyword {keyword!r} is reserved")
+                    f"Keyword {keyword!r} is reserved")
                 assert keyword not in hdr
 
         with fits.open(self.data('comp.fits')) as hdul:

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -124,7 +124,7 @@ class TestImageFunctions(FitsTestCase):
 
         info = ([(0, 'PRIMARY', 1, 'PrimaryHDU', 138, (), '', '')]
                 + [(x, 'SCI', x, 'ImageHDU', 61, (40, 40), 'int16', '')
-                 for x in range(1, 5)])
+                   for x in range(1, 5)])
 
         try:
             assert r.info(output=False) == info

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -167,7 +167,7 @@ class TestImageFunctions(FitsTestCase):
 
     def test_fortran_array(self):
         # Test that files are being correctly written+read for "C" and "F" order arrays
-        a = np.arange(21).reshape(3,7)
+        a = np.arange(21).reshape(3, 7)
         b = np.asfortranarray(a)
 
         afits = self.temp('a_str.fits')
@@ -190,7 +190,7 @@ class TestImageFunctions(FitsTestCase):
 
     def test_fortran_array_non_contiguous(self):
         # Test that files are being correctly written+read for 'C' and 'F' order arrays
-        a = np.arange(105).reshape(3,5,7)
+        a = np.arange(105).reshape(3, 5, 7)
         b = np.asfortranarray(a)
 
         # writting to str specified files
@@ -1153,7 +1153,7 @@ class TestCompressedImage(FitsTestCase):
         """
         import scipy.misc
         np.random.seed(42)
-        data = scipy.misc.ascent() + np.random.randn(512, 512)*10
+        data = scipy.misc.ascent() + np.random.randn(512, 512) * 10
 
         fits.ImageHDU(data).writeto(self.temp('im1.fits'))
         fits.CompImageHDU(data, compression_type='RICE_1', quantize_method=1,
@@ -1202,7 +1202,7 @@ class TestCompressedImage(FitsTestCase):
         with fits.open(self.temp('test.fits')) as hdul:
             # HCOMPRESSed images are allowed to deviate from the original by
             # about 1/quantize_level of the RMS in each tile.
-            assert np.abs(hdul['SCI'].data - cube).max() < 1./15.
+            assert np.abs(hdul['SCI'].data - cube).max() < 1. / 15.
 
     def test_subtractive_dither_seed(self):
         """
@@ -1790,7 +1790,7 @@ class TestCompressedImage(FitsTestCase):
 
         """
         mid = np.iinfo(dtype).max // 2
-        data = np.arange(mid-50, mid+50, dtype=dtype)
+        data = np.arange(mid - 50, mid + 50, dtype=dtype)
         testfile = self.temp('test.fits')
         hdu = fits.CompImageHDU(data=data)
         hdu.writeto(testfile, overwrite=True)
@@ -1835,10 +1835,10 @@ def test_comphdu_bscale(tmpdir):
     filename1 = tmpdir.join('3hdus.fits').strpath
     filename2 = tmpdir.join('3hdus_comp.fits').strpath
 
-    x = np.random.random((100, 100))*100
+    x = np.random.random((100, 100)) * 100
 
     x0 = fits.PrimaryHDU()
-    x1 = fits.ImageHDU(np.array(x-50, dtype=int), uint=True)
+    x1 = fits.ImageHDU(np.array(x - 50, dtype=int), uint=True)
     x1.header['BZERO'] = 20331
     x1.header['BSCALE'] = 2.3
     hdus = fits.HDUList([x0, x1])

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -122,8 +122,8 @@ class TestImageFunctions(FitsTestCase):
     def test_open_2(self):
         r = fits.open(self.data('test0.fits'))
 
-        info = ([(0, 'PRIMARY', 1, 'PrimaryHDU', 138, (), '', '')] +
-                [(x, 'SCI', x, 'ImageHDU', 61, (40, 40), 'int16', '')
+        info = ([(0, 'PRIMARY', 1, 'PrimaryHDU', 138, (), '', '')]
+                + [(x, 'SCI', x, 'ImageHDU', 61, (40, 40), 'int16', '')
                  for x in range(1, 5)])
 
         try:
@@ -259,8 +259,8 @@ class TestImageFunctions(FitsTestCase):
             # append (using "update()") a new card
             r[0].header['xxx'] = 1.234e56
 
-            assert ('\n'.join(str(x) for x in r[0].header.cards[-3:]) ==
-                    "EXPFLAG = 'NORMAL            ' / Exposure interruption indicator                \n"
+            assert ('\n'.join(str(x) for x in r[0].header.cards[-3:])
+                    == "EXPFLAG = 'NORMAL            ' / Exposure interruption indicator                \n"
                     "FILENAME= 'vtest3.fits'        / File name                                      \n"
                     "XXX     =            1.234E+56                                                  ")
 
@@ -375,8 +375,8 @@ class TestImageFunctions(FitsTestCase):
         hdu2 = fits.ImageHDU(header=r[1].header, data=np.array([1, 2],
                                                                dtype='int32'))
 
-        assert ('\n'.join(str(x) for x in hdu2.header.cards[1:5]) ==
-                "BITPIX  =                   32 / array data type                                \n"
+        assert ('\n'.join(str(x) for x in hdu2.header.cards[1:5])
+                == "BITPIX  =                   32 / array data type                                \n"
                 "NAXIS   =                    1 / number of array dimensions                     \n"
                 "NAXIS1  =                    2                                                  \n"
                 "PCOUNT  =                    0 / number of parameters                           ")
@@ -1448,8 +1448,8 @@ class TestCompressedImage(FitsTestCase):
 
         # Some interestingly tiled data so that some of it is quantized and
         # some of it ends up just getting gzip-compressed
-        data2 = ((np.arange(1, 8, dtype=np.float32) * 10)[:, np.newaxis] +
-                 np.arange(1, 7))
+        data2 = ((np.arange(1, 8, dtype=np.float32) * 10)[:, np.newaxis]
+                 + np.arange(1, 7))
         np.random.seed(1337)
         data1 = np.random.uniform(size=(6 * 4, 7 * 4))
         data1[:data2.shape[0], :data2.shape[1]] = data2

--- a/astropy/io/fits/tests/test_image_dask.py
+++ b/astropy/io/fits/tests/test_image_dask.py
@@ -133,7 +133,7 @@ def test_scaled_minmax(dask_array_in_mem, tmp_path):
     filename = tmp_path / 'test.fits'
 
     hdu = PrimaryHDU(data=dask_array_in_mem)
-    hdu.scale('int32',option='minmax')
+    hdu.scale('int32', option='minmax')
     hdu.writeto(filename)
 
     with fits.open(filename) as hdulist_new:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -565,7 +565,7 @@ class TestTableFunctions(FitsTestCase):
              ('NGC6', 434, '', z, True),
              ('NGC7', 408, '', z, False),
              ('NCG8', 417, '', z, False)],
-             formats='a10,u4,a10,5f4,l')
+            formats='a10,u4,a10,5f4,l')
 
         assert comparerecords(hdu.data, array)
 
@@ -673,7 +673,7 @@ class TestTableFunctions(FitsTestCase):
              ('NGC2', 334, '', z, False),
              ('NGC3', 308, '', z, True),
              ('NCG4', 317, '', z, True)],
-             formats='a10,u4,a10,5f4,l')
+            formats='a10,u4,a10,5f4,l')
         assert comparerecords(tbhdu1.data, array)
 
     def test_merge_tables(self):
@@ -714,7 +714,7 @@ class TestTableFunctions(FitsTestCase):
              ('NGC2', 334, '', z, False, 'NGC6', 434, '', z, True),
              ('NGC3', 308, '', z, True, 'NGC7', 408, '', z, False),
              ('NCG4', 317, '', z, True, 'NCG8', 417, '', z, False)],
-             formats='a10,u4,a10,5f4,l,a10,u4,a10,5f4,l')
+            formats='a10,u4,a10,5f4,l,a10,u4,a10,5f4,l')
         assert comparerecords(hdu.data, array)
 
         hdu.writeto(self.temp('newtable.fits'))
@@ -775,7 +775,7 @@ class TestTableFunctions(FitsTestCase):
              ('NGC2', 334, '', z, False, 'NGC6', 434, '', z, True),
              ('NGC3', 308, '', z, True, 'NGC7', 408, '', z, False),
              ('NCG4', 317, '', z, True, 'NCG8', 417, '', z, False)],
-             formats='a10,u4,a10,5f4,l,a10,u4,a10,5f4,l')
+            formats='a10,u4,a10,5f4,l,a10,u4,a10,5f4,l')
         assert comparerecords(hdu.data, array)
 
         # Same verification from the file
@@ -2197,8 +2197,8 @@ class TestTableFunctions(FitsTestCase):
                 h[1].data['F1']
         except ValueError as e:
             assert str(e).endswith(
-                         "the header may be missing the necessary TNULL1 "
-                         "keyword or the table contains invalid data")
+                "the header may be missing the necessary TNULL1 "
+                "keyword or the table contains invalid data")
 
     def test_blank_field_zero(self):
         """Regression test for https://github.com/astropy/astropy/issues/5134
@@ -2632,7 +2632,7 @@ def _refcounting(type_):
     yield refcount
     gc.collect()
     assert len(objgraph.by_type(type_)) <= refcount, \
-            "More {0!r} objects still in memory than before."
+        "More {0!r} objects still in memory than before."
 
 
 class TestVLATables(FitsTestCase):
@@ -3164,7 +3164,7 @@ def test_regression_5383():
 def test_table_to_hdu():
     from astropy.table import Table
     table = Table([[1, 2, 3], ['a', 'b', 'c'], [2.3, 4.5, 6.7]],
-                    names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])
+                  names=['a', 'b', 'c'], dtype=['i', 'U1', 'f'])
     table['a'].unit = 'm/s'
     table['b'].unit = 'not-a-unit'
     table.meta['foo'] = 'bar'

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1005,7 +1005,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] == True  # nopep8
+        assert tbhdu.columns.columns[4].array[0] is True  # nopep8
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -1016,7 +1016,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3] == True  # nopep8
+        assert tbhdu.columns.columns[4].array[3] is True  # nopep8
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1067,7 +1067,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0] == True  # nopep8
+        assert tbhdu2.columns.columns[4].array[0] is True  # nopep8
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1078,13 +1078,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] == False  # nopep8
+        assert tbhdu2.columns.columns[4].array[4] is False  # nopep8
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] == False  # nopep8
+        assert tbhdu2.columns.columns[4].array[8] is False  # nopep8
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1005,7 +1005,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[0] == ''
         assert (tbhdu.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[0] is True  # nopep8
+        assert tbhdu.columns.columns[4].array[0] == True  # noqa
 
         assert tbhdu.data[3][1] == 33
         assert tbhdu.data._coldefs._arrays[1][3] == 33
@@ -1016,7 +1016,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
         assert (tbhdu.columns.columns[3].array[3] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu.columns.columns[4].array[3] is True  # nopep8
+        assert tbhdu.columns.columns[4].array[3] == True  # noqa
 
     def test_assign_multiple_rows_to_table(self):
         counts = np.array([312, 334, 308, 317])
@@ -1067,7 +1067,7 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[0] == ''
         assert (tbhdu2.columns.columns[3].array[0] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[0] is True  # nopep8
+        assert tbhdu2.columns.columns[4].array[0] == True  # noqa
 
         assert tbhdu2.data[4][1] == 112
         assert tbhdu2.data._coldefs._arrays[1][4] == 112
@@ -1078,13 +1078,13 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[2].array[4] == ''
         assert (tbhdu2.columns.columns[3].array[4] ==
                 np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[4] is False  # nopep8
+        assert tbhdu2.columns.columns[4].array[4] == False  # noqa
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
         assert (tbhdu2.columns.columns[3].array[8] ==
                 np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
-        assert tbhdu2.columns.columns[4].array[8] is False  # nopep8
+        assert tbhdu2.columns.columns[4].array[8] == False  # noqa
 
     def test_verify_data_references(self):
         counts = np.array([312, 334, 308, 317])

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -292,8 +292,8 @@ class TestTableFunctions(FitsTestCase):
 
         assert (dict(hdu.data.dtype.fields)
                 == {'abc': (np.dtype('|S3'), 18),
-                 'def': (np.dtype('|S15'), 2),
-                 't1': (np.dtype('|S10'), 21)})
+                    'def': (np.dtype('|S15'), 2),
+                    't1': (np.dtype('|S10'), 21)})
         hdu.writeto(self.temp('toto.fits'), overwrite=True)
         hdul = fits.open(self.temp('toto.fits'))
         assert comparerecords(hdu.data, hdul[1].data)
@@ -767,7 +767,7 @@ class TestTableFunctions(FitsTestCase):
 
         assert (hdu.columns.names
                 == ['target', 'counts', 'notes', 'spectrum', 'flag', 'target1',
-                 'counts1', 'notes1', 'spectrum1', 'flag1'])
+                    'counts1', 'notes1', 'spectrum1', 'flag1'])
 
         z = np.array([0., 0., 0., 0., 0.], dtype=np.float32)
         array = np.rec.array(
@@ -3238,7 +3238,8 @@ def test_new_column_attributes_preserved(tmpdir):
 
     with pytest.warns(AstropyDeprecationWarning) as warning_list:
         hdu = fits.BinTableHDU.from_columns(cd, hdr)
-    assert str(warning_list[0].message).startswith("The following keywords are now recognized as special")
+    assert str(warning_list[0].message).startswith(
+        "The following keywords are now recognized as special")
 
     # First, check that special keywords such as TUNIT are ignored in the header
     # We may want to change that behavior in future, but this is the way it's

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -87,8 +87,8 @@ def comparerecords(a, b):
                 print("fieldb: ", fieldb)
                 print(f'field {i} differs')
                 return False
-        elif (isinstance(fielda, fits.column._VLF) or
-              isinstance(fieldb, fits.column._VLF)):
+        elif (isinstance(fielda, fits.column._VLF)
+              or isinstance(fieldb, fits.column._VLF)):
             for row in range(len(fielda)):
                 if np.any(fielda[row] != fieldb[row]):
                     print('fielda[{}]: {}'.format(row, fielda[row]))
@@ -290,8 +290,8 @@ class TestTableFunctions(FitsTestCase):
         c3 = fits.Column(name='t1', format='I', array=[91, 92, 93])
         hdu = fits.TableHDU.from_columns([c2, c1, c3])
 
-        assert (dict(hdu.data.dtype.fields) ==
-                {'abc': (np.dtype('|S3'), 18),
+        assert (dict(hdu.data.dtype.fields)
+                == {'abc': (np.dtype('|S3'), 18),
                  'def': (np.dtype('|S15'), 2),
                  't1': (np.dtype('|S10'), 21)})
         hdu.writeto(self.temp('toto.fits'), overwrite=True)
@@ -405,12 +405,12 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.data._coldefs._arrays[0]))
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.columns.columns[0].array))
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.columns._arrays[0]))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.data._coldefs._arrays[0]))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.columns.columns[0].array))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.columns._arrays[0]))
 
         # Ensure I can change the value of one data element and it effects
         # all of the others.
@@ -451,12 +451,12 @@ class TestTableFunctions(FitsTestCase):
         assert hdu.columns._arrays[0][0] == 800
         assert hdu.columns.columns[0].array[0] == 800
 
-        assert (hdu.data.field(0) ==
-                np.array([800, 2], dtype=np.int16)).all()
+        assert (hdu.data.field(0)
+                == np.array([800, 2], dtype=np.int16)).all()
         assert hdu.data[0][1] == 'Serius'
         assert hdu.data[1][1] == 'Canopys'
-        assert (hdu.data.field(2) ==
-                np.array([-1.45, -0.73], dtype=np.float64)).all()
+        assert (hdu.data.field(2)
+                == np.array([-1.45, -0.73], dtype=np.float64)).all()
         assert hdu.data[0][3] == 'A1V'
         assert hdu.data[1][3] == 'F0Ib'
 
@@ -464,12 +464,12 @@ class TestTableFunctions(FitsTestCase):
             hdu.writeto(self.temp('toto.fits'), overwrite=True)
 
         with fits.open(self.temp('toto.fits')) as hdul:
-            assert (hdul[1].data.field(0) ==
-                    np.array([800, 2], dtype=np.int16)).all()
+            assert (hdul[1].data.field(0)
+                    == np.array([800, 2], dtype=np.int16)).all()
             assert hdul[1].data[0][1] == 'Serius'
             assert hdul[1].data[1][1] == 'Canopys'
-            assert (hdul[1].data.field(2) ==
-                    np.array([-1.45, -0.73], dtype=np.float64)).all()
+            assert (hdul[1].data.field(2)
+                    == np.array([-1.45, -0.73], dtype=np.float64)).all()
             assert hdul[1].data[0][3] == 'A1V'
             assert hdul[1].data[1][3] == 'F0Ib'
         del hdul
@@ -765,8 +765,8 @@ class TestTableFunctions(FitsTestCase):
         hdul = fits.open(self.temp('newtable.fits'))
         hdu = hdul[1]
 
-        assert (hdu.columns.names ==
-                ['target', 'counts', 'notes', 'spectrum', 'flag', 'target1',
+        assert (hdu.columns.names
+                == ['target', 'counts', 'notes', 'spectrum', 'flag', 'target1',
                  'counts1', 'notes1', 'spectrum1', 'flag1'])
 
         z = np.array([0., 0., 0., 0., 0.], dtype=np.float32)
@@ -989,12 +989,12 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.data._coldefs._arrays[0]))
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.columns.columns[0].array))
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.columns._arrays[0]))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.data._coldefs._arrays[0]))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.columns.columns[0].array))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.columns._arrays[0]))
 
         assert tbhdu.data[0][1] == 312
         assert tbhdu.data._coldefs._arrays[1][0] == 312
@@ -1003,8 +1003,8 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[1].array[0] == 312
         assert tbhdu.columns.columns[0].array[0] == 'NGC1'
         assert tbhdu.columns.columns[2].array[0] == ''
-        assert (tbhdu.columns.columns[3].array[0] ==
-                np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
+        assert (tbhdu.columns.columns[3].array[0]
+                == np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
         assert tbhdu.columns.columns[4].array[0] == True  # noqa
 
         assert tbhdu.data[3][1] == 33
@@ -1014,8 +1014,8 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu.columns.columns[1].array[3] == 33
         assert tbhdu.columns.columns[0].array[3] == 'JIM1'
         assert tbhdu.columns.columns[2].array[3] == 'A Note'
-        assert (tbhdu.columns.columns[3].array[3] ==
-                np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
+        assert (tbhdu.columns.columns[3].array[3]
+                == np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
         assert tbhdu.columns.columns[4].array[3] == True  # noqa
 
     def test_assign_multiple_rows_to_table(self):
@@ -1051,12 +1051,12 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(tbhdu2.data._coldefs.columns[0].array) ==
-                id(tbhdu2.data._coldefs._arrays[0]))
-        assert (id(tbhdu2.data._coldefs.columns[0].array) ==
-                id(tbhdu2.columns.columns[0].array))
-        assert (id(tbhdu2.data._coldefs.columns[0].array) ==
-                id(tbhdu2.columns._arrays[0]))
+        assert (id(tbhdu2.data._coldefs.columns[0].array)
+                == id(tbhdu2.data._coldefs._arrays[0]))
+        assert (id(tbhdu2.data._coldefs.columns[0].array)
+                == id(tbhdu2.columns.columns[0].array))
+        assert (id(tbhdu2.data._coldefs.columns[0].array)
+                == id(tbhdu2.columns._arrays[0]))
 
         assert tbhdu2.data[0][1] == 312
         assert tbhdu2.data._coldefs._arrays[1][0] == 312
@@ -1065,8 +1065,8 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[1].array[0] == 312
         assert tbhdu2.columns.columns[0].array[0] == 'NGC1'
         assert tbhdu2.columns.columns[2].array[0] == ''
-        assert (tbhdu2.columns.columns[3].array[0] ==
-                np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
+        assert (tbhdu2.columns.columns[3].array[0]
+                == np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
         assert tbhdu2.columns.columns[4].array[0] == True  # noqa
 
         assert tbhdu2.data[4][1] == 112
@@ -1076,14 +1076,14 @@ class TestTableFunctions(FitsTestCase):
         assert tbhdu2.columns.columns[1].array[4] == 112
         assert tbhdu2.columns.columns[0].array[4] == 'NGC5'
         assert tbhdu2.columns.columns[2].array[4] == ''
-        assert (tbhdu2.columns.columns[3].array[4] ==
-                np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
+        assert (tbhdu2.columns.columns[3].array[4]
+                == np.array([1., 2., 3., 4., 5.], dtype=np.float32)).all()
         assert tbhdu2.columns.columns[4].array[4] == False  # noqa
         assert tbhdu2.columns.columns[1].array[8] == 0
         assert tbhdu2.columns.columns[0].array[8] == ''
         assert tbhdu2.columns.columns[2].array[8] == ''
-        assert (tbhdu2.columns.columns[3].array[8] ==
-                np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
+        assert (tbhdu2.columns.columns[3].array[8]
+                == np.array([0., 0., 0., 0., 0.], dtype=np.float32)).all()
         assert tbhdu2.columns.columns[4].array[8] == False  # noqa
 
     def test_verify_data_references(self):
@@ -1118,8 +1118,8 @@ class TestTableFunctions(FitsTestCase):
         assert id(coldefs.columns[0]) != id(tbhdu.columns.columns[0])
 
         # Verify new HDU has independent ndarray objects.
-        assert (id(coldefs.columns[0].array) !=
-                id(tbhdu.columns.columns[0].array))
+        assert (id(coldefs.columns[0].array)
+                != id(tbhdu.columns.columns[0].array))
 
         # Verify that both ColDefs objects in the HDU reference the same
         # Coldefs object.
@@ -1127,12 +1127,12 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.data._coldefs._arrays[0]))
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.columns.columns[0].array))
-        assert (id(tbhdu.data._coldefs.columns[0].array) ==
-                id(tbhdu.columns._arrays[0]))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.data._coldefs._arrays[0]))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.columns.columns[0].array))
+        assert (id(tbhdu.data._coldefs.columns[0].array)
+                == id(tbhdu.columns._arrays[0]))
 
         tbhdu.writeto(self.temp('table1.fits'))
 
@@ -1193,12 +1193,12 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(tbhdu1.data._coldefs.columns[0].array) ==
-                id(tbhdu1.data._coldefs._arrays[0]))
-        assert (id(tbhdu1.data._coldefs.columns[0].array) ==
-                id(tbhdu1.columns.columns[0].array))
-        assert (id(tbhdu1.data._coldefs.columns[0].array) ==
-                id(tbhdu1.columns._arrays[0]))
+        assert (id(tbhdu1.data._coldefs.columns[0].array)
+                == id(tbhdu1.data._coldefs._arrays[0]))
+        assert (id(tbhdu1.data._coldefs.columns[0].array)
+                == id(tbhdu1.columns.columns[0].array))
+        assert (id(tbhdu1.data._coldefs.columns[0].array)
+                == id(tbhdu1.columns._arrays[0]))
 
         # Ensure I can change the value of one data element and it effects
         # all of the others.
@@ -1427,17 +1427,17 @@ class TestTableFunctions(FitsTestCase):
 
         # Verify that all ndarray objects within the HDU reference the
         # same ndarray.
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.data._coldefs._arrays[0]))
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.columns.columns[0].array))
-        assert (id(hdu.data._coldefs.columns[0].array) ==
-                id(hdu.columns._arrays[0]))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.data._coldefs._arrays[0]))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.columns.columns[0].array))
+        assert (id(hdu.data._coldefs.columns[0].array)
+                == id(hdu.columns._arrays[0]))
 
         # Verify that the references in the original HDU are the same as the
         # references in the new HDU.
-        assert (id(tbhdu1.data._coldefs.columns[0].array) ==
-                id(hdu.data._coldefs._arrays[0]))
+        assert (id(tbhdu1.data._coldefs.columns[0].array)
+                == id(hdu.data._coldefs._arrays[0]))
 
         # Verify that a change in the new HDU is reflected in both the new
         # and original HDU.
@@ -1571,17 +1571,17 @@ class TestTableFunctions(FitsTestCase):
 
         tbhdu1 = fits.BinTableHDU.from_columns(coldefs)
 
-        assert (tbhdu1.data.field('flag')[0] ==
-                np.array([True, False], dtype=bool)).all()
-        assert (tbhdu1.data.field('flag')[1] ==
-                np.array([False, True], dtype=bool)).all()
+        assert (tbhdu1.data.field('flag')[0]
+                == np.array([True, False], dtype=bool)).all()
+        assert (tbhdu1.data.field('flag')[1]
+                == np.array([False, True], dtype=bool)).all()
 
         tbhdu = fits.BinTableHDU.from_columns(tbhdu1.data)
 
-        assert (tbhdu.data.field('flag')[0] ==
-                np.array([True, False], dtype=bool)).all()
-        assert (tbhdu.data.field('flag')[1] ==
-                np.array([False, True], dtype=bool)).all()
+        assert (tbhdu.data.field('flag')[0]
+                == np.array([True, False], dtype=bool)).all()
+        assert (tbhdu.data.field('flag')[1]
+                == np.array([False, True], dtype=bool)).all()
 
     def test_fits_rec_column_access(self):
         tbdata = fits.getdata(self.data('table.fits'))
@@ -1680,8 +1680,8 @@ class TestTableFunctions(FitsTestCase):
             ahdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
         with fits.open(self.temp('newtable.fits')) as hdul:
-            assert (hdul[1].data.tobytes().decode('raw-unicode-escape') ==
-                    s.replace('\x00', ' '))
+            assert (hdul[1].data.tobytes().decode('raw-unicode-escape')
+                    == s.replace('\x00', ' '))
             assert (hdul[1].data['MEMNAME'] == a).all()
             ahdu = fits.BinTableHDU.from_columns(hdul[1].data.copy())
         del hdul
@@ -1864,8 +1864,8 @@ class TestTableFunctions(FitsTestCase):
             assert h[1].header['TDIM1'] == '(3,3,3)'
             assert len(h[1].data) == 2
             assert len(h[1].data[0]) == 1
-            assert (h[1].data.field(0)[0] ==
-                    np.char.decode(recarr.field(0)[0], 'ascii')).all()
+            assert (h[1].data.field(0)[0]
+                    == np.char.decode(recarr.field(0)[0], 'ascii')).all()
 
         with fits.open(self.temp('test.fits')) as h:
             # Access the data; I think this is necessary to exhibit the bug
@@ -1878,8 +1878,8 @@ class TestTableFunctions(FitsTestCase):
             assert h[1].header['TDIM1'] == '(3,3,3)'
             assert len(h[1].data) == 2
             assert len(h[1].data[0]) == 1
-            assert (h[1].data.field(0)[0] ==
-                    np.char.decode(recarr.field(0)[0], 'ascii')).all()
+            assert (h[1].data.field(0)[0]
+                    == np.char.decode(recarr.field(0)[0], 'ascii')).all()
 
     def test_new_table_with_nd_column(self):
         """Regression test for
@@ -2338,12 +2338,12 @@ class TestTableFunctions(FitsTestCase):
                 # c3 gets converted from float32 to float64 when writing
                 # test.fits, so cast to float32 before testing that the correct
                 # value is retrieved
-                assert np.all(tbdata['c3'].astype(np.float32) ==
-                              tbdata2['c3'].astype(np.float32))
+                assert np.all(tbdata['c3'].astype(np.float32)
+                              == tbdata2['c3'].astype(np.float32))
                 # c4 is a boolean column in the original table; we want ASCII
                 # columns to convert these to columns of 'T'/'F' strings
-                assert np.all(np.where(tbdata['c4'], 'T', 'F') ==
-                              tbdata2['c4'])
+                assert np.all(np.where(tbdata['c4'], 'T', 'F')
+                              == tbdata2['c4'])
 
     def test_pickle(self):
         """
@@ -2650,8 +2650,8 @@ class TestVLATables(FitsTestCase):
 
             with fits.open(self.temp('toto.fits')) as toto:
                 q = toto[1].data.field('QUAL_SPE')
-                assert (q[0][4:8] ==
-                        np.array([0, 0, 0, 0], dtype=np.uint8)).all()
+                assert (q[0][4:8]
+                        == np.array([0, 0, 0, 0], dtype=np.uint8)).all()
                 assert toto[1].columns[0].format.endswith('J(1571)')
 
         for code in ('PJ()', 'QJ()'):

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -109,8 +109,8 @@ class TestUintFunctions(FitsTestCase):
 
             with fits.open(self.temp('tempfile2.fits'), uint=True) as hdulist3:
                 hdudata3 = hdulist3[1].data
-                assert (hdudata3.base[utype] ==
-                        table.data.base.base[utype]).all()
+                assert (hdudata3.base[utype]
+                        == table.data.base.base[utype]).all()
                 assert (hdudata3[utype] == table.data[utype]).all()
                 assert (hdudata3[utype] == u).all()
 

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -25,7 +25,7 @@ class TestUintFunctions(FitsTestCase):
         [('u2', False), ('u4', False), ('u8', False), ('u2', True),
          ('u4', True)])  # ,('u8',True)])
     def test_uint(self, utype, compressed):
-        bits = 8*int(utype[1])
+        bits = 8 * int(utype[1])
         if platform.architecture()[0] == '64bit' or bits != 64:
             if compressed:
                 hdu = fits.CompImageHDU(np.array([-3, -2, -1, 0, 1, 2, 3], dtype=np.int64))
@@ -34,7 +34,7 @@ class TestUintFunctions(FitsTestCase):
                 hdu = fits.PrimaryHDU(np.array([-3, -2, -1, 0, 1, 2, 3], dtype=np.int64))
                 hdu_number = 0
 
-            hdu.scale(f'int{bits:d}', '', bzero=2 ** (bits-1))
+            hdu.scale(f'int{bits:d}', '', bzero=2 ** (bits - 1))
 
             with ignore_warnings():
                 hdu.writeto(self.temp('tempfile.fits'), overwrite=True)
@@ -65,11 +65,11 @@ class TestUintFunctions(FitsTestCase):
         https://github.com/astropy/astropy/pull/906
         """
 
-        bits = 8*int(utype[1])
+        bits = 8 * int(utype[1])
         if platform.architecture()[0] == '64bit' or bits != 64:
-            bzero = self.utype_map[utype](2**(bits-1))
+            bzero = self.utype_map[utype](2**(bits - 1))
             one = self.utype_map[utype](1)
-            u0 = np.arange(bits+1, dtype=self.utype_map[utype])
+            u0 = np.arange(bits + 1, dtype=self.utype_map[utype])
             u = 2**u0 - one
             if bits == 64:
                 u[63] = bzero - one

--- a/astropy/io/fits/tests/test_uint.py
+++ b/astropy/io/fits/tests/test_uint.py
@@ -22,8 +22,8 @@ class TestUintFunctions(FitsTestCase):
     # Test of 64-bit compressed image is disabled.  cfitsio library doesn't
     # like it
     @pytest.mark.parametrize(('utype', 'compressed'),
-        [('u2', False), ('u4', False), ('u8', False), ('u2', True),
-         ('u4', True)])  # ,('u8',True)])
+                             [('u2', False), ('u4', False), ('u8', False), ('u2', True),
+                              ('u4', True)])  # ,('u8',True)])
     def test_uint(self, utype, compressed):
         bits = 8 * int(utype[1])
         if platform.architecture()[0] == '64bit' or bits != 64:
@@ -43,7 +43,7 @@ class TestUintFunctions(FitsTestCase):
                 assert hdul[hdu_number].data.dtype == self.utype_map[utype]
                 assert (hdul[hdu_number].data == np.array(
                     [(2 ** bits) - 3, (2 ** bits) - 2, (2 ** bits) - 1,
-                    0, 1, 2, 3],
+                     0, 1, 2, 3],
                     dtype=self.utype_map[utype])).all()
                 hdul.writeto(self.temp('tempfile1.fits'))
                 with fits.open(self.temp('tempfile1.fits'),

--- a/astropy/io/fits/tests/test_util.py
+++ b/astropy/io/fits/tests/test_util.py
@@ -33,8 +33,8 @@ class TestUtils(FitsTestCase):
                 # One more time, for good measure
                 os.kill(pid, signal.SIGINT)
             assert len(w) == 2
-            assert (str(w[0].message) ==
-                    'KeyboardInterrupt ignored until test is complete!')
+            assert (str(w[0].message)
+                    == 'KeyboardInterrupt ignored until test is complete!')
 
         pytest.raises(KeyboardInterrupt, test)
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -204,8 +204,7 @@ def itersubclasses(cls, _seen=None):
         if sub not in _seen:
             _seen.add(sub)
             yield sub
-            for sub in itersubclasses(sub, _seen):
-                yield sub
+            yield from itersubclasses(sub, _seen)
 
 
 def ignore_sigint(func):

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -33,7 +33,9 @@ except ImportError:
     path_like = (str,)
 
 
-cmp = lambda a, b: (a > b) - (a < b)
+def cmp(a, b):
+    return(a > b) - (a < b)
+
 
 all_integer_types = (int, np.integer)
 
@@ -619,7 +621,8 @@ def _array_to_file(arr, outfile):
     """
 
     if isfile(outfile) and not isinstance(outfile, io.BufferedIOBase):
-        write = lambda a, f: a.tofile(f)
+        def write(a, f):
+            return a.tofile(f)
     else:
         write = _array_to_file_like
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -689,8 +689,8 @@ def _array_to_file_like(arr, fileobj):
         # The problem with flatiter is it doesn't preserve the original
         # byteorder
         byteorder = arr.dtype.byteorder
-        if ((sys.byteorder == 'little' and byteorder == '>')
-                or (sys.byteorder == 'big' and byteorder == '<')):
+        if ((sys.byteorder == 'little' and byteorder == '>') or
+                (sys.byteorder == 'big' and byteorder == '<')):
             for item in arr.flat:
                 fileobj.write(item.byteswap().tobytes())
         else:

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -218,8 +218,8 @@ def ignore_sigint(func):
         # Get the name of the current thread and determine if this is a single
         # threaded application
         curr_thread = threading.currentThread()
-        single_thread = (threading.activeCount() == 1 and
-                         curr_thread.getName() == 'MainThread')
+        single_thread = (threading.activeCount() == 1
+                         and curr_thread.getName() == 'MainThread')
 
         class SigintHandler:
             def __init__(self):
@@ -270,14 +270,14 @@ def pairwise(iterable):
 def encode_ascii(s):
     if isinstance(s, str):
         return s.encode('ascii')
-    elif (isinstance(s, np.ndarray) and
-          issubclass(s.dtype.type, np.str_)):
+    elif (isinstance(s, np.ndarray)
+          and issubclass(s.dtype.type, np.str_)):
         ns = np.char.encode(s, 'ascii').view(type(s))
         if ns.dtype.itemsize != s.dtype.itemsize / 4:
             ns = ns.astype((np.bytes_, s.dtype.itemsize / 4))
         return ns
-    elif (isinstance(s, np.ndarray) and
-          not issubclass(s.dtype.type, np.bytes_)):
+    elif (isinstance(s, np.ndarray)
+          and not issubclass(s.dtype.type, np.bytes_)):
         raise TypeError('string operation on non-string array')
     return s
 
@@ -292,8 +292,8 @@ def decode_ascii(s):
                           'characters', AstropyUserWarning)
             s = s.decode('ascii', errors='replace')
             return s.replace('\ufffd', '?')
-    elif (isinstance(s, np.ndarray) and
-          issubclass(s.dtype.type, np.bytes_)):
+    elif (isinstance(s, np.ndarray)
+          and issubclass(s.dtype.type, np.bytes_)):
         # np.char.encode/decode annoyingly don't preserve the type of the
         # array, hence the view() call
         # It also doesn't necessarily preserve widths of the strings,
@@ -309,8 +309,8 @@ def decode_ascii(s):
         if ns.dtype.itemsize / 4 != s.dtype.itemsize:
             ns = ns.astype((np.str_, s.dtype.itemsize))
         return ns
-    elif (isinstance(s, np.ndarray) and
-          not issubclass(s.dtype.type, np.str_)):
+    elif (isinstance(s, np.ndarray)
+          and not issubclass(s.dtype.type, np.str_)):
         # Don't silently pass through on non-string arrays; we don't want
         # to hide errors where things that are not stringy are attempting
         # to be decoded
@@ -567,8 +567,8 @@ def _array_from_file(infile, dtype, count):
 
         global CHUNKED_FROMFILE
         if CHUNKED_FROMFILE is None:
-            if (sys.platform == 'darwin' and
-                    LooseVersion(platform.mac_ver()[0]) < LooseVersion('10.9')):
+            if (sys.platform == 'darwin'
+                    and LooseVersion(platform.mac_ver()[0]) < LooseVersion('10.9')):
                 CHUNKED_FROMFILE = True
             else:
                 CHUNKED_FROMFILE = False
@@ -635,8 +635,8 @@ def _array_to_file(arr, outfile):
     # Apparently Windows has its own fwrite bug:
     # https://github.com/numpy/numpy/issues/2256
 
-    if (sys.platform == 'darwin' and arr.nbytes >= _OSX_WRITE_LIMIT + 1 and
-            arr.nbytes % 4096 == 0):
+    if (sys.platform == 'darwin' and arr.nbytes >= _OSX_WRITE_LIMIT + 1
+            and arr.nbytes % 4096 == 0):
         # chunksize is a count of elements in the array, not bytes
         chunksize = _OSX_WRITE_LIMIT // arr.itemsize
     elif sys.platform.startswith('win'):
@@ -688,8 +688,8 @@ def _array_to_file_like(arr, fileobj):
         # The problem with flatiter is it doesn't preserve the original
         # byteorder
         byteorder = arr.dtype.byteorder
-        if ((sys.byteorder == 'little' and byteorder == '>') or
-                (sys.byteorder == 'big' and byteorder == '<')):
+        if ((sys.byteorder == 'little' and byteorder == '>')
+                or (sys.byteorder == 'big' and byteorder == '<')):
             for item in arr.flat:
                 fileobj.write(item.byteswap().tobytes())
         else:

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -90,7 +90,8 @@ class _Verify:
         if fix_opt == 'silentfix':
             # Don't print out fixable issues; the first element of each verify
             # item is a boolean indicating whether or not the issue was fixable
-            line_filter = lambda x: not x[0]
+            def line_filter(x):
+                return not x[0]
         elif fix_opt == 'fix' and report_opt == 'ignore':
             # Don't print *unfixable* issues, but do print fixed issues; this
             # is probably not very useful but the option exists for

--- a/astropy/io/fits/verify.py
+++ b/astropy/io/fits/verify.py
@@ -166,7 +166,6 @@ class _ErrList(list):
                                            shift=shift)
                     yield first_line
 
-                for line in next_lines:
-                    yield line
+                yield from next_lines
 
                 element += 1


### PR DESCRIPTION
Following similar PRs (#9781, #9772, #9771) to reduce the number of warnings.
This PR makes the io.fits subpackage pass without errors (and the new 100 characters limit).
Most changes were made with autopep8 and some with pyupgrade (see individual commits). And I reformatted manually some long lines (especially comment blocks) because `io.fits` is mostly respecting the 80 chars limit :).