### PR TITLE
Finalize what's new and mailmap ahead of 4.1 release

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -37,7 +37,9 @@ Benjamin Alan Weaver         <weaver@noao.edu> <benjamin.weaver@nyu.edu>
 Benjamin Roulston            <benjamin.roulston@protonmail.com>
 Benjamin Winkel              <bwinkel@mpifr.de>  <bwinkel78@gmail.com>
 Bogdan Nicula                <bogdan@nicula.net>
+Brett Morris                 <brettmorris21@gmail.com>
 Brett Morris                 <brettmorris21@gmail.com> <bmmorris@uw.edu>
+Brett Morris                 <brettmorris21@gmail.com> <morrisbrettm@gmail.com>
 Brian Svoboda                <bones253@gmail.com> <bsvo@lavabit.com>
 Brigitta Sipőcz              <bsipocz@gmail.com>
 Brigitta Sipőcz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
@@ -149,6 +151,8 @@ Karl Vyhmeister              <kvyh@users.noreply.github.com>
 Kelle Cruz                   <kellecruz@gmail.com>
 Kevin Gullikson              <kevin.gullikson@gmail.com>
 Kirill Tchernyshyov          <ktchernyshyov@pha.jhu.edu>
+Kris Stern                   <kakirastern@users.noreply.github.com>
+Kris Stern                   <kakirastern@users.noreply.github.com> <krisastern@gobuddy.asia>
 Kyle Barbary                 <kylebarbary@gmail.com> <kbarbary@lbl.gov>
 Kyle Oman                    <koman@astro.rug.nl>
 Larry Bradley                <larry.bradley@gmail.com>
@@ -175,6 +179,7 @@ Matteo Bachetti              <matteo@matteobachetti.it> <matteo.bachetti@irap.om
 Matthew Craig                <mattwcraig@gmail.com>
 Matthieu Baumann             <baumannmatthieu0@gmail.com> <matthieu.baumann@astro.unistra.fr>
 Mavani Bhautik               <mavanibhautik@gmail.com>
+Michael Hirsch               <scienceopen@users.noreply.github.com>
 Michael Mommert              <mommermiscience@gmail.com> <michael.mommert@nau.edu>
 Michael Mommert              <mommermiscience@gmail.com> <mommermi@users.noreply.github.com>
 Michael Seifert              <michaelseifert04@yahoo.de>
@@ -191,6 +196,7 @@ Neil Crighton                <neilcrighton@gmail.com>
 Nicholas Earl                <contact@nicholasearl.me>
 Nicholas Earl                <contact@nicholasearl.me> <nchlsearl@gmail.com>
 Nicholas Earl                <contact@nicholasearl.me> <nmearl@localhost.localdomain>
+Nick Lloyd                   <nick.lloyd@usask.ca>
 Nora Luetzgendorf            <nluetzge@gmail.com>
 Ole Streicher                <ole@aip.de> <debian@liska.ath.cx>
 Ole Streicher                <ole@aip.de> <olebole@debian.org>
@@ -202,6 +208,7 @@ Pey Lian Lim                 <lim@stsci.edu>
 Pey Lian Lim                 <lim@stsci.edu> <2090236+pllim@users.noreply.github.com>
 Pratik Patel                 <pratikpatel15133@gmail.com>
 Pritish Chakraborty          <chakrabortypritish@gmail.com>
+Ricky O'Steen                <rosteen@stsci.edu> <39831871+rosteen@users.noreply.github.com>
 Ritiek Malhotra              <ritiekmalhotra123@gmail.com>
 Ritwick DSouza               <ritwick.dsouza@outlook.com>
 Rohan Rajpal                 <rohan17089@iiitd.ac.in>
@@ -215,8 +222,11 @@ Sara Ogaz                    <ogaz@stsci.edu>
 Sergio Pascual               <sergio.pasra@gmail.com> <sergiopr@fis.ucm.es>
 Shantanu Srivastava          <shan_mbic@rediffmail.com>
 Shilpi Jain                  <shilpi1958@gmail.com>
+Shivansh Mishra              <dHoneysh@gmail.com>
+Shivansh Mishra              <dHoneysh@gmail.com> <shivanshmishra@shivanshs-MacBook-Pro.local>
 Simon Conseil                <contact@saimon.org>
 Simon Conseil                <contact@saimon.org> <simon.conseil@univ-lyon1.fr>
+Simon Conseil                <contact@saimon.org> <sconseil@gemini.edu>
 Simon Liedtke                <liedtke.simon@googlemail.com>
 Sourabh Cheedella            <cheedella.sourabh@gmail.com>
 Steve Crawford               <crawfordsm@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -45,6 +45,7 @@ Brigitta Sipőcz              <bsipocz@gmail.com>
 Brigitta Sipőcz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
 Brigitta Sipőcz              <bsipocz@gmail.com> <bsipocz@users.noreply.github.com>
 Bryce Nordgren               <bnordgren@gmail.com>
+Chris Osborne                <2087801o@student.gla.ac.uk>
 Chris Simpson                <csimpson@gemini.edu>
 Christian Clauss             <cclauss@bluewin.ch>
 Christoph Gohlke             <cgohlke@uci.edu>

--- a/.mailmap
+++ b/.mailmap
@@ -161,6 +161,7 @@ Larry Bradley                <larry.bradley@gmail.com>
 Larry Bradley                <larry.bradley@gmail.com> <larrybradley@users.noreply.github.com>
 Laura Watkins                <lauralwatkins@gmail.com>
 Lauren Glattly               <laurenglattly@gmail.com> <44421608+lglattly@users.noreply.github.com>
+Lennard Kiehl                <luzuku@gmail.com>
 Leo Singer                   <leo.singer@ligo.org> <leo.singer@nasa.gov>
 Leonardo Ferreira            <leonardo.ferreira.furg@gmail.com> <[leonardo.ferreira.furg@gmail.com]>
 Lia Corrales                 <liac@umich.edu>
@@ -218,6 +219,7 @@ Rohan Rajpal                 <rohan17089@iiitd.ac.in>
 Rohit Kapoor                 <algorithm059@gmail.com>
 Rohit Patil                  <rohit4change@yahoo.in>
 Rohit Patil                  <rohit4change@yahoo.in> <Quan@Aries.(none)>
+Roman Tolesnikov             <rtolesnikov@yahoo.com>
 Ryan Cooke                   <ryancooke86@gmail.com>
 Sam Verstocken               <sam.verstocken@gmail.com>
 Sanjeev Dubey                <getsanjeevdubey@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -45,6 +45,7 @@ Brigitta Sipőcz              <bsipocz@gmail.com>
 Brigitta Sipőcz              <bsipocz@gmail.com> <b.sipocz@gmail.com>
 Brigitta Sipőcz              <bsipocz@gmail.com> <bsipocz@users.noreply.github.com>
 Bryce Nordgren               <bnordgren@gmail.com>
+Chris Simpson                <csimpson@gemini.edu>
 Christian Clauss             <cclauss@bluewin.ch>
 Christoph Gohlke             <cgohlke@uci.edu>
 Christopher Bonnett          <c.bonnett@gmail.com>
@@ -180,6 +181,7 @@ Matthew Craig                <mattwcraig@gmail.com>
 Matthieu Baumann             <baumannmatthieu0@gmail.com> <matthieu.baumann@astro.unistra.fr>
 Mavani Bhautik               <mavanibhautik@gmail.com>
 Michael Hirsch               <scienceopen@users.noreply.github.com>
+Michael Lindner-D'Addario    <38199062+MDAddario@users.noreply.github.com>
 Michael Mommert              <mommermiscience@gmail.com> <michael.mommert@nau.edu>
 Michael Mommert              <mommermiscience@gmail.com> <mommermi@users.noreply.github.com>
 Michael Seifert              <michaelseifert04@yahoo.de>

--- a/docs/credits.rst
+++ b/docs/credits.rst
@@ -42,6 +42,7 @@ Core Package Contributors
 * Aniket Kulkarni
 * Anirudh Katipally
 * Anne Archibald
+* Antetokounpo
 * Anthony Horton
 * Antony Lee
 * Arfon Smith
@@ -66,8 +67,11 @@ Core Package Contributors
 * Bryce Kalmbach
 * Bryce Nordgren
 * Carl Osterwisch
+* Carl Schaffer
 * Chris Beaumont
 * Chris Hanley
+* Chris Osborne
+* Chris Simpson
 * Christian Clauss
 * Christian Hettlage
 * Christoph Deil
@@ -85,6 +89,7 @@ Core Package Contributors
 * Daniel D'Avella
 * Daniel Datsev
 * Daniel Lenz
+* Daniel Ruschel Dutra
 * Danny Goldstein
 * Daria Cara
 * David Kirkby
@@ -101,6 +106,7 @@ Core Package Contributors
 * Drew Leonard
 * Duncan Macleod
 * Dylan Gregersen
+* Ed Slavich
 * Edward Betts
 * Eli Bressert
 * Elijah Bernstein-Cooper
@@ -112,6 +118,7 @@ Core Package Contributors
 * Eric Koch
 * Erik M. Bray
 * Erik Tollerud
+* Erin Allard
 * Esteban Pardo Sánchez
 * Evert Rol
 * Felix Yan
@@ -121,6 +128,7 @@ Core Package Contributors
 * Frédéric Chapoton
 * Frédéric Grollier
 * Gabriel Brammer
+* Gabriel Perren
 * Geert Barentsen
 * Georgiana Ogrean
 * Gerrit Schellenberger
@@ -133,8 +141,8 @@ Core Package Contributors
 * Gustavo Bragança
 * Hannes Breytenbach
 * Hans Moritz Günther
+* Harry Ferguson
 * Helen Sherwood-Taylor
-* Henry Ferguson
 * Himanshu Pathak
 * Hugo Buddelmeijer
 * Humna Awan
@@ -147,6 +155,7 @@ Core Package Contributors
 * James Noss
 * James Taylor
 * James Turner
+* Jan Skowron
 * Jane Rigby
 * Jani Šumak
 * Javier Pascual Granado
@@ -205,13 +214,17 @@ Core Package Contributors
 * Lisa Walter
 * Luigi Paioro
 * Luke G. Bouma
+* Luke Kelley
 * M Atakan Gürkan
+* M S R Dinesh
 * Mabry Cervin
 * Madhura Parikh
+* Magali Mebsout
 * Manas Satish Bedmutha
 * Maneesh Yadav
 * Mangala Gowri Krishnamoorthy
 * Manish Biswas
+* Manodeep Sinha
 * Mark Fardal
 * Mark Taylor
 * Marten van Kerkwijk
@@ -227,11 +240,14 @@ Core Package Contributors
 * Matthew Turk
 * Mavani Bhautik
 * Max Silbiger
+* Max Voronkov
 * Maximilian Nöthe
 * Médéric Boquien
 * Megan Sosey
 * Michael Droettboom
+* Michael Hirsch
 * Michael Hoenig
+* Michael Lindner-D'Addario
 * Michael Mueller
 * Michael Seifert
 * Michael Wood-Vasey
@@ -243,22 +259,28 @@ Core Package Contributors
 * Mike Alexandersen
 * Mike McCarty
 * Mikhail Minin
+* Mikołaj
 * Miruna Oprescu
 * Moataz Hisham
 * Mohan Agrawal
 * Molly Peeples
 * Nabil Freij
 * Nadia Dencheva
+* Nathanial Hendler
+* Neal McBurnett
 * Neil Crighton
 * Neil Parley
+* Nicholas Earl
 * Nicholas S. Kern
 * Nicholas Saunders
+* Nick Lloyd
 * Nick Murphy
 * Nimit Bhardwaj
 * Noah Zuckman
 * Nora Luetzgendorf
 * Ole Streicher
 * Orion Poplawski
+* Parikshit Sakurikar
 * Patricio Rojo
 * Patti Carroll
 * Paul Barrett
@@ -267,6 +289,7 @@ Core Package Contributors
 * Paul Sladen
 * Pauline Barmby
 * Perry Greenfield
+* Peter Cock
 * Peter Teuben
 * Pey Lian Lim
 * Prasanth Nair
@@ -278,14 +301,17 @@ Core Package Contributors
 * Ray Plante
 * Régis Terrier
 * Ricardo Ogando
+* Ricky O'Steen
 * Ritiek Malhotra
 * Ritwick DSouza
 * Roban Hultman Kramer
+* Robel Geda
 * Robert Cross
 * Rocio Kiman
 * Rohan Rajpal
 * Rohit Kapoor
 * Rohit Patil
+* Roman Tolesnikov
 * Rui Xue
 * Ryan Abernathey
 * Ryan Cooke
@@ -305,7 +331,9 @@ Core Package Contributors
 * SF Graves
 * Shailesh Ahuja
 * Shantanu Srivastava
+* Shilpi Jain
 * Shivan Sornarajah
+* Shivansh Mishra
 * Shresth Verma
 * Shreyas Bapat
 * Sigurd Næss
@@ -356,6 +384,7 @@ Core Package Contributors
 * Zach Edwards
 * Zachary Kurtz
 * Zeljko Ivezic
+* Zlatan Vasović
 * Zé Vinicius
 
 Other Credits

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -32,7 +32,7 @@ smaller improvements and bug fixes, which are described in the
 
 * 211 issues have been closed since v4.0
 * 275 pull requests have been merged since v4.0
-* 62 distinct people have contributed code, 25 of which are first time contributors to Astropy
+* 62 distinct people have contributed code to this release, 25 of which are first time contributors to Astropy
 
 .. _whatsnew-4.1-spectralcoord:
 
@@ -300,6 +300,7 @@ The people who have contributed to the code for this release are:
   * Brett Morris
   * Brigitta Sipőcz
   * Carl Schaffer  *
+  * Chris Osborne  *
   * Chris Simpson  *
   * Clara Brasseur
   * Clare Shanahan
@@ -311,7 +312,6 @@ The people who have contributed to the code for this release are:
   * Erik Tollerud
   * Erin Allard  *
   * Gabriel Perren  *
-  * Goobley  *
   * Hans Moritz Günther
   * James Davies
   * Jan Skowron  *

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -30,9 +30,9 @@ In addition to these major changes, Astropy v4.0 includes a large number of
 smaller improvements and bug fixes, which are described in the
 :ref:`changelog`. By the numbers:
 
-* ... issues have been closed since v4.0
-* ... pull requests have been merged since v4.0
-* ... distinct people have contributed code, .. of which are first time contributors to Astropy
+* 211 issues have been closed since v4.0
+* 275 pull requests have been merged since v4.0
+* 62 distinct people have contributed code, 25 of which are first time contributors to Astropy
 
 .. _whatsnew-4.1-spectralcoord:
 

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -284,8 +284,72 @@ API, please see the :ref:`changelog`.
 Contributors to the v4.0 release
 ================================
 
+The people who have contributed to the code for this release are:
+
 .. hlist::
   :columns: 4
 
-  * ...
-  * ...
+  * Adrian Price-Whelan
+  * Albert Y. Shih
+  * Alex Conley
+  * Anne Archibald
+  * Antetokounpo  *
+  * Arthur Eigenbrot
+  * Benjamin Alan Weaver
+  * Benjamin Roulston
+  * Brett Morris
+  * Brigitta Sipőcz
+  * Carl Schaffer  *
+  * Chris Simpson  *
+  * Clara Brasseur
+  * Clare Shanahan
+  * Dan Foreman-Mackey
+  * Daniel Ruschel Dutra  *
+  * David Stansby
+  * Derek Homeier
+  * Ed Slavich  *
+  * Erik Tollerud
+  * Erin Allard  *
+  * Gabriel Perren  *
+  * Goobley  *
+  * Hans Moritz Günther
+  * James Davies
+  * Jan Skowron  *
+  * Jerry Ma
+  * Juan Luis Cano Rodríguez
+  * Julien Woillez
+  * Kris Stern
+  * Larry Bradley
+  * Lauren Glattly
+  * Leo Singer
+  * M S R Dinesh  *
+  * Manodeep Sinha  *
+  * Marten van Kerkwijk
+  * Max Voronkov  *
+  * Maximilian Nöthe
+  * Michael Lindner-D'Addario  *
+  * Miguel de Val-Borro
+  * Mihai Cara
+  * Nadia Dencheva
+  * Nathanial Hendler  *
+  * Neal McBurnett  *
+  * Nicholas Earl  *
+  * Nick Lloyd  *
+  * Nick Murphy
+  * Perry Greenfield
+  * Peter Cock  *
+  * Pey Lian Lim
+  * Ricky O'Steen  *
+  * Robel Geda  *
+  * Shivansh Mishra  *
+  * Shreyas Bapat
+  * Simon Conseil
+  * Stuart Littlefair
+  * Stuart Mumford
+  * Thomas Robitaille
+  * Tim Jenness
+  * Tom Aldcroft
+  * Tom Donaldson
+  * Zlatan Vasović  *
+
+Where a * indicates their first contribution to the core astropy package.

--- a/docs/whatsnew/4.1.rst
+++ b/docs/whatsnew/4.1.rst
@@ -12,34 +12,32 @@ the 4.0.x series of releases.
 
 In particular, this release includes:
 
-1. Added support for the ``-TAB`` convention in FITS WCS
+* :ref:`whatsnew-4.1-spectralcoord`
+* :ref:`whatsnew-4.1-fitsdask`
+* :ref:`whatsnew-4.1-teme`
+* :ref:`whatsnew-4.1-inplace-skycoord`
+* :ref:`whatsnew-4.1-coordinate-equality`
+* :ref:`whatsnew-4.1-skycoord-stack`
+* :ref:`whatsnew-4.1-table-skycoord-crossmatch`
+* :ref:`whatsnew-4.1-table-custom-attr`
+* :ref:`whatsnew-4.1-time-unix-tai`
+* :ref:`whatsnew-4.1-fits-wcs-tab`
+* :ref:`whatsnew-4.1-replace-submodels`
+* :ref:`whatsnew-4.1-models-units`
+* :ref:`whatsnew-4.1-models-serialization`
 
-2. Support for in-place setting of array-valued ``SkyCoord`` and coordinate
-   frame objects using standard numpy syntax like ``sc1[10:15] == sc2``.
+In addition to these major changes, Astropy v4.0 includes a large number of
+smaller improvements and bug fixes, which are described in the
+:ref:`changelog`. By the numbers:
 
-3. Change in the definition of equality comparison for coordinate classes.
+* ... issues have been closed since v4.0
+* ... pull requests have been merged since v4.0
+* ... distinct people have contributed code, .. of which are first time contributors to Astropy
 
-4. Support use of ``SkyCoord`` in table ``vstack``, ``dstack``, and
-   ``insert_row``.
+.. _whatsnew-4.1-spectralcoord:
 
-5. Support for table "fuzzy" cross-match join with ``SkyCoord``, ``Quantity``
-   or N-d columns.
-
-6. Support for custom attributes in ``Table`` subclasses.
-
-7. Added a new ``Time`` subformat ``unix_tai`` which is analogous to standard
-   ``unix`` time but includes leap-seconds.
-
-8. All models are now serializable to ASDF.
-   Model constraints of type ``fixed``and ``bounds`` are serialized as well.
-
-9. Support for replacing submodels in ``CompoundModel``.
-
-10. Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
-
-
-New ``SpectralCoord`` class for representing and transforming spectral quantities
-=================================================================================
+A new ``SpectralCoord`` class for representing and transforming spectral quantities
+===================================================================================
 
 The :ref:`astropy-coordinates` sub-package now includes a new :class:`~astropy.coordinates.SpectralCoord`
 class which can be used to represent spectral coordinates, and transform between
@@ -93,6 +91,8 @@ or to the rest frame of the target::
 
 For more information and examples, see :ref:`astropy-spectralcoord`.
 
+.. _whatsnew-4.1-fitsdask:
+
 Support for writing Dask arrays to FITS files
 =============================================
 
@@ -109,6 +109,8 @@ written, which will avoid using excessive memory:
     >>> hdu = fits.PrimaryHDU(data=array)
     >>> hdu.writeto('test_dask.fits', overwrite=True)
 
+.. _whatsnew-4.1-teme:
+
 Added True Equator Mean Equinox (TEME) frame for satellite two-line ephemeris data
 ==================================================================================
 
@@ -116,6 +118,8 @@ The True Equator Mean Equinox (`~astropy.coordinates.TEME`) frame has been added
 the built-in frames within :ref:`astropy.coordinates <astropy-coordinates>`.
 
 For more details, see :ref:`astropy-coordinates-satellites`.
+
+.. _whatsnew-4.1-inplace-skycoord:
 
 Support for in-place setting of array-valued ``SkyCoord`` and frame objects
 ===========================================================================
@@ -131,6 +135,8 @@ in-place using the standard syntax for setting elements of a numpy array::
       [(10., 20.), ( 2.,  4.)]>
 
 For more details, see :ref:`astropy-coordinates-modifying-in-place`.
+
+.. _whatsnew-4.1-coordinate-equality:
 
 Change in the definition of equality comparison for coordinate classes
 ======================================================================
@@ -153,6 +159,8 @@ between the coordinates is below a specified angular distance.
 
 For details see: :ref:`coordinates-skycoord-comparing`.
 
+.. _whatsnew-4.1-skycoord-stack:
+
 Support use of ``SkyCoord`` in table ``vstack``, ``dstack``, and ``insert_row``
 ===============================================================================
 
@@ -160,6 +168,8 @@ Support use of ``SkyCoord`` in table ``vstack``, ``dstack``, and ``insert_row``
 ``dstack``, and ``insert_row`` (as long as they do not result in missing
 values). This new functionality is a direct outcome of the new support for
 setting ``SkyCoord`` items in-place.
+
+.. _whatsnew-4.1-table-skycoord-crossmatch:
 
 Support for table cross-match join with ``SkyCoord`` or N-d columns
 ===================================================================
@@ -184,6 +194,8 @@ on words that are sufficiently similar.
 
 For detais see :ref:`astropy-table-join-functions`.
 
+.. _whatsnew-4.1-table-custom-attr:
+
 Support for custom attributes in ``Table`` subclasses
 =====================================================
 
@@ -194,6 +206,8 @@ FITS or ECSV.  In astropy 4.1 there is now an included mechanism to add custom
 attributes which are persistent through all those normal operations.
 
 For details see :ref:`table-custom-attributes`.
+
+.. _whatsnew-4.1-time-unix-tai:
 
 Added a new ``Time`` subformat ``unix_tai``
 ===========================================
@@ -209,6 +223,8 @@ There were 8.0 leap seconds in place at that time.
 
 For details see: `~astropy.time.TimeUnixTai`.
 
+.. _whatsnew-4.1-fits-wcs-tab:
+
 Added support for the ``-TAB`` convention in FITS WCS
 =====================================================
 
@@ -216,6 +232,8 @@ Added support for the ``-TAB`` convention in FITS WCS
 convention as described in ``WCS Paper III``,
 Greisen, E. W., Calabretta, M. R., Valdes, F. G., and Allen, S. L., Astronomy & Astrophysics, 446, 747-771, 2006.
 Currently there is no support for programmatically constructing such WCSs.
+
+.. _whatsnew-4.1-replace-submodels:
 
 Support for replacing submodels in ``CompoundModel``
 ====================================================
@@ -233,6 +251,8 @@ and outputs must match. The model to be replaced is identified by its name::
     >>> model_subst = models.Shift(1) & models.Shift(2)
     >>> new_model = model.replace_submodel("Rotate_and_Project", model_subst | m2)
 
+.. _whatsnew-4.1-models-units:
+
 Support for units on otherwise unitless models via the ``Model.coerce_units`` method.
 =====================================================================================
 
@@ -246,8 +266,26 @@ instances and returning a compound model.
     >>> p_with_units(2 * u.m)
     <Quantity 1. s>
 
+.. _whatsnew-4.1-models-serialization:
+
 Support for ASDF serialization of models
 ========================================
 
 All models (excluding model sets) can be written to an ASDF file. Constraints
-of type ``fixed`` and ``bounds`` can also be serialized::
+of type ``fixed`` and ``bounds`` can also be serialized.
+
+Full change log
+===============
+
+To see a detailed list of all changes in version v4.1, including changes in
+API, please see the :ref:`changelog`.
+
+
+Contributors to the v4.0 release
+================================
+
+.. hlist::
+  :columns: 4
+
+  * ...
+  * ...


### PR DESCRIPTION
I've added a table of contents to the what's new, and updated contributor information