### PR TITLE
BugFix: Bug 10319 fix input_units_equivalencies key error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -721,6 +721,10 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- bugfix. ``Model.input_units_equivalencies`` would throw keyerror on fix_inputs
+  if models have no set unit equivalencies.
+  [#10359]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3236,9 +3236,12 @@ class CompoundModel(Model):
     @property
     def input_units_equivalencies(self):
         inputs_map = self.inputs_map()
-        return {key: inputs_map[key][0].input_units_equivalencies[orig_key]
+        input_units_equivalencies_dict = {key: inputs_map[key][0].input_units_equivalencies[orig_key]
                 for key, (mod, orig_key) in inputs_map.items()
-                if inputs_map[key][0].input_units_equivalencies is not None}
+                if inputs_map[key][0].input_units_equivalencies is not None }
+        if not input_units_equivalencies_dict:
+            return None
+        return input_units_equivalencies_dict
 
     @property
     def input_units_allow_dimensionless(self):

--- a/astropy/modeling/tests/test_models_quantities.py
+++ b/astropy/modeling/tests/test_models_quantities.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
+from astropy.modeling.core import fix_inputs, CompoundModel
 
 from astropy.modeling.functional_models import (
     Gaussian1D,
@@ -314,6 +315,39 @@ def test_models_bounding_box(model):
         for i in range(len(model['bounding_box'])):
             bbox = m.bounding_box
             assert_quantity_allclose(bbox[i], model['bounding_box'][i])
+
+
+@pytest.mark.parametrize('model', MODELS)
+def test_compound_model_input_units_equivalencies_defaults(model):
+    m = model['class'](**model['parameters'])
+
+    assert m.input_units_equivalencies == None
+
+    compound_model = m + m
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    compound_model = m - m
+    assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    compound_model = m & m
+    assert compound_model.inputs_map()['x1'][0].input_units_equivalencies == None
+    fixed_input_model = fix_inputs(compound_model, {'x0':1})
+    assert fixed_input_model.inputs_map()['x1'][0].input_units_equivalencies == None
+
+    assert fixed_input_model.input_units_equivalencies == None
+
+    if m.n_outputs == m.n_inputs:
+        compound_model = m | m
+        assert compound_model.inputs_map()['x'][0].input_units_equivalencies == None
+        fixed_input_model = fix_inputs(compound_model, {'x':1})
+
+        assert fixed_input_model.input_units_equivalencies == None
 
 
 @pytest.mark.skipif('not HAS_SCIPY')

--- a/astropy/modeling/tests/test_quantities_evaluation.py
+++ b/astropy/modeling/tests/test_quantities_evaluation.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-
 from astropy.modeling.core import Model
 from astropy.modeling.models import Gaussian1D, Shift, Scale, Pix2Sky_TAN
 from astropy import units as u


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
As mentioned on issue #10319 
_Model.input_units_equivalencies crashes when the model is the result of fix_inputs operation and the constituent models have no equivalencies set._

I believe this to be a bug within the input_units_equivalencies method in modeling.core. Where the method will recursively call a key that does not exist. I have implemented a simple one-line fix for this problem with the hope this will resolve all problems similar to the one stated. 

This will be my first pull request to the project, and I hope it helps. 

**UPDATE:** 

This current pull request will fix the key error as mentioned in #10319, but there is still another discrepencey. Specifically this one:  

`m.inputs_map()['x1'][0].input_units_equivalencies`
(returns)
None

`mf.inputs_map()['x1'][0].input_units_equivalencies`
(returns)
{}

So I did some digging and this is what I've found out.
`CompoundModel `has the property function `input_units_equivalencies` but the Base `Model ` class simply has the attribute `input_units_equivalencies = None` .

Why does this matter? Let's look at the recursive logic for
`mf.inputs_map()['x1'][0].input_units_equivalencies`. Bare with me here.
.

`Polynomial1D.input_unit_equivalencies` (returns None)--> `CompoundModel.input_unit_equivalencies` (returns {}) --> output

Where` CompoundModel.input_unit_equivalencies` returns {} due to python's list comprehension.

And if we add one more layer of recursion, as we do when we call `fix_input( ... ).input_unit_equivalencies` we get a key error. Note `{}['x1']`.
But this current pull request will take care of the key error.

If we don't want inconsistent default values, I BELIEVE we can change
`input_unit_equivalencies = None` in astropy/core.py Model to
to:
`input_unit_equivalencies = {}`
But I'd like someone else's input before I change default values.

I hope this all makes sense and will be helpful.

Fixes #10319  
