### PR TITLE
MNT: PEP 8 clean-ups of some io.misc.asdf

### DIFF
--- a/astropy/io/misc/asdf/extension.py
+++ b/astropy/io/misc/asdf/extension.py
@@ -4,35 +4,34 @@
 import os
 
 from asdf.extension import AsdfExtension, BuiltinExtension
-from asdf.resolver import Resolver, DEFAULT_URL_MAPPING
 from asdf.util import filepath_to_url
 
 # Make sure that all tag implementations are imported by the time we create
 # the extension class so that _astropy_asdf_types is populated correctly. We
 # could do this using __init__ files, except it causes pytest import errors in
 # the case that asdf is not installed.
-from .tags.coordinates.angle import *
-from .tags.coordinates.frames import *
-from .tags.coordinates.earthlocation import *
-from .tags.coordinates.skycoord import *
-from .tags.coordinates.representation import *
-from .tags.coordinates.spectralcoord import *
-from .tags.fits.fits import *
-from .tags.table.table import *
-from .tags.time.time import *
-from .tags.time.timedelta import *
-from .tags.transform.basic import *
-from .tags.transform.compound import *
-from .tags.transform.functional_models import *
-from .tags.transform.physical_models import *
-from .tags.transform.math import *
-from .tags.transform.polynomial import *
-from .tags.transform.powerlaws import *
-from .tags.transform.projections import *
-from .tags.transform.tabular import *
-from .tags.unit.quantity import *
-from .tags.unit.unit import *
-from .tags.unit.equivalency import *
+from .tags.coordinates.angle import *  # noqa
+from .tags.coordinates.frames import *  # noqa
+from .tags.coordinates.earthlocation import *  # noqa
+from .tags.coordinates.skycoord import *  # noqa
+from .tags.coordinates.representation import *  # noqa
+from .tags.coordinates.spectralcoord import *  # noqa
+from .tags.fits.fits import *  # noqa
+from .tags.table.table import *  # noqa
+from .tags.time.time import *  # noqa
+from .tags.time.timedelta import *  # noqa
+from .tags.transform.basic import *  # noqa
+from .tags.transform.compound import *  # noqa
+from .tags.transform.functional_models import *  # noqa
+from .tags.transform.physical_models import *  # noqa
+from .tags.transform.math import *  # noqa
+from .tags.transform.polynomial import *  # noqa
+from .tags.transform.powerlaws import *  # noqa
+from .tags.transform.projections import *  # noqa
+from .tags.transform.tabular import *  # noqa
+from .tags.unit.quantity import *  # noqa
+from .tags.unit.unit import *  # noqa
+from .tags.unit.equivalency import *  # noqa
 from .types import _astropy_types, _astropy_asdf_types
 
 

--- a/astropy/io/misc/asdf/tags/coordinates/frames.py
+++ b/astropy/io/misc/asdf/tags/coordinates/frames.py
@@ -11,18 +11,13 @@ from astropy.coordinates.baseframe import frame_transform_graph
 from astropy.units import Quantity
 from astropy.coordinates import ICRS, Longitude, Latitude, Angle
 
-from astropy.io.misc.asdf.tags.unit.quantity import QuantityType
 from astropy.io.misc.asdf.types import AstropyType
 
 
 __all__ = ['CoordType']
 
-SCHEMA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                           '..', '..',
-                                           'data',
-                                           'schemas',
-                                           'astropy.org',
-                                           'astropy'))
+SCHEMA_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'schemas', 'astropy.org', 'astropy'))
 
 
 def _get_frames():

--- a/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
+++ b/astropy/io/misc/asdf/tags/coordinates/spectralcoord.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from asdf.tags.core import NDArrayType
-from asdf.yamlutil import custom_tree_to_tagged_tree
 
 from astropy.coordinates.spectral_coordinate import SpectralCoord
 from astropy.io.misc.asdf.types import AstropyType
@@ -24,10 +23,10 @@ class SpectralCoordType(AstropyType):
     def to_tree(cls, spec_coord, ctx):
         node = {}
         if isinstance(spec_coord, SpectralCoord):
-            node['value'] = custom_tree_to_tagged_tree(spec_coord.value, ctx)
-            node['unit'] = custom_tree_to_tagged_tree(spec_coord.unit, ctx)
-            node['observer'] = custom_tree_to_tagged_tree(spec_coord.observer, ctx)
-            node['target'] = custom_tree_to_tagged_tree(spec_coord.target, ctx)
+            node['value'] = spec_coord.value
+            node['unit'] = spec_coord.unit
+            node['observer'] = spec_coord.observer
+            node['target'] = spec_coord.target
             return node
         raise TypeError(f"'{spec_coord}' is not a valid SpectralCoord")
 

--- a/astropy/io/misc/asdf/tags/table/table.py
+++ b/astropy/io/misc/asdf/tags/table/table.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from asdf import tagged
 from asdf.tags.core.ndarray import NDArrayType
 
 from astropy import table

--- a/astropy/io/misc/asdf/tags/time/time.py
+++ b/astropy/io/misc/asdf/tags/time/time.py
@@ -12,9 +12,9 @@ from astropy.units import Quantity
 from astropy.coordinates import EarthLocation
 from astropy.io.misc.asdf.types import AstropyAsdfType
 
+__all__ = ['TimeType']
 
 _guessable_formats = set(['iso', 'byear', 'jyear', 'yday'])
-
 
 _astropy_format_to_asdf_format = {
     'isot': 'iso',

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -1,13 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from asdf import tagged
 from asdf.versioning import AsdfVersion
 
-from astropy.modeling import models, mappings
-from astropy.utils import minversion
+from astropy.modeling import mappings
 from astropy.modeling import functional_models
-from astropy.modeling.core import Model, CompoundModel
+from astropy.modeling.core import CompoundModel
 from astropy.io.misc.asdf.types import AstropyAsdfType, AstropyType
 from . import _parameter_to_value
 
@@ -86,10 +84,10 @@ class TransformType(AstropyAsdfType):
 
         # model / parameter constraints
         if not isinstance(model, CompoundModel):
-            fixed_nondefaults = {k:f for k, f in model.fixed.items() if f}
+            fixed_nondefaults = {k: f for k, f in model.fixed.items() if f}
             if fixed_nondefaults:
                 node['fixed'] = fixed_nondefaults
-            bounds_nondefaults = {k:b for k, b in model.bounds.items() if any(b)}
+            bounds_nondefaults = {k: b for k, b in model.bounds.items() if any(b)}
             if bounds_nondefaults:
                 node['bounds'] = bounds_nondefaults
 
@@ -156,7 +154,8 @@ class ConstantType(TransformType):
     def to_tree_transform(cls, data, ctx):
         if cls.version < AsdfVersion('1.4.0'):
             if not isinstance(data, functional_models.Const1D):
-                raise ValueError(f'constant-{cls.version} does not support models with > 1 dimension')
+                raise ValueError(
+                    f'constant-{cls.version} does not support models with > 1 dimension')
             return {
                 'value': _parameter_to_value(data.amplitude)
             }
@@ -238,10 +237,10 @@ class UnitsMappingType(AstropyType):
 
         return tree
 
-
     @classmethod
     def from_tree(cls, tree, ctx):
-        mapping = tuple((i.get("unit"), o.get("unit")) for i, o in zip(tree["inputs"], tree["outputs"]))
+        mapping = tuple((i.get("unit"), o.get("unit"))
+                        for i, o in zip(tree["inputs"], tree["outputs"]))
 
         equivalencies = None
         for i in tree["inputs"]:
@@ -252,7 +251,8 @@ class UnitsMappingType(AstropyType):
 
         kwargs = {
             "input_units_equivalencies": equivalencies,
-            "input_units_allow_dimensionless": {i["name"]: i.get("allow_dimensionless", False) for i in tree["inputs"]},
+            "input_units_allow_dimensionless": {
+                i["name"]: i.get("allow_dimensionless", False) for i in tree["inputs"]},
         }
 
         if "name" in tree:

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -11,26 +11,26 @@ __all__ = ['CompoundType', 'RemapAxesType']
 
 
 _operator_to_tag_mapping = {
-    '+': 'add',
-    '-': 'subtract',
-    '*': 'multiply',
-    '/': 'divide',
+    '+':  'add',
+    '-':  'subtract',
+    '*':  'multiply',
+    '/':  'divide',
     '**': 'power',
-    '|': 'compose',
-    '&': 'concatenate',
+    '|':  'compose',
+    '&':  'concatenate',
     'fix_inputs': 'fix_inputs'
 }
 
 
 _tag_to_method_mapping = {
-    'add': '__add__',
-    'subtract': '__sub__',
-    'multiply': '__mul__',
-    'divide': '__truediv__',
-    'power': '__pow__',
-    'compose': '__or__',
+    'add':         '__add__',
+    'subtract':    '__sub__',
+    'multiply':    '__mul__',
+    'divide':      '__truediv__',
+    'power':       '__pow__',
+    'compose':     '__or__',
     'concatenate': '__and__',
-    'fix_inputs': 'fix_inputs'
+    'fix_inputs':  'fix_inputs'
 }
 
 

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -11,26 +11,26 @@ __all__ = ['CompoundType', 'RemapAxesType']
 
 
 _operator_to_tag_mapping = {
-    '+'  : 'add',
-    '-'  : 'subtract',
-    '*'  : 'multiply',
-    '/'  : 'divide',
-    '**' : 'power',
-    '|'  : 'compose',
-    '&'  : 'concatenate',
+    '+': 'add',
+    '-': 'subtract',
+    '*': 'multiply',
+    '/': 'divide',
+    '**': 'power',
+    '|': 'compose',
+    '&': 'concatenate',
     'fix_inputs': 'fix_inputs'
 }
 
 
 _tag_to_method_mapping = {
-    'add'         : '__add__',
-    'subtract'    : '__sub__',
-    'multiply'    : '__mul__',
-    'divide'      : '__truediv__',
-    'power'       : '__pow__',
-    'compose'     : '__or__',
-    'concatenate' : '__and__',
-    'fix_inputs'  : 'fix_inputs'
+    'add': '__add__',
+    'subtract': '__sub__',
+    'multiply': '__mul__',
+    'divide': '__truediv__',
+    'power': '__pow__',
+    'compose': '__or__',
+    'concatenate': '__and__',
+    'fix_inputs': 'fix_inputs'
 }
 
 
@@ -50,8 +50,8 @@ class CompoundType(TransformType):
             raise TypeError("Unknown model type '{0}'".format(
                 node['forward'][0]._tag))
         right = node['forward'][1]
-        if not isinstance(right, Model) and \
-            not (oper == 'fix_inputs' and isinstance(right, dict)):
+        if (not isinstance(right, Model) and
+                not (oper == 'fix_inputs' and isinstance(right, dict))):
             raise TypeError("Unknown model type '{0}'".format(
                 node['forward'][1]._tag))
         if oper == 'fix_inputs':

--- a/astropy/io/misc/asdf/tags/transform/polynomial.py
+++ b/astropy/io/misc/asdf/tags/transform/polynomial.py
@@ -83,7 +83,7 @@ class MultiplyType(TransformType):
     @classmethod
     def to_tree_transform(cls, model, ctx):
         factor = model.factor
-        return  {'factor': _parameter_to_value(factor)}
+        return {'factor': _parameter_to_value(factor)}
 
     @classmethod
     def assert_equal(cls, a, b):
@@ -125,7 +125,7 @@ class PolynomialTypeBase(TransformType):
             for i in range(shape[0]):
                 for j in range(shape[0]):
                     if i + j < degree + 1:
-                        name = 'c' + str(i) + '_' +str(j)
+                        name = 'c' + str(i) + '_' + str(j)
                         coeffs[name] = coefficients[i, j]
             model = modeling.models.Polynomial2D(degree,
                                                  x_domain=x_domain,
@@ -239,7 +239,7 @@ class OrthoPolynomialType(TransformType):
             coeffs = {}
             shape = coefficients.shape
             x_degree = shape[0] - 1
-            y_degree = shape[1] -1
+            y_degree = shape[1] - 1
             for i in range(x_degree + 1):
                 for j in range(y_degree + 1):
                     name = f'c{i}_{j}'
@@ -286,12 +286,12 @@ class OrthoPolynomialType(TransformType):
         # TODO: If models become comparable themselves, remove this.
         # There should be a more elegant way of doing this
         TransformType.assert_equal(a, b)
-        assert  ((isinstance(a, (modeling.models.Legendre1D,   modeling.models.Legendre2D))    and
-                  isinstance(b, (modeling.models.Legendre1D,   modeling.models.Legendre2D)))   or
-                 (isinstance(a, (modeling.models.Chebyshev1D,  modeling.models.Chebyshev2D))   and
-                  isinstance(b, (modeling.models.Chebyshev1D,  modeling.models.Chebyshev2D)))  or
-                 (isinstance(a, (modeling.models.Hermite1D,    modeling.models.Hermite2D))     and
-                  isinstance(b, (modeling.models.Hermite1D,    modeling.models.Hermite2D))))
+        assert ((isinstance(a, (modeling.models.Legendre1D,   modeling.models.Legendre2D)) and
+                 isinstance(b, (modeling.models.Legendre1D,   modeling.models.Legendre2D))) or
+                (isinstance(a, (modeling.models.Chebyshev1D,  modeling.models.Chebyshev2D)) and
+                 isinstance(b, (modeling.models.Chebyshev1D,  modeling.models.Chebyshev2D))) or
+                (isinstance(a, (modeling.models.Hermite1D,    modeling.models.Hermite2D)) and
+                 isinstance(b, (modeling.models.Hermite1D,    modeling.models.Hermite2D))))
         assert_array_equal(a.parameters, b.parameters)
 
 

--- a/astropy/io/misc/asdf/tags/unit/quantity.py
+++ b/astropy/io/misc/asdf/tags/unit/quantity.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 # -*- coding: utf-8 -*-
 
-from numpy import isscalar
 from astropy.units import Quantity
 
 from asdf.tags.core import NDArrayType

--- a/astropy/io/misc/asdf/types.py
+++ b/astropy/io/misc/asdf/types.py
@@ -3,14 +3,11 @@
 
 from asdf.types import CustomType, ExtensionTypeMeta
 
-
 __all__ = ['AstropyType', 'AstropyAsdfType']
-
 
 # Names of AstropyType or AstropyAsdfType subclasses that are base classes
 # and aren't used directly for serialization.
 _TYPE_BASE_CLASS_NAMES = {'PolynomialTypeBase'}
-
 
 _astropy_types = set()
 _astropy_asdf_types = set()


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to move over uncontroversial PEP 8 clean-ups done in #10260 .

* Apply #10189 to spectral coordinates added in #10185.
* Removed unused imports.
* Fixed other PEP 8 warnings.

@eslavich already successfully tests #10260 with `jwst`, so I don't see how this will break anything.

Not sure of the proper milestone for this, so feel free to re-milestone if needed.