### PR TITLE
MNT: Remove outdated dependency checks

### DIFF
--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -159,7 +159,7 @@ def test_matching_method():
     assert len(idx1) == len(d2d1) == len(d3d1) == 20
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_search_around():
     from astropy.coordinates import ICRS, SkyCoord
     from astropy.coordinates.matching import search_around_sky, search_around_3d
@@ -241,7 +241,7 @@ def test_search_around():
     assert d3d.unit == u.dimensionless_unscaled
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_search_around_scalar():
     from astropy.coordinates import SkyCoord, Angle
 
@@ -260,7 +260,7 @@ def test_search_around_scalar():
     assert 'search_around_3d' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_match_catalog_empty():
     from astropy.coordinates import SkyCoord
 
@@ -290,7 +290,7 @@ def test_match_catalog_empty():
     assert 'catalog' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 @pytest.mark.filterwarnings(
     r'ignore:invalid value encountered in.*:RuntimeWarning')
 def test_match_catalog_nan():
@@ -325,7 +325,7 @@ def test_match_catalog_nan():
     assert 'Matching coordinates cannot contain' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy")
 def test_match_catalog_nounit():
     from astropy.coordinates import ICRS, CartesianRepresentation
     from astropy.coordinates.matching import match_coordinates_sky

--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -8,7 +8,6 @@ from numpy import testing as npt
 from astropy.tests.helper import assert_quantity_allclose as assert_allclose
 
 from astropy import units as u
-from astropy.utils import minversion
 
 from astropy.coordinates import matching
 
@@ -19,15 +18,10 @@ Note that this requires scipy.
 """
 
 try:
-    import scipy
+    import scipy  # noqa
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
-
-if HAS_SCIPY and minversion(scipy, '0.12.0', inclusive=False):
-    OLDER_SCIPY = False
-else:
-    OLDER_SCIPY = True
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy.")
@@ -145,7 +139,7 @@ def test_matching_method():
         cmatch = ICRS(np.random.rand(20) * 360.*u.degree,
                       (np.random.rand(20) * 180. - 90.)*u.degree)
         ccatalog = ICRS(np.random.rand(100) * 360. * u.degree,
-                       (np.random.rand(100) * 180. - 90.)*u.degree)
+                        (np.random.rand(100) * 180. - 90.)*u.degree)
 
     idx1, d2d1, d3d1 = SkyCoord(cmatch).match_to_catalog_3d(ccatalog)
     idx2, d2d2, d3d2 = match_coordinates_3d(cmatch, ccatalog)
@@ -165,8 +159,7 @@ def test_matching_method():
     assert len(idx1) == len(d2d1) == len(d3d1) == 20
 
 
-@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
-                    reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
 def test_search_around():
     from astropy.coordinates import ICRS, SkyCoord
     from astropy.coordinates.matching import search_around_sky, search_around_3d
@@ -248,8 +241,7 @@ def test_search_around():
     assert d3d.unit == u.dimensionless_unscaled
 
 
-@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
-                    reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
 def test_search_around_scalar():
     from astropy.coordinates import SkyCoord, Angle
 
@@ -268,8 +260,7 @@ def test_search_around_scalar():
     assert 'search_around_3d' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
-                    reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_empty():
     from astropy.coordinates import SkyCoord
 
@@ -299,8 +290,7 @@ def test_match_catalog_empty():
     assert 'catalog' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
-                    reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
 @pytest.mark.filterwarnings(
     r'ignore:invalid value encountered in.*:RuntimeWarning')
 def test_match_catalog_nan():
@@ -335,8 +325,7 @@ def test_match_catalog_nan():
     assert 'Matching coordinates cannot contain' in str(excinfo.value)
 
 
-@pytest.mark.skipif(not HAS_SCIPY or OLDER_SCIPY,
-                    reason="Requires scipy > 0.12.0 ")
+@pytest.mark.skipif(not HAS_SCIPY, reason="Requires scipy > 0.12.0 ")
 def test_match_catalog_nounit():
     from astropy.coordinates import ICRS, CartesianRepresentation
     from astropy.coordinates.matching import match_coordinates_sky

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -12,16 +12,16 @@ import copy
 import pytest
 import numpy as np
 
-
 from astropy import units as u
-from astropy.coordinates import (AltAz, EarthLocation, SkyCoord, get_sun, ICRS,
-                GeocentricMeanEcliptic, Longitude, Latitude, GCRS, HCRS, CIRS,
-                get_moon, FK4, FK4NoETerms, BaseCoordinateFrame, ITRS,
-                QuantityAttribute, UnitSphericalRepresentation,
-                SphericalRepresentation, CartesianRepresentation,
-                FunctionTransform,
-                CylindricalRepresentation, CylindricalDifferential,
-                CartesianDifferential)
+from astropy.coordinates import (
+    AltAz, EarthLocation, SkyCoord, get_sun, ICRS,
+    GeocentricMeanEcliptic, Longitude, Latitude, GCRS, HCRS, CIRS,
+    get_moon, FK4, FK4NoETerms, BaseCoordinateFrame, ITRS,
+    QuantityAttribute, UnitSphericalRepresentation,
+    SphericalRepresentation, CartesianRepresentation,
+    FunctionTransform,
+    CylindricalRepresentation, CylindricalDifferential,
+    CartesianDifferential)
 from astropy.coordinates.sites import get_builtin_sites
 from astropy.utils.exceptions import ErfaWarning
 from astropy.time import Time
@@ -29,11 +29,11 @@ from astropy.utils import iers
 from astropy.table import Table
 
 from astropy.tests.helper import assert_quantity_allclose, catch_warnings
-from .test_matching import HAS_SCIPY, OLDER_SCIPY
+from .test_matching import HAS_SCIPY
 from astropy.units import allclose as quantity_allclose
 
 try:
-    import yaml  # pylint: disable=W0611
+    import yaml  # pylint: disable=W0611  # noqa
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
@@ -166,7 +166,6 @@ def test_regression_4033():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
-@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_4082():
     """
     Issue: https://github.com/astropy/astropy/issues/4082
@@ -394,7 +393,7 @@ def test_regression_5889_5890():
     # ensure we can represent all Representations and transform to ND frames
     greenwich = EarthLocation(
         *u.Quantity([3980608.90246817, -102.47522911, 4966861.27310067],
-        unit=u.m))
+                    unit=u.m))
     times = Time("2017-03-20T12:00:00") + np.linspace(-2, 2, 3)*u.hour
     moon = get_moon(times, location=greenwich)
     targets = SkyCoord([350.7*u.deg, 260.7*u.deg], [18.4*u.deg, 22.4*u.deg])
@@ -461,7 +460,6 @@ def test_regression_6236():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
-@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_6347():
     sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg)
     sc2 = SkyCoord([1.1, 2.1]*u.deg, [3.1, 4.1]*u.deg)
@@ -481,7 +479,6 @@ def test_regression_6347():
 
 
 @pytest.mark.skipif(not HAS_SCIPY, reason='No Scipy')
-@pytest.mark.skipif(OLDER_SCIPY, reason='Scipy too old')
 def test_regression_6347_3d():
     sc1 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5, 6]*u.kpc)
     sc2 = SkyCoord([1, 2]*u.deg, [3, 4]*u.deg, [5.1, 6.1]*u.kpc)

--- a/astropy/io/ascii/tests/test_compressed.py
+++ b/astropy/io/ascii/tests/test_compressed.py
@@ -1,14 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
-
 import pytest
 import numpy as np
 
 from astropy.io.ascii import read
+from astropy.utils.data import get_pkg_data_filename
 
-ROOT = os.path.abspath(os.path.dirname(__file__))
-
-
+# NOTE: Python can be built without bz2 or lzma.
 try:
     import bz2  # noqa
 except ImportError:
@@ -27,8 +24,8 @@ else:
 @pytest.mark.parametrize('filename', ['data/daophot.dat.gz', 'data/latex1.tex.gz',
                                       'data/short.rdb.gz'])
 def test_gzip(filename):
-    t_comp = read(os.path.join(ROOT, filename))
-    t_uncomp = read(os.path.join(ROOT, filename.replace('.gz', '')))
+    t_comp = read(get_pkg_data_filename(filename))
+    t_uncomp = read(get_pkg_data_filename(filename.replace('.gz', '')))
     assert t_comp.dtype.names == t_uncomp.dtype.names
     assert np.all(t_comp.as_array() == t_uncomp.as_array())
 
@@ -36,8 +33,8 @@ def test_gzip(filename):
 @pytest.mark.xfail('not HAS_BZ2')
 @pytest.mark.parametrize('filename', ['data/short.rdb.bz2', 'data/ipac.dat.bz2'])
 def test_bzip2(filename):
-    t_comp = read(os.path.join(ROOT, filename))
-    t_uncomp = read(os.path.join(ROOT, filename.replace('.bz2', '')))
+    t_comp = read(get_pkg_data_filename(filename))
+    t_uncomp = read(get_pkg_data_filename(filename.replace('.bz2', '')))
     assert t_comp.dtype.names == t_uncomp.dtype.names
     assert np.all(t_comp.as_array() == t_uncomp.as_array())
 
@@ -45,7 +42,7 @@ def test_bzip2(filename):
 @pytest.mark.xfail('not HAS_XZ')
 @pytest.mark.parametrize('filename', ['data/short.rdb.xz', 'data/ipac.dat.xz'])
 def test_xz(filename):
-    t_comp = read(os.path.join(ROOT, filename))
-    t_uncomp = read(os.path.join(ROOT, filename.replace('.xz', '')))
+    t_comp = read(get_pkg_data_filename(filename))
+    t_uncomp = read(get_pkg_data_filename(filename.replace('.xz', '')))
     assert t_comp.dtype.names == t_uncomp.dtype.names
     assert np.all(t_comp.as_array() == t_uncomp.as_array())

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-
 import re
 from io import BytesIO, open
 from collections import OrderedDict
@@ -28,6 +27,7 @@ from astropy.utils.exceptions import AstropyWarning
 # setup/teardown function to have the tests run in the correct directory
 from .common import setup_function, teardown_function  # noqa
 
+# NOTE: Python can be built without bz2.
 try:
     import bz2  # noqa
 except ImportError:
@@ -35,7 +35,7 @@ except ImportError:
 else:
     HAS_BZ2 = True
 
-asciiIO = lambda x: BytesIO(x.encode('ascii'))
+asciiIO = lambda x: BytesIO(x.encode('ascii'))  # noqa
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, {'use_fast_converter': False},

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -35,7 +35,9 @@ except ImportError:
 else:
     HAS_BZ2 = True
 
-asciiIO = lambda x: BytesIO(x.encode('ascii'))  # noqa
+
+def asciiIO(x):
+    return BytesIO(x.encode('ascii'))
 
 
 @pytest.mark.parametrize('fast_reader', [True, False, {'use_fast_converter': False},

--- a/astropy/io/fits/file.py
+++ b/astropy/io/fits/file.py
@@ -1,6 +1,5 @@
 # Licensed under a 3-clause BSD style license - see PYFITS.rst
 
-
 import gzip
 import errno
 import http.client
@@ -26,6 +25,7 @@ from astropy.utils.data import download_file, _is_url
 from astropy.utils.decorators import classproperty, deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyUserWarning
 
+# NOTE: Python can be built without bz2.
 try:
     import bz2
 except ImportError:

--- a/astropy/io/fits/hdu/hdulist.py
+++ b/astropy/io/fits/hdu/hdulist.py
@@ -23,6 +23,7 @@ from astropy.utils import indent
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils.decorators import deprecated_renamed_argument
 
+# NOTE: Python can be built without bz2.
 try:
     import bz2
 except ImportError:

--- a/astropy/io/fits/tests/test_core.py
+++ b/astropy/io/fits/tests/test_core.py
@@ -26,6 +26,7 @@ from astropy.utils.data import conf
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.utils import data
 
+# NOTE: Python can be built without bz2.
 try:
     import bz2
 except ImportError:

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -65,6 +65,7 @@ TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
 TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))
 
+# NOTE: Python can be built without bz2 or lzma.
 try:
     import bz2  # noqa
 except ImportError:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request is to address part of #4630, where a dependency check is no longer needed because:

* Minimum supported version for `scipy` is beyond 0.12 (0.18 when PR is opened), so removing `OLDER_SCIPY` checks.
* `bz2` and `lzma` are now part of Python standard library since 3.3 and we only support Python 3.6 or later (when PR is opened), but Python can be built without those modules, so adding a note about that ~removing `HAS_BZ2` and `HAS_XZ` checks~.

Bonus:

* Might as well address some of #10344 that I came across.
* Minor PEP 8 clean-ups.