### PR TITLE
Fix fast_reader parsing of RDB headers with names specified and performance issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,6 +171,11 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
+- Fix failure of ASCII ``fast_reader`` to handle ``names``, ``include_names``,
+  ``exclude_names`` arguments for ``RDB`` formatted tables; homogenised checks
+  and exceptions for invalif ``names`` arguments; improved performance when
+  parsing tables with duplicate column names. [#10306]
+
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,11 +171,6 @@ astropy.extern
 astropy.io.ascii
 ^^^^^^^^^^^^^^^^
 
-- Fix failure of ASCII ``fast_reader`` to handle ``names``, ``include_names``,
-  ``exclude_names`` arguments for ``RDB`` formatted tables; homogenised checks
-  and exceptions for invalif ``names`` arguments; improved performance when
-  parsing tables with duplicate column names. [#10306]
-
 astropy.io.fits
 ^^^^^^^^^^^^^^^
 
@@ -295,6 +290,11 @@ astropy.io.ascii
 - Functional Units can now be processed in CDS-tables. [#9971]
 
 - Allow reading in ASCII tables which have duplicate column names. [#9939]
+
+- Fixed failure of ASCII ``fast_reader`` to handle ``names``, ``include_names``,
+  ``exclude_names`` arguments for ``RDB`` formatted tables. Homogenised checks
+  and exceptions for invalid ``names`` arguments. Improved performance when
+  parsing "wide" tables with many columns. [#10306]
 
 - Added type validation of key arguments in calls to ``io.ascii.read()`` and
   ``io.ascii.write()`` functions. [#10005]

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1039,11 +1039,11 @@ def _deduplicate_names(names):
     existing_names = set()
 
     for name in names:
-        orig_name = name
+        base_name = name + '_'
         i = 1
         while name in existing_names:
             # Iterate until a unique name is found
-            name = orig_name + '_' + str(i)
+            name = base_name + str(i)
             i += 1
         new_names.append(name)
         existing_names.add(name)
@@ -1154,12 +1154,12 @@ def _apply_include_exclude_names(table, names, include_names, exclude_names):
         for ii, name in enumerate(names):
             table.rename_column(xxxs + str(ii), name)
 
-    colnames_uniq = _deduplicate_names(table.colnames)
-    if colnames_uniq != table.colnames:
-        rename_columns(table, colnames_uniq)
-
     if names is not None:
         rename_columns(table, names)
+    else:
+        colnames_uniq = _deduplicate_names(table.colnames)
+        if colnames_uniq != list(table.colnames):
+            rename_columns(table, colnames_uniq)
 
     names_set = set(table.colnames)
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -1556,6 +1556,10 @@ def _get_reader(Reader, Inputter=None, Outputter=None, **kwargs):
         reader.header.splitter = kwargs['header_Splitter']()
     if 'names' in kwargs:
         reader.names = kwargs['names']
+        if None in reader.names:
+            raise TypeError('Cannot have None for column name')
+        if len(set(reader.names)) != len(reader.names):
+            raise ValueError('Duplicate column names')
     if 'include_names' in kwargs:
         reader.include_names = kwargs['include_names']
     if 'exclude_names' in kwargs:

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -308,7 +308,7 @@ cdef class CParser:
         self.tokenizer.source = self.source_bytes
         self.tokenizer.source_len = <size_t>len(self.source_bytes)
 
-    def read_header(self, deduplicate=True):
+    def read_header(self, deduplicate=True, filter_names=True):
         self.tokenizer.source_pos = 0
 
         # header_start is a valid line number
@@ -321,9 +321,9 @@ cdef class CParser:
             self.header_names = []
             name = ''
 
-            for i in range(self.tokenizer.output_len[0]): # header is in first col string
-                c = self.tokenizer.output_cols[0][i] # next char in header string
-                if not c: # zero byte -- field terminator
+            for i in range(self.tokenizer.output_len[0]):  # header is in first col string
+                c = self.tokenizer.output_cols[0][i]       # next char in header string
+                if not c:  # zero byte -- field terminator
                     if name:
                         # replace empty placeholder with ''
                         self.header_names.append(name.replace('\x01', ''))
@@ -341,17 +341,17 @@ cdef class CParser:
             if tokenize(self.tokenizer, -1, 1, 0) != 0:
                 self.raise_error("an error occurred while tokenizing the first line of data")
             self.width = 0
-            for i in range(self.tokenizer.output_len[0]): # header is in first col string
+            for i in range(self.tokenizer.output_len[0]):  # header is in first col string
                 # zero byte -- field terminator
                 if not self.tokenizer.output_cols[0][i]:
                     # ends valid field
                     if i > 0 and self.tokenizer.output_cols[0][i - 1]:
                         self.width += 1
-                    else: # end of line
+                    else:  # end of line
                         break
-            if self.width == 0: # no data
+            if self.width == 0:  # no data
                 raise core.InconsistentTableError('No data lines found, C reader '
-                                            'cannot autogenerate column names')
+                                                  'cannot autogenerate column names')
             # auto-generate names
             self.header_names = ['col{0}'.format(i + 1) for i in range(self.width)]
 
@@ -362,9 +362,9 @@ cdef class CParser:
 
         # self.use_cols should only contain columns included in output
         self.use_cols = set(self.names)
-        if self.include_names is not None:
+        if filter_names and self.include_names is not None:
             self.use_cols.intersection_update(self.include_names)
-        if self.exclude_names is not None:
+        if filter_names and self.exclude_names is not None:
             self.use_cols.difference_update(self.exclude_names)
 
         self.width = <int>len(self.names)

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -245,6 +245,12 @@ cdef class CParser:
         self.fill_names = None
         self.fill_extra_cols = fill_extra_cols
 
+        if self.names is not None:
+            if None in self.names:
+                raise TypeError('Cannot have None for column name')
+            if len(set(self.names)) != len(self.names):
+                raise ValueError('Duplicate column names')
+
         # parallel=True indicates that we should use the CPU count
         if parallel is True:
             parallel = multiprocessing.cpu_count()

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1562,32 +1562,54 @@ def test_deduplicate_names_basic(rdb, fast_reader):
 
 
 def test_include_names_rdb_fast():
-    """Test that selecting column names with `include_names` works for the rdb format
+    """Test that selecting column names via `include_names` works for the RDB format
     with fast reader. This is testing the fix for a bug identified in #9939.
     """
     lines = _get_lines(True)
     lines[0] = 'a\ta_2\ta_1\ta_3\ta_4'
     dat = ascii.read(lines, fast_reader='force', include_names=['a', 'a_2', 'a_3'])
     assert len(dat) == 2
+    assert dat['a'].dtype == np.int
+    assert dat['a_2'].dtype == np.int
 
 
-def test_deduplicate_names_rdb_fast1():
-    """Test that selecting column names with `include_names` works for the rdb format
-    with fast reader and duplicate column names. Testing fix for a bug identified in #9939.
+@pytest.mark.parametrize('fast_reader', [False, 'force'])
+def test_deduplicate_names_with_types(fast_reader):
+    """Test that on selecting column names via `include_names` in the RDB format with
+    different types and duplicate column names type assignment is correctly preserved.
     """
     lines = _get_lines(True)
+    lines[1] = 'N\tN\tN\tS\tS'
 
-    dat = ascii.read(lines, fast_reader='force', include_names=['a', 'a_2', 'a_3'])
+    dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
     assert len(dat) == 2
+    assert dat['a_2'].dtype.kind == 'i'
+    assert dat['a_3'].dtype.kind == 'U'
 
-
-def test_deduplicate_names_rdb_fast2():
-    """Test that selecting column names with `include_names` works for the rdb format
-    with fast reader and duplicate column names. Testing fix for a bug identified in #9939.
-    """
-    lines = _get_lines(True)
-
-    dat = ascii.read(lines, fast_reader='force',
-                     names=['b1', 'b2', 'b3', 'b4', 'b5'],
-                     include_names=['b1', 'b2', 'b4'])
+    dat = ascii.read(lines, fast_reader=fast_reader, names=['b1', 'b2', 'b3', 'b4', 'b5'],
+                     include_names=['a1', 'a_2', 'b1', 'b2', 'b4'])
     assert len(dat) == 2
+    assert dat.colnames == ['b1', 'b2', 'b4']
+    assert dat['b2'].dtype.kind == 'i'
+    assert dat['b4'].dtype.kind == 'U'
+
+
+@pytest.mark.parametrize('rdb', [False, True])
+@pytest.mark.parametrize('fast_reader', [False, 'force'])
+def test_set_invalid_names(rdb, fast_reader):
+    """Test exceptions for invalid (duplicate or `None`) names specified via argument."""
+    lines = _get_lines(rdb)
+    if rdb:
+        fmt = 'rdb'
+    else:
+        fmt = 'basic'
+
+    with pytest.raises(ValueError) as err:
+        ascii.read(lines, fast_reader=fast_reader, format=fmt, guess=rdb,
+                   names=['b1', 'b2', 'b1', 'b4', 'b5'])
+    assert 'Duplicate column names' in str(err.value)
+
+    with pytest.raises(TypeError) as err:
+        ascii.read(lines, fast_reader=fast_reader, format=fmt, guess=rdb,
+                   names=['b1', 'b2', 'b1', None, None])
+    assert 'Cannot have None for column name' in str(err.value)

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1535,40 +1535,45 @@ def test_deduplicate_names_basic(rdb, fast_reader):
     assert dat.colnames == ['a', 'a_2', 'a_1', 'a_3', 'a_4']
     assert len(dat) == 2
 
-    if rdb is False or fast_reader is False:
-        dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
-        assert len(dat) == 2
-        assert dat.colnames == ['a', 'a_2', 'a_3']
-        assert np.all(dat['a'] == [1, 10])
-        assert np.all(dat['a_2'] == [2, 20])
-        assert np.all(dat['a_3'] == [4, 40])
+    dat = ascii.read(lines, fast_reader=fast_reader, include_names=['a', 'a_2', 'a_3'])
+    assert len(dat) == 2
+    assert dat.colnames == ['a', 'a_2', 'a_3']
+    assert np.all(dat['a'] == [1, 10])
+    assert np.all(dat['a_2'] == [2, 20])
+    assert np.all(dat['a_3'] == [4, 40])
 
-        dat = ascii.read(lines, fast_reader=fast_reader,
-                         names=['b1', 'b2', 'b3', 'b4', 'b5'],
-                         include_names=['b1', 'b2', 'b4'])
-        assert len(dat) == 2
-        assert dat.colnames == ['b1', 'b2', 'b4']
-        assert np.all(dat['b1'] == [1, 10])
-        assert np.all(dat['b2'] == [2, 20])
-        assert np.all(dat['b4'] == [4, 40])
+    dat = ascii.read(lines, fast_reader=fast_reader,
+                     names=['b1', 'b2', 'b3', 'b4', 'b5'],
+                     include_names=['b1', 'b2', 'a_4', 'b4'])
+    assert len(dat) == 2
+    assert dat.colnames == ['b1', 'b2', 'b4']
+    assert np.all(dat['b1'] == [1, 10])
+    assert np.all(dat['b2'] == [2, 20])
+    assert np.all(dat['b4'] == [4, 40])
+
+    dat = ascii.read(lines, fast_reader=fast_reader,
+                     names=['b1', 'b2', 'b3', 'b4', 'b5'],
+                     exclude_names=['b3', 'b5', 'a_3', 'a_4'])
+    assert len(dat) == 2
+    assert dat.colnames == ['b1', 'b2', 'b4']
+    assert np.all(dat['b1'] == [1, 10])
+    assert np.all(dat['b2'] == [2, 20])
+    assert np.all(dat['b4'] == [4, 40])
 
 
-@pytest.mark.xfail
-def test_include_names_rdb_fast_fail0():
-    """Test that selecting column names with `include_names` fails for the rdb format for fast reader.
-    This is not desired but reflects a current known limitation.
+def test_include_names_rdb_fast():
+    """Test that selecting column names with `include_names` works for the rdb format
+    with fast reader. This is testing the fix for a bug identified in #9939.
     """
     lines = _get_lines(True)
     lines[0] = 'a\ta_2\ta_1\ta_3\ta_4'
-
     dat = ascii.read(lines, fast_reader='force', include_names=['a', 'a_2', 'a_3'])
     assert len(dat) == 2
 
 
-@pytest.mark.xfail
-def test_include_names_rdb_fast_fail1():
-    """Test that `include_names` fails with duplicate column names for the rdb format for fast reader.
-    This is not desired but reflects a current known limitation.
+def test_deduplicate_names_rdb_fast1():
+    """Test that selecting column names with `include_names` works for the rdb format
+    with fast reader and duplicate column names. Testing fix for a bug identified in #9939.
     """
     lines = _get_lines(True)
 
@@ -1576,10 +1581,9 @@ def test_include_names_rdb_fast_fail1():
     assert len(dat) == 2
 
 
-@pytest.mark.xfail
-def test_include_names_rdb_fast_fail2():
-    """Test that `include_names` fails with duplicate column names for the rdb format for fast reader.
-    This is not desired but reflects a current known limitation.
+def test_deduplicate_names_rdb_fast2():
+    """Test that selecting column names with `include_names` works for the rdb format
+    with fast reader and duplicate column names. Testing fix for a bug identified in #9939.
     """
     lines = _get_lines(True)
 


### PR DESCRIPTION
### Description
#### for 4.2
Proposed fix for a `fast_reader` bug with `format='rdb'` identified in #9939 that occurs however unrelated to duplicate column names, whenever any of the `names`, `include_names` or `exclude_names` arguments are used. E.g.
```
>>> lines = ['a_0\ta_1\ta_2', 'N\tN\tN', '1\t2\t3', '10\t20\t30']
>>> ascii.read(lines, fast_reader='force', include_names=['a_1', 'a_2'])
<Table length=3>
a_1  a_2 
str2 str2
---- ----
   N    N
   2    3
  20   30
>>> ascii.read(lines, fast_reader='force', include_names=['a_1', 'a_2'], format='rdb')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/sw/lib/python3.8/site-packages/astropy/io/ascii/ui.py", line 304, in read
    dat = fast_reader_rdr.read(table)
  File "/sw/lib/python3.8/site-packages/astropy/io/ascii/fastbasic.py", line 118, in read
    conversion_info = self._read_header()
  File "/sw/lib/python3.8/site-packages/astropy/io/ascii/fastbasic.py", line 341, in _read_header
    raise core.InconsistentTableError('RDB header mismatch between number of '
astropy.io.ascii.core.InconsistentTableError: RDB header mismatch between number of column names and column types
```

#### `names` fixes
The reason is `rdb` is using a two-line header format with line 2 storing the type information, both of which are parsed using `CParser.read_header` that has applied to the 2nd line the full set of renaming and selection operations intended for the 1st line with the actual column names.

The fix follows the discussion in https://github.com/astropy/astropy/pull/9939#issuecomment-622574610 by always setting the `types` entries from `header_names`, saving custom `names` once set, and disabling the `in|exclude_names` filtering on the 2nd header line.

#### Timings
I have made some performance tests with a 4096-column table (otherwise equivalent to the test `lines` from #9939 with two rows of integer data):

with unique column names - 4.0.1:
`ascii.read(lines, fast_reader='force')`: 230 ms
`ascii.read(lines, fast_reader=False)`: 260 ms
`ascii.read(lines, fast_reader=False, names=alt_names)`: 35 s

master with #9939 merged:
`ascii.read(lines, fast_reader='force')`: 240 ms
`ascii.read(lines, fast_reader=False)`: 7 s
`ascii.read(lines, fast_reader=False, names=alt_names)`: 17 s
with duplicate names:
`ascii.read(lines, fast_reader=False)`: 9 s

`fast_reader` fixes from this PR:
`ascii.read(lines, fast_reader='force')`: 245 ms
`ascii.read(lines, fast_reader=False)`: 7 s
`ascii.read(lines, fast_reader='force', names=alt_names)`: 316 ms
with duplicate names:
`ascii.read(lines, fast_reader='force')`: 2.7 s
`ascii.read(lines, fast_reader='force', names=alt_names)`: 320 ms

Timings for `include_names` range from ca. 40 ms for up to 2 % of columns selected, to about the same times as with `names` for most of the columns selected.

The primary motivation for these timings were to check if the additional header reading in the fix impacted performance (which it does at the ~1 % level), but it also revealed some changes with  the Python parser:

1. The column renaming (for `names=alt_names`) has significantly gained in performance thanks to the new `rename_columns` implementation in #9939.

2. The standard parsing has nonetheless taken a 20x performance hit over the `fast_reader`.

#### Additional performance tuning
edec8f7 was an attempt to address some of the performance penalties in constructing unique names for `CParser`:

1. by using its own instance of `_deduplicate_names` pulled into `cparser.pyx`; this does not add any string operations on the C level, but since it's giving about 30 % speedup basically for free, it's perhaps worth the slight increase in code complexity.

2. skipping the check for duplicate names entirely if `names` have been passed as input argument, since in that case `header_names` will never be used anyway.

#### Checks and tests for invalid `names` arguments
In the 2nd case above it is of course the user's responsibility to provide unique column names, but invalid `names` have raised different exceptions in various different parts of the code. 4334b08 adds checks directly on calling `ascii.read` both for the Python and fast readers and ensures consistent exceptions with those raised in `Table` plus tests. With the default settings with `guess` enabled the exceptions still tend to be buried among the output on all the different formats tried, but they should at least be a bit easier to identify.

#### Performance fixes for Python parser
The reason for the dramatic slowdown on regular input (with valid, unique column names) turned out to be the check for `colnames_uniq != table.colnames`; since the former is a list and the latter a tuple at that point, the comparison evaluated always `False` enforcing a call to `rename_columns`.
In addition, with `names` specified, `table.colnames` would first be renamed to `colnames_uniq` and then to `names` from input. Changed analogously to the handling in `CParser`. This improves the timings to
unique column names:
`ascii.read(lines, fast_reader=False)`: 280 ms
`ascii.read(lines, fast_reader=False, names=alt_names)`: 5.8 s
duplicate names:
`ascii.read(lines, fast_reader=False)`: 9 s
`ascii.read(lines, fast_reader=False, names=alt_names)`: 6.5 s

