### PR TITLE
Add spectral flux equivalency property to SpectralQuantity

### DIFF
--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -295,7 +295,11 @@ class SpectralQuantity(SpecificTypeQuantity):
     def to_value(self, *args, **kwargs):
         return self.to(*args, **kwargs).value
 
-
     @property
     def spectral_density_equivalency(self):
+        """
+        A `~astropy.units.spectral_density` equivalency for this spectral
+        quantity. I.e., an equivalency that can be passed to ``.to`` for a
+        quantity with spectral flux density units.
+        """
         return spectral_density(self)

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.units import si
+from astropy.units import si, spectral_density
 from astropy.units import equivalencies as eq
 from astropy.units.quantity import SpecificTypeQuantity, Quantity
 from astropy.units.decorators import quantity_input
@@ -294,3 +294,8 @@ class SpectralQuantity(SpecificTypeQuantity):
 
     def to_value(self, *args, **kwargs):
         return self.to(*args, **kwargs).value
+
+
+    @property
+    def spectral_density_equivalency(self):
+        return spectral_density(self)

--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -242,3 +242,12 @@ class TestSpectralQuantity:
         assert isinstance(q1, u.Quantity) and not isinstance(q1, SpectralQuantity)
         assert q1.value == np.sum(sq1.value)
         assert q1.unit == u.AA
+
+    def test_flux_density(self):
+        sq1 = SpectralQuantity([10, 20, 30] * u.AA)
+
+        f_lamb = [1, 1, 1]  * u.erg / u.cm**2 / u.s / u.AA
+
+        to_fnu = f_lamb.to(u.erg / u.cm**2 / u.s / u.Hz,
+                           equivalencies=sq1.spectral_density_equivalency)
+        assert_quantity_allclose(to_fnu, [1, 2**2, 3**2]*(3.33e-17 * u.erg / u.cm**2 / u.s / u.Hz), rtol=.01)


### PR DESCRIPTION
This is a follow-on from #10185 - in https://github.com/astropy/astropy/pull/10185#pullrequestreview-404383900 I suggested this idea, issued it as a PR to @astrofrog's #10185 branch via astrofrog/astropy#100, but then in https://github.com/astropy/astropy/pull/10185#issuecomment-622614974 @mhvk rightly brought up some questions, so I've re-worked it as a PR against master since #10185 was ready to merge. So this has already gotten some review from @astrofrog, but it would be good to hear what @mhvk thinks.

(I've labeled in `no-changelog-entry-needed` on the theory we might get it in for 4.1, but that will have to be revised if it gets pushed to 4.2).