### PR TITLE
Construct CompoundModel inverse lazily

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -302,7 +302,7 @@ astropy.io.misc
   with to allow serialization of all functional and physical models. [#10028, #10293]
 
 - Fix ASDF serialization of circular model inverses, and remove explicit calls
-  to ``asdf.yamlutil`` functions that became unnecessary in asdf 2.6.0. [#10189]
+  to ``asdf.yamlutil`` functions that became unnecessary in asdf 2.6.0. [#10189, #10384]
 
 astropy.io.fits
 ^^^^^^^^^^^^^^^
@@ -336,6 +336,9 @@ astropy.modeling
 
 - Added ``replace_submodel()`` method to ``CompoundModel`` to modify an
   existing instance. [#10176]
+
+- Delay construction of ``CompoundModel`` inverse until property is accessed,
+  to support ASDF deserialization of circular inverses in component models. [#10384]
 
 astropy.nddata
 ^^^^^^^^^^^^^^

--- a/astropy/io/misc/asdf/tags/transform/basic.py
+++ b/astropy/io/misc/asdf/tags/transform/basic.py
@@ -19,9 +19,6 @@ class TransformType(AstropyAsdfType):
 
     @classmethod
     def _from_tree_base_transform_members(cls, model, node, ctx):
-        if 'inverse' in node:
-            model.inverse = node['inverse']
-
         if 'name' in node:
             model.name = node['name']
 
@@ -46,7 +43,10 @@ class TransformType(AstropyAsdfType):
                 param_and_model_constraints[constraint] = node[constraint]
         model._initialize_constraints(param_and_model_constraints)
 
-        return model
+        yield model
+
+        if 'inverse' in node:
+            model.inverse = node['inverse']
 
     @classmethod
     def from_tree_transform(cls, node, ctx):
@@ -56,8 +56,7 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def from_tree(cls, node, ctx):
         model = cls.from_tree_transform(node, ctx)
-        yield model
-        cls._from_tree_base_transform_members(model, node, ctx)
+        return cls._from_tree_base_transform_members(model, node, ctx)
 
     @classmethod
     def _to_tree_base_transform_members(cls, model, node, ctx):
@@ -91,6 +90,8 @@ class TransformType(AstropyAsdfType):
             if bounds_nondefaults:
                 node['bounds'] = bounds_nondefaults
 
+        return node
+
     @classmethod
     def to_tree_transform(cls, model, ctx):
         raise NotImplementedError("Must be implemented in TransformType subclasses")
@@ -98,8 +99,7 @@ class TransformType(AstropyAsdfType):
     @classmethod
     def to_tree(cls, model, ctx):
         node = cls.to_tree_transform(model, ctx)
-        cls._to_tree_base_transform_members(model, node, ctx)
-        return node
+        return cls._to_tree_base_transform_members(model, node, ctx)
 
     @classmethod
     def assert_equal(cls, a, b):

--- a/astropy/io/misc/asdf/tags/transform/compound.py
+++ b/astropy/io/misc/asdf/tags/transform/compound.py
@@ -60,9 +60,7 @@ class CompoundType(TransformType):
         else:
             model = getattr(left, oper)(right)
 
-        yield model
-
-        cls._from_tree_base_transform_members(model, node, ctx)
+        return cls._from_tree_base_transform_members(model, node, ctx)
 
     @classmethod
     def to_tree_tagged(cls, model, ctx):
@@ -86,8 +84,8 @@ class CompoundType(TransformType):
             raise ValueError(f"Unknown operator '{model.op}'")
 
         node = tagged.tag_object(cls.make_yaml_tag(tag_name), node, ctx=ctx)
-        cls._to_tree_base_transform_members(model, node, ctx)
-        return node
+
+        return cls._to_tree_base_transform_members(model, node, ctx)
 
     @classmethod
     def assert_equal(cls, a, b):

--- a/docs/modeling/models.rst
+++ b/docs/modeling/models.rst
@@ -171,8 +171,8 @@ inverse::
       File "<stdin>", line 1, in <module>
       File "astropy\modeling\core.py", line 796, in inverse
         raise NotImplementedError("An analytical inverse transform has not "
-    NotImplementedError: An analytical inverse transform has not been
-    implemented for this model.
+    NotImplementedError: No analytical or user-supplied inverse transform
+    has been implemented for this model.
 
 One may certainly compute an inverse and assign it to a polynomial model
 though.


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request addresses a serious bug caused by recent changes to the ASDF serializer for Model instances.  In #10189 we changed TransformType to yield the partially constructed model before setting all the fields, to support user inverses that form a reference loop.  That creates problems for CompoundModel because it accesses some of those fields in its initializer.

This fix has two parts: the first is to set all fields but inverse before yielding the model from TransformType, since inverse is the only one that might lead to a reference loop.  The second is to change CompoundModel to not construct its inverse in the initializer.  Instead, it will create the inverse only when the inverse property is accessed.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
