### PR TITLE
Allow pixel units in SpectralQuantity and SpectralCoord

### DIFF
--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -719,6 +719,9 @@ class SpectralCoord(SpectralQuantity):
             transformed based on the observer's new velocity frame.
         """
 
+        if self.unit is u.pixel:
+            raise u.UnitsError("Cannot transform spectral coordinates in pixel units")
+
         if self.observer is None or self.target is None:
             raise ValueError("This method can only be used if both observer "
                              "and target are defined on the SpectralCoord.")
@@ -784,6 +787,10 @@ class SpectralCoord(SpectralQuantity):
             New spectral coordinate with the target/observer velocity changed
             to incorporate the shift.
         """
+
+        if self.unit is u.pixel:
+            raise u.UnitsError("Cannot transform spectral coordinates in pixel units")
+
         if observer_shift is not None and (self.target is None or
                                            self.observer is None):
             raise ValueError("Both an observer and target must be defined "

--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.units import si
+from astropy import units as u
 from astropy.units import equivalencies as eq
 from astropy.units.quantity import SpecificTypeQuantity, Quantity
 from astropy.units.decorators import quantity_input
@@ -9,9 +9,9 @@ __all__ = ['SpectralQuantity']
 # We don't want to run doctests in the docstrings we inherit from Quantity
 __doctest_skip__ = ['SpectralQuantity.*']
 
-KMS = si.km / si.s
+KMS = u.km / u.s
 
-SPECTRAL_UNITS = (si.Hz, si.m, si.J, si.m ** -1, KMS)
+SPECTRAL_UNITS = (u.Hz, u.m, u.J, u.m ** -1, KMS, u.pixel)
 
 DOPPLER_CONVENTIONS = {
     'radio': eq.doppler_radio,
@@ -258,7 +258,7 @@ class SpectralQuantity(SpecificTypeQuantity):
 
             vel_equiv1 = DOPPLER_CONVENTIONS[self._doppler_convention](self._doppler_rest)
 
-            freq = super().to(si.Hz, equivalencies=equivalencies + vel_equiv1)
+            freq = super().to(u.Hz, equivalencies=equivalencies + vel_equiv1)
 
             vel_equiv2 = DOPPLER_CONVENTIONS[doppler_convention](doppler_rest)
 

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -235,6 +235,28 @@ def test_init_spectral_quantity():
     assert sc.target is None
 
 
+def test_pixel():
+
+    # Check that most methods don't work if units are pixel (used for uncalibrated
+    # spectral values)
+
+    with pytest.warns(AstropyUserWarning, match='No velocity defined on frame'):
+        sc1 = SpectralCoord(10 * u.pixel, observer=LSRD,
+                            target=SkyCoord(10 * u.deg, 20 * u.deg, distance=10 * u.pc))
+
+    sc2 = sc1.replicate()
+
+    assert isinstance(sc2, SpectralCoord)
+    assert sc2.value == 10
+    assert sc2.unit == u.pixel
+
+    with pytest.raises(u.UnitsError, match='Cannot transform spectral coordinates in pixel units'):
+        sc1.with_observer_stationary_relative_to(sc2.target)
+
+    with pytest.raises(u.UnitsError, match='Cannot transform spectral coordinates in pixel units'):
+        sc1.with_radial_velocity_shift(0.5)
+
+
 def test_init_too_many_args():
 
     with pytest.raises(ValueError, match='Cannot specify radial velocity or redshift if both'):
@@ -379,7 +401,6 @@ def test_replicate():
     sc_init_ref = sc_init.replicate()
     sc_init[0] = 6000 * u.AA
     assert_quantity_allclose(sc_init_ref, [6000, 5000] * u.AA)
-
 
 
 def test_with_observer_stationary_relative_to():

--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -242,3 +242,24 @@ class TestSpectralQuantity:
         assert isinstance(q1, u.Quantity) and not isinstance(q1, SpectralQuantity)
         assert q1.value == np.sum(sq1.value)
         assert q1.unit == u.AA
+
+    def test_pixel(self):
+
+        # SpectralQuantity also supports values in pixel, to represent
+        # uncalibrated spectral values, so we check here that things work
+        # as expected
+
+        sq1 = SpectralQuantity(1, unit=u.pixel)
+        sq2 = SpectralQuantity(1 * u.pixel,
+                               doppler_convention='optical',
+                               doppler_rest=1 * u.GHz)
+        sq3 = SpectralQuantity(SpectralQuantity(1, unit=u.pixel))
+
+        with pytest.raises(u.UnitsError, match='not convertible'):
+            sq1.to(u.GHz)
+
+        with pytest.raises(u.UnitsError, match='not convertible'):
+            sq2.to(u.km / u.s)
+
+        with pytest.raises(u.UnitsError, match='not convertible'):
+            sq3.to_value(u.GHz)


### PR DESCRIPTION
Specutils needs to subclass from ``SpectralCoord`` to represent spectral axes, but needs the ability to represent uncalibrated spectral units - as discussed in https://github.com/astropy/specutils/pull/674, this can be done by allowing ``SpectralCoord`` to take pixel units in addition to the usual spectral units. I think this is an important fix to get in for 4.1 so that specutils can start relying on astropy's SpectralCoord implementation.