### PR TITLE
Do not parse table when no fields are defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,6 +279,8 @@ astropy.io.votable
 - For FIELDs with datatype="char", store the values as strings instead
   of bytes. [#9505]
 
+- Fixed parsing failure of VOTable with no fields. [#10192]
+
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -279,8 +279,6 @@ astropy.io.votable
 - For FIELDs with datatype="char", store the values as strings instead
   of bytes. [#9505]
 
-- Fixed parsing failure of VOTable with no fields. [#10192]
-
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
@@ -401,6 +399,10 @@ astropy.io.registry
 
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
+
+- Fixed parsing failure of VOTable with no fields. When detecting a non-empty
+  table with no fields, the following warning/exception is issued:
+  E25 "No FIELDs are defined; DATA section will be ignored." [#10192]
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^

--- a/astropy/io/votable/exceptions.py
+++ b/astropy/io/votable/exceptions.py
@@ -1484,6 +1484,14 @@ class E24(VOWarning, ValueError):
     default_args = ('', '')
 
 
+class E25(VOTableSpecWarning):
+    """
+    A VOTable cannot have a DATA section without any defined FIELD; DATA will be ignored.
+    """
+
+    message_template = "No FIELDs are defined; DATA section will be ignored."
+
+
 def _get_warning_and_exception_classes(prefix):
     classes = []
     for key, val in globals().items():

--- a/astropy/io/votable/tests/data/no_field_not_empty_table.xml
+++ b/astropy/io/votable/tests/data/no_field_not_empty_table.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Produced with astropy.io.votable version 4.0
  http://www.astropy.org/ -->
-<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.4">
+<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.3">
  <RESOURCE type="results">
   <TABLE>
    <DATA>

--- a/astropy/io/votable/tests/data/no_field_not_empty_table.xml
+++ b/astropy/io/votable/tests/data/no_field_not_empty_table.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Produced with astropy.io.votable version 4.0
+ http://www.astropy.org/ -->
+<VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.4">
+ <RESOURCE type="results">
+  <TABLE>
+   <DATA>
+    <TABLEDATA>
+     <TR></TR>
+     <TR></TR>
+     <TR></TR>
+    </TABLEDATA>
+   </DATA>
+   <INFO name="matches" value="3">matching records</INFO>
+  </TABLE>
+ </RESOURCE>
+</VOTABLE>

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -186,6 +186,13 @@ def test_empty_table():
     astropy_table = table.to_table()  # noqa
 
 
+def test_no_field_not_empty_table():
+    votable = parse(get_pkg_data_filename('data/no_field_not_empty_table.xml'))
+    table = votable.get_first_table()
+    assert len(table.fields) == 0
+    assert len(table.infos) == 1
+
+
 def test_binary2_masked_strings():
     """
     Issue #8995

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -193,9 +193,9 @@ def test_no_field_not_empty_table():
     assert len(table.infos) == 1
 
 
-@raises(E25)
 def test_no_field_not_empty_table_exception():
-    votable = parse(get_pkg_data_filename('data/no_field_not_empty_table.xml'), verify='exception')
+    with pytest.raises(E25):
+        votable = parse(get_pkg_data_filename('data/no_field_not_empty_table.xml'), verify='exception')
 
 
 def test_binary2_masked_strings():

--- a/astropy/io/votable/tests/table_test.py
+++ b/astropy/io/votable/tests/table_test.py
@@ -13,8 +13,8 @@ from astropy.config import set_temp_config, reload_config
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_fileobj
 from astropy.io.votable.table import parse, writeto
 from astropy.io.votable import tree, conf
-from astropy.io.votable.exceptions import VOWarning, W39
-from astropy.tests.helper import catch_warnings
+from astropy.io.votable.exceptions import VOWarning, W39, E25
+from astropy.tests.helper import catch_warnings, raises
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 
@@ -191,6 +191,11 @@ def test_no_field_not_empty_table():
     table = votable.get_first_table()
     assert len(table.fields) == 0
     assert len(table.infos) == 1
+
+
+@raises(E25)
+def test_no_field_not_empty_table_exception():
+    votable = parse(get_pkg_data_filename('data/no_field_not_empty_table.xml'), verify='exception')
 
 
 def test_binary2_masked_strings():

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -2494,7 +2494,7 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
             else:
                 raise TypeError("Invalid columns list")
 
-        if not skip_table:
+        if (not skip_table) and (len(fields) > 0):
             for start, tag, data, pos in iterator:
                 if start:
                     if tag == 'TABLEDATA':

--- a/astropy/io/votable/tree.py
+++ b/astropy/io/votable/tree.py
@@ -25,7 +25,8 @@ from .exceptions import (warn_or_raise, vo_warn, vo_raise, vo_reraise,
                          W13, W15, W17, W18, W19, W20, W21, W22, W26, W27, W28,
                          W29, W32, W33, W35, W36, W37, W38, W40, W41, W42, W43,
                          W44, W45, W50, W52, W53, W54, E06, E08, E09, E10, E11,
-                         E12, E13, E15, E16, E17, E18, E19, E20, E21, E22, E23)
+                         E12, E13, E15, E16, E17, E18, E19, E20, E21, E22, E23,
+                         E25)
 from . import ucd as ucd_mod
 from . import util
 from . import xmlutil
@@ -2451,6 +2452,8 @@ class Table(Element, _IDProperty, _NameProperty, _UcdProperty,
             for start, tag, data, pos in iterator:
                 if start:
                     if tag == 'DATA':
+                        if len(self.fields) == 0:
+                            warn_or_raise(E25, E25, None, config, pos)
                         warn_unknown_attrs(
                             'DATA', data.keys(), config, pos)
                         break


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

[astropy/astroquery](https://github.com/astropy/astroquery) can be used to obtain tables from the Vizier service. Some of the answers can correspond to empty (and admittedly non-compliant) tables that look like the following:

    <?xml version="1.0" encoding="utf-8"?>
    <!-- Produced with astropy.io.votable version 4.0
     http://www.astropy.org/ -->
    <VOTABLE version="1.4" xmlns="http://www.ivoa.net/xml/VOTable/v1.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.ivoa.net/xml/VOTable/v1.4">
     <RESOURCE type="results">
      <TABLE>
       <DATA>
        <TABLEDATA>
         <TR></TR>
         <TR></TR>
         <TR></TR>
        </TABLEDATA>
       </DATA>
       <INFO name="matches" value="3">matching records</INFO>
      </TABLE>
     </RESOURCE>
    </VOTABLE>

The current VOTable parser fails in a rather obscure way. This may be worked around by preventing the parsing of `<DATA>` when no `<FIELD>` are given, as suggested in this pull request.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes astropy/astroquery#1691
