### PR TITLE
Replace uses of tostring with tobytes

### DIFF
--- a/astropy/io/fits/tests/test_division.py
+++ b/astropy/io/fits/tests/test_division.py
@@ -12,7 +12,7 @@ class TestDivisionFunctions(FitsTestCase):
 
     def test_rec_from_string(self):
         with fits.open(self.data('tb.fits')) as t1:
-            s = t1[1].data.tostring()
+            s = t1[1].data.tobytes()
         np.rec.array(
             s,
             dtype=np.dtype([('c1', '>i4'), ('c2', '|S3'),

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -1668,10 +1668,10 @@ class TestTableFunctions(FitsTestCase):
         acol = fits.Column(name='MEMNAME', format='A10',
                            array=chararray.array(a))
         ahdu = fits.BinTableHDU.from_columns([acol])
-        assert ahdu.data.tostring().decode('raw-unicode-escape') == s
+        assert ahdu.data.tobytes().decode('raw-unicode-escape') == s
         ahdu.writeto(self.temp('newtable.fits'))
         with fits.open(self.temp('newtable.fits')) as hdul:
-            assert hdul[1].data.tostring().decode('raw-unicode-escape') == s
+            assert hdul[1].data.tobytes().decode('raw-unicode-escape') == s
             assert (hdul[1].data['MEMNAME'] == a).all()
         del hdul
 
@@ -1680,7 +1680,7 @@ class TestTableFunctions(FitsTestCase):
             ahdu.writeto(self.temp('newtable.fits'), overwrite=True)
 
         with fits.open(self.temp('newtable.fits')) as hdul:
-            assert (hdul[1].data.tostring().decode('raw-unicode-escape') ==
+            assert (hdul[1].data.tobytes().decode('raw-unicode-escape') ==
                     s.replace('\x00', ' '))
             assert (hdul[1].data['MEMNAME'] == a).all()
             ahdu = fits.BinTableHDU.from_columns(hdul[1].data.copy())
@@ -1690,7 +1690,7 @@ class TestTableFunctions(FitsTestCase):
         # revert to zeroes
         ahdu.writeto(self.temp('newtable.fits'), overwrite=True)
         with fits.open(self.temp('newtable.fits')) as hdul:
-            assert hdul[1].data.tostring().decode('raw-unicode-escape') == s
+            assert hdul[1].data.tobytes().decode('raw-unicode-escape') == s
             assert (hdul[1].data['MEMNAME'] == a).all()
 
     def test_multi_dimensional_columns(self):
@@ -2930,7 +2930,7 @@ class TestColumnFunctions(FitsTestCase):
 
             # Check how the raw data looks
             raw = np.rec.recarray.field(hdul[1].data, 'TEST')
-            assert raw.tostring() == b'   1.   2.   3.'
+            assert raw.tobytes() == b'   1.   2.   3.'
 
     def test_column_array_type_mismatch(self):
         """Regression test for https://aeon.stsci.edu/ssb/trac/pyfits/ticket/218"""

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -680,7 +680,7 @@ def _array_to_file_like(arr, fileobj):
     if hasattr(np, 'nditer'):
         # nditer version for non-contiguous arrays
         for item in np.nditer(arr, order='C'):
-            fileobj.write(item.tostring())
+            fileobj.write(item.tobytes())
     else:
         # Slower version for Numpy versions without nditer;
         # The problem with flatiter is it doesn't preserve the original
@@ -689,10 +689,10 @@ def _array_to_file_like(arr, fileobj):
         if ((sys.byteorder == 'little' and byteorder == '>')
                 or (sys.byteorder == 'big' and byteorder == '<')):
             for item in arr.flat:
-                fileobj.write(item.byteswap().tostring())
+                fileobj.write(item.byteswap().tobytes())
         else:
             for item in arr.flat:
-                fileobj.write(item.tostring())
+                fileobj.write(item.tobytes())
 
 
 def _write_string(f, s):

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -141,7 +141,7 @@ def _ndarray_representer(dumper, obj):
     else:
         order = 'C'
 
-    data_b64 = base64.b64encode(obj.tostring())
+    data_b64 = base64.b64encode(obj.tobytes())
 
     out = dict(buffer=data_b64,
                dtype=str(obj.dtype),

--- a/astropy/io/votable/converters.py
+++ b/astropy/io/votable/converters.py
@@ -645,7 +645,7 @@ class NumericArray(Array):
     def binoutput(self, value, mask):
         filtered = self._base.filter_array(value, mask)
         filtered = _ensure_bigendian(filtered)
-        return filtered.tostring()
+        return filtered.tobytes()
 
 
 class Numeric(Converter):
@@ -779,7 +779,7 @@ class FloatingPoint(Numeric):
             return self._null_binoutput
 
         value = _ensure_bigendian(value)
-        return value.tostring()
+        return value.tobytes()
 
     def _filter_nan(self, value, mask):
         return np.where(mask, np.nan, value)
@@ -868,7 +868,7 @@ class Integer(Numeric):
                 value = self.null
 
         value = _ensure_bigendian(value)
-        return value.tostring()
+        return value.tobytes()
 
     def filter_array(self, value, mask):
         if np.any(mask):

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1375,6 +1375,10 @@ class Quantity(np.ndarray):
         raise NotImplementedError("cannot write Quantities to string.  Write "
                                   "array with q.value.tostring(...).")
 
+    def tobytes(self, order='C'):
+        raise NotImplementedError("cannot write Quantities to string.  Write "
+                                  "array with q.value.tobytes(...).")
+
     def tofile(self, fid, sep="", format="%s"):
         raise NotImplementedError("cannot write Quantities to file.  Write "
                                   "array with q.value.tofile(...)")

--- a/astropy/units/tests/test_quantity_array_methods.py
+++ b/astropy/units/tests/test_quantity_array_methods.py
@@ -513,6 +513,8 @@ class TestArrayConversion:
         with pytest.raises(NotImplementedError):
             q1.tostring()
         with pytest.raises(NotImplementedError):
+            q1.tobytes()
+        with pytest.raises(NotImplementedError):
             q1.tofile(0)
         with pytest.raises(NotImplementedError):
             q1.dump('a.a')


### PR DESCRIPTION
`ndarray.tostring` will be deprecated in Numpy 1.19 : numpy/numpy#15867