### PR TITLE
Fix transient failure with warnings catching in test_output_verify

### DIFF
--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -1073,13 +1073,11 @@ class TestHDUListFunctions(FitsTestCase):
         with pytest.raises(VerifyError):
             with fits.open(self.temp('test2.fits'), mode='update') as hdul:
                 hdul[0].header['MORE'] = 'here'
-                hdul.flush(output_verify='ignore')
 
         with pytest.warns(VerifyWarning) as ww:
             with fits.open(self.temp('test2.fits'), mode='update',
                            output_verify='fix+warn') as hdul:
                 hdul[0].header['MORE'] = 'here'
-                hdul.flush(output_verify='ignore')
-        assert len(ww) == 9
-        assert str(ww[1].message).startswith(
-            "Card 'FOOBAR ' is not FITS standard (equal sign not at column 8)")
+        assert len(ww) == 6
+        msg = "Card 'FOOBAR ' is not FITS standard (equal sign not at column 8)"
+        assert msg in str(ww[3].message)


### PR DESCRIPTION
This was failing on the astropy-wheels repo, probably because of some
conflict between warnings catched from `.flush` and from `.__exit__` (which
also calls `.flush`, which is the reason why I removed it here).
This was applied as a patch on astropy-wheels and it works there.