### PR TITLE
add build_ext option to test command hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ directly with::
     pip install -e .[test]
     pytest
 
+or::
+
+    python setup.py build_ext --inplace
+    pytest
+
 For more information, see:
 
   http://docs.astropy.org/en/latest/development/testguide.html#running-tests


### PR DESCRIPTION
This just adds the ``python setup.py build_ext --inplace`` option that's already mentioned in the testing guidelines to the hint that ``python setup.py test`` provides. Hopefully this isn't too controversial since it's already in the testing guidelines as an option...
