### PR TITLE
Set 'Agg' backend after reverting to matplotlib defaults

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -55,6 +55,7 @@ def pytest_configure(config):
             warnings.simplefilter('ignore')
             matplotlibrc_cache.update(matplotlib.rcParams)
             matplotlib.rcdefaults()
+            matplotlib.use('Agg')
 
     # Make sure we use temporary directories for the config and cache
     # so that the tests are insensitive to local configuration. Note that this


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR is an attempt to make the tests pass in v4.0.x, but I'm not sure if it's the correct fix.

What's happening is that in the Travis container, the call to `matplotlib.rcdefaults()` in astropy/conftest.py causes the backend to switch to TkAgg.  This doesn't happen on my laptop (OS X) and I haven't been able to figure out why the result is different on Travis, but it causes tests in astropy/visualization/wcsaxes/tests/test_images.py to fail.  I think maybe the tests try to confirm that the plot is displayed, and without a Tk GUI running somewhere they can't do that?   Anyway, if we override the defaults and set the backend back to Agg again, those tests pass.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->