### PR TITLE
Changed size property for BaseCoordinateFrame to return 0 if there is no data

### DIFF
--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -705,7 +705,10 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
     @property
     def size(self):
-        return self.data.size
+        """
+        Returns the size of the underlying data if it exists, else returns 0.
+        """
+        return self.data.size if self.has_data else 0
 
     @property
     def isscalar(self):

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1445,3 +1445,15 @@ def test_galactocentric_references(reset_galactocentric_defaults):
                 assert k not in galcen_custom.frame_attribute_references
             else:
                 assert k in galcen_custom.frame_attribute_references
+
+
+def test_size():
+    from astropy.coordinates.builtin_frames import ICRS
+
+    c1 = ICRS()
+    c2 = ICRS(1*u.deg, 2*u.deg)
+    c3 = ICRS([1, 2]*u.deg, [3, 4]*u.deg)
+
+    assert c1.size == 0
+    assert c2.size == 1
+    assert c3.size == 2


### PR DESCRIPTION
Currently, the `size` property of `BaseCoordinateFrame` errors if the frame has no data.  This PR changes the property to return 0 instead.

The reason that I want this change is because I'd like to carry a data-less frame as a frame attribute.  The frame-attribute machinery checks the size of each attribute to see whether it is broadcast-able to the same size as overarching frame's data.  Thus, the erroring for the size of a data-less frame is problematic.  Rather than adding any special handling to the frame-attribute machinery, it seems cleaner to have `size` return 0 for a data-less frame.