### PR TITLE
Fixed error in the obliquity for *TrueEcliptic coordinate frames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -432,6 +432,10 @@ astropy.coordinates
 - Ensure that the ``lon`` values in ``SkyOffsetFrame`` are wrapped correctly at
   180 degree regardless of how the underlying data is represented. [#10163]
 
+- Fixed an error in the obliquity of the ecliptic when transforming to/from the
+  ``*TrueEcliptic`` coordinate frames. The error would primarily result in an
+  inaccuracy in the ecliptic latitude on the order of arcseconds. [#10129]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/ecliptic_transforms.py
+++ b/astropy/coordinates/builtin_frames/ecliptic_transforms.py
@@ -43,7 +43,8 @@ def _true_ecliptic_rotation_matrix(equinox):
     # (see https://github.com/astropy/astropy/pull/6508).
     jd1, jd2 = get_jd12(equinox, 'tt')
     rnpb = erfa.pnm06a(jd1, jd2)
-    obl = erfa.obl06(jd1, jd2)*u.radian
+    _, nut_obl = erfa.nut06a(jd1, jd2)*u.radian
+    obl = erfa.obl06(jd1, jd2)*u.radian + nut_obl  # calculate the true obliquity of the ecliptic
     return matrix_product(rotation_matrix(obl, 'x'), rnpb)
 
 

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -54,18 +54,33 @@ def test_ecliptic_heliobary():
                          (HeliocentricTrueEcliptic, HeliocentricMeanEcliptic),
                          (GeocentricTrueEcliptic, GeocentricMeanEcliptic),
                          (HeliocentricEclipticIAU76, HeliocentricMeanEcliptic)])
-def test_ecliptic_true_mean(trueframe, meanframe):
+def test_ecliptic_roundtrips(trueframe, meanframe):
     """
-    Check that the ecliptic true/mean transformations at least roundtrip
+    Check that the various ecliptic transformations at least roundtrip
     """
     icrs = ICRS(1*u.deg, 2*u.deg, distance=1.5*R_sun)
 
     truecoo = icrs.transform_to(trueframe)
-    meancoo = icrs.transform_to(meanframe)
-    truecoo2 = icrs.transform_to(trueframe)
+    meancoo = truecoo.transform_to(meanframe)
+    truecoo2 = meancoo.transform_to(trueframe)
 
     assert not quantity_allclose(truecoo.cartesian.xyz, meancoo.cartesian.xyz)
     assert quantity_allclose(truecoo.cartesian.xyz, truecoo2.cartesian.xyz)
+
+
+@pytest.mark.parametrize(('trueframe', 'meanframe'),
+                        [(BarycentricTrueEcliptic, BarycentricMeanEcliptic),
+                         (HeliocentricTrueEcliptic, HeliocentricMeanEcliptic),
+                         (GeocentricTrueEcliptic, GeocentricMeanEcliptic)])
+def test_ecliptic_true_mean_preserve_latitude(trueframe, meanframe):
+    """
+    Check that the ecliptic true/mean transformations preserve latitude
+    """
+    truecoo = trueframe(90*u.deg, 0*u.deg, distance=1*u.AU)
+    meancoo = truecoo.transform_to(meanframe)
+
+    assert not quantity_allclose(truecoo.lon, meancoo.lon)
+    assert quantity_allclose(truecoo.lat, meancoo.lat, atol=1e-10*u.arcsec)
 
 
 def test_ecl_geo():


### PR DESCRIPTION
The *TrueEcliptic coordinate frames (added in #8394) have a calculation error in their transformations, specifically in the function `_true_ecliptic_rotation_matrix()`.  The function correctly makes use of the transformation matrix from ICRF to "true" equatorial (obtained using `erfa.pnm06a()`), but then rotates it by the "mean" obliquity of the ecliptic (obtained using `erfa.obl06()`) instead of the "true" obliquity of the ecliptic.  In other words, it doesn't account for the effect of nutation on the obliquity of the ecliptic.  This PR modifies the function to use the true obliquity of the ecliptic.

Here's an illustrative before/after example.  Before this PR, a point on the ecliptic plane in `GeocentricMeanEcliptic` (latitude of 0 deg) ends up ~6 arcsec off of the ecliptic plane in `GeocentricTrueEcliptic`.  However, while nutation should change the apparent ecliptic longitude (because the location of the apparent vernal equinox changes), it shouldn't affect ecliptic latitude; objects on the ecliptic plane should stay on the ecliptic plane, regardless of what the Earth is doing.
```python
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord
>>> s = SkyCoord(90*u.deg, 0*u.deg, 1*u.AU, frame='geocentricmeanecliptic')
>>> s.geocentrictrueecliptic
<SkyCoord (GeocentricTrueEcliptic: equinox=J2000.000, obstime=J2000.000): (lon, lat, distance) in (deg, deg, AU)
    (89.99613, -0.00160261, 1.)>
>>> s.geocentrictrueecliptic.lat.to('arcsec')
<Latitude -5.76939806 arcsec>
```
After this PR, the ecliptic latitude does not change (and the ecliptic longitude still does change):
```python
>>> import astropy.units as u
>>> from astropy.coordinates import SkyCoord
>>> s = SkyCoord(90*u.deg, 0*u.deg, 1*u.AU, frame='geocentricmeanecliptic')
>>> s.geocentrictrueecliptic
<SkyCoord (GeocentricTrueEcliptic: equinox=J2000.000, obstime=J2000.000): (lon, lat, distance) in (deg, deg, AU)
    (89.99613, 6.36110936e-15, 1.)>
>>> s.geocentrictrueecliptic.lat.to('arcsec')
<Latitude 2.28999937e-11 arcsec>
```
I've added a test for this preservation of ecliptic latitude.