### PR TITLE
Handle auto_max_age = None consistently

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,8 +117,6 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- Fix case where ``None`` could be used in a numerical computation. [#10126]
-
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -426,6 +424,8 @@ astropy.utils
 ^^^^^^^^^^^^^
 
 - Fixed memory allocation on 64-bit systems within ``xml.iterparse`` [#10076]
+
+- Fix case where ``None`` could be used in a numerical computation. [#10126]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,7 +117,7 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
-- Fix case where ``None`` could be used in a numerical computation. [#12345]
+- Fix case where ``None`` could be used in a numerical computation. [#10126]
 
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -117,6 +117,8 @@ astropy.units
 astropy.utils
 ^^^^^^^^^^^^^
 
+- Fix case where ``None`` could be used in a numerical computation. [#12345]
+
 astropy.visualization
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -97,6 +97,14 @@ def download_file(*args, **kwargs):
         return utils.data.download_file(*args, **kwargs)
 
 
+def _none_to_float(value):
+    """
+    Convert None to a valid floating point value.  Especially
+    for auto_max_age = None.
+    """
+    return (value if value is not None else np.finfo(float).max)
+
+
 class IERSStaleWarning(AstropyWarning):
     pass
 
@@ -697,8 +705,7 @@ class IERS_Auto(IERS_A):
         predictive_mjd = self.meta['predictive_mjd']
 
         # See explanation in _refresh_table_as_needed for these conditions
-        auto_max_age = (conf.auto_max_age if conf.auto_max_age is not None
-                        else np.finfo(float).max)
+        auto_max_age = _none_to_float(conf.auto_max_age)
         if (max_input_mjd > predictive_mjd and
                 self.time_now.mjd - predictive_mjd > auto_max_age):
             raise ValueError(INTERPOLATE_ERROR.format(auto_max_age))
@@ -726,8 +733,7 @@ class IERS_Auto(IERS_A):
         predictive_mjd = self.meta['predictive_mjd']
 
         # Update table in place if necessary
-        auto_max_age = (conf.auto_max_age if conf.auto_max_age is not None
-                        else np.finfo(float).max)
+        auto_max_age = _none_to_float(conf.auto_max_age)
 
         # If auto_max_age is smaller than IERS update time then repeated downloads may
         # occur without getting updated values (giving a IERSStaleWarning).
@@ -972,7 +978,7 @@ class LeapSeconds(QTable):
         that expires more than 180 - `~astropy.utils.iers.Conf.auto_max_age`
         after the present.
         """
-        good_enough = cls._today() + TimeDelta(180-conf.auto_max_age,
+        good_enough = cls._today() + TimeDelta(180-_none_to_float(conf.auto_max_age),
                                                format='jd')
 
         if files is None:

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -109,6 +109,11 @@ class TestAutoOpenExplicitLists:
         ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
 
+    def test_auto_open_max_age_none(self):
+        with iers.conf.auto_max_age.set_temp(None):
+            ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
+        assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
+
     def test_auto_open_erfa(self):
         ls = iers.LeapSeconds.auto_open(['erfa', iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] in ['erfa', iers.IERS_LEAP_SECOND_FILE]

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -109,11 +109,6 @@ class TestAutoOpenExplicitLists:
         ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
 
-    def test_auto_open_max_age_none(self):
-        with iers.conf.auto_max_age.set_temp(None):
-            ls = iers.LeapSeconds.auto_open([iers.IERS_LEAP_SECOND_FILE])
-        assert ls.meta['data_url'] == iers.IERS_LEAP_SECOND_FILE
-
     def test_auto_open_erfa(self):
         ls = iers.LeapSeconds.auto_open(['erfa', iers.IERS_LEAP_SECOND_FILE])
         assert ls.meta['data_url'] in ['erfa', iers.IERS_LEAP_SECOND_FILE]
@@ -150,6 +145,12 @@ class TestAutoOpenExplicitLists:
         assert ls2.meta['data_url'] == fake_file2
         assert ls2.expires == Time('2012-06-27', scale='tai')
 
+        # Use the fake files to make sure auto_max_age is safe.
+        with iers.conf.set_temp('auto_max_age', None):
+            ls3 = iers.LeapSeconds.auto_open([fake_file1,
+                                              iers.IERS_LEAP_SECOND_FILE])
+        assert ls3.meta['data_url'] == fake_file1
+
 
 @pytest.mark.remote_data
 class TestRemoteURLs:
@@ -169,7 +170,7 @@ class TestDefaultAutoOpen:
     def setup(self):
         # Identical to what is used in LeapSeconds.auto_open().
         self.good_enough = (iers.LeapSeconds._today()
-                            + TimeDelta(180 - iers.conf.auto_max_age,
+                            + TimeDelta(180 - iers._none_to_float(iers.conf.auto_max_age),
                                         format='jd'))
         self._auto_open_files = iers.LeapSeconds._auto_open_files.copy()
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This PR fixes a "bare" use of `None` in a numerical computation and ensures
that `None` is converted to a valid float throughout the module.  See also #9479.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


