### PR TITLE
WIP: fix input broadcasting in modeling

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1724,7 +1724,6 @@ class Model(metaclass=_ModelMeta):
 
     def prepare_outputs(self, format_info, *outputs, **kwargs):
         model_set_axis = kwargs.get('model_set_axis', None)
-
         if len(self) == 1:
             return _prepare_outputs_single_model(outputs, format_info)
         else:
@@ -3724,8 +3723,9 @@ def render_model(model, arr=None, coords=None):
 
 
 def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwargs):
-    #broadcasts = []
     shapes_of_inputs = [inp.shape for inp in inputs]
+    if model.standard_broadcasting:
+        shapes_of_inputs = [check_broadcast(shape, broadcasted_shape) for shape in shapes_of_inputs]
     param_broadcast = ()
 
     for idx, _input in enumerate(inputs):
@@ -3738,14 +3738,11 @@ def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwa
             inputs[idx] = _input.reshape((1,))
 
     if params and model.standard_broadcasting:
-        #print('params', params)
         param_shapes = [param.shape for param in params]
 
         param_broadcast = check_broadcast(*param_shapes)
-        #print('param_broadcast', param_broadcast)
         if broadcasted_shape is not None:
             broadcasted_shape = check_broadcast(broadcasted_shape, param_broadcast)
-        #print('broadcasted_shape', broadcasted_shape)
         shapes_of_inputs = [check_broadcast(shape, param_broadcast) for shape in shapes_of_inputs]
 
     if model.n_outputs > model.n_inputs:
@@ -3756,7 +3753,6 @@ def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwa
             # inputs necessary (see _prepare_outputs_single_model)
             shapes_of_inputs.append(None)
         shapes_of_inputs.extend([broadcasted_shape] * extra_outputs)
-
     return inputs, (shapes_of_inputs,)
 
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1602,6 +1602,7 @@ class Model(metaclass=_ModelMeta):
 
         broadcasted_shape = None
         if self.standard_broadcasting:
+            # Compute the broadcasted shape taking into account model_set_axis
             broadcasted_shape = _validate_input_shapes(inputs, self.inputs, n_models, model_set_axis)
 
         inputs_map = kwargs.get('inputs_map', None)
@@ -3723,8 +3724,10 @@ def render_model(model, arr=None, coords=None):
 
 
 def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwargs):
+    # The shapes of the inputs will be used to determine the shape of the outputs.
     shapes_of_inputs = [inp.shape for inp in inputs]
     if model.standard_broadcasting:
+        # Make sure that input shapes broadcast and compute the shape
         shapes_of_inputs = [check_broadcast(shape, broadcasted_shape) for shape in shapes_of_inputs]
     param_broadcast = ()
 
@@ -3740,8 +3743,10 @@ def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwa
     if params and model.standard_broadcasting:
         param_shapes = [param.shape for param in params]
 
+        # Make sure parameter shapes broadcast
         param_broadcast = check_broadcast(*param_shapes)
         if broadcasted_shape is not None:
+            # Ensure parameter and input shapes broadcast
             broadcasted_shape = check_broadcast(broadcasted_shape, param_broadcast)
         shapes_of_inputs = [check_broadcast(shape, param_broadcast) for shape in shapes_of_inputs]
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3749,15 +3749,6 @@ def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwa
         shapes_of_inputs = [check_broadcast(shape, param_broadcast) for shape in shapes_of_inputs]
 
     if model.n_outputs > model.n_inputs:
-        # if len(set(broadcasts)) > 1:
-        #     raise ValueError(
-        #         "For models with n_outputs > n_inputs, the combination of "
-        #         "all inputs and parameters must broadcast to the same shape, "
-        #         "which will be used as the shape of all outputs.  In this "
-        #         "case some of the inputs had different shapes, so it is "
-        #         "ambiguous how to format outputs for this model.  Try using "
-        #        "inputs that are all the same size and shape.")
-        # Extend the broadcasts list to include shapes for all outputs
         extra_outputs = model.n_outputs - model.n_inputs
         if not shapes_of_inputs:
             # If there were no inputs then the broadcasts list is empty
@@ -3767,62 +3758,6 @@ def _prepare_inputs_single_model(model, params, inputs, broadcasted_shape, **kwa
         shapes_of_inputs.extend([broadcasted_shape] * extra_outputs)
 
     return inputs, (shapes_of_inputs,)
-
-
-    # for idx, _input in enumerate(inputs):
-    #     input_shape = _input.shape
-    #
-    #     # Ensure that array scalars are always upgrade to 1-D arrays for the
-    #     # sake of consistency with how parameters work.  They will be cast back
-    #     # to scalars at the end
-    #     if not input_shape:
-    #         inputs[idx] = _input.reshape((1,))
-    #
-    #     if not params:
-    #         max_broadcast = input_shape
-    #     else:
-    #         max_broadcast = ()
-
-
-    #     for param in params:
-    #         try:
-    #             if model.standard_broadcasting:
-    #                 broadcast = check_broadcast(input_shape, param.shape)
-    #             else:
-    #                 broadcast = input_shape
-    #         except IncompatibleShapeError:
-    #             raise ValueError(
-    #                 "Model input argument {0!r} of shape {1!r} cannot be "
-    #                 "broadcast with parameter {2!r} of shape "
-    #                 "{3!r}.".format(model.inputs[idx], input_shape,
-    #                                 param.name, param.shape))
-    #
-    #         if len(broadcast) > len(max_broadcast):
-    #             max_broadcast = broadcast
-    #         elif len(broadcast) == len(max_broadcast):
-    #             max_broadcast = max(max_broadcast, broadcast)
-    #
-    #     broadcasts.append(max_broadcast)
-    #
-    # if model.n_outputs > model.n_inputs:
-    #     if len(set(broadcasts)) > 1:
-    #         raise ValueError(
-    #             "For models with n_outputs > n_inputs, the combination of "
-    #             "all inputs and parameters must broadcast to the same shape, "
-    #             "which will be used as the shape of all outputs.  In this "
-    #             "case some of the inputs had different shapes, so it is "
-    #             "ambiguous how to format outputs for this model.  Try using "
-    #             "inputs that are all the same size and shape.")
-    #     # Extend the broadcasts list to include shapes for all outputs
-    #     extra_outputs = model.n_outputs - model.n_inputs
-    #     if not broadcasts:
-    #         # If there were no inputs then the broadcasts list is empty
-    #         # just add a None since there is no broadcasting of outputs and
-    #         # inputs necessary (see _prepare_outputs_single_model)
-    #         broadcasts.append(None)
-    #     broadcasts.extend([broadcasts[0]] * extra_outputs)
-    #
-    # return inputs, (broadcasts,)
 
 
 def _prepare_outputs_single_model(outputs, format_info):

--- a/astropy/modeling/mappings.py
+++ b/astropy/modeling/mappings.py
@@ -47,6 +47,7 @@ class Mapping(FittableModel):
     (17.0, 14.2)
     """
     linear = True  # FittableModel is non-linear by default
+    standard_broadcasting = False
 
     def __init__(self, mapping, n_inputs=None, name=None, meta=None):
         self._inputs = ()
@@ -124,6 +125,14 @@ class Mapping(FittableModel):
         inv._n_inputs = len(inv._inputs)
         inv._n_outputs = len(inv._outputs)
         return inv
+
+    def prepare_inputs(self, *args):
+        inputs, format_info = super().prepare_inputs(*args)
+        # format_info is a list of shapes of the inputs
+        # They may need to be reordered before passing them to
+        # prepare_outputs.
+        output_shapes = [format_info[0][i] for i in self.mapping]
+        return inputs, (output_shapes,)
 
 
 class Identity(Mapping):

--- a/astropy/modeling/polynomial.py
+++ b/astropy/modeling/polynomial.py
@@ -1035,8 +1035,8 @@ class Polynomial2D(PolynomialModel):
         inputs, format_info = super().prepare_inputs(x, y, **kwargs)
 
         x, y = inputs
-        if x.shape != y.shape:
-            raise ValueError("Expected input arrays to have the same shape")
+        # if x.shape != y.shape:
+        #     raise ValueError("Expected input arrays to have the same shape")
         return (x, y), format_info
 
     def evaluate(self, x, y, *coeffs):

--- a/astropy/modeling/tests/test_input.py
+++ b/astropy/modeling/tests/test_input.py
@@ -961,3 +961,113 @@ def test_call_keyword_mappings(model):
 
     with pytest.raises(ValueError):
         model(1, 2, t=12, r=3)
+
+
+# test broadcasting rules
+broadcast_models = [
+    {'model': models.Identity(2),
+     'inputs': [0, [1,1]],
+     'outputs': [0, [1,1]]
+    },
+    {'model': models.Identity(2),
+     'inputs': [[1,1], 0],
+     'outputs': [[1,1], 0]
+    },
+    {'model': models.Mapping((0, 1)),
+     'inputs': [0, [1,1]],
+     'outputs': [0, [1,1]]
+    },
+    {'model': models.Mapping((1, 0)),
+     'inputs': [0, [1,1]],
+     'outputs': [[1,1], 0]
+    },
+    {'model': models.Mapping((1, 0), n_inputs=3),
+     'inputs': [0, [1,1], 2],
+     'outputs': [[1, 1], 0]
+    },
+    {'model': models.Mapping((0, 1, 0)),
+     'inputs': [0, [1,1]],
+     'outputs': [0, [1,1], 0]
+    },
+    {'model': models.Mapping((0, 1, 1)),
+     'inputs': [0, [1,1]],
+     'outputs': [0, [1,1], [1, 1]]
+    },
+    {'model': models.Polynomial2D(1, c0_0=1),
+     'inputs': [0, [1, 1]],
+     'outputs': [1, 1]
+    },
+    {'model': models.Polynomial2D(1, c0_0=1),
+     'inputs': [0, 1],
+     'outputs': 1
+    },
+    {'model': models.Gaussian2D(1, 1, 2, 1, 1.2),
+     'inputs': [0, [1, 1]],
+     'outputs': [0.42860385, 0.42860385]
+    },
+    {'model': models.Gaussian2D(1, 1, 2, 1, 1.2),
+     'inputs': [0, 1],
+     'outputs': 0.428603846153
+    },
+    {'model': models.Polynomial2D(1, c0_0=1) & models.Polynomial2D(1, c0_0=2),
+     'inputs': [1, 1, 1, 1],
+     'outputs': (1, 2)
+    },
+    {'model': models.Polynomial2D(1, c0_0=1) & models.Polynomial2D(1, c0_0=2),
+     'inputs': [1, 1, [1, 1], [1, 1]],
+     'outputs': (1, [2, 2])
+    },
+    {'model': models.math.MultiplyUfunc(),
+     'inputs': [np.array([np.linspace(0,1,5)]).T, np.arange(2)],
+     'outputs': np.array([[0.  , 0.  ],
+                          [0.  , 0.25],
+                          [0.  , 0.5 ],
+                          [0.  , 0.75],
+                          [0.  , 1.  ]])
+    }
+]
+
+
+@pytest.mark.filterwarnings(
+    r'ignore:Models in math_functions are experimental\.')
+@pytest.mark.parametrize('model', broadcast_models)
+def test_mixed_input(model):
+    result = model['model'](*model['inputs'])
+    if np.isscalar(result):
+        assert_allclose(result, model['outputs'])
+    else:
+        for i in range(len(result)):
+            assert_allclose(result[i], model['outputs'][i])
+
+
+def test_more_outputs():
+
+    class M(FittableModel):
+        standard_broadcasting = False
+        n_inputs = 2
+        n_outputs = 3
+
+        a = Parameter()
+
+        def evaluate(self, x, y, a):
+            return a*x, a-x, a+y
+
+        def __call__(self, *args, **kwargs):
+            inputs, format_info = super().prepare_inputs(*args, **kwargs)
+
+            outputs = self.evaluate(*inputs, *self.parameters)
+            output_shapes = [out.shape for out in outputs]
+            output_shapes = [() if shape==(1,) else shape for shape in output_shapes]
+            return self.prepare_outputs((tuple(output_shapes),), *outputs, **kwargs)
+
+    c = M(1)
+    result = c([1, 1], 1)
+    expected = [[1., 1.], [0., 0.], 2.]
+    for r, e in zip (result, expected):
+        assert_allclose(r, e)
+
+    c = M(1)
+    result = c(1, [1, 1])
+    expected = [1., 0., [2., 2.]]
+    for r, e in zip (result, expected):
+        assert_allclose(r, e)

--- a/astropy/modeling/tests/test_models.py
+++ b/astropy/modeling/tests/test_models.py
@@ -100,8 +100,8 @@ def test_inconsistent_input_shapes():
     # but not array broadcasting
     x.shape = (10, 1)
     y.shape = (1, 10)
-    with pytest.raises(ValueError):
-        g(x, y)
+    result = g(x, y)
+    assert result.shape == (10, 10)
 
 
 def test_custom_model_bounding_box():


### PR DESCRIPTION
This PR is functionally complete but I marked it as WIP to get opinions on the approach. I will add documentation later.

This takes a slightly different approach to validating inputs in modeling. 
The previous behavior was:

- Input shapes were compared (in _validate_input_shapes) and *if not the same* an error was raised.
- If `Model.standard_broadcasting=True` parameters and inputs were broadcasted to a common shape.
- There was no way to specify that inputs should not be broadcast among themselves or with parameters.

The new approach:

- `Model.standard_broadcasting=True` means that broadcasting rules apply to inputs and parameters. `prepare_inputs` is not broadcasting the inputs before passing them to `Model.evaluate` (although it computes the broadcasted shape ) but let's the function implementation deal with this following numpy broadcasting rules.
- If `Model.standard_broadcasting=False` it is not assumed that inputs should broadcast nor that inputs and parameters should broadcast. Dealing with input and output shapes is left to the writer of the model. This is a rare use case but is necessary.
- A special treatment is the case of `n_outputs > n_inputs` with `standard_broadcasting=True`. In this case the shape fo the extra outputs is assumed to be the precomputed broadcasted shape.


Fixes #10170 
Fixes #9953 
