### PR TITLE
Fix asdf minversion in install doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ rst_epilog += """
 .. |minimum_numpy_version| replace:: {0.__minimum_numpy_version__}
 .. |minimum_scipy_version| replace:: {0.__minimum_scipy_version__}
 .. |minimum_yaml_version| replace:: {0.__minimum_yaml_version__}
+.. |minimum_asdf_version| replace:: {0.__minimum_asdf_version__}
 
 .. Astropy
 .. _`Astropy mailing list`: https://mail.python.org/mailman/listinfo/astropy

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -66,7 +66,7 @@ Requirements
 - `mpmath <http://mpmath.org/>`_: Used for the 'kraft-burrows-nousek'
   interval in `~astropy.stats.poisson_conf_interval`.
 
-- `asdf <https://github.com/spacetelescope/asdf>`_ 2.3 or later: Enables the
+- `asdf <https://github.com/spacetelescope/asdf>`_ |minimum_asdf_version| or later: Enables the
   serialization of various Astropy classes into a portable, hierarchical,
   human-readable representation.
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address outdated minversion of `asdf` documented in install doc. Noticed this while working on #10257.
