### PR TITLE
TST: Fix Windows io.ascii fast reader failure

### DIFF
--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -1537,7 +1537,8 @@ def test_single_line_string(delimiter, fast_reader):
         t1 = ascii.read(text, format='no_header', delimiter=delimiter, fast_reader=fast_reader)
         assert_table_equal(t1, expected)
     else:
-        with pytest.raises(FileNotFoundError):
+        # Windows raises OSError, but not the other OSes.
+        with pytest.raises((FileNotFoundError, OSError)):
             t1 = ascii.read(text, format='no_header', delimiter=delimiter, fast_reader=fast_reader)
 
     t2 = ascii.read([text], format='no_header', delimiter=delimiter, fast_reader=fast_reader)


### PR DESCRIPTION
Co-authored-by: @dhomeier 

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address Windows job failure in CI.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10120
