### PR TITLE
Add HDU name and ver to FITSDiff report where appropriate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ astropy.io.fits
 - Added support for writing Dask arrays to disk efficiently for ``ImageHDU`` and
   ``PrimaryHDU``. [#9742]
 
+- Add HDU name and ver to FITSDiff report where appropriate [#10197]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/fits/diff.py
+++ b/astropy/io/fits/diff.py
@@ -356,7 +356,10 @@ class FITSDiff(_BaseDiff):
             hdu_diff = HDUDiff.fromdiff(self, self.a[idx], self.b[idx])
 
             if not hdu_diff.identical:
-                self.diff_hdus.append((idx, hdu_diff))
+                if self.a[idx].name == self.b[idx].name and self.a[idx].ver == self.b[idx].ver:
+                    self.diff_hdus.append((idx, hdu_diff, self.a[idx].name, self.a[idx].ver))
+                else:
+                    self.diff_hdus.append((idx, hdu_diff, "", self.a[idx].ver))
 
     def _report(self):
         wrapper = textwrap.TextWrapper(initial_indent='  ',
@@ -410,14 +413,17 @@ class FITSDiff(_BaseDiff):
             self._writeln('No differences found.')
             return
 
-        for idx, hdu_diff in self.diff_hdus:
+        for idx, hdu_diff, extname, extver in self.diff_hdus:
             # print out the extension heading
             if idx == 0:
                 self._fileobj.write('\n')
                 self._writeln('Primary HDU:')
             else:
                 self._fileobj.write('\n')
-                self._writeln(f'Extension HDU {idx}:')
+                if extname:
+                    self._writeln(f'Extension HDU {idx} ({extname}, {extver}):')
+                else:
+                    self._writeln(f'Extension HDU {idx}:')
             hdu_diff.report(self._fileobj, indent=self._indent + 1)
 
 

--- a/astropy/io/fits/tests/test_diff.py
+++ b/astropy/io/fits/tests/test_diff.py
@@ -793,3 +793,45 @@ class TestDiff(FitsTestCase):
             assert (str(warning_lines[0].message) == '"clobber" was '
                     'deprecated in version 2.0 and will be removed in a '
                     'future version. Use argument "overwrite" instead.')
+
+
+def test_fitsdiff_hdu_name(tmpdir):
+    """Make sure diff report reports HDU name and ver if same in files"""
+    path1 = str(tmpdir.join("test1.fits"))
+    path2 = str(tmpdir.join("test2.fits"))
+
+    hdulist = HDUList([PrimaryHDU(), ImageHDU(data=np.zeros(5), name="SCI")])
+    hdulist.writeto(path1)
+    hdulist[1].data[0] = 1
+    hdulist.writeto(path2)
+
+    diff = FITSDiff(path1, path2)
+    assert "Extension HDU 1 (SCI, 1):" in diff.report()
+
+
+def test_fitsdiff_no_hdu_name(tmpdir):
+    """Make sure diff report doesn't report HDU name if not in files"""
+    path1 = str(tmpdir.join("test1.fits"))
+    path2 = str(tmpdir.join("test2.fits"))
+
+    hdulist = HDUList([PrimaryHDU(), ImageHDU(data=np.zeros(5))])
+    hdulist.writeto(path1)
+    hdulist[1].data[0] = 1
+    hdulist.writeto(path2)
+
+    diff = FITSDiff(path1, path2)
+    assert "Extension HDU 1:" in diff.report()
+
+
+def test_fitsdiff_with_names(tmpdir):
+    """Make sure diff report doesn't report HDU name if not same in files"""
+    path1 = str(tmpdir.join("test1.fits"))
+    path2 = str(tmpdir.join("test2.fits"))
+
+    hdulist = HDUList([PrimaryHDU(), ImageHDU(data=np.zeros(5), name="SCI", ver=1)])
+    hdulist.writeto(path1)
+    hdulist[1].name = "ERR"
+    hdulist.writeto(path2)
+
+    diff = FITSDiff(path1, path2)
+    assert "Extension HDU 1:" in diff.report()


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request adds a small enhance to `FITSDiff` `report()` to show HDU name and ver were appropriate.  Before:

```
E           AssertionError: 
E              fitsdiff: 4.1.dev961+g58ccedb21.d20200422
E              a: /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-71/test_fitsdiff_hdu_name0/test1.fits
E              b: /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-71/test_fitsdiff_hdu_name0/test2.fits
E              Maximum number of different data values to be reported: 10
E              Relative tolerance: 0.0, Absolute tolerance: 0.0
E             
E             Extension HDU 1:
E             
E                Data contains differences:
E                  Data differs at [1]:
E                     a> 0.0
E                     b> 1.0
E                  1 different pixels found (20.00% different).
E             
E           assert False
E            +  where False = <astropy.io.fits.diff.FITSDiff object at 0x1152c4820>.identical
```

Now:
```
E           AssertionError: 
E              fitsdiff: 4.1.dev961+g58ccedb21.d20200422
E              a: /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-71/test_fitsdiff_hdu_name0/test1.fits
E              b: /private/var/folders/jg/by5st33j7ps356dgb4kn8w900001n5/T/pytest-of-jdavies/pytest-71/test_fitsdiff_hdu_name0/test2.fits
E              Maximum number of different data values to be reported: 10
E              Relative tolerance: 0.0, Absolute tolerance: 0.0
E             
E             Extension HDU 1 (SCI, 1):
E             
E                Data contains differences:
E                  Data differs at [1]:
E                     a> 0.0
E                     b> 1.0
E                  1 different pixels found (20.00% different).
E             
E           assert False
E            +  where False = <astropy.io.fits.diff.FITSDiff object at 0x1152c4820>.identical
```

It only does this if the HDU `name` attribute is populated and if the two files being diffed have the same `name` attribute.