### PR TITLE
Fix to ensure ImageNormalize clip is used in the __call__ method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -397,6 +397,9 @@ astropy.utils
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug where the ``ImageNormalize`` ``clip`` keyword was
+  ignored when used with calling the object on data. [#10098]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/mpl_normalize.py
+++ b/astropy/visualization/mpl_normalize.py
@@ -132,7 +132,7 @@ class ImageNormalize(Normalize):
         np.true_divide(values, self.vmax - self.vmin, out=values)
 
         # Clip to the 0 to 1 range
-        if self.clip:
+        if clip:
             values = np.clip(values, 0., 1., out=values)
 
         # Stretch values

--- a/astropy/visualization/tests/test_norm.py
+++ b/astropy/visualization/tests/test_norm.py
@@ -100,6 +100,19 @@ class TestNormalize:
         assert norm.vmax == np.max(DATA)
         assert_allclose(output, norm2(DATA))
 
+    def test_call_clip(self):
+        """Test that the clip keyword is used when calling the object."""
+        data = np.arange(5)
+        norm = ImageNormalize(vmin=1., vmax=3., clip=False)
+
+        output = norm(data, clip=True)
+        assert_equal(output.data, [0, 0, 0.5, 1.0, 1.0])
+        assert np.all(~output.mask)
+
+        output = norm(data, clip=False)
+        assert_equal(output.data, [-0.5, 0, 0.5, 1.0, 1.5])
+        assert np.all(~output.mask)
+
     def test_masked_clip(self):
         mdata = ma.array(DATA, mask=[0, 0, 1, 0, 0, 0])
         norm = ImageNormalize(vmin=2., vmax=10., stretch=SqrtStretch(),


### PR DESCRIPTION
Currently the `ImageNormalize` `clip` keyword is ignored in the `__call__` method:

```python
>>> from astropy.visualization import ImageNormalize
>>> data = np.arange(5)
>>> norm = ImageNormalize(vmin=1, vmax=3)
>>> norm(data, clip=False)  # correct result
masked_array(data=[-0.5, 0.0, 0.5, 1.0, 1.5],
             mask=[False, False, False, False, False],
       fill_value=1e+20)

>>> norm(data, clip=True)  # wrong result (same result as clip=False)
masked_array(data=[-0.5, 0.0, 0.5, 1.0, 1.5],
             mask=[False, False, False, False, False],
       fill_value=1e+20)
```

With this PR:
```python
>>> norm(data, clip=True)  # correct result
masked_array(data=[0.0, 0.0, 0.5, 1.0, 1.0],
             mask=[False, False, False, False, False],
       fill_value=1e+20)
```



