### PR TITLE
quantity_input decorator: Allow numeric values when dimensionless is an allowed unit to an argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -161,6 +161,10 @@ astropy.units
 - Changed ``pixel_scale`` equivalency to allow scales defined in any unit.
   [#10123]
 
+- The ``quantity_input`` decorator now optionally allows passing through
+  numeric values or numpy arrays with numeric dtypes to arguments where
+  ``dimensionless_unscaled`` is an allowed unit. [#10232]
+
 astropy.utils
 ^^^^^^^^^^^^^
 - Added a new ``MetaAttribute`` class to support easily adding custom attributes

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -87,10 +87,10 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
         error_msg = (f"Argument '{param_name}' to function '{func_name}' must "
                      "be in units convertible to")
         if len(targets) > 1:
-            targ_names = ", ".join([str(targ) for targ in targets])
+            targ_names = ", ".join([f"'{str(targ)}'" for targ in targets])
             raise UnitsError(f"{error_msg} one of: {targ_names}.")
         else:
-            raise UnitsError(f"{error_msg} one of: {str(targets[0])}.")
+            raise UnitsError(f"{error_msg} '{str(targets[0])}'.")
 
 
 class QuantityInput:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -86,16 +86,16 @@ class QuantityInput:
         r"""
         A decorator for validating the units of arguments to functions.
 
-        Unit specifications can be provided as keyword arguments to the decorator,
-        or by using function annotation syntax. Arguments to the decorator
-        take precedence over any function annotations present.
+        Unit specifications can be provided as keyword arguments to the
+        decorator, or by using function annotation syntax. Arguments to the
+        decorator take precedence over any function annotations present.
 
         A `~astropy.units.UnitsError` will be raised if the unit attribute of
-        the argument is not equivalent to the unit specified to the decorator
-        or in the annotation.
-        If the argument has no unit attribute, i.e. it is not a Quantity object, a
-        `ValueError` will be raised unless the argument is an annotation. This is to
-        allow non Quantity annotations to pass through.
+        the argument is not equivalent to the unit specified to the decorator or
+        in the annotation. If the argument has no unit attribute, i.e. it is not
+        a Quantity object, a `ValueError` will be raised unless the argument is
+        an annotation. This is to allow non Quantity annotations to pass
+        through.
 
         Where an equivalency is specified in the decorator, the function will be
         executed with that equivalency in force.
@@ -172,7 +172,8 @@ class QuantityInput:
                     continue
 
                 # Catch the (never triggered) case where bind relied on a default value.
-                if param.name not in bound_args.arguments and param.default is not param.empty:
+                if (param.name not in bound_args.arguments
+                        and param.default is not param.empty):
                     bound_args.arguments[param.name] = param.default
 
                 # Get the value of this parameter (argument to new function)
@@ -201,7 +202,8 @@ class QuantityInput:
                 #   were specified in the decorator/annotation, or whether a
                 #   single string (unit or physical type) or a Unit object was
                 #   specified
-                if isinstance(targets, str) or not isinstance(targets, Sequence):
+                if (isinstance(targets, str)
+                        or not isinstance(targets, Sequence)):
                     valid_targets = [targets]
 
                 # Check for None in the supplied list of allowed units and, if
@@ -219,7 +221,8 @@ class QuantityInput:
                 #    are not strings or subclasses of Unit. This is to allow
                 #    non unit related annotations to pass through
                 if is_annotation:
-                    valid_targets = [t for t in valid_targets if isinstance(t, (str, UnitBase))]
+                    valid_targets = [t for t in valid_targets
+                                     if isinstance(t, (str, UnitBase))]
 
                 # Now we loop over the allowed units/physical types and validate
                 #   the value of the argument:
@@ -229,7 +232,9 @@ class QuantityInput:
             # Call the original function with any equivalencies in force.
             with add_enabled_equivalencies(self.equivalencies):
                 return_ = wrapped_function(*func_args, **func_kwargs)
-            if wrapped_signature.return_annotation not in (inspect.Signature.empty, None):
+
+            valid_empty = (inspect.Signature.empty, None)
+            if wrapped_signature.return_annotation not in valid_empty:
                 return return_.to(wrapped_signature.return_annotation)
             else:
                 return return_

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -3,11 +3,13 @@
 
 __all__ = ['quantity_input']
 
+from numbers import Number
 from collections.abc import Sequence
 import inspect
 from astropy.utils.decorators import wraps
 
-from .core import Unit, UnitBase, UnitsError, add_enabled_equivalencies
+from .core import (Unit, UnitBase, UnitsError, add_enabled_equivalencies,
+                   dimensionless_unscaled)
 from .physical import _unit_physical_mapping
 
 
@@ -49,6 +51,9 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
         return
 
     allowed_units = _get_allowed_units(targets)
+
+    if dimensionless_unscaled in allowed_units and isinstance(arg, Number):
+        return
 
     for allowed_unit in allowed_units:
         try:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -43,7 +43,8 @@ def _get_allowed_units(targets):
     return allowed_units
 
 
-def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
+def _validate_arg_value(param_name, func_name, arg, targets, equivalencies,
+                        strict_dimensionless=False):
     """
     Validates the object passed in to the wrapped function, ``arg``, with target
     unit or physical type, ``target``.
@@ -56,7 +57,7 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
 
     # If dimensionless is an allowed unit, allow numbers or numpy arrays with
     #  numeric dtypes:
-    if dimensionless_unscaled in allowed_units:
+    if dimensionless_unscaled in allowed_units and not strict_dimensionless:
         if isinstance(arg, Number):
             return
 
@@ -163,9 +164,10 @@ class QuantityInput:
         else:
             return self
 
-    def __init__(self, func=None, **kwargs):
+    def __init__(self, func=None, strict_dimensionless=False, **kwargs):
         self.equivalencies = kwargs.pop('equivalencies', [])
         self.decorator_kwargs = kwargs
+        self.strict_dimensionless = strict_dimensionless
 
     def __call__(self, wrapped_function):
 
@@ -241,7 +243,8 @@ class QuantityInput:
                 # Now we loop over the allowed units/physical types and validate
                 #   the value of the argument:
                 _validate_arg_value(param.name, wrapped_function.__name__,
-                                    arg, valid_targets, self.equivalencies)
+                                    arg, valid_targets, self.equivalencies,
+                                    self.strict_dimensionless)
 
             # Call the original function with any equivalencies in force.
             with add_enabled_equivalencies(self.equivalencies):

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -29,8 +29,7 @@ def _get_allowed_units(targets):
                 physical_type_id = _unit_physical_mapping[target]
 
             except KeyError:  # Function argument target is invalid
-                raise ValueError("Invalid unit or physical type '{}'."
-                                 .format(target))
+                raise ValueError(f"Invalid unit or physical type '{target}'.")
 
             # get unit directly from physical type id
             target_unit = Unit._from_physical_type_id(physical_type_id)
@@ -61,25 +60,23 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
 
         except AttributeError:  # Either there is no .unit or no .is_equivalent
             if hasattr(arg, "unit"):
-                error_msg = "a 'unit' attribute without an 'is_equivalent' method"
+                error_msg = ("a 'unit' attribute without an 'is_equivalent' "
+                             "method")
             else:
                 error_msg = "no 'unit' attribute"
 
-            raise TypeError("Argument '{}' to function '{}' has {}. "
-                  "You may want to pass in an astropy Quantity instead."
-                     .format(param_name, func_name, error_msg))
+            raise TypeError(f"Argument '{param_name}' to function '{func_name}'"
+                            f" has {error_msg}. You should pass in an astropy "
+                            "Quantity instead.")
 
     else:
+        error_msg = (f"Argument '{param_name}' to function '{func_name}' must "
+                     "be in units convertible to")
         if len(targets) > 1:
-            raise UnitsError("Argument '{}' to function '{}' must be in units"
-                             " convertible to one of: {}."
-                             .format(param_name, func_name,
-                                     [str(targ) for targ in targets]))
+            targ_names = ", ".join([str(targ) for targ in targets])
+            raise UnitsError(f"{error_msg} one of: {targ_names}.")
         else:
-            raise UnitsError("Argument '{}' to function '{}' must be in units"
-                             " convertible to '{}'."
-                             .format(param_name, func_name,
-                                     str(targets[0])))
+            raise UnitsError(f"{error_msg} one of: {str(targets[0])}.")
 
 
 class QuantityInput:

--- a/astropy/units/decorators.py
+++ b/astropy/units/decorators.py
@@ -6,8 +6,10 @@ __all__ = ['quantity_input']
 from numbers import Number
 from collections.abc import Sequence
 import inspect
-from astropy.utils.decorators import wraps
 
+import numpy as np
+
+from astropy.utils.decorators import wraps
 from .core import (Unit, UnitBase, UnitsError, add_enabled_equivalencies,
                    dimensionless_unscaled)
 from .physical import _unit_physical_mapping
@@ -52,8 +54,15 @@ def _validate_arg_value(param_name, func_name, arg, targets, equivalencies):
 
     allowed_units = _get_allowed_units(targets)
 
-    if dimensionless_unscaled in allowed_units and isinstance(arg, Number):
-        return
+    # If dimensionless is an allowed unit, allow numbers or numpy arrays with
+    #  numeric dtypes:
+    if dimensionless_unscaled in allowed_units:
+        if isinstance(arg, Number):
+            return
+
+        elif (isinstance(arg, np.ndarray)
+              and np.issubdtype(arg.dtype, np.number)):
+            return
 
     for allowed_unit in allowed_units:
         try:

--- a/astropy/units/tests/test_quantity_annotations.py
+++ b/astropy/units/tests/test_quantity_annotations.py
@@ -97,7 +97,7 @@ def test_not_quantity3(solarx_unit, solary_unit):
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, 100)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You should pass in an astropy Quantity instead."
 
 
 def test_decorator_override():
@@ -192,7 +192,7 @@ def test_kwarg_not_quantity3(solarx_unit, solary_unit):
 
     with pytest.raises(TypeError) as e:
         solarx, solary = myfunc_args(1*u.arcsec, solary=100)
-    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'solary' to function 'myfunc_args' has no 'unit' attribute. You should pass in an astropy Quantity instead."
 
 
 @pytest.mark.parametrize("solarx_unit,solary_unit", [

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -396,7 +396,8 @@ def test_allow_dimensionless_numeric(val):
 @pytest.mark.parametrize('val', [1., 1, np.arange(10), np.arange(10.)])
 def test_allow_dimensionless_numeric_strict(val):
     """
-    When dimensionless_unscaled is an allowed unit, but we are being strict, don't allow numbers and numeric numpy arrays through
+    When dimensionless_unscaled is an allowed unit, but we are being strict,
+    don't allow numbers and numeric numpy arrays through
     """
 
     @u.quantity_input(velocity=[u.km/u.s, u.dimensionless_unscaled],

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -2,6 +2,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
 import pytest
+import numpy as np
 
 from astropy import units as u
 
@@ -376,3 +377,32 @@ def test_args_None_kwarg():
 
     with pytest.raises(TypeError):
         x, y = myfunc_args(None, None)
+
+
+@pytest.mark.parametrize('val', [1., 1, np.arange(10), np.arange(10.)])
+def test_allow_dimensionless_numeric(val):
+    """
+    When dimensionless_unscaled is an allowed unit, numbers and numeric numpy
+    arrays are allowed through
+    """
+
+    @u.quantity_input(velocity=[u.km/u.s, u.dimensionless_unscaled])
+    def myfunc(velocity):
+        return velocity
+
+    assert np.all(myfunc(val) == val)
+
+
+@pytest.mark.parametrize('val', [1., 1, np.arange(10), np.arange(10.)])
+def test_allow_dimensionless_numeric_strict(val):
+    """
+    When dimensionless_unscaled is an allowed unit, but we are being strict, don't allow numbers and numeric numpy arrays through
+    """
+
+    @u.quantity_input(velocity=[u.km/u.s, u.dimensionless_unscaled],
+                      strict_dimensionless=True)
+    def myfunc(velocity):
+        return velocity
+
+    with pytest.raises(TypeError):
+        assert myfunc(val)

--- a/astropy/units/tests/test_quantity_decorator.py
+++ b/astropy/units/tests/test_quantity_decorator.py
@@ -102,7 +102,7 @@ def test_not_quantity(x_input, y_input):
 
     with pytest.raises(TypeError) as e:
         x, y = myfunc_args(1*x_unit, 100)
-    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You should pass in an astropy Quantity instead."
 
 
 def test_not_quantity_annotated(x_input, y_input):
@@ -115,7 +115,7 @@ def test_not_quantity_annotated(x_input, y_input):
 
     with pytest.raises(TypeError) as e:
         x, y = myfunc_args(1*x_unit, 100)
-    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You should pass in an astropy Quantity instead."
 
 
 def test_kwargs(x_input, y_input):
@@ -180,7 +180,7 @@ def test_kwarg_not_quantity(x_input, y_input):
 
     with pytest.raises(TypeError) as e:
         x, y = myfunc_args(1*x_unit, y=100)
-    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You may want to pass in an astropy Quantity instead."
+    assert str(e.value) == "Argument 'y' to function 'myfunc_args' has no 'unit' attribute. You should pass in an astropy Quantity instead."
 
 
 def test_kwarg_default(x_input, y_input):
@@ -283,7 +283,7 @@ def test_no_equivalent():
     with pytest.raises(TypeError) as e:
         x, y = myfunc_args(test_quantity())
 
-        assert str(e.value) == "Argument 'x' to function 'myfunc_args' has a 'unit' attribute without an 'is_equivalent' method. You may want to pass in an astropy Quantity instead."
+        assert str(e.value) == "Argument 'x' to function 'myfunc_args' has a 'unit' attribute without an 'is_equivalent' method. You should pass in an astropy Quantity instead."
 
 
 def test_kwarg_invalid_physical_type():


### PR DESCRIPTION
Following an idea by @astrofrog in #10185, this is a modification to the `quantity_input` decorator to allow numeric values (or numpy arrays with numeric dtype) through in a function call when `dimensionless_unscaled` is an allowed unit for that argument. 

I got a little carried away with some text wrapping issues that were cropping up in the same file...sorry - I can remove those commits if easier!

I also changed an error message that gets displayed when using `quantity_input`: I changed "you may want to pass in an astropy Quantity" to "you should pass in an astropy Quantity". The new feels a little judgey, but "you may want to" implies to me that there is a way to *not* pass in a Quantity (when there really shouldn't be).

Demo of what this enables:

```python
import astropy.units as u
import numpy as np

@u.quantity_input(redshift_or_velocity=[u.km/u.s, u.dimensionless_unscaled])
def test(redshift_or_velocity):
    print(redshift_or_velocity)

test(15*u.km/u.s)
test(1.)
test(np.array([1., 2., 3.]))
```

But this behavior can also be disabled (should this be the default?):
```python
@u.quantity_input(redshift_or_velocity=[u.km/u.s, 
                                        u.dimensionless_unscaled],
                  strict_dimensionless=True)
def test2(redshift_or_velocity):
    print(redshift_or_velocity)

test2(1.)

...
TypeError: Argument 'redshift_or_velocity' to function 'test' has no 'unit' attribute. You should pass in an astropy Quantity instead.
```