### PR TITLE
Allow more unit types for pixel_scale

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -114,6 +114,9 @@ astropy.units
 - Added integrated flux unit conversion to ``spectral_density`` equivalency.
   [#10015]
 
+- Changed ``pixel_scale`` equivalency to allow scales defined in any unit.
+  [#10123]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/tests/test_equivalency.py
@@ -16,6 +16,7 @@ def get_equivalencies():
     Return a list of example equivalencies for testing serialization.
     """
     return [eq.plate_scale(.3 * u.deg/u.mm), eq.pixel_scale(.5 * u.deg/u.pix),
+            eq.pixel_scale(100. * u.pix/u.cm),
             eq.spectral_density(350 * u.nm, factor=2),
             eq.spectral_density(350 * u.nm), eq.spectral(),
             eq.brightness_temperature(500 * u.GHz),

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -791,6 +791,35 @@ def test_pixel_scale():
     assert_quantity_allclose(asec.to(u.pix, u.pixel_scale(pixscale2)), pix)
 
 
+def test_pixel_scale_invalid_scale_unit():
+
+    pixscale = 0.4 * u.arcsec
+    pixscale2 = 0.4 * u.arcsec / u.pix ** 2
+
+    with pytest.raises(u.UnitsError, match="pixel dimension"):
+        u.pixel_scale(pixscale)
+    with pytest.raises(u.UnitsError, match="pixel dimension"):
+        u.pixel_scale(pixscale2)
+
+
+def test_pixel_scale_acceptable_scale_unit():
+
+    pix = 75 * u.pix
+    v = 3000 * (u.cm / u.s)
+
+    pixscale = 0.4 * (u.m / u.s / u.pix)
+    pixscale2 = 2.5 * (u.pix / (u.m / u.s))
+
+    assert_quantity_allclose(pix.to(u.m / u.s, u.pixel_scale(pixscale)), v)
+    assert_quantity_allclose(pix.to(u.km / u.s, u.pixel_scale(pixscale)), v)
+
+    assert_quantity_allclose(pix.to(u.m / u.s, u.pixel_scale(pixscale2)), v)
+    assert_quantity_allclose(pix.to(u.km / u.s, u.pixel_scale(pixscale2)), v)
+
+    assert_quantity_allclose(v.to(u.pix, u.pixel_scale(pixscale)), pix)
+    assert_quantity_allclose(v.to(u.pix, u.pixel_scale(pixscale2)), pix)
+
+
 def test_plate_scale():
     mm = 1.5*u.mm
     asec = 30*u.arcsec

--- a/docs/units/equivalencies.rst
+++ b/docs/units/equivalencies.rst
@@ -354,6 +354,17 @@ and you want to know how big your pixels need to be to cover half an arcsecond::
     >>> (0.5*u.arcsec).to(u.micron, tel_platescale)  # doctest: +FLOAT_CMP
     <Quantity 18.9077335632719 micron>
 
+The pixel scale equivalency can also work in more general context, where the
+scale is specified as any quantity that is reducible to ``<composite
+unit>/u.pix`` or ``u.pix/<composite unit>`` (that is, the dimensionality of
+``u.pix`` is 1 or -1). For example, one may define the dots-per-inch
+(DPI) for a digital image to calculate its physical size::
+
+    >>> import astropy.units as u
+    >>> dpi = u.pixel_scale(100 * u.pix / u.imperial.inch)
+    >>> (1024 * u.pix).to(u.cm, dpi)  # doctest: +FLOAT_CMP
+    <Quantity 26.0096 cm>
+
 Photometric Zero Point Equivalency
 ----------------------------------
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the need of pixel equivalencies on images where pixels are not related to distances on the sky.

This proposed implementation does not assume an equivalency of the `pixscale` unit to `u.rad/u.pix` (or `u.pix/u.rad`), instead, it constructs the correct scaling relation by decomposing the unit and inspect the dimensionality of `u.pix` in the unit of `pixscale`.
  
<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10110 
