### PR TITLE
Added a context manager to set all of the finite-difference time steps in a TransformGraph

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ astropy.coordinates
 - Avoid an unnecessary call to ``erfa.epv00`` in transformations between
   ``CIRS`` and ``ICRS``, improving performance by 50 %. [#10814]
 
+- Added a context manager ``impose_finite_difference_dt`` to the
+  ``TransformGraph`` class to override the finite-difference time step
+  attribute (``finite_difference_dt``) for all transformations in the graph
+  with that attribute. [#10341]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -695,9 +695,8 @@ class TransformGraph:
         saved_settings = []
 
         try:
-            for from_frame in self._graph:
-                for to_frame in self._graph[from_frame]:
-                    transform = self._graph[from_frame][to_frame]
+            for to_frames in self._graph.values():
+                for transform in to_frames.values():
                     if hasattr(transform, key):
                         old_setting = (transform, key, getattr(transform, key))
                         saved_settings.append(old_setting)

--- a/astropy/coordinates/transformations.py
+++ b/astropy/coordinates/transformations.py
@@ -22,7 +22,7 @@ from warnings import warn
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict, OrderedDict
-from contextlib import suppress
+from contextlib import suppress, contextmanager
 from inspect import signature
 
 import numpy as np
@@ -674,6 +674,38 @@ class TransformGraph:
                      register_graph=self, **kwargs)
             return func
         return deco
+
+    @contextmanager
+    def impose_finite_difference_dt(self, dt):
+        """
+        Context manager to impose a finite-difference time step on all applicable transformations
+
+        For each transformation in this transformation graph that has the attribute
+        ``finite_difference_dt``, that attribute is set to the provided value.  The only standard
+        transformation with this attribute is
+        `~astropy.coordinates.transformations.FunctionTransformWithFiniteDifference`.
+
+        Parameters
+        ----------
+        dt : `~astropy.units.Quantity` or callable
+            If a quantity, this is the size of the differential used to do the finite difference.
+            If a callable, should accept ``(fromcoord, toframe)`` and return the ``dt`` value.
+        """
+        key = 'finite_difference_dt'
+        saved_settings = []
+
+        try:
+            for from_frame in self._graph:
+                for to_frame in self._graph[from_frame]:
+                    transform = self._graph[from_frame][to_frame]
+                    if hasattr(transform, key):
+                        old_setting = (transform, key, getattr(transform, key))
+                        saved_settings.append(old_setting)
+                        setattr(transform, key, dt)
+            yield
+        finally:
+            for setting in saved_settings:
+                setattr(*setting)
 
 
 # <-------------------Define the builtin transform classes-------------------->

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -467,6 +467,18 @@ For example::
     >>> gcrs = aa.transform_to(GCRS(obstime=time))  # doctest: +REMOTE_DATA
     >>> trans.finite_difference_dt = 1 * u.second  # return to default
 
+In the above example, there is exactly one transformation step from
+`~astropy.coordinates.AltAz` to `~astropy.coordinates.GCRS`.  In general, there
+may be more than one step between two frames, or the single step may perform
+other transformations internally.  One can use the context manager
+:func:`~astropy.coordinates.TransformGraph.impose_finite_difference_dt` for the
+transformation graph to override ``finite_difference_dt`` for *all*
+finite-difference transformations on the graph::
+
+    >>> from astropy.coordinates import frame_transform_graph
+    >>> with frame_transform_graph.impose_finite_difference_dt(1 * u.year):
+    ...     gcrs = aa.transform_to(GCRS(obstime=time))  # doctest: +REMOTE_DATA
+
 But beware that this will *not* help in cases like the above, where the relevant
 timescales for the velocities are seconds. (The velocity of the Earth relative
 to a particular direction changes dramatically over the course of one year.)


### PR DESCRIPTION
I've been needing to set the finite-difference time step (`finite_difference_dt`) in coordinate transformations involving velocities to get good accuracy in some situations (similarly described [here in the Astropy documentation](https://docs.astropy.org/en/stable/coordinates/velocities.html#astropy-coordinate-finite-difference-velocities)), but it's a bit of a pain to change it for one transformation, and it's a lot of a pain to change it if one isn't sure which transformations are going to be called.

This PR provides a context manager as a method in the `TransformGraph` class to temporarily set the `finite_difference_dt` attribute for *all* transforms in the graph that have that attribute.  The original settings are restored after the context manager.

For example, with this PR, the example in the documentation:
```python
>>> from astropy.coordinates import frame_transform_graph, AltAz, CIRS
>>> trans = frame_transform_graph.get_transform(AltAz, CIRS).transforms[0]
>>> trans.finite_difference_dt = 1*u.year
>>> gcrs = aa.transform_to(GCRS(obstime=time))  
>>> trans.finite_difference_dt = 1*u.second  # return to default
```
could be rewritten as:
```python
>>> from astropy.coordinates import frame_transform_graph
>>> with frame_transform_graph.impose_finite_difference_dt(1*u.year):
...     gcrs = aa.transform_to(GCRS(obstime=time))
```