### PR TITLE
Ensure mixing regular and long double input to Time is possible.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -459,6 +459,10 @@ astropy.time
 - Fixed bug where the location attribute was lost when creating a new ``Time``
   object from an existing ``Time`` or list of ``Time`` objects. [#9969]
 
+- Fixed a bug where an exception occurred when creating a ``Time`` object
+  if the ``val1`` argument was a regular double and the ``val2`` argument
+  was a ``longdouble``. [#10034]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -419,9 +419,11 @@ class TimeNumeric(TimeFormat):
                 'and second values are only allowed for doubles.'
                 .format(self.name))
 
+        val_dtype = (val1.dtype if val2 is None else
+                     np.result_type(val1.dtype, val2.dtype))
         subfmts = self._select_subfmts(self.in_subfmt)
         for subfmt, dtype, convert, _ in subfmts:
-            if np.issubdtype(val1.dtype, dtype):
+            if np.issubdtype(val_dtype, dtype):
                 break
         else:
             raise ValueError('input type not among selected sub-formats.')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -913,6 +913,22 @@ class TestNumericalSubFormat:
 
     @pytest.mark.skipif(np.finfo(np.longdouble).eps >= np.finfo(float).eps,
                         reason="long double is the same as float")
+    def test_explicit_longdouble_one_val(self):
+        """Ensure either val1 or val2 being longdouble is possible.
+
+        Regression test for issue gh-10033.
+        """
+        i = 54321
+        f = max(2.**(-np.finfo(np.longdouble).nmant) * 65536,
+                np.finfo(float).eps)
+        t1 = Time(i, f, format='mjd')
+        t2 = Time(np.longdouble(i), f, format='mjd')
+        t3 = Time(i, np.longdouble(f), format='mjd')
+        t4 = Time(np.longdouble(i), np.longdouble(f), format='mjd')
+        assert t1 == t2 == t3 == t4
+
+    @pytest.mark.skipif(np.finfo(np.longdouble).eps >= np.finfo(float).eps,
+                        reason="long double is the same as float")
     @pytest.mark.parametrize("fmt", ["mjd", "unix", "cxcsec"])
     def test_longdouble_for_other_types(self, fmt):
         t_fmt = getattr(Time(58000, format="mjd"), fmt)  # Get regular float


### PR DESCRIPTION
Previously, only the type of val1 was checked, and if that was float while val2 was longdouble, this caused an exception. cc @aarchiba.

fixes #10033
