### PR TITLE
EXP: EarthLocation context manager to force builtin sites

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -1,5 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
+from contextlib import contextmanager
 from warnings import warn
 import collections
 import socket
@@ -808,3 +809,24 @@ class EarthLocation(u.Quantity):
             equivalencies = self._equivalencies
         new_array = self.unit.to(unit, array_view, equivalencies=equivalencies)
         return new_array.view(self.dtype).reshape(self.shape)
+
+
+@contextmanager
+def force_builtin_sites():
+    """Context manager to temporarily force usage of built-in `EarthLocation`
+    sites for testing.
+
+    Examples
+    --------
+    >>> from astropy.coordinates.earth import EarthLocation, force_builtin_sites
+    >>> with force_builtin_sites():
+    ...     EarthLocation.of_site('greenwich')  # doctest: +FLOAT_CMP
+    <EarthLocation (3980608.90246817, -102.47522911, 4966861.27310068) m>
+
+    """
+    orig_sites = getattr(EarthLocation, '_site_registry', None)
+    try:
+        EarthLocation._get_site_registry(force_builtin=True)
+        yield
+    finally:
+        EarthLocation._site_registry = orig_sites

--- a/astropy/io/misc/asdf/tags/coordinates/tests/test_earthlocation.py
+++ b/astropy/io/misc/asdf/tags/coordinates/tests/test_earthlocation.py
@@ -8,7 +8,7 @@ from asdf.tests.helpers import assert_roundtrip_tree
 
 from astropy import units as u
 from astropy.coordinates.angles import Longitude, Latitude
-from astropy.coordinates.earth import EarthLocation, ELLIPSOIDS
+from astropy.coordinates.earth import EarthLocation, ELLIPSOIDS, force_builtin_sites
 
 
 @pytest.fixture
@@ -50,11 +50,7 @@ def test_earthlocation_geodetic(position, ellipsoid, tmpdir):
 
 
 def test_earthlocation_site(tmpdir):
-    orig_sites = getattr(EarthLocation, '_site_registry', None)
-    try:
-        EarthLocation._get_site_registry(force_builtin=True)
+    with force_builtin_sites():
         rog = EarthLocation.of_site('greenwich')
         tree = dict(location=rog)
         assert_roundtrip_tree(tree, tmpdir)
-    finally:
-        EarthLocation._site_registry = orig_sites


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to follow-up on the idea at https://github.com/astropy/astropy/pull/10304/files#r420003642 to use context manager to force usage of builtin `sites.json` for testing.

The proof-of-concept part is in `astropy/io/misc/asdf/tags/coordinates/tests/test_earthlocation.py`. You can see how it is more elegant here compared to the implementation over at #10304 without a context manager.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
