### PR TITLE
Add optimize flag in `yacc.yacc` calls to allow importing `units` under `python -OO`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -223,7 +223,9 @@ astropy.wcs
 Other Changes and Additions
 ---------------------------
 
-- Nothing changed yet.
+- Added ``optimize=True`` flag to calls of ``yacc.yacc`` (as already done for
+  ``lex.lex``) to allow running in ``python -OO`` session without raising an
+  exception in ``astropy.units.format``. [#10379]
 
 
 

--- a/astropy/coordinates/angle_utilities.py
+++ b/astropy/coordinates/angle_utilities.py
@@ -313,7 +313,7 @@ class _AngleParser:
 
         parser = yacc.yacc(debug=False, tabmodule='angle_parsetab',
                            outputdir=os.path.dirname(__file__),
-                           write_tables=True)
+                           optimize=True, write_tables=True)
 
         if not parser_exists:
             cls._add_tab_header('angle_parsetab')

--- a/astropy/units/format/cds.py
+++ b/astropy/units/format/cds.py
@@ -279,7 +279,7 @@ class CDS(Base):
 
         parser = yacc.yacc(debug=False, tabmodule='cds_parsetab',
                            outputdir=os.path.dirname(__file__),
-                           write_tables=True)
+                           optimize=True, write_tables=True)
 
         if not parser_exists:
             cls._add_tab_header('cds_parsetab')

--- a/astropy/units/format/generic.py
+++ b/astropy/units/format/generic.py
@@ -446,7 +446,7 @@ class Generic(Base):
                                        'generic_parsetab.py'))
 
         parser = yacc.yacc(debug=False, tabmodule='generic_parsetab',
-                           outputdir=os.path.dirname(__file__))
+                           optimize=True, outputdir=os.path.dirname(__file__))
 
         if not parser_exists:
             cls._add_tab_header('generic_parsetab')

--- a/astropy/units/format/ogip.py
+++ b/astropy/units/format/ogip.py
@@ -365,7 +365,7 @@ class OGIP(generic.Generic):
 
         parser = yacc.yacc(debug=False, tabmodule='ogip_parsetab',
                            outputdir=os.path.dirname(__file__),
-                           write_tables=True)
+                           optimize=True, write_tables=True)
 
         if not parser_exists:
             cls._add_tab_header('ogip_parsetab')


### PR DESCRIPTION
Co-authored-by: Marten van Kerkwijk <mhvk@users.noreply.github.com>

### Description

Fixes #10361 – tested as described in https://github.com/astropy/astropy/issues/10361#issuecomment-630442090 and with `python setup.py -O2`.
Changed the call in `angle_utilities.py` as a cautionary measure, although I could not create a similar failure on importing `coordinates`.
No idea for a genuine test of the original issue, so I am putting this up as is for discussion.