### PR TITLE
Implement __eq__ and __ne__ for coordinate classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,9 +28,7 @@ astropy.coordinates
 - Allow in-place modification of array-valued ``Frame`` and ``SkyCoord`` objects.
   This provides limited support for updating coordinate data values from another
   coordinate object of the same class and equivalent frame attributes. [#9857]
-- Added a robust equality operator for comparing ``SkyCoord``, ``Frame``, and
-  ``Representation`` objects. A comparison like ``sc1 == sc2`` will now return
-  a boolean or boolean array where the objects are strictly equal in all relevant
+
 - Added a robust equality operator for comparing ``SkyCoord``, frame, and
   representation objects. A comparison like ``sc1 == sc2`` will now return a
   boolean or boolean array where the objects are strictly equal in all relevant
@@ -63,6 +61,7 @@ astropy.io.ascii
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 - Added serialization of parameter constraints fixed and bounds.  [#10082]
+
 - Added 'functional_models.py' and 'physical_models.py' to asdf/tags/transform,
   with to allow serialization of all functional and physical models. [#10028]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ astropy.coordinates
 - Added a robust equality operator for comparing ``SkyCoord``, ``Frame``, and
   ``Representation`` objects. A comparison like ``sc1 == sc2`` will now return
   a boolean or boolean array where the objects are strictly equal in all relevant
+- Added a robust equality operator for comparing ``SkyCoord``, frame, and
+  representation objects. A comparison like ``sc1 == sc2`` will now return a
+  boolean or boolean array where the objects are strictly equal in all relevant
   frame attributes and coordinate representation values. [#10154]
 
 - Added the True Equator Mean Equinox (TEME) frame. [#10149]
@@ -246,12 +249,12 @@ astropy.io.ascii
   ``converters`` dict names referred to the *input* table column names, but now
   they refer to the *output* table column names. [#9739]
 
-- The equality operator for comparing ``SkyCoord``, ``Frame``, and
-  ``Representation`` objects was changed. A comparison like ``sc1 == sc2`` would
-  previously return ``True`` only if the objects were actually the same object
-  and ``False`` otherwise. It will now return a boolean or boolean array where
-  the objects are strictly equal in all relevant frame attributes and coordinate
-  representation values. [#10154]
+- The equality operator for comparing ``SkyCoord``, frame, and representation
+  objects was changed. A comparison like ``sc1 == sc2`` was previously
+  equivalent to ``sc1 is sc2``. It will now return a boolean or boolean array
+  where the objects are strictly equal in all relevant frame attributes and
+  coordinate representation values. If the objects have different frame
+  attributes or representation types then an exception will be raised. [#10154]
 
 astropy.io.misc
 ^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -246,6 +246,13 @@ astropy.io.ascii
   ``converters`` dict names referred to the *input* table column names, but now
   they refer to the *output* table column names. [#9739]
 
+- The equality operator for comparing ``SkyCoord``, ``Frame``, and
+  ``Representation`` objects was changed. A comparison like ``sc1 == sc2`` would
+  previously return ``True`` only if the objects were actually the same object
+  and ``False`` otherwise. It will now return a boolean or boolean array where
+  the objects are strictly equal in all relevant frame attributes and coordinate
+  representation values. [#10154]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
@@ -338,13 +345,6 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
-
-- The equality operator for comparing ``SkyCoord``, ``Frame``, and
-  ``Representation`` objects was changed. A comparison like ``sc1 == sc2`` would
-  previously return ``True`` only if the objects were actually the same object
-  and ``False`` otherwise. It will now return a boolean or boolean array where
-  the objects are strictly equal in all relevant frame attributes and coordinate
-  representation values. [#10154]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ astropy.coordinates
 - Allow in-place modification of array-valued ``Frame`` and ``SkyCoord`` objects.
   This provides limited support for updating coordinate data values from another
   coordinate object of the same class and equivalent frame attributes. [#9857]
+- Added a robust equality operator for comparing ``SkyCoord``, ``Frame``, and
+  ``Representation`` objects. A comparison like ``sc1 == sc2`` will now return
+  a boolean or boolean array where the objects are strictly equal in all relevant
+  frame attributes and coordinate representation values. [#10154]
 
 - Added the True Equator Mean Equinox (TEME) frame. [#10149]
 
@@ -334,6 +338,13 @@ astropy.convolution
 
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
+
+- The equality operator for comparing ``SkyCoord``, ``Frame``, and
+  ``Representation`` objects was changed. A comparison like ``sc1 == sc2`` would
+  previously return ``True`` only if the objects were actually the same object
+  and ``False`` otherwise. It will now return a boolean or boolean array where
+  the objects are strictly equal in all relevant frame attributes and coordinate
+  representation values. [#10154]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1634,7 +1634,13 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         This implements strict equality and requires that the frames are
         equivalent and that the representation data are exactly equal.
         """
-        if not self.is_equivalent_frame(value):
+        is_equiv = self.is_equivalent_frame(value)
+
+        if self._data is None and value._data is None:
+            # For Frame with no data, == compare is same as is_equivalent_frame()
+            return is_equiv
+
+        if not is_equiv:
             raise TypeError(f'cannot compare: objects must have equivalent frames: '
                             f'{self.replicate_without_data()} vs. '
                             f'{value.replicate_without_data()}')

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1636,8 +1636,8 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         """
         if not self.is_equivalent_frame(value):
             raise TypeError(f'cannot compare: objects must have equivalent frames: '
-                            f'{self.__class__.__name__} vs. '
-                            f'{value.__class__.__name__}')
+                            f'{self.replicate_without_data()} vs. '
+                            f'{value.replicate_without_data()}')
 
         if ((value._data is None and self._data is not None)
                 or (self._data is None and value._data is not None)):

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1628,6 +1628,36 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         super().__setattr__(attr, value)
 
+    def __eq__(self, value):
+        """Equality operator for frame.
+
+        This implements strict equality and requires that the frames are
+        equivalent and that the representation data are exactly equal.
+        """
+        if not self.is_equivalent_frame(value):
+            return False
+
+        if value._data is None and self._data is not None:
+            return False
+
+        if self._data is None and value._data is not None:
+            return False
+
+        if self._data is None and value._data is None:
+            return True
+
+        if self.shape != value.shape:
+            return False
+
+        return self._data == value._data
+
+    def __ne__(self, value):
+        eq = self.__eq__(value)
+        if isinstance(eq, bool):
+            return not eq
+        else:
+            return ~eq
+
     def separation(self, other):
         """
         Computes on-sky separation between this coordinate and another.

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1635,28 +1635,19 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         equivalent and that the representation data are exactly equal.
         """
         if not self.is_equivalent_frame(value):
-            return False
+            raise TypeError(f'cannot compare: objects must have equivalent frames: '
+                            f'{self.__class__.__name__} vs. '
+                            f'{value.__class__.__name__}')
 
-        if value._data is None and self._data is not None:
-            return False
-
-        if self._data is None and value._data is not None:
-            return False
-
-        if self._data is None and value._data is None:
-            return True
-
-        if self.shape != value.shape:
-            return False
+        if ((value._data is None and self._data is not None)
+                or (self._data is None and value._data is not None)):
+            raise ValueError('cannot compare: one frame has data and the other '
+                             'does not')
 
         return self._data == value._data
 
     def __ne__(self, value):
-        eq = self.__eq__(value)
-        if isinstance(eq, bool):
-            return not eq
-        else:
-            return ~eq
+        return np.logical_not(self == value)
 
     def separation(self, other):
         """

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -356,6 +356,28 @@ class SkyCoord(ShapedLikeNDArray):
     def shape(self):
         return self.frame.shape
 
+    def __eq__(self, value):
+        """Equality operator for SkyCoord
+
+        This implements strict equality and requires that the frames are
+        equivalent, all extra frame attributes are the same and that the
+        representation data are exactly equal.
+        """
+        # Make sure that any extra frame attribute names are equivalent.
+        for attr in self._extra_frameattr_names | value._extra_frameattr_names:
+            if not self.frame._frameattr_equiv(getattr(self, attr),
+                                               getattr(value, attr)):
+                return False
+
+        return self._sky_coord_frame == value._sky_coord_frame
+
+    def __ne__(self, value):
+        eq = self.__eq__(value)
+        if isinstance(eq, bool):
+            return not eq
+        else:
+            return ~eq
+
     def _apply(self, method, *args, **kwargs):
         """Create a new instance, applying a method to the underlying data.
 

--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -360,23 +360,22 @@ class SkyCoord(ShapedLikeNDArray):
         """Equality operator for SkyCoord
 
         This implements strict equality and requires that the frames are
-        equivalent, all extra frame attributes are the same and that the
+        equivalent, extra frame attributes are equivalent, and that the
         representation data are exactly equal.
         """
         # Make sure that any extra frame attribute names are equivalent.
         for attr in self._extra_frameattr_names | value._extra_frameattr_names:
             if not self.frame._frameattr_equiv(getattr(self, attr),
                                                getattr(value, attr)):
-                return False
+                raise ValueError(f"cannot compare: extra frame attribute "
+                                 f"'{attr}' is not equivalent "
+                                 f"(perhaps compare the frames directly to avoid "
+                                 f"this exception)")
 
         return self._sky_coord_frame == value._sky_coord_frame
 
     def __ne__(self, value):
-        eq = self.__eq__(value)
-        if isinstance(eq, bool):
-            return not eq
-        else:
-            return ~eq
+        return np.logical_not(self == value)
 
     def _apply(self, method, *args, **kwargs):
         """Create a new instance, applying a method to the underlying data.

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -269,7 +269,7 @@ def test_array_eq():
     c3 = ICRS([1, 3]*u.deg, [3, 4]*u.deg)
     c4 = ICRS([1, 2]*u.deg, [3, 4.2]*u.deg)
 
-    assert c1 == c1
-    assert c1 != c2
-    assert c1 != c3
-    assert c1 != c4
+    assert np.all(c1 == c1)
+    assert np.any(c1 != c2)
+    assert np.any(c1 != c3)
+    assert np.any(c1 != c4)

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -863,7 +863,7 @@ def test_shorthand_representations():
 
 
 def test_equal():
-    from astropy.coordinates.builtin_frames import FK4
+    from astropy.coordinates.builtin_frames import FK4, ICRS
 
     obstime = 'B1955'
     sc1 = FK4([1, 2]*u.deg, [3, 4]*u.deg, obstime=obstime)
@@ -893,6 +893,9 @@ def test_equal():
     assert np.all(ne == [False, True])
     assert (sc1[0] == sc2[0]) == True  # noqa
     assert (sc1[0] != sc2[0]) == False  # noqa
+
+    assert (FK4() == ICRS()) is False
+    assert (FK4() == FK4(obstime='J1999')) is False
 
 
 def test_equal_exceptions():

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -345,6 +345,47 @@ def test_frame_init():
     assert 'Cannot override frame=' in str(err.value)
 
 
+def test_equal():
+    obstime = 'B1955'
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, obstime=obstime)
+    sc2 = SkyCoord([1, 20]*u.deg, [3, 4]*u.deg, obstime=obstime)
+
+    # Compare arrays and scalars
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+    assert (sc1[0] == sc2[0]) == True  # noqa  (numpy True not Python True)
+    assert (sc1[0] != sc2[0]) == False  # noqa
+
+    # Broadcasting
+    eq = sc1[0] == sc2
+    ne = sc1[0] != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+
+    # With diff only in velocity
+    sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, radial_velocity=[1, 2]*u.km/u.s)
+    sc2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, radial_velocity=[1, 20]*u.km/u.s)
+
+    eq = sc1 == sc2
+    ne = sc1 != sc2
+    assert np.all(eq == [True, False])
+    assert np.all(ne == [False, True])
+    assert (sc1[0] == sc2[0]) == True  # noqa
+    assert (sc1[0] != sc2[0]) == False  # noqa
+
+
+def test_equal_exceptions():
+    sc1 = SkyCoord(1*u.deg, 2*u.deg, obstime='B1955')
+    sc2 = SkyCoord(1*u.deg, 2*u.deg)
+    with pytest.raises(ValueError, match=r"cannot compare: extra frame "
+                       r"attribute 'obstime' is not equivalent \(perhaps compare the "
+                       r"frames directly to avoid this exception\)"):
+        sc1 == sc2
+    # Note that this exception is the only one raised directly in SkyCoord.
+    # All others come from lower-level classes and are tested in test_frames.py.
+
 def test_attr_inheritance():
     """
     When initializing from an existing coord the representation attrs like

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -125,7 +125,8 @@ def test_create_spectral_coord_observer_target(observer, target):
     if observer is None or target is None:
         assert quantity_allclose(coord.redshift, 0)
         assert quantity_allclose(coord.radial_velocity, 0 * u.km/u.s)
-    elif observer in LSRD_EQUIV and target in LSRD_DIR_STATIONARY_EQUIV:
+    elif (any(observer is lsrd for lsrd in LSRD_EQUIV)
+          and any(target is lsrd for lsrd in LSRD_DIR_STATIONARY_EQUIV)):
         assert_quantity_allclose(coord.radial_velocity, -274 ** 0.5 * u.km / u.s, atol=1e-4 * u.km / u.s)
         assert_quantity_allclose(coord.redshift, -5.5213158163147646e-05, atol=1e-9)
     else:

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1461,6 +1461,9 @@ def test_values_equal_part1():
 
     tsk = table.table_helpers.simple_table()
     tsk['sk'] = SkyCoord(1, 2, unit='deg')
+    eqsk = tsk.values_equal(tsk)
+    for col in eqsk.itercols():
+        assert np.all(col)
 
     with pytest.raises(ValueError, match='cannot compare tables with different column names'):
         t2.values_equal(t1)
@@ -1476,8 +1479,6 @@ def test_values_equal_part1():
     with pytest.raises(ValueError, match='unable to compare column c'):
         t1.values_equal([1, 2])
 
-    with pytest.raises(TypeError, match='comparison for column sk'):
-        tsk.values_equal(tsk)
 
     eq = t2.values_equal(t2)
     for col in eq.colnames:

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -583,7 +583,7 @@ class WCSAxes(Axes):
                                             transform_world2pixel.frame_in) +
                         transform_world2pixel)
 
-        elif frame == 'pixel':
+        elif isinstance(frame, str) and frame == 'pixel':
 
             return Affine2D()
 
@@ -593,7 +593,7 @@ class WCSAxes(Axes):
 
         else:
 
-            if frame == 'world':
+            if isinstance(frame, str) and frame == 'world':
 
                 return self._transform_pixel2world
 

--- a/astropy/visualization/wcsaxes/transforms.py
+++ b/astropy/visualization/wcsaxes/transforms.py
@@ -66,18 +66,23 @@ class CoordinateTransform(CurvedTransform):
         self._output_system_name = output_system
 
         if isinstance(self._input_system_name, str):
-            self.input_system = frame_transform_graph.lookup_name(self._input_system_name)
-            if self.input_system is None:
+            frame_cls = frame_transform_graph.lookup_name(self._input_system_name)
+            if frame_cls is None:
                 raise ValueError(f"Frame {self._input_system_name} not found")
+            else:
+                self.input_system = frame_cls()
         elif isinstance(self._input_system_name, BaseCoordinateFrame):
             self.input_system = self._input_system_name
         else:
             raise TypeError("input_system should be a WCS instance, string, or a coordinate frame instance")
 
         if isinstance(self._output_system_name, str):
-            self.output_system = frame_transform_graph.lookup_name(self._output_system_name)
-            if self.output_system is None:
+            frame_cls = frame_transform_graph.lookup_name(self._output_system_name)
+            if frame_cls is None:
                 raise ValueError(f"Frame {self._output_system_name} not found")
+            else:
+                self.output_system = frame_cls()
+
         elif isinstance(self._output_system_name, BaseCoordinateFrame):
             self.output_system = self._output_system_name
         else:

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1100,6 +1100,56 @@ We use the same plotting setup as in the last example:
 ..
   EXAMPLE END
 
+Comparing Objects
+=================
+
+|SkyCoord| objects can be compared to each other like normal floats or numpy
+arrays, but there are some caveats you should understand. These comparisons are
+quite useful in testing for software development, but because of precision issues
+(see below) they are not typically helpful in science analysis where coordinate
+matching with a reasonable offset tolerance is required.
+
+In the first example we show simple comparisons using array-valued coordinates::
+
+  >>> sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
+  >>> sc2 = SkyCoord([1, 20]*u.deg, [3, 4]*u.deg)
+
+  >>> sc1 == sc2  # Array-valued comparison
+  array([ True, False])
+  >>> sc2 == sc2[1]  # Broadcasting comparison with a scalar
+  array([False,  True])
+  >>> sc2[0] == sc2[1]  # Scalar to scalar comparison
+  False
+  >>> sc1 != sc2  # Not equal
+  array([False,  True])
+
+In addition to numerically comparing the representation component data (which
+may include velocities), the equality comparison includes strict tests that all
+of the frame attributes like ``equinox`` or ``obstime`` are exactly equal.  Any
+mismatch in attributes will result in an exception being raised.  For example::
+
+  >>> sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
+  >>> sc2 = SkyCoord([1, 20]*u.deg, [3, 4]*u.deg, obstime='2020-01-01')
+  >>> sc1 == sc2  # doctest: +SKIP
+  ...
+  ValueError: cannot compare: extra frame attribute 'obstime' is not equivalent
+   (perhaps compare the frames directly to avoid this exception)
+
+In this example the ``obstime`` attribute is a so-called "extra" frame attribute
+that does not apply directly to the ICRS coordinate frame. So we could compare
+with::
+
+  >>> sc1.frame == sc2.frame
+  array([ True, False])
+
+The final point to note is that the comparison is made to full floating point
+precision, so any sort of transform will generally result in a ``False``
+comparison::
+
+  >>> sc1 = SkyCoord(1*u.deg, 2*u.deg, frame='fk4')
+  >>> sc1.icrs.fk4 == sc1
+  False
+
 Convenience Methods
 ===================
 

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1106,7 +1106,7 @@ Comparing Objects
 |SkyCoord| objects can be compared to each other like normal floats or numpy
 arrays, but there are some caveats you should understand. These comparisons are
 quite useful in testing for software development, but because of precision issues
-(see below) they are not typically helpful in science analysis where coordinate
+(see below) they may not helpful in science analysis where coordinate
 matching with a reasonable offset tolerance is required.
 
 In the first example we show simple comparisons using array-valued coordinates::
@@ -1141,6 +1141,14 @@ with::
 
   >>> sc1.frame == sc2.frame
   array([ True, False])
+
+One slightly special case is comparing two frames that both have no data, where
+the return value is the same as ``frame1.is_equivalent_frame(frame2)``. For
+example::
+
+  >>> from astropy.coordinates import FK4
+  >>> FK4() == FK4(obstime='2020-01-01')
+  False
 
 The final point to note is that the comparison is made to full floating point
 precision, so any sort of transform will generally result in a ``False``

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1132,10 +1132,10 @@ To test if coordinates are within a certain angular distance of one other, use t
 Exact Equality
 --------------
 
-Astropy also provides an exact equality operator for coordinates. 
+Astropy also provides an exact equality operator for coordinates.
 For example, when comparing, e.g., two |SkyCoord| objects::
 
-    >>> left_skycoord == right_skycoord
+    >>> left_skycoord == right_skycoord  # doctest: +SKIP
 
 the right object must be strictly consistent with the left object for
 comparison:

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1121,7 +1121,7 @@ FK4 => ICRS => FK4 and then compare::
 Matching Within Tolerance
 -------------------------
 
-To test if coordinates are within a certain distance of each other use the
+To test if coordinates are within a certain angular distance of one other, use the
 `~astropy.coordinates.SkyCoord.separation` method::
 
   >>> sc1.icrs.fk4.separation(sc1).to(u.arcsec)  # doctest: +SKIP
@@ -1132,8 +1132,12 @@ To test if coordinates are within a certain distance of each other use the
 Exact Equality
 --------------
 
-Astropy also provides an exact equality operator for coordinates. Specifically,
-the right hand ``value`` must be strictly consistent with the object for
+Astropy also provides an exact equality operator for coordinates. 
+For example, when comparing, e.g., two |SkyCoord| objects::
+
+    >>> left_skycoord == right_skycoord
+
+the right object must be strictly consistent with the left object for
 comparison:
 
 - Identical class

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -1103,7 +1103,7 @@ We use the same plotting setup as in the last example:
 Comparing SkyCoord Objects
 ==========================
 
-There are two primary ways to compare |SkyCoord| objects each other. First is
+There are two primary ways to compare |SkyCoord| objects to each other. First is
 checking if the coordinates are within a specified distance of each other. This
 is what most users should do in their science or processing analysis work
 because it allows for a tolerance due to floating point representation issues.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request implements a strict equality operator for coordinate classes `SkyCoord`, `BaseFrame`, `BaseRepresentationOrDifferential`, and `BaseRepresentation`.

Strict equality means that if any of the attributes don't match then an exception is raised.

The logic is inspired by #9857, having realized that this PR went most of the way to defining when these coordinate objects can be compared meaningfully using the representation data.

This will help in testing and bring consistency with the general numpy array interface.  In 4.0 one gets silly things like this:
```
>>> sc = SkyCoord([1,2], [3,4], unit='deg')
>>> sc2 = SkyCoord([1,2], [3,4], unit='deg')
>>> sc == sc2
False  # Should be [True, True]
>>> sc2 = SkyCoord(1, 3, unit='deg')
>>> sc = SkyCoord(1, 3, unit='deg')
>>> sc == sc2
False  # Should be True
```


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3182
