### PR TITLE
Ensure that table.show_in_browser works for mixin columns.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -441,6 +441,9 @@ astropy.table
 - Fixed bug where adding or inserting a row fails on a table with an index
   defined on a column that is not the first one. [#10027]
 
+- Ensured that ``table.show_in_browser`` also worked for mixin columns like
+  ``Time`` and ``SkyCoord``. [#10068]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/jsviewer.py
+++ b/astropy/table/jsviewer.py
@@ -180,7 +180,7 @@ def write_table_jsviewer(table, filename, table_id=None, max_lines=5000,
     jsv = JSViewer(**jskwargs)
 
     sortable_columns = [i for i, col in enumerate(table.columns.values())
-                        if col.dtype.kind in 'iufc']
+                        if col.info.dtype.kind in 'iufc']
     html_options = {
         'table_id': table_id,
         'table_class': table_class,

--- a/astropy/table/tests/test_jsviewer.py
+++ b/astropy/table/tests/test_jsviewer.py
@@ -3,6 +3,9 @@ import textwrap
 
 import pytest
 
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+
 from astropy.table.table import Table
 from astropy import extern
 
@@ -85,13 +88,43 @@ TPL = ('   <tr>\n'
 
 
 def format_lines(col1, col2):
-    return '\n'.join(TPL.format(a, b) for a, b in zip(col1, col2))
+    col1_format = getattr(col1.info, 'default_format', lambda x: x)
+    col2_format = getattr(col2.info, 'default_format', lambda x: x)
+    return '\n'.join(TPL.format(col1_format(v1), col2_format(v2))
+                     for v1, v2 in zip(col1, col2))
 
 
 def test_write_jsviewer_default(tmpdir):
     t = Table()
     t['a'] = [1, 2, 3, 4, 5]
     t['b'] = ['a', 'b', 'c', 'd', 'e']
+    t['a'].unit = 'm'
+
+    tmpfile = tmpdir.join('test.html').strpath
+
+    t.write(tmpfile, format='jsviewer')
+    ref = REFERENCE % dict(
+        lines=format_lines(t['a'], t['b']),
+        table_class='display compact',
+        table_id='table%s' % id(t),
+        length='50',
+        display_length='10, 25, 50, 100, 500, 1000',
+        datatables_css_url='https://cdn.datatables.net/1.10.12/css/jquery.dataTables.css',
+        datatables_js_url='https://cdn.datatables.net/1.10.12/js/jquery.dataTables.min.js',
+        jquery_url='https://code.jquery.com/jquery-3.1.1.min.js'
+    )
+    with open(tmpfile) as f:
+        assert f.read().strip() == ref.strip()
+
+
+@pytest.mark.parametrize('mixin', [
+    Time(['J2000', 'J2001']),
+    Time([50000., 50001.0001], format='mjd'),
+    SkyCoord(ra=[100., 110.], dec=[-10., 10.], unit='deg')])
+def test_write_jsviewer_mixin(tmpdir, mixin):
+    t = Table()
+    t['a'] = [1, 2]
+    t['b'] = mixin
     t['a'].unit = 'm'
 
     tmpfile = tmpdir.join('test.html').strpath


### PR DESCRIPTION
Simply requires using `col.info.dtype` instead of `col.dtype`. Also has a few simple tests.

Fixes #10067 