### PR TITLE
Fix bugs / performance when sorting a table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -379,6 +379,9 @@ astropy.table
 - Fixed a bug when sorting an indexed table on the indexed column after first
   sorting on another column. [#10103]
 
+- Fixed a bug in table argsort when called with ``reverse=True`` for an
+  indexed table. [#10103]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -410,7 +413,8 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-
+- Improved the speed of sorting a large ``Table`` on a single column by a factor
+  of around 5. [#10103]
 
 4.0.1 (2020-03-27)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -376,6 +376,9 @@ astropy.stats
 astropy.table
 ^^^^^^^^^^^^^
 
+- Fixed a bug when sorting an indexed table on the indexed column after first
+  sorting on another column. [#10103]
+
 astropy.tests
 ^^^^^^^^^^^^^
 

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2875,7 +2875,8 @@ class Table:
         if keys is not None:
             index = get_index(self, names=keys)
             if index is not None:
-                return index.sorted_data()
+                idx = np.asarray(index.sorted_data())
+                return idx[::-1] if reverse else idx
 
         kwargs = {}
         if keys:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -2956,34 +2956,22 @@ class Table:
         if reverse:
             indexes = indexes[::-1]
 
-        sort_index = get_index(self, names=keys)
+        with self.index_mode('freeze'):
+            for name, col in self.columns.items():
+                # Make a new sorted column.  This requires that take() also copies
+                # relevant info attributes for mixin columns.
+                new_col = col.take(indexes, axis=0)
 
-        if sort_index is not None:
-            # avoid inefficient relabelling of sorted index
-            prev_frozen = sort_index._frozen
-            sort_index._frozen = True
-
-        for name, col in self.columns.items():
-            # Make a new sorted column.  This requires that take() also copies
-            # relevant info attributes for mixin columns.
-            new_col = col.take(indexes, axis=0)
-
-            # First statement in try: will succeed if the column supports an in-place
-            # update, and matches the legacy behavior of astropy Table.  However,
-            # some mixin classes may not support this, so in that case just drop
-            # in the entire new column. See #9553 and #9536 for discussion.
-            try:
-                col[:] = new_col
-            except Exception:
-                # In-place update failed for some reason, exception class not
-                # predictable for arbitrary mixin.
-                self[col.info.name] = new_col
-
-        if sort_index is not None:
-            # undo index freeze
-            sort_index._frozen = prev_frozen
-            # now relabel the sort index appropriately
-            sort_index.sort()
+                # First statement in try: will succeed if the column supports an in-place
+                # update, and matches the legacy behavior of astropy Table.  However,
+                # some mixin classes may not support this, so in that case just drop
+                # in the entire new column. See #9553 and #9536 for discussion.
+                try:
+                    col[:] = new_col
+                except Exception:
+                    # In-place update failed for some reason, exception class not
+                    # predictable for arbitrary mixin.
+                    self[col.info.name] = new_col
 
     def reverse(self):
         '''

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -1579,6 +1579,30 @@ def test_join_non_1d_key_column():
         table.join(t1, t2, keys='a')
 
 
+def test_sort_indexed_table():
+    """Test fix for #9473 and #6545"""
+    t = Table([[1, 3, 2], [6, 4, 5]], names=('a', 'b'))
+    t.add_index('a')
+    t.sort('a')
+    assert np.all(t['a'] == [1, 2, 3])
+    assert np.all(t['b'] == [6, 5, 4])
+    t.sort('b')
+    assert np.all(t['b'] == [4, 5, 6])
+    assert np.all(t['a'] == [3, 2, 1])
+
+    from astropy.timeseries import TimeSeries
+    times = ['2016-01-01', '2018-01-01', '2017-01-01']
+    tm = Time(times)
+    ts = TimeSeries(time=times)
+    ts['flux'] = [3, 2, 1]
+    ts.sort('flux')
+    assert np.all(ts['flux'] == [1, 2, 3])
+    ts.sort('time')
+    assert np.all(ts['flux'] == [3, 1, 2])
+    assert np.all(ts['time'] == tm[[0, 2, 1]])
+
+
+
 def test_get_out_class():
     c = table.Column([1, 2])
     mc = table.MaskedColumn([1, 2])

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1115,7 +1115,8 @@ class TestSort():
                                           [3, 4],
                                           [1, 2]]))
 
-    def test_single_reverse(self, table_types):
+    @pytest.mark.parametrize('create_index', [False, True])
+    def test_single_reverse(self, table_types, create_index):
         t = table_types.Table()
         t.add_column(table_types.Column(name='a', data=[2, 1, 3]))
         t.add_column(table_types.Column(name='b', data=[6, 5, 4]))
@@ -1223,10 +1224,13 @@ class TestSort():
         assert np.all(t['a'][i0] == t['a'][i1])
         assert np.all(t['b'][i0] == t['b'][i1])
 
-    def test_argsort_reverse(self, table_types):
+    @pytest.mark.parametrize('add_index', [False, True])
+    def test_argsort_reverse(self, table_types, add_index):
         t = table_types.Table()
         t.add_column(table_types.Column(name='a', data=[2, 1, 3, 2, 3, 1]))
         t.add_column(table_types.Column(name='b', data=[6, 5, 4, 3, 5, 4]))
+        if add_index:
+            t.add_index('a')
         assert np.all(t.argsort(reverse=True) == np.array([4, 2, 0, 3, 1, 5]))
         i0 = t.argsort('a', reverse=True)
         i1 = np.array([4, 2, 3, 0, 5, 1])


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address various bugs / problems when sorting.  In theory these could be three separate PRs, but they kind of go together and should all be backported to LTS.

#### Sorting indexed table on the indexed column after first sorting on another column

As shown in #6545 and #9473.

In looking at the code I never was able to understand the root cause of the problem because in all honesty I have very little understanding of all the indexing machinery.  But just grasping at straws I tried replacing the "by-hand" freezing of the index with the documented context manager, et voila this did the trick.

I checked performance for sorting a large (1e7) table of random numbers, both with and without an index, and this fix did not impact the timing relative to 4.0.

#### Argsort with reverse=True on a table with an index

This is just an obvious mistake ignoring the `reverse` arg in this case.

#### Sorting a table on one column

The most common table sort was slow by a factor of 5-10 because `np.argsort` on a structured array is 5-10 slower than on an ndarray, even if the structured array has only one column.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9473 
Fixes #6545 

