### PR TITLE
Speed up wcsaxes import by avoiding unnecessary pytest import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -621,6 +621,9 @@ astropy.visualization
 - Fixed a bug where the ``ImageNormalize`` ``clip`` keyword was
   ignored when used with calling the object on data. [#10098]
 
+- Sped up ``import astropy.visualization.wcsaxes`` by skipping a pytest import
+  if we are not running the unit tests. [#10302]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/tests/__init__.py
+++ b/astropy/tests/__init__.py
@@ -4,3 +4,6 @@ This package contains utilities to run the astropy test suite, tools
 for writing tests, and general tests that are not associated with a
 particular package.
 """
+
+RUNNING = False
+"""Flag that indicates if our unit tests are running."""

--- a/astropy/tests/conftest.py
+++ b/astropy/tests/conftest.py
@@ -1,0 +1,11 @@
+from .. import tests
+
+
+def pytest_configure(config):
+    tests.RUNNING = True
+    print('SET RUNNING TO TRUE')
+
+
+def pytest_unconfigure(config):
+    tests.RUNNING = False
+    print('SET RUNNING TO FALSE')

--- a/astropy/visualization/wcsaxes/__init__.py
+++ b/astropy/visualization/wcsaxes/__init__.py
@@ -3,12 +3,11 @@
 # The following few lines skip this module when running tests if matplotlib is
 # not available (and will have no impact otherwise)
 
-try:
+from ... import tests
+
+if tests.RUNNING:
     import pytest
     pytest.importorskip("matplotlib")
-    del pytest
-except ImportError:
-    pass
 
 from .core import *
 from .coordinate_helpers import CoordinateHelper


### PR DESCRIPTION
In `astropy.visualization.wcsaxes`, do not import pytest unless we are actually running the tests. Pytest is a fairly heavyweight import, so it should not be imported unless it's actually needed.
