### PR TITLE
Allow in-place modifications of representations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -136,6 +136,9 @@ astropy.table
 - Added support for ``SkyCoord`` mixin columns in ``dstack``, ``vstack`` and
   ``insert_row`` functions. [#9857]
 
+- Added support for coordinate ``Representation`` and ``Differential`` mixin
+  columns. [#10210]
+
 astropy.tests
 ^^^^^^^^^^^^^
 
@@ -209,6 +212,10 @@ astropy.coordinates
   when the ```SkyCoord``` also has an ```obstime``` set. In this situation, the position of the
   ```SkyCoord``` has space motion applied to correct to the passed ```obstime```. This allows
   mm/s radial velocity precision for objects with large space motion. [#10094]
+
+- For consistency with other astropy classes, coordinate ``Representations``
+  and ``Differentials`` can now be initialized with an instance of their own class
+  if that instance is passed in as the first argument. [#10210]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ astropy.coordinates
 - The ``Galactocentric`` frame will now use the "latest" parameter definitions
   by default. This currently corresponds to the values defined in v4.0, but will
   change with future releases. [#10238]
+
 - Allow in-place modification of array-valued ``Representation`` and ``Differential``
   objects, including of representations with attached differentials. [#10210]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ astropy.coordinates
 - The ``Galactocentric`` frame will now use the "latest" parameter definitions
   by default. This currently corresponds to the values defined in v4.0, but will
   change with future releases. [#10238]
+- Allow in-place modification of array-valued ``Representation`` and ``Differential``
+  objects, including of representations with attached differentials. [#10210]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1533,6 +1533,23 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
         if self._data is None:
             raise ValueError('can only set frame if it has data')
 
+        if self._data.__class__ is not value._data.__class__:
+            raise TypeError(f'can only set from object of same class: '
+                            f'{self._data.__class__.__name__} vs. '
+                            f'{value._data.__class__.__name__}')
+
+        if self._data._differentials:
+            # Can this ever occur? (Same class but different differential keys).
+            # This exception is not tested since it is not clear how to generate it.
+            if self._data._differentials.keys() != value._data._differentials.keys():
+                raise ValueError(f'setitem value must have same differentials')
+
+            for key, self_diff in self._data._differentials.items():
+                if self_diff.__class__ is not value._data._differentials[key].__class__:
+                    raise TypeError(f'can only set from object of same class: '
+                                    f'{self_diff.__class__.__name__} vs. '
+                                    f'{value._data._differentials[key].__class__.__name__}')
+
         # Set representation data
         self._data[item] = value._data
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1534,7 +1534,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
             raise ValueError('can only set frame if it has data')
 
         # Set representation data
-        self._data._setitem(item, value._data)
+        self._data[item] = value._data
 
         # Frame attributes required to be identical by is_equivalent_frame,
         # no need to set them here.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -814,8 +814,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
 
         if not (isinstance(value, self.__class__)
                 or len(value.attr_classes) == len(self.attr_classes)):
-            raise ValueError(f'value must be representable as {type(self)} '
-                             f'without loss of information.')
+            raise ValueError(
+                f'value must be representable as {self.__class__.__name__} '
+                f'without loss of information.')
 
         diff_classes = {}
         if self._differentials:
@@ -828,8 +829,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
                 if not (isinstance(value_diff_cls, self_diff_cls)
                         or (len(value_diff_cls.attr_classes)
                             == len(self_diff_cls.attr_classes))):
-                    raise ValueError(f'value differential {key!r} must be representable '
-                                     'as {type(self_diff)} without loss of information.')
+                    raise ValueError(
+                        f'value differential {key!r} must be representable as '
+                        f'{self_diff.__class__.__name__} without loss of information.')
 
         value = value.represent_as(self.__class__, diff_classes)
         super().__setitem__(item, value)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -612,6 +612,9 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     def __init__(self, *args, differentials=None, **kwargs):
         # Handle any differentials passed in.
         super().__init__(*args, **kwargs)
+        if (differentials is None
+                and args and isinstance(args[0], self.__class__)):
+            differentials = args[0]._differentials
         self._differentials = self._validate_differentials(differentials)
 
     def _validate_differentials(self, differentials):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -575,6 +575,16 @@ class MetaBaseRepresentation(abc.ABCMeta):
                                       .format(component))))
 
 
+class RepresentationInfo(BaseRepresentationOrDifferentialInfo):
+
+    @property
+    def _represent_as_dict_attrs(self):
+        attrs = super()._represent_as_dict_attrs
+        if self._parent._differentials:
+            attrs += ('differentials',)
+        return attrs
+
+
 class BaseRepresentation(BaseRepresentationOrDifferential,
                          metaclass=MetaBaseRepresentation):
     """Base for representing a point in a 3D coordinate system.
@@ -608,6 +618,8 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
     class, one should also define ``unit_vectors`` and ``scale_factors``
     methods (see those methods for details).
     """
+
+    info = RepresentationInfo()
 
     def __init__(self, *args, differentials=None, **kwargs):
         # Handle any differentials passed in.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -600,6 +600,20 @@ class RepresentationInfo(BaseRepresentationOrDifferentialInfo):
             attrs += ('differentials',)
         return attrs
 
+    def _represent_as_dict(self, attrs=None):
+        out = super()._represent_as_dict(attrs)
+        for key, value in out.pop('differentials', {}).items():
+            out[f'differentials.{key}'] = value
+        return out
+
+    def _construct_from_dict(self, map):
+        differentials = {}
+        for key in list(map.keys()):
+            if key.startswith('differentials.'):
+                differentials[key[14:]] = map.pop(key)
+        map['differentials'] = differentials
+        return super()._construct_from_dict(map)
+
 
 class BaseRepresentation(BaseRepresentationOrDifferential,
                          metaclass=MetaBaseRepresentation):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -260,13 +260,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                     apply_method(getattr(self, component)))
         return new
 
-    def _setitem(self, item, value):
-        """Private version of __setitem__.
-
-        This cannot be exposed as __setitem__ because it would allow changing
-        frame representation data (frame.data) without clearing the frame cache.
-        """
-        if self.__class__ is not value.__class__:
+    def __setitem__(self, item, value):
+        if value.__class__ is not self.__class__:
             raise TypeError(f'can only set from object of same class: '
                             f'{self.__class__.__name__} vs. '
                             f'{value.__class__.__name__}')
@@ -811,12 +806,7 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
              for k, diff in self._differentials.items()])
         return rep
 
-    def _setitem(self, item, value):
-        """Private version of __setitem__.
-
-        This cannot be exposed as __setitem__ because it would allow changing
-        frame representation data (frame.data) without clearing the frame cache.
-        """
+    def __setitem__(self, item, value):
         if self.__class__ is not value.__class__:
             raise TypeError(f'can only set from object of same class: '
                             f'{self.__class__.__name__} vs. '
@@ -827,10 +817,10 @@ class BaseRepresentation(BaseRepresentationOrDifferential,
         if self._differentials.keys() != value._differentials.keys():
             raise ValueError(f'setitem value must have same differentials')
 
-        super()._setitem(item, value)
+        super().__setitem__(item, value)
         for self_diff, value_diff in zip(self._differentials.values(),
                                          value._differentials.values()):
-            self_diff._setitem(item, value_diff)
+            self_diff[item] = value_diff
 
     def _scale_operation(self, op, *args):
         """Scale all non-angular components, leaving angular ones unchanged.

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -254,7 +254,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                         raise TypeError(f"__init__() got multiple values for "
                                         f"argument {component!r}")
 
-                    raise TypeError(f'unexpected keyword arguments: {kwargs}')
+                raise TypeError(f'unexpected keyword arguments: {kwargs}')
 
         # Pass attributes through the required initializing classes.
         attrs = [self.attr_classes[component](attr, copy=False)

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -112,6 +112,7 @@ class BaseRepresentationOrDifferentialInfo(MixinInfo):
     required when the object is used as a mixin column within a table, but can
     be used as a general way to store meta information.
     """
+    attrs_from_parent = {'unit'}  # Indicates unit is read-only
     _supports_indexing = False
 
     @staticmethod

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -63,6 +63,8 @@ def representation_equal(rep1, rep2):
             return False
         for key, diff1 in rep1._differentials.items():
             result &= components_equal(diff1, rep2._differentials[key])
+    elif getattr(rep2, '_differentials', False):
+        return False
 
     return result & components_equal(rep1, rep2)
 
@@ -1642,3 +1644,12 @@ class TestInfo:
 
     def test_info_unit(self):
         assert self.rep.info.unit == '(deg, deg, pc)'
+        assert self.diff.info.unit == '(mas / yr, mas / yr, km / s)'
+        assert self.rep_w_diff.info.unit == '(deg, deg, pc)'
+
+    @pytest.mark.parametrize('item', ['rep', 'diff', 'rep_w_diff'])
+    def test_roundtrip(self, item):
+        rep_or_diff = getattr(self, item)
+        as_dict = rep_or_diff.info._represent_as_dict()
+        new = rep_or_diff.__class__.info._construct_from_dict(as_dict)
+        assert np.all(representation_equal(new, rep_or_diff))

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1621,3 +1621,17 @@ def test_dtype_preservation_in_indexing():
     cr0 = cr[0]
     # This used to fail.
     assert cr0.xyz.dtype == xyz.dtype
+
+
+class TestInfo:
+    def setup_class(cls):
+        cls.rep = SphericalRepresentation([0, 1]*u.deg, [2, 3]*u.deg,
+                                          10*u.pc)
+        cls.diff = SphericalDifferential([10, 20]*u.mas/u.yr,
+                                         [30, 40]*u.mas/u.yr,
+                                         [50, 60]*u.km/u.s)
+        cls.rep_w_diff = SphericalRepresentation(cls.rep,
+                                                 differentials=cls.diff)
+
+    def test_info_unit(self):
+        assert self.rep.info.unit == '(deg, deg, pc)'

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1643,9 +1643,9 @@ class TestInfo:
                                                  differentials=cls.diff)
 
     def test_info_unit(self):
-        assert self.rep.info.unit == '(deg, deg, pc)'
-        assert self.diff.info.unit == '(mas / yr, mas / yr, km / s)'
-        assert self.rep_w_diff.info.unit == '(deg, deg, pc)'
+        assert self.rep.info.unit == 'deg, deg, pc'
+        assert self.diff.info.unit == 'mas / yr, mas / yr, km / s'
+        assert self.rep_w_diff.info.unit == 'deg, deg, pc'
 
     @pytest.mark.parametrize('item', ['rep', 'diff', 'rep_w_diff'])
     def test_roundtrip(self, item):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -253,6 +253,13 @@ class TestSphericalRepresentation:
         assert_allclose_quantity(new_sph.lon, sph.lon)
         assert_allclose_quantity(new_sph.lat, sph.lat)
 
+    def test_raise_on_extra_arguments(self):
+        with pytest.raises(TypeError, match='got multiple values'):
+            SphericalRepresentation(1*u.deg, 2*u.deg, 1.*u.kpc, lat=10)
+
+        with pytest.raises(TypeError, match='unexpected keyword.*parrot'):
+            SphericalRepresentation(1*u.deg, 2*u.deg, 1.*u.kpc, parrot=10)
+
 
 class TestUnitSphericalRepresentation:
 
@@ -1521,8 +1528,8 @@ def unitphysics():
         attr_classes = OrderedDict([('phi', Angle),
                                     ('theta', Angle)])
 
-        def __init__(self, phi, theta, differentials=None, copy=True):
-            super().__init__(phi, theta, copy=copy, differentials=differentials)
+        def __init__(self, *args, copy=True, **kwargs):
+            super().__init__(*args, copy=copy, **kwargs)
 
             # Wrap/validate phi/theta
             if copy:
@@ -1534,7 +1541,7 @@ def unitphysics():
             if np.any(self._theta < 0.*u.deg) or np.any(self._theta > 180.*u.deg):
                 raise ValueError('Inclination angle(s) must be within '
                                  '0 deg <= angle <= 180 deg, '
-                                 'got {}'.format(theta.to(u.degree)))
+                                 'got {}'.format(self._theta.to(u.degree)))
 
         @property
         def phi(self):
@@ -1610,6 +1617,12 @@ def test_unitphysics(unitphysics):
     assert assph.lon == obj.phi
     assert assph.lat == 80*u.deg
     assert_allclose_quantity(assph.distance, 1*u.dimensionless_unscaled)
+
+    with pytest.raises(TypeError, match='got multiple values'):
+        unitphysics(1*u.deg, 2*u.deg, theta=10)
+
+    with pytest.raises(TypeError, match='unexpected keyword.*parrot'):
+        unitphysics(1*u.deg, 2*u.deg, parrot=10)
 
 
 def test_distance_warning(recwarn):

--- a/astropy/coordinates/tests/test_representation.py
+++ b/astropy/coordinates/tests/test_representation.py
@@ -1238,6 +1238,13 @@ class TestCartesianRepresentationWithDifferential:
             CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc,
                                     differentials='garmonbozia')
 
+        # And that one can add it to another representation.
+        s1 = CartesianRepresentation(
+            CartesianRepresentation(x=1 * u.kpc, y=2 * u.kpc, z=3 * u.kpc),
+            differentials=diff)
+        assert len(s1.differentials) == 1
+        assert s1.differentials['s'] is diff
+
         # make sure differentials can't accept differentials
         with pytest.raises(TypeError):
             CartesianDifferential(d_x=1 * u.km/u.s, d_y=2 * u.km/u.s,

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -19,7 +19,6 @@ from cpython.buffer cimport PyObject_GetBuffer, PyBuffer_Release
 
 from ...utils.data import get_readable_fileobj
 from ...utils.exceptions import AstropyWarning
-from ...table import pprint
 from . import core
 
 
@@ -934,6 +933,8 @@ cdef class FastWriter:
                   fill_include_names=None,
                   fill_exclude_names=None,
                   fast_writer=True):
+
+        from ...table import pprint  # Here to avoid circular import
 
         if fast_writer is True:
             fast_writer = {}

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -657,7 +657,6 @@ def test_many_columns(parallel, read_basic):
     assert_table_equal(table, expected)
 
 
-@pytest.mark.skipif(os.name == 'nt', reason='travis seems to hang')
 def test_fast_reader():
     """
     Make sure that ascii.read() works as expected by default and with

--- a/astropy/io/ascii/tests/test_c_reader.py
+++ b/astropy/io/ascii/tests/test_c_reader.py
@@ -657,6 +657,7 @@ def test_many_columns(parallel, read_basic):
     assert_table_equal(table, expected)
 
 
+@pytest.mark.skipif(os.name == 'nt', reason='travis seems to hang')
 def test_fast_reader():
     """
     Make sure that ascii.read() works as expected by default and with

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -22,7 +22,9 @@ from astropy.units.format.fits import UnitScaleError
 from astropy.utils.exceptions import (AstropyUserWarning,
                                       AstropyDeprecationWarning)
 
-from astropy.coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from astropy.coordinates import (SkyCoord, Latitude, Longitude, Angle, EarthLocation,
+                                 SphericalRepresentation, CartesianRepresentation,
+                                 SphericalCosLatDifferential)
 from astropy.time import Time, TimeDelta
 from astropy.units.quantity import QuantityInfo
 
@@ -634,6 +636,13 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
 
 el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
 el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+sr = SphericalRepresentation(
+    [0, 1]*u.deg, [2, 3]*u.deg, 1*u.kpc)
+cr = CartesianRepresentation(
+    [0, 1]*u.pc, [4, 5]*u.pc, [8, 6]*u.pc)
+sd = SphericalCosLatDifferential(
+    [0, 1]*u.mas/u.yr, [0, 1]*u.mas/u.yr, 10*u.km/u.s)
+srd = SphericalRepresentation(sr, differentials=sd)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
 scc = sc.copy()
@@ -655,6 +664,10 @@ mixin_cols = {
     'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
     'ang': Angle([1, 2] * u.deg),
     'el2': el2,
+    'sr': sr,
+    'cr': cr,
+    'sd': sd,
+    'srd': srd,
 }
 
 time_attrs = ['value', 'shape', 'format', 'scale', 'location']
@@ -672,6 +685,11 @@ compare_attrs = {
     'ang': ['value', 'unit'],
     'el2': ['x', 'y', 'z', 'ellipsoid'],
     'nd': ['x', 'y', 'z'],
+    'sr': ['lon', 'lat', 'distance'],
+    'cr': ['x', 'y', 'z'],
+    'sd': ['d_lon_coslat', 'd_lat', 'd_distance'],
+    'srd': ['lon', 'lat', 'distance', 'differentials.s.d_lon_coslat',
+            'differentials.s.d_lat', 'differentials.s.d_distance'],
 }
 
 
@@ -721,6 +739,7 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
     names = sorted(mixin_cols)
 
     serialized_names = ['ang',
+                        'cr.x', 'cr.y', 'cr.z',
                         'dt.jd1', 'dt.jd2',
                         'el2.x', 'el2.y', 'el2.z',
                         'lat',
@@ -729,6 +748,12 @@ def test_fits_mixins_as_one(table_cls, tmpdir):
                         'scc.x', 'scc.y', 'scc.z',
                         'scd.ra', 'scd.dec', 'scd.distance',
                         'scd.obstime.jd1', 'scd.obstime.jd2',
+                        'sd.d_lon_coslat', 'sd.d_lat', 'sd.d_distance',
+                        'sr.lon', 'sr.lat', 'sr.distance',
+                        'srd.lon', 'srd.lat', 'srd.distance',
+                        'srd.differentials.s.d_lon_coslat',
+                        'srd.differentials.s.d_lat',
+                        'srd.differentials.s.d_distance',
                         'tm',  # serialize_method is formatted_value
                         'x',
                         ]

--- a/astropy/io/misc/tests/test_hdf5.py
+++ b/astropy/io/misc/tests/test_hdf5.py
@@ -10,7 +10,9 @@ from astropy.table.table_helpers import simple_table
 
 from astropy import units as u
 
-from astropy.coordinates import SkyCoord, Latitude, Longitude, Angle, EarthLocation
+from astropy.coordinates import (SkyCoord, Latitude, Longitude, Angle, EarthLocation,
+                                 SphericalRepresentation, CartesianRepresentation,
+                                 SphericalCosLatDifferential)
 from astropy.time import Time, TimeDelta
 from astropy.units.quantity import QuantityInfo
 from astropy.utils.exceptions import AstropyUserWarning
@@ -679,11 +681,18 @@ def assert_objects_equal(obj1, obj2, attrs, compare_class=True):
         assert np.all(a1 == a2)
 
 # Testing HDF5 table read/write with mixins.  This is mostly
-# copied from FITS mixin testing.
+# copied from FITS mixin testing, and it might be good to unify it.
 
 
 el = EarthLocation(x=1 * u.km, y=3 * u.km, z=5 * u.km)
 el2 = EarthLocation(x=[1, 2] * u.km, y=[3, 4] * u.km, z=[5, 6] * u.km)
+sr = SphericalRepresentation(
+    [0, 1]*u.deg, [2, 3]*u.deg, 1*u.kpc)
+cr = CartesianRepresentation(
+    [0, 1]*u.pc, [4, 5]*u.pc, [8, 6]*u.pc)
+sd = SphericalCosLatDifferential(
+    [0, 1]*u.mas/u.yr, [0, 1]*u.mas/u.yr, 10*u.km/u.s)
+srd = SphericalRepresentation(sr, differentials=sd)
 sc = SkyCoord([1, 2], [3, 4], unit='deg,deg', frame='fk4',
               obstime='J1990.5')
 scc = sc.copy()
@@ -708,6 +717,10 @@ mixin_cols = {
     'lon': Longitude([1, 2] * u.deg, wrap_angle=180. * u.deg),
     'ang': Angle([1, 2] * u.deg),
     'el2': el2,
+    'sr': sr,
+    'cr': cr,
+    'sd': sd,
+    'srd': srd,
 }
 
 time_attrs = ['value', 'shape', 'format', 'scale', 'location']
@@ -728,6 +741,11 @@ compare_attrs = {
     'ang': ['value', 'unit'],
     'el2': ['x', 'y', 'z', 'ellipsoid'],
     'nd': ['x', 'y', 'z'],
+    'sr': ['lon', 'lat', 'distance'],
+    'cr': ['x', 'y', 'z'],
+    'sd': ['d_lon_coslat', 'd_lat', 'd_distance'],
+    'srd': ['lon', 'lat', 'distance', 'differentials.s.d_lon_coslat',
+            'differentials.s.d_lat', 'differentials.s.d_distance'],
 }
 
 
@@ -777,6 +795,7 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
     names = sorted(mixin_cols)
 
     serialized_names = ['ang',
+                        'cr.x', 'cr.y', 'cr.z',
                         'dt.jd1', 'dt.jd2',
                         'el2.x', 'el2.y', 'el2.z',
                         'lat',
@@ -788,6 +807,12 @@ def test_hdf5_mixins_as_one(table_cls, tmpdir):
                         'scc.x', 'scc.y', 'scc.z',
                         'scd.ra', 'scd.dec', 'scd.distance',
                         'scd.obstime.jd1', 'scd.obstime.jd2',
+                        'sd.d_lon_coslat', 'sd.d_lat', 'sd.d_distance',
+                        'sr.lon', 'sr.lat', 'sr.distance',
+                        'srd.lon', 'srd.lat', 'srd.distance',
+                        'srd.differentials.s.d_lon_coslat',
+                        'srd.differentials.s.d_lat',
+                        'srd.differentials.s.d_distance',
                         'tm.jd1', 'tm.jd2',
                         'x',
                         ]

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -299,6 +299,16 @@ for cls, tag in ((u.Quantity, '!astropy.units.Quantity'),
     AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
 
 
+for cls in (list(coords.representation.REPRESENTATION_CLASSES.values())
+            + list(coords.representation.DIFFERENTIAL_CLASSES.values())):
+    name = cls.__name__
+    # Add representations/differentials defined in astropy.
+    if name in coords.representation.__all__:
+        tag = '!astropy.coordinates.' + name
+        AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
+        AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
+
+
 def load(stream):
     """Parse the first YAML document in a stream using the AstropyLoader and
     produce the corresponding Python object.

--- a/astropy/table/operations.py
+++ b/astropy/table/operations.py
@@ -73,14 +73,16 @@ def _get_out_class(objs):
     From a list of input objects ``objs`` get merged output object class.
 
     This is just taken as the deepest subclass. This doesn't handle complicated
-    inheritance schemes.
+    inheritance schemes, but as a special case, classes which share ``info``
+    are taken to be compatible.
     """
     out_class = objs[0].__class__
     for obj in objs[1:]:
         if issubclass(obj.__class__, out_class):
             out_class = obj.__class__
 
-    if any(not issubclass(out_class, obj.__class__) for obj in objs):
+    if any(not (issubclass(out_class, obj.__class__)
+                or out_class.info is obj.__class__.info) for obj in objs):
         raise ValueError('unmergeable object classes {}'
                          .format([obj.__class__.__name__ for obj in objs]))
 

--- a/astropy/table/serialize.py
+++ b/astropy/table/serialize.py
@@ -7,6 +7,7 @@ from astropy.utils.data_info import MixinInfo
 from .column import Column
 from .table import Table, QTable, has_info_class
 from astropy.units.quantity import QuantityInfo
+from astropy.coordinates import representation as coorep
 
 
 __construct_mixin_classes = ('astropy.time.core.Time',
@@ -23,6 +24,11 @@ __construct_mixin_classes = ('astropy.time.core.Time',
                              'astropy.coordinates.sky_coordinate.SkyCoord',
                              'astropy.table.table.NdarrayMixin',
                              'astropy.table.column.MaskedColumn')
+__construct_mixin_classes += tuple(
+        f'astropy.coordinates.representation.{cls.__name__}'
+        for cls in (list(coorep.REPRESENTATION_CLASSES.values())
+                    + list(coorep.DIFFERENTIAL_CLASSES.values()))
+        if cls.__name__ in coorep.__all__)
 
 
 class SerializedColumn(dict):

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -137,6 +137,10 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
               'time': time.Time([2000, 2001, 2002, 2003], format='jyear'),
               'skycoord': coordinates.SkyCoord(ra=[0, 1, 2, 3] * u.deg,
                                                dec=[0, 1, 2, 3] * u.deg),
+              'sphericalrep': coordinates.SphericalRepresentation(
+                  [0, 1, 2, 3]*u.deg, [0, 1, 2, 3]*u.deg, 1*u.kpc),
+              'cartesianrep': coordinates.CartesianRepresentation(
+                  [0, 1, 2, 3]*u.pc, [4, 5, 6, 7]*u.pc, [9, 8, 8, 6]*u.pc),
               'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3]),
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                                   dtype='<i4,|S1').view(table.NdarrayMixin),

--- a/astropy/table/tests/conftest.py
+++ b/astropy/table/tests/conftest.py
@@ -141,6 +141,9 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
                   [0, 1, 2, 3]*u.deg, [0, 1, 2, 3]*u.deg, 1*u.kpc),
               'cartesianrep': coordinates.CartesianRepresentation(
                   [0, 1, 2, 3]*u.pc, [4, 5, 6, 7]*u.pc, [9, 8, 8, 6]*u.pc),
+              'sphericaldiff': coordinates.SphericalCosLatDifferential(
+                  [0, 1, 2, 3]*u.mas/u.yr, [0, 1, 2, 3]*u.mas/u.yr,
+                  10*u.km/u.s),
               'arraywrap': table_helpers.ArrayWrapper([0, 1, 2, 3]),
               'ndarray': np.array([(7, 'a'), (8, 'b'), (9, 'c'), (9, 'c')],
                                   dtype='<i4,|S1').view(table.NdarrayMixin),
@@ -148,6 +151,8 @@ MIXIN_COLS = {'quantity': [0, 1, 2, 3] * u.m,
 MIXIN_COLS['earthlocation'] = coordinates.EarthLocation(
     lon=MIXIN_COLS['longitude'], lat=MIXIN_COLS['latitude'],
     height=MIXIN_COLS['quantity'])
+MIXIN_COLS['sphericalrepdiff'] = coordinates.SphericalRepresentation(
+    MIXIN_COLS['sphericalrep'], differentials=MIXIN_COLS['sphericaldiff'])
 
 
 @pytest.fixture(params=sorted(MIXIN_COLS))

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -31,6 +31,7 @@ from astropy.table.column import BaseColumn
 from astropy.table import table_helpers
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.metadata import MergeConflictWarning
+from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
 from .conftest import MIXIN_COLS
@@ -388,7 +389,7 @@ def assert_table_name_col_equal(t, name, col):
         assert np.all(t[name].ra == col.ra)
         assert np.all(t[name].dec == col.dec)
     elif isinstance(col, coordinates.BaseRepresentation):
-        assert np.all((t[name] - col).norm() == 0)
+        assert np.all(representation_equal(t[name], col))
     elif isinstance(col, u.Quantity):
         if type(t) is QTable:
             assert np.all(t[name] == col)
@@ -761,7 +762,7 @@ def test_rename_mixin_columns(mixin_cols):
         assert np.all(t['mm'].ra == tc['m'].ra)
         assert np.all(t['mm'].dec == tc['m'].dec)
     elif isinstance(t['mm'], coordinates.BaseRepresentation):
-        assert np.all((t['mm']-tc['m']).norm() == 0)
+        assert np.all(representation_equal(t['mm'], tc['m']))
     else:
         assert np.all(t['mm'] == tc['m'])
 

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -819,6 +819,7 @@ def test_represent_mixins_as_columns_unit_fix():
     serialize.represent_mixins_as_columns(t)
 
 
+@pytest.mark.skipif(not HAS_YAML, reason='mixin columns in .ecsv need yaml')
 def test_skycoord_with_velocity():
     # Regression test for gh-6447
     sc = SkyCoord([1], [2], unit='deg', galcen_v_sun=None)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -21,7 +21,7 @@ from io import StringIO
 import pytest
 import numpy as np
 
-from astropy.coordinates import EarthLocation
+from astropy.coordinates import EarthLocation, SkyCoord
 from astropy.table import Table, QTable, join, hstack, vstack, Column, NdarrayMixin
 from astropy.table import serialize
 from astropy import time
@@ -624,6 +624,47 @@ def test_quantity_representation():
                            ' 2.0']
 
 
+def test_representation_representation():
+    """
+    Test that Representations are represented correctly.
+    """
+    # With no unit we get "None" in the unit row
+    c = coordinates.CartesianRepresentation([0], [1], [0], unit=u.one)
+    t = Table([c])
+    assert t.pformat() == ['    col0    ',
+                           '------------',
+                           '(0., 1., 0.)']
+
+    c = coordinates.CartesianRepresentation([0], [1], [0], unit='m')
+    t = Table([c])
+    assert t.pformat() == ['    col0    ',
+                           '     m      ',
+                           '------------',
+                           '(0., 1., 0.)']
+
+    c = coordinates.SphericalRepresentation([10]*u.deg, [20]*u.deg, [1]*u.pc)
+    t = Table([c])
+    assert t.pformat() == ['     col0     ',
+                           ' deg, deg, pc ',
+                           '--------------',
+                           '(10., 20., 1.)']
+
+    c = coordinates.UnitSphericalRepresentation([10]*u.deg, [20]*u.deg)
+    t = Table([c])
+    assert t.pformat() == ['   col0   ',
+                           '   deg    ',
+                           '----------',
+                           '(10., 20.)']
+
+    c = coordinates.SphericalCosLatDifferential(
+        [10]*u.mas/u.yr, [2]*u.mas/u.yr, [10]*u.km/u.s)
+    t = Table([c])
+    assert t.pformat() == ['           col0           ',
+                           'mas / yr, mas / yr, km / s',
+                           '--------------------------',
+                           '            (10., 2., 10.)']
+
+
 def test_skycoord_representation():
     """
     Test that skycoord representation works, both in the way that the
@@ -776,3 +817,14 @@ def test_represent_mixins_as_columns_unit_fix():
     t['a'].unit = 'not a valid unit'
     t['a'].mask[1] = True
     serialize.represent_mixins_as_columns(t)
+
+
+def test_skycoord_with_velocity():
+    # Regression test for gh-6447
+    sc = SkyCoord([1], [2], unit='deg', galcen_v_sun=None)
+    t = Table([sc])
+    s = StringIO()
+    t.write(s, format='ascii.ecsv', overwrite=True)
+    s.seek(0)
+    t2 = Table.read(s.read(), format='ascii.ecsv')
+    assert skycoord_equal(t2['col0'], sc)

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -388,7 +388,7 @@ def assert_table_name_col_equal(t, name, col):
     if isinstance(col, coordinates.SkyCoord):
         assert np.all(t[name].ra == col.ra)
         assert np.all(t[name].dec == col.dec)
-    elif isinstance(col, coordinates.BaseRepresentation):
+    elif isinstance(col, coordinates.BaseRepresentationOrDifferential):
         assert np.all(representation_equal(t[name], col))
     elif isinstance(col, u.Quantity):
         if type(t) is QTable:
@@ -761,7 +761,7 @@ def test_rename_mixin_columns(mixin_cols):
     elif isinstance(t['mm'], coordinates.SkyCoord):
         assert np.all(t['mm'].ra == tc['m'].ra)
         assert np.all(t['mm'].dec == tc['m'].dec)
-    elif isinstance(t['mm'], coordinates.BaseRepresentation):
+    elif isinstance(t['mm'], coordinates.BaseRepresentationOrDifferential):
         assert np.all(representation_equal(t['mm'], tc['m']))
     else:
         assert np.all(t['mm'] == tc['m'])

--- a/astropy/table/tests/test_mixin.py
+++ b/astropy/table/tests/test_mixin.py
@@ -48,7 +48,8 @@ def test_attributes(mixin_cols):
     assert m.info.description == 'a'
 
     # Cannot set unit for these classes
-    if isinstance(m, (u.Quantity, coordinates.SkyCoord, time.Time)):
+    if isinstance(m, (u.Quantity, coordinates.SkyCoord, time.Time,
+                      coordinates.BaseRepresentationOrDifferential)):
         with pytest.raises(AttributeError):
             m.info.unit = u.m
     else:
@@ -386,6 +387,8 @@ def assert_table_name_col_equal(t, name, col):
     if isinstance(col, coordinates.SkyCoord):
         assert np.all(t[name].ra == col.ra)
         assert np.all(t[name].dec == col.dec)
+    elif isinstance(col, coordinates.BaseRepresentation):
+        assert np.all((t[name] - col).norm() == 0)
     elif isinstance(col, u.Quantity):
         if type(t) is QTable:
             assert np.all(t[name] == col)
@@ -757,6 +760,8 @@ def test_rename_mixin_columns(mixin_cols):
     elif isinstance(t['mm'], coordinates.SkyCoord):
         assert np.all(t['mm'].ra == tc['m'].ra)
         assert np.all(t['mm'].dec == tc['m'].dec)
+    elif isinstance(t['mm'], coordinates.BaseRepresentation):
+        assert np.all((t['mm']-tc['m']).norm() == 0)
     else:
         assert np.all(t['mm'] == tc['m'])
 

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -16,6 +16,7 @@ from astropy.time import Time
 from astropy.coordinates import (SkyCoord, SphericalRepresentation,
                                  CartesianRepresentation,
                                  BaseRepresentationOrDifferential)
+from astropy.coordinates.tests.test_representation import representation_equal
 from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 
 
@@ -512,8 +513,8 @@ class TestJoin():
             assert skycoord_equal(out['m1'], col[[0, 3]])
             assert skycoord_equal(out['m2'], col[[0, 3]])
         elif 'Repr' in cls_name:
-            assert np.all((out['m1'] - col[[0, 3]]).norm() == 0.)
-            assert np.all((out['m2'] - col[[0, 3]]).norm() == 0.)
+            assert np.all(representation_equal(out['m1'], col[[0, 3]]))
+            assert np.all(representation_equal(out['m2'], col[[0, 3]]))
         else:
             assert np.all(out['m1'] == col[[0, 3]])
             assert np.all(out['m2'] == col[[0, 3]])
@@ -991,8 +992,8 @@ class TestVStack():
                 assert skycoord_equal(out['a'][len_col:], col)
                 assert skycoord_equal(out['a'][:len_col], col)
             elif 'Repr' in cls_name:
-                assert np.all((out['a'][:len_col] - col).norm() == 0)
-                assert np.all((out['a'][len_col:] - col).norm() == 0)
+                assert np.all(representation_equal(out['a'][:len_col], col))
+                assert np.all(representation_equal(out['a'][len_col:], col))
             else:
                 assert np.all(out['a'][:len_col] == col)
                 assert np.all(out['a'][len_col:] == col)
@@ -1145,8 +1146,8 @@ class TestDStack():
         t1 = Table([rep1])
         t2 = Table([rep2])
         t12 = table.dstack([t1, t2])
-        assert np.all((t12['col0'][:, 0]-rep1).norm() == 0.)
-        assert np.all((t12['col0'][:, 1]-rep2).norm() == 0.)
+        assert np.all(representation_equal(t12['col0'][:, 0], rep1))
+        assert np.all(representation_equal(t12['col0'][:, 1], rep2))
 
     def test_dstack_skycoord(self):
         sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
@@ -1394,8 +1395,8 @@ class TestHStack():
             assert skycoord_equal(out['col0_1'], col1[:len(col2)])
             assert skycoord_equal(out['col0_2'], col2)
         elif 'Repr' in cls_name:
-            assert np.all((out['col0_1'] - col1[:len(col2)]).norm() == 0)
-            assert np.all((out['col0_2'] - col2).norm() == 0)
+            assert np.all(representation_equal(out['col0_1'], col1[:len(col2)]))
+            assert np.all(representation_equal(out['col0_2'], col2))
         else:
             assert np.all(out['col0_1'] == col1[:len(col2)])
             assert np.all(out['col0_2'] == col2)

--- a/astropy/table/tests/test_operations.py
+++ b/astropy/table/tests/test_operations.py
@@ -512,7 +512,7 @@ class TestJoin():
             # SkyCoord doesn't support __eq__ so use our own
             assert skycoord_equal(out['m1'], col[[0, 3]])
             assert skycoord_equal(out['m2'], col[[0, 3]])
-        elif 'Repr' in cls_name:
+        elif 'Repr' in cls_name or 'Diff' in cls_name:
             assert np.all(representation_equal(out['m1'], col[[0, 3]]))
             assert np.all(representation_equal(out['m2'], col[[0, 3]]))
         else:
@@ -991,7 +991,7 @@ class TestVStack():
                 # Argh, SkyCoord needs __eq__!!
                 assert skycoord_equal(out['a'][len_col:], col)
                 assert skycoord_equal(out['a'][:len_col], col)
-            elif 'Repr' in cls_name:
+            elif 'Repr' in cls_name or 'Diff' in cls_name:
                 assert np.all(representation_equal(out['a'][:len_col], col))
                 assert np.all(representation_equal(out['a'][len_col:], col))
             else:
@@ -1022,7 +1022,6 @@ class TestVStack():
                 table.vstack([t, t2], join_type='outer')
             assert ('vstack requires masking' in str(err.value)
                     or 'vstack unavailable' in str(err.value))
-
 
 class TestDStack():
 
@@ -1394,7 +1393,7 @@ class TestHStack():
         if cls_name == 'SkyCoord':
             assert skycoord_equal(out['col0_1'], col1[:len(col2)])
             assert skycoord_equal(out['col0_2'], col2)
-        elif 'Repr' in cls_name:
+        elif 'Repr' in cls_name or 'Diff' in cls_name:
             assert np.all(representation_equal(out['col0_1'], col1[:len(col2)]))
             assert np.all(representation_equal(out['col0_2'], col2))
         else:

--- a/astropy/utils/data_info.py
+++ b/astropy/utils/data_info.py
@@ -239,12 +239,14 @@ class DataInfoMeta(type):
                 # automatically defined look-up-on-parent attribute?
                 cls_attr = getattr(cls, attr, None)
                 if attr in cls.attrs_from_parent:
-                    # If the attribute is stored on the parent, and it
-                    # was not the case on the superclass, override it.
-                    if not isinstance(cls_attr, ParentAttribute):
+                    # If the attribute is supposed to be stored on the parent,
+                    # and that is stated by this class yet it was not the case
+                    # on the superclass, override it.
+                    if 'attrs_from_parent' in dct and not isinstance(cls_attr, ParentAttribute):
                         setattr(cls, attr, ParentAttribute(attr))
                 elif not cls_attr or isinstance(cls_attr, ParentAttribute):
-                    # Otherwise, if not defined already or previously defined
+                    # If the attribute is not meant to be stored on the parent,
+                    # and if it was not defined already or was previously defined
                     # as an attribute on the parent, define a regular
                     # look-up-on-info attribute
                     setattr(cls, attr,

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -23,7 +23,6 @@ import numpy as np
 from astropy.time import Time, TimeDelta
 from astropy import _erfa as erfa
 from astropy import config as _config
-from astropy.io.ascii import convert_numpy
 from astropy import units as u
 from astropy.table import QTable, MaskedColumn
 from astropy.utils.data import (get_pkg_data_filename, clear_download_cache,
@@ -1090,6 +1089,8 @@ class LeapSeconds(QTable):
         The file *must* contain the expiration date in a comment line, like
         '# File expires on:  28 June 2020'
         """
+        from astropy.io.ascii import convert_numpy  # Here to avoid circular import
+
         names = ['ntp_seconds', 'tai_utc', 'comment', 'day', 'month', 'year']
         # Note: ntp_seconds does not fit in 32 bit, so causes problems on
         # 32-bit systems without the np.int64 converter.

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -280,6 +280,8 @@ take a different lower-level approach which is described in the section
   ``coo1.ra[1] = 40 * u.deg``. However, while this will *appear* to give a correct
   result it does not actually modify the underlying representation data. This
   is related to the current implementation of performance-based caching.
+  The current cache implementation is similarly unable to handle in-place changes
+  to the representation (``.data``) or frame attributes such as ``.obstime``.
 
 Transforming between Frames
 ===========================

--- a/docs/coordinates/representations.rst
+++ b/docs/coordinates/representations.rst
@@ -132,14 +132,30 @@ manipulate::
   <CartesianRepresentation (x, y, z) in m
       [(0., 10., 20.), (1., 11., 21.), (2., 12., 22.),
        (3., 13., 23.), (4., 14., 24.), (5., 15., 25.)]>
-  >>> car_array[2]  # doctest: +FLOAT_CMP
-  <CartesianRepresentation (x, y, z) in m
-      (2., 12., 22.)>
   >>> car_array.reshape(3, 2)  # doctest: +FLOAT_CMP
   <CartesianRepresentation (x, y, z) in m
       [[(0., 10., 20.), (1., 11., 21.)],
        [(2., 12., 22.), (3., 13., 23.)],
        [(4., 14., 24.), (5., 15., 25.)]]>
+  >>> car_array[2]  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      (2., 12., 22.)>
+  >>> car_array[2] = car_array[1]
+  >>> car_array[:3]  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      [(0., 10., 20.), (1., 11., 21.), (1., 11., 21.)]>
+
+Elements can also be set using other representation classes, as long
+as they are compatible in their units and number of dimensions.
+
+  >>> car_array[0] = SphericalRepresentation(0*u.deg, 0*u.deg, 99*u.m)
+  >>> car_array[:3]  # doctest: +FLOAT_CMP
+  <CartesianRepresentation (x, y, z) in m
+      [(99., 0., 0.), (1., 11., 21.), (1., 11., 21.)]>
+  >>> car_array[0] = UnitSphericalRepresentation(0*u.deg, 0*u.deg)
+  Traceback (most recent call last):
+  ...
+  ValueError: value must be representable as CartesianRepresentation without loss of information.
 
 ..
   EXAMPLE END

--- a/docs/coordinates/skycoord.rst
+++ b/docs/coordinates/skycoord.rst
@@ -428,6 +428,9 @@ take a different lower-level approach which is described in the section
   ``sc1.ra[1] = 40 * u.deg``. However, while this will *appear* to give a correct
   result it does not actually modify the underlying representation data. This
   is related to the current implementation of performance-based caching.
+  The current cache implementation is similarly unable to handle in-place changes
+  to the representation (``.data``) or frame attributes such as ``.obstime``.
+
 
 Attributes
 ==========


### PR DESCRIPTION
This is a follow-up of #9857 ~(EDIT: and builds upon it, hence the many commits)~, making also representations mutable. As commented there, representations themselves have no reason not to be mutable, since the behaviour of setting is well defined (in a way, they are just glorified quantities). Now that coordinates have become mutable, it makes little sense to keep the representations immutable.

~I hope to follow this up with an `DataInfo` class such that representations can also be added to tables; without this, they would be second-class citizens.~ EDIT: now added

fixes #6447 (as a side effect)