### PR TITLE
Units interaction with other packages (unyt, amuse)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ addons:
             - language-pack-de
             # tzdata is included to ensure system leap seconds are up to date.
             - tzdata
+            # The comparison tests with amuse need a fortran compiler
+            - gfortran
 
 env:
     global:

--- a/astropy/units/core.py
+++ b/astropy/units/core.py
@@ -1885,6 +1885,16 @@ class _UnitMetaClass(type):
         elif s is None:
             raise TypeError("None is not a valid Unit")
 
+        elif 'unit' in s.__class__.__name__.lower():
+            try:
+                # Some unity thing. Try conversion via string.
+                string = str(s)
+                # But ensure we don't do dimensionless (unyt) or none (amuse).
+                string = string.replace('dimensionless', '').replace('none', '')
+                return Unit(string, parse_strict=parse_strict)
+            except Exception:
+                pass
+
         else:
             raise TypeError(f"{s} can not be converted to a Unit")
 

--- a/astropy/units/tests/test_interaction_with_others.py
+++ b/astropy/units/tests/test_interaction_with_others.py
@@ -1,0 +1,66 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""Test that astropy's Unit class can deal with units from other projects."""
+
+import pytest
+
+from astropy.units import Unit, UnitBase, dimensionless_unscaled
+
+
+pytestmark = pytest.mark.filterwarnings("ignore")
+
+
+class OtherUnitModuleTests:
+    # Subclasses must define a setup_class that sets
+    # - oum for the module to the units.
+    # - dimensionless to its dimensionless unit.
+
+    @pytest.mark.parametrize('unit', ['m', 's', 'kg', 'g', 'cm'])
+    def test_simple(self, unit):
+        u_unit = getattr(self.oum, unit)
+        assert str(u_unit == unit)
+        u_m = Unit(u_unit)
+        assert u_m == Unit(unit)
+
+    def test_dimensionless(self):
+        u_dimensionless = Unit(self.dimensionless)
+        assert isinstance(u_dimensionless, UnitBase)
+        assert u_dimensionless == dimensionless_unscaled
+
+    def test_more_complicated(self):
+        u_unit = self.oum.m / self.oum.s
+        u_m_per_s = Unit(u_unit)
+        assert isinstance(u_m_per_s, UnitBase)
+        assert u_m_per_s == Unit('m/s')
+
+
+class TestUnyt(OtherUnitModuleTests):
+    def setup_class(cls):
+        try:
+            import unyt
+        except ImportError:
+            pytest.skip('unyt not available.')
+
+        cls.oum = unyt
+        cls.dimensionless = unyt.dimensionless
+
+
+@pytest.mark.filterwarnings('ignore')
+class TestAmuse(OtherUnitModuleTests):
+    def setup_class(cls):
+        try:
+            from amuse.units import units as amuse_units
+        except ImportError:
+            pytest.skip('amuse not available.')
+
+        cls.oum = amuse_units
+        cls.dimensionless = amuse_units.none
+
+    def teardown_class(cls):
+        # Annoyingly, amuse thinks it is OK to just override
+        # numpy operators by monkeypatching, which can obviously
+        # screw up further tests.  So, we need to get rid of it.
+        from amuse.units import quantities
+        import atexit
+        if quantities._previous_operators:
+            quantities.unset_numpy_operators()
+            atexit.unregister(quantities.unset_numpy_operators)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,9 @@ test =
     ipython
     coverage
     skyfield
+testextra =
+    amuse-framework
+    unyt
 all =
     scipy>=0.18
     dask[array]

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
 extras =
     test
     alldeps: all
+    test-alldeps: testextra
 
 commands =
     pip freeze


### PR DESCRIPTION
An alternative to #10196, extending my earlier PR #8213 that allowed interaction with `unyt` to also interact with `amuse`. 

@rieder - you mentioned over at #10196 that you were worried about strings not sufficing - could you  give explicit examples of amuse units that you think might be problematic?

@bsipocz, @astrofrog - I'm not quite sure what to do with "dependencies" such as these - we do want to test them but they do not really belong in "all", since we do not actually interact with either package.  I made a hack around this in `setup.cfg` and `tox.ini`...

EDIT: to do list:
- [ ] wait for version of `amuse` that includes https://github.com/amusecode/amuse/commit/7dbbadf65dbb7b09f5debeb139874bfa7d2d84b4 (or have version check in tests)