### PR TITLE
Astrometric versions of coordinate frames

### DIFF
--- a/astropy/coordinates/builtin_frames/__init__.py
+++ b/astropy/coordinates/builtin_frames/__init__.py
@@ -39,6 +39,7 @@ from .hcrs import HCRS
 from .teme import TEME
 from .ecliptic import *  # there are a lot of these so we don't list them all explicitly
 from .skyoffset import SkyOffsetFrame
+from .astrometric import AstrometricFrame
 # need to import transformations so that they get registered in the graph
 from . import icrs_fk5_transforms
 from . import fk4_fk5_transforms
@@ -65,6 +66,7 @@ __all__ = ['ICRS', 'FK5', 'FK4', 'FK4NoETerms', 'Galactic', 'Galactocentric',
            'GeocentricTrueEcliptic', 'BarycentricTrueEcliptic',
            'HeliocentricTrueEcliptic',
            'SkyOffsetFrame', 'GalacticLSR', 'LSR', 'LSRK', 'LSRD',
+           'AstrometricFrame',
            'BaseEclipticFrame', 'BaseRADecFrame', 'make_transform_graph_docs',
            'HeliocentricEclipticIAU76', 'CustomBarycentricEcliptic']
 

--- a/astropy/coordinates/builtin_frames/astrometric.py
+++ b/astropy/coordinates/builtin_frames/astrometric.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+from astropy import coordinates
+from astropy import log
+from astropy import units as u
+from astropy.constants import c as speed_of_light
+from astropy.coordinates.transformations import FunctionTransform
+from astropy.coordinates.baseframe import (frame_transform_graph,
+                                           BaseCoordinateFrame)
+from astropy.coordinates.attributes import CoordinateAttribute, TimeAttribute
+
+from .icrs import ICRS
+from .utils import DEFAULT_OBSTIME
+
+_astrometric_cache = {}
+
+
+def make_astrometric_cls(framecls):
+    """
+    Create a new class that is the astrometric frame for a specific class of
+    origin frame. If such a class has already been created for this frame, the
+    same class will be returned.
+
+    Parameters
+    ----------
+    framecls : coordinate frame class (i.e., subclass of `~astropy.coordinates.BaseCoordinateFrame`)
+        The class to create the AstrometricFrame of.
+
+    Returns
+    -------
+    astrometricframecls : class
+        The class for the new astrometric frame.
+
+    Notes
+    -----
+    This function is necessary because Astropy's frame transformations depend
+    on connection between specific frame *classes*.  So each type of frame
+    needs its own distinct astrometric frame class.  This function generates
+    just that class, as well as ensuring that only one example of such a class
+    actually gets created in any given python session.
+    """
+
+    if framecls in _astrometric_cache:
+        return _astrometric_cache[framecls]
+
+    # the class of a class object is the metaclass
+    framemeta = framecls.__class__
+
+    class AstrometricMeta(framemeta):
+        """
+        This metaclass renames the class to be "Astrometric<framecls>".
+        """
+
+        def __new__(cls, name, bases, members):
+            # Define the frame attributes that are not copied from `origin`
+            members['origin'] = CoordinateAttribute(frame=framecls, default=None)
+            if 'obstime' not in framecls.get_frame_attr_names():
+                members['obstime'] = TimeAttribute(default=DEFAULT_OBSTIME)
+            members['ref_epoch'] = TimeAttribute(default=DEFAULT_OBSTIME)
+
+            # This has to be done because FrameMeta will set these attributes
+            # to the defaults from BaseCoordinateFrame when it creates the base
+            # AstrometricFrame class initially.
+            members['_default_representation'] = framecls._default_representation
+            members['_default_differential'] = framecls._default_differential
+
+            members['_frame_specific_representation_info'] = framecls._frame_specific_representation_info
+
+            newname = name[:-5] if name.endswith('Frame') else name
+            newname += framecls.__name__
+
+            return super().__new__(cls, newname, bases, members)
+
+    # We need this to handle the intermediate metaclass correctly, otherwise we could
+    # just subclass AstrometricFrame.
+    _AstrometricFramecls = AstrometricMeta('AstrometricFrame',
+                                           (AstrometricFrame, framecls),
+                                           {'__doc__': AstrometricFrame.__doc__})
+
+    @frame_transform_graph.transform(FunctionTransform, _AstrometricFramecls, _AstrometricFramecls)
+    def astrometric_to_astrometric(from_astrometric_coord, to_astrometric_frame):
+        """Transform between two astrometric frames."""
+
+        # This transform goes through the parent frames on each side.
+        # from_frame -> from_frame.origin -> to_frame.origin -> to_frame
+        intermediate_from = from_astrometric_coord.transform_to(from_astrometric_coord.origin)
+        intermediate_to = intermediate_from.transform_to(to_astrometric_frame.origin)
+        return intermediate_to.transform_to(to_astrometric_frame)
+
+    @frame_transform_graph.transform(FunctionTransform, framecls, _AstrometricFramecls)
+    def reference_to_astrometric(reference_coord, astrometric_frame):
+        """Add motion to the reference coordinate."""
+        reference_coord = reference_coord.transform_to(astrometric_frame.origin)
+        icrs_coord = reference_coord.transform_to(ICRS)
+
+        posvel = icrs_coord.cartesian
+        if 's' in posvel.differentials:
+            distance = posvel.norm()
+            if np.all(distance < astrometric_frame._distance_threshold):  # solar-system body
+                pos = posvel.without_differentials()
+                vel = posvel.differentials['s'].to_cartesian()
+
+                # The light travel time (dt) for a body in linear motion satisfies the equation:
+                #   norm(D - V * dt) = c * dt
+                # where D is the observer-body vector, V is the body velocity vector,
+                # and c is the speed of light.  This turns into a quadratic equation in dt, and
+                # only the positive solution is valid:
+                #   dt = (sqrt((D dot V)^2 + (D dot D) * c2_V2) - D dot V) / c2_V2
+                # where c2_V2 = c^2 - V dot V
+                D = pos - astrometric_frame._observer_icrs_cartesian
+                c2_V2 = speed_of_light ** 2 - vel.dot(vel)
+                DdotV = D.dot(vel)
+                dt = (np.sqrt(DdotV ** 2 + D.dot(D) * c2_V2) - DdotV) / c2_V2
+                log.debug(f"Retarding for {dt.to(u.s)} of light travel time")
+
+                pos -= vel * dt
+                posvel = pos.with_differentials(posvel.differentials)
+                icrs_coord = ICRS(posvel)
+            elif np.all(distance >= astrometric_frame._distance_threshold):  # cosmic object
+                dt = (astrometric_frame.obstime - astrometric_frame.ref_epoch).to(u.yr)
+                log.debug(f"Propagating forward by {dt} after {astrometric_frame.ref_epoch}")
+                icrs_coord = coordinates.SkyCoord(icrs_coord).apply_space_motion(dt=dt).frame
+            else:  # a mix
+                raise ConvertError("The transformation cannot handle a mix of solar-system bodies "
+                                   "and cosmic objects.")
+
+        reference_coord = icrs_coord.transform_to(reference_coord)
+        return astrometric_frame.realize_frame(reference_coord.data)
+
+    @frame_transform_graph.transform(FunctionTransform, _AstrometricFramecls, framecls)
+    def astrometric_to_reference(astrometric_coord, reference_frame):
+        """Remove motion from the astrometric coordinate."""
+
+        base_coord = astrometric_coord.as_base()
+        icrs_coord = base_coord.transform_to(ICRS)
+
+        posvel = icrs_coord.cartesian
+        if 's' in posvel.differentials:
+            distance = posvel.norm()
+            if np.all(distance < astrometric_coord._distance_threshold):  # solar-system body
+                pos = posvel.without_differentials()
+
+                # The light travel time is straightforward to compute for an astrometric location
+                dt = (pos - astrometric_coord._observer_icrs_cartesian).norm() / speed_of_light
+                log.debug(f"Advancing for {dt.to(u.s)} of light travel time")
+
+                pos += posvel.differentials['s'] * dt
+                posvel = pos.with_differentials(posvel.differentials)
+                icrs_coord = ICRS(posvel)
+            elif np.all(distance >= astrometric_coord._distance_threshold):  # cosmic object
+                dt = (astrometric_coord.obstime - astrometric_coord.ref_epoch).to(u.yr)
+                log.debug(f"Propagating backward by {dt} before {astrometric_coord.ref_epoch}")
+                icrs_coord = coordinates.SkyCoord(icrs_coord).apply_space_motion(dt=-dt).frame
+            else:  # a mix
+                raise ConvertError("The transformation cannot handle a mix of solar-system bodies "
+                                   "and cosmic objects.")
+
+        base_coord = icrs_coord.transform_to(base_coord)
+        return base_coord.transform_to(reference_frame)
+
+    _astrometric_cache[framecls] = _AstrometricFramecls
+    return _AstrometricFramecls
+
+
+class AstrometricFrame(BaseCoordinateFrame):
+    """
+    An astrometric version of a base coordinate frame, relative to a specified
+    observer location.
+
+    .. note::
+
+        For more on astrometric frames, see
+        :ref:`astropy-coordinates-astrometricframe`.
+
+    The astrometric location of a body is the location of the body as measured
+    by an observer, which depends on the motion of that body:
+
+    * For a body in the solar system, its coordinate normally represents the
+      instantaneous location of that body.  However, due to the finite speed of
+      light, the light that reaches an observer at a certain observation time
+      was emitted at an earlier time.  If the body is moving, then the observer
+      will measure the body to be where it was at that earlier time.  This
+      effect is also known as "planetary aberration".
+
+    * For a cosmic object, its coordinate normally represents its catalog
+      location at a reference epoch (e.g., J2000.0).  If the body is moving
+      (i.e., has non-zero "proper motion" and/or "radial velocity"), its
+      measured location will evolve over time.  In this case, light travel time
+      is already included in the catalog location.
+
+    .. warning::
+        The astrometric calculation assumes that the body is moving in a
+        straight line with its specified velocity.  The accuracy of this
+        assumption depends on the body's true motion during the time it takes
+        for light to travel the observer-body distance (for solar-system
+        bodies) or the time since the reference epoch (for cosmic objects).
+
+    Parameters
+    ----------
+    representation : `~astropy.coordinates.BaseRepresentation` or None
+        A representation object or ``None`` to have no data.  Alternatively,
+        use coordinate component keyword arguments, which depend on the base
+        coordinate frame.
+    origin : `~astropy.coordinates.SkyCoord` or low-level coordinate object.
+        The coordinate which specifies both the base coordinate frame and the
+        3D location of the observer.
+    ref_epoch : `~astropy.time.Time`
+        The reference epoch for the location of cosmic objects.  Defaults to
+        J2000.0.
+    obstime : `~astropy.time.Time`
+        The observation time to use when the base coordinate frame does not
+        have such a frame attribute (e.g., `~astropy.coordinates.ICRS`).
+        Defaults to J2000.0
+
+    Notes
+    -----
+    The astrometric calculation distinguishes between bodies in the solar
+    system and cosmic objects by the distance from the solar-system barycenter
+    (SSB).  The coordinates of bodies less than 1 light-year from the SSB are
+    treated as instantaneous locations.  The coordinates of bodies greater than
+    1 light-year from the SSB are treated as locations at the reference epoch.
+
+    As these are "astrometric" coordinates rather than "apparent" coordinates,
+    effects such as stellar aberration and gravitational deflection are not
+    included, at least not explicitly.  Such effects may be implicitly
+    included if they are accounted for in the base coordinate frame.
+
+    ``AstrometricFrame`` is a factory class.  That is, the objects that it
+    yields are *not* actually objects of class ``AstrometricFrame``.  Instead,
+    distinct classes are created on-the-fly for whatever the frame class is
+    of ``origin``.
+    """
+    # The distance threshold used to distinguish between solar-system bodies and cosmic objects
+    _distance_threshold = 1*u.lyr
+
+    def __new__(cls, *args, **kwargs):
+        # We don't want to call this method if we've already set up
+        # an astrometric frame for this class.
+        if not (issubclass(cls, AstrometricFrame) and cls is not AstrometricFrame):
+            # We get the origin argument, and handle it here.
+            origin_frame = kwargs.get('origin', None)
+            if origin_frame is None:
+                raise TypeError("Can't initialize an AstrometricFrame without origin= keyword.")
+            if hasattr(origin_frame, 'frame'):
+                origin_frame = origin_frame.frame
+            newcls = make_astrometric_cls(origin_frame.__class__)
+            return newcls.__new__(newcls, *args, **kwargs)
+
+        # http://stackoverflow.com/questions/19277399/why-does-object-new-work-differently-in-these-three-cases
+        # See above for why this is necessary. Basically, because some child
+        # may override __new__, we must override it here to never pass
+        # arguments to the object.__new__ method.
+        if super().__new__ is object.__new__:
+            return super().__new__(cls)
+        return super().__new__(cls, *args, **kwargs)
+
+    def _frame_attrs_repr(self):
+        # Overrides BaseCoordinateFrame._frame_attrs_repr() to hide the copied frame attributes
+        attr_names = self.get_frame_attr_names()
+        for attribute_name in self.origin.get_frame_attr_names():
+            del attr_names[attribute_name]
+
+        attr_strs = []
+        for attribute_name in attr_names:
+            attr = getattr(self, attribute_name)
+            if hasattr(attr, "_astropy_repr_in_frame"):
+                attrstr = attr._astropy_repr_in_frame()
+            else:
+                attrstr = str(attr)
+            attr_strs.append(f"{attribute_name}={attrstr}")
+
+        return ', '.join(attr_strs)
+
+    def __setattr__(self, attr, value):
+        if attr == "_origin":
+            if not value.has_data:
+                raise ValueError('The origin supplied to AstrometricFrame has no data.')
+
+            if value.data.norm().unit is u.one:
+                raise ValueError("The data for `origin` must have distance units.")
+
+            # Pre-compute the Cartesian representation of the observer location in ICRS
+            self._observer_icrs_cartesian = value.transform_to(ICRS).cartesian
+
+            # Copy out all frame attributes from the `origin` frame attribute
+            for attr2 in value.get_frame_attr_names():
+                super().__setattr__("_" + attr2, getattr(value, attr2))
+
+        super().__setattr__(attr, value)
+
+    def as_base(self):
+        """
+        Returns a coordinate with the current representation and in the base
+        coordinate frame.
+
+        This method can be thought of as "removing" the
+        `~astropy.coordinates.AstrometricFrame` layer.  Be aware that this
+        method is not merely a coordinate transformation, because this method
+        changes the location in inertial space that is being pointed to.
+        """
+        return self.origin.realize_frame(self.data)

--- a/docs/coordinates/astrometricframe.rst
+++ b/docs/coordinates/astrometricframe.rst
@@ -1,0 +1,209 @@
+.. include:: references.txt
+
+.. |AstrometricFrame| replace:: `~astropy.coordinates.AstrometricFrame`
+.. |ICRS| replace:: `~astropy.coordinates.ICRS`
+.. |HCRS| replace:: `~astropy.coordinates.HCRS`
+
+.. _astropy-coordinates-astrometricframe:
+
+Astrometric Versions of Coordinate Frames
+*****************************************
+
+|AstrometricFrame| creates an astrometric version of a base coordinate frame,
+relative to a specified observer location.
+The astrometric location of a body is the location of the body as measured
+by an observer, which depends on the motion of that body:
+
+* For a body in the solar system, its coordinate normally represents the
+  instantaneous location of that body.  However, due to the finite speed of
+  light, the light that reaches an observer at a certain observation time
+  was emitted at an earlier time.  If the body is moving, then the observer
+  will measure the body to be where it was at that earlier time.  This
+  effect is also known as "planetary aberration".
+* For a cosmic object, its coordinate normally represents its catalog
+  location at a reference epoch (e.g., J2000.0).  If the body is moving
+  (i.e., has non-zero "proper motion" and/or "radial velocity"), its
+  measured location will evolve over time.  In this case, light travel time
+  is already included in the catalog location.
+
+.. warning::
+
+    The astrometric calculation assumes that the body is moving in a
+    straight line with its specified velocity.  The accuracy of this
+    assumption depends on the body's true motion during the time it takes
+    for light to travel the observer-body distance (for solar-system
+    bodies) or the time since the reference epoch (for cosmic objects).
+
+The astrometric calculation distinguishes between bodies in the solar
+system and cosmic objects by the distance from the solar-system barycenter
+(SSB).  The coordinates of bodies less than 1 light-year from the SSB are
+treated as instantaneous locations.  The coordinates of bodies greater than
+1 light-year from the SSB are treated as locations at the reference epoch.
+
+As these are "astrometric" coordinates rather than "apparent" coordinates,
+effects such as stellar aberration and gravitational deflection are not
+included, at least not explicitly.  Such effects may be implicitly
+included if they are accounted for in the base coordinate frame.
+
+Solar-system bodies
+===================
+
+Example using the Venus transit
+-------------------------------
+
+During the Venus transit of the Sun as seen from Earth.
+Instantaneous position/velocity of Venus.
+Use a JPL ephemeris for accuracy::
+
+    >>> from astropy.coordinates import (SkyCoord, solar_system_ephemeris,
+    ...                                  get_body_barycentric_posvel,
+    ...                                  CartesianDifferential)
+    >>> import astropy.units as u
+    >>> earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
+    ...                  frame='gcrs', obstime='2012-06-06 04:07:29')
+    >>> solar_system_ephemeris.set('de432s')  # doctest: +REMOTE_DATA
+    <ScienceState solar_system_ephemeris: 'de432s'>
+    >>> venus_pos, venus_vel = get_body_barycentric_posvel('venus',
+    ...                                                    earth.obstime)
+    >>> venus_vel = venus_vel.represent_as(CartesianDifferential)
+    >>> venus = SkyCoord(venus_pos.with_differentials(venus_vel),
+    ...                  frame='icrs')
+    >>> venus = venus.transform_to(earth)
+    >>> venus  # doctest: +REMOTE_DATA
+    <SkyCoord (GCRS: obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, km)
+        (74.22533319, 22.7724864, 43190032.91493926)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (-7.87423767e+08, -4.03196311e+08, 0.09882208)>
+
+Using |AstrometricFrame|::
+
+    >>> from astropy.coordinates import AstrometricFrame
+    >>> ast_gcrs = AstrometricFrame(origin=earth)
+    >>> ast_gcrs
+    <AstrometricGCRS Frame (origin=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
+        (0., 0., 0.)>, ref_epoch=J2000.000)>
+
+    >>> venus_ast = venus.transform_to(ast_gcrs)
+    >>> venus_ast  # doctest: +REMOTE_DATA
+    <SkyCoord (AstrometricGCRS: origin=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
+        (0., 0., 0.)>, ref_epoch=J2000.000): (ra, dec, distance) in (deg, deg, km)
+        (74.23245792, 22.77361214, 43190037.9814361)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (-7.87503393e+08, -4.03424187e+08, 0.09816952)>
+
+Transforming to a non-astrometric frame will "undo" the astrometric calculation.
+Convert to a real coordinate using :meth:`~astropy.coordinates.AstrometricFrame.as_base`::
+
+    >>> venus_ast_real = SkyCoord(venus_ast.as_base())
+    >>> venus_ast_real  # doctest: +REMOTE_DATA
+    <SkyCoord (GCRS: obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, km)
+        (74.23245792, 22.77361214, 43190037.9814361)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (-7.87503393e+08, -4.03424187e+08, 0.09816952)>
+
+Compare against :func:`~astropy.coordinates.get_body`::
+
+    >>> from astropy.coordinates import get_body
+    >>> venus_gb = get_body('venus', earth.obstime)
+    >>> venus_gb  # doctest: +REMOTE_DATA
+    <SkyCoord (GCRS: obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, km)
+        (74.23245792, 22.77361214, 43190038.0981755)>
+
+Discrepancies are small::
+
+    >>> venus_gb.separation(venus_ast_real).to('mas')  # doctest: +REMOTE_DATA
+    <Angle 0.00325284 mas>
+    >>> venus_gb.separation_3d(venus_ast_real).to('km')  # doctest: +REMOTE_DATA
+    <Distance 0.11674138 km>
+
+Size of errors for planets
+--------------------------
+
+For an observer at Earth, these are the astrometric errors due to the linear-motion approximation:
+
+======= ===================== =================== ===================
+Planet  Light travel time (s) Angular error (mas) Position error (km)
+======= ===================== =================== ===================
+Mercury 300--700              <11                 <14
+Venus   150--900              <2.0                <4.3
+Mars    300--1200             <0.6                <2.2
+Jupiter 2000--3200            <0.05               <1.1
+Saturn  4200--5300            <0.02               <1.0
+Uranus  9500--10500           <0.01               <0.9
+Neptune 14000--15000          <0.01               <0.9
+======= ===================== =================== ===================
+
+Cosmic objects
+==============
+
+Consider a star with a high proper motion.
+The reference epoch will be J2010.0, but we supply that later::
+
+    >>> from astropy.coordinates import ICRS
+    >>> star_ref = ICRS(ra=10*u.deg, dec=45*u.deg, distance=10*u.pc,
+    ...                 pm_ra_cosdec=10*u.arcsec/u.yr, pm_dec=-20*u.arcsec/u.yr,
+    ...                 radial_velocity=100*u.km/u.s)
+    >>> star_ref
+    <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
+        (10., 45., 10.)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (10000., -20000., 100.)>
+
+Create the |AstrometricFrame| version of |ICRS|.
+For cosmic objects, the observer location does not matter.
+Specify ``obstime`` separately because |ICRS| does not have that frame attribute.
+Specify the reference epoch::
+
+    >>> ast_icrs = AstrometricFrame(origin=ICRS(0*u.deg, 0*u.deg, 0*u.AU),
+    ...                             obstime=earth.obstime, ref_epoch='J2010')
+    >>> ast_icrs
+    <AstrometricICRS Frame (origin=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
+        (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000)>
+
+    >>> star_ref.transform_to(ast_icrs)
+    <AstrometricICRS Coordinate (origin=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
+        (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000): (ra, dec, distance) in (deg, deg, pc)
+        (10.00953932, 44.98650579, 10.00024406)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (9997.14835121, -20000.18211581, 100.27901197)>
+
+|AstrometricFrame| calls :meth:`~astropy.coordinates.SkyCoord.apply_space_motion` internally, so using that method will give the same answer (see :ref:`astropy-coordinates-apply-space-motion` for usage)::
+
+    >>> star_ref_sc = SkyCoord(star_ref, obstime=ast_icrs.ref_epoch)
+    >>> star_ref_sc.apply_space_motion(new_obstime=ast_icrs.obstime)
+    <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, pc)
+        (10.00953932, 44.98650579, 10.00024406)
+     (pm_ra, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (14134.77417664, -20000.18211581, 100.27901197)>
+
+The astrometric frame can be based on any coordinate frame, not just |ICRS|.
+Use the same Earth observer and observation time as earlier, but now with |HCRS| as the base coordinate frame::
+
+    >>> ast_hcrs = AstrometricFrame(origin=earth.hcrs, ref_epoch='J2010')
+    >>> ast_hcrs  # doctest: +REMOTE_DATA
+    <AstrometricHCRS Frame (origin=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
+        (254.4656737, -22.66944306, 1.01475669)>, ref_epoch=J2010.000)>
+
+Need to change the finite-difference time step for the |HCRS| to |HCRS| transformation::
+
+    >>> from astropy.coordinates import HCRS, frame_transform_graph
+    >>> hcrs_to_hcrs = frame_transform_graph.get_transform(HCRS, HCRS).transforms[0]
+    >>> hcrs_to_hcrs.finite_difference_dt = 1*u.yr
+
+Perform the astrometric transformation::
+
+    >>> star_ref.transform_to(ast_hcrs)  # doctest: +REMOTE_DATA
+    <AstrometricHCRS Coordinate (origin=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
+        (254.4656737, -22.66944306, 1.01475669)>, ref_epoch=J2010.000): (ra, dec, distance) in (deg, deg, pc)
+        (10.00953937, 44.98650575, 10.00024407)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (9997.28930526, -20000.02695705, 100.27513164)>
+
+Again, check that :meth:`~astropy.coordinates.SkyCoord.apply_space_motion` gives the same answer::
+
+    >>> star_ref_sc = SkyCoord(star_ref, obstime=ast_hcrs.ref_epoch)
+    >>> star_ref_sc.apply_space_motion(new_obstime=ast_hcrs.obstime).hcrs  # doctest: +REMOTE_DATA
+    <SkyCoord (HCRS: obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, pc)
+        (10.00953937, 44.98650575, 10.00024407)
+     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
+        (9997.28930526, -20000.02695707, 100.27513164)>

--- a/docs/coordinates/astrometricframe.rst
+++ b/docs/coordinates/astrometricframe.rst
@@ -78,14 +78,14 @@ Use a JPL ephemeris for accuracy::
 Using |AstrometricFrame|::
 
     >>> from astropy.coordinates import AstrometricFrame
-    >>> ast_gcrs = AstrometricFrame(origin=earth)
+    >>> ast_gcrs = AstrometricFrame(observer=earth)
     >>> ast_gcrs
-    <AstrometricGCRS Frame (origin=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
+    <AstrometricGCRS Frame (observer=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
         (0., 0., 0.)>, ref_epoch=J2000.000)>
 
     >>> venus_ast = venus.transform_to(ast_gcrs)
     >>> venus_ast  # doctest: +REMOTE_DATA
-    <SkyCoord (AstrometricGCRS: origin=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
+    <SkyCoord (AstrometricGCRS: observer=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
         (0., 0., 0.)>, ref_epoch=J2000.000): (ra, dec, distance) in (deg, deg, km)
         (74.23245792, 22.77361214, 43190037.9814361)
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
@@ -154,14 +154,14 @@ For cosmic objects, the observer location does not matter.
 Specify ``obstime`` separately because |ICRS| does not have that frame attribute.
 Specify the reference epoch::
 
-    >>> ast_icrs = AstrometricFrame(origin=ICRS(0*u.deg, 0*u.deg, 0*u.AU),
+    >>> ast_icrs = AstrometricFrame(observer=ICRS(0*u.deg, 0*u.deg, 0*u.AU),
     ...                             obstime=earth.obstime, ref_epoch='J2010')
     >>> ast_icrs
-    <AstrometricICRS Frame (origin=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
+    <AstrometricICRS Frame (observer=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
         (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000)>
 
     >>> star_ref.transform_to(ast_icrs)
-    <AstrometricICRS Coordinate (origin=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
+    <AstrometricICRS Coordinate (observer=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
         (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000): (ra, dec, distance) in (deg, deg, pc)
         (10.00953932, 44.98650579, 10.00024406)
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
@@ -179,9 +179,9 @@ Specify the reference epoch::
 The astrometric frame can be based on any coordinate frame, not just |ICRS|.
 Use the same Earth observer and observation time as earlier, but now with |HCRS| as the base coordinate frame::
 
-    >>> ast_hcrs = AstrometricFrame(origin=earth.hcrs, ref_epoch='J2010')
+    >>> ast_hcrs = AstrometricFrame(observer=earth.hcrs, ref_epoch='J2010')
     >>> ast_hcrs  # doctest: +REMOTE_DATA
-    <AstrometricHCRS Frame (origin=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
+    <AstrometricHCRS Frame (observer=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
         (254.4656737, -22.66944306, 1.01475669)>, ref_epoch=J2010.000)>
 
 Need to change the finite-difference time step for the |HCRS| to |HCRS| transformation::
@@ -193,7 +193,7 @@ Need to change the finite-difference time step for the |HCRS| to |HCRS| transfor
 Perform the astrometric transformation::
 
     >>> star_ref.transform_to(ast_hcrs)  # doctest: +REMOTE_DATA
-    <AstrometricHCRS Coordinate (origin=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
+    <AstrometricHCRS Coordinate (observer=<HCRS Coordinate (obstime=2012-06-06 04:07:29.000): (ra, dec, distance) in (deg, deg, AU)
         (254.4656737, -22.66944306, 1.01475669)>, ref_epoch=J2010.000): (ra, dec, distance) in (deg, deg, pc)
         (10.00953937, 44.98650575, 10.00024407)
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)

--- a/docs/coordinates/index.rst
+++ b/docs/coordinates/index.rst
@@ -467,6 +467,7 @@ listed below.
    remote_methods
    definitions
    inplace
+   astrometricframe
 
 
 In addition, another resource for the capabilities of this package is the


### PR DESCRIPTION
This PR was inspired by discussions in #10230.  Ping @mhvk @mkbrewer @astrojuanlu 

This PR introduces `AstrometricFrame` for creating an astrometric version of a coordinate frame, relative to a specified observer location.  (It does so in a similar manner to `SkyOffsetFrame`.)  These astrometric frames integrate astrometric calculations directly into the transformation framework.
- For solar-system bodies, the coordinate is propagated backwards in time *assuming linear motion* to account for light travel time (i.e., "planetary aberration").  The documentation includes [a table showing the size of errors](https://68880-2081289-gh.circle-artifacts.com/0/docs/_build/html/coordinates/astrometricframe.html#size-of-errors-for-planets) due to the assumption of linear motion.
- For cosmic objects, proper motion is added for the difference between the observation time and the specified reference epoch (basically a wrapper to `SkyCoord.apply_space_motion()`).

There's [a tutorial in the PR](https://68880-2081289-gh.circle-artifacts.com/0/docs/_build/html/coordinates/astrometricframe.html), and here are some excerpts:
### Venus
```python
    >>> earth = SkyCoord(0*u.deg, 0*u.deg, 0*u.AU,
    ...                  frame='gcrs', obstime='2012-06-06 04:07:29')
    >>> ast_gcrs = AstrometricFrame(observer=earth)
    >>> ast_gcrs
    <AstrometricGCRS Frame (observer=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
        (0., 0., 0.)>, ref_epoch=J2000.000)>

    >>> venus  # instantaneous position/velocity, not corrected for any light travel time
    <SkyCoord (GCRS: obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, km)
        (74.22533319, 22.7724864, 43190032.91493926)
     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
        (-7.87423767e+08, -4.03196311e+08, 0.09882208)>

    >>> venus_ast = venus.transform_to(ast_gcrs)
    >>> venus_ast
    <SkyCoord (AstrometricGCRS: observer=<GCRS Coordinate (obstime=2012-06-06 04:07:29.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (ra, dec, distance) in (deg, deg, AU)
        (0., 0., 0.)>, ref_epoch=J2000.000): (ra, dec, distance) in (deg, deg, km)
        (74.23245792, 22.77361214, 43190037.9814361)
     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
        (-7.87503393e+08, -4.03424187e+08, 0.09816952)>
```
### A star
```python
    >>> star_ref = ICRS(ra=10*u.deg, dec=45*u.deg, distance=100*u.pc,
    ...                 pm_ra_cosdec=10*u.arcsec/u.yr, pm_dec=-20*u.arcsec/u.yr,
    ...                 radial_velocity=100*u.km/u.s)
    >>> star_ref
    <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
        (10., 45., 100.)
     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
        (10000., -20000., 100.)>

    >>> ast_icrs = AstrometricFrame(observer=ICRS(0*u.deg, 0*u.deg, 0*u.AU),
    ...                             obstime=earth.obstime, ref_epoch='J2010')
    >>> ast_icrs
    <AstrometricICRS Frame (observer=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
        (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000)>

    >>> star_ref.transform_to(ast_icrs)
    <AstrometricICRS Coordinate (observer=<ICRS Coordinate: (ra, dec, distance) in (deg, deg, AU)
        (0., 0., 0.)>, obstime=2012-06-06 04:07:29.000, ref_epoch=J2010.000): (ra, dec, distance) in (deg, deg, pc)
        (10.00953953, 44.98650549, 99.99978632)
     (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
        (9997.59524072, -20001.07628946, 102.79019574)>
```

This PR needs tests and even more documentation, but it's more than ready for feedback.

