### PR TITLE
Add docs for Wtbarr

### DIFF
--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -688,15 +688,11 @@ An undefined value is represented by NaN.
 """
 
 extlev = """
-``int`` (read-only)
-
-``EXTLEV`` identifying the binary table extension.
+``int`` (read-only) ``EXTLEV`` identifying the binary table extension.
 """
 
 extnam = """
-``str`` (read-only)
-
-``EXTNAME`` identifying the binary table extension.
+``str`` (read-only) ``EXTNAME`` identifying the binary table extension.
 """
 
 extrema = """
@@ -715,9 +711,7 @@ speed up table searches.
 """
 
 extver = """
-``int`` (read-only)
-
-``EXTVER`` identifying the binary table extension.
+``int`` (read-only) ``EXTVER`` identifying the binary table extension.
 """
 
 find_all_wcs = """
@@ -995,9 +989,7 @@ hglt_obs = """
 """
 
 i = """
-``int`` (read-only)
-
-Image axis number.
+``int`` (read-only) Image axis number.
 """
 
 imgpix_matrix = """
@@ -1024,9 +1016,9 @@ the coordinate array and of each indexing vector.
 """
 
 kind = """
-``str`` (read-only)
+``str`` (read-only) ``wcstab`` array type.
 
-Character identifying the wcstab array type:
+Character identifying the ``wcstab`` array type:
 
     - ``'c'``: coordinate array,
     - ``'i'``: index vector.
@@ -1073,9 +1065,7 @@ M = """
 """
 
 m = """
-``int`` (read-only)
-
-Array axis number for index vectors.
+``int`` (read-only) ``wcstab`` axis number for index vectors.
 """
 
 map = """
@@ -1300,9 +1290,7 @@ product K_1 * K_2 * ... * K_M.
 """
 
 ndim = """
-``int`` (read-only)
-
-Expected dimensionality of the wcstab array.
+``int`` (read-only) Expected dimensionality of the ``wcstab`` array.
 """
 
 obsgeo = """
@@ -1518,6 +1506,16 @@ removed in the future.
 To get a string of the contents, use `repr`.
 """
 
+print_contents_wtbarr = """
+print_contents()
+
+Print the contents of the `~astropy.wcs.Wtbarr` object to
+stdout. Probably only useful for debugging purposes, and may be
+removed in the future.
+
+To get a string of the contents, use `repr`.
+"""
+
 radesys = """
 ``string`` The equatorial or ecliptic coordinate system type,
 ``RADESYSa``.
@@ -1536,9 +1534,7 @@ An undefined value is represented by NaN.
 """
 
 row = """
-``int`` (read-only)
-
-Table row number.
+``int`` (read-only) Table row number.
 """
 
 rsun_ref = """
@@ -2118,9 +2114,7 @@ header : str
 """
 
 ttype = """
-``str`` (read-only)
-
-``TTYPEn`` identifying the column of the binary table that contains
+``str`` (read-only) ``TTYPEn`` identifying the column of the binary table that contains
 the wcstab array.
 """
 
@@ -2291,6 +2285,11 @@ ValueError
 
 KeyError
      Key not found in FITS header.
+"""
+
+wtb = """
+``list of Wtbarr`` objects to construct coordinate lookup tables from BINTABLE.
+
 """
 
 Wtbarr = """

--- a/astropy/wcs/src/wcslib_wrap.c
+++ b/astropy/wcs/src/wcslib_wrap.c
@@ -4091,7 +4091,7 @@ static PyGetSetDef PyWcsprm_getset[] = {
   {"velosys", (getter)PyWcsprm_get_velosys, (setter)PyWcsprm_set_velosys, (char *)doc_velosys},
   {"velref", (getter)PyWcsprm_get_velref, (setter)PyWcsprm_set_velref, (char *)doc_velref},
   {"xposure", (getter)PyWcsprm_get_xposure, (setter)PyWcsprm_set_xposure, (char *)doc_xposure},
-  {"wtb", (getter)PyWcsprm_get_wtb, NULL, (char *) NULL},
+  {"wtb", (getter)PyWcsprm_get_wtb, NULL, (char *) doc_wtb},
   {"zsource", (getter)PyWcsprm_get_zsource, (setter)PyWcsprm_set_zsource, (char *)doc_zsource},
   {NULL}
 };

--- a/astropy/wcs/src/wcslib_wtbarr_wrap.c
+++ b/astropy/wcs/src/wcslib_wtbarr_wrap.c
@@ -163,15 +163,15 @@ static PyObject* PyWtbarr_get_kind(PyWtbarr* self, void* closure) {
  */
 
 static PyGetSetDef PyWtbarr_getset[] = {
-  {"i", (getter)PyWtbarr_get_i, NULL, (char *) NULL},
-  {"m", (getter)PyWtbarr_get_m, NULL, (char *) NULL},
-  {"kind", (getter)PyWtbarr_get_kind, NULL, (char *) NULL},
-  {"extnam", (getter)PyWtbarr_get_extnam, NULL, (char *) NULL},
-  {"extver", (getter)PyWtbarr_get_extver, NULL, (char *) NULL},
-  {"extlev", (getter)PyWtbarr_get_extlev, NULL, (char *) NULL},
-  {"ttype", (getter)PyWtbarr_get_ttype, NULL, (char *) NULL},
-  {"row", (getter)PyWtbarr_get_row, NULL, (char *) NULL},
-  {"ndim", (getter)PyWtbarr_get_ndim, NULL, (char *) NULL},
+  {"i", (getter)PyWtbarr_get_i, NULL, (char *) doc_i},
+  {"m", (getter)PyWtbarr_get_m, NULL, (char *) doc_m},
+  {"kind", (getter)PyWtbarr_get_kind, NULL, (char *) doc_kind},
+  {"extnam", (getter)PyWtbarr_get_extnam, NULL, (char *) doc_extnam},
+  {"extver", (getter)PyWtbarr_get_extver, NULL, (char *) doc_extver},
+  {"extlev", (getter)PyWtbarr_get_extlev, NULL, (char *) doc_extlev},
+  {"ttype", (getter)PyWtbarr_get_ttype, NULL, (char *) doc_ttype},
+  {"row", (getter)PyWtbarr_get_row, NULL, (char *) doc_row},
+  {"ndim", (getter)PyWtbarr_get_ndim, NULL, (char *) doc_ndim},
 /*  {"dimlen", (getter)PyWtbarr_get_dimlen, NULL, (char *) NULL}, */
 /*  {"arrayp", (getter)PyWtbarr_get_arrayp, NULL, (char *) NULL}, */
   {NULL}
@@ -179,7 +179,7 @@ static PyGetSetDef PyWtbarr_getset[] = {
 
 
 static PyMethodDef PyWtbarr_methods[] = {
-  {"print_contents", (PyCFunction)PyWtbarr_print_contents, METH_NOARGS, NULL},
+  {"print_contents", (PyCFunction)PyWtbarr_print_contents, METH_NOARGS, doc_print_contents_wtbarr},
   {NULL}
 };
 
@@ -204,9 +204,9 @@ PyTypeObject PyWtbarrType = {
   0,                            /*tp_setattro*/
   0,                            /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  0,                            /* tp_doc */
-  0,                            /* tp_traverse */
-  0,                            /* tp_clear */
+  doc_Wtbarr,                   /* tp_doc */
+  PyWtbarr_traverse,            /* tp_traverse */
+  PyWtbarr_clear,               /* tp_clear */
   0,                            /* tp_richcompare */
   0,                            /* tp_weaklistoffset */
   0,                            /* tp_iter */

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -58,7 +58,7 @@ from .wcsapi.fitswcs import FITSWCSAPIMixin, SlicedFITSWCS
 
 __all__ = ['FITSFixedWarning', 'WCS', 'find_all_wcs',
            'DistortionLookupTable', 'Sip', 'Tabprm', 'Wcsprm', 'Auxprm',
-           'WCSBase', 'validate', 'WcsError', 'SingularMatrixError',
+           'Wtbarr', 'WCSBase', 'validate', 'WcsError', 'SingularMatrixError',
            'InconsistentAxisTypesError', 'InvalidTransformError',
            'InvalidCoordinateError', 'NoSolutionError',
            'InvalidSubimageSpecificationError', 'NoConvergence',
@@ -88,6 +88,7 @@ if _wcs is not None:
     Wcsprm = _wcs.Wcsprm
     Auxprm = _wcs.Auxprm
     Tabprm = _wcs.Tabprm
+    Wtbarr = _wcs.Wtbarr
     WcsError = _wcs.WcsError
     SingularMatrixError = _wcs.SingularMatrixError
     InconsistentAxisTypesError = _wcs.InconsistentAxisTypesError
@@ -125,6 +126,7 @@ else:
     DistortionLookupTable = object
     Sip = object
     Tabprm = object
+    Wtbarr = object
     WcsError = None
     SingularMatrixError = None
     InconsistentAxisTypesError = None


### PR DESCRIPTION
This PR adds documentation for the `Wtbarr` structure that was not added in https://github.com/astropy/astropy/pull/9641.

In addition, this PR enables `tp_traverse` and `tp_clear` slots for `Wtbarr` structure. 

Fixes #10335