### PR TITLE
Fix some problems with converting unitspherical representations with differentials

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -741,6 +741,13 @@ astropy.coordinates
   Earth location of the observer was ignored during the correction for light travel
   time. [#10292]
 
+- Ensure that coordinates with proper motion that are transformed to other
+  coordinate frames still can be represented properly. [#10276]
+
+- Improve the error message given when trying to get a cartesian representation
+  for coordinates that have both proper motion and radial velocity, but no
+  distance. [#10276]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1125,7 +1125,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                             continue
 
                         if new_attr_unit and hasattr(diff, comp):
-                            diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit)
+                            try:
+                                diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit)
+                            except Exception:
+                                diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit / u.m).decompose()
 
                     diff = diff.__class__(copy=False, **diffkwargs)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1124,11 +1124,16 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                               and comp not in data_diff.__class__.attr_classes):
                             continue
 
+                        # Try to convert to requested units. Since that might
+                        # not be possible (e.g., for a coordinate with proper
+                        # motion but without distance, one cannot convert to a
+                        # cartesian differential in km/s), we allow the unit
+                        # conversion to fail.  See gh-7028 for discussion.
                         if new_attr_unit and hasattr(diff, comp):
                             try:
                                 diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit)
                             except Exception:
-                                diffkwargs[comp] = diffkwargs[comp].to(new_attr_unit / u.m).decompose()
+                                pass
 
                     diff = diff.__class__(copy=False, **diffkwargs)
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1087,9 +1087,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                                        (r.UnitSphericalDifferential,
                                         r.UnitSphericalCosLatDifferential,
                                         r.RadialDifferential))):
-                    raise ValueError('need a distance to retrieve a cartesian representation '
-                                     'when both radial velocity and proper motion are '
-                                     'present.')
+                    raise u.UnitConversionError(
+                        'need a distance to retrieve a cartesian representation '
+                        'when both radial velocity and proper motion are present, '
+                        'since otherwise the units cannot match.')
 
                 # TODO NOTE: only supports a single differential
                 data = self.data.represent_as(representation_cls,

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -5,7 +5,7 @@ import pytest
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates.builtin_frames import ICRS, Galactic, Galactocentric
+from astropy.coordinates.builtin_frames import CIRS, ICRS, Galactic, Galactocentric
 from astropy.coordinates import builtin_frames as bf
 from astropy.coordinates import galactocentric_frame_defaults
 from astropy.units import allclose as quantity_allclose
@@ -320,3 +320,9 @@ def test_velocity_units():
             representation_type=r.CartesianRepresentation,
             differential_type=r.CartesianDifferential)
     assert "data units are not compatible with" in str(excinfo.value)
+
+
+def test_frame_with_velocity_without_distance_can_be_transformed():
+    frame = CIRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
+    rep = frame.transform_to(ICRS)
+    assert "<ICRS Coordinate: (ra, dec, distance) in" in repr(rep)


### PR DESCRIPTION
This is based on #9086 by @shreyasbapat, fixing problems occurring when transforming frames that have unitspherical representation (i.e., no distance), but associated differentials. For the case where both an PM and RV are passed in, transforming to `Cartesian` now gives a proper error:
```
from astropy import units as u, coordinates as coord
f = coord.ICRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr, radial_velocity=10*u.km/u.s)
f.cartesian
# ValueError: need a distance to retrieve a cartesian representation when both radial velocity and proper motion are present.
```
(was: `UnitConversionError: 'mas / (rad yr)' (frequency) and 'km / s' (speed) are not convertible`)

While transformation to another coordinate system (when just proper motion is present) is now possible without error:
```
f = coord.ICRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
f.transform_to(coord.GCRS)                                                                     
Out[6]: 
<GCRS Coordinate (obstime=J2000.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, )
    (0.99913887, 1.99978324, 1.)
 (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, 1 / s)
    (-120973.77841962, -52927.83682285, -3.8490435e-17)>
```
(where before that gave an error)

Note that the small RV component that is created is rather unfortunate, and it would be nice to get rid of it, but since that also happens for quite a few other cases, I think it is out of scope here. Similarly, we'd need to think a bit more about the case where an RV is present (either on its own, or as well) - that continues to fail, but is trickier to deal with.

fixes #7028
