### PR TITLE
Remove duplicate MJD-OBS and do not write default MJDREF

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -893,8 +893,8 @@ astropy.wcs
 - Implemented a workaround to a bug in WCSLIB due to which ``MJD-OBS`` may be
   written twice to a FITS header. [#10412]
 
-- ``MJDREF``, ``MJDREFI``, and/or ``MJDREFF`` are no longer reported in
-  FITS header when the corresponding values are set to default values. [#100412]
+- ``MJDREFF``, ``MJDREFI``, are replaced with ``MJDREF`` in FITS header when
+  they have default values. [#100412]
 
 Other Changes and Additions
 ---------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -728,6 +728,7 @@ astropy.wcs
 - The new auxiliary WCS parameters added in WCSLIB 7.1 are now exposed as
   the ``aux`` attribute of ``Wcsprm``. [#10333]
 
+
 Bug fixes
 ---------
 
@@ -888,6 +889,12 @@ astropy.wcs
 ^^^^^^^^^^^
 
 - Handled WCS 360 -> 0 deg crossover in ``fit_wcs_from_points`` [#10155]
+
+- Implemented a workaround to a bug in WCSLIB due to which ``MJD-OBS`` may be
+  written twice to a FITS header. [#10412]
+
+- ``MJDREF``, ``MJDREFI``, and/or ``MJDREFF`` are no longer reported in
+  FITS header when the corresponding values are set to default values. [#100412]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -378,8 +378,6 @@ def test_to_header_string():
     if _WCSLIB_VER >= '7.1':
         hdrstr += (
             "DATEREF = '1858-11-17'         / ISO-8601 fiducial time                         ",
-            "MJDREFI =                  0.0 / [d] MJD of fiducial time, integer part         ",
-            "MJDREFF =                  0.0 / [d] MJD of fiducial time, fractional part      "
         )
     hdrstr += ("END", )
 
@@ -396,7 +394,7 @@ def test_to_header_string():
 
 
 def test_to_fits():
-    nrec = 11 if _WCSLIB_VER >= '7.1' else 8
+    nrec = 9 if _WCSLIB_VER >= '7.1' else 8
     w = wcs.WCS()
     header_string = w.to_header()
     wfits = w.to_fits()
@@ -1371,17 +1369,18 @@ class TestWcsWithTime:
         for key in char_keys:
             assert getattr(self.w.wcs, key) == self.header.get(key, "")
 
-        num_keys = ['mjdref', 'mjdobs', 'mjdbeg', 'mjdend',
+        num_keys = ['mjdobs', 'mjdbeg', 'mjdend',
                     'jepoch', 'bepoch', 'tstart', 'tstop', 'xposure',
                     'timsyer', 'timrder', 'timedel', 'timepixr',
                     'timeoffs', 'telapse', 'czphs', 'cperi']
 
+        assert_allclose(
+            self.w.wcs.mjdref,
+            [self.header.get('mjdrefia'), self.header.get('mjdreffa')]
+        )
+
         for key in num_keys:
-            if key.upper() == 'MJDREF':
-                hdrv = [self.header.get('MJDREFIA', np.nan),
-                        self.header.get('MJDREFFA', np.nan)]
-            else:
-                hdrv = self.header.get(key, np.nan)
+            hdrv = self.header.get(key, np.nan)
             assert_allclose(getattr(self.w.wcs, key), hdrv)
 
     def test_transforms(self):

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -378,6 +378,7 @@ def test_to_header_string():
     if _WCSLIB_VER >= '7.1':
         hdrstr += (
             "DATEREF = '1858-11-17'         / ISO-8601 fiducial time                         ",
+            "MJDREF  =                  0.0 / [d] MJD of fiducial time                       "
         )
     hdrstr += ("END", )
 
@@ -394,7 +395,7 @@ def test_to_header_string():
 
 
 def test_to_fits():
-    nrec = 9 if _WCSLIB_VER >= '7.1' else 8
+    nrec = 10 if _WCSLIB_VER >= '7.1' else 8
     w = wcs.WCS()
     header_string = w.to_header()
     wfits = w.to_fits()


### PR DESCRIPTION
This pull request implements a temporary workaround that addresses the bug in WCSLIB due to which `MJD-OBS` is written twice to a FITS header when using `WCS.to_header()` method. ~In addition, if this this PR is merged, `to_header` will no longer write `MJDREF`, `MJDREFI`, and `MJDREFF` if they are set to default value (`0.0`).~

Fixes #10397
