### PR TITLE
Fix remote data doctest for wcsapi

### DIFF
--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -288,8 +288,6 @@ If you are implementing your own WCS class, you could choose to implement
 more succinctly as::
 
     >>> wcs[10, 30:100, 30:100]  # doctest: +REMOTE_DATA +ELLIPSIS
-    <BLANKLINE>
-    ...
     SlicedFITSWCS Transformation
     <BLANKLINE>
     This transformation has 2 pixel and 2 world dimensions
@@ -319,8 +317,6 @@ image plane of a spectral slice, the final WCS will have one pixel dimension
 and two world dimensions (since both RA/Dec vary over the extracted 1D slice)::
 
     >>> wcs[10, 40, :]  # doctest: +REMOTE_DATA +ELLIPSIS
-    <BLANKLINE>
-    ...
     SlicedFITSWCS Transformation
     <BLANKLINE>
     This transformation has 1 pixel and 2 world dimensions


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address remote data doctest output behavioral change for `wcsapi`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10086

**Note for reviewer: Please check remote data test job that is allowed to fail.**