### PR TITLE
Fix column access by attribute with FITS_rec

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -405,6 +405,10 @@ astropy.io.fits
 - Prevent instantiation of ``PrimaryHDU`` and ``ImageHDU`` with a scalar.
   [#10041]
 
+- Fix column access by attribute with FITS_rec: columns with scaling or columns
+  from ASCII tables where not properly converted when accessed by attribute
+  name. [#10069]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -479,6 +479,20 @@ class FITS_rec(np.recarray):
         # one added for recarray in Numpy 1.10) for backwards compat
         return np.ndarray.__repr__(self)
 
+    def __getattribute__(self, attr):
+        # See if ndarray has this attr, and return it if so. (note that this
+        # means a field with the same name as an ndarray attr cannot be
+        # accessed by attribute). NOTE: this is Numpy's default behavior.
+        try:
+            return object.__getattribute__(self, attr)
+        except AttributeError:  # attr must be a fieldname
+            pass
+
+        if self._coldefs is None:
+            return super().__getattribute__(attr)
+
+        return self.field(attr)
+
     def __getitem__(self, key):
         if self._coldefs is None:
             return super().__getitem__(key)

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -480,21 +480,24 @@ class FITS_rec(np.recarray):
         return np.ndarray.__repr__(self)
 
     def __getattribute__(self, attr):
-        # See if ndarray has this attr, and return it if so. (note that this
-        # means a field with the same name as an ndarray attr cannot be
-        # accessed by attribute). NOTE: this is Numpy's default behavior.
+        # First, see if ndarray has this attr, and return it if so. Note that
+        # this means a field with the same name as an ndarray attr cannot be
+        # accessed by attribute, this is Numpy's default behavior.
+        # We avoid using np.recarray.__getattribute__ here because after doing
+        # this check it would access the columns without doing the conversions
+        # that we need (with .field, see below).
         try:
             return object.__getattribute__(self, attr)
-        except AttributeError:  # attr must be a fieldname
+        except AttributeError:
             pass
 
-        if self._coldefs is None:
-            return super().__getattribute__(attr)
-
-        if attr in self.columns.names:
+        # attr might still be a fieldname.  If we have column definitions,
+        # we should access this via .field, as the data may have to be scaled.
+        if self._coldefs is not None and attr in self.columns.names:
             return self.field(attr)
-        else:
-            raise AttributeError
+
+        # If not, just let the usual np.recarray override deal with it.
+        return super().__getattribute__(attr)
 
     def __getitem__(self, key):
         if self._coldefs is None:

--- a/astropy/io/fits/fitsrec.py
+++ b/astropy/io/fits/fitsrec.py
@@ -491,7 +491,10 @@ class FITS_rec(np.recarray):
         if self._coldefs is None:
             return super().__getattribute__(attr)
 
-        return self.field(attr)
+        if attr in self.columns.names:
+            return self.field(attr)
+        else:
+            raise AttributeError
 
     def __getitem__(self, key):
         if self._coldefs is None:

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1602,6 +1602,15 @@ class TestTableFunctions(FitsTestCase):
             assert (data == tbdata.field(col)).all()
             assert (data == tbdata[col]).all()
 
+        # with VLA column
+        col1 = fits.Column(name='x', format='PI()',
+                           array=np.array([[45, 56], [11, 12, 13]],
+                                          dtype=np.object_))
+        hdu = fits.BinTableHDU.from_columns([col1])
+        assert type(hdu.data['x']) == type(hdu.data.x)  # noqa
+        assert (hdu.data['x'][0] == hdu.data.x[0]).all()
+        assert (hdu.data['x'][1] == hdu.data.x[1]).all()
+
     def test_table_with_zero_width_column(self):
         hdul = fits.open(self.data('zerowidth.fits'))
         tbhdu = hdul[2]  # This HDU contains a zero-width column 'ORBPARM'

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1584,12 +1584,23 @@ class TestTableFunctions(FitsTestCase):
                 np.array([False, True], dtype=bool)).all()
 
     def test_fits_rec_column_access(self):
-        t = fits.open(self.data('table.fits'))
-        tbdata = t[1].data
+        tbdata = fits.getdata(self.data('table.fits'))
         assert (tbdata.V_mag == tbdata.field('V_mag')).all()
         assert (tbdata.V_mag == tbdata['V_mag']).all()
 
-        t.close()
+        # Table with scaling (c3) and tnull (c1)
+        tbdata = fits.getdata(self.data('tb.fits'))
+        for col in ('c1', 'c2', 'c3', 'c4'):
+            data = getattr(tbdata, col)
+            assert (data == tbdata.field(col)).all()
+            assert (data == tbdata[col]).all()
+
+        # ascii table
+        tbdata = fits.getdata(self.data('ascii.fits'))
+        for col in ('a', 'b'):
+            data = getattr(tbdata, col)
+            assert (data == tbdata.field(col)).all()
+            assert (data == tbdata[col]).all()
 
     def test_table_with_zero_width_column(self):
         hdul = fits.open(self.data('zerowidth.fits'))


### PR DESCRIPTION
Fix #10065: columns with scaling or columns from ASCII tables where not
properly converted when accessed by attribute name.
cc @mhvk, would be great if you can have a look, since you have more experience with ndarray subclasses.