### PR TITLE
fixed bug in constant model tag

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -8,6 +8,7 @@ from astropy.utils import minversion
 from astropy.modeling import functional_models
 from astropy.modeling.core import Model, CompoundModel
 from astropy.io.misc.asdf.types import AstropyAsdfType, AstropyType
+from . import _parameter_to_value
 
 
 __all__ = ['TransformType', 'IdentityType', 'ConstantType']
@@ -148,7 +149,7 @@ class ConstantType(TransformType):
         elif isinstance(data, functional_models.Const2D):
             dimension = 2
         return {
-            'value': data.amplitude.value,
+            'value': _parameter_to_value(data.amplitude),
             'dimensions': dimension
         }
 


### PR DESCRIPTION
I noticed a bug that wasn't being picked up in the tests when writing out constant type models. In the round trip, parameter units weren't preserved because `_parameter_to_value` was not being used in `to_tree`. 

This never caused the asdf roundtrip test to fail, so that might need to be looked into. 