### PR TITLE
bug fix: model name search can crash

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -462,6 +462,9 @@ astropy.modeling
 
 - Removed hard-coded names of inputs and outputs. [#10174]
 
+- Fixed a problem where slicing a ``CompoundModel`` by name will crash if
+  there ``fix_inputs`` operators are present. [#10224]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -2832,7 +2832,7 @@ class CompoundModel(Model):
         # Search through leaflist for item with that name
         found = []
         for nleaf, leaf in enumerate(self._leaflist):
-            if leaf.name == str_index:
+            if getattr(leaf, 'name', None) == str_index:
                 found.append(nleaf)
         if len(found) == 0:
             raise IndexError("No component with name '{}' found".format(str_index))

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -409,6 +409,11 @@ def test_indexing_on_instance():
     with pytest.raises(IndexError):
         m['foobar']
 
+    # Confirm index-by-name works with fix_inputs
+    g = Gaussian2D(1, 2, 3, 4, 5, name='g')
+    m = fix_inputs(g, {0: 1})
+    assert m['g'].name == 'g'
+
     # Test string slicing
     A = Const1D(1.1, name='A')
     B = Const1D(2.1, name='B')


### PR DESCRIPTION
### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This is a quick fix to the following bug:
```
>>> m = models.Scale(2) & models.Shift(2, name='shift')
>>> m2 = core.fix_inputs(m, {0: 1})
>>> print(m['shift'])
Model: Shift
Name: shift
Inputs: ('x',)
Outputs: ('y',)
Model set size: 1
Parameters:
    offset
    ------
       2.0
>>> print(m2['shift'])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/anaconda3/lib/python3.7/site-packages/astropy/modeling/core.py", line 2827, in __getitem__
    return leaflist[self._str_index_to_int(index)]
  File "/opt/anaconda3/lib/python3.7/site-packages/astropy/modeling/core.py", line 2835, in _str_index_to_int
    if leaf.name == str_index:
AttributeError: 'dict' object has no attribute 'name'
```

This is caused by an attempt to access `leaf.name` when `leaf` is a `dict` if the compounding operator is `fix_inputs()`. So I've just wrapped it in a `getattr()`.
