### PR TITLE
Add TimeUnixTai (unix_tai) time format class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,11 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Added a new time format ``unix_tai`` which is essentially Unix time but with
+  leap seconds included.  More precisely, this is the number of seconds since
+  ``1970-01-01 00:00:08 TAI`` and corresponds to the ``CLOCK_TAI`` clock
+  available on some linux platforms. [#10081]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -331,7 +331,7 @@ class Time(ShapedLikeNDArray):
     The allowed values for ``format`` can be listed with::
 
       >>> list(Time.FORMATS)
-      ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
+      ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'cxcsec', 'gps', 'plot_date',
        'stardate', 'datetime', 'ymdhms', 'iso', 'isot', 'yday', 'datetime64',
        'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
 
@@ -660,7 +660,7 @@ class Time(ShapedLikeNDArray):
         that could be used for initialization.  These can be listed with::
 
           >>> list(Time.FORMATS)
-          ['jd', 'mjd', 'decimalyear', 'unix', 'cxcsec', 'gps', 'plot_date',
+          ['jd', 'mjd', 'decimalyear', 'unix', 'unix_tai', 'cxcsec', 'gps', 'plot_date',
            'stardate', 'datetime', 'ymdhms', 'iso', 'isot', 'yday', 'datetime64',
            'fits', 'byear', 'jyear', 'byear_str', 'jyear_str']
         """

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -663,7 +663,8 @@ class TimeFromEpoch(TimeNumeric):
 
 class TimeUnix(TimeFromEpoch):
     """
-    Unix time: seconds from 1970-01-01 00:00:00 UTC.
+    Unix time: seconds from 1970-01-01 00:00:00 UTC, ignoring leap seconds.
+
     For example, 946684800.0 in Unix time is midnight on January 1, 2000.
 
     NOTE: this quantity is not exactly unix time and differs from the strict
@@ -678,6 +679,43 @@ class TimeUnix(TimeFromEpoch):
     epoch_val2 = None
     epoch_scale = 'utc'
     epoch_format = 'iso'
+
+
+class TimeUnixTai(TimeUnix):
+    """
+    Seconds from 1970-01-01 00:00:08 TAI (see notes), including leap seconds.
+
+    This will generally differ from Unix time by the cumulative integral number
+    of leap seconds since 1970-01-01 UTC.  This convention matches the definition
+    for linux CLOCK_TAI (https://www.cl.cam.ac.uk/~mgk25/posix-clocks.html).
+
+    Caveats:
+
+    - Before 1972, fractional adjustments to UTC were made, so the difference
+      between ``unix`` and ``unix_tai`` time is no longer an integer.
+    - Because of the fractional adjustments, to be very precise, ``unix_tai``
+      is the number of seconds since ``1970-01-01 00:00:08 TAI`` or equivalently
+      ``1969-12-31 23:59:59.999918 UTC``.  The difference between TAI and UTC
+      at that epoch was 8.000082 sec.
+    - On the day of a leap second the difference between `unix` and `unix_tai`
+      times increases linearly through the day by 1.0.  See also the
+      documentation for the `~astropy.time.TimeUnix` class.
+
+    Examples
+    --------
+
+      >>> from astropy.time import Time
+      >>> t = Time('2020-01-01', scale='utc')
+      >>> t.unix_tai - t.unix
+      29.0
+
+      >>> t = Time('1970-01-01', scale='utc')
+      >>> t.unix_tai - t.unix
+      8.200000198854696e-05  # doctest: +FLOAT_CMP
+    """
+    name = 'unix_tai'
+    epoch_val = '1970-01-01 00:00:08'
+    epoch_scale = 'tai'
 
 
 class TimeCxcSec(TimeFromEpoch):

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -20,7 +20,7 @@ from .utils import day_frac, quantity_day_frac, two_sum, two_product
 
 
 __all__ = ['TimeFormat', 'TimeJD', 'TimeMJD', 'TimeFromEpoch', 'TimeUnix',
-           'TimeCxcSec', 'TimeGPS', 'TimeDecimalYear',
+           'TimeUnixTai', 'TimeCxcSec', 'TimeGPS', 'TimeDecimalYear',
            'TimePlotDate', 'TimeUnique', 'TimeDatetime', 'TimeString',
            'TimeISO', 'TimeISOT', 'TimeFITS', 'TimeYearDayTime',
            'TimeEpochDate', 'TimeBesselianEpoch', 'TimeJulianEpoch',

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -697,7 +697,7 @@ class TimeUnixTai(TimeUnix):
       is the number of seconds since ``1970-01-01 00:00:08 TAI`` or equivalently
       ``1969-12-31 23:59:59.999918 UTC``.  The difference between TAI and UTC
       at that epoch was 8.000082 sec.
-    - On the day of a leap second the difference between `unix` and `unix_tai`
+    - On the day of a leap second the difference between ``unix`` and ``unix_tai``
       times increases linearly through the day by 1.0.  See also the
       documentation for the `~astropy.time.TimeUnix` class.
 
@@ -710,8 +710,8 @@ class TimeUnixTai(TimeUnix):
       29.0
 
       >>> t = Time('1970-01-01', scale='utc')
-      >>> t.unix_tai - t.unix
-      8.200000198854696e-05  # doctest: +FLOAT_CMP
+      >>> t.unix_tai - t.unix  # doctest: +FLOAT_CMP
+      8.200000198854696e-05
     """
     name = 'unix_tai'
     epoch_val = '1970-01-01 00:00:08'

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1382,6 +1382,13 @@ def test_set_format_basic():
         assert t._time.jd2 is t0._time.jd2
 
 
+def test_unix_tai_format():
+    t = Time('2020-01-01', scale='utc')
+    assert allclose_sec(t.unix_tai - t.unix, 29.0)
+    t = Time('1970-01-01', scale='utc')
+    assert allclose_sec(t.unix_tai - t.unix, 8.2e-05)
+
+
 def test_set_format_shares_subfmt():
     """
     Set format and round trip through a format that shares out_subfmt

--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -182,6 +182,7 @@ jyear_str    :class:`~astropy.time.TimeJulianEpochString`       'J2000.0'
 mjd          :class:`~astropy.time.TimeMJD`                     51544.0
 plot_date    :class:`~astropy.time.TimePlotDate`                730120.0003703703
 unix         :class:`~astropy.time.TimeUnix`                    946684800.0
+unix_tai     :class:`~astropy.time.TimeUnixTai`                 946684800.0
 yday         :class:`~astropy.time.TimeYearDayTime`             2000:001:00:00:00.000
 ymdhms       :class:`~astropy.time.TimeYMDHMS`                  {'year': 2010, 'month': 3, 'day': 1}
 datetime64   :class:`~astropy.time.TimeDatetime64`              np.datetime64('2000-01-01T01:01:01')
@@ -284,6 +285,7 @@ Format           Subformats
 ``mjd``          float, long, decimal, str, bytes
 ``plot_date``    float, long, decimal, str, bytes
 ``unix``         float, long, decimal, str, bytes
+``unix_tai``     float, long, decimal, str, bytes
 ``yday``         date_hms, date_hm, date
 ================ ========================================
 
@@ -300,19 +302,20 @@ Format           Subformats
 Time from epoch formats
 """""""""""""""""""""""
 
-The formats ``cxcsec``, ``gps``, and ``unix`` are a little special in
+The formats ``cxcsec``, ``gps``, ``unix``, and ``unix_tai`` are a little special in
 that they provide a floating point representation of the elapsed
 time in seconds since a particular reference date.  These formats have
 a intrinsic time scale which is used to compute the elapsed seconds
 since the reference date.
 
-========== ====== ========================
-Format      Scale  Reference date
-========== ====== ========================
-``cxcsec``   TT   ``1998-01-01 00:00:00``
-``unix``    UTC   ``1970-01-01 00:00:00``
-``gps``     TAI   ``1980-01-06 00:00:19``
-========== ====== ========================
+============ ====== ========================
+Format       Scale  Reference date
+============ ====== ========================
+``cxcsec``   TT     ``1998-01-01 00:00:00``
+``unix``     UTC    ``1970-01-01 00:00:00``
+``unix_tai`` TAI    ``1970-01-01 00:00:08``
+``gps``      TAI    ``1980-01-06 00:00:19``
+============ ====== ========================
 
 Unlike the other formats which default to UTC, if no ``scale`` is provided when
 initializing a |Time| object then the above intrinsic scale is used.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR adds a new time format `unix_tai` which is roughly Unix time (`unix` format) but with leap seconds included.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Closes #10052
