### PR TITLE
TST: Pin pytest<5.4 due to doctestplus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,7 +205,13 @@ install:
 
 script:
     - pip install tox
-    - tox $TOXARGS -- $TOXPOSARGS
+    # Pin pytest for now, see https://github.com/astropy/astropy/issues/10039
+    - if [[ $TRAVIS_OS_NAME == linux && $TOXENV != codestyle ]]; then
+        pip install tox-pypi-filter;
+        tox --pypi-filter="pytest<5.4" $TOXARGS -- $TOXPOSARGS;
+      else
+        tox $TOXARGS -- $TOXPOSARGS;
+      fi
 
 after_success:
     - if [[ $TOXENV == *-cov ]]; then


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address deprecation warning from `pytest>=5.4` in `pytest-doctestplus` plugin causing failure in CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10039 

A version of #10040 for `>=4.1`

Based on astropy/ci-helpers#429 but our Linux CIs don't use `ci-helpers`.