### PR TITLE
Bugfix: Adding bounds to wcs fitting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -431,6 +431,8 @@ astropy.wcs
 
 - Add .upper() to ctype or ctype names to wcsapi/fitwcs.py to mitigate bugs from
   unintended lower/upper case issues [#10557]
+- Added bounds to ``fit_wcs_from_points`` to ensure CRPIX is on
+  input image. [#10346] 
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1219,23 +1219,20 @@ TELAPSE =        0.02083332443 / [d] Elapsed time (start to stop)
 TIMEDEL =    0.020833333333333 / [d] Time resolution
 TIMEPIXR=                  0.5 / Reference position of timestamp in binned data
 RADESYS = 'ICRS'               / Equatorial coordinate system
-DATE-REF= '1858-11-17'
-END
 """
-
-    ffi_wcs = WCS(wcs_str)
+    wcs_header = fits.Header.fromstring(wcs_str, sep='\n')
+    ffi_wcs = WCS(wcs_header)
 
     yi, xi = (1000,1000)
     y, x = (10,200)
 
     center_coord = SkyCoord(ffi_wcs.all_pix2world([[xi+x//2, yi+y//2]], 0), unit='deg')[0]
-    pix_inds = np.mgrid[xi : xi + x, yi : yi + y]
-    world_pix = SkyCoord(ffi_wcs.all_pix2world(pix_inds, 0), unit='deg')
+    ypix, xpix = [arr.flatten() for arr in np.mgrid[xi : xi + x, yi : yi + y]]
+    world_pix = SkyCoord(*ffi_wcs.all_pix2world(xpix, ypix, 0), unit='deg')
 
-    fit_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]],
-                                  world_pix, proj_point='center')
+    fit_wcs = fit_wcs_from_points((ypix, xpix), world_pix, proj_point='center')
 
-    assert (fit_wcs.wcs.crpix.astype(int) == [1100, 1006]).all()
+    assert (fit_wcs.wcs.crpix.astype(int) == [1100, 1005]).all()
     assert fit_wcs.pixel_shape == (200, 10)
 
 

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1186,42 +1186,41 @@ B_DMAX  =    44.62692873032506
 
     # Test CRPIX bounds requirement
     wcs_str = """
-WCSAXES =                    2 / Number of coordinate axes                      
-CRPIX1  =               1045.0 / Pixel coordinate of reference point            
-CRPIX2  =               1001.0 / Pixel coordinate of reference point            
-PC1_1   =  0.00056205870415378 / Coordinate transformation matrix element       
-PC1_2   =    -0.00569181083243 / Coordinate transformation matrix element       
-PC2_1   =   0.0056776810932466 / Coordinate transformation matrix element       
-PC2_2   =   0.0004208048403273 / Coordinate transformation matrix element       
-CDELT1  =                  1.0 / [deg] Coordinate increment at reference point  
-CDELT2  =                  1.0 / [deg] Coordinate increment at reference point  
-CUNIT1  = 'deg'                / Units of coordinate increment and value        
-CUNIT2  = 'deg'                / Units of coordinate increment and value        
-CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection           
-CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection               
-CRVAL1  =      104.57797893504 / [deg] Coordinate value at reference point      
-CRVAL2  =     -74.195502593322 / [deg] Coordinate value at reference point      
-LONPOLE =                180.0 / [deg] Native longitude of celestial pole       
-LATPOLE =     -74.195502593322 / [deg] Native latitude of celestial pole        
-TIMESYS = 'TDB'                / Time scale                                     
-TIMEUNIT= 'd'                  / Time units                                     
-DATEREF = '1858-11-17'         / ISO-8601 fiducial time                         
-MJDREFI =                  0.0 / [d] MJD of fiducial time, integer part         
-MJDREFF =                  0.0 / [d] MJD of fiducial time, fractional part      
-DATE-OBS= '2019-03-27T03:30:13.832Z' / ISO-8601 time of observation             
-MJD-OBS =      58569.145993426 / [d] MJD of observation                         
-MJD-OBS =      58569.145993426 / [d] MJD at start of observation                
-TSTART  =      1569.6467941661 / [d] Time elapsed since fiducial time at start  
-DATE-END= '2019-03-27T04:00:13.831Z' / ISO-8601 time at end of observation      
-MJD-END =      58569.166826748 / [d] MJD at end of observation                  
-TSTOP   =      1569.6676274905 / [d] Time elapsed since fiducial time at end    
-TELAPSE =        0.02083332443 / [d] Elapsed time (start to stop)               
-TIMEDEL =    0.020833333333333 / [d] Time resolution                            
-TIMEPIXR=                  0.5 / Reference position of timestamp in binned data 
-RADESYS = 'ICRS'               / Equatorial coordinate system                   
-DATE-REF= '1858-11-17'                                                          
-END                                                                             
-                                                                                
+WCSAXES =                    2 / Number of coordinate axes
+CRPIX1  =               1045.0 / Pixel coordinate of reference point
+CRPIX2  =               1001.0 / Pixel coordinate of reference point
+PC1_1   =  0.00056205870415378 / Coordinate transformation matrix element
+PC1_2   =    -0.00569181083243 / Coordinate transformation matrix element
+PC2_1   =   0.0056776810932466 / Coordinate transformation matrix element
+PC2_2   =   0.0004208048403273 / Coordinate transformation matrix element
+CDELT1  =                  1.0 / [deg] Coordinate increment at reference point
+CDELT2  =                  1.0 / [deg] Coordinate increment at reference point
+CUNIT1  = 'deg'                / Units of coordinate increment and value
+CUNIT2  = 'deg'                / Units of coordinate increment and value
+CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection
+CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection
+CRVAL1  =      104.57797893504 / [deg] Coordinate value at reference point
+CRVAL2  =     -74.195502593322 / [deg] Coordinate value at reference point
+LONPOLE =                180.0 / [deg] Native longitude of celestial pole
+LATPOLE =     -74.195502593322 / [deg] Native latitude of celestial pole
+TIMESYS = 'TDB'                / Time scale
+TIMEUNIT= 'd'                  / Time units
+DATEREF = '1858-11-17'         / ISO-8601 fiducial time
+MJDREFI =                  0.0 / [d] MJD of fiducial time, integer part
+MJDREFF =                  0.0 / [d] MJD of fiducial time, fractional part
+DATE-OBS= '2019-03-27T03:30:13.832Z' / ISO-8601 time of observation
+MJD-OBS =      58569.145993426 / [d] MJD of observation
+MJD-OBS =      58569.145993426 / [d] MJD at start of observation
+TSTART  =      1569.6467941661 / [d] Time elapsed since fiducial time at start
+DATE-END= '2019-03-27T04:00:13.831Z' / ISO-8601 time at end of observation
+MJD-END =      58569.166826748 / [d] MJD at end of observation
+TSTOP   =      1569.6676274905 / [d] Time elapsed since fiducial time at end
+TELAPSE =        0.02083332443 / [d] Elapsed time (start to stop)
+TIMEDEL =    0.020833333333333 / [d] Time resolution
+TIMEPIXR=                  0.5 / Reference position of timestamp in binned data
+RADESYS = 'ICRS'               / Equatorial coordinate system
+DATE-REF= '1858-11-17'
+END
 """
 
     ffi_wcs = WCS(wcs_str)

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from io import StringIO
+from itertools import product
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal, assert_allclose
 
@@ -1180,6 +1183,61 @@ B_DMAX  =    44.62692873032506
 
     assert dists.max() < 7e-5*u.deg
     assert np.std(dists) < 2.5e-5*u.deg
+
+    # Test CRPIX bounds requirement
+    wcs_str = """
+WCSAXES =                    2 / Number of coordinate axes                      
+CRPIX1  =               1045.0 / Pixel coordinate of reference point            
+CRPIX2  =               1001.0 / Pixel coordinate of reference point            
+PC1_1   =  0.00056205870415378 / Coordinate transformation matrix element       
+PC1_2   =    -0.00569181083243 / Coordinate transformation matrix element       
+PC2_1   =   0.0056776810932466 / Coordinate transformation matrix element       
+PC2_2   =   0.0004208048403273 / Coordinate transformation matrix element       
+CDELT1  =                  1.0 / [deg] Coordinate increment at reference point  
+CDELT2  =                  1.0 / [deg] Coordinate increment at reference point  
+CUNIT1  = 'deg'                / Units of coordinate increment and value        
+CUNIT2  = 'deg'                / Units of coordinate increment and value        
+CTYPE1  = 'RA---TAN'           / Right ascension, gnomonic projection           
+CTYPE2  = 'DEC--TAN'           / Declination, gnomonic projection               
+CRVAL1  =      104.57797893504 / [deg] Coordinate value at reference point      
+CRVAL2  =     -74.195502593322 / [deg] Coordinate value at reference point      
+LONPOLE =                180.0 / [deg] Native longitude of celestial pole       
+LATPOLE =     -74.195502593322 / [deg] Native latitude of celestial pole        
+TIMESYS = 'TDB'                / Time scale                                     
+TIMEUNIT= 'd'                  / Time units                                     
+DATEREF = '1858-11-17'         / ISO-8601 fiducial time                         
+MJDREFI =                  0.0 / [d] MJD of fiducial time, integer part         
+MJDREFF =                  0.0 / [d] MJD of fiducial time, fractional part      
+DATE-OBS= '2019-03-27T03:30:13.832Z' / ISO-8601 time of observation             
+MJD-OBS =      58569.145993426 / [d] MJD of observation                         
+MJD-OBS =      58569.145993426 / [d] MJD at start of observation                
+TSTART  =      1569.6467941661 / [d] Time elapsed since fiducial time at start  
+DATE-END= '2019-03-27T04:00:13.831Z' / ISO-8601 time at end of observation      
+MJD-END =      58569.166826748 / [d] MJD at end of observation                  
+TSTOP   =      1569.6676274905 / [d] Time elapsed since fiducial time at end    
+TELAPSE =        0.02083332443 / [d] Elapsed time (start to stop)               
+TIMEDEL =    0.020833333333333 / [d] Time resolution                            
+TIMEPIXR=                  0.5 / Reference position of timestamp in binned data 
+RADESYS = 'ICRS'               / Equatorial coordinate system                   
+DATE-REF= '1858-11-17'                                                          
+END                                                                             
+                                                                                
+"""
+
+    ffi_wcs = WCS(wcs_str)
+
+    yi, xi = (1000,1000)
+    y, x = (10,200)
+
+    center_coord = SkyCoord(ffi_wcs.all_pix2world([[xi+x//2, yi+y//2]], 0), unit='deg')[0]
+    pix_inds = np.mgrid[xi : xi + x, yi : yi + y]
+    world_pix = SkyCoord(ffi_wcs.all_pix2world(pix_inds, 0), unit='deg')
+
+    fit_wcs = fit_wcs_from_points([pix_inds[:, 0], pix_inds[:, 1]],
+                                  world_pix, proj_point='center')
+
+    assert (fit_wcs.wcs.crpix.astype(int) == [1100, 1006]).all()
+    assert fit_wcs.pixel_shape == (200, 10)
 
 
 @pytest.mark.remote_data

--- a/astropy/wcs/utils.py
+++ b/astropy/wcs/utils.py
@@ -1015,8 +1015,8 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
     from .wcs import Sip
     from scipy.optimize import least_squares
 
+    xp, yp = xy
     try:
-        xp, yp = xy
         lon, lat = world_coords.data.lon.deg, world_coords.data.lat.deg
     except AttributeError:
         unit_sph =  world_coords.unit_spherical
@@ -1056,7 +1056,7 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
         raise ValueError("sip_degree must be None, or integer.")
 
     # set pixel_shape to span of input points
-    wcs.pixel_shape = (xp.max()-xp.min(), yp.max()-yp.min())
+    wcs.pixel_shape = (xp.max()+1-xp.min(), yp.max()+1-yp.min())
 
     # determine CRVAL from input
     close = lambda l, p: p[np.argmin(np.abs(l))]
@@ -1077,9 +1077,18 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
     # fit linear terms, assign to wcs
     # use (1, 0, 0, 1) as initial guess, in case input wcs was passed in
     # and cd terms are way off.
+    # Use bounds to require that the fit center pixel is on the input image
+    xpmin, xpmax, ypmin, ypmax = xp.min(), xp.max(), yp.min(), yp.max()
+    if xpmin == xpmax:
+        xpmin, xpmax = xpmin - 0.5, xpmax + 0.5
+    if ypmin == ypmax:
+        ypmin, ypmax = ypmin - 0.5, ypmax + 0.5
+
     p0 = np.concatenate([wcs.wcs.cd.flatten(), wcs.wcs.crpix.flatten()])
     fit = least_squares(_linear_wcs_fit, p0,
-                        args=(lon, lat, xp, yp, wcs))
+                        args=(lon, lat, xp, yp, wcs),
+                        bounds=[[-np.inf, -np.inf, -np.inf, -np.inf, xpmin, ypmin],
+                                [ np.inf, np.inf, np.inf, np.inf, xpmax, ypmax]])
     wcs.wcs.crpix = np.array(fit.x[4:6])
     wcs.wcs.cd = np.array(fit.x[0:4].reshape((2, 2)))
 
@@ -1096,7 +1105,9 @@ def fit_wcs_from_points(xy, world_coords, proj_point='center',
                              np.zeros(2*len(coef_names))))
 
         fit = least_squares(_sip_fit, p0,
-                            args=(lon, lat, xp, yp, wcs, degree, coef_names))
+                            args=(lon, lat, xp, yp, wcs, degree, coef_names),
+                            bounds=[[xpmin, ypmin] + [-np.inf]*(4 + 2*len(coef_names)),
+                                    [xpmax, ypmax] + [np.inf]*(4 + 2*len(coef_names))])
         coef_fit = (list(fit.x[6:6+len(coef_names)]),
                     list(fit.x[6+len(coef_names):]))
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

This pull request addresses three small bugs in `wcs.utils.fit_wcs_from_points`:
- Added bounds to the least square fit requiring that the fit CRPIX value be within the bounds of the input coordinate/pixel pairs. This prevents getting physically meaningless CRPIX fits like "-44811.23089933425  -40821.30343222443" .
- Corrected the pixel shape by adding 1 to each dimension because it is a subtraction of indices, not lengths.
- Moved the xp,xy assignment of the try/except so that they get assigned regardless.

The first two bugs are illustrated in the following code snippet:
![Screen Shot 2020-05-12 at 3 34 01 PM](https://user-images.githubusercontent.com/9406508/81737486-29f94b00-9466-11ea-8571-7df7f4eab09c.png)

And the corrected result is:
![Screen Shot 2020-05-12 at 3 36 50 PM](https://user-images.githubusercontent.com/9406508/81737653-6cbb2300-9466-11ea-9254-d5f7de5f1a14.png)

@cshanahan1 will want to look at this.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->


