### PR TITLE
Add to what's new in 4.1 and fix constraints serialization

### DIFF
--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -84,12 +84,13 @@ class TransformType(AstropyAsdfType):
             node['outputs'] = model.outputs
 
         # model / parameter constraints
-        fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
-        if fixed_nondefaults:
-            node['fixed'] = fixed_nondefaults
-        bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
-        if bounds_nondefaults:
-            node['bounds'] = bounds_nondefaults
+        if not isinstance(model, CompoundModel):
+            fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
+            if fixed_nondefaults:
+                node['fixed'] = fixed_nondefaults
+            bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
+            if bounds_nondefaults:
+                node['bounds'] = bounds_nondefaults
 
     @classmethod
     def to_tree_transform(cls, model, ctx):

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -19,23 +19,31 @@ In particular, this release includes:
 
 2. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
 
-3. Added the True Equator Mean Equinox frame.
-
-4. Support for in-place setting of array-valued ``SkyCoord`` and coordinate
+3. Support for in-place setting of array-valued ``SkyCoord`` and coordinate
    frame objects using standard numpy syntax like ``sc1[10:15] == sc2``.
 
-5. Change in the definition of equality comparison for coordinate classes.
+4. Change in the definition of equality comparison for coordinate classes.
 
-6. Support use of ``SkyCoord`` in table ``vstack``, ``dstack``, and
+5. Support use of ``SkyCoord`` in table ``vstack``, ``dstack``, and
    ``insert_row``.
 
-7. Support for table "fuzzy" cross-match join with ``SkyCoord``, ``Quantity``
+6. Support for table "fuzzy" cross-match join with ``SkyCoord``, ``Quantity``
    or N-d columns.
 
-8. Support for custom attributes in ``Table`` subclasses.
+7. Support for custom attributes in ``Table`` subclasses.
 
-9. Added a new ``Time`` subformat ``unix_tai`` which is analogous to standard
+8. Added a new ``Time`` subformat ``unix_tai`` which is analogous to standard
    ``unix`` time but includes leap-seconds.
+
+9. All models are now serializable to ASDF.
+   Model constraints of type ``fixed``and ``bounds`` are serialized as well.
+
+10. It is now possible to create a new ``CompoundModel`` by modifying an existing one with the ``replace_submodel`` method.
+
+11. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
+
+12. Added a ``Plummer`` model.
+
 
 New ``SpectralCoord`` class for representing and transforming spectral quantities
 =================================================================================


### PR DESCRIPTION
Constraints of compound models are serialized twice - once on the compound model and once on the constituent models. This PR removes constraints serialization from the compound models.

Added what's new items for modeling (should have done this probably in a separate PR.