### PR TITLE
Some maintenance commits for io.fits _File

### DIFF
--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -113,17 +113,24 @@ class _File:
         self.strict_memmap = bool(memmap)
         memmap = True if memmap is None else memmap
 
+        self._file = None
+        self.closed = False
+        self.binary = True
+        self.mode = mode
+        self.memmap = memmap
+        self.compression = None
+        self.readonly = False
+        self.writeonly = False
+
+        # Should the object be closed on error: see
+        # https://github.com/astropy/astropy/issues/6168
+        self.close_on_error = False
+
+        # Holds mmap instance for files that use mmap
+        self._mmap = None
+
         if fileobj is None:
-            self._file = None
-            self.closed = False
-            self.binary = True
-            self.mode = mode
-            self.memmap = memmap
-            self.compression = None
-            self.readonly = False
-            self.writeonly = False
             self.simulateonly = True
-            self.close_on_error = False
             return
         else:
             self.simulateonly = False
@@ -140,9 +147,6 @@ class _File:
                 # TODO: This could be revised when Python 3.5 support is dropped
                 # See also: https://github.com/astropy/astropy/issues/6789
                 raise TypeError("names should be `str` not `bytes`.")
-
-        # Holds mmap instance for files that use mmap
-        self._mmap = None
 
         if mode is not None and mode not in IO_FITS_MODES:
             raise ValueError(f"Mode '{mode}' not recognized")
@@ -169,22 +173,10 @@ class _File:
         else:
             self.name = fileobj_name(fileobj)
 
-        self.closed = False
-        self.binary = True
         self.mode = mode
-        self.memmap = memmap
 
         # Underlying fileobj is a file-like object, but an actual file object
         self.file_like = False
-
-        # Should the object be closed on error: see
-        # https://github.com/astropy/astropy/issues/6168
-        self.close_on_error = False
-
-        # More defaults to be adjusted below as necessary
-        self.compression = None
-        self.readonly = False
-        self.writeonly = False
 
         # Initialize the internal self._file object
         if isfile(fileobj):

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -347,6 +347,8 @@ class _File:
         return iswritable(self._file)
 
     def write(self, string):
+        if self.simulateonly:
+            return
         if hasattr(self._file, 'write'):
             _write_string(self._file, string)
 
@@ -358,10 +360,14 @@ class _File:
         the file on disk reflects the data written.
         """
 
+        if self.simulateonly:
+            return
         if hasattr(self._file, 'write'):
             _array_to_file(array, self._file)
 
     def flush(self):
+        if self.simulateonly:
+            return
         if hasattr(self._file, 'flush'):
             self._file.flush()
 
@@ -376,6 +382,8 @@ class _File:
                           .format(self.size, pos), AstropyUserWarning)
 
     def tell(self):
+        if self.simulateonly:
+            raise OSError
         if not hasattr(self._file, 'tell'):
             raise EOFError
         return self._file.tell()

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -137,16 +137,6 @@ class _File:
             # If fileobj is of type pathlib.Path
             if isinstance(fileobj, pathlib.Path):
                 fileobj = str(fileobj)
-            elif isinstance(fileobj, bytes):
-                # Using bytes as filename is tricky, it's deprecated for Windows
-                # in Python 3.5 (because it could lead to false-positives) but
-                # was fixed and un-deprecated in Python 3.6.
-                # However it requires that the bytes object is encoded with the
-                # file system encoding.
-                # Probably better to error out and ask for a str object instead.
-                # TODO: This could be revised when Python 3.5 support is dropped
-                # See also: https://github.com/astropy/astropy/issues/6789
-                raise TypeError("names should be `str` not `bytes`.")
 
         if mode is not None and mode not in IO_FITS_MODES:
             raise ValueError(f"Mode '{mode}' not recognized")
@@ -161,7 +151,7 @@ class _File:
             mode = 'readonly'
 
         # Handle raw URLs
-        if (isinstance(fileobj, str) and
+        if (isinstance(fileobj, (str, bytes)) and
                 mode not in ('ostream', 'append', 'update') and _is_url(fileobj)):
             self.name = download_file(fileobj, cache=cache)
         # Handle responses from URL requests that have already been opened
@@ -181,7 +171,7 @@ class _File:
         # Initialize the internal self._file object
         if isfile(fileobj):
             self._open_fileobj(fileobj, mode, overwrite)
-        elif isinstance(fileobj, str):
+        elif isinstance(fileobj, (str, bytes)):
             self._open_filename(fileobj, mode, overwrite)
         else:
             self._open_filelike(fileobj, mode, overwrite)

--- a/astropy/io/fits/hdu/base.py
+++ b/astropy/io/fits/hdu/base.py
@@ -590,33 +590,25 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
 
     def _writeheader(self, fileobj):
         offset = 0
-        if not fileobj.simulateonly:
-            with suppress(AttributeError, OSError):
-                offset = fileobj.tell()
+        with suppress(AttributeError, OSError):
+            offset = fileobj.tell()
 
-            self._header.tofile(fileobj)
+        self._header.tofile(fileobj)
 
-            try:
-                size = fileobj.tell() - offset
-            except (AttributeError, OSError):
-                size = len(str(self._header))
-        else:
+        try:
+            size = fileobj.tell() - offset
+        except (AttributeError, OSError):
             size = len(str(self._header))
 
         return offset, size
 
     def _writedata(self, fileobj):
-        # TODO: A lot of the simulateonly stuff should be moved back into the
-        # _File class--basically it should turn write and flush into a noop
-        offset = 0
         size = 0
-
-        if not fileobj.simulateonly:
-            fileobj.flush()
-            try:
-                offset = fileobj.tell()
-            except OSError:
-                offset = 0
+        fileobj.flush()
+        try:
+            offset = fileobj.tell()
+        except (AttributeError, OSError):
+            offset = 0
 
         if self._data_loaded or self._data_needs_rescale:
             if self.data is not None:
@@ -637,8 +629,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
             size += self._writedata_direct_copy(fileobj)
 
         # flush, to make sure the content is written
-        if not fileobj.simulateonly:
-            fileobj.flush()
+        fileobj.flush()
 
         # return both the location and the size of the data area
         return offset, size
@@ -652,8 +643,7 @@ class _BaseHDU(metaclass=_BaseHDUMeta):
         Should return the size in bytes of the data written.
         """
 
-        if not fileobj.simulateonly:
-            fileobj.writearray(self.data)
+        fileobj.writearray(self.data)
         return self.data.size * self.data.itemsize
 
     def _writedata_direct_copy(self, fileobj):
@@ -867,19 +857,17 @@ class _NonstandardHDU(_BaseHDU, _Verify):
         offset = 0
         size = 0
 
-        if not fileobj.simulateonly:
-            fileobj.flush()
-            try:
-                offset = fileobj.tell()
-            except OSError:
-                offset = 0
+        fileobj.flush()
+        try:
+            offset = fileobj.tell()
+        except OSError:
+            offset = 0
 
         if self.data is not None:
-            if not fileobj.simulateonly:
-                fileobj.write(self.data)
-                # flush, to make sure the content is written
-                fileobj.flush()
-                size = len(self.data)
+            fileobj.write(self.data)
+            # flush, to make sure the content is written
+            fileobj.flush()
+            size = len(self.data)
 
         # return both the location and the size of the data area
         return offset, size

--- a/astropy/io/fits/hdu/groups.py
+++ b/astropy/io/fits/hdu/groups.py
@@ -484,21 +484,19 @@ class GroupsHDU(PrimaryHDU, _TableLikeHDU):
                 byteorder = self.data.dtype.fields[fname][0].str[0]
                 should_swap = (byteorder in swap_types)
 
-            if not fileobj.simulateonly:
-
-                if should_swap:
-                    if output.flags.writeable:
+            if should_swap:
+                if output.flags.writeable:
+                    output.byteswap(True)
+                    try:
+                        fileobj.writearray(output)
+                    finally:
                         output.byteswap(True)
-                        try:
-                            fileobj.writearray(output)
-                        finally:
-                            output.byteswap(True)
-                    else:
-                        # For read-only arrays, there is no way around making
-                        # a byteswapped copy of the data.
-                        fileobj.writearray(output.byteswap(False))
                 else:
-                    fileobj.writearray(output)
+                    # For read-only arrays, there is no way around making
+                    # a byteswapped copy of the data.
+                    fileobj.writearray(output.byteswap(False))
+            else:
+                fileobj.writearray(output)
 
             size += output.size * output.itemsize
         return size

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -194,8 +194,6 @@ class HDUList(list, _Verify):
             self._file = file
             self._data = None
 
-        self._save_backup = False
-
         # For internal use only--the keyword args passed to fitsopen /
         # HDUList.fromfile/string when opening the file
         self._open_kwargs = {}
@@ -808,7 +806,8 @@ class HDUList(list, _Verify):
                          .format(self._file.mode), AstropyUserWarning)
             return
 
-        if self._save_backup and self._file.mode in ('append', 'update'):
+        save_backup = self._open_kwargs.get('save_backup', False)
+        if save_backup and self._file.mode in ('append', 'update'):
             filename = self._file.name
             if os.path.exists(filename):
                 # The the file doesn't actually exist anymore for some reason
@@ -1039,9 +1038,8 @@ class HDUList(list, _Verify):
         return None
 
     @classmethod
-    def _readfrom(cls, fileobj=None, data=None, mode=None,
-                  memmap=None, save_backup=False, cache=True,
-                  lazy_load_hdus=True, **kwargs):
+    def _readfrom(cls, fileobj=None, data=None, mode=None, memmap=None,
+                  cache=True, lazy_load_hdus=True, **kwargs):
         """
         Provides the implementations from HDUList.fromfile and
         HDUList.fromstring, both of which wrap this method, as their
@@ -1067,7 +1065,7 @@ class HDUList(list, _Verify):
             # fromstring case; the data type of ``data`` will be checked in the
             # _BaseHDU.fromstring call.
 
-        hdulist._save_backup = save_backup
+        # Store additional keyword args that were passed to fits.open
         hdulist._open_kwargs = kwargs
 
         if fileobj is not None and fileobj.writeonly:

--- a/astropy/io/fits/hdu/image.py
+++ b/astropy/io/fits/hdu/image.py
@@ -640,21 +640,19 @@ class _ImageBaseHDU(_ValidHDU):
                 byteorder = output.dtype.str[0]
                 should_swap = (byteorder in swap_types)
 
-            if not fileobj.simulateonly:
-
-                if should_swap:
-                    if output.flags.writeable:
+            if should_swap:
+                if output.flags.writeable:
+                    output.byteswap(True)
+                    try:
+                        fileobj.writearray(output)
+                    finally:
                         output.byteswap(True)
-                        try:
-                            fileobj.writearray(output)
-                        finally:
-                            output.byteswap(True)
-                    else:
-                        # For read-only arrays, there is no way around making
-                        # a byteswapped copy of the data.
-                        fileobj.writearray(output.byteswap(False))
                 else:
-                    fileobj.writearray(output)
+                    # For read-only arrays, there is no way around making
+                    # a byteswapped copy of the data.
+                    fileobj.writearray(output.byteswap(False))
+            else:
+                fileobj.writearray(output)
 
             size += output.size * output.itemsize
 

--- a/astropy/io/fits/hdu/table.py
+++ b/astropy/io/fits/hdu/table.py
@@ -949,14 +949,12 @@ class BinTableHDU(_TableBaseHDU):
                     for row in field:
                         if len(row) > 0:
                             nbytes += row.nbytes
-                            if not fileobj.simulateonly:
-                                fileobj.writearray(row)
+                            fileobj.writearray(row)
             else:
                 heap_data = data._get_heap_data()
                 if len(heap_data) > 0:
                     nbytes += len(heap_data)
-                    if not fileobj.simulateonly:
-                        fileobj.writearray(heap_data)
+                    fileobj.writearray(heap_data)
 
             data._heapsize = nbytes - data._gap
             size += nbytes

--- a/astropy/io/fits/header.py
+++ b/astropy/io/fits/header.py
@@ -744,10 +744,9 @@ class Header:
                         len(blocks) - actual_block_size + BLOCK_SIZE,
                         BLOCK_SIZE))
 
-            if not fileobj.simulateonly:
-                fileobj.flush()
-                fileobj.write(blocks.encode('ascii'))
-                fileobj.flush()
+            fileobj.flush()
+            fileobj.write(blocks.encode('ascii'))
+            fileobj.flush()
         finally:
             if close_file:
                 fileobj.close()

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -1285,6 +1285,14 @@ class TestFileFunctions(FitsTestCase):
 
         return bzfile
 
+    def test_simulateonly(self):
+        """Write to None simulates writing."""
+
+        with fits.open(self.data('test0.fits')) as hdul:
+            hdul.writeto(None)
+            hdul[0].writeto(None)
+            hdul[0].header.tofile(None)
+
 
 class TestStreamingFunctions(FitsTestCase):
     """Test functionality of the StreamingHDU class."""

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -22,7 +22,7 @@ from astropy.io.fits.file import _File, GZIP_MAGIC
 
 from astropy.io import fits
 from astropy.tests.helper import raises, catch_warnings, ignore_warnings
-from astropy.utils.data import conf, get_pkg_data_filename
+from astropy.utils.data import conf
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
 
@@ -39,10 +39,6 @@ class TestCore(FitsTestCase):
     @raises(OSError)
     def test_missing_file(self):
         fits.open(self.temp('does-not-exist.fits'))
-
-    def test_filename_is_bytes_object(self):
-        with pytest.raises(TypeError):
-            fits.open(self.data('ascii.fits').encode())
 
     def test_naxisj_check(self):
         with fits.open(self.data('o4sp040b0_raw.fits')) as hdulist:
@@ -77,8 +73,19 @@ class TestCore(FitsTestCase):
         """
         Testing when fits file is passed as pathlib.Path object #4412.
         """
-        fpath = pathlib.Path(get_pkg_data_filename('data/tdim.fits'))
+        fpath = pathlib.Path(self.data('tdim.fits'))
         with fits.open(fpath) as hdulist:
+            assert hdulist[0].filebytes() == 2880
+            assert hdulist[1].filebytes() == 5760
+
+            with fits.open(self.data('tdim.fits')) as hdulist2:
+                assert FITSDiff(hdulist2, hdulist).identical is True
+
+    def test_fits_file_bytes_object(self):
+        """
+        Testing when fits file is passed as bytes.
+        """
+        with fits.open(self.data('tdim.fits').encode()) as hdulist:
             assert hdulist[0].filebytes() == 2880
             assert hdulist[1].filebytes() == 5760
 

--- a/astropy/io/fits/util.py
+++ b/astropy/io/fits/util.py
@@ -403,7 +403,7 @@ def fileobj_name(f):
     string f itself is returned.
     """
 
-    if isinstance(f, str):
+    if isinstance(f, (str, bytes)):
         return f
     elif isinstance(f, gzip.GzipFile):
         # The .name attribute on GzipFiles does not always represent the name


### PR DESCRIPTION
While looking at the `_File` class for other purposes I ended up doing a few commits to improve the code there :
-  Removing duplicates when setting default values in `_File` 
- Allowing bytes as filename, which undoes #6793 (by @MSeifert04 ) since we now require Python 3.6+ (let's see if this works on Windows)
- Move `simulateonly` logic to `_File`, one TODO less :)
- Use `_open_kwargs` for `save_backup`, since this is used for several other kwargs for which the logic is the same, we can avoid one private variable for this.