### PR TITLE
MAINT: Trying to limit pytest version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 packages = find:
 requires = numpy
 zip_safe = False
-tests_require = pytest-astropy
+tests_require = pytest<5.4 pytest-astropy
 setup_requires = setuptools_scm
 install_requires = numpy>=1.16
 python_requires = >=3.6
@@ -46,6 +46,7 @@ asdf_extensions =
 
 [options.extras_require]
 test =
+    pytest<5.4
     pytest-astropy>=0.8
     pytest-xdist
     objgraph
@@ -69,10 +70,10 @@ all =
     asdf>=2.5
     bottleneck
     ipython
-    pytest
+    pytest<5.4
 docs =
     sphinx-astropy
-    pytest
+    pytest<5.4
     pyyaml
     scipy
     scikit-image
@@ -86,6 +87,7 @@ astropy.wcs.tests = extension/*.c
 
 [tool:pytest]
 minversion = 3.1
+maxversion = 5.3.5
 testpaths = "astropy" "docs"
 norecursedirs = "docs[\/]_build" "docs[\/]generated" "astropy[\/]extern"
 astropy_header = true


### PR DESCRIPTION
This feels so bad on so many levels. 

@astrofrog @Cadair - is hacking the packaging files is the way to limit version now, or could it go into the tox config?