### PR TITLE
Sigma clipping fixed for fully-masked input MaskedArray

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -373,6 +373,14 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed an issue where fully masked ``MaskedArray`` input to
+  ``sigma_clipped_stats`` gave incorrect results. [#10099]
+
+- Fixed an issued where ``sigma_clip`` and ``SigmaClip.__call__``
+  would return a masked array instead of a ``ndarray`` when
+  ``masked=False`` and the input was a full-masked ``MaskedArray``.
+  [#10099]
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -455,7 +455,10 @@ class SigmaClip:
             return data
 
         if isinstance(data, np.ma.MaskedArray) and data.mask.all():
-            return data
+            if masked:
+                return data
+            else:
+                return np.ma.filled(data.astype(float), fill_value=np.nan)
 
         # These two cases are treated separately because when
         # ``axis=None`` we can simply remove clipped values from the

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -737,6 +737,9 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     SigmaClip, sigma_clip
     """
 
+    if isinstance(data, np.ma.MaskedArray) and data.mask.all():
+        return np.ma.masked, np.ma.masked, np.ma.masked
+
     if mask is not None:
         data = np.ma.MaskedArray(data, mask)
     if mask_value is not None:

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -748,13 +748,13 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
     SigmaClip, sigma_clip
     """
 
-    if isinstance(data, np.ma.MaskedArray) and data.mask.all():
-        return np.ma.masked, np.ma.masked, np.ma.masked
-
     if mask is not None:
         data = np.ma.MaskedArray(data, mask)
     if mask_value is not None:
         data = np.ma.masked_values(data, mask_value)
+
+    if isinstance(data, np.ma.MaskedArray) and data.mask.all():
+        return np.ma.masked, np.ma.masked, np.ma.masked
 
     sigclip = SigmaClip(sigma=sigma, sigma_lower=sigma_lower,
                         sigma_upper=sigma_upper, maxiters=maxiters,

--- a/astropy/stats/sigma_clipping.py
+++ b/astropy/stats/sigma_clipping.py
@@ -98,7 +98,7 @@ class SigmaClip:
         data < cenfunc(data [,axis=int]) - (sigma_lower * stdfunc(data [,axis=int]))
         data > cenfunc(data [,axis=int]) + (sigma_upper * stdfunc(data [,axis=int]))
 
-    Invalid data values (i.e. NaN or inf) are automatically clipped.
+    Invalid data values (i.e., NaN or inf) are automatically clipped.
 
     For a functional interface to sigma clipping, see
     :func:`sigma_clip`.
@@ -108,7 +108,7 @@ class SigmaClip:
         <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sigmaclip.html>`_
         provides a subset of the functionality in this class.  Also, its
         input data cannot be a masked array and it does not handle data
-        that contains invalid values (i.e.  NaN or inf).  Also note that
+        that contains invalid values (i.e., NaN or inf).  Also note that
         it uses the mean as the centering function.
 
         If your data is a `~numpy.ndarray` with no invalid values and
@@ -149,7 +149,7 @@ class SigmaClip:
         ``'mean'`` then having the optional `bottleneck`_ package
         installed will result in the best performance.  If using a
         callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g. `numpy.nanmean`)
+        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
         and has an ``axis`` keyword to return an array with axis
         dimension(s) removed.  The default is ``'median'``.
 
@@ -161,7 +161,7 @@ class SigmaClip:
         then having the optional `bottleneck`_ package installed will
         result in the best performance.  If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g. `numpy.nanstd`) and has
+        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 
@@ -429,12 +429,14 @@ class SigmaClip:
         -------
         result : flexible
             If ``masked=True``, then a `~numpy.ma.MaskedArray` is
-            returned, where the mask is `True` for clipped values.  If
-            ``masked=False``, then a `~numpy.ndarray` is returned.
+            returned, where the mask is `True` for clipped values and
+            where the input mask was `True`.
 
-            If ``return_bounds=True``, then in addition to the (masked)
-            array above, the minimum and maximum clipping bounds are
-            returned.
+            If ``masked=False``, then a `~numpy.ndarray` is returned.
+
+            If ``return_bounds=True``, then in addition to the masked
+            array or array above, the minimum and maximum clipping
+            bounds are returned.
 
             If ``masked=False`` and ``axis=None``, then the output array
             is a flattened 1D `~numpy.ndarray` where the clipped values
@@ -444,9 +446,11 @@ class SigmaClip:
             If ``masked=False`` and ``axis`` is specified, then the
             output `~numpy.ndarray` will have the same shape as the
             input ``data`` and contain ``np.nan`` where values were
-            clipped.  If ``return_bounds=True`` then the returned
-            minimum and maximum clipping thresholds will be be
-            `~numpy.ndarray`\\s.
+            clipped.  If the input ``data`` was a masked array, then the
+            output `~numpy.ndarray` will also contain ``np.nan`` where
+            the input mask was `True`.  If ``return_bounds=True`` then
+            the returned minimum and maximum clipping thresholds will be
+            be `~numpy.ndarray`\\s.
         """
 
         data = np.asanyarray(data)
@@ -490,7 +494,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         data < cenfunc(data [,axis=int]) - (sigma_lower * stdfunc(data [,axis=int]))
         data > cenfunc(data [,axis=int]) + (sigma_upper * stdfunc(data [,axis=int]))
 
-    Invalid data values (i.e. NaN or inf) are automatically clipped.
+    Invalid data values (i.e., NaN or inf) are automatically clipped.
 
     For an object-oriented interface to sigma clipping, see
     :class:`SigmaClip`.
@@ -500,7 +504,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         <https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.sigmaclip.html>`_
         provides a subset of the functionality in this class.  Also, its
         input data cannot be a masked array and it does not handle data
-        that contains invalid values (i.e.  NaN or inf).  Also note that
+        that contains invalid values (i.e., NaN or inf).  Also note that
         it uses the mean as the centering function.
 
         If your data is a `~numpy.ndarray` with no invalid values and
@@ -544,7 +548,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         ``'mean'`` then having the optional `bottleneck`_ package
         installed will result in the best performance.  If using a
         callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g. `numpy.nanmean`)
+        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
         and has an ``axis`` keyword to return an array with axis
         dimension(s) removed.  The default is ``'median'``.
 
@@ -556,7 +560,7 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
         then having the optional `bottleneck`_ package installed will
         result in the best performance.  If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g. `numpy.nanstd`) and has
+        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 
@@ -586,11 +590,13 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
     -------
     result : flexible
         If ``masked=True``, then a `~numpy.ma.MaskedArray` is returned,
-        where the mask is `True` for clipped values.  If
-        ``masked=False``, then a `~numpy.ndarray` is returned.
+        where the mask is `True` for clipped values and where the input
+        mask was `True`.
 
-        If ``return_bounds=True``, then in addition to the (masked)
-        array above, the minimum and maximum clipping bounds are
+        If ``masked=False``, then a `~numpy.ndarray` is returned.
+
+        If ``return_bounds=True``, then in addition to the masked array
+        or array above, the minimum and maximum clipping bounds are
         returned.
 
         If ``masked=False`` and ``axis=None``, then the output array is
@@ -600,8 +606,10 @@ def sigma_clip(data, sigma=3, sigma_lower=None, sigma_upper=None, maxiters=5,
 
         If ``masked=False`` and ``axis`` is specified, then the output
         `~numpy.ndarray` will have the same shape as the input ``data``
-        and contain ``np.nan`` where values were clipped.  If
-        ``return_bounds=True`` then the returned minimum and maximum
+        and contain ``np.nan`` where values were clipped.  If the input
+        ``data`` was a masked array, then the output `~numpy.ndarray`
+        will also contain ``np.nan`` where the input mask was `True`.
+        If ``return_bounds=True`` then the returned minimum and maximum
         clipping thresholds will be be `~numpy.ndarray`\\s.
 
     See Also
@@ -702,7 +710,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         ``'mean'`` then having the optional `bottleneck`_ package
         installed will result in the best performance.  If using a
         callable function/object and the ``axis`` keyword is used, then
-        it must be callable that can ignore NaNs (e.g. `numpy.nanmean`)
+        it must be callable that can ignore NaNs (e.g., `numpy.nanmean`)
         and has an ``axis`` keyword to return an array with axis
         dimension(s) removed.  The default is ``'median'``.
 
@@ -714,7 +722,7 @@ def sigma_clipped_stats(data, mask=None, mask_value=None, sigma=3.0,
         then having the optional `bottleneck`_ package installed will
         result in the best performance.  If using a callable
         function/object and the ``axis`` keyword is used, then it must
-        be callable that can ignore NaNs (e.g. `numpy.nanstd`) and has
+        be callable that can ignore NaNs (e.g., `numpy.nanstd`) and has
         an ``axis`` keyword to return an array with axis dimension(s)
         removed.  The default is ``'std'``.
 

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -279,3 +279,13 @@ def test_sigma_clippped_stats_unit():
     data = np.array([1, 1]) * u.kpc
     result = sigma_clipped_stats(data)
     assert result == (1. * u.kpc, 1. * u.kpc, 0. * u.kpc)
+
+
+def test_sigma_clippped_stats_all_masked():
+    """
+    Test sigma_clipped_stats when the input array is completely masked.
+    """
+
+    arr = np.ma.MaskedArray(np.arange(10),  mask=True)
+    result = sigma_clipped_stats(arr)
+    assert result == (np.ma.masked, np.ma.masked, np.ma.masked)

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -219,6 +219,10 @@ def test_sigmaclip_fully_masked():
     clipped_data = sigma_clip(data)
     np.ma.allequal(data, clipped_data)
 
+    clipped_data = sigma_clip(data, masked=False)
+    assert not isinstance(clipped_data, np.ma.MaskedArray)
+    assert np.all(np.isnan(clipped_data))
+
 
 def test_sigmaclip_empty_masked():
     """Make sure a empty masked array is returned when sigma clipping an empty

--- a/astropy/stats/tests/test_sigma_clipping.py
+++ b/astropy/stats/tests/test_sigma_clipping.py
@@ -290,6 +290,15 @@ def test_sigma_clippped_stats_all_masked():
     Test sigma_clipped_stats when the input array is completely masked.
     """
 
-    arr = np.ma.MaskedArray(np.arange(10),  mask=True)
+    arr = np.ma.MaskedArray(np.arange(10), mask=True)
     result = sigma_clipped_stats(arr)
+    assert result == (np.ma.masked, np.ma.masked, np.ma.masked)
+
+    arr = np.ma.MaskedArray(np.zeros(10), mask=False)
+    result = sigma_clipped_stats(arr, mask_value=0.)
+    assert result == (np.ma.masked, np.ma.masked, np.ma.masked)
+
+    arr = np.ma.MaskedArray(np.arange(10), mask=False)
+    mask = arr < 20
+    result = sigma_clipped_stats(arr, mask=mask)
     assert result == (np.ma.masked, np.ma.masked, np.ma.masked)


### PR DESCRIPTION
This PR fixes two sigma-clipping issues with inputs that are fully-masked `MaskedArray`.

For `sigma_clipped_stats`, the mask was ignored (even though it was all `True`):

```python
>>> from astropy.stats import sigma_clipped_stats
>>> arr = np.ma.MaskedArray(np.arange(10), mask=True)
>>> sigma_clipped_stats(arr)  # very wrong output since there are no valid input values!
(4.5, 4.5, 2.8722813232690143)
```

After this PR:
```python
>>> sigma_clipped_stats(arr)
(masked, masked, masked)
```

`np.ma.masked` is the expected output for fully-masked arrays, e.g.:
```python
>>> np.ma.mean(arr)
masked
```

This PR also fixes an issue in `sigma_clip` and `SigmaClip` where a `MaskedArray` was returned instead of a plain `ndarray` when the `masked` keyword was set to `False` (for a fully-masked `MaskedArray` input):

```python
>>> from astropy.stats import sigma_clip
>>> arr = np.ma.MaskedArray(np.arange(10), mask=False)
>>> sigma_clip(arr, masked=False)
masked_array(data=[--, --, --, --, --, --, --, --, --, --],
             mask=[ True,  True,  True,  True,  True,  True,  True,  True,
                    True,  True],
       fill_value=999999,
            dtype=int64)
```

After this PR:
```python
>>> sigma_clip(arr, masked=False)
array([nan, nan, nan, nan, nan, nan, nan, nan, nan, nan])
```
which is the expected result.

I also updated the docstrings some to clarify the expected outputs.

Fix #9973