### PR TITLE
Introduce a Masked class, apply to Quantity, attempt Column, Representation

### DIFF
--- a/astropy/coordinates/angles.py
+++ b/astropy/coordinates/angles.py
@@ -477,7 +477,7 @@ def _no_angle_subclass(obj):
     if isinstance(obj, tuple):
         return tuple(_no_angle_subclass(_obj) for _obj in obj)
 
-    return obj.view(Angle) if isinstance(obj, Angle) else obj
+    return obj.view(Angle) if isinstance(obj, (Latitude, Longitude)) else obj
 
 
 class Latitude(Angle):

--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -432,6 +432,16 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
                 else:
                     reshaped.append(val)
 
+    @property
+    def mask(self):
+        masks = [getattr(getattr(self, component), 'mask', False)
+                 for component in self.components]
+        masks = [mask for mask in masks if mask is not False]
+        if masks:
+            return functools.reduce(np.logical_or, masks)
+        else:
+            return np.broadcast_to(np.False_, self.shape)
+
     # Required to support multiplication and division, and defined by the base
     # representation and differential classes.
     @abc.abstractmethod

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -20,7 +20,7 @@ def test_masked_row_with_object_col():
     t['col0'].mask = False
     assert t[0]['col0'] == 1
     t['col0'].mask = True
-    assert t[0]['col0'] is np.ma.masked
+    assert t[0]['col0'].mask
 
 
 @pytest.mark.usefixtures('table_types')
@@ -185,7 +185,7 @@ class TestRow():
             # row_void is not a view, need to re-make
             assert row_void['a'] == 1
             row_void = row.as_void()  # but row is a view
-            assert row['a'] is np.ma.masked
+            assert row['a'].mask
 
     def test_row_and_as_void_with_objects(self, table_types):
         """Test the deprecated data property and as_void() method"""

--- a/astropy/uncertainty/core.py
+++ b/astropy/uncertainty/core.py
@@ -281,6 +281,9 @@ class ArrayDistribution(Distribution, np.ndarray):
             else:
                 raise ValueError('Cannot set just dtype for a Distribution.')
 
+        if issubclass(type, Distribution):
+            return super().view(type)
+
         result = self.distribution.view(dtype, type)
         return Distribution(result)
 

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -373,7 +373,7 @@ class Quantity(np.ndarray):
                     copy = False  # copy will be made in conversion at end
 
         value = np.array(value, dtype=dtype, copy=copy, order=order,
-                         subok=False, ndmin=ndmin)
+                         subok=True, ndmin=ndmin)
 
         # check that array contains numbers or long int objects
         if (value.dtype.kind in 'OSU' and
@@ -405,6 +405,13 @@ class Quantity(np.ndarray):
         # If we're a new object or viewing an ndarray, nothing has to be done.
         if obj is None or obj.__class__ is np.ndarray:
             return
+
+        # Check whether super().__array_finalize should be called
+        # (sadly, ndarray.__array_finalize__ is None; we cannot be sure
+        # what is above us).
+        super_array_finalize = super().__array_finalize__
+        if super_array_finalize is not None:
+            super_array_finalize(obj)
 
         # If our unit is not set and obj has a valid one, use it.
         if self._unit is None:

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -607,7 +607,7 @@ class Quantity(np.ndarray):
         if obj is None:
             obj = self.view(np.ndarray)
         else:
-            obj = np.array(obj, copy=False)
+            obj = np.array(obj, copy=False, subok=True)
 
         # Take the view, set the unit, and update possible other properties
         # such as ``info``, ``wrap_angle`` in `Longitude`, etc.
@@ -1369,9 +1369,9 @@ class Quantity(np.ndarray):
         if check_precision:
             # If, e.g., we are casting double to float, we want to fail if
             # precision is lost, but let things pass if it works.
-            _value = np.array(_value, copy=False)
+            _value = np.array(_value, copy=False, subok=True)
             if not np.can_cast(_value.dtype, self.dtype):
-                self_dtype_array = np.array(_value, self.dtype)
+                self_dtype_array = np.array(_value, self.dtype, subok=True)
                 if not np.all(np.logical_or(self_dtype_array == _value,
                                             np.isnan(_value))):
                     raise TypeError("cannot convert value type to array type "

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -1614,15 +1614,18 @@ class Quantity(np.ndarray):
         return self._wrap_function(np.trace, offset, axis1, axis2, dtype,
                                    out=out)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0):
+    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
         return self._wrap_function(np.var, axis, dtype,
-                                   out=out, ddof=ddof, unit=self.unit**2)
+                                   out=out, ddof=ddof, keepdims=keepdims,
+                                   unit=self.unit**2)
 
-    def std(self, axis=None, dtype=None, out=None, ddof=0):
-        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof)
+    def std(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
+        return self._wrap_function(np.std, axis, dtype, out=out, ddof=ddof,
+                                   keepdims=keepdims)
 
-    def mean(self, axis=None, dtype=None, out=None):
-        return self._wrap_function(np.mean, axis, dtype, out=out)
+    def mean(self, axis=None, dtype=None, out=None, keepdims=False):
+        return self._wrap_function(np.mean, axis, dtype, out=out,
+                                   keepdims=keepdims)
 
     def round(self, decimals=0, out=None):
         return self._wrap_function(np.round, decimals, out=out)

--- a/astropy/units/quantity_helper/converters.py
+++ b/astropy/units/quantity_helper/converters.py
@@ -315,14 +315,18 @@ def check_output(output, unit, inputs, function=None):
                                 (f" from {function.__name__} function"
                                  if function is not None else ""),
                                 type(output)))
-
-        if output.__quantity_subclass__(unit)[0] is not type(output):
+        # Check whether the type of quantity is right by trying to
+        # set the unit.  In order to ensure we do not change the output
+        # before a possible error, we try it on a view.
+        try:
+            output.view()._set_unit(unit)
+        except Exception as exc:
             raise UnitTypeError(
                 "Cannot store output with unit '{}'{} "
                 "in {} instance.  Use {} instance instead."
                 .format(unit, (f" from {function.__name__} function"
                                if function is not None else ""), type(output),
-                        output.__quantity_subclass__(unit)[0]))
+                        output.__quantity_subclass__(unit)[0])) from exc
 
         # check we can handle the dtype (e.g., that we are not int
         # when float is required).  Note that we only do this for Quantity

--- a/astropy/utils/masked/__init__.py
+++ b/astropy/utils/masked/__init__.py
@@ -1,0 +1,1 @@
+from .core import Masked

--- a/astropy/utils/masked/__init__.py
+++ b/astropy/utils/masked/__init__.py
@@ -1,1 +1,1 @@
-from .core import Masked
+from .core import *

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Built-in mask mixin class.
+"""
+import numpy as np
+
+
+__all__ = ['Masked']
+
+
+class Masked:
+    """A scalar value or array of values with associated mask.
+
+    This object will take its exact type from whatever the contents are.
+    In general this is expected to be an `~astropy.units.Quantity` or
+    `numpy.ndarray`, although anything compatible with `numpy.asanyarray` is
+    possible.
+
+    Parameters
+    ----------
+    data : array-like
+        The data for which a mask is to be added.
+    """
+    _generated_subclasses = {}
+
+    def __new__(cls, data, mask=None):
+        data_mask = getattr(data, 'mask', None)
+
+        if data_mask is None:
+            data = np.asanyarray(data)
+            if mask is None:
+                mask = False
+        else:
+            data = data.data
+            if mask is None:
+                mask = data_mask
+
+        data_cls = type(data)
+        if not issubclass(data_cls, Masked):
+            # Make sure first letter is uppercase, but note that we can't use
+            # str.capitalize since that converts the rest of the name to lowercase.
+            new_name = cls.__name__ + data_cls.__name__[0].upper() + data_cls.__name__[1:]
+            if new_name in cls._generated_subclasses:
+                new_cls = cls._generated_subclasses[new_name]
+            else:
+                new_cls = type(new_name, (cls, data_cls),
+                               {'_data_cls': data_cls})
+                cls._generated_subclasses[new_name] = new_cls
+
+        self = data.view(new_cls)
+        self._data_cls = data_cls
+        self._mask = np.zeros(data.shape, dtype='?')
+        self._mask[...] = mask
+        return self
+
+    @property
+    def data(self):
+        return self.view(self._data_cls)
+
+    @property
+    def mask(self):
+        return self._mask
+
+    @mask.setter
+    def mask(self, mask):
+        self._mask[...] = mask
+
+    def __getitem__(self, item):
+        result = super().__getitem__(item)
+        mask = self.mask[item]
+        if isinstance(result, Masked):
+            result._mask = mask
+            return result
+        else:
+            return self.__class__(result, mask=mask)
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        converted = []
+        if method in {'reduce', 'accumulate', 'reduceat'}:
+            raise NotImplementedError
+
+        masks = []
+        for input_ in inputs:
+            mask = getattr(input_, 'mask', None)
+            if mask is not None:
+                masks.append(mask)
+                converted.append(input_.data)
+            else:
+                converted.append(input_)
+
+        results = getattr(ufunc, method)(*converted, **kwargs)
+        if masks:
+            mask = masks[0]
+            for mask_ in masks[1:]:
+                mask |= mask_
+        else:
+            mask = False
+
+        if not isinstance(results, tuple):
+            return Masked(results, mask)
+        else:
+            return [Masked(result, mask) for result in results]
+
+    # TODO: improve (greatly) repr and str!!
+    def __repr__(self):
+        reprarr = repr(self.data)
+        if reprarr.endswith('>'):
+            firstspace = reprarr.find(' ')
+            reprarr = reprarr[firstspace+1:-1]  # :-1] removes the ending '>'
+            return '<{} {} with mask={}>'.format(self.__class__.__name__,
+                                                 reprarr, self.mask)
+        else:  # numpy array-like
+            firstparen = reprarr.find('(')
+            reprarr = reprarr[firstparen:]
+            return '{}{} with mask={}'.format(self.__class__.__name__,
+                                              reprarr, self.mask)
+            return reprarr
+
+    def __str__(self):
+        datastr = str(self.data)
+        toadd = ' with mask={}'.format(self.mask)
+        return datastr + toadd

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -3,7 +3,7 @@
 """
 Built-in mask mixin class.
 """
-from functools import reduce
+import functools
 import operator
 
 import numpy as np
@@ -230,7 +230,7 @@ class Masked:
 
             result = getattr(ufunc, method)(*converted, **kwargs)
             if masks:
-                mask = reduce(operator.or_, masks)
+                mask = functools.reduce(np.logical_or, masks)
             else:
                 mask = False
 
@@ -268,7 +268,7 @@ class Masked:
 
             result = getattr(ufunc, method)(converted, **kwargs)
 
-        elif method in {'accumulate', 'reduceat'}:
+        elif method in {'accumulate', 'reduceat', 'at'}:
             return NotImplemented
 
         if mask is False or result is None or result is NotImplemented:

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -293,6 +293,12 @@ class Masked(NDArrayShapeMethods):
             kwargs['initial'] = initial_func(self.unmasked)
         return kwargs
 
+    def trace(self, offset=0, axis1=0, axis2=1, dtype=None, out=None):
+        # Unfortunately, cannot override the call to diagonal inside trace, so
+        # duplicate implementation in numpy/core/src/multiarray/calculation.c.
+        diagonal = self.diagonal(offset=offset, axis1=axis1, axis2=axis2)
+        return diagonal.sum(-1, dtype=dtype, out=out)
+
     def min(self, axis=None, out=None, **kwargs):
         return super().min(axis=axis, out=out,
                            **self._reduce_defaults(kwargs, np.max))

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -245,9 +245,9 @@ class Masked(NDArrayShapeMethods):
 
         elif function in APPLY_TO_BOTH_FUNCTIONS:
             helper = APPLY_TO_BOTH_FUNCTIONS[function]
-            data, mask, args, kwargs, out = helper(*args, **kwargs)
-            if mask is not None:
-                mask = function(mask, *args, **kwargs)
+            data_args, mask_args, kwargs, out = helper(*args, **kwargs)
+            if mask_args is not None:
+                mask = function(*mask_args, **kwargs)
             if out is not None:
                 if isinstance(out, Masked):
                     if mask is None:
@@ -256,7 +256,7 @@ class Masked(NDArrayShapeMethods):
                 elif mask is not None:
                     return NotImplemented
                 kwargs['out'] = out
-            result = function(data, *args, **kwargs)
+            result = function(*data_args, **kwargs)
 
         elif function in DISPATCHED_FUNCTIONS:
             dispatched_function = DISPATCHED_FUNCTIONS[function]

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -170,7 +170,9 @@ class Masked(NDArrayShapeMethods):
             data = getattr(self.unmasked, method)(*args, **kwargs)
             mask = getattr(self._mask, method)(*args, **kwargs)
 
-        result = data[...].view(self.__class__)
+        if not isinstance(data, np.ndarray):
+            data = np.array(data)
+        result = data.view(self.__class__)
         result._mask = mask
         return result
 

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -101,7 +101,7 @@ class Masked(NDArrayShapeMethods):
         return super().view(self._get_subclass(type))
 
     def __array_finalize__(self, obj):
-        if obj is None or type(obj) is np.ndarray:
+        if obj is None:
             return None
 
         super_array_finalize = super().__array_finalize__
@@ -109,7 +109,10 @@ class Masked(NDArrayShapeMethods):
             super_array_finalize(obj)
 
         if self._mask is None:
-            self._mask = getattr(obj, '_mask', None)
+            mask = getattr(obj, '_mask', None)
+            if mask is None:
+                mask = np.zeros(self.shape, dtype=bool)
+            self._mask = mask
 
     @staticmethod
     def _data_mask(data):

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -7,7 +7,7 @@ import functools
 
 import numpy as np
 
-from astropy.utils.misc import ShapedLikeNDArray
+from astropy.utils.shapes import NDArrayShapeMethods
 
 from .function_helpers import APPLY_TO_BOTH_FUNCTIONS
 
@@ -15,10 +15,7 @@ from .function_helpers import APPLY_TO_BOTH_FUNCTIONS
 __all__ = ['Masked']
 
 
-# Note: at present, ShapedLikeNDArray is a bit unhandy because it forces
-# one to unnecessarily override shape.  Would be good to split off
-# a separate NDArrayShapeMethods, which is not an ABC.
-class Masked(ShapedLikeNDArray):
+class Masked(NDArrayShapeMethods):
     """A scalar value or array of values with associated mask.
 
     This object will take its exact type from whatever the contents are.
@@ -49,10 +46,6 @@ class Masked(ShapedLikeNDArray):
         self = data.view(subclass)
         self._set_mask(mask, copy=copy)
         return self
-
-    @property
-    def shape(self):
-        return super(ShapedLikeNDArray, self).shape
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -336,14 +329,3 @@ class Masked(ShapedLikeNDArray):
 
 class MaskedNDArray(Masked, np.ndarray):
     _data_cls = np.ndarray
-
-    # Override ShapedLikeNDArray __bool__ for ndarray.
-    def __bool__(self):
-        if self.size == 1:
-            if self.mask:
-                return False
-            else:
-                return self.unmasked.__bool__()
-
-        # Raise ndarray error.
-        return np.ndarray.__bool__(self)

--- a/astropy/utils/masked/core.py
+++ b/astropy/utils/masked/core.py
@@ -10,7 +10,9 @@ import numpy as np
 
 from astropy.utils.shapes import NDArrayShapeMethods
 
-from .function_helpers import APPLY_TO_BOTH_FUNCTIONS, DISPATCHED_FUNCTIONS
+from .function_helpers import (MASKED_SAFE_FUNCTIONS,
+                               APPLY_TO_BOTH_FUNCTIONS,
+                               DISPATCHED_FUNCTIONS)
 
 
 __all__ = ['Masked']
@@ -238,7 +240,10 @@ class Masked(NDArrayShapeMethods):
         return self._masked_result(result, mask, out)
 
     def __array_function__(self, function, types, args, kwargs):
-        if function in APPLY_TO_BOTH_FUNCTIONS:
+        if function in MASKED_SAFE_FUNCTIONS:
+            return super().__array_function__(function, types, args, kwargs)
+
+        elif function in APPLY_TO_BOTH_FUNCTIONS:
             helper = APPLY_TO_BOTH_FUNCTIONS[function]
             data, mask, args, kwargs, out = helper(*args, **kwargs)
             if mask is not None:

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -10,23 +10,33 @@ APPLY_TO_BOTH_FUNCTIONS = {}
 apply_to_both = FunctionAssigner(APPLY_TO_BOTH_FUNCTIONS)
 
 
-def _data_mask(*args):
+def _data_mask(array):
     from .core import Masked
 
+    if isinstance(array, Masked):
+        return array.unmasked, array.mask
+    else:
+        return array, np.zeros(np.shape(array), bool)
+
+
+def _data_masks(*args):
     data = []
     masks = []
     for arg in args:
-        if isinstance(arg, Masked):
-            data.append(arg.unmasked)
-            masks.append(arg.mask)
-        else:
-            data.append(arg)
-            masks.append(np.zeros(np.shape(arg), bool))
+        datum, mask = _data_mask(arg)
+        data.append(datum)
+        masks.append(mask)
 
     return data, masks
 
 
 @apply_to_both
 def concatenate(arrays, axis=0, out=None):
-    data, masks = _data_mask(*arrays)
+    data, masks = _data_masks(*arrays)
     return data, masks, (axis,), {}, out
+
+
+@apply_to_both
+def take_along_axis(arr, indices, axis):
+    data, mask = _data_mask(arr)
+    return data, mask, (indices, axis), {}, None

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -5,9 +5,11 @@ from astropy.units.quantity_helper.function_helpers import FunctionAssigner
 
 
 APPLY_TO_BOTH_FUNCTIONS = {}
+DISPATCHED_FUNCTIONS = {}
 
 
 apply_to_both = FunctionAssigner(APPLY_TO_BOTH_FUNCTIONS)
+dispatched_function = FunctionAssigner(DISPATCHED_FUNCTIONS)
 
 
 def _data_mask(array):
@@ -40,3 +42,29 @@ def concatenate(arrays, axis=0, out=None):
 def take_along_axis(arr, indices, axis):
     data, mask = _data_mask(arr)
     return data, mask, (indices, axis), {}, None
+
+
+@apply_to_both
+def broadcast_to(array, shape, subok=True):
+    data, mask = _data_mask(array) if subok else (array.unmasked, None)
+    return data, mask, (shape, subok), {}, None
+
+
+@dispatched_function
+def broadcast_arrays(*args, subok=True):
+    from .core import Masked
+
+    are_masked = [isinstance(arg, Masked) for arg in args]
+    data = [(arg.unmasked if is_masked else arg)
+            for arg, is_masked in zip(args, are_masked)]
+    results = np.broadcast_arrays(*data, subok=subok)
+    if not subok:
+        return results
+
+    shape = results[0].shape if isinstance(results, list) else results.shape
+    masks = [(np.broadcast_to(arg.mask, shape, subok=subok)
+              if is_masked else None)
+             for arg, is_masked in zip(args, are_masked)]
+    results = [(Masked(result, mask) if mask is not None else result)
+               for (result, mask) in zip(results, masks)]
+    return (results if len(results) > 1 else results[0]), None, None

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -1,0 +1,32 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+
+from astropy.units.quantity_helper.function_helpers import FunctionAssigner
+
+
+APPLY_TO_BOTH_FUNCTIONS = {}
+
+
+apply_to_both = FunctionAssigner(APPLY_TO_BOTH_FUNCTIONS)
+
+
+def _data_mask(*args):
+    from .core import Masked
+
+    data = []
+    masks = []
+    for arg in args:
+        if isinstance(arg, Masked):
+            data.append(arg.unmasked)
+            masks.append(arg.mask)
+        else:
+            data.append(arg)
+            masks.append(np.zeros(np.shape(arg), bool))
+
+    return data, masks
+
+
+@apply_to_both
+def concatenate(arrays, axis=0, out=None):
+    data, masks = _data_mask(*arrays)
+    return data, masks, (axis,), {}, out

--- a/astropy/utils/masked/function_helpers.py
+++ b/astropy/utils/masked/function_helpers.py
@@ -4,8 +4,12 @@ import numpy as np
 from astropy.units.quantity_helper.function_helpers import FunctionAssigner
 
 
+MASKED_SAFE_FUNCTIONS = set()
 APPLY_TO_BOTH_FUNCTIONS = {}
 DISPATCHED_FUNCTIONS = {}
+
+
+MASKED_SAFE_FUNCTIONS |= {np.diff}
 
 
 apply_to_both = FunctionAssigner(APPLY_TO_BOTH_FUNCTIONS)

--- a/astropy/utils/masked/tests/test_containers.py
+++ b/astropy/utils/masked/tests/test_containers.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+
+from astropy import units as u
+from astropy.coordinates import representation as r
+
+from .. import Masked
+
+
+class TestRepresentations:
+    def setup(self):
+        self.x = np.array([3., 5., 0.]) << u.m
+        self.y = np.array([4., 12., 1.]) << u.m
+        self.z = np.array([0., 0., 1.]) << u.m
+        self.c = r.CartesianRepresentation(self.x, self.y, self.z)
+        self.mask = np.array([False, False, True])
+        self.mx = Masked(self.x, self.mask)
+        self.my = Masked(self.y, self.mask)
+        self.mz = Masked(self.z, self.mask)
+        self.mc = r.CartesianRepresentation(self.mx, self.my, self.mz)
+
+    def test_initialization(self):
+        check = self.mc.z == self.mz
+        assert_array_equal(check.unmasked, np.ones(3, bool))
+        assert_array_equal(check.mask, self.mask)
+        assert_array_equal(self.mc.x, self.mx)
+        assert_array_equal(self.mc.y, self.my)
+        assert_array_equal(self.mc.z, self.mz)
+
+    def test_norm(self):
+        # Need stacking and erfa override.
+        norm = self.mc.norm()
+        assert_array_equal(norm.unmasked, self.c.norm())
+        assert_array_equal(norm.mask, self.mask)
+
+    def test_transformation(self):
+        msh = self.mc.represent_as(r.SphericalRepresentation)
+        sh = self.c.represent_as(r.SphericalRepresentation)
+        for comp in msh.components:
+            mc = getattr(msh, comp)
+            c = getattr(sh, comp)
+            assert_array_equal(mc.unmasked, c)
+            assert_array_equal(mc.mask, self.mask)

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -19,6 +19,19 @@ class TestMaskedArrayConcatenation(MaskedArraySetup):
         assert_array_equal(concat_a_b.unmasked, expected_data)
         assert_array_equal(concat_a_b.mask, expected_mask)
 
+    @pytest.mark.parametrize('obj', (1, slice(2, 3)))
+    def test_insert(self, obj):
+        mc_in_a = np.insert(self.ma, obj, self.mc, axis=-1)
+        expected = Masked(np.insert(self.a, obj, self.c, axis=-1),
+                          np.insert(self.mask_a, obj, self.mask_c, axis=-1))
+        assert_masked_equal(mc_in_a, expected)
+
+    def test_append(self):
+        mc_to_a = np.append(self.ma, self.mc, axis=-1)
+        expected = Masked(np.append(self.a, self.c, axis=-1),
+                          np.append(self.mask_a, self.mask_c, axis=-1))
+        assert_masked_equal(mc_to_a, expected)
+
 
 class TestMaskedQuantityConcatenation(TestMaskedArrayConcatenation,
                                       QuantitySetup):

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -2,8 +2,10 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
+from ..core import Masked
 
-from .test_masked import MaskedArraySetup, QuantitySetup, LongitudeSetup
+from .test_masked import (MaskedArraySetup, QuantitySetup, LongitudeSetup,
+                          assert_masked_equal)
 
 
 class TestMaskedArrayConcatenation(MaskedArraySetup):
@@ -24,4 +26,39 @@ class TestMaskedQuantityConcatenation(TestMaskedArrayConcatenation,
 
 class TestMaskedLongitudeConcatenation(TestMaskedArrayConcatenation,
                                        LongitudeSetup):
+    pass
+
+
+class TestMaskedArrayBroadcast(MaskedArraySetup):
+    def test_broadcast_to(self):
+        shape = self.ma.shape
+        ba = np.broadcast_to(self.mb, shape, subok=True)
+        assert ba.shape == shape
+        assert ba.mask.shape == shape
+        expected = Masked(np.broadcast_to(self.mb.unmasked, shape, subok=True),
+                          np.broadcast_to(self.mb.mask, shape, subok=True))
+        assert_masked_equal(ba, expected)
+
+    def test_broadcast_arrays(self):
+        mb = np.broadcast_arrays(self.ma, self.mb, self.mc, subok=True)
+        b = np.broadcast_arrays(self.a, self.b, self.c, subok=True)
+        bm = np.broadcast_arrays(self.mask_a, self.mask_b, self.mask_c)
+        for mb_, b_, bm_ in zip(mb, b, bm):
+            assert_array_equal(mb_.unmasked, b_)
+            assert_array_equal(mb_.mask, bm_)
+
+    def test_broadcast_arrays_not_all_masked(self):
+        mb = np.broadcast_arrays(self.a, self.mb, self.c, subok=True)
+        assert_array_equal(mb[0], self.a)
+        expected1 = np.broadcast_to(self.mb, self.a.shape, subok=True)
+        assert_masked_equal(mb[1], expected1)
+        expected2 = np.broadcast_to(self.c, self.a.shape, subok=True)
+        assert_array_equal(mb[2], expected2)
+
+
+class TestMaskedQuantityBroadcast(TestMaskedArrayBroadcast, QuantitySetup):
+    pass
+
+
+class TestMaskedLongitudeBroadcast(TestMaskedArrayBroadcast, LongitudeSetup):
     pass

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
@@ -61,4 +62,36 @@ class TestMaskedQuantityBroadcast(TestMaskedArrayBroadcast, QuantitySetup):
 
 
 class TestMaskedLongitudeBroadcast(TestMaskedArrayBroadcast, LongitudeSetup):
+    pass
+
+
+class TestMaskedArrayCalculation(MaskedArraySetup):
+    @pytest.mark.parametrize('n,axis', [(1, -1), (2, -1), (1, 0)])
+    def test_diff(self, n, axis):
+        mda = np.diff(self.ma, n=n, axis=axis)
+        expected_data = np.diff(self.a, n, axis)
+        nan_mask = np.zeros_like(self.a)
+        nan_mask[self.ma.mask] = np.nan
+        expected_mask = np.isnan(np.diff(nan_mask, n=n, axis=axis))
+        assert_array_equal(mda.unmasked, expected_data)
+        assert_array_equal(mda.mask, expected_mask)
+
+    def test_diff_explicit(self):
+        ma = Masked(np.arange(8.),
+                    [True, False, False, False, False, True, False, False])
+        mda = np.diff(ma)
+        assert np.all(mda.unmasked == 1.)
+        assert np.all(mda.mask ==
+                      [True, False, False, False, True, True, False])
+        mda = np.diff(ma, n=2)
+        assert np.all(mda.unmasked == 0.)
+        assert np.all(mda.mask == [True, False, False, True, True, True])
+
+
+class TestMaskedQuantityCalculation(TestMaskedArrayCalculation, QuantitySetup):
+    pass
+
+
+class TestMaskedLongitudeCalculation(TestMaskedArrayCalculation,
+                                     LongitudeSetup):
     pass

--- a/astropy/utils/masked/tests/test_functions.py
+++ b/astropy/utils/masked/tests/test_functions.py
@@ -1,0 +1,27 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+from numpy.testing import assert_array_equal
+
+
+from .test_masked import MaskedArraySetup, QuantitySetup, LongitudeSetup
+
+
+class TestMaskedArrayConcatenation(MaskedArraySetup):
+    def test_concatenate(self):
+        mb = self.mb[np.newaxis]
+        concat_a_b = np.concatenate((self.ma, mb), axis=0)
+        expected_data = np.concatenate((self.a, self.b[np.newaxis]), axis=0)
+        expected_mask = np.concatenate((self.mask_a, self.mask_b[np.newaxis]),
+                                       axis=0)
+        assert_array_equal(concat_a_b.unmasked, expected_data)
+        assert_array_equal(concat_a_b.mask, expected_mask)
+
+
+class TestMaskedQuantityConcatenation(TestMaskedArrayConcatenation,
+                                      QuantitySetup):
+    pass
+
+
+class TestMaskedLongitudeConcatenation(TestMaskedArrayConcatenation,
+                                       LongitudeSetup):
+    pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -336,3 +336,24 @@ class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
 
 class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
     pass
+
+
+class TestMaskedArrayConcatenation(MaskedArraySetup):
+    def test_concatenate(self):
+        mb = self.mb[np.newaxis]
+        concat_a_b = np.concatenate((self.ma, mb), axis=0)
+        expected_data = np.concatenate((self.a, self.b[np.newaxis]), axis=0)
+        expected_mask = np.concatenate((self.mask_a, self.mask_b[np.newaxis]),
+                                       axis=0)
+        assert_array_equal(concat_a_b.unmasked, expected_data)
+        assert_array_equal(concat_a_b.mask, expected_mask)
+
+
+class TestMaskedQuantityConcatenation(TestMaskedArrayConcatenation,
+                                      QuantitySetup):
+    pass
+
+
+class TestMaskedLongitudeConcatenation(TestMaskedArrayConcatenation,
+                                       LongitudeSetup):
+    pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -523,6 +523,7 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         assert result is out
         assert_masked_equal(out, expected)
 
+    @pytest.mark.filterwarnings("ignore:.*true_divide.*")
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_var(self, axis):
         ma_var = self.ma.var(axis)

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -114,6 +114,11 @@ class TestMaskSetting(ArraySetup):
         assert np.may_share_memory(ma.mask, mask)
         assert_array_equal(ma.mask, mask)
 
+    def test_viewing(self):
+        ma = Masked(self.a)
+        ma2 = self.a.view(type(ma))
+        assert_masked_equal(ma2, ma)
+
 
 # Following are tests where we trust the initializer works.
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -30,7 +30,7 @@ class QuantitySetup(ArraySetup):
         super().setup_arrays()
         self.a = Quantity(self.a, u.m)
         self.b = Quantity(self.b, u.cm)
-        self.c = Quantity(self.c, u.s)
+        self.c = Quantity(self.c, u.km)
 
 
 class LongitudeSetup(ArraySetup):
@@ -230,13 +230,20 @@ class TestMaskedLongitudeOperators(TestMaskedArrayOperators, LongitudeSetup):
 
 class MaskedUfuncTests(MaskedArraySetup):
     @pytest.mark.parametrize('ufunc', (np.add, np.subtract, np.divide,
-                                       np.arctan2))
+                                       np.arctan2, np.minimum))
     def test_2op_ufunc(self, ufunc):
         ma_mb = ufunc(self.ma, self.mb)
         expected_data = ufunc(self.a, self.b)
         expected_mask = (self.ma.mask | self.mb.mask)
         # Note: assert_array_equal also checks type, i.e., that, e.g.,
         # Longitude decays into an Angle.
+        assert_array_equal(ma_mb.data, expected_data)
+        assert_array_equal(ma_mb.mask, expected_mask)
+
+    def test_3op_ufunc(self):
+        ma_mb = np.clip(self.ma, self.mb, self.mc)
+        expected_data = np.clip(self.a, self.b, self.c)
+        expected_mask = (self.ma.mask | self.mb.mask | self.mc.mask)
         assert_array_equal(ma_mb.data, expected_data)
         assert_array_equal(ma_mb.mask, expected_mask)
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -240,8 +240,8 @@ class MaskedUfuncTests(MaskedArraySetup):
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_sum(self, axis):
         ma_sum = self.ma.sum(axis)
-        masked0 = self.ma.data * (1. - self.ma.mask)
-        expected_data = masked0.sum(axis)
+        filled = self.ma.data * (1. - self.ma.mask)
+        expected_data = filled.sum(axis)
         assert_array_equal(ma_sum.data, expected_data)
         assert not np.any(ma_sum.mask)
 
@@ -250,7 +250,9 @@ class TestMaskedArrayUfuncs(MaskedUfuncTests, ArraySetup):
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_reduce_filled_one(self, axis):
         ma_reduce = np.prod(self.ma, axis=axis)
-        expected_data = np.prod(self.ma.filled(1), axis=axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = 1
+        expected_data = np.prod(filled, axis=axis)
         expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
         assert_array_equal(ma_reduce.data, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
@@ -268,16 +270,18 @@ class TestMaskedArrayMinMax(MaskedArraySetup):
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_min(self, axis):
         ma_sum = self.ma.min(axis)
-        masked0 = self.ma.filled(self.a.max())
-        expected_data = masked0.min(axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = self.a.max()
+        expected_data = filled.min(axis)
         assert_array_equal(ma_sum.data, expected_data)
         assert not np.any(ma_sum.mask)
 
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_max(self, axis):
         ma_sum = self.ma.max(axis)
-        masked0 = self.ma.filled(self.a.min())
-        expected_data = masked0.max(axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = self.a.min()
+        expected_data = filled.max(axis)
         assert_array_equal(ma_sum.data, expected_data)
         assert not np.any(ma_sum.mask)
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -290,37 +290,48 @@ class TestMaskedLongitudeUfuncs(MaskedUfuncTests, LongitudeSetup):
     pass
 
 
-# class TestMaskedArrayMethods(MaskedArraySetup):
-#     @pytest.mark.parametrize('axis', (0, 1, None))
-#     def test_sum_method(self, axis):
-#         ma_sum = self.ma.sum(axis)
-#         filled = self.a.data * (1. - self.ma.mask)
-#         expected_data = filled.sum(axis)
-#         assert_array_equal(ma_sum.data, expected_data)
-#         assert not np.any(ma_sum.mask)
+class TestMaskedArrayMethods(MaskedArraySetup):
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    def test_sum_method(self, axis):
+        ma_sum = self.ma.sum(axis)
+        expected_data = self.a.sum(axis)
+        expected_mask = self.ma.mask.any(axis)
+        assert_array_equal(ma_sum.unmasked, expected_data)
+        assert_array_equal(ma_sum.mask, expected_mask)
 
-#     @pytest.mark.parametrize('axis', (0, 1, None))
-#     def test_min(self, axis):
-#         ma_min = self.ma.min(axis)
-#         filled = self.a.copy()
-#         filled[self.mask_a] = self.a.max()
-#         expected_data = filled.min(axis)
-#         assert_array_equal(ma_min.data, expected_data)
-#         assert not np.any(ma_min.mask)
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    def test_mean_method(self, axis):
+        ma_mean = self.ma.mean(axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = 0.
+        count = 1 - self.ma.mask.copy().astype(int)
+        expected_data = filled.sum(axis) / count.sum(axis)
+        expected_mask = self.ma.mask.all(axis)
+        assert_array_equal(ma_mean.unmasked, expected_data)
+        assert_array_equal(ma_mean.mask, expected_mask)
 
-#     @pytest.mark.parametrize('axis', (0, 1, None))
-#     def test_max(self, axis):
-#         ma_max = self.ma.max(axis)
-#         filled = self.a.copy()
-#         filled[self.mask_a] = self.a.min()
-#         expected_data = filled.max(axis)
-#         assert_array_equal(ma_max.data, expected_data)
-#         assert not np.any(ma_max.mask)
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    def test_min(self, axis):
+        ma_min = self.ma.min(axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = self.a.max()
+        expected_data = filled.min(axis)
+        assert_array_equal(ma_min.unmasked, expected_data)
+        assert not np.any(ma_min.mask)
+
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    def test_max(self, axis):
+        ma_max = self.ma.max(axis)
+        filled = self.a.copy()
+        filled[self.mask_a] = self.a.min()
+        expected_data = filled.max(axis)
+        assert_array_equal(ma_max.unmasked, expected_data)
+        assert not np.any(ma_max.mask)
 
 
-# class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
-#     pass
+class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
+    pass
 
 
-# class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
-#     pass
+class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
+    pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -338,6 +338,30 @@ class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
     pass
 
 
+class TestMaskedArrayRepr(MaskedArraySetup):
+    def test_array_str(self):
+        # very blunt check they work at all.
+        str(self.ma)
+        str(self.mb)
+        str(self.mb)
+
+    def test_scalar_str(self):
+        assert self.mb[0].shape == ()
+        str(self.mb[0])
+
+    def test_array_repr(self):
+        repr(self.ma)
+        repr(self.mb)
+        repr(self.mc)
+
+    def test_scalar_repr(self):
+        repr(self.mb[0])
+
+
+class TestMaskedQuantityRepr(TestMaskedArrayRepr, QuantitySetup):
+    pass
+
+
 class TestMaskedArrayConcatenation(MaskedArraySetup):
     def test_concatenate(self):
         mb = self.mb[np.newaxis]

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -555,24 +555,3 @@ class TestMaskedArrayRepr(MaskedArraySetup):
 
 class TestMaskedQuantityRepr(TestMaskedArrayRepr, QuantitySetup):
     pass
-
-
-class TestMaskedArrayConcatenation(MaskedArraySetup):
-    def test_concatenate(self):
-        mb = self.mb[np.newaxis]
-        concat_a_b = np.concatenate((self.ma, mb), axis=0)
-        expected_data = np.concatenate((self.a, self.b[np.newaxis]), axis=0)
-        expected_mask = np.concatenate((self.mask_a, self.mask_b[np.newaxis]),
-                                       axis=0)
-        assert_array_equal(concat_a_b.unmasked, expected_data)
-        assert_array_equal(concat_a_b.mask, expected_mask)
-
-
-class TestMaskedQuantityConcatenation(TestMaskedArrayConcatenation,
-                                      QuantitySetup):
-    pass
-
-
-class TestMaskedLongitudeConcatenation(TestMaskedArrayConcatenation,
-                                       LongitudeSetup):
-    pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -352,6 +352,12 @@ class TestMaskedLongitudeUfuncs(MaskedUfuncTests, LongitudeSetup):
 
 
 class TestMaskedArrayMethods(MaskedArraySetup):
+    def test_round(self):
+        # Goes via ufunc, hence easy.
+        mrc = self.mc.round()
+        expected = Masked(self.c.round(), self.mask_c)
+        assert_masked_equal(mrc, expected)
+
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_sum(self, axis):
         ma_sum = self.ma.sum(axis)
@@ -523,6 +529,20 @@ class TestMaskedArrayMethods(MaskedArraySetup):
         result = ma_eq.any(1, out=out)
         assert result is out
         assert_masked_equal(result, expected)
+
+    @pytest.mark.parametrize('offset', (0, 1))
+    def test_diagonal(self, offset):
+        mda = self.ma.diagonal(offset=offset)
+        expected = Masked(self.a.diagonal(offset=offset),
+                          self.mask_a.diagonal(offset=offset))
+        assert_masked_equal(mda, expected)
+
+    @pytest.mark.parametrize('offset', (0, 1))
+    def test_trace(self, offset):
+        mta = self.ma.trace(offset=offset)
+        expected = Masked(self.a.trace(offset=offset),
+                          self.mask_a.trace(offset=offset, dtype=bool))
+        assert_masked_equal(mta, expected)
 
 
 class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -193,10 +193,11 @@ class TestMaskedArrayItems(MaskedArraySetup):
         expected_data = self.a.copy()
         expected_mask = self.mask_a.copy()
         for mask in True, False:
-            value = self.ma.__class__(base[0, 0], mask)
+            value = Masked(base[0, 0], mask)
             base[item] = value
             expected_data[item] = value.unmasked
             expected_mask[item] = value.mask
+            assert_array_equal(base.unmasked, expected_data)
             assert_array_equal(base.mask, expected_mask)
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -260,6 +260,12 @@ class MaskedItemTests(MaskedArraySetup):
 
 
 class TestMaskedArrayItems(MaskedItemTests):
+    def setup(self):
+        super().setup()
+        self.d = np.array(['aa', 'bb'])
+        self.mask_d = np.array([True, False])
+        self.md = Masked(self.d, self.mask_d)
+
     # TODO: make this work for Quantity & Longitude as well.
     # Or decide that it just shouldn't work...
     @pytest.mark.parametrize('item', ((1, 1),
@@ -273,6 +279,21 @@ class TestMaskedArrayItems(MaskedItemTests):
         expected_mask[item] = True
         assert_array_equal(base.unmasked, self.a)
         assert_array_equal(base.mask, expected_mask)
+
+    # Quantity, Longitude cannot hold strings.
+    def test_getitem_strings(self):
+        md = self.md.copy()
+        md0 = md[0]
+        assert md0.unmasked == self.d[0]
+        assert md0.mask
+        md_all = md[:]
+        assert_masked_equal(md_all, md)
+
+    def test_setitem_strings_np_ma_masked(self):
+        md = self.md.copy()
+        md[1] = np.ma.masked
+        assert_array_equal(md.unmasked, self.d)
+        assert_array_equal(md.mask, np.ones(2, bool))
 
 
 class TestMaskedQuantityItems(MaskedItemTests, QuantitySetup):

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 
 from .... import units as u
 from ..core import Masked
-from ....tests.helper import assert_quantity_allclose, pytest
+from ....tests.helper import pytest
 
 
 class TestMaskedArrayInitialization:
@@ -24,6 +24,19 @@ class TestMaskedArrayInitialization:
 class TestMaskedQuantityInitialization(TestMaskedArrayInitialization):
     def setup(self):
         self.a = np.array([1., 2.]) * u.m
+
+
+class TestFilled:
+    def setup(self):
+        self.a = np.arange(6.).reshape(2, 3)
+        self.ma = Masked(self.a, mask=np.array([[True, False, False],
+                                                [False, True, False]]))
+
+    @pytest.mark.parametrize('fill_value', (0, 1))
+    def test_filled(self, fill_value):
+        expected = np.where(self.ma.mask, fill_value, self.a)
+        result = self.ma.filled(fill_value)
+        assert_array_equal(expected, result)
 
 
 class TestMaskedArrayUfuncs:
@@ -47,6 +60,25 @@ class TestMaskedArrayUfuncs:
         ma_mb = ufunc(self.ma, self.mb)
         assert_array_equal(ma_mb.data, ufunc(self.a, self.b))
         assert_array_equal(ma_mb.mask, (self.ma.mask | self.mb.mask))
+
+    @pytest.mark.parametrize('ufunc', (np.add, np.subtract))
+    @pytest.mark.parametrize('axis', (0, 1))
+    def test_reduce_filled_zero(self, ufunc, axis):
+        reduction = getattr(ufunc, 'reduce')
+        ma_reduce = reduction(self.ma, axis=axis)
+        expected_data = reduction(self.a * (1 - self.ma.mask),
+                                  axis=axis)
+        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        assert isinstance(ma_reduce, type(self.ma))
+        assert_array_equal(ma_reduce.data, expected_data)
+        assert_array_equal(ma_reduce.mask, expected_mask)
+
+    @pytest.mark.parametrize('axis', (0, 1))
+    def test_sum(self, axis):
+        ma_sum = self.ma.sum(axis)
+        masked0 = self.ma.data * (1. - self.ma.mask)
+        assert_array_equal(ma_sum.data, masked0.sum(axis))
+        assert not np.any(ma_sum.mask)
 
 
 class TestMaskedQuantityUfuncs(TestMaskedArrayUfuncs):

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -1,0 +1,60 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from .... import units as u
+from ..core import Masked
+from ....tests.helper import assert_quantity_allclose, pytest
+
+
+class TestMaskedArrayInitialization:
+    def setup(self):
+        self.a = np.array([1., 2.])
+
+    def test_simple(self):
+        m = np.array([True, False])
+        ma = Masked(self.a, mask=m)
+        assert isinstance(ma, np.ndarray)
+        assert isinstance(ma, type(self.a))
+        assert isinstance(ma, Masked)
+        assert_array_equal(ma.data, self.a)
+        assert_array_equal(ma.mask, m)
+
+
+class TestMaskedQuantityInitialization(TestMaskedArrayInitialization):
+    def setup(self):
+        self.a = np.array([1., 2.]) * u.m
+
+
+class TestMaskedArrayUfuncs:
+    def setup(self):
+        self.a = np.arange(6.).reshape(2, 3)
+        self.b = np.array([-3., -2., -1.])
+        self.c = np.array([[0.25], [0.5]])
+        self.ma = Masked(self.a, mask=np.array([[True, False, False],
+                                                [False, True, False]]))
+        self.mb = Masked(self.b, mask=np.array([False, True, False]))
+        self.mc = Masked(self.c, mask=np.array([[False], [True]]))
+
+    def test_add(self):
+        mapmb = self.ma + self.mb
+        assert_array_equal(mapmb.data, self.a + self.b)
+        assert_array_equal(mapmb.mask, (self.ma.mask | self.mb.mask))
+
+    @pytest.mark.parametrize('ufunc', (np.add, np.subtract, np.divide,
+                                       np.arctan2))
+    def test_2op_ufunc(self, ufunc):
+        ma_mb = ufunc(self.ma, self.mb)
+        assert_array_equal(ma_mb.data, ufunc(self.a, self.b))
+        assert_array_equal(ma_mb.mask, (self.ma.mask | self.mb.mask))
+
+
+class TestMaskedQuantityUfuncs(TestMaskedArrayUfuncs):
+    def setup(self):
+        self.a = np.arange(6.).reshape(2, 3) * u.m
+        self.b = np.array([-3., -2., -1.]) * u.m
+        self.c = np.array([[0.25], [0.5]]) * u.s
+        self.ma = Masked(self.a, mask=np.array([[True, False, False],
+                                                [False, True, False]]))
+        self.mb = Masked(self.b, mask=np.array([False, True, False]))
+        self.mc = Masked(self.c, mask=np.array([[False], [True]]))

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -211,6 +211,17 @@ class MaskedItemTests(MaskedArraySetup):
         assert_array_equal(ma_part.unmasked, expected_data)
         assert_array_equal(ma_part.mask, expected_mask)
 
+    @pytest.mark.parametrize('indices,axis', [
+        ([0, 1], 1), ([0, 1], 0), ([0, 1], None), ([[0, 1], [2, 3]], None)])
+    def test_take(self, indices, axis):
+        ma_take = self.ma.take(indices, axis=axis)
+        expected_data = self.a.take(indices, axis=axis)
+        expected_mask = self.mask_a.take(indices, axis=axis)
+        assert_array_equal(ma_take.unmasked, expected_data)
+        assert_array_equal(ma_take.mask, expected_mask)
+        ma_take2 = np.take(self.ma, indices, axis=axis)
+        assert_masked_equal(ma_take2, ma_take)
+
     @pytest.mark.parametrize('item', ((1, 1),
                                       slice(None, 1),
                                       (),

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -304,7 +304,7 @@ class TestMaskedLongitudeItems(MaskedItemTests, LongitudeSetup):
     pass
 
 
-class TestMaskedArrayOperators(MaskedArraySetup):
+class MaskedOperatorTests(MaskedArraySetup):
     @pytest.mark.parametrize('op', (operator.add, operator.sub))
     def test_add_subtract(self, op):
         mapmb = op(self.ma, self.mb)
@@ -377,11 +377,25 @@ class TestMaskedArrayOperators(MaskedArraySetup):
         assert not result2.mask
 
 
-class TestMaskedQuantityOperators(TestMaskedArrayOperators, QuantitySetup):
+class TestMaskedArrayOperators(MaskedOperatorTests):
+    # Some further tests that use strings, which are not useful for Quantity.
+    @pytest.mark.parametrize('op', (operator.eq, operator.ne))
+    def test_equality_strings(self, op):
+        m1 = Masked(np.array(['a', 'b', 'c']), mask=[True, False, False])
+        m2 = Masked(np.array(['a', 'b', 'd']), mask=[False, False, False])
+        result = op(m1, m2)
+        assert_array_equal(result.unmasked, op(m1.unmasked, m2.unmasked))
+        assert_array_equal(result.mask, m1.mask | m2.mask)
+
+        result2 = op(m1, m2.unmasked)
+        assert_masked_equal(result2, result)
+
+
+class TestMaskedQuantityOperators(MaskedOperatorTests, QuantitySetup):
     pass
 
 
-class TestMaskedLongitudeOperators(TestMaskedArrayOperators, LongitudeSetup):
+class TestMaskedLongitudeOperators(MaskedOperatorTests, LongitudeSetup):
     pass
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -2,78 +2,128 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from .... import units as u
+from astropy import units as u
+from astropy.units import Quantity
+from astropy.coordinates import Longitude
 from ..core import Masked
 from ....tests.helper import pytest
 
 
-class TestMaskedArrayInitialization:
+class ArraySetup:
+    def setup_arrays(self):
+        self.a = np.arange(6.).reshape(2, 3)
+        self.mask_a = np.array([[True, False, False],
+                                [False, True, False]])
+        self.b = np.array([-3., -2., -1.])
+        self.mask_b = np.array([False, True, False])
+        self.c = np.array([[0.25], [0.5]])
+        self.mask_c = np.array([[False], [True]])
+
     def setup(self):
-        self.a = np.array([1., 2.])
+        self.setup_arrays()
+
+
+class QuantitySetup(ArraySetup):
+    def setup_arrays(self):
+        super().setup_arrays()
+        self.a = Quantity(self.a, u.m)
+        self.b = Quantity(self.b, u.cm)
+        self.c = Quantity(self.c, u.s)
+
+
+class LongitudeSetup(ArraySetup):
+    def setup_arrays(self):
+        super().setup_arrays()
+        self.a = Longitude(self.a, u.deg)
+        self.b = Longitude(self.b, u.deg)
+        self.c = Longitude(self.c, u.deg)
+
+
+class TestMaskedArrayInitialization(ArraySetup):
+    def setup_arrays(self):
+        self.a = np.arange(6.).reshape(2, 3)
+        self.mask_a = np.array([[True, False, False],
+                                [False, True, False]])
+
+    def setup(self):
+        self.setup_arrays()
 
     def test_simple(self):
-        m = np.array([True, False])
-        ma = Masked(self.a, mask=m)
+        ma = Masked(self.a, mask=self.mask_a)
         assert isinstance(ma, np.ndarray)
         assert isinstance(ma, type(self.a))
         assert isinstance(ma, Masked)
         assert_array_equal(ma.data, self.a)
-        assert_array_equal(ma.mask, m)
+        assert_array_equal(ma.mask, self.mask_a)
 
 
 class TestMaskedQuantityInitialization(TestMaskedArrayInitialization):
+    def setup_arrays(self):
+        super().setup_arrays()
+        self.a = Quantity(self.a, u.m)
+
+
+# Following are tests where we trust the initializer works.
+
+
+class MaskedArraySetup(ArraySetup):
     def setup(self):
-        self.a = np.array([1., 2.]) * u.m
+        self.setup_arrays()
+        self.ma = Masked(self.a, mask=self.mask_a)
+        self.mb = Masked(self.b, mask=self.mask_b)
+        self.mc = Masked(self.c, mask=self.mask_c)
 
 
-class TestFilled:
-    def setup(self):
-        self.a = np.arange(6.).reshape(2, 3)
-        self.ma = Masked(self.a, mask=np.array([[True, False, False],
-                                                [False, True, False]]))
-
+class TestMaskedArrayFilled(MaskedArraySetup):
     @pytest.mark.parametrize('fill_value', (0, 1))
     def test_filled(self, fill_value):
-        expected = np.where(self.ma.mask, fill_value, self.a)
+        fill_value = fill_value * getattr(self.a, 'unit', 1)
+        expected = self.a.copy()
+        expected[self.ma.mask] = fill_value
         result = self.ma.filled(fill_value)
         assert_array_equal(expected, result)
 
 
-class TestMaskedArrayUfuncs:
-    def setup(self):
-        self.a = np.arange(6.).reshape(2, 3)
-        self.b = np.array([-3., -2., -1.])
-        self.c = np.array([[0.25], [0.5]])
-        self.ma = Masked(self.a, mask=np.array([[True, False, False],
-                                                [False, True, False]]))
-        self.mb = Masked(self.b, mask=np.array([False, True, False]))
-        self.mc = Masked(self.c, mask=np.array([[False], [True]]))
+class TestMaskedQuantityFilled(TestMaskedArrayFilled, QuantitySetup):
+    pass
 
+
+class TestMaskedLongitudeFilled(TestMaskedArrayFilled, LongitudeSetup):
+    pass
+
+
+class MaskedUfuncTests(MaskedArraySetup):
     def test_add(self):
         mapmb = self.ma + self.mb
-        assert_array_equal(mapmb.data, self.a + self.b)
-        assert_array_equal(mapmb.mask, (self.ma.mask | self.mb.mask))
+        expected_data = self.a + self.b
+        expected_mask = (self.ma.mask | self.mb.mask)
+        assert_array_equal(mapmb.data, expected_data)
+        assert_array_equal(mapmb.mask, expected_mask)
 
     @pytest.mark.parametrize('ufunc', (np.add, np.subtract, np.divide,
                                        np.arctan2))
     def test_2op_ufunc(self, ufunc):
         ma_mb = ufunc(self.ma, self.mb)
-        assert_array_equal(ma_mb.data, ufunc(self.a, self.b))
-        assert_array_equal(ma_mb.mask, (self.ma.mask | self.mb.mask))
+        expected_data = ufunc(self.a, self.b)
+        expected_mask = (self.ma.mask | self.mb.mask)
+        # Note: assert_array_equal also checks type, i.e., that, e.g.,
+        # Longitude decays into an Angle.
+        assert_array_equal(ma_mb.data, expected_data)
+        assert_array_equal(ma_mb.mask, expected_mask)
 
     @pytest.mark.parametrize('ufunc', (np.add, np.subtract))
     @pytest.mark.parametrize('axis', (0, 1))
     def test_reduce_filled_zero(self, ufunc, axis):
+        # axis=None for np.add tested indirectly by test_sum below.
         reduction = getattr(ufunc, 'reduce')
         ma_reduce = reduction(self.ma, axis=axis)
         expected_data = reduction(self.a * (1 - self.ma.mask),
                                   axis=axis)
         expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
-        assert isinstance(ma_reduce, type(self.ma))
         assert_array_equal(ma_reduce.data, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
 
-    @pytest.mark.parametrize('axis', (0, 1))
+    @pytest.mark.parametrize('axis', (0, 1, None))
     def test_sum(self, axis):
         ma_sum = self.ma.sum(axis)
         masked0 = self.ma.data * (1. - self.ma.mask)
@@ -81,12 +131,19 @@ class TestMaskedArrayUfuncs:
         assert not np.any(ma_sum.mask)
 
 
-class TestMaskedQuantityUfuncs(TestMaskedArrayUfuncs):
-    def setup(self):
-        self.a = np.arange(6.).reshape(2, 3) * u.m
-        self.b = np.array([-3., -2., -1.]) * u.m
-        self.c = np.array([[0.25], [0.5]]) * u.s
-        self.ma = Masked(self.a, mask=np.array([[True, False, False],
-                                                [False, True, False]]))
-        self.mb = Masked(self.b, mask=np.array([False, True, False]))
-        self.mc = Masked(self.c, mask=np.array([[False], [True]]))
+class TestMaskedArrayUfuncs(MaskedUfuncTests, ArraySetup):
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    def test_reduce_filled_one(self, axis):
+        ma_reduce = np.prod(self.ma, axis=axis)
+        expected_data = np.prod(self.ma.filled(1), axis=axis)
+        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        assert_array_equal(ma_reduce.data, expected_data)
+        assert_array_equal(ma_reduce.mask, expected_mask)
+
+
+class TestMaskedQuantityUfuncs(MaskedUfuncTests, QuantitySetup):
+    pass
+
+
+class TestMaskedLongitude(MaskedUfuncTests, LongitudeSetup):
+    pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -250,29 +250,24 @@ class MaskedUfuncTests(MaskedArraySetup):
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_add_reduce(self, axis):
         ma_reduce = np.add.reduce(self.ma, axis=axis)
-        filled = self.ma.unmasked * (1. - self.ma.mask)
-        expected_data = np.sum(filled, axis=axis)
-        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        expected_data = np.add.reduce(self.a, axis=axis)
+        expected_mask = np.logical_or.reduce(self.ma.mask, axis=axis)
         assert_array_equal(ma_reduce.unmasked, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
 
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_minimum_reduce(self, axis):
         ma_reduce = np.minimum.reduce(self.ma, axis=axis)
-        filled = self.a.copy()
-        filled[self.mask_a] = self.a.max()
-        expected_data = np.min(filled, axis=axis)
-        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        expected_data = np.minimum.reduce(self.a, axis=axis)
+        expected_mask = np.logical_or.reduce(self.ma.mask, axis=axis)
         assert_array_equal(ma_reduce.unmasked, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
 
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_maximum_reduce(self, axis):
         ma_reduce = np.maximum.reduce(self.ma, axis=axis)
-        filled = self.a.copy()
-        filled[self.mask_a] = self.a.min()
-        expected_data = np.max(filled, axis=axis)
-        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        expected_data = np.maximum.reduce(self.a, axis=axis)
+        expected_mask = np.logical_or.reduce(self.ma.mask, axis=axis)
         assert_array_equal(ma_reduce.unmasked, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
 
@@ -281,10 +276,8 @@ class TestMaskedArrayUfuncs(MaskedUfuncTests, ArraySetup):
     @pytest.mark.parametrize('axis', (0, 1, None))
     def test_multiply_reduce(self, axis):
         ma_reduce = np.multiply.reduce(self.ma, axis=axis)
-        filled = self.a.copy()
-        filled[self.mask_a] = 1
-        expected_data = np.prod(filled, axis=axis)
-        expected_mask = np.logical_and.reduce(self.ma.mask, axis=axis)
+        expected_data = np.multiply.reduce(self.a, axis=axis)
+        expected_mask = np.logical_or.reduce(self.ma.mask, axis=axis)
         assert_array_equal(ma_reduce.unmasked, expected_data)
         assert_array_equal(ma_reduce.mask, expected_mask)
 
@@ -297,37 +290,37 @@ class TestMaskedLongitudeUfuncs(MaskedUfuncTests, LongitudeSetup):
     pass
 
 
-class TestMaskedArrayMethods(MaskedArraySetup):
-    @pytest.mark.parametrize('axis', (0, 1, None))
-    def test_sum_method(self, axis):
-        ma_sum = self.ma.sum(axis)
-        filled = self.ma.data * (1. - self.ma.mask)
-        expected_data = filled.sum(axis)
-        assert_array_equal(ma_sum.data, expected_data)
-        assert not np.any(ma_sum.mask)
+# class TestMaskedArrayMethods(MaskedArraySetup):
+#     @pytest.mark.parametrize('axis', (0, 1, None))
+#     def test_sum_method(self, axis):
+#         ma_sum = self.ma.sum(axis)
+#         filled = self.a.data * (1. - self.ma.mask)
+#         expected_data = filled.sum(axis)
+#         assert_array_equal(ma_sum.data, expected_data)
+#         assert not np.any(ma_sum.mask)
 
-    @pytest.mark.parametrize('axis', (0, 1, None))
-    def test_min(self, axis):
-        ma_min = self.ma.min(axis)
-        filled = self.a.copy()
-        filled[self.mask_a] = self.a.max()
-        expected_data = filled.min(axis)
-        assert_array_equal(ma_min.data, expected_data)
-        assert not np.any(ma_min.mask)
+#     @pytest.mark.parametrize('axis', (0, 1, None))
+#     def test_min(self, axis):
+#         ma_min = self.ma.min(axis)
+#         filled = self.a.copy()
+#         filled[self.mask_a] = self.a.max()
+#         expected_data = filled.min(axis)
+#         assert_array_equal(ma_min.data, expected_data)
+#         assert not np.any(ma_min.mask)
 
-    @pytest.mark.parametrize('axis', (0, 1, None))
-    def test_max(self, axis):
-        ma_max = self.ma.max(axis)
-        filled = self.a.copy()
-        filled[self.mask_a] = self.a.min()
-        expected_data = filled.max(axis)
-        assert_array_equal(ma_max.data, expected_data)
-        assert not np.any(ma_max.mask)
-
-
-class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
-    pass
+#     @pytest.mark.parametrize('axis', (0, 1, None))
+#     def test_max(self, axis):
+#         ma_max = self.ma.max(axis)
+#         filled = self.a.copy()
+#         filled[self.mask_a] = self.a.min()
+#         expected_data = filled.max(axis)
+#         assert_array_equal(ma_max.data, expected_data)
+#         assert not np.any(ma_max.mask)
 
 
-class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
-    pass
+# class TestMaskedQuantityMethods(TestMaskedArrayMethods, QuantitySetup):
+#     pass
+
+
+# class TestMaskedLongitudeMethods(TestMaskedArrayMethods, LongitudeSetup):
+#     pass

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -199,7 +199,7 @@ class TestMaskedArrayShaping(MaskedArraySetup):
             assert_array_equal(ma.mask, m)
 
 
-class TestMaskedArrayItems(MaskedArraySetup):
+class MaskedItemTests(MaskedArraySetup):
     @pytest.mark.parametrize('item', ((1, 1),
                                       slice(None, 1),
                                       (),
@@ -220,19 +220,50 @@ class TestMaskedArrayItems(MaskedArraySetup):
         expected_data = self.a.copy()
         expected_mask = self.mask_a.copy()
         for mask in True, False:
-            value = Masked(base[0, 0], mask)
+            value = Masked(self.a[0, 0], mask)
             base[item] = value
             expected_data[item] = value.unmasked
             expected_mask[item] = value.mask
             assert_array_equal(base.unmasked, expected_data)
             assert_array_equal(base.mask, expected_mask)
 
+    @pytest.mark.parametrize('item', ((1, 1),
+                                      slice(None, 1),
+                                      (),
+                                      1))
+    def test_setitem_without_mask(self, item):
+        base = self.ma.copy()
+        expected_data = self.a.copy()
+        expected_mask = self.mask_a.copy()
+        value = self.a[0, 0]
+        base[item] = value
+        expected_data[item] = value
+        expected_mask[item] = False
+        assert_array_equal(base.unmasked, expected_data)
+        assert_array_equal(base.mask, expected_mask)
 
-class TestMaskedQuantityItems(TestMaskedArrayItems, QuantitySetup):
+
+class TestMaskedArrayItems(MaskedItemTests):
+    # TODO: make this work for Quantity & Longitude as well.
+    # Or decide that it just shouldn't work...
+    @pytest.mark.parametrize('item', ((1, 1),
+                                      slice(None, 1),
+                                      (),
+                                      1))
+    def test_setitem_np_ma_masked(self, item):
+        base = self.ma.copy()
+        expected_mask = self.mask_a.copy()
+        base[item] = np.ma.masked
+        expected_mask[item] = True
+        assert_array_equal(base.unmasked, self.a)
+        assert_array_equal(base.mask, expected_mask)
+
+
+class TestMaskedQuantityItems(MaskedItemTests, QuantitySetup):
     pass
 
 
-class TestMaskedLongitudeItems(TestMaskedArrayItems, LongitudeSetup):
+class TestMaskedLongitudeItems(MaskedItemTests, LongitudeSetup):
     pass
 
 

--- a/astropy/utils/masked/tests/test_masked.py
+++ b/astropy/utils/masked/tests/test_masked.py
@@ -138,6 +138,22 @@ class TestMaskedArrayCopyFilled(MaskedArraySetup):
         result = self.ma.unmask(fill_value)
         assert_array_equal(expected, result)
 
+    def test_flat(self):
+        ma_copy = self.ma.copy()
+        ma_flat = ma_copy.flat
+        # Check that single item keeps class and mask
+        ma_flat1 = ma_flat[1]
+        assert ma_flat1.unmasked == self.a.flat[1]
+        assert ma_flat1.mask == self.mask_a.flat[1]
+        # As well as getting items via iteration.
+        assert all((ma.unmasked == a and ma.mask == m) for (ma, a, m)
+                   in zip(self.ma.flat, self.a.flat, self.mask_a.flat))
+
+        # check that flat works like a view of the real array
+        ma_flat[1] = self.b[1]
+        assert ma_flat[1] == self.b[1]
+        assert ma_copy[0, 1] == self.b[1]
+
 
 class TestMaskedQuantityCopyFilled(TestMaskedArrayCopyFilled, QuantitySetup):
     pass

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -122,12 +122,15 @@ class NDArrayShapeMethods:
         """
         return self._apply('squeeze', *args, **kwargs)
 
-    def take(self, indices, axis=None, mode='raise'):
+    def take(self, indices, axis=None, out=None, mode='raise'):
         """Return a new instance formed from the elements at the given indices.
 
         Parameters are as for :meth:`~numpy.ndarray.take`, except that,
         obviously, no output array can be given.
         """
+        if out is not None:
+            return NotImplementedError("cannot pass 'out' argument to 'take.")
+
         return self._apply('take', indices, axis=axis, mode=mode)
 
 

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -10,7 +10,7 @@ __all__ = ['ShapedLikeNDArray', 'check_broadcast', 'IncompatibleShapeError',
            'unbroadcast']
 
 
-class ShapedLikeNDArray(metaclass=abc.ABCMeta):
+class NDArrayShapeMethods:
     """Mixin class to provide shape-changing methods.
 
     The class proper is assumed to have some underlying data, which are arrays
@@ -24,9 +24,10 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
     (and, unlike the ``reshape`` method raises an exception if this is not
     possible).
 
-    This class also defines default implementations for ``ndim`` and ``size``
-    properties, calculating those from the ``shape``.  These can be overridden
-    by subclasses if there are faster ways to obtain those numbers.
+    This class only provides the shape-changing methods and is meant in
+    particular for `~numpy.ndarray` subclasses that need to keep track of
+    other arrays.  For other classes, `~astropy.utils.misc.ShapedLikeNDArray`
+    is recommended.
 
     """
 
@@ -37,81 +38,8 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
     # copies rather than views of data (see the special-case treatment of
     # 'flatten' in Time).
 
-    @property
-    @abc.abstractmethod
-    def shape(self):
-        """The shape of the underlying data."""
-
-    @abc.abstractmethod
-    def _apply(method, *args, **kwargs):
-        """Create a new instance, with ``method`` applied to underlying data.
-
-        The method is any of the shape-changing methods for `~numpy.ndarray`
-        (``reshape``, ``swapaxes``, etc.), as well as those picking particular
-        elements (``__getitem__``, ``take``, etc.). It will be applied to the
-        underlying arrays (e.g., ``jd1`` and ``jd2`` in `~astropy.time.Time`),
-        with the results used to create a new instance.
-
-        Parameters
-        ----------
-        method : str
-            Method to be applied to the instance's internal data arrays.
-        args : tuple
-            Any positional arguments for ``method``.
-        kwargs : dict
-            Any keyword arguments for ``method``.
-
-        """
-
-    @property
-    def ndim(self):
-        """The number of dimensions of the instance and underlying arrays."""
-        return len(self.shape)
-
-    @property
-    def size(self):
-        """The size of the object, as calculated from its shape."""
-        size = 1
-        for sh in self.shape:
-            size *= sh
-        return size
-
-    @property
-    def isscalar(self):
-        return self.shape == ()
-
-    def __len__(self):
-        if self.isscalar:
-            raise TypeError(f"Scalar {self.__class__.__name__!r} object has no len()")
-        return self.shape[0]
-
-    def __bool__(self):
-        """Any instance should evaluate to True, except when it is empty."""
-        return self.size > 0
-
     def __getitem__(self, item):
-        try:
-            return self._apply('__getitem__', item)
-        except IndexError:
-            if self.isscalar:
-                raise TypeError('scalar {!r} object is not subscriptable.'
-                                .format(self.__class__.__name__))
-            else:
-                raise
-
-    def __iter__(self):
-        if self.isscalar:
-            raise TypeError('scalar {!r} object is not iterable.'
-                            .format(self.__class__.__name__))
-
-        # We cannot just write a generator here, since then the above error
-        # would only be raised once we try to use the iterator, rather than
-        # upon its definition using iter(self).
-        def self_iter():
-            for idx in range(len(self)):
-                yield self[idx]
-
-        return self_iter()
+        return self._apply('__getitem__', item)
 
     def copy(self, *args, **kwargs):
         """Return an instance containing copies of the internal data.
@@ -128,7 +56,7 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
         data (see :func:`~numpy.reshape` documentation). If you want an error
         to be raise if the data is copied, you should assign the new shape to
         the shape attribute (note: this may not be implemented for all classes
-        using ``ShapedLikeNDArray``).
+        using ``NDArrayShapeMethods``).
         """
         return self._apply('reshape', *args, **kwargs)
 
@@ -201,6 +129,111 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
         obviously, no output array can be given.
         """
         return self._apply('take', indices, axis=axis, mode=mode)
+
+
+class ShapedLikeNDArray(NDArrayShapeMethods, metaclass=abc.ABCMeta):
+    """Mixin class to provide shape-changing methods.
+
+    The class proper is assumed to have some underlying data, which are arrays
+    or array-like structures. It must define a ``shape`` property, which gives
+    the shape of those data, as well as an ``_apply`` method that creates a new
+    instance in which a `~numpy.ndarray` method has been applied to those.
+
+    Furthermore, for consistency with `~numpy.ndarray`, it is recommended to
+    define a setter for the ``shape`` property, which, like the
+    `~numpy.ndarray.shape` property allows in-place reshaping the internal data
+    (and, unlike the ``reshape`` method raises an exception if this is not
+    possible).
+
+    This class also defines default implementations for ``ndim`` and ``size``
+    properties, calculating those from the ``shape``.  These can be overridden
+    by subclasses if there are faster ways to obtain those numbers.
+
+    """
+
+    # Note to developers: if new methods are added here, be sure to check that
+    # they work properly with the classes that use this, such as Time and
+    # BaseRepresentation, i.e., look at their ``_apply`` methods and add
+    # relevant tests.  This is particularly important for methods that imply
+    # copies rather than views of data (see the special-case treatment of
+    # 'flatten' in Time).
+
+    @property
+    @abc.abstractmethod
+    def shape(self):
+        """The shape of the underlying data."""
+
+    @abc.abstractmethod
+    def _apply(method, *args, **kwargs):
+        """Create a new instance, with ``method`` applied to underlying data.
+
+        The method is any of the shape-changing methods for `~numpy.ndarray`
+        (``reshape``, ``swapaxes``, etc.), as well as those picking particular
+        elements (``__getitem__``, ``take``, etc.). It will be applied to the
+        underlying arrays (e.g., ``jd1`` and ``jd2`` in `~astropy.time.Time`),
+        with the results used to create a new instance.
+
+        Parameters
+        ----------
+        method : str
+            Method to be applied to the instance's internal data arrays.
+        args : tuple
+            Any positional arguments for ``method``.
+        kwargs : dict
+            Any keyword arguments for ``method``.
+
+        """
+
+    @property
+    def ndim(self):
+        """The number of dimensions of the instance and underlying arrays."""
+        return len(self.shape)
+
+    @property
+    def size(self):
+        """The size of the object, as calculated from its shape."""
+        size = 1
+        for sh in self.shape:
+            size *= sh
+        return size
+
+    @property
+    def isscalar(self):
+        return self.shape == ()
+
+    def __len__(self):
+        if self.isscalar:
+            raise TypeError("Scalar {!r} object has no len()"
+                            .format(self.__class__.__name__))
+        return self.shape[0]
+
+    def __bool__(self):
+        """Any instance should evaluate to True, except when it is empty."""
+        return self.size > 0
+
+    def __getitem__(self, item):
+        try:
+            return self._apply('__getitem__', item)
+        except IndexError:
+            if self.isscalar:
+                raise TypeError('scalar {!r} object is not subscriptable.'
+                                .format(self.__class__.__name__))
+            else:
+                raise
+
+    def __iter__(self):
+        if self.isscalar:
+            raise TypeError('scalar {!r} object is not iterable.'
+                            .format(self.__class__.__name__))
+
+        # We cannot just write a generator here, since then the above error
+        # would only be raised once we try to use the iterator, rather than
+        # upon its definition using iter(self).
+        def self_iter():
+            for idx in range(len(self)):
+                yield self[idx]
+
+        return self_iter()
 
     # Functions that change shape or essentially do indexing.
     _APPLICABLE_FUNCTIONS = {


### PR DESCRIPTION
EDIT: the base implementation is in #11127 - this one tries to use `Masked` for columns and gives a sense how it would work for representations.

@astrofrog - as per your request in #10119, here's what I have. I got things to working quite well with `Quantity` and all its subclasses; the first thing to look at may be the quite detailed tests (which should be useful for whatever we end up implementing).

I had started on `MaskedColumn` and had also tried to move the information up in representations (to go for coordinates) but that is not finished.  Part of the difficulty with `MaskedColumn` is that I made some design choices which are different from `MaskedArray`, so it would need a kind of compatibility layer if we want to keep exact one-to-one matches, and/or some way to decide which type one wants.

It may be worth pointing out two specific things:
- I very much on purpose decided to treat reductions different from `MaskedArray` - any time there is any items in the reduction masked, the result is masked as well. So, e.g., for `.sum()`, masked elements are not implicitly replaced by zero. The logic is that one cannot interpret the sum meaningfully without knowing how many elements actually contributed. Conversely, following that same logic, for methods where skipping a masked element does make sense (like `.mean()`, where one divides by the number of unmasked elements), I do use it.
- Currently, the implementation does not support structured arrays. The question for those, which I haven't really found a "best" answer for, is whether the mask should be per full item, or whether the mask itself should also be a structured array, i.e., allow masking individual pieces. `MaskedArray` does the latter and it is quite a hassle to keep track, but perhaps better.

Anyway, suggestions very welcome. Indeed, this is definitely at a point where some further design choices have to be made, and it would be good to step back a bit and decide what exactly we want masking to mean.

cc @taldcroft

EDIT: Masked column was very much a work in progress. Tests still passed without the 3 last commits (i.e., at 379a8812e87ad95995c42db45998eec147e5a57e)