### PR TITLE
TST: switch to use numpy nightly wheels

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,8 @@ requires =
     pip >= 19.3.1
     tox-pypi-filter >= 0.12
 isolated_build = true
+indexserver =
+    NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple
 
 [testenv]
 
@@ -71,8 +73,8 @@ deps =
     oldestdeps: pytest-openfiles==0.4.0
 
     # The devdeps factor is intended to be used to install the latest developer version
-    # of key dependencies.
-    devdeps: git+https://github.com/numpy/numpy.git#egg=numpy
+    # or nightly wheel of key dependencies.
+    devdeps: :NIGHTLY:numpy
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
 


### PR DESCRIPTION
Numpy distributes dev version wheels. Switching to use these we can avoid to build numpy from source. 

Downside is that these are in fact weekly "nighly" builds, so if a failure is due to a bug upstream we may not catch the fix right away and may stuck with the job failing for a few days. Given that we allow the numpy dev job to fail for PRs, I don't think it's a big deal.

The same server serves scipy, scikit-learn, and pandas nightly so we can't switch the mpl dependency yet. On the other hand we may want to see whether astropy nightly/weekly builds could be distributed using the same infrastructure. 

cc @astrofrog  and @mhvk for input