### PR TITLE
Improve performance creating TimeFromEpoch object

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,10 @@ astropy.tests
 astropy.time
 ^^^^^^^^^^^^
 
+- Improve initialization time by a factor of four when creating a scalar ``Time``
+  object in a format like ``unix`` or ``cxcsec`` (time delta from a reference
+  epoch time). [#10406]
+
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -409,9 +409,13 @@ class TimeNumeric(TimeFormat):
 
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
+        # Save original state of val2 because the super()._check_val_type below
+        # may change val2 from None to np.array(0).
+        val2_is_none = val2 is None
+
         if val1.dtype.kind == 'f':
             val1, val2 = super()._check_val_type(val1, val2)
-        elif (val2 is not None
+        elif (not val2_is_none
               or not (val1.dtype.kind in 'US'
                       or (val1.dtype.kind == 'O'
                           and all(isinstance(v, Decimal) for v in val1.flat)))):
@@ -420,7 +424,7 @@ class TimeNumeric(TimeFormat):
                 'and second values are only allowed for doubles.'
                 .format(self.name))
 
-        val_dtype = (val1.dtype if val2 is None else
+        val_dtype = (val1.dtype if val2_is_none else
                      np.result_type(val1.dtype, val2.dtype))
         subfmts = self._select_subfmts(self.in_subfmt)
         for subfmt, dtype, convert, _ in subfmts:

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -580,10 +580,11 @@ class TimeFromEpoch(TimeNumeric):
     def __init__(self, val1, val2, scale, precision,
                  in_subfmt, out_subfmt, from_jd=False):
         self.scale = scale
+        if not hasattr(self.__class__, 'epoch'):
         # Initialize the reference epoch (a single time defined in subclasses)
         epoch = Time(self.epoch_val, self.epoch_val2, scale=self.epoch_scale,
                      format=self.epoch_format)
-        self.epoch = epoch
+            self.__class__.epoch = epoch
 
         # Now create the TimeFormat object as normal
         super().__init__(val1, val2, scale, precision, in_subfmt, out_subfmt,

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -287,7 +287,7 @@ class TimeFormat(metaclass=TimeFormatMeta):
             raise TypeError('Cannot mix float and Quantity inputs')
 
         if val2 is None:
-            val2 = np.zeros_like(val1)
+            val2 = np.array(0, dtype=val1.dtype)
 
         def asarray_or_scalar(val):
             """

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, defaultdict
 
 import numpy as np
 
-from astropy.utils.decorators import lazyproperty
+from astropy.utils.decorators import lazyproperty, classproperty
 from astropy.utils.exceptions import AstropyDeprecationWarning
 from astropy import units as u
 from astropy import _erfa as erfa
@@ -582,14 +582,15 @@ class TimeFromEpoch(TimeNumeric):
     or days).
     """
 
+    @classproperty(lazy=True)
+    def epoch(cls):
+        return Time(cls.epoch_val, cls.epoch_val2, scale=cls.epoch_scale,
+                    format=cls.epoch_format)
+
+
     def __init__(self, val1, val2, scale, precision,
                  in_subfmt, out_subfmt, from_jd=False):
         self.scale = scale
-        if not hasattr(self.__class__, 'epoch'):
-            # Initialize the reference epoch (a single time defined in subclasses)
-            epoch = Time(self.epoch_val, self.epoch_val2, scale=self.epoch_scale,
-                         format=self.epoch_format)
-            self.__class__.epoch = epoch
 
         # Now create the TimeFormat object as normal
         super().__init__(val1, val2, scale, precision, in_subfmt, out_subfmt,

--- a/astropy/time/formats.py
+++ b/astropy/time/formats.py
@@ -247,8 +247,9 @@ class TimeFormat(metaclass=TimeFormatMeta):
     def _check_val_type(self, val1, val2):
         """Input value validation, typically overridden by derived classes"""
         # val1 cannot contain nan, but val2 can contain nan
+        isfinite1 = (val1.size == 1 and np.isfinite(val1)) or np.all(np.isfinite(val1))
         ok1 = (val1.dtype.kind == 'f' and val1.dtype.itemsize >= 8
-               and np.all(np.isfinite(val1)) or val1.size == 0)
+               and isfinite1 or val1.size == 0)
         ok2 = val2 is None or (
             val2.dtype.kind == 'f' and val2.dtype.itemsize >= 8
             and not np.any(np.isinf(val2))) or val2.size == 0

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1307,7 +1307,6 @@ def test_time_from_epoch_jds():
     assert np.any(np.abs(t.jd2) == 0.5)  # At least one exactly 0.5
 
 
-
 def test_bool():
     """Any Time object should evaluate to True unless it is empty [#3520]."""
     t = Time(np.arange(50000, 50010), format='mjd', scale='utc')

--- a/astropy/time/tests/test_basic.py
+++ b/astropy/time/tests/test_basic.py
@@ -1289,6 +1289,25 @@ def test_dir():
     assert 'utc' in dir(t)
 
 
+def test_time_from_epoch_jds():
+    """Test that jd1/jd2 in a TimeFromEpoch format is always well-formed:
+    jd1 is an integral value and abs(jd2) <= 0.5.
+    """
+    # From 1999:001 00:00 to 1999:002 12:00 by a non-round step. This will
+    # catch jd2 == 0 and a case of abs(jd2) == 0.5.
+    cxcsecs = np.linspace(0, 86400 * 1.5, 49)
+    for cxcsec in cxcsecs:
+        t = Time(cxcsec, format='cxcsec')
+        assert np.round(t.jd1) == t.jd1
+        assert np.abs(t.jd2) <= 0.5
+
+    t = Time(cxcsecs, format='cxcsec')
+    assert np.all(np.round(t.jd1) == t.jd1)
+    assert np.all(np.abs(t.jd2) <= 0.5)
+    assert np.any(np.abs(t.jd2) == 0.5)  # At least one exactly 0.5
+
+
+
 def test_bool():
     """Any Time object should evaluate to True unless it is empty [#3520]."""
     t = Time(np.arange(50000, 50010), format='mjd', scale='utc')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address poor performance when creating a Time object in a format like `cxcsec` or `unix` using the `TimeFromEpoch` subclass.  The changes here were all driven by profiling with `prun` and `lprun`.

The biggest problem was unnecessarily creating two entirely separate `Time` objects, one for the `epoch` time with each new `Time` instance and a temporary one for doing the JD math. Instead this now does this once for the class and stores `epoch` as a common class attribute, and avoids the temporary one if the scale does not need changing (which is the most common case).

Other things:
- `day_frac` is slow (10 us) and can contribute noticeably to initialization time. I think there are opportunities to make this faster for common cases, e.g. `val2 == 0` or `0 <= val2 <= 1` (and `val1` a multiple of `0.5`.  Also cythonizing it seems like it might be worthwhile.
- `np.all()` is curiously slow for a scalar input.

#### Performance

See script below.

*Revision: 3ee79d1cd*
Scalar time = 64 us
Array time (1_000_000) = 91 us

*Revision: master*
Scalar time = 283 us
Array time (1_000_000) = 313 us

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

```
import time
import subprocess
import sys
import numpy as np

out = subprocess.run(['git', 'rev-parse', 'HEAD'], stdout=subprocess.PIPE)
curr_rev = out.stdout.decode('ascii')[:8]

rev = sys.argv[1]
subprocess.run(['git', 'checkout', rev])
print(f'Revision: {rev}')

from astropy.time import Time

n_loop = 10000
Time(1.5, format='cxcsec')
t0 = time.time()
for _ in range(n_loop):
    Time(1.5, format='cxcsec')
t1 = time.time()
print(f'Scalar time = {(t1 - t0) / n_loop * 1e6:.0f} us')

n_loop = 10000
n_times = 1_000_000
cxcsecs = np.arange(0.0, n_times, n_times, dtype=np.float64)
t0 = time.time()
for _ in range(n_loop):
    Time(cxcsecs, format='cxcsec')
t1 = time.time()
print(f'Array time (1_000_000) = {(t1 - t0) / n_loop * 1e6:.0f} us')

subprocess.run(['git', 'checkout', 'time-faster-epoch-time'])
```

Fixes #<Issue Number>
