### PR TITLE
Store information about dimensions that are dropped in SlicedLowLevelWCS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,10 @@ astropy.wcs
 
 - ``WCS.to_header()`` now appends comments to SIP coefficients. [#10480]
 
+- A new property ``dropped_world_dimensions`` has been added to
+  ``SlicedLowLevelWCS`` to record information about any world axes removed by
+  slicing a WCS. [#10195]
+
 
 API Changes
 -----------

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -62,6 +62,20 @@ def spectral_cube_3d_fitswcs():
     return wcs
 
 
+@pytest.fixture
+def cube_4d_fitswcs():
+    wcs = WCS(naxis=4)
+    wcs.wcs.ctype = 'RA---CAR', 'DEC--CAR', 'FREQ', 'TIME'
+    wcs.wcs.cunit = 'deg', 'deg', 'Hz', 's'
+    wcs.wcs.cdelt = -2., 2., 3.e9, 1
+    wcs.wcs.crval = 4., 0., 4.e9, 3,
+    wcs.wcs.crpix = 6., 7., 11., 11.
+    wcs.wcs.cname = 'Right Ascension', 'Declination', 'Frequency', 'Time'
+    wcs.wcs.mjdref = (30042, 0)
+    return wcs
+
+
+
 class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -75,7 +75,6 @@ def cube_4d_fitswcs():
     return wcs
 
 
-
 class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property

--- a/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/sliced_wcs.py
@@ -153,7 +153,6 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
             raise ValueError("Cannot slice WCS: the resulting WCS should have "
                              "at least one pixel and one world dimension.")
 
-
     @lazyproperty
     def dropped_world_dimensions(self):
         """
@@ -226,7 +225,6 @@ class SlicedLowLevelWCS(BaseWCSWrapper):
 
         pixel_arrays_new = np.broadcast_arrays(*pixel_arrays_new)
         return self._wcs.pixel_to_world_values(*pixel_arrays_new)
-
 
     def pixel_to_world_values(self, *pixel_arrays):
         world_arrays = self._pixel_to_world_values_all(*pixel_arrays)

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -760,7 +760,6 @@ def test_1d_sliced_low_level(time_1d_wcs):
     assert np.allclose(world, [27, 29])
 
 
-
 def validate_info_dict(result, expected):
     result_value = result.pop("value")
     expected_value = expected.pop("value")
@@ -772,16 +771,13 @@ def validate_info_dict(result, expected):
 def test_dropped_dimensions():
     wcs = WCS_SPECTRAL_CUBE
 
-
     sub = SlicedLowLevelWCS(wcs, np.s_[:, :, :])
 
     assert sub.dropped_world_dimensions == {}
 
-
     sub = SlicedLowLevelWCS(wcs, np.s_[:, 2:5, :])
 
     assert sub.dropped_world_dimensions == {}
-
 
     sub = SlicedLowLevelWCS(wcs, np.s_[:, 0])
 
@@ -795,7 +791,6 @@ def test_dropped_dimensions():
         "world_axis_object_classes": {'freq': (u.Quantity, (), {'unit': u.Hz})}
         })
 
-
     sub = SlicedLowLevelWCS(wcs, np.s_[:, 0, 0])
 
     validate_info_dict(sub.dropped_world_dimensions, {
@@ -807,7 +802,6 @@ def test_dropped_dimensions():
         "world_axis_object_components": [('freq', 0, 'value')],
         "world_axis_object_classes": {'freq': (u.Quantity, (), {'unit': u.Hz})}
         })
-
 
     sub = SlicedLowLevelWCS(wcs, np.s_[0, :, 0])
 
@@ -826,7 +820,6 @@ def test_dropped_dimensions():
     assert wao_classes['celestial'][1] == ()
     assert isinstance(wao_classes['celestial'][2]['frame'], Galactic)
     assert wao_classes['celestial'][2]['unit'] is u.deg
-
 
     sub = SlicedLowLevelWCS(wcs, np.s_[5, :5, 12])
 
@@ -869,7 +862,6 @@ def test_dropped_dimensions_4d(cube_4d_fitswcs):
     assert isinstance(wao_classes['celestial'][2]['frame'], ICRS)
     assert wao_classes['celestial'][2]['unit'] is u.deg
     assert wao_classes['freq'] == (u.Quantity, (), {'unit': u.Hz})
-
 
     sub = SlicedLowLevelWCS(cube_4d_fitswcs, np.s_[12, 12])
 

--- a/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
+++ b/astropy/wcs/wcsapi/wrappers/tests/test_sliced_wcs.py
@@ -4,14 +4,15 @@ import pytest
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
-from astropy.wcs.wcs import FITSFixedWarning
+from astropy.wcs.wcs import WCS, FITSFixedWarning
+from astropy.time import Time
 from astropy.wcs import WCS
 from astropy.io.fits import Header
 from astropy.io.fits.verify import VerifyWarning
-from astropy.coordinates import SkyCoord, Galactic
+from astropy.coordinates import SkyCoord, Galactic, ICRS
 from astropy.units import Quantity
-from astropy.wcs.wcsapi.wrappers.sliced_wcs import (
-    SlicedLowLevelWCS, sanitize_slices, combine_slices)
+from astropy.wcs.wcsapi.wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices, combine_slices
+from astropy.wcs.wcsapi.utils import wcs_info_str
 import astropy.units as u
 
 # To test the slicing we start off from standard FITS WCS
@@ -757,3 +758,136 @@ def test_1d_sliced_low_level(time_1d_wcs):
     world = sll.pixel_to_world_values([1, 2])
     assert isinstance(world, np.ndarray)
     assert np.allclose(world, [27, 29])
+
+
+
+def validate_info_dict(result, expected):
+    result_value = result.pop("value")
+    expected_value = expected.pop("value")
+
+    np.testing.assert_allclose(result_value, expected_value)
+    assert result == expected
+
+
+def test_dropped_dimensions():
+    wcs = WCS_SPECTRAL_CUBE
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[:, :, :])
+
+    assert sub.dropped_world_dimensions == {}
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[:, 2:5, :])
+
+    assert sub.dropped_world_dimensions == {}
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[:, 0])
+
+    validate_info_dict(sub.dropped_world_dimensions, {
+        "value": [0.5],
+        "world_axis_physical_types": ["em.freq"],
+        "world_axis_names": ["Frequency"],
+        "world_axis_units": ["Hz"],
+        "serialized_classes": False,
+        "world_axis_object_components": [('freq', 0, 'value')],
+        "world_axis_object_classes": {'freq': (u.Quantity, (), {'unit': u.Hz})}
+        })
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[:, 0, 0])
+
+    validate_info_dict(sub.dropped_world_dimensions, {
+        "value": [0.5],
+        "world_axis_physical_types": ["em.freq"],
+        "world_axis_names": ["Frequency"],
+        "world_axis_units": ["Hz"],
+        "serialized_classes": False,
+        "world_axis_object_components": [('freq', 0, 'value')],
+        "world_axis_object_classes": {'freq': (u.Quantity, (), {'unit': u.Hz})}
+        })
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[0, :, 0])
+
+    dwd = sub.dropped_world_dimensions
+    wao_classes = dwd.pop("world_axis_object_classes")
+    validate_info_dict(dwd, {
+        "value": [12.86995801, 20.49217541],
+        "world_axis_physical_types": ["pos.galactic.lat", "pos.galactic.lon"],
+        "world_axis_names": ["Latitude", "Longitude"],
+        "world_axis_units": ["deg", "deg"],
+        "serialized_classes": False,
+        "world_axis_object_components": [('celestial', 1, 'spherical.lat.degree'), ('celestial', 0, 'spherical.lon.degree')],
+        })
+
+    assert wao_classes['celestial'][0] is SkyCoord
+    assert wao_classes['celestial'][1] == ()
+    assert isinstance(wao_classes['celestial'][2]['frame'], Galactic)
+    assert wao_classes['celestial'][2]['unit'] is u.deg
+
+
+    sub = SlicedLowLevelWCS(wcs, np.s_[5, :5, 12])
+
+    dwd = sub.dropped_world_dimensions
+    wao_classes = dwd.pop("world_axis_object_classes")
+    validate_info_dict(dwd, {
+        "value": [11.67648267, 21.01921192],
+        "world_axis_physical_types": ["pos.galactic.lat", "pos.galactic.lon"],
+        "world_axis_names": ["Latitude", "Longitude"],
+        "world_axis_units": ["deg", "deg"],
+        "serialized_classes": False,
+        "world_axis_object_components": [('celestial', 1, 'spherical.lat.degree'), ('celestial', 0, 'spherical.lon.degree')],
+        })
+
+    assert wao_classes['celestial'][0] is SkyCoord
+    assert wao_classes['celestial'][1] == ()
+    assert isinstance(wao_classes['celestial'][2]['frame'], Galactic)
+    assert wao_classes['celestial'][2]['unit'] is u.deg
+
+
+def test_dropped_dimensions_4d(cube_4d_fitswcs):
+
+    sub = SlicedLowLevelWCS(cube_4d_fitswcs, np.s_[:, 12, 5, 5])
+
+    dwd = sub.dropped_world_dimensions
+    wao_classes = dwd.pop("world_axis_object_classes")
+    validate_info_dict(dwd, {
+        "value": [ 4.e+00, -2.e+00,  1.e+10],
+        "world_axis_physical_types": ["pos.eq.ra", "pos.eq.dec", "em.freq"],
+        "world_axis_names": ['Right Ascension', 'Declination', 'Frequency'],
+        "world_axis_units": ["deg", "deg", "Hz"],
+        "serialized_classes": False,
+        "world_axis_object_components": [('celestial', 0, 'spherical.lon.degree'),
+                                         ('celestial', 1, 'spherical.lat.degree'),
+                                         ('freq', 0, 'value')],
+        })
+
+    assert wao_classes['celestial'][0] is SkyCoord
+    assert wao_classes['celestial'][1] == ()
+    assert isinstance(wao_classes['celestial'][2]['frame'], ICRS)
+    assert wao_classes['celestial'][2]['unit'] is u.deg
+    assert wao_classes['freq'] == (u.Quantity, (), {'unit': u.Hz})
+
+
+    sub = SlicedLowLevelWCS(cube_4d_fitswcs, np.s_[12, 12])
+
+    dwd = sub.dropped_world_dimensions
+    wao_classes = dwd.pop("world_axis_object_classes")
+    wao_components = dwd.pop("world_axis_object_components")
+    validate_info_dict(dwd, {
+        "value": [1.e+10, 5.e+00],
+        "world_axis_physical_types": ["em.freq", "time"],
+        "world_axis_names": ["Frequency", "Time"],
+        "world_axis_units": ["Hz", "s"],
+        "serialized_classes": False,
+        })
+    assert wao_components[0] == ('freq', 0, 'value')
+    assert wao_components[1][0] == 'time'
+    assert wao_components[1][1] == 0
+
+    assert wao_classes['freq'] == (u.Quantity, (), {'unit': u.Hz})
+    assert wao_classes['time'][0] == Time
+    assert wao_classes['time'][1] == tuple()
+    assert wao_classes['time'][2] == {}


### PR DESCRIPTION
~This is based on #9736 because otherwise they would conflict horrifically but they are actually orthogonal changes, it's just the last commit that needs to be looked at here.~

Now based on #10229 

The objective of this is to provide a structured way of inspecting dimensions that are dropped from a WCS when it is sliced. Take for example a spectral cube (space, space, wave), and you slice down to a two dimensional WCS (space, space) you loose access to the wavelength information for that slice. This PR implements a property `dropped_world_dimensions` onto `SlicedLowLevelWCS` which returns a dict containing the information hidden from the low level API (so you could construct a pixel_n_dim=0 Low Level WCS from it in theory).