### PR TITLE
MNT: Make asdf import truly optional in io.misc.asdf

### DIFF
--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -3,26 +3,25 @@
 import os
 import glob
 
-from asdf import tagged
-
 import astropy.units as u
 import astropy.coordinates
 from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
 
-from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
 from astropy.io.misc.asdf.types import AstropyType
 
+try:
+    from asdf import tagged
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
 
 __all__ = ['CoordType']
 
-SCHEMA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                           '..', '..',
-                                           'data',
-                                           'schemas',
-                                           'astropy.org',
-                                           'astropy'))
+SCHEMA_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..', '..', 'data', 'schemas', 'astropy.org', 'astropy'))
 
 
 def _get_frames():
@@ -78,6 +77,9 @@ class BaseCoordType:
 
     @classmethod
     def to_tree_tagged(cls, frame, ctx):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
         if type(frame) not in frame_transform_graph.frame_set:
             raise ValueError("Can only save frames that are registered with the "
                              "transformation graph.")

--- a/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
@@ -1,13 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf.tags.core import NDArrayType
-from asdf.yamlutil import custom_tree_to_tagged_tree
-
 from astropy.coordinates.spectral_coordinate import SpectralCoord
 from astropy.io.misc.asdf.types import AstropyType
 from astropy.io.misc.asdf.tags.unit.unit import UnitType
 
+try:
+    from asdf.tags.core import NDArrayType
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
 
 __all__ = ['SpectralCoordType']
 
@@ -24,15 +27,18 @@ class SpectralCoordType(AstropyType):
     def to_tree(cls, spec_coord, ctx):
         node = {}
         if isinstance(spec_coord, SpectralCoord):
-            node['value'] = custom_tree_to_tagged_tree(spec_coord.value, ctx)
-            node['unit'] = custom_tree_to_tagged_tree(spec_coord.unit, ctx)
-            node['observer'] = custom_tree_to_tagged_tree(spec_coord.observer, ctx)
-            node['target'] = custom_tree_to_tagged_tree(spec_coord.target, ctx)
+            node['value'] = spec_coord.value
+            node['unit'] = spec_coord.unit
+            node['observer'] = spec_coord.observer
+            node['target'] = spec_coord.target
             return node
         raise TypeError(f"'{spec_coord}' is not a valid SpectralCoord")
 
     @classmethod
     def from_tree(cls, node, ctx):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
         if isinstance(node, SpectralCoord):
             return node
 

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -2,11 +2,15 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from asdf import tagged
-from asdf.tags.core.ndarray import NDArrayType
-
 from astropy import table
 from astropy.io.misc.asdf.types import AstropyType, AstropyAsdfType
+
+try:
+    from asdf.tags.core.ndarray import NDArrayType
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
 
 
 class TableType:
@@ -58,6 +62,9 @@ class TableType:
 
     @classmethod
     def assert_equal(cls, old, new):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
         assert old.meta == new.meta
         try:
             NDArrayType.assert_equal(np.array(old), np.array(new))
@@ -130,6 +137,9 @@ class ColumnType(AstropyAsdfType):
 
     @classmethod
     def assert_equal(cls, old, new):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
         assert old.meta == new.meta
         assert old.description == new.description
         assert old.unit == new.unit

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -4,17 +4,24 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from asdf.versioning import AsdfSpec
-
 from astropy import time
 from astropy import units as u
 from astropy.units import Quantity
 from astropy.coordinates import EarthLocation
 from astropy.io.misc.asdf.types import AstropyAsdfType
 
+try:
+    from asdf.versioning import AsdfSpec
+except ImportError:
+    HAS_ASDF = False
+    asdf_spec_ver = ''
+else:
+    HAS_ASDF = True
+    asdf_spec_ver = AsdfSpec('>=1.1.0')
+
+__all__ = ['TimeType']
 
 _guessable_formats = set(['iso', 'byear', 'jyear', 'yday'])
-
 
 _astropy_format_to_asdf_format = {
     'isot': 'iso',
@@ -31,10 +38,13 @@ def _assert_earthlocation_equal(a, b):
     assert_array_equal(a.lon, b.lon)
 
 
+# Cannot use super() in __init__ to check for asdf import here because it
+# raises TypeError, similar to
+# https://github.com/waveform80/picamera/issues/355#issuecomment-272547797
 class TimeType(AstropyAsdfType):
     name = 'time/time'
     version = '1.1.0'
-    supported_versions = ['1.0.0', AsdfSpec('>=1.1.0')]
+    supported_versions = ['1.0.0', asdf_spec_ver]
     types = ['astropy.time.core.Time']
     requires = ['astropy']
 

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -1,16 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf import tagged
-from asdf.versioning import AsdfVersion
-
-from astropy.modeling import models, mappings
-from astropy.utils import minversion
-from astropy.modeling import functional_models
-from astropy.modeling.core import Model, CompoundModel
+from astropy.modeling import mappings
+from astropy.modeling import functional_models, CompoundModel
 from astropy.io.misc.asdf.types import AstropyAsdfType, AstropyType
 from . import _parameter_to_value
-
 
 __all__ = ['TransformType', 'IdentityType', 'ConstantType']
 
@@ -86,10 +80,10 @@ class TransformType(AstropyAsdfType):
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):
-            fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
+            fixed_nondefaults = {k: f for k, f in model.fixed.items() if f}
             if fixed_nondefaults:
                 node['fixed'] = fixed_nondefaults
-            bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
+            bounds_nondefaults = {k: b for k, b in model.bounds.items() if any(b)}
             if bounds_nondefaults:
                 node['bounds'] = bounds_nondefaults
 
@@ -143,6 +137,8 @@ class ConstantType(TransformType):
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
+        from asdf.versioning import AsdfVersion
+
         if cls.version < AsdfVersion('1.4.0'):
             # The 'dimensions' property was added in 1.4.0,
             # previously all values were 1D.
@@ -154,9 +150,12 @@ class ConstantType(TransformType):
 
     @classmethod
     def to_tree_transform(cls, data, ctx):
+        from asdf.versioning import AsdfVersion
+
         if cls.version < AsdfVersion('1.4.0'):
             if not isinstance(data, functional_models.Const1D):
-                raise ValueError(f'constant-{cls.version} does not support models with > 1 dimension')
+                raise ValueError(
+                    f'constant-{cls.version} does not support models with > 1 dimension')
             return {
                 'value': _parameter_to_value(data.amplitude)
             }
@@ -238,10 +237,10 @@ class UnitsMappingType(AstropyType):
 
         return tree
 
-
     @classmethod
     def from_tree(cls, tree, ctx):
-        mapping = tuple((i.get("unit"), o.get("unit")) for i, o in zip(tree["inputs"], tree["outputs"]))
+        mapping = tuple((i.get("unit"), o.get("unit"))
+                        for i, o in zip(tree["inputs"], tree["outputs"]))
 
         equivalencies = None
         for i in tree["inputs"]:
@@ -252,7 +251,8 @@ class UnitsMappingType(AstropyType):
 
         kwargs = {
             "input_units_equivalencies": equivalencies,
-            "input_units_allow_dimensionless": {i["name"]: i.get("allow_dimensionless", False) for i in tree["inputs"]},
+            "input_units_allow_dimensionless": {
+                i["name"]: i.get("allow_dimensionless", False) for i in tree["inputs"]},
         }
 
         if "name" in tree:

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -1,36 +1,39 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
-from asdf import tagged
-from asdf.tests.helpers import assert_tree_match
+
 from .basic import TransformType
 from astropy.modeling.core import Model, CompoundModel
 from astropy.modeling.models import Identity, Mapping, Const1D
 
+try:
+    from asdf import tagged
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
 
 __all__ = ['CompoundType', 'RemapAxesType']
 
-
 _operator_to_tag_mapping = {
-    '+'  : 'add',
-    '-'  : 'subtract',
-    '*'  : 'multiply',
-    '/'  : 'divide',
-    '**' : 'power',
-    '|'  : 'compose',
-    '&'  : 'concatenate',
+    '+': 'add',
+    '-': 'subtract',
+    '*': 'multiply',
+    '/': 'divide',
+    '**': 'power',
+    '|': 'compose',
+    '&': 'concatenate',
     'fix_inputs': 'fix_inputs'
 }
 
-
 _tag_to_method_mapping = {
-    'add'         : '__add__',
-    'subtract'    : '__sub__',
-    'multiply'    : '__mul__',
-    'divide'      : '__truediv__',
-    'power'       : '__pow__',
-    'compose'     : '__or__',
-    'concatenate' : '__and__',
-    'fix_inputs'  : 'fix_inputs'
+    'add': '__add__',
+    'subtract': '__sub__',
+    'multiply': '__mul__',
+    'divide': '__truediv__',
+    'power': '__pow__',
+    'compose': '__or__',
+    'concatenate': '__and__',
+    'fix_inputs': 'fix_inputs'
 }
 
 
@@ -50,8 +53,8 @@ class CompoundType(TransformType):
             raise TypeError("Unknown model type '{0}'".format(
                 node['forward'][0]._tag))
         right = node['forward'][1]
-        if not isinstance(right, Model) and \
-            not (oper == 'fix_inputs' and isinstance(right, dict)):
+        if (not isinstance(right, Model) and
+                not (oper == 'fix_inputs' and isinstance(right, dict))):
             raise TypeError("Unknown model type '{0}'".format(
                 node['forward'][1]._tag))
         if oper == 'fix_inputs':
@@ -66,6 +69,9 @@ class CompoundType(TransformType):
 
     @classmethod
     def to_tree_tagged(cls, model, ctx):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
         left = model.left
 
         if isinstance(model.right, dict):
@@ -91,6 +97,11 @@ class CompoundType(TransformType):
 
     @classmethod
     def assert_equal(cls, a, b):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
+        from asdf.tests.helpers import assert_tree_match
+
         # TODO: If models become comparable themselves, remove this.
         TransformType.assert_equal(a, b)
         assert_tree_match(a.left, b.left)

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -1,12 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from numpy import isscalar
 from astropy.units import Quantity
-
-from asdf.tags.core import NDArrayType
-
 from astropy.io.misc.asdf.types import AstropyAsdfType
+
+try:
+    from asdf.tags.core import NDArrayType
+except ImportError:
+    HAS_ASDF = False
+else:
+    HAS_ASDF = True
 
 
 class QuantityType(AstropyAsdfType):
@@ -14,6 +17,12 @@ class QuantityType(AstropyAsdfType):
     types = ['astropy.units.Quantity']
     requires = ['astropy']
     version = '1.1.0'
+
+    def __init__(self, *args, **kwargs):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
+        super().__init__(*args, **kwargs)
 
     @classmethod
     def to_tree(cls, quantity, ctx):

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -1,37 +1,41 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf.types import CustomType, ExtensionTypeMeta
+try:
+    from asdf.types import CustomType, ExtensionTypeMeta
+except ImportError:
+    HAS_ASDF = False
+    CustomType = object
+    AstropyTypeMeta = object
+else:
+    HAS_ASDF = True
+
+    class AstropyTypeMeta(ExtensionTypeMeta):
+        """
+        Keeps track of `AstropyType` subclasses that are created so that they can
+        be stored automatically by astropy extensions for ASDF.
+        """
+        def __new__(mcls, name, bases, attrs):
+            cls = super().__new__(mcls, name, bases, attrs)
+            # Classes using this metaclass are automatically added to the list of
+            # astropy extensions
+            if cls.__name__ not in _TYPE_BASE_CLASS_NAMES:
+                if cls.organization == 'astropy.org' and cls.standard == 'astropy':
+                    _astropy_types.add(cls)
+                elif cls.organization == 'stsci.edu' and cls.standard == 'asdf':
+                    _astropy_asdf_types.add(cls)
+
+            return cls
 
 
 __all__ = ['AstropyType', 'AstropyAsdfType']
-
 
 # Names of AstropyType or AstropyAsdfType subclasses that are base classes
 # and aren't used directly for serialization.
 _TYPE_BASE_CLASS_NAMES = {'PolynomialTypeBase'}
 
-
 _astropy_types = set()
 _astropy_asdf_types = set()
-
-
-class AstropyTypeMeta(ExtensionTypeMeta):
-    """
-    Keeps track of `AstropyType` subclasses that are created so that they can
-    be stored automatically by astropy extensions for ASDF.
-    """
-    def __new__(mcls, name, bases, attrs):
-        cls = super().__new__(mcls, name, bases, attrs)
-        # Classes using this metaclass are automatically added to the list of
-        # astropy extensions
-        if cls.__name__ not in _TYPE_BASE_CLASS_NAMES:
-            if cls.organization == 'astropy.org' and cls.standard == 'astropy':
-                _astropy_types.add(cls)
-            elif cls.organization == 'stsci.edu' and cls.standard == 'asdf':
-                _astropy_asdf_types.add(cls)
-
-        return cls
 
 
 class AstropyType(CustomType, metaclass=AstropyTypeMeta):
@@ -45,6 +49,12 @@ class AstropyType(CustomType, metaclass=AstropyTypeMeta):
     organization = 'astropy.org'
     standard = 'astropy'
 
+    def __init__(self, *args, **kwargs):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
+        super().__init__(*args, **kwargs)
+
 
 class AstropyAsdfType(CustomType, metaclass=AstropyTypeMeta):
     """
@@ -56,3 +66,9 @@ class AstropyAsdfType(CustomType, metaclass=AstropyTypeMeta):
     """
     organization = 'stsci.edu'
     standard = 'asdf'
+
+    def __init__(self, *args, **kwargs):
+        if not HAS_ASDF:
+            raise ImportError('asdf is not installed')
+
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address `asdf` import errors reported in #10246. Also fixed PEP 8 in the files I touched.

```
__________________________________ ERROR collecting astropy/io/misc/asdf/extension.py __________________________________
astropy/io/misc/asdf/extension.py:6: in <module>
    from asdf.extension import AsdfExtension, BuiltinExtension
E   ModuleNotFoundError: No module named 'asdf'
____________________________________ ERROR collecting astropy/io/misc/asdf/types.py ____________________________________
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
___________________________ ERROR collecting astropy/io/misc/asdf/tags/coordinates/angle.py ____________________________
astropy/io/misc/asdf/tags/coordinates/angle.py:6: in <module>
    from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
astropy/io/misc/asdf/tags/unit/quantity.py:7: in <module>
    from asdf.tags.core import NDArrayType
E   ModuleNotFoundError: No module named 'asdf'
_______________________ ERROR collecting astropy/io/misc/asdf/tags/coordinates/earthlocation.py ________________________
astropy/io/misc/asdf/tags/coordinates/earthlocation.py:5: in <module>
    from ...types import AstropyType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
___________________________ ERROR collecting astropy/io/misc/asdf/tags/coordinates/frames.py ___________________________
astropy/io/misc/asdf/tags/coordinates/frames.py:6: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
_______________________ ERROR collecting astropy/io/misc/asdf/tags/coordinates/representation.py _______________________
astropy/io/misc/asdf/tags/coordinates/representation.py:5: in <module>
    from astropy.io.misc.asdf.types import AstropyType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
__________________________ ERROR collecting astropy/io/misc/asdf/tags/coordinates/skycoord.py __________________________
astropy/io/misc/asdf/tags/coordinates/skycoord.py:6: in <module>
    from ...types import AstropyType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
_______________________________ ERROR collecting astropy/io/misc/asdf/tags/fits/fits.py ________________________________
astropy/io/misc/asdf/tags/fits/fits.py:9: in <module>
    from astropy.io.misc.asdf.types import AstropyType, AstropyAsdfType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
______________________________ ERROR collecting astropy/io/misc/asdf/tags/table/table.py _______________________________
astropy/io/misc/asdf/tags/table/table.py:5: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
_______________________________ ERROR collecting astropy/io/misc/asdf/tags/time/time.py ________________________________
astropy/io/misc/asdf/tags/time/time.py:7: in <module>
    from asdf.versioning import AsdfSpec
E   ModuleNotFoundError: No module named 'asdf'
_____________________________ ERROR collecting astropy/io/misc/asdf/tags/time/timedelta.py _____________________________
astropy/io/misc/asdf/tags/time/timedelta.py:9: in <module>
    from ...types import AstropyType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
____________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/basic.py _____________________________
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
___________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/compound.py ___________________________
astropy/io/misc/asdf/tags/transform/compound.py:3: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
______________________ ERROR collecting astropy/io/misc/asdf/tags/transform/functional_models.py _______________________
astropy/io/misc/asdf/tags/transform/functional_models.py:7: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
_____________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/math.py _____________________________
astropy/io/misc/asdf/tags/transform/math.py:10: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
_______________________ ERROR collecting astropy/io/misc/asdf/tags/transform/physical_models.py ________________________
astropy/io/misc/asdf/tags/transform/physical_models.py:8: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
__________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/polynomial.py __________________________
astropy/io/misc/asdf/tags/transform/polynomial.py:7: in <module>
    from asdf.versioning import AsdfVersion
E   ModuleNotFoundError: No module named 'asdf'
__________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/powerlaws.py ___________________________
astropy/io/misc/asdf/tags/transform/powerlaws.py:7: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
_________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/projections.py __________________________
astropy/io/misc/asdf/tags/transform/projections.py:7: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
___________________________ ERROR collecting astropy/io/misc/asdf/tags/transform/tabular.py ____________________________
astropy/io/misc/asdf/tags/transform/tabular.py:9: in <module>
    from .basic import TransformType
astropy/io/misc/asdf/tags/transform/basic.py:4: in <module>
    from asdf import tagged
E   ModuleNotFoundError: No module named 'asdf'
____________________________ ERROR collecting astropy/io/misc/asdf/tags/unit/equivalency.py ____________________________
astropy/io/misc/asdf/tags/unit/equivalency.py:8: in <module>
    from astropy.io.misc.asdf.types import AstropyType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
_____________________________ ERROR collecting astropy/io/misc/asdf/tags/unit/quantity.py ______________________________
astropy/io/misc/asdf/tags/unit/quantity.py:7: in <module>
    from asdf.tags.core import NDArrayType
E   ModuleNotFoundError: No module named 'asdf'
_______________________________ ERROR collecting astropy/io/misc/asdf/tags/unit/unit.py ________________________________
astropy/io/misc/asdf/tags/unit/unit.py:7: in <module>
    from astropy.io.misc.asdf.types import AstropyAsdfType
astropy/io/misc/asdf/types.py:4: in <module>
    from asdf.types import CustomType, ExtensionTypeMeta
E   ModuleNotFoundError: No module named 'asdf'
```

With this patch, all `io.misc.asdf` tests are skipped without collection error when `asdf` is not installed. But I am not familiar with how `asdf` works, so review from experts would be greatly appreciated.

cc @eslavich 

**TODO**

- [ ] If this is acceptable, does this need a change log after milestone is set?