### PR TITLE
Build nightly wheels with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,14 +10,15 @@ resources:
     name: OpenAstronomy/azure-pipelines-templates
     ref: master
 
-# NOTE: for now we only use Azure Pipelines on v* branches and tags
-# for building the source and wheel distributions. If you want to
-# make changes to this configuration via a pull request, you can
-# *temporarily* change the branches include trigger to just '*'
+# NOTE: for now we only use Azure Pipelines on v* branches, tags, and master
+# only on a cron for building the source and wheel distributions. If you want to
+# make changes to this configuration via a pull request, you can *temporarily*
+# change the pr branches include trigger to just '*'
 trigger:
   branches:
     include:
     - 'v*'
+    - master
   tags:
     include:
     - 'v*'
@@ -26,6 +27,14 @@ pr:
     include:
     - 'v*'
 
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily Build for Nightly Wheels
+    branches:
+      include:
+        - master
+    always: true
+
 # Build Linux wheels using manylinux1 for compatibility with old versions
 # of pip and old platforms.
 variables:
@@ -33,6 +42,8 @@ variables:
   CIBW_MANYLINUX_I686_IMAGE: manylinux1
 
 jobs:
+# Run this job on non-master branches (when triggered) or if we are on master and on the cron, or if manually triggered through the web ui.
+- ${{ if or(ne(variables['Build.SourceBranchName'], 'master'), eq(variables['Build.Reason'], 'Schedule'), eq(variables['Build.Reason'], 'Manual')) }}:
   - template: publish.yml@OpenAstronomy
     parameters:
 
@@ -46,6 +57,12 @@ jobs:
       # for information on how to configure things on the Azure Pipelines side
       ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
         pypi_connection_name : 'pypi_endpoint'
+
+      # If the build has run on master then upload the artifacts to the nightly feed
+      ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+        artifact_project : 'astropy'
+        artifact_feed : 'nightly'
+        remove_local_scheme: true
 
       targets:
       - sdist
@@ -63,3 +80,8 @@ jobs:
       - wheels_cp38*win_amd64
       - wheels_cp39*win32
       - wheels_cp39*win_amd64
+
+# We always need to specify a job, so always run a do nothing.
+- job: skipping
+  steps:
+    - checkout: none


### PR DESCRIPTION
This adds an Azure Pipelines configuration file and uploads built packages (wheels on all 3 platforms and sdist) to Azure Artifacts each night. To use these you can run (once the first build is complete):

```
pip install --pre --extra-index-url https://pkgs.dev.azure.com/astropy-project/astropy/_packaging/astropy/pypi/simple/ astropy
```

it's also easy to [configure tox](https://tox.readthedocs.io/en/latest/example/basic.html#using-a-different-default-pypi-url) to use these for dev deps builds.

---

Notes on implementation:

* This builds nightly, on master, *iff* there have been no changes since the last nightly build.
* This uses the OpenAstronomy [pipelines templates](https://github.com/OpenAstronomy/azure-pipelines-templates)
* You can read about the publish template, and specifically the artifact uploads here: https://openastronomy-azure-pipelines.readthedocs.io/en/latest/publish.html#publishing-to-azure-artifacts
* This uses [cibuildwheel](https://github.com/joerick/cibuildwheel/) to do the actual wheel building, it does not build 32 bit windows or linux builds (they are explicitly excluded, they don't have to be).
* It is configured to build for 3.6, 3.7 and 3.8
* This can be *very* easily extended to upload to PyPI instead of Azure artifacts when the build is triggered by a tag, which is what sunpy and a bunch of other projects use the templates to do.