### PR TITLE
Correct treatment of size-1 array times and coordinates.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -340,6 +340,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Ensure that for size-1 array ``SkyCoord`` and coordinate frames
+  the attributes also properly become scalars when indexed with 0.
+  [#10113]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
@@ -395,6 +399,10 @@ astropy.tests
 
 astropy.time
 ^^^^^^^^^^^^
+
+- Ensure that for size-1 array ``Time``, the location also properly becomes
+  a scalars when indexed with 0. [#10113]
+
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -401,7 +401,7 @@ astropy.time
 ^^^^^^^^^^^^
 
 - Ensure that for size-1 array ``Time``, the location also properly becomes
-  a scalars when indexed with 0. [#10113]
+  a scalar when indexed with 0. [#10113]
 
 
 astropy.timeseries

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -103,7 +103,7 @@ class Attribute(OrderedDescriptor):
         out, converted = self.convert_input(out)
         if instance is not None:
             instance_shape = getattr(instance, 'shape', None)
-            if instance_shape is not None and (getattr(out, 'size', 1) > 1 and
+            if instance_shape is not None and (getattr(out, 'shape', ()) and
                                                out.shape != instance_shape):
                 # If the shapes do not match, try broadcasting.
                 try:

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -615,7 +615,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             # have consistent shapes. Collect them for all attributes with
             # size > 1 (which should be array-like and thus have a shape).
             shapes = {fnm: value.shape for fnm, value in values.items()
-                      if getattr(value, 'size', 1) > 1}
+                      if getattr(value, 'shape', ())}
             if shapes:
                 if len(shapes) > 1:
                     try:
@@ -1485,7 +1485,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                 setattr(new, _attr, getattr(self, _attr))
             else:
                 value = getattr(self, _attr)
-                if getattr(value, 'size', 1) > 1:
+                if getattr(value, 'shape', ()):
                     value = apply_method(value)
                 elif method == 'copy' or method == 'flatten':
                     # flatten should copy also for a single element array, but
@@ -1502,7 +1502,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             shapes = [getattr(new, '_' + attr).shape
                       for attr in new.frame_attributes
                       if (attr not in new._attr_names_with_defaults
-                          and getattr(getattr(new, '_' + attr), 'size', 1) > 1)]
+                          and getattr(getattr(new, '_' + attr), 'shape', ()))]
             if shapes:
                 new._no_data_shape = (check_broadcast(*shapes)
                                       if len(shapes) > 1 else shapes[0])

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -339,7 +339,7 @@ class SkyCoord(ShapedLikeNDArray):
         new._extra_frameattr_names = self._extra_frameattr_names.copy()
         for attr in self._extra_frameattr_names:
             value = getattr(self, attr)
-            if getattr(value, 'size', 1) > 1:
+            if getattr(value, 'shape', ()):
                 value = apply_method(value)
             elif method == 'copy' or method == 'flatten':
                 # flatten should copy also for a single element array, but

--- a/astropy/coordinates/tests/test_shape_manipulation.py
+++ b/astropy/coordinates/tests/test_shape_manipulation.py
@@ -1,6 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import numpy as np
+from numpy.testing import assert_array_equal
 import pytest
 
 from astropy import units as u
@@ -56,6 +57,58 @@ class TestManipulation():
                        obsgeovel=self.obsgeovel)
         # And make a SkyCoord
         self.sc = SkyCoord(ra=lon[:, np.newaxis], dec=lat, frame=self.s3)
+
+    def test_getitem0101(self):
+        # We on purpose take a slice with only one element, as for the
+        # general tests it doesn't matter, but it allows us to check
+        # for a few cases that shapes correctly become scalar if we
+        # index our size-1 array down to a scalar.  See gh-10113.
+        item = (slice(0, 1), slice(0, 1))
+        s0_0101 = self.s0[item]
+        assert s0_0101.shape == (1, 1)
+        assert_array_equal(s0_0101.data.lon, self.s0.data.lon[item])
+        assert np.may_share_memory(s0_0101.data.lon, self.s0.data.lon)
+        assert np.may_share_memory(s0_0101.data.lat, self.s0.data.lat)
+        s0_0101_00 = s0_0101[0, 0]
+        assert s0_0101_00.shape == ()
+        assert s0_0101_00.data.lon.shape == ()
+        assert_array_equal(s0_0101_00.data.lon, self.s0.data.lon[0, 0])
+        s1_0101 = self.s1[item]
+        assert s1_0101.shape == (1, 1)
+        assert_array_equal(s1_0101.data.lon, self.s1.data.lon[item])
+        assert np.may_share_memory(s1_0101.data.lat, self.s1.data.lat)
+        assert np.all(s1_0101.obstime == self.s1.obstime[item])
+        assert np.may_share_memory(s1_0101.obstime.jd1, self.s1.obstime.jd1)
+        assert_array_equal(s1_0101.location, self.s1.location[0, 0])
+        assert np.may_share_memory(s1_0101.location, self.s1.location)
+        assert_array_equal(s1_0101.temperature, self.s1.temperature[item])
+        assert np.may_share_memory(s1_0101.temperature, self.s1.temperature)
+        # scalar should just be transferred.
+        assert s1_0101.pressure is self.s1.pressure
+        s1_0101_00 = s1_0101[0, 0]
+        assert s1_0101_00.shape == ()
+        assert s1_0101_00.obstime.shape == ()
+        assert s1_0101_00.obstime == self.s1.obstime[0, 0]
+        s2_0101 = self.s2[item]
+        assert s2_0101.shape == (1, 1)
+        assert np.all(s2_0101.data.lon == self.s2.data.lon[item])
+        assert np.may_share_memory(s2_0101.data.lat, self.s2.data.lat)
+        assert np.all(s2_0101.obstime == self.s2.obstime[item])
+        assert np.may_share_memory(s2_0101.obstime.jd1, self.s2.obstime.jd1)
+        assert_array_equal(s2_0101.obsgeoloc.xyz, self.s2.obsgeoloc[item].xyz)
+        s3_0101 = self.s3[item]
+        assert s3_0101.shape == (1, 1)
+        assert s3_0101.obstime.shape == (1, 1)
+        assert np.all(s3_0101.obstime == self.s3.obstime[item])
+        assert np.may_share_memory(s3_0101.obstime.jd1, self.s3.obstime.jd1)
+        assert_array_equal(s3_0101.obsgeoloc.xyz, self.s3.obsgeoloc[item].xyz)
+        sc_0101 = self.sc[item]
+        assert sc_0101.shape == (1, 1)
+        assert_array_equal(sc_0101.data.lon, self.sc.data.lon[item])
+        assert np.may_share_memory(sc_0101.data.lat, self.sc.data.lat)
+        assert np.all(sc_0101.obstime == self.sc.obstime[item])
+        assert np.may_share_memory(sc_0101.obstime.jd1, self.sc.obstime.jd1)
+        assert_array_equal(sc_0101.obsgeoloc.xyz, self.sc.obsgeoloc[item].xyz)
 
     def test_ravel(self):
         s0_ravel = self.s0.ravel()

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -1461,9 +1461,9 @@ class Time(ShapedLikeNDArray):
 
             if apply_method:
                 # Apply the method to any value arrays (though skip if there is
-                # only a single element and the method would return a view,
+                # only an array scalar and the method would return a view,
                 # since in that case nothing would change).
-                if getattr(val, 'size', 1) > 1:
+                if getattr(val, 'shape', ()):
                     val = apply_method(val)
                 elif method == 'copy' or method == 'flatten':
                     # flatten should copy also for a single element array, but

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -175,8 +175,15 @@ class TestBasic:
         assert np.all(t3._delta_tdb_tt == t._delta_tdb_tt[4:6])
         t4 = Time(mjd, format='mjd', scale='utc',
                   location=(np.arange(len(mjd)), np.arange(len(mjd))))
-        t5 = t4[3]
-        assert t5.location == t4.location[3]
+        t5a = t4[3]
+        assert t5a.location == t4.location[3]
+        assert t5a.location.shape == ()
+        t5b = t4[3:4]
+        assert t5b.location.shape == (1,)
+        # Check that indexing a size-1 array returns a scalar location as well;
+        # see gh-10113.
+        t5c = t5b[0]
+        assert t5c.location.shape == ()
         t6 = t4[4:6]
         assert np.all(t6.location == t4.location[4:6])
         # check it is a view


### PR DESCRIPTION
Found this while working with PINT, which does a lot with object `ndarray` of times (since their locations and scales can differ), which at times get turned into size-1 arrays. This became a problem because current master special-cases scalars by simply looking whether an attribute had `size == 1`, but this means that indexing an size-1 array item might leave an attribute with higher dimensions (but still size 1, so many things just work, but not our new `TimeAstropyTime`):
```
from astropy.time import Time
t = Time(['J2010', 'J2011'], location=([10., 20.], [10., 10.]))[:1]                           
t                                                                                             
# <Time object: scale='tt' format='jyear_str' value=['J2010.000']>
t.location                                                                                    
# <EarthLocation [(6186437.06603022, 1090835.76919604, 1100248.54773536)] m>
t[0]                                                                                          
# <Time object: scale='tt' format='jyear_str' value=J2010.000>
t[0].location  # should not give shape=(1,) result                                                                       
# <EarthLocation [(6186437.06603022, 1090835.76919604, 1100248.54773536)] m>
Time([t[0]])
# ... exception - TimeAstropyTime cannot handle it.
```
This PR removes the mistake (did I do it for speed? I cannot remember), ensuring that shapes remain consistent.