### PR TITLE
EXP: Pin pytest-openfiles in old deps job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -66,6 +66,7 @@ deps =
     oldestdeps: matplotlib==2.1.*
     oldestdeps: asdf==2.4.*
     oldestdeps: scipy==0.18.*
+    oldestdeps: pytest-openfiles==0.4.0
 
     # The devdeps factor is intended to be used to install the latest developer version
     # of key dependencies.

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,8 @@ deps =
     image: pytest-mpl
 
     # The oldestdeps factor is intended to be used to install the oldest versions of all
-    # dependencies that have a minimum version
+    # dependencies that have a minimum version.
+    # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160
     oldestdeps: numpy==1.16.*
     oldestdeps: matplotlib==2.1.*
     oldestdeps: asdf==2.4.*


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address Travis CI failure related to old dependencies.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10160

**Note to reviewer:** Please also check remote data job on Travis CI that is allowed to fail.