### PR TITLE
Check and restrict keyword names for FITS RVKC header entries

### DIFF
--- a/astropy/io/fits/column.py
+++ b/astropy/io/fits/column.py
@@ -162,7 +162,7 @@ TFORMAT_ASCII_RE = re.compile(r'(?:(?P<format>[AIJ])(?P<width>[0-9]+)?)|'
                               r'(?:(?P<widthf>[0-9]+)\.'
                               r'(?P<precision>[0-9]+))?)')
 
-TTYPE_RE = re.compile(r'[0-9a-zA-Z_]+')
+TTYPE_RE = re.compile(r'[0-9a-zA-Z_]+$')
 """
 Regular expression for valid table column names.  See FITS Standard v3.0 section
 7.2.2.


### PR DESCRIPTION
### Description
#10233 reported side effects of parsing FITS header cards as record-valued keyword cards: any key value following the RVKC pattern of `name: <int or float>` triggers the creation of a RVKC with an unexpected card value.
For reserved keywords that are (against the recommendations) given values like `'A: 0'` this results in errors as the keyword is inserted multiple times, apparently trying to create a regular card.

In https://github.com/astropy/astropy/issues/10233#issuecomment-621589224 two limiting cases for restricting the allowed names for RVKCs were discussed:

1. Allow **only** names closely following the patterns defined in https://fits.gsfc.nasa.gov/wcs/dcs_20040422.pdf

2. Reject **only** mandatory or reserved keywords (Appendix C of https://fits.gsfc.nasa.gov/fits_standard.html)

Since the full scope in which RVKCs are used is not exactly known, this PR adopts a somewhat relaxed version of the 1. option. As it turned out, some of the existing tests expect names like `D2IM1` to be accepted, so the pattern was made a bit more general than proposed in https://github.com/astropy/astropy/issues/10233#issuecomment-621919377; this in turn required to explicitly exclude some reserved keywords which would otherwise match the pattern.

Fix #13273