### PR TITLE
BUG: Fix wcsapi doctest

### DIFF
--- a/docs/wcs/wcsapi.rst
+++ b/docs/wcs/wcsapi.rst
@@ -270,8 +270,7 @@ any WCS object that conforms to the :class:`~astropy.wcs.wcsapi.BaseLowLevelWCS`
 API. To demonstrate this, let's start off by reading in a spectral cube file::
 
     >>> filename = get_pkg_data_filename('l1448/l1448_13co.fits')  # doctest: +REMOTE_DATA
-    >>> hdu = fits.open(filename)[0]  # doctest: +REMOTE_DATA
-    >>> wcs = WCS(hdu.header)  # doctest: +REMOTE_DATA
+    >>> wcs = WCS(fits.getheader(filename, ext=0))  # doctest: +REMOTE_DATA
 
 The ``wcs`` object is an instance of :class:`~astropy.wcs.WCS` which conforms to the
 :class:`~astropy.wcs.wcsapi.BaseLowLevelWCS` API. We can then use the
@@ -293,6 +292,7 @@ If you are implementing your own WCS class, you could choose to implement
 more succinctly as::
 
     >>> wcs[10, 30:100, 30:100]  # doctest: +REMOTE_DATA +ELLIPSIS
+    <...>
     SlicedFITSWCS Transformation
     <BLANKLINE>
     This transformation has 2 pixel and 2 world dimensions
@@ -322,6 +322,7 @@ image plane of a spectral slice, the final WCS will have one pixel dimension
 and two world dimensions (since both RA/Dec vary over the extracted 1D slice)::
 
     >>> wcs[10, 40, :]  # doctest: +REMOTE_DATA +ELLIPSIS
+    <...>
     SlicedFITSWCS Transformation
     <BLANKLINE>
     This transformation has 1 pixel and 2 world dimensions


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address failing remote data doctest for `wcsapi` example. I think this is a direct follow-up of #10229.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10299 
