### PR TITLE
BUG: fix deprecated_renamed_argument to accept arg removal from signature

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -386,6 +386,11 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fixed ``deprecated_renamed_argument`` to accept case when argument is
+  deprecated without replacement and removed from signature as
+  well. Deprecated argument cannot be used as positional argument, unless
+  it's being kept in signature.  [#10093]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/tests/test_decorators.py
+++ b/astropy/utils/tests/test_decorators.py
@@ -488,6 +488,32 @@ def test_deprecated_argument_remove():
         assert len(w) == 0
 
 
+def test_deprecated_argument_remove_from_signature():
+    @deprecated_renamed_argument('x', None, '2.0', alternative='astropy.y')
+    def test(dummy=11):
+        return dummy
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test(x=1) == (11)
+        assert len(w) == 1
+        assert 'Use astropy.y instead' in str(w[0].message)
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test(x=1, dummy=10) == (10)
+        assert len(w) == 1
+
+    with pytest.raises(TypeError):
+        # Can't pass in deprecated parameter as positional arg when it's missing from signature
+        # as its position is ambigious
+        test(121, 1)
+
+    with catch_warnings(AstropyDeprecationWarning) as w:
+        assert test() == (11)
+        assert test(121) == (121)
+        assert test(dummy=121) == (121)
+        assert len(w) == 0
+
+
 def test_sharedmethod_reuse_on_subclasses():
     """
     Regression test for an issue where sharedmethod would bind to one class


### PR DESCRIPTION
A possible fix #10084

I'm still not convinced that this is the right approach, as oppose to require the deprecated argument to stay in the signature, during the deprecation, but nevertheless, this patch fixes the issue we see with reproject.