### PR TITLE
Skip doctest collection for subpackages depending on available dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,13 @@ matrix:
 
     include:
 
+        # Linux job with minimal dependencies
+        - language: python
+          python: 3.7
+          name: Python 3.7 with minimal dependencies
+          stage: Initial tests
+          env: TOXENV="py37-test"
+
         # Try MacOS X.
         - os: osx
           name: Python 3.7 with all optional dependencies for OSX

--- a/astropy/io/misc/yaml.py
+++ b/astropy/io/misc/yaml.py
@@ -1,7 +1,62 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-#
-# NOTE: docstring is in docs/io/misc.rst because of
-# https://github.com/astropy/pytest-doctestplus/issues/109
+
+"""
+This module contains functions for serializing core astropy objects via the
+YAML protocol.
+It provides functions `~astropy.io.misc.yaml.dump`,
+`~astropy.io.misc.yaml.load`, and `~astropy.io.misc.yaml.load_all` which
+call the corresponding functions in `PyYaml <https://pyyaml.org>`_ but use the
+`~astropy.io.misc.yaml.AstropyDumper` and `~astropy.io.misc.yaml.AstropyLoader`
+classes to define custom YAML tags for the following astropy classes:
+- `astropy.units.Unit`
+- `astropy.units.Quantity`
+- `astropy.time.Time`
+- `astropy.time.TimeDelta`
+- `astropy.coordinates.SkyCoord`
+- `astropy.coordinates.Angle`
+- `astropy.coordinates.Latitude`
+- `astropy.coordinates.Longitude`
+- `astropy.coordinates.EarthLocation`
+- `astropy.table.SerializedColumn`
+
+.. note:: This module requires PyYaml version 3.12 or later.
+
+Example
+=======
+::
+  >>> from astropy.io.misc import yaml
+  >>> import astropy.units as u
+  >>> from astropy.time import Time
+  >>> from astropy.coordinates import EarthLocation
+  >>> t = Time(2457389.0, format='mjd',
+  ...          location=EarthLocation(1000, 2000, 3000, unit=u.km))
+  >>> td = yaml.dump(t)
+  >>> print(td)
+  !astropy.time.Time
+  format: mjd
+  in_subfmt: '*'
+  jd1: 4857390.0
+  jd2: -0.5
+  location: !astropy.coordinates.earth.EarthLocation
+    ellipsoid: WGS84
+    x: !astropy.units.Quantity
+      unit: &id001 !astropy.units.Unit {unit: km}
+      value: 1000.0
+    y: !astropy.units.Quantity
+      unit: *id001
+      value: 2000.0
+    z: !astropy.units.Quantity
+      unit: *id001
+      value: 3000.0
+  out_subfmt: '*'
+  precision: 3
+  scale: utc
+  >>> ty = yaml.load(td)
+  >>> ty
+  <Time object: scale='utc' format='mjd' value=2457389.0>
+  >>> ty.location  # doctest: +FLOAT_CMP
+  <EarthLocation (1000., 2000., 3000.) km>
+"""
 
 import base64
 
@@ -16,14 +71,11 @@ from astropy.table import SerializedColumn
 try:
     import yaml
 except ImportError:
-    YAML_LT_3_12 = True
-
-    class yaml:  # hacky not-quite-a-duck-type
-        SafeLoader = object
-        SafeDumper = object
-
+    raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 3.12 or later')
 else:
-    YAML_LT_3_12 = not minversion(yaml, '3.12')
+    if not minversion(yaml, '3.12'):
+        raise ImportError('The PyYAML package is required for astropy.io.misc.yaml and must be 3.12 or later')
+
 
 __all__ = ['AstropyLoader', 'AstropyDumper', 'load', 'load_all', 'dump']
 __doctest_requires__ = {'*': ['yaml']}
@@ -153,11 +205,6 @@ class AstropyLoader(yaml.SafeLoader):
     <https://pyyaml.org/wiki/PyYAMLDocumentation>`_ for details of the
     class signature.
     """
-    def __init__(self, *args, **kwargs):
-        if YAML_LT_3_12:
-            raise ImportError('`import yaml` failed, PyYAML package is required for YAML and must be 3.12 or later')
-
-        super().__init__(*args, **kwargs)
 
     def _construct_python_tuple(self, node):
         return tuple(self.construct_sequence(node))
@@ -177,73 +224,67 @@ class AstropyDumper(yaml.SafeDumper):
     `PyYaml documentation <https://pyyaml.org/wiki/PyYAMLDocumentation>`_
     for details of the class signature.
     """
-    def __init__(self, *args, **kwargs):
-        if YAML_LT_3_12:
-            raise ImportError('`import yaml` failed, PyYAML package is required for YAML and must be 3.12 or later')
-
-        super().__init__(*args, **kwargs)
 
     def _represent_tuple(self, data):
         return self.represent_sequence('tag:yaml.org,2002:python/tuple', data)
 
 
-if not YAML_LT_3_12:
-    AstropyDumper.add_multi_representer(u.UnitBase, _unit_representer)
-    AstropyDumper.add_multi_representer(u.FunctionUnitBase, _unit_representer)
-    AstropyDumper.add_representer(tuple, AstropyDumper._represent_tuple)
-    AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
-    AstropyDumper.add_representer(Time, _time_representer)
-    AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
-    AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
-    AstropyDumper.add_representer(SerializedColumn, _serialized_column_representer)
+AstropyDumper.add_multi_representer(u.UnitBase, _unit_representer)
+AstropyDumper.add_multi_representer(u.FunctionUnitBase, _unit_representer)
+AstropyDumper.add_representer(tuple, AstropyDumper._represent_tuple)
+AstropyDumper.add_representer(np.ndarray, _ndarray_representer)
+AstropyDumper.add_representer(Time, _time_representer)
+AstropyDumper.add_representer(TimeDelta, _timedelta_representer)
+AstropyDumper.add_representer(coords.SkyCoord, _skycoord_representer)
+AstropyDumper.add_representer(SerializedColumn, _serialized_column_representer)
 
-    # Numpy dtypes
-    AstropyDumper.add_representer(np.bool_, yaml.representer.SafeRepresenter.represent_bool)
-    for np_type in [np.int_, np.intc, np.intp, np.int8, np.int16, np.int32,
-                    np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
-        AstropyDumper.add_representer(np_type,
-                                      yaml.representer.SafeRepresenter.represent_int)
-    for np_type in [np.float_, np.float16, np.float32, np.float64,
-                    np.longdouble]:
-        AstropyDumper.add_representer(np_type,
-                                      yaml.representer.SafeRepresenter.represent_float)
-    for np_type in [np.complex_, complex, np.complex64, np.complex128]:
-        AstropyDumper.add_representer(np_type, _complex_representer)
+# Numpy dtypes
+AstropyDumper.add_representer(np.bool_, yaml.representer.SafeRepresenter.represent_bool)
+for np_type in [np.int_, np.intc, np.intp, np.int8, np.int16, np.int32,
+                np.int64, np.uint8, np.uint16, np.uint32, np.uint64]:
+    AstropyDumper.add_representer(np_type,
+                                    yaml.representer.SafeRepresenter.represent_int)
+for np_type in [np.float_, np.float16, np.float32, np.float64,
+                np.longdouble]:
+    AstropyDumper.add_representer(np_type,
+                                    yaml.representer.SafeRepresenter.represent_float)
+for np_type in [np.complex_, complex, np.complex64, np.complex128]:
+    AstropyDumper.add_representer(np_type, _complex_representer)
 
-    AstropyLoader.add_constructor('tag:yaml.org,2002:python/complex',
-                                  _complex_constructor)
-    AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',
-                                  AstropyLoader._construct_python_tuple)
-    AstropyLoader.add_constructor('tag:yaml.org,2002:python/unicode',
-                                  AstropyLoader._construct_python_unicode)
-    AstropyLoader.add_constructor('!astropy.units.Unit', _unit_constructor)
-    AstropyLoader.add_constructor('!numpy.ndarray', _ndarray_constructor)
-    AstropyLoader.add_constructor('!astropy.time.Time', _time_constructor)
-    AstropyLoader.add_constructor('!astropy.time.TimeDelta', _timedelta_constructor)
-    AstropyLoader.add_constructor('!astropy.coordinates.sky_coordinate.SkyCoord',
-                                  _skycoord_constructor)
-    AstropyLoader.add_constructor('!astropy.table.SerializedColumn',
-                                  _serialized_column_constructor)
+AstropyLoader.add_constructor('tag:yaml.org,2002:python/complex',
+                                _complex_constructor)
+AstropyLoader.add_constructor('tag:yaml.org,2002:python/tuple',
+                                AstropyLoader._construct_python_tuple)
+AstropyLoader.add_constructor('tag:yaml.org,2002:python/unicode',
+                                AstropyLoader._construct_python_unicode)
+AstropyLoader.add_constructor('!astropy.units.Unit', _unit_constructor)
+AstropyLoader.add_constructor('!numpy.ndarray', _ndarray_constructor)
+AstropyLoader.add_constructor('!astropy.time.Time', _time_constructor)
+AstropyLoader.add_constructor('!astropy.time.TimeDelta', _timedelta_constructor)
+AstropyLoader.add_constructor('!astropy.coordinates.sky_coordinate.SkyCoord',
+                                _skycoord_constructor)
+AstropyLoader.add_constructor('!astropy.table.SerializedColumn',
+                                _serialized_column_constructor)
 
-    for cls, tag in ((u.Quantity, '!astropy.units.Quantity'),
-                     (u.Magnitude, '!astropy.units.Magnitude'),
-                     (u.Dex, '!astropy.units.Dex'),
-                     (u.Decibel, '!astropy.units.Decibel'),
-                     (coords.Angle, '!astropy.coordinates.Angle'),
-                     (coords.Latitude, '!astropy.coordinates.Latitude'),
-                     (coords.Longitude, '!astropy.coordinates.Longitude'),
-                     (coords.EarthLocation, '!astropy.coordinates.earth.EarthLocation')):
+for cls, tag in ((u.Quantity, '!astropy.units.Quantity'),
+                    (u.Magnitude, '!astropy.units.Magnitude'),
+                    (u.Dex, '!astropy.units.Dex'),
+                    (u.Decibel, '!astropy.units.Decibel'),
+                    (coords.Angle, '!astropy.coordinates.Angle'),
+                    (coords.Latitude, '!astropy.coordinates.Latitude'),
+                    (coords.Longitude, '!astropy.coordinates.Longitude'),
+                    (coords.EarthLocation, '!astropy.coordinates.earth.EarthLocation')):
+    AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
+    AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
+
+for cls in (list(coords.representation.REPRESENTATION_CLASSES.values())
+            + list(coords.representation.DIFFERENTIAL_CLASSES.values())):
+    name = cls.__name__
+    # Add representations/differentials defined in astropy.
+    if name in coords.representation.__all__:
+        tag = '!astropy.coordinates.' + name
         AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
         AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
-
-    for cls in (list(coords.representation.REPRESENTATION_CLASSES.values())
-                + list(coords.representation.DIFFERENTIAL_CLASSES.values())):
-        name = cls.__name__
-        # Add representations/differentials defined in astropy.
-        if name in coords.representation.__all__:
-            tag = '!astropy.coordinates.' + name
-            AstropyDumper.add_multi_representer(cls, _quantity_representer(tag))
-            AstropyLoader.add_constructor(tag, _quantity_constructor(cls))
 
 
 def load(stream):
@@ -260,9 +301,6 @@ def load(stream):
     obj : object
         Object corresponding to YAML document
     """
-    if YAML_LT_3_12:
-        raise ImportError('`import yaml` failed, PyYAML package is required '
-                          'for YAML and must be 3.12 or later')
     return yaml.load(stream, Loader=AstropyLoader)
 
 
@@ -281,9 +319,6 @@ def load_all(stream):
         Object corresponding to YAML document
 
     """
-    if YAML_LT_3_12:
-        raise ImportError('`import yaml` failed, PyYAML package is required '
-                          'for YAML and must be 3.12 or later')
     return yaml.load_all(stream, Loader=AstropyLoader)
 
 
@@ -306,9 +341,6 @@ def dump(data, stream=None, **kwargs):
         If no ``stream`` is supplied then YAML output is returned as str
 
     """
-    if YAML_LT_3_12:
-        raise ImportError('`import yaml` failed, PyYAML package is required '
-                          'for YAML and must be 3.12 or later')
     kwargs['Dumper'] = AstropyDumper
     kwargs.setdefault('default_flow_style', None)
     return yaml.dump(data, stream=stream, **kwargs)

--- a/docs/io/misc.rst
+++ b/docs/io/misc.rst
@@ -17,73 +17,8 @@ listed in the `astropy.io.misc` section.
 .. automodapi:: astropy.io.misc.hdf5
    :headings: =-
 
-astropy.io.misc.yaml Module
-===========================
-
-This module contains functions for serializing core astropy objects via the
-YAML protocol.
-
-It provides functions `~astropy.io.misc.yaml.dump`,
-`~astropy.io.misc.yaml.load`, and `~astropy.io.misc.yaml.load_all` which
-call the corresponding functions in `PyYaml <https://pyyaml.org>`_ but use the
-`~astropy.io.misc.yaml.AstropyDumper` and `~astropy.io.misc.yaml.AstropyLoader`
-classes to define custom YAML tags for the following astropy classes:
-
-- `astropy.units.Unit`
-- `astropy.units.Quantity`
-- `astropy.time.Time`
-- `astropy.time.TimeDelta`
-- `astropy.coordinates.SkyCoord`
-- `astropy.coordinates.Angle`
-- `astropy.coordinates.Latitude`
-- `astropy.coordinates.Longitude`
-- `astropy.coordinates.EarthLocation`
-- `astropy.table.SerializedColumn`
-
-.. Note ::
-
-   This module requires PyYaml version 3.12 or later.
-
-Example
--------
-
-.. doctest-requires:: yaml
-
-    >>> from astropy.io.misc import yaml
-    >>> import astropy.units as u
-    >>> from astropy.time import Time
-    >>> from astropy.coordinates import EarthLocation
-    >>> t = Time(2457389.0, format='mjd',
-    ...          location=EarthLocation(1000, 2000, 3000, unit=u.km))
-    >>> td = yaml.dump(t)
-    >>> print(td)
-    !astropy.time.Time
-    format: mjd
-    in_subfmt: '*'
-    jd1: 4857390.0
-    jd2: -0.5
-    location: !astropy.coordinates.earth.EarthLocation
-      ellipsoid: WGS84
-      x: !astropy.units.Quantity
-        unit: &id001 !astropy.units.Unit {unit: km}
-        value: 1000.0
-      y: !astropy.units.Quantity
-        unit: *id001
-        value: 2000.0
-      z: !astropy.units.Quantity
-        unit: *id001
-        value: 3000.0
-    out_subfmt: '*'
-    precision: 3
-    scale: utc
-    >>> ty = yaml.load(td)
-    >>> ty
-    <Time object: scale='utc' format='mjd' value=2457389.0>
-    >>> ty.location  # doctest: +FLOAT_CMP
-    <EarthLocation (1000., 2000., 3000.) km>
-
 .. automodapi:: astropy.io.misc.yaml
-   :no-heading:
+   :headings: =-
 
 astropy.io.misc.asdf Package
 ============================

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,10 @@ filterwarnings =
     ignore:PY_SSIZE_T_CLEAN will be required for '#' formats
     ignore:::astropy.tests.plugins.display
     ignore:::astropy.tests.disable_internet
+doctest_norecursedirs =
+    */setup_package.py
+doctest_subpackage_requires =
+        astropy/io/misc/asdf/*:asdf
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,7 @@ filterwarnings =
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =
-        astropy/io/misc/asdf/*:asdf
+    astropy/io/misc/asdf/*=asdf
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp

--- a/setup.cfg
+++ b/setup.cfg
@@ -117,7 +117,8 @@ filterwarnings =
 doctest_norecursedirs =
     */setup_package.py
 doctest_subpackage_requires =
-    astropy/io/misc/asdf/*=asdf
+    astropy/io/misc/asdf/* = asdf
+    astropy/io/misc/yaml.py = PyYAML
 
 [bdist_wininst]
 bitmap = static/wininst_background.bmp


### PR DESCRIPTION
This is an experiment to try out the proposed fix for https://github.com/astropy/pytest-doctestplus/pull/112 which allows doctest collection to be skipped per subpackage based on requirements.

The first commit's CI should fail before I actually define any options in ``setup.cfg`` (this is a deliberate test). Once I've checked that it fails, I'll push the fixes.