### PR TITLE
DOC: Un-skip coordinate example for doctest

### DIFF
--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -381,13 +381,11 @@ and transforming velocities. These are available both via the lower-level
 objects::
 
     >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)
-    >>> sc  # doctest: +SKIP
+    >>> sc  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        ( 1.,  2.)
+        (1., 2.)
      (radial_velocity) in km / s
-        ( 20.,)>
-
-.. the SKIP above in the ``sc`` line is because NumPy has a subtly different output in versions < 12 - the trailing comma is missing. If a NPY_LT_1_12 comes in to being this can switch to that. But don't forget to *also* change this in the velocities.rst file.
+        (20.,)>
 
 For more details on velocity support (and limitations), see the
 :doc:`velocities` page.

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -24,15 +24,13 @@ proper motion and distance could be created as::
     >>> from astropy.coordinates import SkyCoord
     >>> import astropy.units as u
     >>> sc = SkyCoord(1*u.deg, 2*u.deg, radial_velocity=20*u.km/u.s)
-    >>> sc  # doctest: +SKIP
+    >>> sc  # doctest: +FLOAT_CMP
     <SkyCoord (ICRS): (ra, dec) in deg
-        ( 1.,  2.)
+        (1., 2.)
      (radial_velocity) in km / s
-        ( 20.,)>
+        (20.,)>
     >>> sc.radial_velocity  # doctest: +FLOAT_CMP
     <Quantity 20.0 km / s>
-
-.. the SKIP above in the ``sc`` line is because numpy has a subtly different output in versions < 12 - the trailing comma is missing.  If a NPY_LT_1_12 comes in to being this can switch to that.  But don't forget to *also* change this in the coordinates/index.rst file
 
 |skycoord| objects created in this manner follow all of the same transformation
 rules and will correctly update their velocities when transformed to other
@@ -449,14 +447,25 @@ precision is not sufficient to compute differences of order km over distances
 of order kiloparsecs. Hence, the straightforward finite difference method will
 not work for this use case with the default values.
 
+.. testsetup::
+
+    >>> import numpy as np
+    >>> from astropy.coordinates import EarthLocation, AltAz, GCRS
+    >>> from astropy.time import Time
+    >>> time = Time('J2010') + np.linspace(-1,1,1000) * u.min
+    >>> location = EarthLocation(lon=0*u.deg, lat=45*u.deg)
+    >>> aa = AltAz(alt=[45]*1000*u.deg, az=90*u.deg, distance=100*u.kpc,
+    ...            radial_velocity=[10]*1000*u.km/u.s,
+    ...            location=location, obstime=time)
+
 It is possible to override the timestep over which the finite difference occurs.
 For example::
 
     >>> from astropy.coordinates import frame_transform_graph, AltAz, CIRS
     >>> trans = frame_transform_graph.get_transform(AltAz, CIRS).transforms[0]
-    >>> trans.finite_difference_dt = 1*u.year
-    >>> gcrs = aa.transform_to(GCRS(obstime=time))  # doctest: +SKIP
-    >>> trans.finite_difference_dt = 1*u.second  # return to default
+    >>> trans.finite_difference_dt = 1 * u.year
+    >>> gcrs = aa.transform_to(GCRS(obstime=time))  # doctest: +REMOTE_DATA
+    >>> trans.finite_difference_dt = 1 * u.second  # return to default
 
 But beware that this will *not* help in cases like the above, where the relevant
 timescales for the velocities are seconds. (The velocity of the Earth relative


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to undo skipping of doctest in `coordinates` that claims different result under Numpy 1.12 because now our Numpy minversion is 1.16. There is also one example that is skipped for no apparent reason.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

I noticed this while working on #10304 .

**TODO**

- [x] I'll let someone else set the milestone.