### PR TITLE
Add parameter restrictions in visualization stretch classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -235,6 +235,19 @@ astropy.visualization
 - Deprecated the ``imshow_only_kwargs`` keyword in ``imshow_norm``.
   [#9915]
 
+- Non-finite input values are now automatically excluded in
+  ``HistEqStretch`` and ``InvertedHistEqStretch``. [#10177]
+
+- The ``PowerDistStretch`` and ``InvertedPowerDistStretch`` ``a``
+  value is restricted to be ``a >= 0`` in addition to ``a != 1``.
+  [#10177]
+
+- The ``PowerStretch``, ``LogStretch``, and ``InvertedLogStretch``
+  ``a`` value is restricted to be ``a > 0``. [#10177]
+
+- The ``AsinhStretch`` and ``SinhStretch`` ``a`` value is restricted
+  to be ``0 < a <= 1``. [#10177]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -151,7 +151,8 @@ class PowerStretch(BaseStretch):
     Parameters
     ----------
     a : float
-        The power index (see the above formula).  ``a`` must be > 0.
+        The power index (see the above formula).  ``a`` must be greater
+        than 0.
     """
 
     def __init__(self, a):
@@ -183,8 +184,9 @@ class PowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be >=
-        0, but cannot be set to 1.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be
+        greater than or equal to 0, but cannot be set to 1.  Default is
+        1000.
     """
 
     def __init__(self, a=1000.0):
@@ -219,8 +221,9 @@ class InvertedPowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be >=
-        0, but cannot be set to 1.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be
+        greater than or equal to 0, but cannot be set to 1.  Default is
+        1000.
     """
 
     def __init__(self, a=1000.0):
@@ -273,8 +276,8 @@ class LogStretch(BaseStretch):
     Parameters
     ----------
     a : float
-        The ``a`` parameter used in the above formula.  ``a`` must be >
-        0.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be
+        greater than 0.  Default is 1000.
     """
 
     def __init__(self, a=1000.0):
@@ -310,8 +313,8 @@ class InvertedLogStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be >
-        0.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be
+        greater than 0.  Default is 1000.
     """
 
     def __init__(self, a):
@@ -349,8 +352,8 @@ class AsinhStretch(BaseStretch):
         The ``a`` parameter used in the above formula.  The value of
         this parameter is where the asinh curve transitions from linear
         to logarithmic behavior, expressed as a fraction of the
-        normalized image.  ``a`` must be in the range 0 < a <= 1.
-        Default is 0.1.
+        normalized image.  ``a`` must be greater than 0 and less than or
+        equal to 1 (0 < a <= 1).  Default is 0.1.
     """
 
     def __init__(self, a=0.1):
@@ -384,8 +387,9 @@ class SinhStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  ``a`` must be in
-        the range 0 < a <= 1.  Default is 1/3.
+        The ``a`` parameter used in the above formula.  ``a`` must be
+        greater than 0 and less than or equal to 1 (0 < a <= 1).
+        Default is 1/3.
     """
 
     def __init__(self, a=1./3.):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -419,9 +419,9 @@ class HistEqStretch(BaseStretch):
     """
 
     def __init__(self, data, values=None):
-
         # Assume data is not necessarily normalized at this point
         self.data = np.sort(data.ravel())
+        self.data = self.data[np.isfinite(self.data)]
         vmin = self.data.min()
         vmax = self.data.max()
         self.data = (self.data - vmin) / (vmax - vmin)
@@ -457,7 +457,7 @@ class InvertedHistEqStretch(BaseStretch):
     """
 
     def __init__(self, data, values=None):
-        self.data = data
+        self.data = data[np.isfinite(data)]
         if values is None:
             self.values = np.linspace(0., 1., len(self.data))
         else:

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -347,12 +347,14 @@ class AsinhStretch(BaseStretch):
         The ``a`` parameter used in the above formula.  The value of
         this parameter is where the asinh curve transitions from linear
         to logarithmic behavior, expressed as a fraction of the
-        normalized image.  Must be in the range between 0 and 1.
-        Default is 0.1
+        normalized image.  ``a`` must be in the range 0 < a <= 1.
+        Default is 0.1.
     """
 
     def __init__(self, a=0.1):
         super().__init__()
+        if a <= 0 or a > 1:
+            raise ValueError("a must be > 0 and <= 1")
         self.a = a
 
     def __call__(self, values, clip=True, out=None):
@@ -380,11 +382,14 @@ class SinhStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  Default is 1/3.
+        The ``a`` parameter used in the above formula.  ``a`` must be in
+        the range 0 < a <= 1.  Default is 1/3.
     """
 
     def __init__(self, a=1./3.):
         super().__init__()
+        if a <= 0 or a > 1:
+            raise ValueError("a must be > 0 and <= 1")
         self.a = a
 
     def __call__(self, values, clip=True, out=None):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -151,11 +151,13 @@ class PowerStretch(BaseStretch):
     Parameters
     ----------
     a : float
-        The power index (see the above formula).
+        The power index (see the above formula).  ``a`` must be > 0.
     """
 
     def __init__(self, a):
         super().__init__()
+        if a <= 0:
+            raise ValueError("a must be > 0")
         self.power = a
 
     def __call__(self, values, clip=True, out=None):

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -181,13 +181,13 @@ class PowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  Default is 1000.
-        ``a`` cannot be set to 1.
+        The ``a`` parameter used in the above formula.  ``a`` must be >=
+        0, but cannot be set to 1.  Default is 1000.
     """
 
     def __init__(self, a=1000.0):
-        if a == 1:  # singularity
-            raise ValueError("a cannot be set to 1")
+        if a < 0 or a == 1:  # singularity
+            raise ValueError("a must be >= 0, but cannot be set to 1")
         super().__init__()
         self.exp = a
 
@@ -217,13 +217,13 @@ class InvertedPowerDistStretch(BaseStretch):
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  Default is 1000.
-        ``a`` cannot be set to 1.
+        The ``a`` parameter used in the above formula.  ``a`` must be >=
+        0, but cannot be set to 1.  Default is 1000.
     """
 
     def __init__(self, a=1000.0):
-        if a == 1:  # singularity
-            raise ValueError("a cannot be set to 1")
+        if a < 0 or a == 1:  # singularity
+            raise ValueError("a must be >= 0, but cannot be set to 1")
         super().__init__()
         self.exp = a
 

--- a/astropy/visualization/stretch.py
+++ b/astropy/visualization/stretch.py
@@ -266,16 +266,19 @@ class LogStretch(BaseStretch):
     The stretch is given by:
 
     .. math::
-        y = \frac{\log{(a x + 1)}}{\log{(a + 1)}}.
+        y = \frac{\log{(a x + 1)}}{\log{(a + 1)}}
 
     Parameters
     ----------
     a : float
-        The ``a`` parameter used in the above formula.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be >
+        0.  Default is 1000.
     """
 
     def __init__(self, a=1000.0):
         super().__init__()
+        if a <= 0:  # singularity
+            raise ValueError("a must be > 0")
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):
@@ -299,16 +302,20 @@ class InvertedLogStretch(BaseStretch):
     The stretch is given by:
 
     .. math::
-        y = \frac{e^{y} (a + 1) -1}{a}
+        y = \frac{e^{y \log{a + 1}} - 1}{a} \\
+        y = \frac{e^{y} (a + 1) - 1}{a}
 
     Parameters
     ----------
     a : float, optional
-        The ``a`` parameter used in the above formula.  Default is 1000.
+        The ``a`` parameter used in the above formula.  ``a`` must be >
+        0.  Default is 1000.
     """
 
     def __init__(self, a):
         super().__init__()
+        if a <= 0:  # singularity
+            raise ValueError("a must be > 0")
         self.exp = a
 
     def __call__(self, values, clip=True, out=None):

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -2,6 +2,7 @@
 
 import pytest
 import numpy as np
+from numpy.testing import assert_equal
 
 from astropy.visualization.stretch import (LinearStretch, SqrtStretch,
                                            PowerStretch, PowerDistStretch,
@@ -9,7 +10,9 @@ from astropy.visualization.stretch import (LinearStretch, SqrtStretch,
                                            SquaredStretch, LogStretch,
                                            InvertedLogStretch,
                                            AsinhStretch, SinhStretch,
-                                           HistEqStretch, ContrastBiasStretch)
+                                           HistEqStretch,
+                                           InvertedHistEqStretch,
+                                           ContrastBiasStretch)
 
 
 DATA = np.array([0.00, 0.25, 0.50, 0.75, 1.00])
@@ -137,3 +140,10 @@ def test_invalid_sinh_a(a):
         AsinhStretch(a=a)
     with pytest.raises(ValueError, match=match):
         SinhStretch(a=a)
+
+
+def test_histeqstretch_invalid():
+    data = np.array([-np.inf, 0.00, 0.25, 0.50, 0.75, 1.00, np.inf])
+    result = np.array([0.0, 0.0, 0.25, 0.5, 0.75, 1.0, 1.0])
+    assert_equal(HistEqStretch(data)(data), result)
+    assert_equal(InvertedHistEqStretch(data)(data), result)

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -5,7 +5,9 @@ import numpy as np
 
 from astropy.visualization.stretch import (LinearStretch, SqrtStretch,
                                            PowerStretch, PowerDistStretch,
+                                           InvertedPowerDistStretch,
                                            SquaredStretch, LogStretch,
+                                           InvertedLogStretch,
                                            AsinhStretch, SinhStretch,
                                            HistEqStretch, ContrastBiasStretch)
 
@@ -106,3 +108,29 @@ def test_clip_invalid():
 
     values = stretch([-1., 0., 0.5, 1., 1.5], clip=False)
     np.testing.assert_allclose(values, [np.nan, 0., 0.70710678, 1., 1.2247448])
+
+
+@pytest.mark.parametrize('a', [-2., -1, 1.])
+def test_invalid_powerdist_a(a):
+    with pytest.raises(ValueError):
+        PowerDistStretch(a=a)
+    with pytest.raises(ValueError):
+        InvertedPowerDistStretch(a=a)
+
+
+@pytest.mark.parametrize('a', [-2., -1, 0.])
+def test_invalid_power_log_a(a):
+    with pytest.raises(ValueError):
+        PowerStretch(a=a)
+    with pytest.raises(ValueError):
+        LogStretch(a=a)
+    with pytest.raises(ValueError):
+        InvertedLogStretch(a=a)
+
+
+@pytest.mark.parametrize('a', [-2., -1, 0., 1.5])
+def test_invalid_sinh_a(a):
+    with pytest.raises(ValueError):
+        AsinhStretch(a=a)
+    with pytest.raises(ValueError):
+        SinhStretch(a=a)

--- a/astropy/visualization/tests/test_stretch.py
+++ b/astropy/visualization/tests/test_stretch.py
@@ -112,25 +112,28 @@ def test_clip_invalid():
 
 @pytest.mark.parametrize('a', [-2., -1, 1.])
 def test_invalid_powerdist_a(a):
-    with pytest.raises(ValueError):
+    match = 'a must be >= 0, but cannot be set to 1'
+    with pytest.raises(ValueError, match=match):
         PowerDistStretch(a=a)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         InvertedPowerDistStretch(a=a)
 
 
 @pytest.mark.parametrize('a', [-2., -1, 0.])
 def test_invalid_power_log_a(a):
-    with pytest.raises(ValueError):
+    match = 'a must be > 0'
+    with pytest.raises(ValueError, match=match):
         PowerStretch(a=a)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         LogStretch(a=a)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         InvertedLogStretch(a=a)
 
 
 @pytest.mark.parametrize('a', [-2., -1, 0., 1.5])
 def test_invalid_sinh_a(a):
-    with pytest.raises(ValueError):
+    match = 'a must be > 0 and <= 1'
+    with pytest.raises(ValueError, match=match):
         AsinhStretch(a=a)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=match):
         SinhStretch(a=a)


### PR DESCRIPTION
This PR adds several parameter restrictions in the visualization `Stretch` classes to avoid generating NaN, inf (e.g. 1/0), etc.  Such values of `a` are not useful and can cause issues with mpl normalization.

* The `PowerDistStretch` and `InvertedPowerDistStretch` `a` value must be >= 0, but not cannot be 1.

* The ``PowerStretch``, ``LogStretch``, and ``InvertedLogStretch`` ``a`` value is restricted to be ``a > 0``.  For the `PowerStretch`, issues can arise using the `np.power` function with a negative or zero base and a negative exponent (`a`).

* The ``AsinhStretch`` and ``SinhStretch`` ``a`` value is restricted to be ``0 < a <= 1``.

A `ValueError` is raised for invalid `a` values.

Also, this PR automatically masks non-finite input values in `HistEqStretch` and `InvertedHistEqStretch`.  Previously, non-finite values resulted in useless normalization values.