### PR TITLE
Fix new failure of spectral coord test because of quantity_input changes

### DIFF
--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -262,7 +262,7 @@ def test_init_wrong_type():
         SpectralCoord(10 * u.GHz, radial_velocity=1 * u.kg)
 
     with pytest.raises(TypeError, match="Argument 'radial_velocity' to function "
-                                        "'__new__' has no 'unit' attribute. You may want to "
+                                        "'__new__' has no 'unit' attribute. You should "
                                         "pass in an astropy Quantity instead."):
         SpectralCoord(10 * u.GHz, radial_velocity='banana')
 


### PR DESCRIPTION
Because of two merged PRs (SpectralCoord and changes to quantity_input_) that weren't consistent, travis is now failing. This should fix it!