### PR TITLE
Fix id bug in baseframe-1.0.0 schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -444,6 +444,8 @@ astropy.io.fits
 astropy.io.misc
 ^^^^^^^^^^^^^^^
 
+- Fix id URL in ``baseframe-1.0.0`` ASDF schema. [#10223]
+
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/frames/baseframe-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/frames/baseframe-1.0.0.yaml
@@ -1,12 +1,12 @@
 %YAML 1.1
 ---
 $schema: "http://stsci.edu/schemas/yaml-schema/draft-01"
-id: "http://astropy.org/schemas/astropy/coordinates/baseframe-1.0.0"
+id: "http://astropy.org/schemas/astropy/coordinates/frames/baseframe-1.0.0"
 
 title: |
   Represents a coordinate frame object from astropy
 
-description:
+description: |
   This schema is designed to be extended by other schemas to restrict the
   allowable frame_attributes.
 
@@ -15,7 +15,7 @@ properties:
   data:
     description: |
       The representation object holding any data associated with the frame.
-    $ref: "./representation-1.0.0"
+    $ref: "../representation-1.0.0"
   frame_attributes:
     description: |
       Attributes on the coordinate frame.

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/frames/icrs-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/frames/icrs-1.0.0.yaml
@@ -7,7 +7,7 @@ tag: "tag:astropy.org:astropy/coordinates/frames/icrs-1.0.0"
 title: |
   Represents an ICRS coordinate object from astropy
 
-description:
+description: |
   This object represents the right ascension (RA) and declination of an ICRS
   coordinate or frame. The ICRS class contains additional fields that may be
   useful to add here in the future.

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/latitude-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/latitude-1.0.0.yaml
@@ -7,7 +7,7 @@ tag: "tag:astropy.org:astropy/coordinates/latitude-1.0.0"
 title: |
   Represents latitude-like angles.
 
-description:
+description: |
   Represents latitude-like angle(s) which must be in the range -90 to +90 deg.
 
 examples:

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/longitude-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/longitude-1.0.0.yaml
@@ -7,7 +7,7 @@ tag: "tag:astropy.org:astropy/coordinates/longitude-1.0.0"
 title: |
   Represents longitude-like angles.
 
-description:
+description: |
     Longitude-like angle(s) which are wrapped within a contiguous 360 degree range.
 
 examples:

--- a/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/representation-1.0.0.yaml
+++ b/astropy/io/misc/asdf/data/schemas/astropy.org/astropy/coordinates/representation-1.0.0.yaml
@@ -7,7 +7,7 @@ tag: "tag:astropy.org:astropy/coordinates/representation-1.0.0"
 title: |
   Representation of points or differentials in two or three dimensional space.
 
-description:
+description: |
   Representation of points or differentials in two or three dimensional space.
 
 examples:


### PR DESCRIPTION
This fixes a bug found in the ASDF `baseframe-1.0.0` schema where it's `id` field does not match its actual location in the `astropy` package.  This fixes that and fixes a few other syntax errors in the YAML.
