### PR TITLE
MNT: Make yaml import truly optional in io.misc.yaml

### DIFF
--- a/astropy/__init__.py
+++ b/astropy/__init__.py
@@ -18,6 +18,9 @@ __minimum_scipy_version__ = '0.18'
 # ASDF is an optional dependency, but this is the minimum version that is
 # compatible with Astropy when it is installed.
 __minimum_asdf_version__ = '2.6.0'
+# PyYAML is an optional dependency, but this is the minimum version that is
+# advertised to be supported.
+__minimum_yaml_version__ = '3.12'
 
 
 class UnsupportedPythonError(Exception):

--- a/astropy/io/misc/tests/test_yaml.py
+++ b/astropy/io/misc/tests/test_yaml.py
@@ -17,13 +17,9 @@ from astropy.time import Time
 from astropy.table import QTable, SerializedColumn
 from astropy.tests.helper import catch_warnings
 
-try:
-    from astropy.io.misc.yaml import load, load_all, dump
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+yaml = pytest.importorskip('yaml', minversion='3.12')
 
-pytestmark = pytest.mark.skipif('not HAS_YAML')
+from astropy.io.misc.yaml import load, load_all, dump
 
 
 @pytest.mark.parametrize('c', [True, np.uint8(8), np.int16(4),
@@ -181,7 +177,6 @@ def test_load_all():
     assert unity == unit
 
 
-@pytest.mark.skipif('not HAS_YAML')
 def test_ecsv_astropy_objects_in_meta():
     """
     Test that astropy core objects in ``meta`` are serialized.

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -1,70 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-"""
-This module contains functions for serializing core astropy objects via the
-YAML protocol.
-
-It provides functions `~astropy.io.misc.yaml.dump`,
-`~astropy.io.misc.yaml.load`, and `~astropy.io.misc.yaml.load_all` which
-call the corresponding functions in `PyYaml <https://pyyaml.org>`_ but use the
-`~astropy.io.misc.yaml.AstropyDumper` and `~astropy.io.misc.yaml.AstropyLoader`
-classes to define custom YAML tags for the following astropy classes:
-
-- `astropy.units.Unit`
-- `astropy.units.Quantity`
-- `astropy.time.Time`
-- `astropy.time.TimeDelta`
-- `astropy.coordinates.SkyCoord`
-- `astropy.coordinates.Angle`
-- `astropy.coordinates.Latitude`
-- `astropy.coordinates.Longitude`
-- `astropy.coordinates.EarthLocation`
-- `astropy.table.SerializedColumn`
-
-.. Note ::
-
-   This module requires PyYaml version 3.12 or later.
-
-Example
-=======
-::
-
-  >>> from astropy.io.misc import yaml
-  >>> import astropy.units as u
-  >>> from astropy.time import Time
-  >>> from astropy.coordinates import EarthLocation
-
-  >>> t = Time(2457389.0, format='mjd',
-  ...          location=EarthLocation(1000, 2000, 3000, unit=u.km))
-  >>> td = yaml.dump(t)
-
-  >>> print(td)
-  !astropy.time.Time
-  format: mjd
-  in_subfmt: '*'
-  jd1: 4857390.0
-  jd2: -0.5
-  location: !astropy.coordinates.earth.EarthLocation
-    ellipsoid: WGS84
-    x: !astropy.units.Quantity
-      unit: &id001 !astropy.units.Unit {unit: km}
-      value: 1000.0
-    y: !astropy.units.Quantity
-      unit: *id001
-      value: 2000.0
-    z: !astropy.units.Quantity
-      unit: *id001
-      value: 3000.0
-  out_subfmt: '*'
-  precision: 3
-  scale: utc
-
-  >>> ty = yaml.load(td)
-  >>> ty
-  <Time object: scale='utc' format='mjd' value=2457389.0>
-
-  >>> ty.location  # doctest: +FLOAT_CMP
-  <EarthLocation (1000., 2000., 3000.) km>
-"""
+#
+# NOTE: docstring is in docs/io/misc.rst because of
+# https://github.com/astropy/pytest-doctestplus/issues/109
 
 import base64
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,6 +92,7 @@ rst_epilog += """
 .. |minimum_python_version| replace:: {0.__minimum_python_version__}
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 .. |minimum_scipy_version| replace:: {0.__minimum_scipy_version__}
+.. |minimum_yaml_version| replace:: {0.__minimum_yaml_version__}
 
 .. Astropy
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -31,7 +31,7 @@ Requirements
 - `bleach <https://bleach.readthedocs.io/>`_: Used to sanitize text when
   disabling HTML escaping in the :class:`~astropy.table.Table` HTML writer.
 
-- `PyYAML <https://pyyaml.org>`_: To read/write
+- `PyYAML <https://pyyaml.org>`_ |minimum_yaml_version| or later: To read/write
   :class:`~astropy.table.Table` objects from/to the Enhanced CSV ASCII table
   format and to serialize mixins for various formats.
 

--- a/docs/io/misc.rst
+++ b/docs/io/misc.rst
@@ -17,8 +17,73 @@ listed in the `astropy.io.misc` section.
 .. automodapi:: astropy.io.misc.hdf5
    :headings: =-
 
+astropy.io.misc.yaml Module
+===========================
+
+This module contains functions for serializing core astropy objects via the
+YAML protocol.
+
+It provides functions `~astropy.io.misc.yaml.dump`,
+`~astropy.io.misc.yaml.load`, and `~astropy.io.misc.yaml.load_all` which
+call the corresponding functions in `PyYaml <https://pyyaml.org>`_ but use the
+`~astropy.io.misc.yaml.AstropyDumper` and `~astropy.io.misc.yaml.AstropyLoader`
+classes to define custom YAML tags for the following astropy classes:
+
+- `astropy.units.Unit`
+- `astropy.units.Quantity`
+- `astropy.time.Time`
+- `astropy.time.TimeDelta`
+- `astropy.coordinates.SkyCoord`
+- `astropy.coordinates.Angle`
+- `astropy.coordinates.Latitude`
+- `astropy.coordinates.Longitude`
+- `astropy.coordinates.EarthLocation`
+- `astropy.table.SerializedColumn`
+
+.. Note ::
+
+   This module requires PyYaml version 3.12 or later.
+
+Example
+-------
+
+.. doctest-requires:: yaml
+
+    >>> from astropy.io.misc import yaml
+    >>> import astropy.units as u
+    >>> from astropy.time import Time
+    >>> from astropy.coordinates import EarthLocation
+    >>> t = Time(2457389.0, format='mjd',
+    ...          location=EarthLocation(1000, 2000, 3000, unit=u.km))
+    >>> td = yaml.dump(t)
+    >>> print(td)
+    !astropy.time.Time
+    format: mjd
+    in_subfmt: '*'
+    jd1: 4857390.0
+    jd2: -0.5
+    location: !astropy.coordinates.earth.EarthLocation
+      ellipsoid: WGS84
+      x: !astropy.units.Quantity
+        unit: &id001 !astropy.units.Unit {unit: km}
+        value: 1000.0
+      y: !astropy.units.Quantity
+        unit: *id001
+        value: 2000.0
+      z: !astropy.units.Quantity
+        unit: *id001
+        value: 3000.0
+    out_subfmt: '*'
+    precision: 3
+    scale: utc
+    >>> ty = yaml.load(td)
+    >>> ty
+    <Time object: scale='utc' format='mjd' value=2457389.0>
+    >>> ty.location  # doctest: +FLOAT_CMP
+    <EarthLocation (1000., 2000., 3000.) km>
+
 .. automodapi:: astropy.io.misc.yaml
-   :headings: =-
+   :no-heading:
 
 astropy.io.misc.asdf Package
 ============================

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ all =
     beautifulsoup4
     html5lib
     bleach
-    PyYAML
+    PyYAML>=3.12
     pandas
     sortedcontainers
     pytz
@@ -74,7 +74,7 @@ all =
 docs =
     sphinx-astropy>=1.3
     pytest
-    pyyaml
+    PyYAML>=3.12
     scipy
     matplotlib
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ deps =
     oldestdeps: matplotlib==2.1.*
     oldestdeps: asdf==2.6.*
     oldestdeps: scipy==0.18.*
+    oldestdeps: pyyaml==3.12
     oldestdeps: pytest-openfiles==0.4.0
 
     # The devdeps factor is intended to be used to install the latest developer version


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address the `yaml` import error mentioned in #10246 .

```
_______________________________________ ERROR collecting astropy/io/misc/yaml.py _______________________________________
astropy/io/misc/yaml.py:81: in <module>
    import yaml
E   ModuleNotFoundError: No module named 'yaml'

During handling of the above exception, another exception occurred:
astropy/io/misc/yaml.py:83: in <module>
    raise ImportError('`import yaml` failed, PyYAML package is required for YAML')
E   ImportError: `import yaml` failed, PyYAML package is required for YAML
```

With this patch, without PyYAML installed:
```python
>>> from astropy.io.misc import yaml  # No more error
>>> a = yaml.AstropyLoader()
ImportError: `import yaml` failed, PyYAML package is required for YAML and must be 3.12 or later
```

**TODO**

- [ ] If this is acceptable, add a change log after milestone is set.