### PR TITLE
Support circular references in ASDF-serialized models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,9 @@ astropy.io.misc
 ^^^^^^^^^^^^^^^
 - Added serialization of parameter constraints fixed and bounds.  [#10082]
 
+- Fix ASDF serialization of circular model inverses, and remove explicit calls
+  to ``asdf.yamlutil`` functions that because unnecssary in asdf 2.6.0. [#10189]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -343,7 +346,7 @@ Other Changes and Additions
 
 - Bundled ``expat`` is updated to version 2.2.9. [#10038]
 
-
+- Increase minimum asdf version to 2.6.0. [#10189]
 
 4.0.2 (unreleased)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ astropy.io.misc
 - Added serialization of parameter constraints fixed and bounds.  [#10082]
 
 - Fix ASDF serialization of circular model inverses, and remove explicit calls
-  to ``asdf.yamlutil`` functions that because unnecssary in asdf 2.6.0. [#10189]
+  to ``asdf.yamlutil`` functions that became unnecessary in asdf 2.6.0. [#10189]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^

--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -17,7 +17,7 @@ __minimum_numpy_version__ = '1.16.0'
 __minimum_scipy_version__ = '0.18'
 # ASDF is an optional dependency, but this is the minimum version that is
 # compatible with Astropy when it is installed.
-__minimum_asdf_version__ = '2.5.2'
+__minimum_asdf_version__ = '2.6.0'
 
 
 class UnsupportedPythonError(Exception):

--- a/astropy/io/misc/asdf/tags/coordinates/angle.py
+++ b/astropy/io/misc/asdf/tags/coordinates/angle.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf.yamlutil import custom_tree_to_tagged_tree
 from astropy.coordinates import Angle, Latitude, Longitude
 
 from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
@@ -44,6 +43,6 @@ class LongitudeType(AngleType):
     @classmethod
     def to_tree(cls, longitude, ctx):
         tree = super().to_tree(longitude, ctx)
-        tree['wrap_angle'] = custom_tree_to_tagged_tree(longitude.wrap_angle, ctx)
+        tree['wrap_angle'] = longitude.wrap_angle
 
         return tree

--- a/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/earthlocation.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-from asdf.yamlutil import custom_tree_to_tagged_tree
-
 from astropy.coordinates import EarthLocation
 
 from ...types import AstropyType
@@ -15,7 +12,7 @@ class EarthLocationType(AstropyType):
 
     @classmethod
     def to_tree(cls, obj, ctx):
-        return custom_tree_to_tagged_tree(obj.info._represent_as_dict(), ctx)
+        return obj.info._represent_as_dict()
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -4,7 +4,6 @@ import os
 import glob
 
 from asdf import tagged
-from asdf.yamlutil import custom_tree_to_tagged_tree
 
 import astropy.units as u
 import astropy.coordinates
@@ -85,13 +84,13 @@ class BaseCoordType:
 
         node = {}
         if frame.has_data:
-            node['data'] = custom_tree_to_tagged_tree(frame.data, ctx)
+            node['data'] = frame.data
         frame_attributes = {}
         for attr in frame.frame_attributes.keys():
             value = getattr(frame, attr, None)
             if value is not None:
                 frame_attributes[attr] = value
-        node['frame_attributes'] = custom_tree_to_tagged_tree(frame_attributes, ctx)
+        node['frame_attributes'] = frame_attributes
 
         return tagged.tag_object(cls._frame_name_to_tag(frame.name), node, ctx=ctx)
 
@@ -129,8 +128,7 @@ class ICRSType10(AstropyType):
 
     @classmethod
     def from_tree(cls, node, ctx):
-        angle = Angle(QuantityType.from_tree(node['ra']['wrap_angle'], ctx))
-        wrap_angle = Angle(angle)
+        wrap_angle = Angle(node['ra']['wrap_angle'])
         ra = Longitude(
             node['ra']['value'],
             unit=node['ra']['unit'],
@@ -147,7 +145,7 @@ class ICRSType10(AstropyType):
         node['ra'] = {
             'value': frame.ra.value,
             'unit': frame.ra.unit.to_string(),
-            'wrap_angle': custom_tree_to_tagged_tree(wrap_angle, ctx)
+            'wrap_angle': wrap_angle
         }
         node['dec'] = {
             'value': frame.dec.value,

--- a/astropy/io/misc/asdf/tags/coordinates/representation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/representation.py
@@ -1,5 +1,3 @@
-from asdf.yamlutil import custom_tree_to_tagged_tree
-
 import astropy.units as u
 import astropy.coordinates.representation
 from astropy.coordinates.representation import BaseRepresentationOrDifferential
@@ -27,7 +25,7 @@ class RepresentationType(AstropyType):
 
         node = {}
         node['type'] = t.__name__
-        node['components'] = custom_tree_to_tagged_tree(components, ctx)
+        node['components'] = components
 
         return node
 

--- a/astropy/io/misc/asdf/tags/coordinates/skycoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/skycoord.py
@@ -1,8 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-from asdf.yamlutil import custom_tree_to_tagged_tree
-
 from astropy.coordinates import SkyCoord
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
@@ -16,7 +13,7 @@ class SkyCoordType(AstropyType):
 
     @classmethod
     def to_tree(cls, obj, ctx):
-        return custom_tree_to_tagged_tree(obj.info._represent_as_dict(), ctx)
+        return obj.info._represent_as_dict()
 
     @classmethod
     def from_tree(cls, tree, ctx):

--- a/astropy/io/misc/asdf/tags/fits/fits.py
+++ b/astropy/io/misc/asdf/tags/fits/fits.py
@@ -4,8 +4,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
-
 from astropy import table
 from astropy.io import fits
 from astropy.io.misc.asdf.types import AstropyType, AstropyAsdfType
@@ -64,7 +62,7 @@ class FitsType:
                     data = table.Table(hdu.data)
                 else:
                     data = hdu.data
-                hdu_dict['data'] = yamlutil.custom_tree_to_tagged_tree(data, ctx)
+                hdu_dict['data'] = data
 
             units.append(hdu_dict)
 

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -4,7 +4,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
 from asdf.versioning import AsdfSpec
 
 from astropy import time
@@ -61,7 +60,7 @@ class TimeType(AstropyAsdfType):
         if node.scale == 'utc' and guessable_format and node.isscalar:
             return node.value
 
-        d = {'value': yamlutil.custom_tree_to_tagged_tree(node.value, ctx)}
+        d = {'value': node.value}
 
         if not guessable_format:
             d['format'] = fmt
@@ -80,16 +79,16 @@ class TimeType(AstropyAsdfType):
                     'x': x.value,
                     'y': y.value,
                     'z': z.value,
-                    'unit': yamlutil.custom_tree_to_tagged_tree(unit, ctx)
+                    'unit': unit
                 }
             else:
                 d['location'] = {
                     # It seems like EarthLocations can be represented either in
                     # terms of Cartesian coordinates or latitude and longitude, so
                     # we rather arbitrarily choose the former for our representation
-                    'x': yamlutil.custom_tree_to_tagged_tree(x, ctx),
-                    'y': yamlutil.custom_tree_to_tagged_tree(y, ctx),
-                    'z': yamlutil.custom_tree_to_tagged_tree(z, ctx)
+                    'x': x,
+                    'y': y,
+                    'z': z
                 }
 
         return d

--- a/astropy/io/misc/asdf/tags/time/timedelta.py
+++ b/astropy/io/misc/asdf/tags/time/timedelta.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import functools
 
-from asdf.yamlutil import custom_tree_to_tagged_tree
 import numpy as np
 
 from astropy.time import TimeDelta
@@ -25,7 +24,7 @@ class TimeDeltaType(AstropyType):
 
     @classmethod
     def to_tree(cls, obj, ctx):
-        return custom_tree_to_tagged_tree(obj.info._represent_as_dict(), ctx)
+        return obj.info._represent_as_dict()
 
     @classmethod
     def from_tree(cls, node, ctx):

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -1,7 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf import tagged, yamlutil
+from asdf import tagged
 
 from astropy.modeling import models, mappings
 from astropy.utils import minversion
@@ -20,14 +20,13 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def _from_tree_base_transform_members(cls, model, node, ctx):
         if 'inverse' in node:
-            model.inverse = yamlutil.tagged_tree_to_custom_tree(
-                node['inverse'], ctx)
+            model.inverse = node['inverse']
 
         if 'name' in node:
-            model = model.rename(node['name'])
+            model.name = node['name']
 
         if 'bounding_box' in node:
-            model.bounding_box = yamlutil.tagged_tree_to_custom_tree(node['bounding_box'], ctx)
+            model.bounding_box = node['bounding_box']
 
         if "inputs" in node:
             if model.n_inputs == 1:
@@ -57,13 +56,13 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def from_tree(cls, node, ctx):
         model = cls.from_tree_transform(node, ctx)
-        model = cls._from_tree_base_transform_members(model, node, ctx)
-        return model
+        yield model
+        cls._from_tree_base_transform_members(model, node, ctx)
 
     @classmethod
     def _to_tree_base_transform_members(cls, model, node, ctx):
         if getattr(model, '_user_inverse', None) is not None:
-            node['inverse'] = yamlutil.custom_tree_to_tagged_tree(model._user_inverse, ctx)
+            node['inverse'] = model._user_inverse
 
         if model.name is not None:
             node['name'] = model.name
@@ -78,7 +77,7 @@ class TransformType(AstropyAsdfType):
                 bb = list(bb)
             else:
                 bb = [list(item) for item in model.bounding_box]
-            node['bounding_box'] = yamlutil.custom_tree_to_tagged_tree(bb, ctx)
+            node['bounding_box'] = bb
         if type(model.__class__.inputs) != property:
             node['inputs'] = model.inputs
             node['outputs'] = model.outputs
@@ -86,7 +85,7 @@ class TransformType(AstropyAsdfType):
         # model / parameter constraints
         node['fixed'] = dict(model.fixed)
         node['bounds'] = dict(model.bounds)
-        
+
     @classmethod
     def to_tree_transform(cls, model, ctx):
         raise NotImplementedError("Must be implemented in TransformType subclasses")
@@ -193,16 +192,16 @@ class UnitsMappingType(AstropyType):
                 "allow_dimensionless": node.input_units_allow_dimensionless[i],
             }
             if m[0] is not None:
-                input["unit"] = yamlutil.custom_tree_to_tagged_tree(m[0], ctx)
+                input["unit"] = m[0]
             if node.input_units_equivalencies is not None and i in node.input_units_equivalencies:
-                input["equivalencies"] = yamlutil.custom_tree_to_tagged_tree(node.input_units_equivalencies[i], ctx)
+                input["equivalencies"] = node.input_units_equivalencies[i]
             inputs.append(input)
 
             output = {
                 "name": o,
             }
             if m[-1] is not None:
-                output["unit"] = yamlutil.custom_tree_to_tagged_tree(m[-1], ctx)
+                output["unit"] = m[-1]
             outputs.append(output)
 
         tree["inputs"] = inputs
@@ -220,7 +219,7 @@ class UnitsMappingType(AstropyType):
             if "equivalencies" in i:
                 if equivalencies is None:
                     equivalencies = {}
-                equivalencies[i["name"]] = yamlutil.tagged_tree_to_custom_tree(i["equivalencies"], ctx)
+                equivalencies[i["name"]] = i["equivalencies"]
 
         kwargs = {
             "input_units_equivalencies": equivalencies,

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -120,7 +120,7 @@ class RemapAxesType(TransformType):
                 new_mapping.append(entry)
             else:
                 new_mapping.append(i)
-                transform = transform & Const1D(int(entry.value))
+                transform = transform & Const1D(entry.value)
                 i += 1
         return transform | Mapping(new_mapping)
 

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -1,15 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-
-
-from asdf.yamlutil import tagged_tree_to_custom_tree
-
 from asdf import tagged
-from asdf import yamlutil
 from asdf.tests.helpers import assert_tree_match
-from .basic import TransformType, ConstantType
+from .basic import TransformType
 from astropy.modeling.core import Model, CompoundModel
-from astropy.modeling.models import Identity, Mapping
+from astropy.modeling.models import Identity, Mapping, Const1D
 
 
 __all__ = ['CompoundType', 'RemapAxesType']
@@ -50,13 +45,11 @@ class CompoundType(TransformType):
         tag = node._tag[node._tag.rfind('/')+1:]
         tag = tag[:tag.rfind('-')]
         oper = _tag_to_method_mapping[tag]
-        left = yamlutil.tagged_tree_to_custom_tree(
-            node['forward'][0], ctx)
+        left = node['forward'][0]
         if not isinstance(left, Model):
             raise TypeError("Unknown model type '{0}'".format(
                 node['forward'][0]._tag))
-        right = yamlutil.tagged_tree_to_custom_tree(
-            node['forward'][1], ctx)
+        right = node['forward'][1]
         if not isinstance(right, Model) and \
             not (oper == 'fix_inputs' and isinstance(right, dict)):
             raise TypeError("Unknown model type '{0}'".format(
@@ -67,44 +60,32 @@ class CompoundType(TransformType):
         else:
             model = getattr(left, oper)(right)
 
-        model = cls._from_tree_base_transform_members(model, node, ctx)
-        return model
+        yield model
+
+        cls._from_tree_base_transform_members(model, node, ctx)
 
     @classmethod
-    def _to_tree_from_model_tree(cls, tree, ctx):
+    def to_tree_tagged(cls, model, ctx):
+        left = model.left
 
-        if not isinstance(tree.left, CompoundModel):
-            left = yamlutil.custom_tree_to_tagged_tree(
-                tree.left, ctx)
+        if isinstance(model.right, dict):
+            right = {
+                'keys': list(model.right.keys()),
+                'values': list(model.right.values())
+            }
         else:
-            left = cls._to_tree_from_model_tree(tree.left, ctx)
-
-        if not isinstance(tree.right, CompoundModel):
-            if isinstance(tree.right, dict):
-                right = {'keys': list(tree.right.keys()),
-                         'values': list(tree.right.values())
-                        }
-            else:
-                right = yamlutil.custom_tree_to_tagged_tree(
-                    tree.right, ctx)
-        else:
-            right = cls._to_tree_from_model_tree(tree.right, ctx)
+            right = model.right
 
         node = {
             'forward': [left, right]
         }
 
         try:
-            tag_name = 'transform/' + _operator_to_tag_mapping[tree.op]
+            tag_name = 'transform/' + _operator_to_tag_mapping[model.op]
         except KeyError:
-            raise ValueError(f"Unknown operator '{tree.op}'")
+            raise ValueError(f"Unknown operator '{model.op}'")
 
         node = tagged.tag_object(cls.make_yaml_tag(tag_name), node, ctx=ctx)
-        return node
-
-    @classmethod
-    def to_tree_tagged(cls, model, ctx):
-        node = cls._to_tree_from_model_tree(model, ctx)
         cls._to_tree_base_transform_members(model, node, ctx)
         return node
 
@@ -139,8 +120,7 @@ class RemapAxesType(TransformType):
                 new_mapping.append(entry)
             else:
                 new_mapping.append(i)
-                transform = transform & ConstantType.from_tree(
-                    {'value': int(entry.value)}, ctx)
+                transform = transform & Const1D(int(entry.value))
                 i += 1
         return transform | Mapping(new_mapping)
 

--- a/astropy/io/misc/asdf/tags/transform/math.py
+++ b/astropy/io/misc/asdf/tags/transform/math.py
@@ -3,8 +3,6 @@
 
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
-
 from astropy import modeling
 from astropy.modeling.math_functions import __all__ as math_classes
 from astropy.modeling.math_functions import *
@@ -28,5 +26,4 @@ class NpUfuncType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'func_name': model.func.__name__}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return {'func_name': model.func.__name__}

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -4,7 +4,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
 from asdf.versioning import AsdfVersion
 
 import astropy.units as u
@@ -32,8 +31,7 @@ class ShiftType(TransformType):
     @classmethod
     def to_tree_transform(cls, model, ctx):
         offset = model.offset
-        node = {'offset': _parameter_to_value(offset)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return {'offset': _parameter_to_value(offset)}
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -61,8 +59,7 @@ class ScaleType(TransformType):
     @classmethod
     def to_tree_transform(cls, model, ctx):
         factor = model.factor
-        node = {'factor': _parameter_to_value(factor)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return {'factor': _parameter_to_value(factor)}
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -86,8 +83,7 @@ class MultiplyType(TransformType):
     @classmethod
     def to_tree_transform(cls, model, ctx):
         factor = model.factor
-        node = {'factor': _parameter_to_value(factor)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return  {'factor': _parameter_to_value(factor)}
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -173,7 +169,7 @@ class PolynomialTypeBase(TransformType):
                 if model.x_window or model.y_window is not None:
                     node['window'] = (model.x_window, model.y_window)
 
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -283,8 +279,7 @@ class OrthoPolynomialType(TransformType):
                 node['domain'] = (model.x_domain, model.y_domain)
             if model.x_window or model.y_window is not None:
                 node['window'] = (model.x_window, model.y_window)
-
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -314,11 +309,10 @@ class Linear1DType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {
+        return {
             'slope': _parameter_to_value(model.slope),
             'intercept': _parameter_to_value(model.intercept),
         }
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
     @classmethod
     def assert_equal(cls, a, b):

--- a/astropy/io/misc/asdf/tags/transform/projections.py
+++ b/astropy/io/misc/asdf/tags/transform/projections.py
@@ -3,8 +3,6 @@
 
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
-
 from astropy import modeling
 from .basic import TransformType
 from . import _parameter_to_value
@@ -36,9 +34,8 @@ class AffineType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'matrix': _parameter_to_value(model.matrix),
+        return {'matrix': _parameter_to_value(model.matrix),
                 'translation': _parameter_to_value(model.translation)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -60,8 +57,7 @@ class Rotate2DType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, model, ctx):
-        node = {'angle': _parameter_to_value(model.angle)}
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return {'angle': _parameter_to_value(model.angle)}
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -130,7 +126,7 @@ class Rotate3DType(TransformType):
                     "direction": model.axes_order
                     }
 
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -175,7 +171,7 @@ class RotationSequenceType(TransformType):
             node['rotation_type'] = "cartesian"
         else:
             raise ValueError(f"Cannot serialize model of type {type(model)}")
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):

--- a/astropy/io/misc/asdf/tags/transform/tabular.py
+++ b/astropy/io/misc/asdf/tags/transform/tabular.py
@@ -4,8 +4,6 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from asdf import yamlutil
-
 from astropy import modeling
 from astropy import units as u
 from .basic import TransformType
@@ -55,7 +53,7 @@ class TabularType(TransformType):
         node["method"] = str(model.method)
         node["bounds_error"] = model.bounds_error
         node["name"] = model.name
-        return yamlutil.custom_tree_to_tagged_tree(node, ctx)
+        return node
 
     @classmethod
     def assert_equal(cls, a, b):

--- a/astropy/io/misc/asdf/tags/unit/equivalency.py
+++ b/astropy/io/misc/asdf/tags/unit/equivalency.py
@@ -4,7 +4,6 @@
 from astropy.units.equivalencies import Equivalency
 from astropy.units import equivalencies
 from astropy.units.quantity import Quantity
-from asdf.yamlutil import custom_tree_to_tagged_tree
 
 from astropy.io.misc.asdf.types import AstropyType
 
@@ -24,8 +23,6 @@ class EquivalencyType(AstropyType):
         for e, kwargs in zip(equiv.name, equiv.kwargs):
             kwarg_names = list(kwargs.keys())
             kwarg_values = list(kwargs.values())
-            kwarg_values = [custom_tree_to_tagged_tree(val, ctx) if isinstance(val, Quantity)
-                            else val for val in kwarg_values]
             eq = {'name': e, 'kwargs_names': kwarg_names, 'kwargs_values': kwarg_values}
             eqs.append(eq)
         return eqs

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -4,11 +4,9 @@
 from numpy import isscalar
 from astropy.units import Quantity
 
-from asdf.yamlutil import custom_tree_to_tagged_tree
 from asdf.tags.core import NDArrayType
 
 from astropy.io.misc.asdf.types import AstropyAsdfType
-from .unit import UnitType
 
 
 class QuantityType(AstropyAsdfType):
@@ -21,8 +19,8 @@ class QuantityType(AstropyAsdfType):
     def to_tree(cls, quantity, ctx):
         node = {}
         if isinstance(quantity, Quantity):
-            node['value'] = custom_tree_to_tagged_tree(quantity.value, ctx)
-            node['unit'] = custom_tree_to_tagged_tree(quantity.unit, ctx)
+            node['value'] = quantity.value
+            node['unit'] = quantity.unit
             return node
         raise TypeError(f"'{quantity}' is not a valid Quantity")
 
@@ -31,7 +29,7 @@ class QuantityType(AstropyAsdfType):
         if isinstance(node, Quantity):
             return node
 
-        unit = UnitType.from_tree(node['unit'], ctx)
+        unit = node['unit']
         value = node['value']
         if isinstance(value, NDArrayType):
             value = value._make_array()

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ all =
     matplotlib>=2.1
     scikit-image
     mpmath
-    asdf>=2.5
+    asdf>=2.6
     bottleneck
     ipython
     pytest

--- a/tox.ini
+++ b/tox.ini
@@ -65,7 +65,7 @@ deps =
     # pytest-openfiles pinned because of https://github.com/astropy/astropy/issues/10160
     oldestdeps: numpy==1.16.*
     oldestdeps: matplotlib==2.1.*
-    oldestdeps: asdf==2.4.*
+    oldestdeps: asdf==2.6.*
     oldestdeps: scipy==0.18.*
     oldestdeps: pytest-openfiles==0.4.0
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request updates the minimum asdf version to 2.6.0, and uses a new asdf feature (generators returned from `ExtensionType.from_tree_tagged` methods) to enable handling of models with circular user inverses.

I'm also removing explicit calls to `asdf.yamlutil.custom_tree_to_tagged_tree` and `asdf.yamlutil.custom_tree_to_tagged_tree` as those are no longer necessary.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
