### PR TITLE
Adding docs build env for osx

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy116,-numpy117,-numpy118}{,-cov}
-    build_docs
+    build_docs{_osx}
     linkcheck
     codestyle
 requires =
@@ -93,6 +93,16 @@ extras = docs
 commands =
     pip freeze
     sphinx-build -W -b html . _build/html
+
+
+[testenv:build_docs_osx]
+changedir = docs
+description = invoke sphinx-build to build the HTML docs
+extras = docs
+commands =
+    pip freeze
+    sphinx-build -b html . _build/html
+
 
 [testenv:linkcheck]
 changedir = docs


### PR DESCRIPTION
osx is case insensitive thus we always get warnings for ``m_bol`` and ``M_bol``. This PR thus adds a new tox env to handle it.

Alternative: create a `build_docs_strict` that has the `-W` and being the one CI runs. pro: more convenient for osx users, con: folks will be surprised why the docs build works for them locally while it fails on CI.

Close #10026

