### PR TITLE
Allow caching in io.registry read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,9 @@ astropy.io.fits
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
+- Added ``cache`` keyword option to allow caching for ``read`` if filename
+  is a URL. [#10136]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -277,6 +277,9 @@ class BaseInputter:
     encoding = None
     """Encoding used to read the file"""
 
+    cache = True
+    """"Caching behavior if file is a URL."""
+
     def get_lines(self, table, newline=None):
         """
         Get the lines from the ``table`` input. The input table can be one of:
@@ -303,7 +306,7 @@ class BaseInputter:
             if (hasattr(table, 'read')
                     or ('\n' not in table + '' and '\r' not in table + '')):
                 with get_readable_fileobj(table,
-                                          encoding=self.encoding) as fileobj:
+                                          encoding=self.encoding, cache=self.cache) as fileobj:
                     table = fileobj.read()
             if newline is None:
                 lines = table.splitlines()

--- a/astropy/io/ascii/ui.py
+++ b/astropy/io/ascii/ui.py
@@ -311,8 +311,9 @@ def read(table, guess=None, **kwargs):
         # intact.
         if 'readme' not in new_kwargs:
             encoding = kwargs.get('encoding')
+            cache = kwargs.get('cache', False)
             try:
-                with get_readable_fileobj(table, encoding=encoding) as fileobj:
+                with get_readable_fileobj(table, encoding=encoding, cache=cache) as fileobj:
                     table = fileobj.read()
             except ValueError:  # unreadable or invalid binary file
                 raise
@@ -668,7 +669,7 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
     """
 
     @contextlib.contextmanager
-    def passthrough_fileobj(fileobj, encoding=None):
+    def passthrough_fileobj(fileobj, encoding=None, cache=False):
         """Stub for get_readable_fileobj, which does not seem to work in Py3
         for input File-like object, see #6460"""
         yield fileobj
@@ -693,7 +694,7 @@ def _read_in_chunks_generator(table, chunk_size, **kwargs):
     prev_chunk_chars = ''  # Chars from previous chunk after last newline
     first_chunk = True  # True for the first chunk, False afterward
 
-    with fileobj_context(table, encoding=kwargs.get('encoding')) as fh:
+    with fileobj_context(table, encoding=kwargs.get('encoding'), cache=kwargs.get('cache')) as fh:
 
         while True:
             chunk = fh.read(chunk_size)

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -504,7 +504,7 @@ def read(cls, *args, format=None, **kwargs):
                         args = (str(args[0]),) + args[1:]
                     path = args[0]
                     try:
-                        ctx = get_readable_fileobj(args[0], encoding='binary')
+                        ctx = get_readable_fileobj(args[0], encoding='binary', cache=True)
                         fileobj = ctx.__enter__()
                     except OSError:
                         raise

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -483,7 +483,7 @@ def get_writer(data_format, data_class):
                 data_format, data_class.__name__, format_table_str))
 
 
-def read(cls, *args, format=None, **kwargs):
+def read(cls, *args, format=None, cache=False, **kwargs):
     """
     Read in data.
 
@@ -504,7 +504,7 @@ def read(cls, *args, format=None, **kwargs):
                         args = (str(args[0]),) + args[1:]
                     path = args[0]
                     try:
-                        ctx = get_readable_fileobj(args[0], encoding='binary', cache=True)
+                        ctx = get_readable_fileobj(args[0], encoding='binary', cache=cache)
                         fileobj = ctx.__enter__()
                     except OSError:
                         raise

--- a/astropy/nddata/mixins/ndio.py
+++ b/astropy/nddata/mixins/ndio.py
@@ -37,6 +37,8 @@ class NDDataRead(registry.UnifiedReadWrite):
         first argument is the input filename.
     format : str, optional
         File format specifier.
+    cache : bool, optional
+        Caching behavior if file is a URL.
     **kwargs : dict, optional
         Keyword arguments passed through to data reader.
 

--- a/astropy/table/connect.py
+++ b/astropy/table/connect.py
@@ -33,6 +33,8 @@ class TableRead(registry.UnifiedReadWrite):
         first argument is typically the input filename.
     format : str
         File format specifier.
+    cache : bool, optional
+        Caching behavior if file is a URL.
     units : list, dict, optional
         List or dict of units to apply to columns
     descriptions : list, dict, optional

--- a/docs/io/unified.rst
+++ b/docs/io/unified.rst
@@ -26,7 +26,8 @@ though the `~astropy.nddata.CCDData` class using FITS file format:
     >>> ccd.write('new_image.fits')
 
 Note that the unit is stored in the ``BUNIT`` keyword in the header on saving,
-and is read from the header if it is present.
+and is read from the header if it is present. If you run into problem reading
+in a URL on Windows, try setting ``cache=True``.
 
 Detailed help on the available keyword arguments for reading and writing
 can be obtained via the ``help()`` method as follows:
@@ -76,8 +77,8 @@ example, download tables from Vizier catalogues in CDS format
 (``'ascii.cds'``)::
 
     >>> t = Table.read("ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/snrs.dat",
-    ...         readme="ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/ReadMe",
-    ...         format="ascii.cds")  # doctest: +SKIP
+    ...                readme="ftp://cdsarc.u-strasbg.fr/pub/cats/VII/253/ReadMe",
+    ...                format="ascii.cds", cache=True)  # doctest: +SKIP
 
 For certain file formats the format can be automatically detected, for
 example, from the filename extension::
@@ -241,7 +242,7 @@ To read and write formats supported by `astropy.io.ascii`:
 
 .. doctest-skip::
 
-  >>> t = Table.read('astropy/io/ascii/tests/t/latex1.tex', format='ascii')
+  >>> t = Table.read('astropy/io/ascii/tests/data/latex1.tex', format='ascii')
   >>> print(t)
   cola colb colc
   ---- ---- ----


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the problem of `CCDData` hitting permission issue on Windows when trying to read in a URL.

While simply forcing `cache=True` works for me, I wonder if there is a way to expose `cache` in user API. Someone familiar with how `io.registry` works should review this and advise. Thanks!

```
PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process: 'C:\\...\\Temp\\astropy-download-30692-8xtfvq4i'
```

p.s. I am not sure who is the `io.registry` sub-package maintainer(s), so I am tagging `table` maintainers for now. 😬 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #8556
