### PR TITLE
added ability to serialize parameter and model constraints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ astropy.io.ascii
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
+- Added serialization of parameter constraints `fixed` and `bounds`.  [#10082]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,7 @@ astropy.io.ascii
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^
-- Added serialization of parameter constraints `fixed` and `bounds`.  [#10082]
+- Added serialization of parameter constraints fixed and bounds.  [#10082]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from astropy import __minimum_asdf_version__
 
-asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
+#asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf import util
 from asdf.tests import helpers
 from asdf import AsdfFile
@@ -64,6 +64,11 @@ for kl in astmodels.math.__all__:
 
 test_models.extend(math_models)
 
+test_models_with_constraints = [astmodels.Legendre2D(x_degree=1, y_degree=1,
+                                c0_0=1, c0_1=2, c1_0=3,
+                                fixed={'c1_0': True, 'c0_1': True},
+                                bounds={'c0_0': (-10, 10)})]
+test_models.extend(test_models_with_constraints)
 
 def test_transforms_compound(tmpdir):
     tree = {

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from astropy import __minimum_asdf_version__
 
-#asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
+asdf = pytest.importorskip('asdf', minversion=__minimum_asdf_version__)
 from asdf import util
 from asdf.tests import helpers
 from asdf import AsdfFile


### PR DESCRIPTION
I added the ability to serialize parameter constraints (fixed/tied/bounds) and model constraints (ineqcons/eqcons). While in general any callable can be assigned to 'tied' for each parameter, for serialization it must be either False, or a Model/CompoundModel.

I also added a new section in test_transform for models with constraints, and added one example there for testing this.
