### PR TITLE
Don't set observer or target on SpectralCoord in FITS WCS if they can't be converted to ICRS

### DIFF
--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 
 from astropy import units as u
-from astropy.coordinates import SpectralCoord, Galactic
+from astropy.coordinates import SpectralCoord, Galactic, ICRS
 from astropy.coordinates.spectral_coordinate import update_differentials_to_match, attach_zero_velocities
 from astropy.utils.exceptions import AstropyUserWarning
 from astropy.constants import c
@@ -452,6 +452,27 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             else:
 
                 target = None
+
+            # SpectralCoord does not work properly if either observer or target
+            # are not convertible to ICRS, so if this is the case, we (for now)
+            # drop the observer and target from the SpectralCoord and warn the
+            # user.
+
+            if observer is not None:
+                try:
+                    observer.transform_to(ICRS())
+                except Exception:
+                    warnings.warn('observer cannot be converted to ICRS, so will '
+                                  'not be set on SpectralCoord', AstropyUserWarning)
+                    observer = None
+
+            if target is not None:
+                try:
+                    target.transform_to(ICRS())
+                except Exception:
+                    warnings.warn('target cannot be converted to ICRS, so will '
+                                  'not be set on SpectralCoord', AstropyUserWarning)
+                    target = None
 
             # NOTE: below we include Quantity in classes['spectral'] instead
             # of SpectralCoord - this is because we want to also be able to


### PR DESCRIPTION
This is a fix (I think) for https://github.com/astropy/astropy/issues/10399 - basically SpectralCoord as it is written right now works properly only if observer and/or target can be converted to ICRS. This requirement meant that the APE 14 WCS API was broken compared to previously in some cases where the observer or target was not convertible to ICRS. To preserve backward-compatibility, this PR therefore discards observer/target information if it cannot be used in SpectralCoord - this is not a step backwards compared to 4.0 since there the WCS just returned a Quantity anyway.

Refactoring such as #10398 allows the ICRS restriction to be relaxed a bit but we should maybe leave refactoring that significant to 4.2 in which case this PR should I think provide a stop-gap measure to make sure we don't break some WCS transformations as described in #10399.

EDIT: Fix #10399 