### PR TITLE
Fix SkyOffsetFrame wrap angle for data stored as non-spherical repres…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -365,6 +365,9 @@ astropy.coordinates
   the attributes also properly become scalars when indexed with 0.
   [#10113]
 
+- Ensure that the ``lon`` values in ``SkyOffsetFrame`` are wrapped correctly at
+  180 degree regardless of how the underlying data is represented. [#10163]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/builtin_frames/skyoffset.py
+++ b/astropy/coordinates/builtin_frames/skyoffset.py
@@ -179,5 +179,20 @@ class SkyOffsetFrame(BaseCoordinateFrame):
         if self.origin is not None and not self.origin.has_data:
             raise ValueError('The origin supplied to SkyOffsetFrame has no '
                              'data.')
-        if self.has_data and hasattr(self.data, 'lon'):
-            self.data.lon.wrap_angle = 180*u.deg
+        if self.has_data:
+            self._set_skyoffset_data_lon_wrap_angle(self.data)
+
+    @staticmethod
+    def _set_skyoffset_data_lon_wrap_angle(data):
+        if hasattr(data, 'lon'):
+            data.lon.wrap_angle = 180. * u.deg
+        return data
+
+    def represent_as(self, base, s='base', in_frame_units=False):
+        """
+        Ensure the wrap angle for any spherical
+        representations.
+        """
+        data = super().represent_as(base, s, in_frame_units=in_frame_units)
+        self._set_skyoffset_data_lon_wrap_angle(data)
+        return data

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -290,6 +290,15 @@ def test_skyoffset_lonwrap():
     sc = SkyCoord(190*u.deg, -45*u.deg, frame=SkyOffsetFrame(origin=origin))
     assert sc.lon < 180 * u.deg
 
+    sc2 = SkyCoord(-10*u.deg, -45*u.deg, frame=SkyOffsetFrame(origin=origin))
+    assert sc2.lon < 180 * u.deg
+
+    sc3 = sc.realize_frame(sc.represent_as('cartesian'))
+    assert sc3.lon < 180 * u.deg
+
+    sc4 = sc2.realize_frame(sc2.represent_as('cartesian'))
+    assert sc4.lon < 180 * u.deg
+
 
 def test_skyoffset_velocity():
     c = ICRS(ra=170.9*u.deg, dec=-78.4*u.deg,


### PR DESCRIPTION
…entation.

<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

It is observed that when a coordinate in SkyOffsetFrame is created with data of non-spherical data representation type (e.g., cartesian), the `lon` values does not wrap correctly around 180 degree.
 
This pull request is to address this issue by following the discussion and information in #7462. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

