### PR TITLE
Add bit flag name map

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,10 @@ astropy.modeling
 astropy.nddata
 ^^^^^^^^^^^^^^
 
+- Added support in the ``bitmask`` module for using mnemonic bit flag names
+  when specifying the bit flags to be used or ignored when converting a bit
+  field to a boolean. [#10095]
+
 astropy.samp
 ^^^^^^^^^^^^
 

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -633,14 +633,14 @@ good_mask_value=False, dtype=numpy.bool_)
         ...                                  dtype=int)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='CR,CLOUDY',
-        ...                                  flip_bits=True, good_mask_value=0,
-        ...                                  dtype=int, flag_name_map=flag_map)
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='~(CR,CLOUDY)',
+        ...                                  good_mask_value=0, dtype=int,
+        ...                                  flag_name_map=flag_map)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='CR+CLOUDY',
-        ...                                  flip_bits=True, good_mask_value=0,
-        ...                                  dtype=int, flag_name_map=flag_map)
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='~(CR+CLOUDY)',
+        ...                                  good_mask_value=0, dtype=int,
+        ...                                  flag_name_map=flag_map)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
 

--- a/astropy/nddata/bitmask.py
+++ b/astropy/nddata/bitmask.py
@@ -218,10 +218,10 @@ def extend_bit_flag_map(cls_name, base_cls=BitFlagNameMap, **kwargs):
         >>> from astropy.nddata.bitmask import extend_bit_flag_map
         >>> ST_DQ = extend_bit_flag_map('ST_DQ', __version__='1.0.0', CR=1, CLOUDY=4, RAINY=8)
         >>> ST_CAM1_DQ = extend_bit_flag_map('ST_CAM1_DQ', ST_DQ, HOT=16, DEAD=32)
-        >>> JWST_MIRI_DQ['HOT']  # <-- Access flags as dictionary keys
-        256
-        >>> JWST_MIRI_DQ.HOT  # <-- Access flags as class attributes
-        256
+        >>> ST_CAM1_DQ['HOT']  # <-- Access flags as dictionary keys
+        16
+        >>> ST_CAM1_DQ.HOT  # <-- Access flags as class attributes
+        16
 
     """
     new_cls = BitFlagNameMeta.__new__(
@@ -246,7 +246,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None, flag_name_map=None):
     Converts input bit flags to a single integer value (bit mask) or `None`.
 
     When input is a list of flags (either a Python list of integer flags or a
-    sting of comma-, ``'|'``-, or ``'+'``-separated list of flags),
+    string of comma-, ``'|'``-, or ``'+'``-separated list of flags),
     the returned bit mask is obtained by summing input flags.
 
     .. note::
@@ -313,7 +313,7 @@ def interpret_bit_flags(bit_flags, flip_bits=None, flag_name_map=None):
         >>> "{0:016b}".format(0xFFFF & interpret_bit_flags('~(4+8+16)'))
         '1111111111100011'
         >>> "{0:016b}".format(0xFFFF & interpret_bit_flags('~(CLOUDY+RAINY+HOT)',
-        ... flag_name_map=ST_DQ)))
+        ... flag_name_map=ST_DQ))
         '1111111111100011'
         >>> "{0:016b}".format(0xFFFF & interpret_bit_flags([4, 8, 16]))
         '0000000000011100'
@@ -599,46 +599,46 @@ good_mask_value=False, dtype=numpy.bool_)
 
         >>> from astropy.nddata import bitmask
         >>> import numpy as np
-        >>> dqbits = np.asarray([[0, 0, 1, 2, 0, 8, 12, 0],
-        ...                      [10, 4, 0, 0, 0, 16, 6, 0]])
+        >>> dqarr = np.asarray([[0, 0, 1, 2, 0, 8, 12, 0],
+        ...                     [10, 4, 0, 0, 0, 16, 6, 0]])
         >>> flag_map = bitmask.extend_bit_flag_map(
-        ...     'ST_DQ', CR=2, CLOUDY=4, RAINY=8, HOT=16, DEAD=32)
+        ...     'ST_DQ', CR=2, CLOUDY=4, RAINY=8, HOT=16, DEAD=32
         ... )
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=0,
         ...                                  dtype=int)
         array([[0, 0, 1, 1, 0, 1, 1, 0],
                [1, 1, 0, 0, 0, 1, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=0,
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=0,
         ...                                  dtype=bool)
         array([[False, False,  True,  True, False,  True,  True, False],
                [ True,  True, False, False, False,  True,  True, False]]...)
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6,
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=6,
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 1, 0, 0, 1, 1, 0],
                [1, 0, 0, 0, 0, 1, 0, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=~6,
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=~6,
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=6, dtype=int,
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=6, dtype=int,
         ...                                  flip_bits=True, good_mask_value=0)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags='~(2+4)',
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='~(2+4)',
         ...                                  good_mask_value=0, dtype=int)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags=[2, 4],
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags=[2, 4],
         ...                                  flip_bits=True, good_mask_value=0,
         ...                                  dtype=int)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags='CR,CLOUDY',
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='CR,CLOUDY',
         ...                                  flip_bits=True, good_mask_value=0,
         ...                                  dtype=int, flag_name_map=flag_map)
         array([[0, 0, 0, 1, 0, 0, 1, 0],
                [1, 1, 0, 0, 0, 0, 1, 0]])
-        >>> bitmask.bitfield_to_boolean_mask(dqbits, ignore_flags='CR+CLOUDY',
+        >>> bitmask.bitfield_to_boolean_mask(dqarr, ignore_flags='CR+CLOUDY',
         ...                                  flip_bits=True, good_mask_value=0,
         ...                                  dtype=int, flag_name_map=flag_map)
         array([[0, 0, 0, 1, 0, 0, 1, 0],

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -187,8 +187,8 @@ or by using the `~astropy.nddata.bitmask.extend_bit_flag_map` class factory:
     Bit flag values must be integer numbers that are powers of 2.
 
 Once constructed, bit flag values of a map cannot be modified, deleted, or
-added. Adding flags to a map is allowed only through subclassing through the
-one of the two methods shown above or by adding lists of tuples of
+added. Adding flags to a map is allowed only through subclassing using one of
+the two methods shown above or by adding lists of tuples of
 the form ``('NAME', value)`` to the class. This will create a new map class
 subclassed from the original map but containing the additional flags
 

--- a/docs/nddata/bitmask.rst
+++ b/docs/nddata/bitmask.rst
@@ -132,13 +132,13 @@ It is also possible to specify the type of the output mask:
     array([0, 1, 0, 1], dtype=uint8)
 
 In order to use lists of mnemonic bit flags names, one must provide a map,
-a subclass of `~astropy.nddata.bitmask.BaseBitFlagNameMap`, that can be
+a subclass of `~astropy.nddata.bitmask.BitFlagNameMap`, that can be
 used to map mnemonic names to bit flag values. Normally these maps should be
 provided by a third-patry package supporting a specific instrument. In the
 example below we define a simple mask map:
 
-    >>> from astropy.nddata.bitmask import BaseBitFlagNameMap
-    >>> class ST_DQ(BaseBitFlagNameMap):
+    >>> from astropy.nddata.bitmask import BitFlagNameMap
+    >>> class ST_DQ(BitFlagNameMap):
     ...     CR = 1
     ...     CLOUDY = 4
     ...     RAINY = 8
@@ -162,12 +162,12 @@ to be taken into consideration or ignored when creating a *boolean* mask, we
 use bit flag name maps. These maps perform case-insensitive translation of
 mnemonic bit flag names to the corresponding integer value.
 
-Bit flag name maps are subclasses of `~astropy.nddata.bitmask.BaseBitFlagNameMap`
+Bit flag name maps are subclasses of `~astropy.nddata.bitmask.BitFlagNameMap`
 and can be constructed in two ways, either by directly subclassing
-`~astropy.nddata.bitmask.BaseBitFlagNameMap`, e.g.,
+`~astropy.nddata.bitmask.BitFlagNameMap`, e.g.,
 
-    >>> from astropy.nddata.bitmask import BaseBitFlagNameMap
-    >>> class ST_DQ(BaseBitFlagNameMap):
+    >>> from astropy.nddata.bitmask import BitFlagNameMap
+    >>> class ST_DQ(BitFlagNameMap):
     ...     CR = 1
     ...     CLOUDY = 4
     ...     RAINY = 8


### PR DESCRIPTION
### Description
This PR adds support for using mnemonic bit field names in the `nddata.bitmask` module when specifying which bit fields can be used (or ignored) when converting, i.e., a DQ array to a boolean mask.

CC: @perrygreenfield @crawfordsm 

**TODO**

- [x] Get approval for the proof of concept to proceed.
- [x] Add tests.