### PR TITLE
Replace submodel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@ astropy.modeling
 - Polynomial attributes ``domain`` and ``window`` are now tuples of size 2 and are
   validated. `repr` and `print` show only their non-default values. [#10145]
 
+- Added ``replace_submodel()`` method to ``CompoundModel`` to modify an
+  existing instance. [#10176]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -19,6 +19,9 @@ In particular, this release includes:
 
 2. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
 
+3. Ability to create a new ``CompoundModel`` by modifying an existing one
+   with the ``replace_submodel`` method.
+
 
 Support for writing Dask arrays to FITS files
 =============================================


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address some of the difficulties modifying `CompoundModel` instances. There's a need to do this in `gwcs`, for example updating the model describing the wavelength solution, but I think it has more general uses so should be part of `modeling`. The replacement need not have the same length as the thing it's replacing, but the number of inputs and outputs will need to match.

Here's a very simple example:
```
S1 = Shift(2, name='shift2') | Scale(3, name='scale3')  # First shift then scale
S2 = Scale(2, name='scale2') | Shift(3, name='shift3')  # First scale then shift
S1.name = 'S1'
m = S1 & S2
assert m(1, 2) == (9, 7)
m2 = m.replace_submodel('shift2', Shift(4))
assert m2(1, 2) == (15, 7)
m3 = m.replace_submodel('S1', Identity(1))
assert m3(1, 2) == (1, 7)
assert m3.inverse(1, 7) == (1, 2)
```
Note that, even though m2 replaced part of "S1", the name was propagated into the new compound model, allowing us to replace it.

This has possible connections to #9888. (*edit: fixed link*)