### PR TITLE
Add support for custom attributes in Table subclasses

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -141,6 +141,9 @@ astropy.units
 
 astropy.utils
 ^^^^^^^^^^^^^
+- Added a new ``MetaAttribute`` class to support easily adding custom attributes
+  to a subclass of classes like ``Table`` or ``NDData`` that have a ``meta``
+  attribute. [#10097]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -103,6 +103,9 @@ astropy.table
 - The HDF5 writer, ``write_table_hdf5()``, now allows passing through
   additional keyword arguments to the ``h5py.Group.create_dataset()``. [#9602]
 
+- Added capability to add custom table attributes to a ``Table`` subclass.
+  These attributes are persistent and can be set during table creation. [#10097]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/__init__.py
+++ b/astropy/table/__init__.py
@@ -4,9 +4,9 @@ from astropy import config as _config
 from .column import Column, MaskedColumn, StringTruncateWarning, ColumnInfo
 
 __all__ = ['BST', 'Column', 'ColumnGroups', 'ColumnInfo', 'Conf', 'FastBST',
-           'FastRBT', 'JSViewer', 'MaskedColumn', 'NdarrayMixin', 'QTable',
-           'Row', 'SCEngine', 'SerializedColumn', 'SortedArray',
-           'StringTruncateWarning', 'Table', 'TableColumns', 'TableFormatter',
+           'FastRBT', 'JSViewer', 'MaskedColumn', 'NdarrayMixin', 'QTable', 'Row',
+           'SCEngine', 'SerializedColumn', 'SortedArray', 'StringTruncateWarning',
+           'Table', 'TableAttribute', 'TableColumns', 'TableFormatter',
            'TableGroups', 'TableMergeError', 'TableReplaceWarning', 'conf',
            'connect', 'hstack', 'join', 'registry', 'represent_mixins_as_columns',
            'setdiff', 'unique', 'vstack', 'dstack', 'conf']
@@ -46,7 +46,7 @@ conf = Conf()  # noqa
 
 from .groups import TableGroups, ColumnGroups
 from .table import (Table, QTable, TableColumns, Row, TableFormatter,
-                    NdarrayMixin, TableReplaceWarning)
+                    NdarrayMixin, TableReplaceWarning, TableAttribute)
 from .operations import join, setdiff, hstack, dstack, vstack, unique, TableMergeError
 from .bst import BST, FastBST, FastRBT
 from .sorted_array import SortedArray

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -17,7 +17,7 @@ from astropy import log
 from astropy.units import Quantity, QuantityInfo
 from astropy.utils import isiterable, ShapedLikeNDArray
 from astropy.utils.console import color_print
-from astropy.utils.metadata import MetaData
+from astropy.utils.metadata import MetaData, MetaAttribute
 from astropy.utils.data_info import BaseColumnInfo, MixinInfo, ParentDtypeInfo, DataInfo
 from astropy.utils.decorators import format_doc
 from astropy.io.registry import UnifiedReadWriteMethod
@@ -3678,40 +3678,34 @@ class NdarrayMixin(np.ndarray):
         self.__dict__.update(own_state)
 
 
-class TableAttribute:
+class TableAttribute(MetaAttribute):
     """
-    Descriptor to define custom Table attribute which gets stored in the object
-    meta dict and can have a defined default.
+    Descriptor to define a custom attribute for a Table subclass.
 
-    :param default: default value
+    The value of the ``TableAttribute`` will be stored in a dict named
+    ``__attributes__`` that is stored in the table ``meta``.  The attribute
+    can be accessed and set in the usual way, and it can be provided when
+    creating the object.
 
+    Defining an attribute by this mechanism ensures that it will persist if
+    the table is sliced or serialized, for example as a pickle or ECSV file.
+
+    See the `~astropy.utils.metadata.MetaAttribute` documentation for additional
+    details.
+
+    Parameters
+    ----------
+    default : object
+        Default value for attribute
+
+    Examples
+    --------
+      >>> from astropy.table import Table, TableAttribute
+      >>> class MyTable(Table):
+      ...     identifier = TableAttribute(default=1)
+      >>> t = MyTable(identifier=10)
+      >>> t.identifier
+      10
+      >>> t.meta
+      OrderedDict([('__attributes__', {'identifier': 10})])
     """
-    def __init__(self, default=None):
-        self.default = default
-
-    def __get__(self, instance, owner):
-        try:
-            return instance.meta[self.name]
-        except AttributeError:
-            # When called without an instance, return self to allow access
-            # to descriptor attributes.
-            # AttributeError: 'NoneType' object has no attribute 'meta'
-            return self
-        except KeyError:
-            if self.default is not None:
-                instance.meta[self.name] = deepcopy(self.default)
-            return instance.meta.get(self.name)
-
-    def __set__(self, instance, value):
-        instance.meta[self.name] = value
-
-    def __set_name__(self, owner, name):
-        reserved = ('data', 'masked', 'names', 'dtype',
-                    'meta', 'copy', 'rows', 'copy_indices',
-                    'units', 'descriptions')
-        if hasattr(Table, name) or name in reserved:
-            raise ValueError(f'{name} not allowed as TableAttribute')
-        self.name = name
-
-    def __repr__(self):
-        return f'<{self.__class__.__name__} name={self.name} default={self.default}'

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -2487,9 +2487,13 @@ class MyTable(Table):
 
 
 def test_table_attribute():
+    assert repr(MyTable.baz) == '<TableAttribute name=baz default=1>'
 
     t = MyTable([[1, 2]])
+    # __attributes__ created on the fly on the first access of an attribute
+    assert '__attributes__' not in t.meta
     assert t.foo is None
+    assert '__attributes__' in t.meta
     t.bar.append(2.0)
     assert t.bar == [2.0]
     assert t.baz == 1
@@ -2527,7 +2531,7 @@ def test_table_attribute_fail():
     # context it gets re-raised as a RuntimeError during class definition.
     with pytest.raises(RuntimeError, match='Error calling __set_name__'):
         class MyTable2(Table):
-            data = TableAttribute()  # Conflicts with init arg
+            descriptions = TableAttribute()  # Conflicts with init arg
 
     with pytest.raises(RuntimeError, match='Error calling __set_name__'):
         class MyTable3(Table):

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -7,13 +7,15 @@ import sys
 import copy
 from io import StringIO
 from collections import OrderedDict
+import pickle
 
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
 
 from astropy.io import fits
-from astropy.table import Table, QTable, MaskedColumn, TableReplaceWarning
+from astropy.table import (Table, QTable, MaskedColumn, TableReplaceWarning,
+                           TableAttribute)
 from astropy.tests.helper import (assert_follows_unicode_guidelines,
                                   ignore_warnings, catch_warnings)
 from astropy.coordinates import SkyCoord
@@ -2469,6 +2471,57 @@ def test_tolist():
     assert t['c'].tolist() == [['foo', 'bar'], ['hello', 'world']]
     assert isinstance(t['a'].tolist()[0][0], int)
     assert isinstance(t['c'].tolist()[0][0], str)
+
+
+class MyTable(Table):
+    foo = TableAttribute()
+    bar = TableAttribute(default=[])
+    baz = TableAttribute(default=1)
+
+
+def test_table_attribute():
+
+    t = MyTable([[1, 2]])
+    assert t.foo is None
+    t.bar.append(2.0)
+    assert t.bar == [2.0]
+    assert t.baz == 1
+
+    t.baz = 'baz'
+    assert t.baz == 'baz'
+
+    # Table attributes round-trip through pickle
+    tp = pickle.loads(pickle.dumps(t))
+    assert tp.foo is None
+    assert tp.baz == 'baz'
+    assert tp.bar == [2.0]
+
+    # Table attribute round-trip through ECSV
+    out = StringIO()
+    t.write(out, format='ascii.ecsv')
+    t2 = MyTable.read(out.getvalue(), format='ascii.ecsv')
+    assert t2.foo is None
+    assert t2.bar == [2.0]
+    assert t2.baz == 'baz'
+
+    # Allow initialization of attributes in table creation
+    t2 = MyTable([[1, 2]], foo=3, bar='bar', baz='baz')
+    assert t2.foo == 3
+    assert t2.bar == 'bar'
+    assert t2.baz == 'baz'
+
+
+def test_table_attribute_fail():
+    # Code raises ValueError(f'{attr} not allowed as TableAttribute') but in this
+    # context it gets re-raised as a RuntimeError during class definition.
+    with pytest.raises(RuntimeError, match='Error calling __set_name__'):
+        class MyTable2(Table):
+            data = TableAttribute()  # Conflicts with init arg
+
+    with pytest.raises(RuntimeError, match='Error calling __set_name__'):
+        class MyTable3(Table):
+            colnames = TableAttribute()  # Conflicts with built-in property
+
 
 
 def test_set_units_fail():

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -37,6 +37,13 @@ else:
     HAS_PANDAS = True
 
 
+try:
+    import yaml  # noqa
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+
 class SetupData:
     def _setup(self, table_types):
         self._table_type = table_types.Table
@@ -2496,18 +2503,22 @@ def test_table_attribute():
     assert tp.baz == 'baz'
     assert tp.bar == [2.0]
 
+    # Allow initialization of attributes in table creation
+    t2 = MyTable([[1, 2]], foo=3, bar='bar', baz='baz')
+    assert t2.foo == 3
+    assert t2.bar == 'bar'
+    assert t2.baz == 'baz'
+
+
+@pytest.mark.skipif('not HAS_YAML')
+def test_table_attribute_ecsv():
     # Table attribute round-trip through ECSV
+    t = MyTable([[1, 2]], bar=[2.0], baz='baz')
     out = StringIO()
     t.write(out, format='ascii.ecsv')
     t2 = MyTable.read(out.getvalue(), format='ascii.ecsv')
     assert t2.foo is None
     assert t2.bar == [2.0]
-    assert t2.baz == 'baz'
-
-    # Allow initialization of attributes in table creation
-    t2 = MyTable([[1, 2]], foo=3, bar='bar', baz='baz')
-    assert t2.foo == 3
-    assert t2.bar == 'bar'
     assert t2.baz == 'baz'
 
 

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -456,20 +456,20 @@ class MetaAttribute:
             return self
 
         # Get the __attributes__ dict and create if not there already.
-        meta = instance.meta.setdefault('__attributes__', {})
+        attributes = instance.meta.setdefault('__attributes__', {})
         try:
-            value = meta[self.name]
+            value = attributes[self.name]
         except KeyError:
             if self.default is not None:
-                meta[self.name] = deepcopy(self.default)
+                attributes[self.name] = deepcopy(self.default)
             # Return either specified default or None
-            value = meta.get(self.name)
+            value = attributes.get(self.name)
         return value
 
     def __set__(self, instance, value):
         # Get the __attributes__ dict and create if not there already.
-        meta = instance.meta.setdefault('__attributes__', {})
-        meta[self.name] = value
+        attributes = instance.meta.setdefault('__attributes__', {})
+        attributes[self.name] = value
 
     def __set_name__(self, owner, name):
         import inspect

--- a/astropy/utils/metadata.py
+++ b/astropy/utils/metadata.py
@@ -18,7 +18,8 @@ from astropy.utils.misc import dtype_bytes_or_chars
 
 __all__ = ['MergeConflictError', 'MergeConflictWarning', 'MERGE_STRATEGIES',
            'common_dtype', 'MergePlus', 'MergeNpConcatenate', 'MergeStrategy',
-           'MergeStrategyMeta', 'enable_merge_strategies', 'merge', 'MetaData']
+           'MergeStrategyMeta', 'enable_merge_strategies', 'merge', 'MetaData',
+           'MetaAttribute']
 
 
 class MergeConflictError(TypeError):
@@ -414,3 +415,73 @@ class MetaData:
                     instance._meta = value
             else:
                 raise TypeError("meta attribute must be dict-like")
+
+
+class MetaAttribute:
+    """
+    Descriptor to define custom attribute which gets stored in the object
+    ``meta`` dict and can have a defined default.
+
+    This descriptor is intended to provide a convenient way to add attributes
+    to a subclass of a complex class such as ``Table`` or ``NDData``.
+
+    This requires that the object has an attribute ``meta`` which is a
+    dict-like object.  The value of the MetaAttribute will be stored in a
+    new dict meta['__attributes__'] that is created when required.
+
+    Classes that define MetaAttributes are encouraged to support initializing
+    the attributes via the class ``__init__``.  For example::
+
+        for attr in list(kwargs):
+            descr = getattr(self.__class__, attr, None)
+            if isinstance(descr, MetaAttribute):
+                setattr(self, attr, kwargs.pop(attr))
+
+    The name of a ``MetaAttribute`` cannot be the same as any of the following:
+
+    - Keyword argument in the owner class ``__init__``
+    - Method or attribute of the "parent class", where the parent class is
+      taken to be ``owner.__mro__[1]``.
+
+    :param default: default value
+
+    """
+    def __init__(self, default=None):
+        self.default = default
+
+    def __get__(self, instance, owner):
+        # When called without an instance, return self to allow access
+        # to descriptor attributes.
+        if instance is None:
+            return self
+
+        # Get the __attributes__ dict and create if not there already.
+        meta = instance.meta.setdefault('__attributes__', {})
+        try:
+            value = meta[self.name]
+        except KeyError:
+            if self.default is not None:
+                meta[self.name] = deepcopy(self.default)
+            # Return either specified default or None
+            value = meta.get(self.name)
+        return value
+
+    def __set__(self, instance, value):
+        # Get the __attributes__ dict and create if not there already.
+        meta = instance.meta.setdefault('__attributes__', {})
+        meta[self.name] = value
+
+    def __set_name__(self, owner, name):
+        import inspect
+        params = [param.name for param in inspect.signature(owner).parameters.values()
+                  if param.kind not in (inspect.Parameter.VAR_KEYWORD,
+                                        inspect.Parameter.VAR_POSITIONAL)]
+
+        # Reject names from existing params or best guess at parent class
+        if name in params or hasattr(owner.__mro__[1], name):
+            raise ValueError(f'{name} not allowed as {self.__class__.__name__}')
+
+        self.name = name
+
+    def __repr__(self):
+        return f'<{self.__class__.__name__} name={self.name} default={self.default}>'

--- a/docs/table/construct_table.rst
+++ b/docs/table/construct_table.rst
@@ -977,8 +977,44 @@ Subclassing Table
 =================
 
 For some applications it can be useful to subclass the |Table| class in order
-to introduce specialized behavior. In addition to subclassing |Table|, it is
-frequently desirable to change the behavior of the internal class objects which
+to introduce specialized behavior. Here we address two particular use cases
+for subclassing: adding custom table attributes and changing the behavior of
+internal class objects.
+
+Adding Custom Table Attributes
+------------------------------
+
+One simple customization that can be useful is adding new attributes to
+the table object.  There is nothing preventing setting an attribute on an
+existing table object, for example ``t.foo = 'hello'``.  However, this attribute
+would be ephemeral because it will be lost if the table is sliced, copied, or
+pickled. Instead, you can add persistent attributes as shown in this example::
+
+  from astropy.table import Table, TableAttribute
+
+  class MyTable(Table):
+      foo = TableAttribute()
+      bar = TableAttribute(default=[])
+      baz = TableAttribute(default=1)
+
+  t = MyTable([[1, 2]], foo='foo')
+  t.bar.append(2.0)
+  t.baz = 'baz'
+
+Some key points:
+
+- A custom attribute can be set when the table is created or using
+  the usual syntax for setting an object attribute.
+- A custom attribute always has a default value, either explicitly set
+  in the class definition or ``None``.
+- The attribute values are stored in the table ``meta`` dictionary. This is
+  the mechanism by which they are persistent through copy, slice, and
+  serialization such as pickling or writing to an ECSV ASCII file.
+
+Changing Behavior of Internal Class Objects
+-------------------------------------------
+
+It is also possible to change the behavior of the internal class objects which
 are contained or created by a Table. This includes rows, columns, formatting,
 and the columns container. In order to do this the subclass needs to declare
 what class to use (if it is different from the built-in version). This is done
@@ -1009,7 +1045,7 @@ subcomponents::
 
 
 Example
--------
+^^^^^^^
 
 .. EXAMPLE START: Subclassing the Table Class
 
@@ -1097,7 +1133,7 @@ fields. This might look something like::
 .. EXAMPLE END
 
 Columns and Quantities
-----------------------
+======================
 
 .. EXAMPLE START: Handling Astropy Column and Quantity Objects within Tables
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Quoting the docs:

One simple customization that can be useful is adding new attributes to the table object.  There is nothing preventing setting an attribute on an existing table object, for example ``t.foo = 'hello'``.  However, this attribute would be ephemeral because it will be lost if the table is sliced, copied, or pickled. Instead, you can add persistent attributes as shown in this example.
```
  from astropy.table import Table, TableAttribute

  class MyTable(Table):
      foo = TableAttribute()
      bar = TableAttribute(default=[])
      baz = TableAttribute(default=1)

  t = MyTable([[1, 2]], foo='foo')
  t.bar.append(2.0)
  t.baz = 'baz'
```
Some key points:

- A custom attribute can be set when the table is created or using the usual syntax for setting an object attribute.
- A custom attribute always has a default value, either explicitly set  in the class definition or ``None``.
- The attribute values are stored in the table ``meta`` dictionary. This is  the mechanism by which they are persistent through copy, slice, and  serialization such as pickling or writing to an ECSV ASCII file.

### Background

I used a version of this extensively in one Chandra operations package (including subclassing the attribute descriptor for even more customization).  After deciding to use the same thing in another package, I thought it might be more widely useful.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

