### PR TITLE
Add support for 0d NaN / NaT Times

### DIFF
--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -416,7 +416,10 @@ class Time(ShapedLikeNDArray):
         if self.isscalar:
             return self.mask
 
-        return np.isnan(self.jd2.filled())
+        if np.ma.is_masked(self.jd2):
+            return np.isnan(self.jd2.filled())
+        else:
+            return np.isnan(self.jd2)
 
     def __getnewargs__(self):
         return (self._time,)

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -216,8 +216,12 @@ class TimeFormat(metaclass=TimeFormatMeta):
         self._scale = val
 
     def mask_if_needed(self, value):
+        # fill value for integer array is not straight forward
+        # what could be an appriopriate value here?
+        # 999999 is the numpy default
+        fill_value = np.nan if value.dtype.kind == 'f' else 999999
         if self.masked:
-            value = np.ma.array(value, mask=self.mask, copy=False, fill_value=np.nan)
+            value = np.ma.array(value, mask=self.mask, copy=False, fill_value=fill_value)
         return value
 
     @property

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -517,9 +517,6 @@ class TestBasic:
             Time(50000.0, 'bad', format='mjd', scale='tai')
         with pytest.raises(ValueError):
             Time('2005-08-04T00:01:02.000Z', scale='tai')
-        # regression test against #3396
-        with pytest.raises(ValueError):
-            Time(np.nan, format='jd', scale='utc')
         with pytest.raises(ValueError):
             with pytest.warns(AstropyDeprecationWarning):
                 Time('2000-01-02T03:04:05(TAI)', scale='utc')

--- a/astropy/time/tests/test_mask.py
+++ b/astropy/time/tests/test_mask.py
@@ -76,7 +76,7 @@ def test_str():
 
     expected = ["masked_array(data=['2000-01-01 00:00:00.000', --],",
                 '             mask=[False,  True],',
-                "       fill_value='N/A',",
+                "       fill_value='999999',",
                 "            dtype='<U23')"]
 
     # Note that we need to take care to allow for big-endian platforms,

--- a/astropy/time/tests/test_nan.py
+++ b/astropy/time/tests/test_nan.py
@@ -1,0 +1,98 @@
+import numpy as np
+from astropy.time import Time, TimeDelta
+import astropy.units as u
+import pytest
+
+
+FLOAT_FORMATS = [
+    'byear',
+    'cxcsec',
+    'decimalyear',
+    'gps',
+    'jd',
+    'jyear',
+    'mjd',
+    'plot_date',
+    'stardate',
+    'unix',
+    'unix_tai',
+]
+
+STRING_FORMATS = {
+    'byear_str': 'B1950.0',
+    'jyear_str': 'J2000.0',
+    'iso': '2020-01-01 20:00:00.5',
+    'isot': '2020-01-01T20:00:00.5',
+    'yday': '2020:300:20:00:05',
+}
+
+
+def test_time_creation():
+    '''Test a time scalar can be created as nan'''
+    t = Time(np.nan, format='jd')  # for now, in principle, it shouldn't matter
+    assert np.isnan(t)
+    assert np.isnat(t)
+
+    ts = Time([0, 1, np.nan, 2, 3], format='jd')
+    assert np.all(np.isnan(ts) == [False, False, True, False, False])
+
+
+def test_timedelta_creation():
+    '''Test a timedelta scalar can be created as nan'''
+    t = TimeDelta(np.nan)
+
+    t = TimeDelta(np.nan * u.s)
+    assert np.isnan(t)
+    assert np.isnat(t)
+
+    assert np.isnan(t.to_value(u.h))
+    assert np.isnan(t.to_value(u.s))
+
+    ts = TimeDelta([0, 1, np.nan, 2, 3] * u.s)
+    assert np.all(np.isnan(ts) == [False, False, True, False, False])
+
+
+def test_nan_behaviour():
+    '''Test if times follow the usual nan behaviour'''
+
+    valid_time = Time('2020-01-01T00:00')
+    valid_delta = TimeDelta(1 * u.hour)
+    nan_time = Time(np.nan, format='jd')
+    nan_delta = TimeDelta(np.nan)
+    valid_quantity = 5 * u.hour
+    nan_quantity = np.nan * u.s
+
+    assert np.isnan(valid_time + nan_delta)
+    assert np.isnan(valid_time + nan_quantity)
+
+    assert np.isnan(nan_time + valid_delta)
+    assert np.isnan(nan_time + valid_quantity)
+
+    assert np.isnan(nan_time + nan_quantity)
+    assert np.isnan(nan_time + nan_delta)
+
+    assert np.isnan(nan_time - valid_time)
+    assert np.isnan(valid_time - nan_time)
+
+    assert Time(np.nan, format='jd') != Time(np.nan, format='jd')
+    assert TimeDelta(np.nan) != TimeDelta(np.nan)
+
+
+@pytest.mark.parametrize('fmt', FLOAT_FORMATS)
+def test_float_formats(fmt):
+    '''Test a time scalar can be created as nan'''
+    t = Time(np.nan, format=fmt)
+    assert np.isnat(t)
+
+    t = Time([np.nan, 2000.0], format=fmt)
+    assert np.all(np.isnat(t) == [True, False])
+
+
+@pytest.mark.parametrize('fmt,example', STRING_FORMATS.items())
+def test_string_formats(fmt, example):
+    '''Test a time scalar can be created as nan'''
+    t = Time('NaT', format=fmt)
+    assert np.isnat(t)
+
+    t = Time(['NaT', example], format=fmt)
+    assert np.all(np.isnat(t) == [True, False])

--- a/astropy/time/tests/test_nan.py
+++ b/astropy/time/tests/test_nan.py
@@ -74,6 +74,7 @@ def test_nan_behaviour():
     assert np.isnan(nan_time - valid_time)
     assert np.isnan(valid_time - nan_time)
 
+    assert not (Time(np.nan, format='jd') == Time(np.nan, format='jd'))
     assert Time(np.nan, format='jd') != Time(np.nan, format='jd')
     assert TimeDelta(np.nan) != TimeDelta(np.nan)
 

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -119,7 +119,7 @@ def can_have_arbitrary_unit(value):
     -------
     `True` if each member is either zero or not finite, `False` otherwise
     """
-    return np.all(np.logical_or(np.equal(value, 0.), ~np.isfinite(value)))
+    return np.all(np.logical_or(value == 0.0, ~np.isfinite(value)))
 
 
 def converters_and_unit(function, method, *args):


### PR DESCRIPTION
# Description

For further discussion relevant to #6509, I here add test cases for possible `nan` / `NaT` values for `astropy.time` objects.

I have also started to look into implementing this.