### PR TITLE
Use ci helpers pinnings file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ jobs:
           command: /opt/python/cp36-cp36m/bin/pip install tox
       - run:
           name: Run tests for Python 3.6
-          command: PYTHONHASHSEED=42 /opt/python/cp36-cp36m/bin/python -m tox -e py36-test -- -n=4 --durations=50
+          command: /opt/python/cp36-cp36m/bin/python -m tox -e py36-test -- -n=4 --durations=50
       - run:
           name: Install dependencies for Python 3.7
           command: /opt/python/cp37-cp37m/bin/pip install tox
       - run:
           name: Run tests for Python 3.7
-          command: PYTHONHASHSEED=42 /opt/python/cp37-cp37m/bin/python  -m tox -e py37-test -- -n=4 --durations=50
+          command: /opt/python/cp37-cp37m/bin/python -m tox -e py37-test -- -n=4 --durations=50
       # We use the 3.8 build to check that running tests twice in a row in the
       # same Python session works without issues. This catches cases where
       # running the tests changes the module state permanently. Note that we
@@ -34,10 +34,10 @@ jobs:
       # here.
       - run:
           name: Install dependencies for Python 3.8
-          command: /opt/python/cp38-cp38/bin/pip install -e .[test]
+          command: /opt/python/cp38-cp38/bin/pip install tox
       - run:
           name: Run tests for Python 3.8
-          command: PYTHONHASHSEED=42 /opt/python/cp38-cp38/bin/python -c 'import sys; from astropy import test; test(); sys.exit(test())'
+          command: /opt/python/cp38-cp38/bin/python -m tox -e py38-test-double
 
   image-tests-mpl212:
     docker:
@@ -101,13 +101,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install Python dependencies, including developer version of Matplotlib
-          command: |
-            pip3 install git+https://github.com/matplotlib/matplotlib.git
-            pip3 install -e .[test] pytest-mpl
+          name: Install tox
+          command: pip3 install tox
       - run:
           name: Run tests
-          command: pytest -P visualization --remote-data=astropy --open-files --mpl --mpl-results-path=$PWD/results -W ignore:np.asscalar
+          command: tox -e py37-test-image-mpldev -- -P visualization --remote-data=astropy --open-files --mpl-results-path=$PWD/results -W ignore:np.asscalar
       - store_artifacts:
           path: results
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
     tox-pypi-filter >= 0.10
-    # See https://github.com/tox-dev/tox/issues/1538 for the following pin
-    virtualenv < 20
 isolated_build = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,18 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
+    tox-pypi-filter >= 0.10
+    # See https://github.com/tox-dev/tox/issues/1538 for the following pin
+    virtualenv < 20
 isolated_build = true
 
 [testenv]
+
+# The following option combined with the use of the tox-pypi-filter above allows
+# project-wide pinning of dependencies, e.g. if new versions of pytest do not
+# work correctly with pytest-astropy plugins. Most of the time the pinnings file
+# should be empty.
+pypi_filter_requirements = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
 
 # Pass through the following environemnt variables which are needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TEST_READ_HUGE_FILE
@@ -17,6 +26,8 @@ passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TEST_READ_HUGE_FILE
 # For coverage, we need to pass extra options to the C compiler
 setenv =
     cov: CFLAGS = --coverage -fno-inline-functions -O0
+    image: MPLFLAGS = --mpl
+    !image: MPLFLAGS =
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree
@@ -39,12 +50,17 @@ description =
     numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
+    image: with image tests
+    mpldev: with the latest developer version of matplotlib
+    double: twice in a row to check for global state changes
 
 deps =
 
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
+
+    image: pytest-mpl
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
     # dependencies that have a minimum version
@@ -55,7 +71,7 @@ deps =
     # The devdeps factor is intended to be used to install the latest developer version
     # of key dependencies.
     devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
-    devdeps: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
+    devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
 
 # The following indicates which extras_require from setup.cfg will be installed
@@ -65,8 +81,9 @@ extras =
 
 commands =
     pip freeze
-    !cov: pytest --pyargs astropy {toxinidir}/docs {posargs}
-    cov: pytest --pyargs astropy {toxinidir}/docs --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}
+    !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
+    cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}
+    double: python -c 'import sys; from astropy import test; test(); sys.exit(test())'
 
 [testenv:build_docs]
 changedir = docs


### PR DESCRIPTION
This will allow us to pin things centrally in ci-helpers if needed. For now I'm testing pinning pytest<5.4 from my fork, if it works we should then merge the ci-helpers changes first (https://github.com/astropy/ci-helpers/pull/440) and remove the temporary commit here.