### PR TITLE
Fitting uncertainties on model / parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ astropy.io.votable
 
 astropy.modeling
 ^^^^^^^^^^^^^^^^
+- Added fitting uncertanties to models and parameters fit with LevMarLSQFitter and LinearLSQFitter. [#10375]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/modeling/parameters.py
+++ b/astropy/modeling/parameters.py
@@ -251,6 +251,8 @@ class Parameter(OrderedDescriptor):
         self._prior = None
         self._posterior = None
 
+        self._std = None
+
     def __len__(self):
         val = self.value
         if val.shape == ():
@@ -429,6 +431,18 @@ class Parameter(OrderedDescriptor):
         """The size of this parameter's value array."""
 
         return np.size(self.value)
+
+    @property
+    def std(self):
+        """Standard deviation, if available from fit."""
+
+        return self._std
+
+    @std.setter
+    def std(self, value):
+
+        self._std = value
+        return self._std
 
     @property
     def prior(self):


### PR DESCRIPTION
This adds attributes related to fitting uncertainties on Models and Parameters. I implemented it for LevMarLSQFitter to begin with, but if possible all fitters should set uncertainties on models and their parameters. 

-`model.cov_matrix` is the parameter covariance matrix, and is set by the fitter. 
-`model.stds` is an array that contains the uncertainties on the individual parameters, in the same order as `model.param_names` for all non-fixed parameters. These values are calculated from `model.cov_matrix`, and therefore will only be set if the covariance matrix is set by the fitter.
-If available, each individual `parameter` in the model has a `parameter.std` attribute.