### PR TITLE
parameter constraints are no longer serialized if they are default values

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -84,8 +84,12 @@ class TransformType(AstropyAsdfType):
             node['outputs'] = model.outputs
 
         # model / parameter constraints
-        node['fixed'] = dict(model.fixed)
-        node['bounds'] = dict(model.bounds)
+        fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
+        if fixed_nondefaults: 
+            node['fixed'] = fixed_nondefaults
+        bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
+        if bounds_nondefaults: 
+            node['bounds'] = bounds_nondefaults
 
     @classmethod
     def to_tree_transform(cls, model, ctx):

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -85,10 +85,10 @@ class TransformType(AstropyAsdfType):
 
         # model / parameter constraints
         fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
-        if fixed_nondefaults: 
+        if fixed_nondefaults:
             node['fixed'] = fixed_nondefaults
         bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
-        if bounds_nondefaults: 
+        if bounds_nondefaults:
             node['bounds'] = bounds_nondefaults
 
     @classmethod


### PR DESCRIPTION
Previously all parameter constraints were serialized even if they were default values. This information doesn't need to be stored for the model to be reconstructed, and is inefficient - for example reading in files with polynomial models that have defaults serialized for every one of the many coefficient becomes slow.  


