### PR TITLE
Fix codestyle checks in tox and fix PEP8 whitespace issues

### DIFF
--- a/astropy/coordinates/sky_coordinate.py
+++ b/astropy/coordinates/sky_coordinate.py
@@ -456,7 +456,6 @@ class SkyCoord(ShapedLikeNDArray):
                             f'{self.__class__.__name__} vs. '
                             f'{value.__class__.__name__}')
 
-
         # Make sure that any extra frame attribute names are equivalent.
         for attr in self._extra_frameattr_names | value._extra_frameattr_names:
             if not self.frame._frameattr_equiv(getattr(self, attr),

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -381,6 +381,7 @@ def test_equal_exceptions():
     # Note that this exception is the only one raised directly in SkyCoord.
     # All others come from lower-level classes and are tested in test_frames.py.
 
+
 def test_attr_inheritance():
     """
     When initializing from an existing coord the representation attrs like

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -381,7 +381,6 @@ def test_replicate():
     assert_quantity_allclose(sc_init_ref, [6000, 5000] * u.AA)
 
 
-
 def test_with_observer_stationary_relative_to():
 
     # Simple tests of with_observer_stationary_relative_to to cover different

--- a/astropy/io/ascii/tests/test_cds_header_from_readme.py
+++ b/astropy/io/ascii/tests/test_cds_header_from_readme.py
@@ -170,6 +170,7 @@ def test_cds_function_units():
     assert table['Age'].unit == u.Myr
     assert table['e_Age'].unit == u.Myr
 
+
 if __name__ == "__main__":  # run from main directory; not from test/
     test_header_from_readme()
     test_multi_header()

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1553,8 +1553,6 @@ def test_deduplicate_names_basic(rdb, fast_reader):
         assert np.all(dat['b4'] == [4, 40])
 
 
-
-
 @pytest.mark.xfail
 def test_include_names_rdb_fast_fail0():
     """Test that selecting column names with `include_names` fails for the rdb format for fast reader.

--- a/astropy/io/misc/asdf/tags/transform/functional_models.py
+++ b/astropy/io/misc/asdf/tags/transform/functional_models.py
@@ -8,8 +8,8 @@ from .basic import TransformType
 from . import _parameter_to_value
 
 
-__all__ = ['AiryDisk2DType', 'Box1DType', 'Box2DType', 
-           'Disk2DType', 'Ellipse2DType', 'Exponential1DType', 
+__all__ = ['AiryDisk2DType', 'Box1DType', 'Box2DType',
+           'Disk2DType', 'Ellipse2DType', 'Exponential1DType',
            'Gaussian1DType', 'Gaussian2DType', 'KingProjectedAnalytic1DType',
            'Logarithmic1DType', 'Lorentz1DType', 'Moffat1DType',
            'Moffat2DType', 'Planar2D', 'RedshiftScaleFactorType',

--- a/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
+++ b/astropy/io/misc/asdf/tags/transform/tests/test_transform.py
@@ -103,6 +103,7 @@ test_models_with_constraints = [astmodels.Legendre2D(x_degree=1, y_degree=1,
                                 bounds={'c0_0': (-10, 10)})]
 test_models.extend(test_models_with_constraints)
 
+
 def test_transforms_compound(tmpdir):
     tree = {
         'compound':

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3334,7 +3334,6 @@ class CompoundModel(Model):
 
         return out
 
-
     def replace_submodel(self, name, model):
         """
         Construct a new `~astropy.modeling.CompoundModel` instance from an

--- a/astropy/modeling/fitting.py
+++ b/astropy/modeling/fitting.py
@@ -56,6 +56,7 @@ STATISTICS = [leastsquare]
 # Optimizers implemented in `astropy.modeling.optimizers.py
 OPTIMIZERS = [Simplex, SLSQP]
 
+
 class ModelsError(Exception):
     """Base class for model exceptions"""
 

--- a/astropy/modeling/physical_models.py
+++ b/astropy/modeling/physical_models.py
@@ -16,6 +16,7 @@ from .parameters import Parameter, InputParameterError
 
 __all__ = ["BlackBody", "Drude1D", "Plummer1D"]
 
+
 class BlackBody(Fittable1DModel):
     """
     Blackbody model using the Planck function.

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -304,6 +304,7 @@ def test_compound_with_polynomials_2d(poly):
     result = shift(poly(x, y))
     assert_allclose(result, result_compound)
 
+
 def test_fix_inputs():
     g1 = Gaussian2D(1, 0, 0, 1, 2)
     g2 = Gaussian2D(1.5, .5, -.2, .5, .3)

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -329,7 +329,7 @@ def test_render_model_3d():
             return ((self.z0 - self.c, self.z0 + self.c),
                     (self.y0 - self.b, self.y0 + self.b),
                     (self.x0 - self.a, self.x0 + self.a))
-   
+
     model = Ellipsoid3D()
 
     # test points for edges

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -1479,7 +1479,6 @@ def test_values_equal_part1():
     with pytest.raises(ValueError, match='unable to compare column c'):
         t1.values_equal([1, 2])
 
-
     eq = t2.values_equal(t2)
     for col in eq.colnames:
         assert np.all(eq[col] == [True, True])
@@ -2557,7 +2556,6 @@ def test_table_attribute_fail():
     with pytest.raises(RuntimeError, match='Error calling __set_name__'):
         class MyTable3(Table):
             colnames = TableAttribute()  # Conflicts with built-in property
-
 
 
 def test_set_units_fail():

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -980,6 +980,7 @@ class _FTPTLSHandler(urllib.request.FTPHandler):
         return _ftptlswrapper(user, passwd, host, port, dirs, timeout,
                               persistent=False)
 
+
 def _download_file_from_source(source_url, show_progress=True, timeout=None,
                                remote_url=None, cache=False, pkgname='astropy',
                                http_headers=None, ftp_tls=False):

--- a/astropy/wcs/tests/test_utils.py
+++ b/astropy/wcs/tests/test_utils.py
@@ -1182,6 +1182,7 @@ B_DMAX  =    44.62692873032506
     assert dists.max() < 7e-5*u.deg
     assert np.std(dists) < 2.5e-5*u.deg
 
+
 @pytest.mark.remote_data
 @pytest.mark.parametrize('x_in,y_in', [[0, 0], [np.arange(5), np.arange(5)]])
 def test_pixel_to_world_itrs(x_in, y_in):

--- a/astropy/wcs/wcsapi/conftest.py
+++ b/astropy/wcs/wcsapi/conftest.py
@@ -58,7 +58,6 @@ def spectral_cube_3d_fitswcs():
     return wcs
 
 
-
 class Spectral1DLowLevelWCS(BaseLowLevelWCS):
 
     @property
@@ -114,7 +113,6 @@ class Spectral1DLowLevelWCS(BaseLowLevelWCS):
     @property
     def world_axis_object_classes(self):
         return {'test': (Quantity, (), {'unit': 'Hz'})}
-
 
 
 @pytest.fixture

--- a/tox.ini
+++ b/tox.ini
@@ -135,4 +135,5 @@ commands =
 skip_install = true
 description = check code style, e.g. with flake8
 deps = flake8
+changedir = {toxinidir}
 commands = flake8 astropy --count --select=E101,W191,W291,W292,W293,W391,E111,E112,E113,E30,E502,E722,E901,E902,E999,F822,F823


### PR DESCRIPTION
The tox ``codestyle`` environment was actually not running in the correct directory (sorry :fearful:) so this PR fixes this and PEP8 issues that have crept in in the mean time. A new release of flake8 this weeks means we actually got an error because of the wrong directory, whereas before it was silently 'failing'. This should fix the CircleCI html-docs job which was failing because of this.

EDIT: Fix #10348