### PR TITLE
Allow units to be passed as strings to SpectralQuantity.to

### DIFF
--- a/astropy/coordinates/spectral_quantity.py
+++ b/astropy/coordinates/spectral_quantity.py
@@ -1,6 +1,7 @@
 import numpy as np
 from astropy.units import si
 from astropy.units import equivalencies as eq
+from astropy.units import Unit
 from astropy.units.quantity import SpecificTypeQuantity, Quantity
 from astropy.units.decorators import quantity_input
 
@@ -213,6 +214,9 @@ class SpectralQuantity(SpecificTypeQuantity):
         `SpectralQuantity`
             New spectral coordinate object with data converted to the new unit.
         """
+
+        # Make sure units can be passed as strings
+        unit = Unit(unit)
 
         # If equivalencies is explicitly set to None, we should just use the
         # default Quantity.to with equivalencies also set to None

--- a/astropy/coordinates/tests/test_spectral_quantity.py
+++ b/astropy/coordinates/tests/test_spectral_quantity.py
@@ -36,7 +36,7 @@ class TestSpectralQuantity:
     def test_spectral_conversion(self, unit1, unit2):
         sq1 = SpectralQuantity(1 * unit1)
         sq2 = sq1.to(unit2)
-        sq3 = sq2.to(unit1)
+        sq3 = sq2.to(str(unit1))  # check that string units work
         assert isinstance(sq2, SpectralQuantity)
         assert isinstance(sq3, SpectralQuantity)
         assert_quantity_allclose(sq1, sq3)


### PR DESCRIPTION
This is a bug fix which we should include in 4.1