### PR TITLE
DO NOT MERGE TST: testing upstream ci-helpers

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ isolated_build = true
 # project-wide pinning of dependencies, e.g. if new versions of pytest do not
 # work correctly with pytest-astropy plugins. Most of the time the pinnings file
 # should be empty.
-pypi_filter = https://raw.githubusercontent.com/astropy/ci-helpers/master/pip_pinnings.txt
+pypi_filter = https://raw.githubusercontent.com/bsipocz/ci-helpers/pytest_remove_5.4_pin/pip_pinnings.txt
 
 # Pass through the following environemnt variables which are needed for the CI
 passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS TEST_READ_HUGE_FILE


### PR DESCRIPTION
This PR is to smoke out issues around the removal of the pytest limitation upstream. Do not merge it.

Failures are expected based on experiences with tests run locally.