### PR TITLE
Fix unwanted behavior of CompoundModel inverse from my PR#10176

### DIFF
--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -3356,8 +3356,7 @@ class CompoundModel(Model):
                     branch = getattr(branch, node)
                 setattr(branch, tree[-1], model)
                 model = CompoundModel(branch.op, branch.left, branch.right,
-                                      name=branch.name,
-                                      inverse=branch._user_inverse)
+                                      name=branch.name)
                 tree = tree[:-1]
             return model
 

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -701,9 +701,12 @@ def test_replace_submodel():
     S1 = Shift(1)
     S2 = Shift(2)
     S3 = Shift(3, name='S3')
-    S3.inverse = Shift(-2.9)
 
-    m = S1 & (S2 | S3)
+    S23 = S2 | S3
+    S23.inverse = Shift(-4.9)
+    m = S1 & S23
+
+    # This should delete the S23._user_inverse
     m2 = m.replace_submodel('S3', Shift(4))
     assert m2(1, 2) == (2, 8)
     assert m2.inverse(2, 8) == (1, 2)

--- a/astropy/modeling/tests/test_compound.py
+++ b/astropy/modeling/tests/test_compound.py
@@ -696,3 +696,14 @@ def test_replace_submodel():
     m2 = m.replace_submodel('poly', Polynomial1D(degree=1, c0=[1, 2],
                                                  n_models=2))
     assert_array_equal(m2([0, 1]), (2, 4))
+
+    # Ensure previous _user_inverse doesn't stick around
+    S1 = Shift(1)
+    S2 = Shift(2)
+    S3 = Shift(3, name='S3')
+    S3.inverse = Shift(-2.9)
+
+    m = S1 & (S2 | S3)
+    m2 = m.replace_submodel('S3', Shift(4))
+    assert m2(1, 2) == (2, 8)
+    assert m2.inverse(2, 8) == (1, 2)


### PR DESCRIPTION
### Description

This pull request is to address unwanted behaviour in the `CompoundModel.replace_submodel()` method regarding inverses. I had flagged this up in the original PR #10176 but hadn't fully appreciated the consequences.

Suppose I have a model
```
m = A & (B | C)
```
and `C` has a user inverse defined when `m` is created. This means that a user inverse is defined for the `CompoundModel` `(B | C)` when `m` in built. The behaviour in #10176 is to not change user inverses, but this means that if I replace `C` with `C2` then the inverse of `(B | C2)` remains as the inverse of `(B | C)`. I think this is unwanted, and new user inverses should be created as `m` is rebuilt up the tree (from actually using this method in such a case). This is easily fixed.

I note that the fact that inverses are defined when the `CompoundModel` instance is created leads to other slightly odd (but well-defined) behaviour. For examples, if I define `m` as above, and _then_ define an inverse for `C` by setting `m[2].inverse`, `m.inverse` is not changed.

I've added a test to confirm the new behaviour.