### PR TITLE
Avoid crash when reading data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -389,6 +389,8 @@ astropy.io.fits
 - Fix unclosed memory-mapped FITS files in ``FITSDiff`` when difference found.
   [#10159]
 
+- Fix crash when reading an invalid table file. [#10171]
+
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -1467,16 +1467,17 @@ class ColDefs(NotifierMixin):
         # go through header keywords to pick out column definition keywords
         # definition dictionaries for each field
         col_keywords = [{} for i in range(nfields)]
-        for keyword, value in hdr.items():
+        for keyword in hdr:
             key = TDEF_RE.match(keyword)
             try:
-                keyword = key.group('label')
+                label = key.group('label')
             except Exception:
                 continue  # skip if there is no match
-            if keyword in KEYWORD_NAMES:
+            if label in KEYWORD_NAMES:
                 col = int(key.group('num'))
                 if 0 < col <= nfields:
-                    attr = KEYWORD_TO_ATTRIBUTE[keyword]
+                    attr = KEYWORD_TO_ATTRIBUTE[label]
+                    value = hdr[keyword]
                     if attr == 'format':
                         # Go ahead and convert the format value to the
                         # appropriate ColumnFormat container now

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3344,3 +3344,15 @@ def test_a3dtable(tmpdir):
             'Converted the XTENSION keyword to BINTABLE.')
 
         assert hdul[1].header['XTENSION'] == 'BINTABLE'
+
+
+def test_invalid_file(tmp_path):
+    hdu = fits.BinTableHDU()
+    # little trick to write an invalid card ...
+    hdu.header['FOO'] = None
+    hdu.header.cards['FOO']._value = np.nan
+
+    testfile = tmp_path / 'test.fits'
+    hdu.writeto(testfile, output_verify='ignore')
+    hdul = fits.open(testfile)
+    assert hdul[1].data is not None

--- a/astropy/io/fits/tests/test_table.py
+++ b/astropy/io/fits/tests/test_table.py
@@ -3354,5 +3354,5 @@ def test_invalid_file(tmp_path):
 
     testfile = tmp_path / 'test.fits'
     hdu.writeto(testfile, output_verify='ignore')
-    hdul = fits.open(testfile)
-    assert hdul[1].data is not None
+    with fits.open(testfile) as hdul:
+        assert hdul[1].data is not None


### PR DESCRIPTION
To avoid crash like in #10153, this invalid should trigger a validation warning or error later but not when reading the data.
See also https://github.com/astropy/astropy/pull/10165#issuecomment-616018021 and my commit comment below, hopefully this is clear enough (but it's late :)).

Reading data for a table uses a loop on all header keywords and
values, so if a value is invalid this triggers an exception. This can be
avoided by looping only on keywords, and reading values only for the
structural keywords. This makes the behavior more consistent with other
HDU classes, and delay the verification errors.
