### PR TITLE
Skip wcsaxes tests if pytest-mpl is not installed

### DIFF
--- a/astropy/visualization/time.py
+++ b/astropy/visualization/time.py
@@ -10,7 +10,7 @@ from astropy import units as u
 
 __all__ = ['time_support']
 
-__doctest_requires__ = {'time_support': ['matplotlib']}
+__doctest_requires__ = {'time_support': ['matplotlib', 'pytest-mpl']}
 
 UNSUPPORTED_FORMATS = ('datetime', 'datetime64')
 YMDHMS_FORMATS = ('fits', 'iso', 'isot', 'yday')

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -6,6 +6,7 @@
 try:
     import pytest
     pytest.importorskip("matplotlib")
+    pytest.importorskip("pytest-mpl")
     del pytest
 except ImportError:
     pass

--- a/docs/visualization/matplotlib_integration.rst
+++ b/docs/visualization/matplotlib_integration.rst
@@ -12,7 +12,7 @@ Plotting quantities
 |quantity| objects can be conveniently plotted using matplotlib.  This
 feature needs to be explicitly turned on:
 
-.. doctest-requires:: matplotlib
+.. doctest-requires:: matplotlib, pytest-mpl
 
     >>> from astropy.visualization import quantity_support
     >>> quantity_support()  # doctest: +IGNORE_OUTPUT
@@ -69,7 +69,7 @@ precise scale and format to use for the tick labels, in which case you can make
 use of the `~astropy.visualization.time_support` function. This feature needs to
 be explicitly turned on:
 
-.. doctest-requires:: matplotlib
+.. doctest-requires:: matplotlib, pytest-mpl
 
     >>> from astropy.visualization import time_support
     >>> time_support()  # doctest: +IGNORE_OUTPUT


### PR DESCRIPTION
After installing with `pip install -e .[test]`, running `pytest` manually in the `astropy/visualization` gives a bunch of `pytest.PytestUnknownMarkWarning: Unknown pytest.mark.mpl_image_compare` errors, preventing the tests from running.  This subpackage requires the `pytest-mpl` to be installed.  I added that package to the setup in the `test` section.
