### PR TITLE
Fix some backwards compatibility and conftest issues in WCS wrappers

### DIFF
--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -23,10 +23,11 @@ def spectral_1d_fitswcs():
 def time_1d_fitswcs():
     wcs = WCS(naxis=1)
     wcs.wcs.ctype = 'TIME',
-    wcs.wcs.mjdref = 30042,
+    wcs.wcs.mjdref = (30042, 0)
     wcs.wcs.crval = 3.,
     wcs.wcs.crpix = 11.,
-    wcs.wcs.cname = 'Frequency',
+    wcs.wcs.cname = 'Time',
+    wcs.wcs.cunit = 's'
     return wcs
 
 

--- a/astropy/wcs/wcsapi/sliced_low_level_wcs.py
+++ b/astropy/wcs/wcsapi/sliced_low_level_wcs.py
@@ -1,6 +1,6 @@
 import warnings
 
-from .wrappers.sliced_wcs import SlicedLowLevelWCS
+from .wrappers.sliced_wcs import SlicedLowLevelWCS, sanitize_slices
 from astropy.utils.exceptions import AstropyDeprecationWarning
 
 warnings.warn(


### PR DESCRIPTION
This fixes a deprecated import I missed in #10229 and corrects some issues with the fixtures I just noticed.

(This is a bugfix that needs to make it into 4.1 I assume I have milestoned it right?)