### PR TITLE
Simplify SpectralCoord implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ astropy.coordinates
   ``TransformGraph`` class to override the finite-difference time step
   attribute (``finite_difference_dt``) for all transformations in the graph
   with that attribute. [#10341]
+- Improve performance of ``SpectralCoord`` by refactoring internal implementation. [#10398]
 
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -656,7 +656,8 @@ class SpectralCoord(SpectralQuantity):
         -------
         `SpectralCoord`
             New spectral coordinate with the target/observer velocity changed
-            to incorporate the shift.
+            to incorporate the shift. This is always a new object even if
+            ``target_shift`` and ``observer_shift`` are both `None`.
         """
 
         if observer_shift is not None and (self.target is None or

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -294,7 +294,7 @@ class SpectralCoord(SpectralQuantity):
         if 's' not in coord.data.differentials:
             warnings.warn(
                 "No velocity defined on frame, assuming {}.".format(
-                    u.Quantity([0, 0, 0], unit=u.km/u.s)),
+                    ZERO_VELOCITIES),
                 NoVelocityWarning)
 
             coord = attach_zero_velocities(coord)

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -680,7 +680,7 @@ class SpectralCoord(SpectralQuantity):
                 target_shift = _redshift_to_velocity(target_shift)
             if self._observer is None or self._target is None:
                 return self.replicate(value=_apply_relativistic_doppler_shift(self, target_shift),
-                                      radial_velocity=self._radial_velocity + target_shift)
+                                      radial_velocity=self.radial_velocity + target_shift)
 
         if observer_shift is None:
             observer_shift = 0 * KMS

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -24,6 +24,7 @@ class NoDistanceWarning(AstropyUserWarning):
 
 
 KMS = u.km / u.s
+C_KMS = c.to(KMS)
 ZERO_VELOCITIES = CartesianDifferential([0, 0, 0] * KMS)
 
 # Default distance to use for target when none is provided
@@ -37,7 +38,7 @@ def _velocity_to_redshift(velocity):
     """
     Convert a velocity to a relativistic redshift.
     """
-    beta = velocity / c
+    beta = velocity / C_KMS
     return np.sqrt((1 + beta) / (1 - beta)) - 1
 
 
@@ -46,7 +47,7 @@ def _redshift_to_velocity(redshift):
     Convert a relativistic redshift to a velocity.
     """
     zponesq = (1 + redshift) ** 2
-    return (c * (zponesq - 1) / (zponesq + 1))
+    return (C_KMS * (zponesq - 1) / (zponesq + 1))
 
 
 def _relativistic_velocity_addition(vel1, vel2):

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -713,11 +713,6 @@ class SpectralCoord(SpectralQuantity):
 
         new_data = _apply_relativistic_doppler_shift(self, fin_obs_vel - init_obs_vel)
 
-        # If an observer/target pair were not defined already, we want to avoid
-        # providing an explicit pair, so create a new SpectralCoord object
-        # with just the radial velocity set so new implicit observer/target
-        # will be created. Otherwise, use the available observer/target
-        # instances to create the pair.
         return self.replicate(value=new_data,
                               observer=new_observer,
                               target=new_target)

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -50,13 +50,6 @@ def _redshift_to_velocity(redshift):
     return (C_KMS * (zponesq - 1) / (zponesq + 1))
 
 
-def _relativistic_velocity_addition(vel1, vel2):
-    """
-    Add two velocities using the full relativistic equation.
-    """
-    return (vel1 + vel2) / (1 + vel1 * vel2 / c ** 2)
-
-
 def _apply_relativistic_doppler_shift(scoord, velocity):
     """
     Given a `SpectralQuantity` and a velocity, return a new `SpectralQuantity`

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -520,6 +520,13 @@ def test_los_shift_radial_velocity():
     sc12 = sc10.with_radial_velocity_shift(-3 * u.km / u.s)
     assert_quantity_allclose(sc12.radial_velocity, -2 * u.km / u.s)
 
+    # Check that things work if radial_velocity wasn't specified at all
+
+    sc13 = SpectralCoord(500 * u.nm)
+    sc14 = sc13.with_radial_velocity_shift(1 * u.km / u.s)
+    assert_quantity_allclose(sc14.radial_velocity, 1 * u.km / u.s)
+
+
 
 @pytest.mark.xfail
 def test_relativistic_radial_velocity():

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -527,7 +527,6 @@ def test_los_shift_radial_velocity():
     assert_quantity_allclose(sc14.radial_velocity, 1 * u.km / u.s)
 
 
-
 @pytest.mark.xfail
 def test_relativistic_radial_velocity():
 

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -627,11 +627,6 @@ def test_shift_to_rest_galaxy():
     with pytest.raises(AttributeError):
         assert_frame_allclose(rest_spc.observer, rest_spc.target)
 
-    with pytest.raises(ValueError):
-        # *any* observer shift should fail, since we didn't specify one at the
-        # outset
-        rest_spc._change_observer_to(ICRS(CartesianRepresentation([0, 0, 0] * u.au)))
-
 
 def test_shift_to_rest_star_withobserver():
     rv = -8.3283011*u.km/u.s
@@ -654,8 +649,7 @@ def test_shift_to_rest_star_withobserver():
     rest_spc = observed_spc.to_rest()
     assert_quantity_allclose(rest_spc, rest_line_wls)
 
-    with pytest.warns(AstropyUserWarning, match='No velocity defined on frame'):
-        barycentric_spc = observed_spc._change_observer_to(ICRS(CartesianRepresentation([0, 0, 0] * u.au)))
+    barycentric_spc = observed_spc.with_observer_stationary_relative_to('icrs')
     baryrest_spc = barycentric_spc.to_rest()
     assert quantity_allclose(baryrest_spc, rest_line_wls)
 

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -464,12 +464,24 @@ def test_with_observer_stationary_relative_to():
                                                  differential_type='cartesian'),
                                                  velocity=[-2**0.5, 0, -2**0.5] * u.km / u.s)
 
+    # And velocities should have three elements
+
+    with pytest.raises(ValueError, match='velocity should be a Quantity vector with 3 elements'):
+        sc2.with_observer_stationary_relative_to(ICRS, velocity=[-2**0.5, 0, -2**0.5, -3] * u.km / u.s)
+
     # Make sure things don't change depending on what frame class is used for reference
     sc11 = sc2.with_observer_stationary_relative_to(SkyCoord(ICRS(0 * u.km, 0 * u.km, 0 * u.km,
                                                                   2**0.5 * u.km / u.s, 0 * u.km / u.s, 2**0.5 * u.km / u.s,
                                                                   representation_type='cartesian',
                                                                   differential_type='cartesian')).transform_to(Galactic))
     assert_quantity_allclose(sc11.radial_velocity, 0 * u.km / u.s, atol=1e-10 * u.km / u.s)
+
+    # Check that it is possible to preserve the observer frame
+    sc12 = sc2.with_observer_stationary_relative_to(LSRD)
+    sc13 = sc2.with_observer_stationary_relative_to(LSRD, preserve_observer_frame=True)
+
+    assert isinstance(sc12.observer, Galactic)
+    assert isinstance(sc13.observer, ICRS)
 
 
 def test_los_shift_radial_velocity():
@@ -525,6 +537,16 @@ def test_los_shift_radial_velocity():
     sc13 = SpectralCoord(500 * u.nm)
     sc14 = sc13.with_radial_velocity_shift(1 * u.km / u.s)
     assert_quantity_allclose(sc14.radial_velocity, 1 * u.km / u.s)
+
+    sc15 = sc1.with_radial_velocity_shift()
+    assert_quantity_allclose(sc15.radial_velocity, 1 * u.km / u.s)
+
+    # Check that units are verified
+
+    with pytest.raises(u.UnitsError, match="Argument must have unit physical "
+                                           "type 'speed' for radial velocty or "
+                                           "'dimensionless' for redshift."):
+        sc1.with_radial_velocity_shift(target_shift=1 * u.kg)
 
 
 @pytest.mark.xfail

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -319,16 +319,16 @@ the effect of the Earth's rotation), we can use the ``'gcrs'`` which stands for
     >>> sc_ttau.with_observer_stationary_relative_to('gcrs')  # doctest: +FLOAT_CMP +REMOTE_DATA
     <SpectralCoord
        (observer: <GCRS Coordinate (obstime=2019-04-24T02:32:10.000, obsgeoloc=(0., 0., 0.) m, obsgeovel=(0., 0., 0.) m / s): (x, y, z) in m
-                      (-5878853.86160149, -192921.84793754, -2470794.19798818)
+                      (-5878853.86171412, -192921.84773269, -2470794.19765021)
                    (v_x, v_y, v_z) in km / s
-                      (-1.09225512e-08, 8.96006823e-08, -1.49346888e-08)>
+                      (4.33251262e-09, 8.96175625e-08, -1.49258412e-08)>
         target: <ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)
                     (65.497625, 19.53511111, 144.321)
                  (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)
                     (1.37949782e-15, 1.46375638e-15, 23.9)>
         observer to target (computed from above):
-          radial_velocity=40.67408633585573 km / s
-          redshift=0.00013568335305236268)
+          radial_velocity=40.674086368345165 km / s
+          redshift=0.00013568335316072044)
       [200.00024141, 210.00025348, 220.00026555, 230.00027762, 240.00028969,
        250.00030176, 260.00031383, 270.0003259 , 280.00033797, 290.00035004,
        300.00036211] GHz>

--- a/docs/coordinates/spectralcoord.rst
+++ b/docs/coordinates/spectralcoord.rst
@@ -146,7 +146,7 @@ between 500 and 900nm::
 
     >>> import numpy as np
     >>> wavs = SpectralCoord(np.linspace(500, 900, 9) * u.nm, redshift=0.5)
-    >>> wavs
+    >>> wavs  # doctest: +FLOAT_CMP
     <SpectralCoord
        (observer to target:
           radial_velocity=115304.79153846153 km / s
@@ -184,7 +184,7 @@ this method is to give a single value that will be applied to the target - if
 this value does not have units, it is interpreted as a redshift::
 
     >>> wavs_orig = wavs_rest.with_radial_velocity_shift(0.5)
-    >>> wavs_orig
+    >>> wavs_orig  # doctest: +FLOAT_CMP
     <SpectralCoord
        (observer to target:
           radial_velocity=115304.79153846153 km / s


### PR DESCRIPTION
The current SpectralCoord implementation relies on an internal 'fake' observer and target when these are not specified explicitly, but I believe this actually makes the implementation more complicated than it needs to be (the original intent was to actually make it simpler but this is not the case in the end!).

In addition, some of the implementation is also overly complex because of an original use case (changing the actual observer location and taking into account parallax effects) which didn't make it into the final API since we determined that this might not be needed. This PR shows how we can simplify the implementation while still having the tests pass (at least they do for me locally).

Even if we do eventually implement more complex use cases, I think we should keep the implementation as simple as possible for the current use cases, for maintainability and speed.

The resulting code in this PR has fewer frame transformations and vector operations, and is therefore faster. For instance:

**Before**

```python
In [1]: from astropy.coordinates import SpectralCoord                                                                                                                            

In [2]: from astropy import units as u                                                                                                                                           

In [3]: velocity = 100 * u.km / u.s                                                                                                                                              

In [4]: %timeit sc = SpectralCoord(100, 'GHz')                                                                                                                                   
2.77 ms ± 121 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [5]: sc = SpectralCoord(100, 'GHz')                                                                                                                                   

In [6]: %timeit res = sc.with_radial_velocity_shift(velocity)                                                                                                                    
7.11 ms ± 410 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

**After**

```python
In [1]: from astropy.coordinates import SpectralCoord                                                                                                                            
^[[A^[[A
In [2]: from astropy import units as u                                                                                                                                           

In [3]: velocity = 100 * u.km / u.s                                                                                                                                              

In [4]: %timeit sc = SpectralCoord(100, 'GHz')                                                                                                                                   
134 µs ± 2.37 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)

In [5]: sc = SpectralCoord(100, 'GHz')                                                                                                                                           

In [6]: %timeit res = sc.with_radial_velocity_shift(velocity)                                                                                                                    
418 µs ± 34.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

So the initialization in this case is 20x faster and the call to ``with_radial_velocity_shift`` is 17x faster. This is just an example of course, but overall I think all operations will be the same or faster.

This will require a careful review to make sure I haven't actually broken anything. It might be possible to simplify things further but I haven't had a chance to work on this more as I'm not going to be working much on astropy for a couple of months. So if anyone would like to review this in detail and push commits to it, please feel free to do so!

(cc @mhvk who originally commented on the SpectralCoord PR that the internal coordinates seemed unnecessary)