### PR TITLE
Fixed a check of non-equality between frames in a test

### DIFF
--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -444,5 +444,5 @@ def test_highlevel_api_remote():
 
     m31fk4 = coords.SkyCoord.from_name('M31', frame='fk4')
 
-    assert m31icrs.frame != m31fk4.frame
+    assert not m31icrs.is_equivalent_frame(m31fk4)
     assert np.abs(m31icrs.ra - m31fk4.ra) > .5*u.deg


### PR DESCRIPTION
Fixes #10297 

The test had a `!=`, which now raises an error after #10154.  It has been replaced with `not ... ._is_equivalent_frame()`, which works after #10290.