### PR TITLE
Apply space motion of SkyCoords for rv corrections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -129,6 +129,11 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- ```SkyCoord.radial_velocity_correction``` now allows you to pass an ```obstime``` directly
+  when the ```SkyCoord``` also has an ```obstime``` set. In this situation, the position of the
+  ```SkyCoord``` has space motion applied to correct to the passed ```obstime```. This allows
+  mm/s radial velocity precision for objects with large space motion. [#10094]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,9 +18,6 @@ astropy.coordinates
 - Angle parsing now supports ``cardinal direction`` in the cases
   where angles are initialized as ``string`` instances. eg ``"17°53'27"W"``.[#9859]
 
-- ```SkyCoord.radial_velocity_correction``` no longer raises an Exception when space motion
-  information is present on the SkyCoord. [#9980]
-
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -429,6 +426,12 @@ astropy.coordinates
 
 - ```SkyCoord.radial_velocity_correction``` no longer raises an Exception
   when space motion information is present on the SkyCoord. [#9980]
+
+astropy.cosmology
+^^^^^^^^^^^^^^^^^
+
+astropy.extern
+^^^^^^^^^^^^^^
 
 astropy.io
 ^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -427,12 +427,6 @@ astropy.coordinates
 - ```SkyCoord.radial_velocity_correction``` no longer raises an Exception
   when space motion information is present on the SkyCoord. [#9980]
 
-astropy.cosmology
-^^^^^^^^^^^^^^^^^
-
-astropy.extern
-^^^^^^^^^^^^^^
-
 astropy.io
 ^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ astropy.coordinates
 - Angle parsing now supports ``cardinal direction`` in the cases
   where angles are initialized as ``string`` instances. eg ``"17°53'27"W"``.[#9859]
 
+- ```SkyCoord.radial_velocity_correction``` no longer raises an Exception when space motion
+  information is present on the SkyCoord. [#9980]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1579,12 +1579,14 @@ class SkyCoord(ShapedLikeNDArray):
             # warn the user if the object has differentials set
             if 's' in self.data.differentials:
                 warnings.warn(
-                    "SkyCoord has space motion, and therefore the posiion "
-                    "of the SkyCoord at `obstime` may not be the same as "
+                    "SkyCoord has space motion, and therefore the specified "
+                    "position of the SkyCoord may not be the same as "
                     "the `obstime` for the radial velocity measurement. "
-                    "However, if you want to apply space motion of the "
-                    "SkyCoord to correct for this, the `obstime` attribute of"
-                    "the SkyCoord must be set", AstropyUserWarning
+                    "This may affect the rv correction at the order of km/s"
+                    "for very high proper motions sources. If you wish to "
+                    "apply space motion of the SkyCoord to correct for this"
+                    "the `obstime` attribute of the SkyCoord must be set",
+                    AstropyUserWarning
                 )
             coo_at_rv_obstime = self
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1566,15 +1566,16 @@ class SkyCoord(ShapedLikeNDArray):
                              'the passed-in `obstime`.')
 
         # obstime validation
+        coo_at_rv_obstime = self  # assume we need no space motion for now
         if obstime is None:
             obstime = self.obstime
-            coo_at_rv_obstime = self
             if obstime is None:
                 raise TypeError('Must provide an `obstime` to '
                                 'radial_velocity_correction, either as a '
                                 'SkyCoord frame attribute or in the method '
                                 'call.')
-        elif self.obstime is not None:
+        elif self.obstime is not None and self.frame.data.differentials:
+            # we do need space motion after all
             coo_at_rv_obstime = self.apply_space_motion(obstime)
         elif self.obstime is None:
             # warn the user if the object has differentials set
@@ -1589,7 +1590,6 @@ class SkyCoord(ShapedLikeNDArray):
                     "the `obstime` attribute of the SkyCoord must be set",
                     AstropyUserWarning
                 )
-            coo_at_rv_obstime = self
 
         pos_earth, v_earth = get_body_barycentric_posvel('earth', obstime)
         if kind == 'barycentric':

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1568,6 +1568,7 @@ class SkyCoord(ShapedLikeNDArray):
         # obstime validation
         if obstime is None:
             obstime = self.obstime
+            coo_at_rv_obstime = self
             if obstime is None:
                 raise TypeError('Must provide an `obstime` to '
                                 'radial_velocity_correction, either as a '

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -1574,7 +1574,7 @@ class SkyCoord(ShapedLikeNDArray):
                                 'SkyCoord frame attribute or in the method '
                                 'call.')
         elif self.obstime is not None:
-            actual_coo = self.apply_space_motion(obstime)
+            coo_at_rv_obstime = self.apply_space_motion(obstime)
         elif self.obstime is None:
             # warn the user if the object has differentials set
             if 's' in self.data.differentials:
@@ -1586,7 +1586,7 @@ class SkyCoord(ShapedLikeNDArray):
                     "SkyCoord to correct for this, the `obstime` attribute of"
                     "the SkyCoord must be set", AstropyUserWarning
                 )
-            actual_coo = self
+            coo_at_rv_obstime = self
 
         pos_earth, v_earth = get_body_barycentric_posvel('earth', obstime)
         if kind == 'barycentric':
@@ -1602,7 +1602,7 @@ class SkyCoord(ShapedLikeNDArray):
         gcrs_p, gcrs_v = location.get_gcrs_posvel(obstime)
         # transforming to GCRS is not the correct thing to do here, since we don't want to
         # include aberration (or light deflection)? Instead, only apply parallax if necessary
-        icrs_cart = actual_coo.icrs.cartesian
+        icrs_cart = coo_at_rv_obstime.icrs.cartesian
         icrs_cart_novel = icrs_cart.without_differentials()
         if self.data.__class__ is UnitSphericalRepresentation:
             targcart = icrs_cart_novel

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -401,7 +401,7 @@ def _get_barycorr_bvcs_withvels(coos, loc, injupyter=False):
 
 
 @pytest.mark.remote_data
-def test_regression_XXXX():
+def test_regression_10094():
     """
     Make sure that when we include the proper motion and radial velocity of
     a SkyCoord, our velocity corrections remain close to TEMPO2.

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -305,19 +305,18 @@ def test_invalid_argument_combos():
     with pytest.raises(ValueError):
         scwattrs.radial_velocity_correction(timel)
 
+
 @pytest.mark.remote_data
-@pytest.mark.filterwarnings('ignore')
 def test_regression_9645():
-    sc = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc,
+    sc = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc, obstime=test_input_time,
                   pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr, radial_velocity=0*u.km/u.s)
-    sc_novel = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc)
+    sc_novel = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc, obstime=test_input_time)
     corr = sc.radial_velocity_correction(obstime=test_input_time, location=test_input_loc)
     corr_novel = sc_novel.radial_velocity_correction(obstime=test_input_time, location=test_input_loc)
     assert_quantity_allclose(corr, corr_novel)
 
 
 @pytest.mark.remote_data
-@pytest.mark.filterwarnings('ignore')
 def test_barycorr_withvels():
     # this is the result of calling _get_barycorr_bvcs_withvels
     barycorr_bvcs = u.Quantity(
@@ -367,7 +366,9 @@ def _get_test_input_radecvels():
     pmdec = np.linspace(0, 1000, coos.size)*u.mas/u.yr
     rvs = np.linspace(0, 100, coos.size)*u.km/u.s
     distance = np.linspace(10, 1000, coos.size)*u.pc
-    return SkyCoord(ras, decs, pm_ra_cosdec=pmra, pm_dec=pmdec, radial_velocity=rvs, distance=distance)
+    return SkyCoord(ras, decs, pm_ra_cosdec=pmra, pm_dec=pmdec,
+                    radial_velocity=rvs, distance=distance,
+                    obstime=test_input_time)
 
 
 def _get_barycorr_bvcs_withvels(coos, loc, injupyter=False):
@@ -427,7 +428,7 @@ def test_regression_XXXX():
     # CTIO location as used in Wright & Eastmann
     xyz = u.Quantity([1814985.3, -5213916.8, -3187738.1], u.m)
     obs = EarthLocation(*xyz)
-    times = Time(reduced_jds + 2400000, format='jd')
+    times = Time(2400000, reduced_jds, format='jd')
     tempo2 = tempo2 * speed_of_light
     barycorr = barycorr * speed_of_light
     astropy = tauCet.radial_velocity_correction(location=obs, obstime=times)

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -401,6 +401,16 @@ def _get_barycorr_bvcs_withvels(coos, loc, injupyter=False):
 
 
 @pytest.mark.remote_data
+def test_warning_no_obstime_on_skycoord():
+    c = SkyCoord(l=10*u.degree, b=45*u.degree,
+                 pm_l_cosb=34*u.mas/u.yr, pm_b=-117*u.mas/u.yr,
+                 distance=50*u.pc, frame='galactic')
+    with pytest.warns(Warning):
+        c.radial_velocity_correction('barycentric', test_input_time,
+                                     test_input_loc)
+
+
+@pytest.mark.remote_data
 def test_regression_10094():
     """
     Make sure that when we include the proper motion and radial velocity of

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -10,6 +10,7 @@ from astropy.coordinates import EarthLocation, SkyCoord, Angle, Distance
 from astropy.coordinates.sites import get_builtin_sites
 from astropy.utils.data import download_file
 from astropy.constants import c as speed_of_light
+from astropy.table import Table
 
 
 @pytest.mark.remote_data
@@ -408,8 +409,12 @@ def test_regression_XXXX():
     """
     # Wright & Eastman (2014) Table2
     # Corrections for tau Ceti
-    reduced_jds, tempo2, barycorr = np.loadtxt(
-        download_file('http://astroutils.astronomy.ohio-state.edu/exofast/pro/exofast/bary/zb.txt')).T
+    wright_table = Table.read(
+        download_file('http://data.astropy.org/coordinates/wright_eastmann_2014_tau_ceti.fits')
+    )
+    reduced_jds = wright_table['JD-2400000']
+    tempo2 = wright_table['TEMPO2']
+    barycorr = wright_table['BARYCORR']
 
     # tau Ceti Hipparchos data
     tauCet = SkyCoord('01 44 05.1275 -15 56 22.4006',

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -305,6 +305,7 @@ def test_invalid_argument_combos():
         scwattrs.radial_velocity_correction(timel)
 
 @pytest.mark.remote_data
+@pytest.mark.filterwarnings('ignore')
 def test_regression_9645():
     sc = SkyCoord(10*u.deg, 20*u.deg, distance=5*u.pc,
                   pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr, radial_velocity=0*u.km/u.s)
@@ -315,6 +316,7 @@ def test_regression_9645():
 
 
 @pytest.mark.remote_data
+@pytest.mark.filterwarnings('ignore')
 def test_barycorr_withvels():
     # this is the result of calling _get_barycorr_bvcs_withvels
     barycorr_bvcs = u.Quantity(
@@ -401,7 +403,7 @@ def test_regression_XXXX():
     # Wright & Eastman (2014) Table2
     # Corrections for tau Ceti
     jds, tempo2, barycorr = np.loadtxt(
-        download_file('http://astroutils.astronomy.ohio-state.edu/exofast/pro/exofast/bary/zb.txt'))
+        download_file('http://astroutils.astronomy.ohio-state.edu/exofast/pro/exofast/bary/zb.txt')).T
 
     # tau Ceti Hipparchos data
     tauCet = SkyCoord('01 44 05.1275 -15 56 22.4006',

--- a/astropy/coordinates/tests/test_velocity_corrs.py
+++ b/astropy/coordinates/tests/test_velocity_corrs.py
@@ -400,9 +400,15 @@ def _get_barycorr_bvcs_withvels(coos, loc, injupyter=False):
 
 @pytest.mark.remote_data
 def test_regression_XXXX():
+    """
+    Make sure that when we include the proper motion and radial velocity of
+    a SkyCoord, our velocity corrections remain close to TEMPO2.
+
+    We check that tau Ceti is within 5mm/s
+    """
     # Wright & Eastman (2014) Table2
     # Corrections for tau Ceti
-    jds, tempo2, barycorr = np.loadtxt(
+    reduced_jds, tempo2, barycorr = np.loadtxt(
         download_file('http://astroutils.astronomy.ohio-state.edu/exofast/pro/exofast/bary/zb.txt')).T
 
     # tau Ceti Hipparchos data
@@ -413,10 +419,10 @@ def test_regression_XXXX():
                       distance=Distance(parallax=273.96*u.mas),
                       radial_velocity=-16.597*u.km/u.s,
                       obstime=Time(48348.5625, format='mjd'))
-    # CTIO
+    # CTIO location as used in Wright & Eastmann
     xyz = u.Quantity([1814985.3, -5213916.8, -3187738.1], u.m)
     obs = EarthLocation(*xyz)
-    times = Time(jds + 2400000, format='jd')
+    times = Time(reduced_jds + 2400000, format='jd')
     tempo2 = tempo2 * speed_of_light
     barycorr = barycorr * speed_of_light
     astropy = tauCet.radial_velocity_correction(location=obs, obstime=times)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Now that we no longer throw an Exception when ```SkyCoord```s with velocity information are passed to ```SkyCoord.radial_velocity_correction``` we have to address a bug that is unfortunately baked into the API.

Currently if the passed ```SkyCoord``` had it's own obstime, and it was inconsistent with the passed obstime, we raised an Exception. However, the correct thing to do is to correct the ```SkyCoord``` for it's space motion so that it points to the proper location at the *passed* obstime. 

Failure to do so for nearby or fast moving objects (e.g tau Ceti below) leads to errors of metres/second:

![RVs_before](https://user-images.githubusercontent.com/4570807/78016482-c518e400-7342-11ea-9833-93ecfe50bba3.png)

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

This PR fixes #9979 by updating the object's position to the passed obstime, resulting in better than 10 mm/s agreement with TEMPO2 or BARYCORR.

![RVs_after](https://user-images.githubusercontent.com/4570807/78016666-04dfcb80-7343-11ea-84b9-715124af3ea5.png)

Unfortunately I don't think this can be considered a bug fix, since code that used to raise an exception will now run. 

Note that the test I have added for regression downloads the TEMPO2/BARYCORR corrections for tau Ceti from an external website. I have submitted a seperate PR (https://github.com/astropy/astropy-data/pull/88)  to astropy-data to host those corrections there, and then update this PR accordingly, so perhaps hold off until then to merge.