### PR TITLE
Fixed a bug with frame attributes that are coordinates when checking for frame equivalency

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -966,7 +966,8 @@ class SkyCoord(ShapedLikeNDArray):
                 return False
 
             for fattrnm in frame_transform_graph.frame_attributes:
-                if np.any(getattr(self, fattrnm) != getattr(other, fattrnm)):
+                if not BaseCoordinateFrame._frameattr_equiv(getattr(self, fattrnm),
+                                                            getattr(other, fattrnm)):
                     return False
             return True
         else:

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1094,6 +1094,29 @@ def test_equivalent_frames():
     assert not aa1.is_equivalent_frame(aa2)
 
 
+def test_equivalent_frame_coordinateattribute():
+    from astropy.coordinates import BaseCoordinateFrame
+    from astropy.coordinates.attributes import CoordinateAttribute
+    from astropy.coordinates.builtin_frames import HCRS
+
+    class FrameWithCoordinateAttribute(BaseCoordinateFrame):
+        coord_attr = CoordinateAttribute(HCRS)
+
+    # These frames should not be considered equivalent
+    f1 = FrameWithCoordinateAttribute(coord_attr=HCRS(1*u.deg, 2*u.deg, obstime='J2000'))
+    f2 = FrameWithCoordinateAttribute(coord_attr=HCRS(3*u.deg, 4*u.deg, obstime='J2000'))
+    f3 = FrameWithCoordinateAttribute(coord_attr=HCRS(1*u.deg, 2*u.deg, obstime='J2001'))
+
+    assert not f1.is_equivalent_frame(f2)
+    assert not f1.is_equivalent_frame(f3)
+    assert not f2.is_equivalent_frame(f3)
+
+    # They each should still be equivalent to a deep copy of themselves
+    assert f1.is_equivalent_frame(deepcopy(f1))
+    assert f2.is_equivalent_frame(deepcopy(f2))
+    assert f3.is_equivalent_frame(deepcopy(f3))
+
+
 def test_representation_subclass():
 
     # Regression test for #3354


### PR DESCRIPTION
Fixes #10287 

* `BaseCoordinateFrame`'s version of `is_equivalent_frame()` already had a private function for special handling of representation attributes (which is possibly removable in light of #10154, but I did not touch that), so I added special handling for coordinate attributes.  Now, if the coordinate attributes do not have equivalent frames, it avoids checking for equality (which would raise an error).
* I changed `SkyCoord`'s version of `is_equivalent_frame()` to call the private function under `BaseCoordinateFrame`.