### PR TITLE
TST: Disable IERS download for testing

### DIFF
--- a/astropy/conftest.py
+++ b/astropy/conftest.py
@@ -48,6 +48,11 @@ def ignore_matplotlibrc():
 
 
 def pytest_configure(config):
+    from astropy.utils.iers import conf as iers_conf
+
+    # Disable IERS auto download for testing
+    iers_conf.auto_download = False
+
     builtins._pytest_running = True
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:
@@ -78,6 +83,11 @@ def pytest_configure(config):
 
 
 def pytest_unconfigure(config):
+    from astropy.utils.iers import conf as iers_conf
+
+    # Undo IERS auto download setting for testing
+    iers_conf.reset('auto_download')
+
     builtins._pytest_running = False
     # do not assign to matplotlibrc_cache in function scope
     if HAS_MATPLOTLIB:

--- a/astropy/coordinates/tests/test_solar_system.py
+++ b/astropy/coordinates/tests/test_solar_system.py
@@ -55,13 +55,13 @@ def test_positions_skyfield(tmpdir):
     # skyfield ephemeris
     try:
         planets = load('de421.bsp')
+        ts = load.timescale()
     except OSError as e:
         if os.environ.get('CI', False) and 'timed out' in str(e):
             pytest.xfail('Timed out in CI')
         else:
             raise
 
-    ts = load.timescale()
     mercury, jupiter, moon = planets['mercury'], planets['jupiter barycenter'], planets['moon']
     earth = planets['earth']
 

--- a/astropy/utils/iers/tests/test_leap_second.py
+++ b/astropy/utils/iers/tests/test_leap_second.py
@@ -153,6 +153,15 @@ class TestAutoOpenExplicitLists:
 
 @pytest.mark.remote_data
 class TestRemoteURLs:
+    def setup_class(cls):
+        # Need auto_download so that IERS_B won't be loaded and cause tests to
+        # fail.
+        iers.conf.auto_download = True
+
+    def teardown_class(cls):
+        # This setting is to be consistent with astropy/conftest.py
+        iers.conf.auto_download = False
+
     # In these tests, the results may be cached.
     # This is fine - no need to download again.
     def test_iers_url(self):
@@ -270,11 +279,19 @@ class TestDefaultAutoOpen:
     def test_auto_open_urls_always_good_enough(self):
         # Avoid using the erfa, built-in and system files, as they might
         # be good enough already.
-        self.remove_auto_open_files('erfa', iers.IERS_LEAP_SECOND_FILE,
-                                    'system_leap_second_file')
-        ls = iers.LeapSeconds.open()
-        assert ls.expires > self.good_enough
-        assert ls.meta['data_url'].startswith('http')
+        try:
+            # Need auto_download so that IERS_B won't be loaded and
+            # cause tests to fail.
+            iers.conf.auto_download = True
+
+            self.remove_auto_open_files('erfa', iers.IERS_LEAP_SECOND_FILE,
+                                        'system_leap_second_file')
+            ls = iers.LeapSeconds.open()
+            assert ls.expires > self.good_enough
+            assert ls.meta['data_url'].startswith('http')
+        finally:
+            # This setting is to be consistent with astropy/conftest.py
+            iers.conf.auto_download = False
 
 
 class ERFALeapSecondsSafe:

--- a/docs/coordinates/performance.inc.rst
+++ b/docs/coordinates/performance.inc.rst
@@ -52,7 +52,7 @@ properties::
     >>> aa_frame = coord.AltAz(obstime=times[:, np.newaxis], location=lapalma)
 
     >>> # calculate alt-az of each object at each time.
-    >>> aa_coos = coos.transform_to(aa_frame)  # doctest: +REMOTE_DATA
+    >>> aa_coos = coos.transform_to(aa_frame)  # doctest: +REMOTE_DATA +IGNORE_WARNINGS
 
 ..
   EXAMPLE END

--- a/docs/coordinates/satellites.rst
+++ b/docs/coordinates/satellites.rst
@@ -86,9 +86,9 @@ For example, to find the overhead latitude, longitude, and height of the satelli
 .. doctest-requires:: sgp4
 
     >>> from astropy.coordinates import ITRS
-    >>> itrs = teme.transform_to(ITRS(obstime=t))  # doctest: +REMOTE_DATA
-    >>> location = itrs.earth_location  # doctest: +REMOTE_DATA
-    >>> location.geodetic  # doctest: +REMOTE_DATA +FLOAT_CMP
+    >>> itrs = teme.transform_to(ITRS(obstime=t))  # doctest: +IGNORE_WARNINGS
+    >>> location = itrs.earth_location
+    >>> location.geodetic  # doctest: +FLOAT_CMP
     GeodeticLocation(lon=<Longitude 160.34199789 deg>, lat=<Latitude -24.6609379 deg>, height=<Quantity 420.17927591 km>)
 
 .. testsetup::
@@ -102,10 +102,10 @@ Or, if you want to find the altitude and azimuth of the satellite from a particu
 
     >>> from astropy.coordinates import EarthLocation, AltAz
     >>> siding_spring = EarthLocation.of_site('aao')  # doctest: +SKIP
-    >>> aa = teme.transform_to(AltAz(obstime=t, location=siding_spring))  # doctest: +REMOTE_DATA
-    >>> aa.alt  # doctest: +FLOAT_CMP +REMOTE_DATA
-    <Latitude 10.94798427 deg>
-    >>> aa.az  # doctest: +FLOAT_CMP +REMOTE_DATA
-    <Longitude 59.28807348 deg>
+    >>> aa = teme.transform_to(AltAz(obstime=t, location=siding_spring))  # doctest: +IGNORE_WARNINGS
+    >>> aa.alt  # doctest: +FLOAT_CMP
+    <Latitude 10.94898792 deg>
+    >>> aa.az  # doctest: +FLOAT_CMP
+    <Longitude 59.28626163 deg>
 
 .. EXAMPLE END

--- a/docs/coordinates/satellites.rst
+++ b/docs/coordinates/satellites.rst
@@ -104,8 +104,8 @@ Or, if you want to find the altitude and azimuth of the satellite from a particu
     >>> siding_spring = EarthLocation.of_site('aao')  # doctest: +SKIP
     >>> aa = teme.transform_to(AltAz(obstime=t, location=siding_spring))  # doctest: +IGNORE_WARNINGS
     >>> aa.alt  # doctest: +FLOAT_CMP
-    <Latitude 10.94898792 deg>
+    <Latitude 10.94798428 deg>
     >>> aa.az  # doctest: +FLOAT_CMP
-    <Longitude 59.28626163 deg>
+    <Longitude 59.28807348 deg>
 
 .. EXAMPLE END

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -190,7 +190,7 @@ following::
 
   >>> dat = iers.earth_orientation_table.get()  # doctest: +REMOTE_DATA
   >>> type(dat)  # doctest: +REMOTE_DATA
-  <class 'astropy.utils.iers.iers.IERS_Auto'>
+  <class 'astropy.utils.iers.iers.IERS...'>
   >>> dat  # doctest: +SKIP
   <IERS_Auto length=16196>
    year month  day    MJD   PolPMFlag_A ... UT1Flag    PM_x     PM_y   PolPMFlag

--- a/docs/utils/iers.rst
+++ b/docs/utils/iers.rst
@@ -183,7 +183,7 @@ To reset to the default, pass in `None` (which is equivalent to passing in
 ``iers.IERS_Auto.open()``)::
 
   >>> iers.earth_orientation_table.set(None)  # doctest: +REMOTE_DATA
-  <ScienceState earth_orientation_table: <IERS_Auto length=...>...>
+  <ScienceState earth_orientation_table: <IERS...>...>
 
 To see the internal IERS data that gets used in astropy you can do the
 following::


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to follow-up on the idea in https://github.com/astropy/astropy/pull/10304#discussion_r420123116 that we can disable auto-downloading of IERS data completely for testing purpose.

The proof-of-concept part of this is in `docs/coordinates/satellites.rst` in that this fixes #10255 albeit slight changes in expected results. (This builds upon #10304 to disable `of_site` download.)

This also moves stuff from `astropy/conftest.py` up to root level `conftest.py`, as stated in #10310. 

~I took advantage of a set but unused `builtins._pytest_running` variable I saw in `astropy/conftest.py`.~ If people are interested to disable it outside of testing environment, say, for computing clusters or multiprocessing, we might need to resort to setting system environment variable instead though I am not sure if even that would solve the problem for everyone because it solves the download problem but not if you still need to download something but has race condition in caching.

**TODO**

- [x] Are we really doing this?
- [x] Fix failing tests -- most of them will warn about something is out of range and need to be handled accordingly
- [x] Not sure how to identify the rest of the tests that no longer need really need remote data that are not failing. (Battle for another day.)

Bonus:

* Minor PEP 8 fixes.
* Address some of #10344 where I see them.
* Use `pathlib` to handle file URIs.
* Attempt to fix flaky `test_positions_skyfield` failing CI.