### PR TITLE
BUG: Fix typo in error message

### DIFF
--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1321,7 +1321,7 @@ class Quantity(np.ndarray):
 
     def tolist(self):
         raise NotImplementedError("cannot make a list of Quantities.  Get "
-                                  "list of values with q.value.list()")
+                                  "list of values with q.value.tolist()")
 
     def _to_own_unit(self, value, check_precision=True):
         try:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address a typo in error message when someone does this:

```python
>>> from astropy import units as u
>>> x = [100] * u.m
>>> x.tolist()
NotImplementedError: cannot make a list of Quantities.  Get list of values with q.value.list()
>>> x.value.list()
AttributeError: 'numpy.ndarray' object has no attribute 'list'
>>> x.value.tolist()
[100.0]
```

I'll let CI run in case some of the tests have strict error message checks.