### PR TITLE
set skyfield requirement to work around deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ test =
     objgraph
     ipython
     coverage
-    skyfield
+    skyfield>=1.20
 all =
     scipy>=0.18
     dask[array]


### PR DESCRIPTION
This is an alternative solution for #10200 - a new version of skyfield (1.20) was released to address the underlying problem, and since `skyfield` is only used for testing it seems like not a big deal to require a very recent version.

(so this closes #10200 if merged)