### PR TITLE
Fix test_unicode_as_char test

### DIFF
--- a/astropy/io/votable/tests/converter_test.py
+++ b/astropy/io/votable/tests/converter_test.py
@@ -75,7 +75,7 @@ def test_unicode_as_char():
 
     # Test parsing.
     c.parse('XYZ')  # ASCII succeeds
-    with pytest.raises(
+    with pytest.warns(
             exceptions.W55,
             match=r'FIELD \(unicode_in_char\) has datatype="char" but contains non-ASCII value'):
         c.parse("zła")  # non-ASCII
@@ -85,11 +85,11 @@ def test_unicode_as_char():
     c.output(b'XYZ', False)  # ASCII bytes succeeds
     value = 'zła'
     value_bytes = value.encode('utf-8')
-    with pytest.raises(
+    with pytest.warns(
             exceptions.E24,
             match=r'E24: Attempt to write non-ASCII value'):
         c.output(value, False)  # non-ASCII str raises
-    with pytest.raises(
+    with pytest.warns(
             exceptions.E24,
             match=r'E24: Attempt to write non-ASCII value'):
         c.output(value_bytes, False)  # non-ASCII bytes raises


### PR DESCRIPTION
This fixes the ``test_unicode_as_char`` test - we didn't see any failures in CI because we automatically upgrade warnings to exceptions, but if ``error`` is commented out from the pytest warning control in ``setup.cfg``, this test fails. This is manifesting itself in the wheel building since the warning control options aren't getting picked up there. In any case tests should definitely pass without ``error`` set (regardless of why the warning control options aren't picked up in the wheel building).

The code in the tests seems to trigger warnings not exceptions, hence the change from ``raises`` to ``warns``.

This is currently a release blocker for 4.1, so I'll merge it as soon as CI passes, but tagging @tomdonaldson @pllim @tboch in case anyone has time for a quick review, and in case any follow up PR is needed to actually change the main code to raise exceptions rather than warnings (for now the priority is to fix the test).

Fixes https://github.com/astropy/astropy/issues/10382

In future we'll need to think about having a CI job that *doesn't* raise warnings to errors to better catch cases like this.