### PR TITLE
Expose auxillary parameters from WCSLIB in astropy.wcs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -711,6 +711,12 @@ astropy.utils
 
 - ``astropy.utils.data.download_file`` now supports FTPS/FTP over TLS. [#9964]
 
+astropy.wcs
+^^^^^^^^^^^
+
+- The new auxiliary WCS parameters added in WCSLIB 7.1 are now exposed as
+  the ``aux`` attribute of ``Wcsprm``. [#10333]
+
 Bug fixes
 ---------
 

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -153,6 +153,18 @@ ap_order = """
 ``int`` (read-only) Order of the polynomial (``AP_ORDER``).
 """
 
+aux = """
+`~astropy.wcs.Auxprm` Auxiliary coordinate system information of a specialist nature.
+"""
+
+Auxprm = """
+Class that contains auxiliary coordinate system information of a specialist
+nature.
+
+This class can not be constructed directly from Python, but instead is
+returned from `~astropy.wcs.Wcsprm.aux`.
+"""
+
 axis_types = """
 ``int array[naxis]`` An array of four-digit type codes for each axis.
 
@@ -423,6 +435,11 @@ crder = """
 An undefined value is represented by NaN.
 """
 
+crln_obs = """
+``double`` Carrington heliographic longitude of the observer (deg). If
+undefined, this is set to `None`.
+"""
+
 crota = """
 ``double array[naxis]`` ``CROTAia`` keyvalues for each coordinate
 axis.
@@ -653,6 +670,11 @@ crval : 2-tuple
 
 cdelt : 2-tuple
     The grid step size
+"""
+
+dsun_obs = """
+``double`` Distance between the centre of the Sun and the observer (m). If
+undefined, this is set to `None`.
 """
 
 equinox = """
@@ -960,6 +982,16 @@ has_pci_ja() -> bool
 
 Alias for `~astropy.wcs.Wcsprm.has_pc`.  Maintained for backward
 compatibility.
+"""
+
+hgln_obs = """
+``double`` Stonyhurst heliographic longitude of the observer. If
+undefined, this is set to `None`.
+"""
+
+hglt_obs = """
+``double``  Heliographic latitude (Carrington or Stonyhurst) of the observer
+(deg). If undefined, this is set to `None`.
 """
 
 i = """
@@ -1507,6 +1539,11 @@ row = """
 ``int`` (read-only)
 
 Table row number.
+"""
+
+rsun_ref = """
+``double`` Reference radius of the Sun used in coordinate calculations (m).
+If undefined, this is set to `None`.
 """
 
 s2p = """

--- a/astropy/wcs/include/astropy_wcs/wcslib_auxprm_wrap.h
+++ b/astropy/wcs/include/astropy_wcs/wcslib_auxprm_wrap.h
@@ -1,0 +1,20 @@
+#ifndef __WCSLIB_AUXPRM_WRAP_H__
+#define __WCSLIB_AUXPRM_WRAP_H__
+
+#include "pyutil.h"
+#include "wcs.h"
+
+extern PyTypeObject PyAuxprmType;
+
+typedef struct {
+  PyObject_HEAD
+  struct auxprm* x;
+  PyObject* owner;
+} PyAuxprm;
+
+PyAuxprm*
+PyAuxprm_cnew(PyObject* wcsprm, struct auxprm* x);
+
+int _setup_auxprm_type(PyObject* m);
+
+#endif

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -289,6 +289,7 @@ def get_extensions():
         'unit_list_proxy.c',
         'util.c',
         'wcslib_wrap.c',
+        'wcslib_auxprm_wrap.c',
         'wcslib_tabprm_wrap.c',
         'wcslib_wtbarr_wrap.c'
     ]

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -856,6 +856,7 @@ PyInit__wcs(void)
       _setup_str_list_proxy_type(m) ||
       _setup_unit_list_proxy_type(m)||
       _setup_wcsprm_type(m)         ||
+      _setup_auxprm_type(m)         ||
       _setup_tabprm_type(m)         ||
       _setup_wtbarr_type(m)         ||
       _setup_distortion_type(m)     ||

--- a/astropy/wcs/src/astropy_wcs.c
+++ b/astropy/wcs/src/astropy_wcs.c
@@ -6,6 +6,7 @@
 #include "astropy_wcs/astropy_wcs.h"
 #include "astropy_wcs/wcslib_wrap.h"
 #include "astropy_wcs/wcslib_tabprm_wrap.h"
+#include "astropy_wcs/wcslib_auxprm_wrap.h"
 #include "astropy_wcs/wcslib_units_wrap.h"
 #include "astropy_wcs/wcslib_wtbarr_wrap.h"
 #include "astropy_wcs/distortion_wrap.h"

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -65,7 +65,6 @@ static void auxprmprt(const struct auxprm *aux) {
   if (aux->rsun_ref != UNDEFINED) wcsprintf("rsun_ref: %f\n", aux->rsun_ref);
   if (aux->dsun_obs != UNDEFINED) wcsprintf("dsun_obs: %f\n", aux->dsun_obs);
   if (aux->crln_obs != UNDEFINED) wcsprintf("crln_obs: %f\n", aux->crln_obs);
-  // if (aux->crlt_obs != UNDEFINED) wcsprintf("crlt_obs: %f\n", aux->crlt_obs);
   if (aux->hgln_obs != UNDEFINED) wcsprintf("hgln_obs: %f\n", aux->hgln_obs);
   if (aux->hglt_obs != UNDEFINED) wcsprintf("hglt_obs: %f\n", aux->hglt_obs);
 
@@ -145,25 +144,6 @@ static int PyAuxprm_set_crln_obs(PyAuxprm* self, PyObject* value, void* closure)
   }
 }
 
-// For now the WCSLIB struct does not include crlt_obs, so we keep the
-// following commented out until this is fixed
-//
-// static PyObject* PyAuxprm_get_crlt_obs(PyAuxprm* self, void* closure) {
-//   if(self->x == NULL) {
-//     Py_RETURN_NONE;
-//   } else {
-//     return get_double("crlt_obs", self->x->crlt_obs);
-//   }
-// }
-//
-// static int PyAuxprm_set_crlt_obs(PyAuxprm* self, PyObject* value, void* closure) {
-//   if(self->x == NULL) {
-//     return -1;
-//   } else {
-//     return set_double("crlt_obs", value, &self->x->crlt_obs);
-//   }
-// }
-
 static PyObject* PyAuxprm_get_hgln_obs(PyAuxprm* self, void* closure) {
   if(self->x == NULL) {
     Py_RETURN_NONE;
@@ -204,7 +184,6 @@ static PyGetSetDef PyAuxprm_getset[] = {
   {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, PyAuxprm_set_rsun_ref, (char *) NULL},
   {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, PyAuxprm_set_dsun_obs, (char *) NULL},
   {"crln_obs", (getter)PyAuxprm_get_crln_obs, PyAuxprm_set_crln_obs, (char *) NULL},
-  // {"crlt_obs", (getter)PyAuxprm_get_crlt_obs, PyAuxprm_set_crlt_obs, (char *) NULL},
   {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, PyAuxprm_set_hgln_obs, (char *) NULL},
   {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, PyAuxprm_set_hglt_obs, (char *) NULL},
   {NULL}

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -1,0 +1,211 @@
+#define NO_IMPORT_ARRAY
+
+#include "astropy_wcs/wcslib_auxprm_wrap.h"
+
+#include <wcs.h>
+#include <wcsprintf.h>
+#include <tab.h>
+
+/*
+ It gets to be really tedious to type long docstrings in ANSI C syntax
+ (since multi-line strings literals are not valid).  Therefore, the
+ docstrings are written in doc/docstrings.py, which are then converted
+ by setup.py into docstrings.h, which we include here.
+*/
+#include "astropy_wcs/docstrings.h"
+
+
+/***************************************************************************
+ * PyAuxprm methods                                                        *
+ ***************************************************************************/
+
+static PyObject*
+PyAuxprm_new(PyTypeObject* type, PyObject* args, PyObject* kwds) {
+  PyAuxprm* self;
+  self = (PyAuxprm*)type->tp_alloc(type, 0);
+  return (PyObject*)self;
+}
+
+
+static int
+PyAuxprm_traverse(PyAuxprm* self, visitproc visit, void *arg) {
+  Py_VISIT(self->owner);
+  return 0;
+}
+
+
+static int
+PyAuxprm_clear(PyAuxprm* self) {
+  Py_CLEAR(self->owner);
+  return 0;
+}
+
+
+static void PyAuxprm_dealloc(PyAuxprm* self) {
+  PyAuxprm_clear(self);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+PyAuxprm* PyAuxprm_cnew(PyObject* wcsprm, struct auxprm* x) {
+  PyAuxprm* self;
+  self = (PyAuxprm*)(&PyAuxprmType)->tp_alloc(&PyAuxprmType, 0);
+  if (self == NULL) return NULL;
+  self->x = x;
+  Py_INCREF(wcsprm);
+  self->owner = wcsprm;
+  return self;
+}
+
+
+static void auxprmprt(const struct auxprm *aux) {
+
+  if (aux == 0x0) return;
+
+  wcsprintf("rsun_ref: %d\n", aux->rsun_ref);
+  wcsprintf("dsun_obs: %d\n", aux->dsun_obs);
+  wcsprintf("crln_obs: %c\n", aux->crln_obs);
+  wcsprintf("hgln_obs: %s\n", aux->hgln_obs);
+  wcsprintf("hglt_obs: %d\n", aux->hglt_obs);
+
+  return;
+}
+
+
+static PyObject* PyAuxprm_print_contents(PyAuxprm* self) {
+  /* This is not thread-safe, but since we're holding onto the GIL,
+     we can assume we won't have thread conflicts */
+  wcsprintf_set(NULL);
+  auxprmprt(self->x);
+  printf("%s", wcsprintf_buf());
+  fflush(stdout);
+  Py_RETURN_NONE;
+}
+
+
+static PyObject* PyAuxprm___str__(PyAuxprm* self) {
+  /* This is not thread-safe, but since we're holding onto the GIL,
+     we can assume we won't have thread conflicts */
+  wcsprintf_set(NULL);
+  auxprmprt(self->x);
+  return PyUnicode_FromString(wcsprintf_buf());
+}
+
+
+/***************************************************************************
+ * Member getters/setters (properties)
+ */
+
+static PyObject* PyAuxprm_get_rsun_ref(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    return NULL;
+  } else {
+    return get_double("rsun_ref", self->x->rsun_ref);
+  }
+}
+
+static PyObject* PyAuxprm_get_dsun_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    return NULL;
+  } else {
+    return get_double("dsun_obs", self->x->dsun_obs);
+  }
+}
+
+static PyObject* PyAuxprm_get_crln_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    return NULL;
+  } else {
+    return get_double("crln_obs", self->x->rsun_ref);
+  }
+}
+
+static PyObject* PyAuxprm_get_hgln_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    return NULL;
+  } else {
+    return get_double("hgln_obs", self->x->rsun_ref);
+  }
+}
+
+static PyObject* PyAuxprm_get_hglt_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    return NULL;
+  } else {
+    return get_double("hglt_obs", self->x->rsun_ref);
+  }
+}
+
+/***************************************************************************
+ * PyAuxprm definition structures
+ */
+
+static PyGetSetDef PyAuxprm_getset[] = {
+  {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, NULL, (char *) NULL},
+  {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, NULL, (char *) NULL},
+  {"crln_obs", (getter)PyAuxprm_get_crln_obs, NULL, (char *) NULL},
+  {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, NULL, (char *) NULL},
+  {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, NULL, (char *) NULL},
+  {NULL}
+};
+
+
+static PyMethodDef PyAuxprm_methods[] = {
+  {"print_contents", (PyCFunction)PyAuxprm_print_contents, METH_NOARGS, NULL},
+  {NULL}
+};
+
+PyTypeObject PyAuxprmType = {
+  PyVarObject_HEAD_INIT(NULL, 0)
+  "astropy.wcs.Auxprm",         /*tp_name*/
+  sizeof(PyAuxprm),             /*tp_basicsize*/
+  0,                            /*tp_itemsize*/
+  (destructor)PyAuxprm_dealloc, /*tp_dealloc*/
+  0,                            /*tp_print*/
+  0,                            /*tp_getattr*/
+  0,                            /*tp_setattr*/
+  0,                            /*tp_compare*/
+  0,                            /*tp_repr*/
+  0,                            /*tp_as_number*/
+  0,                            /*tp_as_sequence*/
+  0,                            /*tp_as_mapping*/
+  0,                            /*tp_hash */
+  0,                            /*tp_call*/
+  (reprfunc)PyAuxprm___str__,   /*tp_str*/
+  0,                            /*tp_getattro*/
+  0,                            /*tp_setattro*/
+  0,                            /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+  0,                            /* tp_doc */
+  (traverseproc)PyAuxprm_traverse, /* tp_traverse */
+  (inquiry)PyAuxprm_clear,         /* tp_clear */
+  0,                            /* tp_richcompare */
+  0,                            /* tp_weaklistoffset */
+  0,                            /* tp_iter */
+  0,                            /* tp_iternext */
+  PyAuxprm_methods,             /* tp_methods */
+  0,                            /* tp_members */
+  PyAuxprm_getset,              /* tp_getset */
+  0,                            /* tp_base */
+  0,                            /* tp_dict */
+  0,                            /* tp_descr_get */
+  0,                            /* tp_descr_set */
+  0,                            /* tp_dictoffset */
+  0,                            /* tp_init */
+  0,                            /* tp_alloc */
+  0,                            /* tp_new */
+};
+
+
+int
+_setup_auxprm_type(PyObject* m) {
+  if (PyType_Ready(&PyAuxprmType) < 0) {
+    return -1;
+  }
+
+  Py_INCREF(&PyAuxprmType);
+
+  PyModule_AddObject(m, "Auxprm", (PyObject *)&PyAuxprmType);
+
+  return 0;
+}

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -62,11 +62,12 @@ static void auxprmprt(const struct auxprm *aux) {
 
   if (aux == 0x0) return;
 
-  wcsprintf("rsun_ref: %d\n", aux->rsun_ref);
-  wcsprintf("dsun_obs: %d\n", aux->dsun_obs);
-  wcsprintf("crln_obs: %c\n", aux->crln_obs);
-  wcsprintf("hgln_obs: %s\n", aux->hgln_obs);
-  wcsprintf("hglt_obs: %d\n", aux->hglt_obs);
+  if (aux->rsun_ref != UNDEFINED) wcsprintf("rsun_ref: %f\n", aux->rsun_ref);
+  if (aux->dsun_obs != UNDEFINED) wcsprintf("dsun_obs: %f\n", aux->dsun_obs);
+  if (aux->crln_obs != UNDEFINED) wcsprintf("crln_obs: %f\n", aux->crln_obs);
+  // if (aux->crlt_obs != UNDEFINED) wcsprintf("crlt_obs: %f\n", aux->crlt_obs);
+  if (aux->hgln_obs != UNDEFINED) wcsprintf("hgln_obs: %f\n", aux->hgln_obs);
+  if (aux->hglt_obs != UNDEFINED) wcsprintf("hglt_obs: %f\n", aux->hglt_obs);
 
   return;
 }
@@ -97,42 +98,101 @@ static PyObject* PyAuxprm___str__(PyAuxprm* self) {
  */
 
 static PyObject* PyAuxprm_get_rsun_ref(PyAuxprm* self, void* closure) {
-  if(self->x == NULL) {
-    return NULL;
+  if(self->x == NULL || self->x->rsun_ref == UNDEFINED) {
+    Py_RETURN_NONE;
   } else {
     return get_double("rsun_ref", self->x->rsun_ref);
   }
 }
 
+static int PyAuxprm_set_rsun_ref(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else {
+    return set_double("rsun_ref", value, &self->x->rsun_ref);
+  }
+}
+
 static PyObject* PyAuxprm_get_dsun_obs(PyAuxprm* self, void* closure) {
   if(self->x == NULL) {
-    return NULL;
+    Py_RETURN_NONE;
   } else {
     return get_double("dsun_obs", self->x->dsun_obs);
   }
 }
 
-static PyObject* PyAuxprm_get_crln_obs(PyAuxprm* self, void* closure) {
+static int PyAuxprm_set_dsun_obs(PyAuxprm* self, PyObject* value, void* closure) {
   if(self->x == NULL) {
-    return NULL;
+    return -1;
   } else {
-    return get_double("crln_obs", self->x->rsun_ref);
+    return set_double("dsun_obs", value, &self->x->dsun_obs);
   }
 }
 
+static PyObject* PyAuxprm_get_crln_obs(PyAuxprm* self, void* closure) {
+  if(self->x == NULL) {
+    Py_RETURN_NONE;
+  } else {
+    return get_double("crln_obs", self->x->crln_obs);
+  }
+}
+
+static int PyAuxprm_set_crln_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else {
+    return set_double("crln_obs", value, &self->x->crln_obs);
+  }
+}
+
+// For now the WCSLIB struct does not include crlt_obs, so we keep the
+// following commented out until this is fixed
+//
+// static PyObject* PyAuxprm_get_crlt_obs(PyAuxprm* self, void* closure) {
+//   if(self->x == NULL) {
+//     Py_RETURN_NONE;
+//   } else {
+//     return get_double("crlt_obs", self->x->crlt_obs);
+//   }
+// }
+//
+// static int PyAuxprm_set_crlt_obs(PyAuxprm* self, PyObject* value, void* closure) {
+//   if(self->x == NULL) {
+//     return -1;
+//   } else {
+//     return set_double("crlt_obs", value, &self->x->crlt_obs);
+//   }
+// }
+
 static PyObject* PyAuxprm_get_hgln_obs(PyAuxprm* self, void* closure) {
   if(self->x == NULL) {
-    return NULL;
+    Py_RETURN_NONE;
   } else {
-    return get_double("hgln_obs", self->x->rsun_ref);
+    return get_double("hgln_obs", self->x->hgln_obs);
+  }
+}
+
+static int PyAuxprm_set_hgln_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else {
+    return set_double("hgln_obs", value, &self->x->hgln_obs);
   }
 }
 
 static PyObject* PyAuxprm_get_hglt_obs(PyAuxprm* self, void* closure) {
   if(self->x == NULL) {
-    return NULL;
+    Py_RETURN_NONE;
   } else {
-    return get_double("hglt_obs", self->x->rsun_ref);
+    return get_double("hglt_obs", self->x->hglt_obs);
+  }
+}
+
+static int PyAuxprm_set_hglt_obs(PyAuxprm* self, PyObject* value, void* closure) {
+  if(self->x == NULL) {
+    return -1;
+  } else {
+    return set_double("hglt_obs", value, &self->x->hglt_obs);
   }
 }
 
@@ -141,11 +201,12 @@ static PyObject* PyAuxprm_get_hglt_obs(PyAuxprm* self, void* closure) {
  */
 
 static PyGetSetDef PyAuxprm_getset[] = {
-  {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, NULL, (char *) NULL},
-  {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, NULL, (char *) NULL},
-  {"crln_obs", (getter)PyAuxprm_get_crln_obs, NULL, (char *) NULL},
-  {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, NULL, (char *) NULL},
-  {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, NULL, (char *) NULL},
+  {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, PyAuxprm_set_rsun_ref, (char *) NULL},
+  {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, PyAuxprm_set_dsun_obs, (char *) NULL},
+  {"crln_obs", (getter)PyAuxprm_get_crln_obs, PyAuxprm_set_crln_obs, (char *) NULL},
+  // {"crlt_obs", (getter)PyAuxprm_get_crlt_obs, PyAuxprm_set_crlt_obs, (char *) NULL},
+  {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, PyAuxprm_set_hgln_obs, (char *) NULL},
+  {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, PyAuxprm_set_hglt_obs, (char *) NULL},
   {NULL}
 };
 

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -62,11 +62,16 @@ static void auxprmprt(const struct auxprm *aux) {
 
   if (aux == 0x0) return;
 
-  if (aux->rsun_ref != UNDEFINED) wcsprintf("rsun_ref: %f\n", aux->rsun_ref);
-  if (aux->dsun_obs != UNDEFINED) wcsprintf("dsun_obs: %f\n", aux->dsun_obs);
-  if (aux->crln_obs != UNDEFINED) wcsprintf("crln_obs: %f\n", aux->crln_obs);
-  if (aux->hgln_obs != UNDEFINED) wcsprintf("hgln_obs: %f\n", aux->hgln_obs);
-  if (aux->hglt_obs != UNDEFINED) wcsprintf("hglt_obs: %f\n", aux->hglt_obs);
+  wcsprintf("rsun_ref:");
+  if (aux->rsun_ref != UNDEFINED) wcsprintf(" %f", aux->rsun_ref);
+  wcsprintf("\ndsun_obs:");
+  if (aux->dsun_obs != UNDEFINED) wcsprintf(" %f", aux->dsun_obs);
+  wcsprintf("\ncrln_obs:");
+  if (aux->crln_obs != UNDEFINED) wcsprintf(" %f", aux->crln_obs);
+  wcsprintf("\nhgln_obs:");
+  if (aux->hgln_obs != UNDEFINED) wcsprintf(" %f", aux->hgln_obs);
+  wcsprintf("\nhglt_obs:");
+  if (aux->hglt_obs != UNDEFINED) wcsprintf(" %f", aux->hglt_obs);
 
   return;
 }
@@ -102,7 +107,7 @@ static int PyAuxprm_set_rsun_ref(PyAuxprm* self, PyObject* value, void* closure)
 }
 
 static PyObject* PyAuxprm_get_dsun_obs(PyAuxprm* self, void* closure) {
-  if(self->x == NULL) {
+  if(self->x == NULL || self->x->dsun_obs == UNDEFINED) {
     Py_RETURN_NONE;
   } else {
     return get_double("dsun_obs", self->x->dsun_obs);
@@ -118,7 +123,7 @@ static int PyAuxprm_set_dsun_obs(PyAuxprm* self, PyObject* value, void* closure)
 }
 
 static PyObject* PyAuxprm_get_crln_obs(PyAuxprm* self, void* closure) {
-  if(self->x == NULL) {
+  if(self->x == NULL || self->x->crln_obs == UNDEFINED) {
     Py_RETURN_NONE;
   } else {
     return get_double("crln_obs", self->x->crln_obs);
@@ -134,7 +139,7 @@ static int PyAuxprm_set_crln_obs(PyAuxprm* self, PyObject* value, void* closure)
 }
 
 static PyObject* PyAuxprm_get_hgln_obs(PyAuxprm* self, void* closure) {
-  if(self->x == NULL) {
+  if(self->x == NULL || self->x->hgln_obs == UNDEFINED) {
     Py_RETURN_NONE;
   } else {
     return get_double("hgln_obs", self->x->hgln_obs);
@@ -150,7 +155,7 @@ static int PyAuxprm_set_hgln_obs(PyAuxprm* self, PyObject* value, void* closure)
 }
 
 static PyObject* PyAuxprm_get_hglt_obs(PyAuxprm* self, void* closure) {
-  if(self->x == NULL) {
+  if(self->x == NULL || self->x->hglt_obs == UNDEFINED) {
     Py_RETURN_NONE;
   } else {
     return get_double("hglt_obs", self->x->hglt_obs);

--- a/astropy/wcs/src/wcslib_auxprm_wrap.c
+++ b/astropy/wcs/src/wcslib_auxprm_wrap.c
@@ -72,17 +72,6 @@ static void auxprmprt(const struct auxprm *aux) {
 }
 
 
-static PyObject* PyAuxprm_print_contents(PyAuxprm* self) {
-  /* This is not thread-safe, but since we're holding onto the GIL,
-     we can assume we won't have thread conflicts */
-  wcsprintf_set(NULL);
-  auxprmprt(self->x);
-  printf("%s", wcsprintf_buf());
-  fflush(stdout);
-  Py_RETURN_NONE;
-}
-
-
 static PyObject* PyAuxprm___str__(PyAuxprm* self) {
   /* This is not thread-safe, but since we're holding onto the GIL,
      we can assume we won't have thread conflicts */
@@ -181,17 +170,11 @@ static int PyAuxprm_set_hglt_obs(PyAuxprm* self, PyObject* value, void* closure)
  */
 
 static PyGetSetDef PyAuxprm_getset[] = {
-  {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, PyAuxprm_set_rsun_ref, (char *) NULL},
-  {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, PyAuxprm_set_dsun_obs, (char *) NULL},
-  {"crln_obs", (getter)PyAuxprm_get_crln_obs, PyAuxprm_set_crln_obs, (char *) NULL},
-  {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, PyAuxprm_set_hgln_obs, (char *) NULL},
-  {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, PyAuxprm_set_hglt_obs, (char *) NULL},
-  {NULL}
-};
-
-
-static PyMethodDef PyAuxprm_methods[] = {
-  {"print_contents", (PyCFunction)PyAuxprm_print_contents, METH_NOARGS, NULL},
+  {"rsun_ref", (getter)PyAuxprm_get_rsun_ref, (setter)PyAuxprm_set_rsun_ref, (char *)doc_rsun_ref},
+  {"dsun_obs", (getter)PyAuxprm_get_dsun_obs, (setter)PyAuxprm_set_dsun_obs, (char *)doc_dsun_obs},
+  {"crln_obs", (getter)PyAuxprm_get_crln_obs, (setter)PyAuxprm_set_crln_obs, (char *)doc_crln_obs},
+  {"hgln_obs", (getter)PyAuxprm_get_hgln_obs, (setter)PyAuxprm_set_hgln_obs, (char *)doc_hgln_obs},
+  {"hglt_obs", (getter)PyAuxprm_get_hglt_obs, (setter)PyAuxprm_set_hglt_obs, (char *)doc_hglt_obs},
   {NULL}
 };
 
@@ -216,14 +199,14 @@ PyTypeObject PyAuxprmType = {
   0,                            /*tp_setattro*/
   0,                            /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  0,                            /* tp_doc */
+  doc_Auxprm,                   /* tp_doc */
   (traverseproc)PyAuxprm_traverse, /* tp_traverse */
-  (inquiry)PyAuxprm_clear,         /* tp_clear */
+  (inquiry)PyAuxprm_clear,      /* tp_clear */
   0,                            /* tp_richcompare */
   0,                            /* tp_weaklistoffset */
   0,                            /* tp_iter */
   0,                            /* tp_iternext */
-  PyAuxprm_methods,             /* tp_methods */
+  0,                            /* tp_methods */
   0,                            /* tp_members */
   PyAuxprm_getset,              /* tp_getset */
   0,                            /* tp_base */

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -3996,7 +3996,7 @@ PyWcsprm_set_zsource(
 
 
 static PyObject*
-PyWcsprm_get_auxprm(
+PyWcsprm_get_aux(
     PyWcsprm* self,
     /*@unused@*/ void* closure) {
 
@@ -4019,7 +4019,7 @@ PyWcsprm_get_auxprm(
 
 static PyGetSetDef PyWcsprm_getset[] = {
   {"alt", (getter)PyWcsprm_get_alt, (setter)PyWcsprm_set_alt, (char *)doc_alt},
-  {"auxprm", (getter)PyWcsprm_get_auxprm, NULL, NULL},
+  {"aux", (getter)PyWcsprm_get_aux, NULL, NULL},
   {"axis_types", (getter)PyWcsprm_get_axis_types, NULL, (char *)doc_axis_types},
   {"bepoch", (getter)PyWcsprm_get_bepoch, (setter)PyWcsprm_set_bepoch, (char *)doc_bepoch},
   {"cd", (getter)PyWcsprm_get_cd, (setter)PyWcsprm_set_cd, (char *)doc_cd},

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -4001,14 +4001,8 @@ PyWcsprm_get_aux(
     /*@unused@*/ void* closure) {
 
   PyObject* result;
-  double test = 1.2;
 
   result = (PyObject *)PyAuxprm_cnew((PyObject *)self, self->x.aux);
-
-  if (result == NULL) {
-    Py_DECREF(result);
-    return NULL;
-  }
 
   return result;
 }
@@ -4019,7 +4013,7 @@ PyWcsprm_get_aux(
 
 static PyGetSetDef PyWcsprm_getset[] = {
   {"alt", (getter)PyWcsprm_get_alt, (setter)PyWcsprm_set_alt, (char *)doc_alt},
-  {"aux", (getter)PyWcsprm_get_aux, NULL, NULL},
+  {"aux", (getter)PyWcsprm_get_aux, NULL, (char *)doc_aux},
   {"axis_types", (getter)PyWcsprm_get_axis_types, NULL, (char *)doc_axis_types},
   {"bepoch", (getter)PyWcsprm_get_bepoch, (setter)PyWcsprm_set_bepoch, (char *)doc_bepoch},
   {"cd", (getter)PyWcsprm_get_cd, (setter)PyWcsprm_set_cd, (char *)doc_cd},

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -4002,6 +4002,13 @@ PyWcsprm_get_aux(
 
   PyObject* result;
 
+    // If wcsprm.aux is not initialized, we should do so here so that users can
+    // set auxiliary parameters on an empty WCS.
+
+    if (self->x.aux == 0x0) {
+      wcsauxi(1, &self->x);
+    }
+
   result = (PyObject *)PyAuxprm_cnew((PyObject *)self, self->x.aux);
 
   return result;

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -6,6 +6,7 @@
 #define NO_IMPORT_ARRAY
 
 #include "astropy_wcs/wcslib_wrap.h"
+#include "astropy_wcs/wcslib_auxprm_wrap.h"
 #include "astropy_wcs/wcslib_tabprm_wrap.h"
 #include "astropy_wcs/wcslib_wtbarr_wrap.h"
 #include "astropy_wcs/wcslib_units_wrap.h"
@@ -3993,12 +3994,32 @@ PyWcsprm_set_zsource(
   return set_double("zsource", value, &self->x.zsource);
 }
 
+
+static PyObject*
+PyWcsprm_get_auxprm(
+    PyWcsprm* self,
+    /*@unused@*/ void* closure) {
+
+  PyObject* result;
+  double test = 1.2;
+
+  result = (PyObject *)PyAuxprm_cnew((PyObject *)self, self->x.aux);
+
+  if (result == NULL) {
+    Py_DECREF(result);
+    return NULL;
+  }
+
+  return result;
+}
+
 /***************************************************************************
  * PyWcsprm definition structures
  */
 
 static PyGetSetDef PyWcsprm_getset[] = {
   {"alt", (getter)PyWcsprm_get_alt, (setter)PyWcsprm_set_alt, (char *)doc_alt},
+  {"auxprm", (getter)PyWcsprm_get_auxprm, NULL, NULL},
   {"axis_types", (getter)PyWcsprm_get_axis_types, NULL, (char *)doc_axis_types},
   {"bepoch", (getter)PyWcsprm_get_bepoch, (setter)PyWcsprm_set_bepoch, (char *)doc_bepoch},
   {"cd", (getter)PyWcsprm_get_cd, (setter)PyWcsprm_set_cd, (char *)doc_cd},

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -9,16 +9,12 @@ from numpy.testing import assert_allclose
 from astropy.io import fits
 from astropy.wcs import WCS
 
-# NOTE: For now the WCSLIB struct does not include crlt_obs, so we keep it
-# commented out for now in the following tests.
-
 
 def test_empty():
     w = WCS(naxis=1)
     assert w.wcs.aux.rsun_ref is None
     assert w.wcs.aux.dsun_obs is None
     assert w.wcs.aux.crln_obs is None
-    # assert w.wcs.aux.crlt_obs is None
     assert w.wcs.aux.hgln_obs is None
     assert w.wcs.aux.hglt_obs is None
     assert str(w.wcs.aux) == ''
@@ -49,7 +45,7 @@ DSUN_OBS=       147724815128.0 / [m] Distance from centre of Sun to observer
 CRLN_OBS=            22.814522 / [deg] Carrington heliographic lng of observer
 CRLT_OBS=            -6.820544 / [deg] Heliographic latitude of observer
 HGLN_OBS=             8.431123 / [deg] Stonyhurst heliographic lng of observer
-HGLT_OBS=             3.122233 / [deg] Heliographic latitude of observer
+HGLT_OBS=            -6.820544 / [deg] Heliographic latitude of observer
 """.lstrip(), sep='\n')
 
 
@@ -58,7 +54,7 @@ rsun_ref: 696000000.000000
 dsun_obs: 147724815128.000000
 crln_obs: 22.814522
 hgln_obs: 8.431123
-hglt_obs: 3.122233
+hglt_obs: -6.820544
 """.lstrip()
 
 
@@ -67,9 +63,8 @@ def test_solar_aux_get():
     assert_allclose(w.wcs.aux.rsun_ref, 696000000)
     assert_allclose(w.wcs.aux.dsun_obs, 147724815128)
     assert_allclose(w.wcs.aux.crln_obs, 22.814522)
-    # assert_allclose(w.wcs.aux.crlt_obs, -6.820544)
     assert_allclose(w.wcs.aux.hgln_obs, 8.431123)
-    assert_allclose(w.wcs.aux.hglt_obs, 3.122233)
+    assert_allclose(w.wcs.aux.hglt_obs, -6.820544)
     assert str(w.wcs.aux) == STR_EXPECTED_GET
 
 
@@ -95,9 +90,6 @@ def test_solar_aux_set():
     w.wcs.aux.crln_obs = 10.
     assert_allclose(w.wcs.aux.crln_obs, 10.)
 
-    # w.wcs.aux.crlt_obs = 20.
-    # assert_allclose(w.wcs.aux.crlt_obs, 20.)
-
     w.wcs.aux.hgln_obs = 30.
     assert_allclose(w.wcs.aux.hgln_obs, 30.)
 
@@ -110,6 +102,5 @@ def test_solar_aux_set():
     assert_allclose(header['RSUN_REF'], 698000000)
     assert_allclose(header['DSUN_OBS'], 140000000000)
     assert_allclose(header['CRLN_OBS'], 10.)
-    # assert_allclose(header['CRLT_OBS'], 20.)
     assert_allclose(header['HGLN_OBS'], 30.)
     assert_allclose(header['HGLT_OBS'], 40.)

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+# Tests for the auxiliary parameters contained in wcsaux
+
+from numpy.testing import assert_allclose
+
+from astropy.io import fits
+from astropy.wcs import WCS
+
+# NOTE: For now the WCSLIB struct does not include crlt_obs, so we keep it
+# commented out for now in the following tests.
+
+
+def test_empty():
+    w = WCS(naxis=1)
+    assert w.wcs.aux.rsun_ref is None
+    assert w.wcs.aux.dsun_obs is None
+    assert w.wcs.aux.crln_obs is None
+    # assert w.wcs.aux.crlt_obs is None
+    assert w.wcs.aux.hgln_obs is None
+    assert w.wcs.aux.hglt_obs is None
+    assert str(w.wcs.aux) == ''
+
+
+HEADER_SOLAR = fits.Header.fromstring("""
+WCSAXES =                    2 / Number of coordinate axes
+CRPIX1  =                 64.5 / Pixel coordinate of reference point
+CRPIX2  =                 64.5 / Pixel coordinate of reference point
+PC1_1   =     0.99999994260024 / Coordinate transformation matrix element
+PC1_2   = -0.00033882076120692 / Coordinate transformation matrix element
+PC2_1   =  0.00033882076120692 / Coordinate transformation matrix element
+PC2_2   =     0.99999994260024 / Coordinate transformation matrix element
+CDELT1  =   0.0053287911111111 / [deg] Coordinate increment at reference point
+CDELT2  =   0.0053287911111111 / [deg] Coordinate increment at reference point
+CUNIT1  = 'deg'                / Units of coordinate increment and value
+CUNIT2  = 'deg'                / Units of coordinate increment and value
+CTYPE1  = 'HPLN-TAN'           / Coordinate type codegnomonic projection
+CTYPE2  = 'HPLT-TAN'           / Coordinate type codegnomonic projection
+CRVAL1  =  -0.0012589367249586 / [deg] Coordinate value at reference point
+CRVAL2  =  0.00079599300143911 / [deg] Coordinate value at reference point
+LONPOLE =                180.0 / [deg] Native longitude of celestial pole
+LATPOLE =  0.00079599300143911 / [deg] Native latitude of celestial pole
+DATE-OBS= '2011-02-15T00:00:00.34' / ISO-8601 time of observation
+MJD-OBS =      55607.000003935 / [d] MJD at start of observation
+RSUN_REF=          696000000.0 / [m] Solar radius
+DSUN_OBS=       147724815128.0 / [m] Distance from centre of Sun to observer
+CRLN_OBS=            22.814522 / [deg] Carrington heliographic lng of observer
+CRLT_OBS=            -6.820544 / [deg] Heliographic latitude of observer
+HGLN_OBS=             8.431123 / [deg] Stonyhurst heliographic lng of observer
+HGLT_OBS=             3.122233 / [deg] Heliographic latitude of observer
+""".lstrip(), sep='\n')
+
+
+STR_EXPECTED_GET = """
+rsun_ref: 696000000.000000
+dsun_obs: 147724815128.000000
+crln_obs: 22.814522
+hgln_obs: 8.431123
+hglt_obs: 3.122233
+""".lstrip()
+
+
+def test_solar_aux_get():
+    w = WCS(HEADER_SOLAR)
+    assert_allclose(w.wcs.aux.rsun_ref, 696000000)
+    assert_allclose(w.wcs.aux.dsun_obs, 147724815128)
+    assert_allclose(w.wcs.aux.crln_obs, 22.814522)
+    # assert_allclose(w.wcs.aux.crlt_obs, -6.820544)
+    assert_allclose(w.wcs.aux.hgln_obs, 8.431123)
+    assert_allclose(w.wcs.aux.hglt_obs, 3.122233)
+    assert str(w.wcs.aux) == STR_EXPECTED_GET
+
+
+STR_EXPECTED_SET = """
+rsun_ref: 698000000.000000
+dsun_obs: 140000000000.000000
+crln_obs: 10.000000
+hgln_obs: 30.000000
+hglt_obs: 40.000000
+""".lstrip()
+
+
+def test_solar_aux_set():
+
+    w = WCS(HEADER_SOLAR)
+
+    w.wcs.aux.rsun_ref = 698000000
+    assert_allclose(w.wcs.aux.rsun_ref, 698000000)
+
+    w.wcs.aux.dsun_obs = 140000000000
+    assert_allclose(w.wcs.aux.dsun_obs, 140000000000)
+
+    w.wcs.aux.crln_obs = 10.
+    assert_allclose(w.wcs.aux.crln_obs, 10.)
+
+    # w.wcs.aux.crlt_obs = 20.
+    # assert_allclose(w.wcs.aux.crlt_obs, 20.)
+
+    w.wcs.aux.hgln_obs = 30.
+    assert_allclose(w.wcs.aux.hgln_obs, 30.)
+
+    w.wcs.aux.hglt_obs = 40.
+    assert_allclose(w.wcs.aux.hglt_obs, 40.)
+
+    assert str(w.wcs.aux) == STR_EXPECTED_SET
+
+    header = w.to_header()
+    assert_allclose(header['RSUN_REF'], 698000000)
+    assert_allclose(header['DSUN_OBS'], 140000000000)
+    assert_allclose(header['CRLN_OBS'], 10.)
+    # assert_allclose(header['CRLT_OBS'], 20.)
+    assert_allclose(header['HGLN_OBS'], 30.)
+    assert_allclose(header['HGLT_OBS'], 40.)

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -4,6 +4,8 @@
 
 # Tests for the auxiliary parameters contained in wcsaux
 
+import pytest
+
 from numpy.testing import assert_allclose
 
 from astropy.io import fits
@@ -80,6 +82,36 @@ hglt_obs: 40.000000
 def test_solar_aux_set():
 
     w = WCS(HEADER_SOLAR)
+
+    w.wcs.aux.rsun_ref = 698000000
+    assert_allclose(w.wcs.aux.rsun_ref, 698000000)
+
+    w.wcs.aux.dsun_obs = 140000000000
+    assert_allclose(w.wcs.aux.dsun_obs, 140000000000)
+
+    w.wcs.aux.crln_obs = 10.
+    assert_allclose(w.wcs.aux.crln_obs, 10.)
+
+    w.wcs.aux.hgln_obs = 30.
+    assert_allclose(w.wcs.aux.hgln_obs, 30.)
+
+    w.wcs.aux.hglt_obs = 40.
+    assert_allclose(w.wcs.aux.hglt_obs, 40.)
+
+    assert str(w.wcs.aux) == STR_EXPECTED_SET
+
+    header = w.to_header()
+    assert_allclose(header['RSUN_REF'], 698000000)
+    assert_allclose(header['DSUN_OBS'], 140000000000)
+    assert_allclose(header['CRLN_OBS'], 10.)
+    assert_allclose(header['HGLN_OBS'], 30.)
+    assert_allclose(header['HGLT_OBS'], 40.)
+
+
+@pytest.mark.xfail
+def test_set_aux_on_empty():
+
+    w = WCS(naxis=2)
 
     w.wcs.aux.rsun_ref = 698000000
     assert_allclose(w.wcs.aux.rsun_ref, 698000000)

--- a/astropy/wcs/tests/test_auxprm.py
+++ b/astropy/wcs/tests/test_auxprm.py
@@ -4,12 +4,18 @@
 
 # Tests for the auxiliary parameters contained in wcsaux
 
-import pytest
-
 from numpy.testing import assert_allclose
 
 from astropy.io import fits
 from astropy.wcs import WCS
+
+
+STR_EXPECTED_EMPTY = """
+rsun_ref:
+dsun_obs:
+crln_obs:
+hgln_obs:
+hglt_obs:""".lstrip()
 
 
 def test_empty():
@@ -19,7 +25,7 @@ def test_empty():
     assert w.wcs.aux.crln_obs is None
     assert w.wcs.aux.hgln_obs is None
     assert w.wcs.aux.hglt_obs is None
-    assert str(w.wcs.aux) == ''
+    assert str(w.wcs.aux) == STR_EXPECTED_EMPTY
 
 
 HEADER_SOLAR = fits.Header.fromstring("""
@@ -56,8 +62,7 @@ rsun_ref: 696000000.000000
 dsun_obs: 147724815128.000000
 crln_obs: 22.814522
 hgln_obs: 8.431123
-hglt_obs: -6.820544
-""".lstrip()
+hglt_obs: -6.820544""".lstrip()
 
 
 def test_solar_aux_get():
@@ -75,8 +80,7 @@ rsun_ref: 698000000.000000
 dsun_obs: 140000000000.000000
 crln_obs: 10.000000
 hgln_obs: 30.000000
-hglt_obs: 40.000000
-""".lstrip()
+hglt_obs: 40.000000""".lstrip()
 
 
 def test_solar_aux_set():
@@ -108,7 +112,6 @@ def test_solar_aux_set():
     assert_allclose(header['HGLT_OBS'], 40.)
 
 
-@pytest.mark.xfail
 def test_set_aux_on_empty():
 
     w = WCS(naxis=2)

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -57,7 +57,7 @@ from astropy.utils.exceptions import AstropyWarning, AstropyUserWarning, Astropy
 from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
 
 __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
-           'DistortionLookupTable', 'Sip', 'Tabprm', 'Wcsprm',
+           'DistortionLookupTable', 'Sip', 'Tabprm', 'Wcsprm', 'Auxprm',
            'WCSBase', 'validate', 'WcsError', 'SingularMatrixError',
            'InconsistentAxisTypesError', 'InvalidTransformError',
            'InvalidCoordinateError', 'NoSolutionError',
@@ -86,6 +86,7 @@ if _wcs is not None:
     DistortionLookupTable = _wcs.DistortionLookupTable
     Sip = _wcs.Sip
     Wcsprm = _wcs.Wcsprm
+    Auxprm = _wcs.Auxprm
     Tabprm = _wcs.Tabprm
     WcsError = _wcs.WcsError
     SingularMatrixError = _wcs.SingularMatrixError


### PR DESCRIPTION
Astropy 4.1 will include WCSLIB 7.2, which now includes (since 7.1) additional WCS parameters that are standardized but not used in transformations (so called 'auxillary parameters') - however, these were not exposed in the Python layer when WCSLIB was updated, so this PR fixes this by exposing these parameters. I would ideally like to get this into the 4.1.x series of releases since I would consider it a bug that these were not exposed, but I'm happy to discuss it more. However, we don't have to rush to merge it into 4.1 as long as it can be included in 4.1.1 - it's more important to make sure this is all correct.

A caveat is that I am not the most experienced in the C code in astropy.wcs, so this should be reviewed carefully by people who are (I've tagged a few people for review, plus @mcara who I can't assign for reviews yet - trying to fix that). I'm also tagging @Cadair for review since this should in principle be useful for SunPy, but he will need to confirm that this is adequate for SunPy's purposes.

If people are happy for this to be included in 4.1.1, I'll add the changelog entry once 4.1 is released. If this gets reviewed and is ready before the first RC, then we could consider backporting it to include it in the 4.1 release, but I don't feel strongly about that so happy to defer to @bsipocz and @eteq once the review process is complete.

Fixes https://github.com/astropy/astropy/issues/10331

EDIT: I've been informed by @Cadair that WCSLIB was actually updated in the 4.0.x release cycle so we could even backport to 4.0.x :smile: 