### PR TITLE
TST: GitHub Actions as CI

### DIFF
--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,0 +1,68 @@
+name: Run tests (cron)
+
+on:
+  schedule:
+    # run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
+
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          - name: Python 3.7 with all optional dependencies (MacOS X)
+            os: macos-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+            toxposargs: --remote-data=astropy
+            # compiler: clang
+
+          # We check numpy-dev also in a job that only runs from cron, so that
+          # we can spot issues sooner. We do not use remote data here, since
+          # that gives too many false positives due to URL timeouts. We also
+          # install all dependencies via pip here so we pick up the latest
+          # releases.
+          - name: Python 3.7 with dev version of key dependencies
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+
+          - name: Documentation link check
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: linkcheck
+
+          - name: Bundling with pyinstaller
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: pyinstaller
+
+          # Test against Python dev in cron job.
+          - name: Python dev with basic dependencies
+            os: ubuntu-latest
+            python: 3.10-dev
+            toxenv: pydev-test
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install language-pack-de and tzdata
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt-get install language-pack-de tzdata
+    - name: Install graphviz
+      if: ${{ matrix.toxenv == 'linkcheck' }}
+      run: sudo apt-get install graphviz
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
+    - name: Run tests
+      run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -14,13 +14,6 @@ jobs:
       matrix:
         include:
 
-          - name: Python 3.7 with all optional dependencies (MacOS X)
-            os: macos-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
-            toxposargs: --remote-data=astropy
-            # compiler: clang
-
           # We check numpy-dev also in a job that only runs from cron, so that
           # we can spot issues sooner. We do not use remote data here, since
           # that gives too many false positives due to URL timeouts. We also

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -4,7 +4,6 @@ on:
   push:
   pull_request:
 
-
 jobs:
   tests:
     name: ${{ matrix.name }}
@@ -38,7 +37,6 @@ jobs:
             os: ubuntu-16.04
             python: 3.7
             toxenv: py37-test-oldestdeps
-            toxposargs: --open-files
 
           - name: Python 3.7 with numpy 1.17 and full coverage
             os: ubuntu-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -30,7 +30,6 @@ jobs:
             toxenv: py38-test-alldeps
             toxargs: -v --develop
             toxposargs: --durations=50
-            # compiler: clang
 
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the
@@ -51,6 +50,11 @@ jobs:
             os: windows-latest
             python: 3.8
             toxenv: py38-test-alldeps
+
+          - name: Python 3.7 with all optional dependencies (MacOS X)
+            os: macos-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
 
           - name: Python 3.7 with remote data and dev version of key dependencies
             os: ubuntu-latest

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -80,8 +80,8 @@ jobs:
     - name: Run tests
       run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     # TODO: Do we need --gcov-glob "*cextern*" ?
-    - name: Coverage report
-      uses: codecov/codecov-action@v1
+    - name: Upload coverage to codecov
       if: ${{ matrix.toxenv == 'py37-test-alldeps-numpy117-cov-clocale' }}
+      uses: codecov/codecov-action@v1
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -3,14 +3,10 @@ name: Run tests
 # TODO: cron on a separate YAML?
 on:
   push:
-    # Sequence of patterns matched against refs/heads
-    branches:
-    - master
-    - stable
-    - LTS
   pull_request:
-    branches:
-    - master
+  schedule:
+    # run every Monday at 6am UTC
+    - cron: '0 6 * * 1'
 
 jobs:
   tests:
@@ -20,14 +16,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
+
+          # Standard jobs
+
           - name: Code style checks
             os: ubuntu-latest
             python: 3.x
             toxenv: codestyle
+
           - name: Python 3.7 with minimal dependencies
             os: ubuntu-latest
             python: 3.7
             toxenv: py37-test
+
           - name: Python 3.8 with all optional dependencies
             os: ubuntu-latest
             python: 3.8
@@ -35,6 +36,7 @@ jobs:
             toxargs: -v --develop
             toxposargs: --durations=50
             # compiler: clang
+
           # NOTE: In the build below we also check that tests do not open and
           # leave open any files. This has a performance impact on running the
           # tests, hence why it is not enabled by default.
@@ -43,41 +45,88 @@ jobs:
             python: 3.7
             toxenv: py37-test-oldestdeps
             toxposargs: --open-files
+
           - name: Python 3.7 with numpy 1.17 and full coverage
             os: ubuntu-latest
             python: 3.7
             toxenv: py37-test-alldeps-numpy117-cov-clocale
             toxposargs: --remote-data=astropy
+
           - name: Python 3.8 with all optional dependencies (Windows)
             os: windows-latest
             python: 3.8
             toxenv: py38-test-alldeps
+
           - name: Python 3.7 with remote data and dev version of key dependencies
             os: ubuntu-latest
             python: 3.7
             toxenv: py37-test-devdeps
             toxposargs: --remote-data=any
 
+          # Cron jobs
+
+          - name: Python 3.7 with all optional dependencies (MacOS X)
+            skip: ${{ github.event_name != 'schedule'}}
+            os: macos-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+            toxposargs: --remote-data=astropy
+            # compiler: clang
+
+          # We check numpy-dev also in a job that only runs from cron, so that
+          # we can spot issues sooner. We do not use remote data here, since
+          # that gives too many false positives due to URL timeouts. We also
+          # install all dependencies via pip here so we pick up the latest
+          # releases.
+          - name: Python 3.7 with dev version of key dependencies
+            skip: ${{ github.event_name != 'schedule'}}
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+
+          - name: Documentation link check
+            skip: ${{ github.event_name != 'schedule'}}
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: linkcheck
+
+          - name: Bundling with pyinstaller
+            skip: ${{ github.event_name != 'schedule'}}
+            os: ubuntu-latest
+            python: 3.8
+            toxenv: pyinstaller
+
+          # Test against Python dev in cron job.
+          - name: Python dev with basic dependencies
+            skip: ${{ github.event_name != 'schedule'}}
+            os: ubuntu-latest
+            python: 3.10-dev
+            toxenv: pydev-test
+
     steps:
     - name: Checkout code
+      if: ${{ !matrix.skip }}
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up Python
+      if: ${{ !matrix.skip }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    - name: Install library dependencies
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+    - name: Install language-pack-de and tzdata
+      if: ${{ !matrix.skip && matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get install language-pack-de tzdata
+    - name: Install graphviz
+      if: ${{ !matrix.skip && matrix.toxenv == 'linkcheck' }}
+      run: sudo apt-get install graphviz
     - name: Install Python dependencies
+      if: ${{ !matrix.skip }}
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
-      run: |
-        echo "CC="$CC
-        echo "LC_CTYPE="$LC_CTYPE
-        echo "LC_ALL="$LC_ALL
-        tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
+      if: ${{ !matrix.skip }}
+      run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
     # TODO: Do we need --gcov-glob "*cextern*" ?
     - name: Coverage report
+      if: ${{ !matrix.skip }}
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -32,6 +32,7 @@ jobs:
             os: ubuntu-latest
             python: 3.8
             toxenv: py38-test-alldeps
+            toxargs: -v --develop
             toxposargs: --durations=50
             # compiler: clang
           # NOTE: In the build below we also check that tests do not open and

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Run tests
 
 # TODO: cron on a separate YAML?
 on:
@@ -12,120 +12,71 @@ on:
     branches:
     - master
 
-# The following is needed to avoid issues if e.g. Matplotlib tries
-# to open a GUI window.
-env:
-  SETUP_XVFB: True
-
 jobs:
-  code_style:
-    runs-on: ubuntu-latest
-    env:
-      TOXENV: codestyle
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Code style checks
-      run: |
-        echo "TOXENV="$TOXENV
-        tox -v
-
-  initial_tests:
-    runs-on: ubuntu-latest
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python: ['3.7', '3.8']
-        # Customize the jobs a little based on Python version
         include:
-          # Minimal dependencies
-          - python: '3.7'
+          - name: Code style checks
+            os: ubuntu-latest
+            python: 3.x
+            toxenv: codestyle
+          - name: Python 3.7 with minimal dependencies
+            os: ubuntu-latest
+            python: 3.7
             toxenv: py37-test
-            toxargs: -v
-            cc: ''
-          # All optional dependencies
-          - python: '3.8'
+          - name: Python 3.8 with all optional dependencies
+            os: ubuntu-latest
+            python: 3.8
             toxenv: py38-test-alldeps
-            toxargs: --durations=50
-            cc: clang
-    env:
-      TOXENV: ${{ matrix.toxenv }}
-      TOXARGS: ${{ matrix.toxargs }}
-      CC: ${{ matrix.cc }}
+            toxposargs: --durations=50
+            # compiler: clang
+          # NOTE: In the build below we also check that tests do not open and
+          # leave open any files. This has a performance impact on running the
+          # tests, hence why it is not enabled by default.
+          - name: Python 3.7 with oldest supported version of all dependencies
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-oldestdeps
+            toxposargs: --open-files
+          - name: Python 3.7 with numpy 1.17 and full coverage
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-alldeps-numpy117-cov-clocale
+            toxposargs: --remote-data=astropy
+          - name: Python 3.8 with all optional dependencies (Windows)
+            os: windows-latest
+            python: 3.8
+            toxenv: py38-test-alldeps
+          - name: Python 3.7 with remote data and dev version of key dependencies
+            os: ubuntu-latest
+            python: 3.7
+            toxenv: py37-test-devdeps
+            toxposargs: --remote-data=any
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Fetch tags
-      run: git fetch --prune --unshallow --tags
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
-    # Write configuration items to standard location to make sure they are
-    # ignored (the tests will fail if not)
-    - name: Before install
-      run: |
-        mkdir -p $HOME/.astropy/config/
-        printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
-      shell: bash
-    - name: Install
-      run: |
-        sudo apt-get install language-pack-de tzdata
-        python -m pip install --upgrade tox
-    - name: Run tests
-      run: |
-        echo "CC="$CC
-        echo "TOXENV="$TOXENV
-        echo "TOXARGS="$TOXARGS
-        tox ${TOXARGS}
-
-  # TODO: Maybe this can be part of a matrix too but I just want to show
-  #       stages without porting everything for now.
-  # Full tests with coverage checks.
-  coverage_test:
-    runs-on: ubuntu-latest
-    needs: [code_style, initial_tests]
-    env:
-      TOXENV: py37-test-alldeps-numpy117-cov
-      TOXPOSARGS: --remote-data=astropy
-      LC_CTYPE: C.ascii
-      LC_ALL: C
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Fetch tags
-      run: git fetch --prune --unshallow --tags
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.7'
-    # Write configuration items to standard location to make sure they are
-    # ignored (the tests will fail if not)
-    - name: Before install
-      run: |
-        mkdir -p $HOME/.astropy/config/
-        printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
-      shell: bash
-    - name: Install
-      run: |
-        sudo apt-get install language-pack-de tzdata
-        python -m pip install --upgrade tox
-        python -m pip install codecov
+    - name: Install library dependencies
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt-get install language-pack-de tzdata
+    - name: Install Python dependencies
+      run: python -m pip install --upgrade tox codecov
     - name: Run tests
       run: |
         echo "CC="$CC
         echo "LC_CTYPE="$LC_CTYPE
         echo "LC_ALL="$LC_ALL
-        echo "TOXENV="$TOXENV
-        echo "TOXARGS="$TOXARGS
-        echo "TOXPOSARGS="$TOXPOSARGS
-        tox ${TOXARGS} -- ${TOXPOSARGS}
+        tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
     # TODO: Do we need --gcov-glob "*cextern*" ?
     - name: Coverage report
       uses: codecov/codecov-action@v1
-    # TODO: Do we need token?
-    #  with:
-    #    token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -35,7 +35,7 @@ jobs:
           # leave open any files. This has a performance impact on running the
           # tests, hence why it is not enabled by default.
           - name: Python 3.7 with oldest supported version of all dependencies
-            os: ubuntu-latest
+            os: ubuntu-16.04
             python: 3.7
             toxenv: py37-test-oldestdeps
             toxposargs: --open-files
@@ -73,15 +73,15 @@ jobs:
       with:
         python-version: ${{ matrix.python }}
     - name: Install language-pack-de and tzdata
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: startsWith(matrix.os, 'ubuntu')
       run: sudo apt-get install language-pack-de tzdata
-    - name: Install graphviz
-      if: ${{ matrix.toxenv == 'linkcheck' }}
-      run: sudo apt-get install graphviz
     - name: Install Python dependencies
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
-      run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
+      run: tox ${{ matrix.toxargs }} -e ${{ matrix.toxenv }} -- ${{ matrix.toxposargs }}
     # TODO: Do we need --gcov-glob "*cextern*" ?
     - name: Coverage report
       uses: codecov/codecov-action@v1
+      if: ${{ matrix.toxenv == 'py37-test-alldeps-numpy117-cov-clocale' }}
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,12 +1,9 @@
 name: Run tests
 
-# TODO: cron on a separate YAML?
 on:
   push:
   pull_request:
-  schedule:
-    # run every Monday at 6am UTC
-    - cron: '0 6 * * 1'
+
 
 jobs:
   tests:
@@ -16,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-
-          # Standard jobs
 
           - name: Code style checks
             os: ubuntu-latest
@@ -63,70 +58,26 @@ jobs:
             toxenv: py37-test-devdeps
             toxposargs: --remote-data=any
 
-          # Cron jobs
-
-          - name: Python 3.7 with all optional dependencies (MacOS X)
-            skip: ${{ github.event_name != 'schedule'}}
-            os: macos-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
-            toxposargs: --remote-data=astropy
-            # compiler: clang
-
-          # We check numpy-dev also in a job that only runs from cron, so that
-          # we can spot issues sooner. We do not use remote data here, since
-          # that gives too many false positives due to URL timeouts. We also
-          # install all dependencies via pip here so we pick up the latest
-          # releases.
-          - name: Python 3.7 with dev version of key dependencies
-            skip: ${{ github.event_name != 'schedule'}}
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: py37-test-devdeps
-
-          - name: Documentation link check
-            skip: ${{ github.event_name != 'schedule'}}
-            os: ubuntu-latest
-            python: 3.7
-            toxenv: linkcheck
-
-          - name: Bundling with pyinstaller
-            skip: ${{ github.event_name != 'schedule'}}
-            os: ubuntu-latest
-            python: 3.8
-            toxenv: pyinstaller
-
-          # Test against Python dev in cron job.
-          - name: Python dev with basic dependencies
-            skip: ${{ github.event_name != 'schedule'}}
-            os: ubuntu-latest
-            python: 3.10-dev
-            toxenv: pydev-test
 
     steps:
     - name: Checkout code
-      if: ${{ !matrix.skip }}
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - name: Set up Python
-      if: ${{ !matrix.skip }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install language-pack-de and tzdata
-      if: ${{ !matrix.skip && matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: sudo apt-get install language-pack-de tzdata
     - name: Install graphviz
-      if: ${{ !matrix.skip && matrix.toxenv == 'linkcheck' }}
+      if: ${{ matrix.toxenv == 'linkcheck' }}
       run: sudo apt-get install graphviz
     - name: Install Python dependencies
-      if: ${{ !matrix.skip }}
       run: python -m pip install --upgrade tox codecov
     - name: Run tests
-      if: ${{ !matrix.skip }}
       run: tox ${{ matrix.toxargs}} -e ${{ matrix.toxenv}} -- ${{ matrix.toxposargs}}
     # TODO: Do we need --gcov-glob "*cextern*" ?
     - name: Coverage report
-      if: ${{ !matrix.skip }}
       uses: codecov/codecov-action@v1

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,0 +1,131 @@
+name: CI
+
+# TODO: cron on a separate YAML?
+on:
+  push:
+    # Sequence of patterns matched against refs/heads
+    branches:
+    - master
+    - stable
+    - LTS
+  pull_request:
+    branches:
+    - master
+
+# The following is needed to avoid issues if e.g. Matplotlib tries
+# to open a GUI window.
+env:
+  SETUP_XVFB: True
+
+jobs:
+  code_style:
+    runs-on: ubuntu-latest
+    env:
+      TOXENV: codestyle
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Code style checks
+      run: |
+        echo "TOXENV="$TOXENV
+        tox -v
+
+  initial_tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.7', '3.8']
+        # Customize the jobs a little based on Python version
+        include:
+          # Minimal dependencies
+          - python: '3.7'
+            toxenv: py37-test
+            toxargs: -v
+            cc: ''
+          # All optional dependencies
+          - python: '3.8'
+            toxenv: py38-test-alldeps
+            toxargs: --durations=50
+            cc: clang
+    env:
+      TOXENV: ${{ matrix.toxenv }}
+      TOXARGS: ${{ matrix.toxargs }}
+      CC: ${{ matrix.cc }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python }}
+    # Write configuration items to standard location to make sure they are
+    # ignored (the tests will fail if not)
+    - name: Before install
+      run: |
+        mkdir -p $HOME/.astropy/config/
+        printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
+      shell: bash
+    - name: Install
+      run: |
+        sudo apt-get install language-pack-de tzdata
+        python -m pip install --upgrade tox
+    - name: Run tests
+      run: |
+        echo "CC="$CC
+        echo "TOXENV="$TOXENV
+        echo "TOXARGS="$TOXARGS
+        tox ${TOXARGS}
+
+  # TODO: Maybe this can be part of a matrix too but I just want to show
+  #       stages without porting everything for now.
+  # Full tests with coverage checks.
+  coverage_test:
+    runs-on: ubuntu-latest
+    needs: [code_style, initial_tests]
+    env:
+      TOXENV: py37-test-alldeps-numpy117-cov
+      TOXPOSARGS: --remote-data=astropy
+      LC_CTYPE: C.ascii
+      LC_ALL: C
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+    # Write configuration items to standard location to make sure they are
+    # ignored (the tests will fail if not)
+    - name: Before install
+      run: |
+        mkdir -p $HOME/.astropy/config/
+        printf "unicode_output = True\nmax_width = 500" > $HOME/.astropy/config/astropy.cfg
+      shell: bash
+    - name: Install
+      run: |
+        sudo apt-get install language-pack-de tzdata
+        python -m pip install --upgrade tox
+        python -m pip install codecov
+    - name: Run tests
+      run: |
+        echo "CC="$CC
+        echo "LC_CTYPE="$LC_CTYPE
+        echo "LC_ALL="$LC_ALL
+        echo "TOXENV="$TOXENV
+        echo "TOXARGS="$TOXARGS
+        echo "TOXPOSARGS="$TOXPOSARGS
+        tox ${TOXARGS} -- ${TOXPOSARGS}
+    # TODO: Do we need --gcov-glob "*cextern*" ?
+    - name: Coverage report
+      uses: codecov/codecov-action@v1
+    # TODO: Do we need token?
+    #  with:
+    #    token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: CI
 
 on:
   push:
@@ -9,6 +9,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
+      # TODO: Change to true when we know how to handle remote data job correctly
       fail-fast: false
       matrix:
         include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,55 +71,6 @@ matrix:
 
     include:
 
-        # Try MacOS X.
-        - os: osx
-          name: Python 3.7 with all optional dependencies for OSX
-          stage: Cron tests
-          env: PYTHON_VERSION=3.7
-               TOXENV="py37-test-alldeps"
-               TOXPOSARGS="--remote-data=astropy"
-               CCOMPILER=clang
-
-        # Try all python versions and Numpy versions. Since we can assume that
-        # the Numpy developers have taken care of testing Numpy with different
-        # versions of Python, we can vary Python and Numpy versions at the same
-        # time.
-
-
-        # We check numpy-dev also in a job that only runs from cron, so that
-        # we can spot issues sooner. We do not use remote data here, since
-        # that gives too many false positives due to URL timeouts.
-        # We also install all dependencies via pip here so we pick up the latest
-        # releases.
-        - language: python
-          python: 3.7
-          name: Python 3.7 with dev version of key dependencies
-          stage: Cron tests
-          env: TOXENV="py37-test-devdeps"
-
-        # Run documentation link check in a cron job.
-        # Was originally in CircleCI doc build but links are too flaky, so
-        # we moved it here instead.
-        - language: python
-          python: 3.7
-          name: Documentation link check
-          stage: Cron tests
-          env: TOXENV='linkcheck'
-          addons:
-              apt:
-                  packages:
-                      - graphviz
-
-        # Test against Python dev in cron job.
-        - language: python
-          python: 3.9-dev
-          dist: bionic
-          name: Python dev with basic dependencies
-          stage: Cron tests
-          env: TOXENV="pydev-test"
-               TOXPOSARGS="--durations=50"
-          compiler: clang
-
         # Also regularly try the big-endian s390 architecture, in the
         # process checking that installing dependencies with apt works,
         # and that astropy can properly use the system libraries,
@@ -165,14 +116,6 @@ matrix:
                       - python3-ply
                       - python3-pytest-astropy
                       - python3-astropy
-
-        # Regularly make sure that astropy can be used in application bundles
-        - language: python
-          python: 3.8
-          dist: bionic
-          name: bundling with pyinstaller
-          stage: Cron tests
-          env: TOXENV="pyinstaller"
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,13 +71,6 @@ matrix:
 
     include:
 
-        # Linux job with minimal dependencies
-        - language: python
-          python: 3.7
-          name: Python 3.7 with minimal dependencies
-          stage: Initial tests
-          env: TOXENV="py37-test"
-
         # Try MacOS X.
         - os: osx
           name: Python 3.7 with all optional dependencies for OSX
@@ -92,61 +85,6 @@ matrix:
         # versions of Python, we can vary Python and Numpy versions at the same
         # time.
 
-        # For the Numpy 1.17 build we use oldestdeps not numpy117 since we can check
-        # the oldest version of all dependencies where this is known. We also check
-        # that tests do not open and leave open any files. This has a performance
-        # impact on running the tests, hence why it is not enabled by default.
-        - language: python
-          python: 3.7
-          stage: Comprehensive tests
-          name: Python 3.7 with oldest supported version of all dependencies
-          env: TOXENV="py37-test-oldestdeps"
-               TOXPOSARGS="--open-files"
-
-        # Now try with all optional dependencies.
-        - language: python
-          python: 3.8
-          dist: bionic
-          name: Python 3.8 with all optional dependencies
-          stage: Initial tests
-          env: TOXENV="py38-test-alldeps"
-               TOXARGS="-v --develop"
-               TOXPOSARGS="--durations=50"
-          compiler: clang
-
-        # Full tests with coverage checks.
-        - language: python
-          python: 3.7
-          stage: Comprehensive tests
-          name: Python 3.7 with numpy 1.17 and full coverage
-          env: TOXENV="py37-test-alldeps-numpy117-cov"
-               TOXPOSARGS="--remote-data=astropy"
-               LC_CTYPE=C.ascii LC_ALL=C
-
-        # Try on Windows
-        - os: windows
-          stage: Final tests
-          name: Python 3.8 with all optional dependencies
-          env: PYTHON_VERSION=3.8
-               TOXENV='py38-test-alldeps'
-
-        # Do a PEP8/pyflakes test with flake8
-        - language: python
-          python: 3.7
-          name: Code style checks
-          stage: Initial tests
-          env: TOXENV='codestyle'
-
-        # Try developer version of Numpy with optional dependencies and also
-        # run all remote tests. Since both cases will be potentially
-        # unstable, we combine them into a single unstable build that we can
-        # mark as an allowed failure below.
-        - language: python
-          python: 3.7
-          name: Python 3.7 with remote data and dev version of key dependencies
-          stage: Final tests
-          env: TOXENV="py37-test-devdeps"
-               TOXPOSARGS="--remote-data=any"
 
         # We check numpy-dev also in a job that only runs from cron, so that
         # we can spot issues sooner. We do not use remote data here, since
@@ -235,14 +173,6 @@ matrix:
           name: bundling with pyinstaller
           stage: Cron tests
           env: TOXENV="pyinstaller"
-
-    allow_failures:
-        - language: python
-          python: 3.7
-          name: Python 3.7 with remote data and dev version of key dependencies
-          stage: Final tests
-          env: TOXENV="py37-test-devdeps"
-               TOXPOSARGS="--remote-data=any"
 
 before_install:
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
 .. |Actions Status| image:: https://github.com/astropy/astropy/workflows/CI/badge.svg
+    :target: https://github.com/astropy/astropy/actions
     :alt: Astropy's GitHub Actions CI Status
 
 .. |CircleCI Status| image::  https://img.shields.io/circleci/build/github/astropy/astropy/master?logo=circleci&label=CircleCI

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Astropy
 =======
 
-|Travis Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status|
+|Actions Status| |CircleCI Status| |Coverage Status| |PyPI Status| |Documentation Status|
 
 The Astropy Project (http://astropy.org/) is a community effort to develop a
 single core package for Astronomy in Python and foster interoperability between
@@ -48,9 +48,8 @@ License
 Astropy is licensed under a 3-clause BSD style license - see the
 `LICENSE.rst <LICENSE.rst>`_ file.
 
-.. |Travis Status| image:: https://img.shields.io/travis/astropy/astropy/master?logo=travis%20ci&logoColor=white&label=Travis%20CI
-    :target: https://travis-ci.com/astropy/astropy
-    :alt: Astropy's Travis CI Status
+.. |Actions Status| image:: https://github.com/astropy/astropy/workflows/CI/badge.svg
+    :alt: Astropy's GitHub Actions CI Status
 
 .. |CircleCI Status| image::  https://img.shields.io/circleci/build/github/astropy/astropy/master?logo=circleci&label=CircleCI
     :target: https://circleci.com/gh/astropy/astropy

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -59,6 +59,7 @@ from astropy.utils.data import (
 )
 
 TRAVIS = os.environ.get('TRAVIS', False) == "true"
+CI = os.environ.get('CI', False) == "true"
 TESTURL = "http://www.astropy.org"
 TESTURL2 = "http://www.astropy.org/about.html"
 TESTLOCAL = get_pkg_data_filename(os.path.join("data", "local.dat"))
@@ -831,7 +832,7 @@ def test_download_parallel_update(temp_cache, tmpdir):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8) or
-                    (sys.platform.startswith('win') and TRAVIS),
+                    (sys.platform.startswith('win') and CI),
                     reason="mystery segfault that is possibly bug #10008 "
                            "for python < 3.8, flaky cache error on Windows CI")
 def test_update_parallel(temp_cache, valid_urls):
@@ -853,7 +854,7 @@ def test_update_parallel(temp_cache, valid_urls):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8) or
-                    (sys.platform.startswith('win') and TRAVIS),
+                    (sys.platform.startswith('win') and CI),
                     reason="mystery segfault that is possibly bug #10008 "
                            "for python < 3.8, flaky cache error on Windows CI")
 def test_update_parallel_multi(temp_cache, valid_urls):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}
+    py{37,38,39,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -28,6 +28,8 @@ setenv =
     cov: CFLAGS = --coverage -fno-inline-functions -O0
     image: MPLFLAGS = --mpl
     !image: MPLFLAGS =
+    clocale: LC_CTYPE = C.ascii
+    clocale: LC_ALL = C
 
 # Run the tests in a temporary directory to make sure that we don't import
 # astropy from the source tree

--- a/tox.ini
+++ b/tox.ini
@@ -97,6 +97,7 @@ commands =
     !cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} {posargs}
     cov-!double: pytest --pyargs astropy {toxinidir}/docs {env:MPLFLAGS} --cov astropy --cov-config={toxinidir}/setup.cfg {posargs}
     double: python -c 'import sys; from astropy import test; test(); sys.exit(test())'
+    cov: coverage xml -o {toxinidir}/coverage.xml
 
 # This lets developers to use tox to build docs and ignores warnings.
 # This is not used in CI; For that, we have RTD PR builder.

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ deps =
     oldestdeps: asdf==2.6.*
     oldestdeps: scipy==1.1.*
     oldestdeps: pyyaml==3.13
-    oldestdeps: pytest-openfiles==0.4.0
 
     # The devdeps factor is intended to be used to install the latest developer version
     # or nightly wheel of key dependencies.


### PR DESCRIPTION
**Update:** Due to Travis CI changes in pricing, we decided to push ahead with this as soon as we have a minimal viable product. We will fix the rest of the jobs in follow-up PRs.

~This is a small proof-of-concept of using GitHub Actions as CI. Might expand if there is buy-in, or abandon if there isn't.~

**Pros**

- [Artifact support](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts) but I haven't tried to use it yet.
- Better integration with GitHub UI.
  - The cancel button is easier to access than Azure Pipelines.
- Unlike Azure, no need for special Microsoft account or let Microsoft access GitHub credentials. (The latter is probably moot point, har har...).
- Performance on par with Azure (theoretically, considering they probably share the same servers or something...).
- Potentially useful for other things too, like bot work and delivery.

**Cons**

- No [anchors](https://github.community/t5/GitHub-Actions/Support-for-YAML-anchors/m-p/30336) or [templating](https://github.community/t5/GitHub-Actions/Yaml-templating-like-azure-pipeline/td-p/39636).
- No [allowed failures](https://github.community/t5/GitHub-Actions/continue-on-error-allow-failure-UI-indication/td-p/37033). Also see actions/toolkit#399
- No built in support for [skip ci](https://github.community/t5/GitHub-Actions/GitHub-Actions-does-not-respect-skip-ci/td-p/42834).
  - On the bright side, I can use `[skip ci]` to skip all the other CIs and only run Actions. (Har har...)
- No `ccache`? If there is one, it is not documented.
- Cannot [re-run only one job](https://github.community/t5/GitHub-Actions/Ability-to-rerun-just-a-single-job-in-a-workflow/td-p/41629).
- No extra architecture support (e.g., ARM64) without [hosting self-runners](https://github.blog/changelog/2019-12-03-github-actions-self-hosted-runners-on-arm-architectures/).
- No [re-run with SSH](https://github.community/t5/GitHub-Actions/Debugging-github-actions-locally-or-ssh-to-workspace/td-p/38949) like CircleCI.

**CI jobs and features to implement (please check off if done)**

From `.travis.yml`:

- [ ] Caching with `ccache` and `.hypothesis`.
- [ ] `pytest` conditions in test modules using `TRAVIS` env var.
- [ ] Slack notification (both on success and failure) for cron job.
- Initial tests stage:
  - [x] Python 3.7 with minimal dependencies
  - [x] Python 3.8 with all optional dependencies (`-v --develop`, `--durations=50`, `clang`)
  - [x] Code style checks
- Comprehensive tests stage:
  - [x] Python 3.7 with oldest supported version of all dependencies (`--open-files`)
  - [x] Python 3.7 with numpy 1.17 and full coverage (`--remote-data=astropy`, `LC_CTYPE=C.ascii`, `LC_ALL=C`) -- need `codecov` token
- Final tests stage:
  - [x] Python 3.8 with all optional dependencies
  - [x] Python 3.7 with remote data and dev version of key dependencies (`--remote-data=any`) -- allowed to fail
- Cron:
  - [x] Python 3.7 with all optional dependencies for OSX (`clang`, `--remote-data=astropy`)
  - [x] Python 3.7 with dev version of key dependencies
  - [x] Documentation link check
  - [x] Python dev with basic dependencies (`3.9-dev`, `--durations=50`, `clang`)
  - [ ] Big-endian s390x architecture with apt (`arch: s390x`, `ASTROPY_USE_SYSTEM_ALL=1`) (@astrofrog will do in a follow-up PR)
  - [ ] ARM64 architecture with apt (`arch: arm64`, `ASTROPY_USE_SYSTEM_ALL=1`) (@astrofrog will do in a follow-up PR)
  - [x] Bundling with pyinstaller

From `.circleci/config.yml`:

- [ ] 32-bit and parallel (custom `astropy.cfg`, Python 3.7 `-n=4 --durations=50`, Python 3.8 `py38-test-double`)
- [ ] `image-tests-mpl302`
- [ ] `image-tests-mpl310`
- [ ] `image-tests-mpldev`

From `azure-piplines.yml`:

- [ ] Build wheels and publish to PyPI for release.

**TODO**

- [ ] Fix failures. It kicked off at https://github.com/pllim/astropy/actions/runs but probably affected by the degraded GitHub service that was happening.
  - [ ] Once Actions reports to the PR, will adding branch filters back break it?
- [x] Discuss and compare to #8445 .
- [x] See what to do with the cron stuff -- separate or same YAML?
- [x] See how much more we can port to Actions from Travis CI and maybe even CircleCI. Should use matrix where possible.
- [x] Remove ported jobs from the other CIs.
- [x] Figure out the badge situations in README.
- [x] Determine if we are happy to make remote/numpy dev be not allowed failures since there isn't an equivalent feature
- [ ] See if we can add `--open-files` back to a newer job in future PR.
- [ ] See if codecov reports back to PR. If not, find solution.

**Possible links of interest**

Thanks to everyone who provided these resources:

- https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/sharing-workflows-with-your-organization
- https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
- https://github.com/uraimo/run-on-arch-action 
- https://github.com/tepickering/package-template/blob/add_github_actions/%7B%7B%20cookiecutter.package_name%20%7D%7D/.github/workflows/tox-tests.yml