### PR TITLE
Fix test to avoid use of cache internals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -505,6 +505,9 @@ astropy.coordinates
   and ``Differentials`` can now be initialized with an instance of their own class
   if that instance is passed in as the first argument. [#10210]
 
+- Cleaned up coordinate caching test so it no longer depends on internals of the caching
+  mechanism. [#10430]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -143,33 +143,27 @@ def test_names():
 
 @pytest.mark.remote_data
 def test_name_resolve_cache(tmpdir):
-    from astropy.utils.data import _get_download_cache_locs, get_cached_urls
-    import shelve
+    from astropy.utils.data import get_cached_urls
 
     target_name = "castor"
 
     temp_cache_dir = str(tmpdir.mkdir('cache'))
     with paths.set_temp_cache(temp_cache_dir, delete=True):
-        download_dir, urlmapfn = _get_download_cache_locs()
 
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 0
+        assert not get_cached_urls()
 
         icrs1 = get_icrs_coordinates(target_name, cache=True)
 
-        # This is a weak test: we just check to see that a url is added to the
-        #  cache!
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
-            url = get_cached_urls()[0]
-            assert 'http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/' in url
+        urls = get_cached_urls()
+        assert len(urls) == 1
+        url = urls[0]
+        assert 'http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/' in url
 
         # Try reloading coordinates, now should just reload cached data:
         with no_internet():
             icrs2 = get_icrs_coordinates(target_name, cache=True)
 
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
+        assert len(get_cached_urls()) == 1
 
         assert u.allclose(icrs1.ra, icrs2.ra)
         assert u.allclose(icrs1.dec, icrs2.dec)


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

Update the test in astropy/coordinates/tests/test_name_resolve.py so that it does not use the internals of the caching mechanism. Probably fixes #10401 ? Or at least should clarify what is going on.

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
