### PR TITLE
Updated tox configuration to be compatible with latest version of tox-pypi-filter

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
-    tox-pypi-filter >= 0.10
+    tox-pypi-filter >= 0.12
 isolated_build = true
 
 [testenv]
@@ -16,7 +16,7 @@ isolated_build = true
 # project-wide pinning of dependencies, e.g. if new versions of pytest do not
 # work correctly with pytest-astropy plugins. Most of the time the pinnings file
 # should be empty.
-pypi_filter_requirements = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
+pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
 
 # Pass through the following environemnt variables which are needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TEST_READ_HUGE_FILE


### PR DESCRIPTION
@Cadair and I have been making improvements to tox-pypi-filter and cleaning up the API - there is now a single pypi_filter option (instead of a separate one depending on whether requirements were in a file or not) so this needs to be updated in tox.ini.