### PR TITLE
add deprecation warning targeted to skyfield deprecation warning

### DIFF
--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -39,7 +39,9 @@ de432s_distance_tolerance = 20*u.km
 skyfield_angular_separation_tolerance = 1*u.arcsec
 skyfield_separation_tolerance = 10*u.km
 
-
+# the ignore is here because skyfield is using a deprecated construct in urllib.requests.urlopen
+# this is both here *and* setup.cfg because some versions of pytest seem to respect it here and others only setup.cfg
+@pytest.mark.filterwarnings("ignore:cafile:DeprecationWarning") 
 @pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_SKYFIELD')
 def test_positions_skyfield():

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -39,9 +39,7 @@ de432s_distance_tolerance = 20*u.km
 skyfield_angular_separation_tolerance = 1*u.arcsec
 skyfield_separation_tolerance = 10*u.km
 
-# the ignore is here because skyfield is using a deprecated construct in urllib.requests.urlopen
-# this is both here *and* setup.cfg because some versions of pytest seem to respect it here and others only setup.cfg
-@pytest.mark.filterwarnings("ignore:cafile:DeprecationWarning") 
+
 @pytest.mark.remote_data
 @pytest.mark.skipif('not HAS_SKYFIELD')
 def test_positions_skyfield():

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,7 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
-    ignore:cafile:DeprecationWarning  # also in coordinates/tests/test_solar_system.py - see comment for details
+    ignore:cafile, capath:DeprecationWarning:skyfield
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,7 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
-    ignore:cafile, capath:DeprecationWarning:skyfield
+    ignore:cafile:DeprecationWarning  # also in coordinates/tests/test_solar_system.py - see comment for details
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,6 +113,7 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
+    ignore:cafile:DeprecationWarning  # also in coordinates/tests/test_solar_system.py - see comment for details
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -113,7 +113,8 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
-    ignore:cafile:DeprecationWarning  # also in coordinates/tests/test_solar_system.py - see comment for details
+    ignore:cafile:DeprecationWarning
+# the cafile ignore is  also in coordinates/tests/test_solar_system.py - see comment for details
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
The original problem was pointed out by @pllim on Slack - the remote data tests are currently failing (see https://travis-ci.org/github/astropy/astropy/jobs/678839193) in `test_solar_system.py` due to ``OSError: cannot get ftp://ssd.jpl.nasa.gov/pub/eph/planets/bsp/de421.bsp because cafile, cpath and cadefault are deprecated, use a custom context instead.``.

After some sleuthing it turns out the underlying problem is that skyfield is using a deprecated usage of the Python stdlib `urllib.request.urlopen`.  `skyfield` is only used in a remote data test to generate some data we use to test against some coordinates transformations.  So this PR just allows that particular test to succeed by letting the deprecation warning pass through without getting raised as an error.

Note that this problem might return more seriously if the deprecated functionality is eventually removed in a future Python version.  I'll make an issue in `skyfield` to address this, but in the meantime this PR should get things working again.

Note also I could not get the `pytest.mark.filterwarnings` to work consistently in newer versions of pytest.  I don't understand why, but I found putting it *also* in `setup.cfg` seems to work everywhere.  But if @bsipocz, @pllim, or @astrofrog have any idea which I should actually be preferring, I'm all ears!