### PR TITLE
bug fix 10408: int for N in Poisson Conf throws error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -280,6 +280,9 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
+- Fixed bug with ``funcs.poisson_conf_interval`` where N > 100
+  with ``interval='kraft-burrows-nousek'`` would throw an error
+
 astropy.table
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -280,8 +280,9 @@ astropy.samp
 astropy.stats
 ^^^^^^^^^^^^^
 
-- Fixed bug with ``funcs.poisson_conf_interval`` where N > 100
-  with ``interval='kraft-burrows-nousek'`` would throw an error [#10427]
+- Fixed bug with ``funcs.poisson_conf_interval`` where an integer for N
+  with ``interval='kraft-burrows-nousek'`` would throw an error with
+  mpmath backend [#10427]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -281,7 +281,7 @@ astropy.stats
 ^^^^^^^^^^^^^
 
 - Fixed bug with ``funcs.poisson_conf_interval`` where N > 100
-  with ``interval='kraft-burrows-nousek'`` would throw an error
+  with ``interval='kraft-burrows-nousek'`` would throw an error [#10427]
 
 astropy.table
 ^^^^^^^^^^^^^

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1178,17 +1178,11 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
     '''
     from mpmath import mpf, factorial, findroot, fsum, power, exp, quad
 
-    if type(N).__module__ == np.__name__:
-        N = N.item()
-
-    if type(B).__module__ == np.__name__:
-        B = B.item()
-
-    if type(CL).__module__ == np.__name__:
-        CL = CL.item()
-    N = mpf(N)
-    B = mpf(B)
-    CL = mpf(CL)
+    # We convert these values to float. Because for some reason, 
+    # mpmath.mpf cannot convert from numpy.int64
+    N = mpf(float(N))
+    B = mpf(float(B))
+    CL = mpf(float(CL))
 
     def eqn8(N, B):
         sumterms = [power(B, n) / factorial(n) for n in range(int(N) + 1)]

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1178,7 +1178,7 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
     '''
     from mpmath import mpf, factorial, findroot, fsum, power, exp, quad
 
-    # We convert these values to float. Because for some reason, 
+    # We convert these values to float. Because for some reason,
     # mpmath.mpf cannot convert from numpy.int64
     N = mpf(float(N))
     B = mpf(float(B))

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -1072,12 +1072,12 @@ def _scipy_kraft_burrows_nousek(N, B, CL):
 
     Parameters
     ----------
-    N : int
+    N : int or np.int32/np.int64
         Total observed count number
-    B : float
+    B : float or np.float32/np.float64
         Background count rate (assumed to be known with negligible error
         from a large background area).
-    CL : float
+    CL : float or np.float32/np.float64
        Confidence level (number between 0 and 1)
 
     Returns
@@ -1157,12 +1157,12 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
 
     Parameters
     ----------
-    N : int
+    N : int or np.int32/np.int64
         Total observed count number
-    B : float
+    B : float or np.float32/np.float64
         Background count rate (assumed to be known with negligible error
         from a large background area).
-    CL : float
+    CL : float or np.float32/np.float64
        Confidence level (number between 0 and 1)
 
     Returns
@@ -1178,6 +1178,14 @@ def _mpmath_kraft_burrows_nousek(N, B, CL):
     '''
     from mpmath import mpf, factorial, findroot, fsum, power, exp, quad
 
+    if type(N).__module__ == np.__name__:
+        N = N.item()
+
+    if type(B).__module__ == np.__name__:
+        B = B.item()
+
+    if type(CL).__module__ == np.__name__:
+        CL = CL.item()
     N = mpf(N)
     B = mpf(B)
     CL = mpf(CL)
@@ -1234,12 +1242,12 @@ def _kraft_burrows_nousek(N, B, CL):
 
     Parameters
     ----------
-    N : int
+    N : int or np.int32/np.int64
         Total observed count number
-    B : float
+    B : float or np.float32/np.float64
         Background count rate (assumed to be known with negligible error
         from a large background area).
-    CL : float
+    CL : float or np.float32/np.float64
        Confidence level (number between 0 and 1)
 
     Returns

--- a/astropy/stats/tests/test_funcs.py
+++ b/astropy/stats/tests/test_funcs.py
@@ -594,6 +594,20 @@ def test_scipy_poisson_limit():
     '''
     assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, .99),
                     (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5, 2.5, .99),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(np.int32(5.), 2.5, .99),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(np.int64(5.), 2.5, .99),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., np.float32(2.5), .99),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., np.float64(2.5), .99),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, np.float32(.99)),
+                    (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._scipy_kraft_burrows_nousek(5., 2.5, np.float64(.99)),
+                    (0, 10.67), rtol=1e-3)
     conf = funcs.poisson_conf_interval([5., 6.], 'kraft-burrows-nousek',
                                        background=[2.5, 2.],
                                        confidence_level=[.99, .9])
@@ -607,6 +621,24 @@ def test_mpmath_poisson_limit():
                     (0.81, 8.99), rtol=5e-3)
     assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 2.5, .99),
                     (0, 10.67), rtol=1e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(np.int32(6), 2., .9),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(np.int64(6), 2., .9),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(6., np.float32(2.), .9),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(6., np.float64(2.), .9),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(6., 2., np.float32(.9)),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(6., 2., np.float64(.9)),
+                    (0.81, 8.99), rtol=5e-3)
+    assert_allclose(funcs._mpmath_kraft_burrows_nousek(5., 2.5, .99),
+                    (0, 10.67), rtol=1e-3)
+
+    assert_allclose(funcs.poisson_conf_interval(
+        n=160, background=154.543,
+        confidence_level=.95, interval='kraft-burrows-nousek')[:, 0], (0, 30.30454909))
 
 
 @pytest.mark.skipif('not HAS_SCIPY')


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

A Bug fix for issue #10408 

**The Problem**
Ints for parameter N appear to break `funcs.poisson_conf_interval(... interval='kraft-burrows-nousek')`

**Why?** 
`N` is type numpy.int64 when passed to `def _mpmath_kraft_burrows_nousek(N, B, CL)`
and mpmath.mpf() cannot convert from numpy.int64 so we get the error in the aforementioned issue. Though it appears mpmath.mpf can convert from numpy.float32. 

This happens because `numpy.vectorize()`  in `funcs.poisson_conf_interval(...)` passes dtype objects to its function (numpy.int64, numpy.float 32 etc... )

**My Solution**
In `def _mpmath_kraft_burrows_nousek(N, B, CL)` I check to see if the parameters are from the numpy module, if they are I convert them to their pythonic equivalencies. 

I also updated the doc string on the appropriate functions to make it clear the functions take python datatypes along with the appropriate numpy equivalency. 

**TL;DR**
Ints for parameter N now work in `funcs.poisson_conf_interval(... interval='kraft-burrows-nousek')`

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10408 
