### PR TITLE
MNT: Move earth.py circular imports into relevant method

### DIFF
--- a/astropy/coordinates/earth.py
+++ b/astropy/coordinates/earth.py
@@ -519,6 +519,9 @@ class EarthLocation(u.Quantity):
         -------
         reg : astropy.coordinates.sites.SiteRegistry
         """
+        # need to do this here at the bottom to avoid circular dependencies
+        from .sites import get_builtin_sites, get_downloaded_sites
+
         if force_builtin and force_download:
             raise ValueError('Cannot have both force_builtin and force_download True')
 
@@ -805,7 +808,3 @@ class EarthLocation(u.Quantity):
             equivalencies = self._equivalencies
         new_array = self.unit.to(unit, array_view, equivalencies=equivalencies)
         return new_array.view(self.dtype).reshape(self.shape)
-
-
-# need to do this here at the bottom to avoid circular dependencies
-from .sites import get_builtin_sites, get_downloaded_sites  # noqa


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to follow up on a comment in https://github.com/astropy/astropy/pull/10304#discussion_r420115995 . There is no reason why the circular import needs to be module level and not method level?