### PR TITLE
Ensure we catch all exceptions when trying to set shape.

### DIFF
--- a/astropy/coordinates/representation.py
+++ b/astropy/coordinates/representation.py
@@ -422,6 +422,8 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
 
         Raises
         ------
+        ValueError
+            If the new shape has the wrong total number of elements.
         AttributeError
             If the shape of any of the components cannot be changed without the
             arrays being copied.  For these cases, use the ``reshape`` method
@@ -441,7 +443,7 @@ class BaseRepresentationOrDifferential(ShapedLikeNDArray):
             if val.size > 1:
                 try:
                     val.shape = shape
-                except AttributeError:
+                except Exception:
                     for val2 in reshaped:
                         val2.shape = oldshape
                     raise

--- a/astropy/coordinates/tests/test_representation_methods.py
+++ b/astropy/coordinates/tests/test_representation_methods.py
@@ -267,6 +267,8 @@ class TestSetShape(ShapeSetup):
 
         # but this one does not.
         oldshape = self.s1.shape
+        with pytest.raises(ValueError):
+            self.s1.shape = (1,)
         with pytest.raises(AttributeError):
             self.s1.shape = (42,)
         assert self.s1.shape == oldshape

--- a/astropy/time/core.py
+++ b/astropy/time/core.py
@@ -863,6 +863,8 @@ class Time(ShapedLikeNDArray):
 
         Raises
         ------
+        ValueError
+            If the new shape has the wrong total number of elements.
         AttributeError
             If the shape of the ``jd1``, ``jd2``, ``location``,
             ``delta_ut1_utc``, or ``delta_tdb_tt`` attributes cannot be changed
@@ -895,7 +897,7 @@ class Time(ShapedLikeNDArray):
             if val is not None and val.size > 1:
                 try:
                     val.shape = shape
-                except AttributeError:
+                except Exception:
                     for val2 in reshaped:
                         val2.shape = oldshape
                     raise

--- a/astropy/time/tests/test_methods.py
+++ b/astropy/time/tests/test_methods.py
@@ -277,8 +277,10 @@ class TestSetShape(ShapeSetup):
         assert t0_reshape.location is None
         # But if the shape doesn't work, one should get an error.
         t0_reshape_t = t0_reshape.T
+        with pytest.raises(ValueError):
+            t0_reshape_t.shape = (12,)  # Wrong number of elements.
         with pytest.raises(AttributeError):
-            t0_reshape_t.shape = (10, 5)
+            t0_reshape_t.shape = (10, 5)  # Cannot be done without copy.
         # check no shape was changed.
         assert t0_reshape_t.shape == t0_reshape.T.shape
         assert t0_reshape_t.jd1.shape == t0_reshape.T.shape


### PR DESCRIPTION
The check was only for AttributeError, but as noted in https://github.com/astropy/astropy/pull/10337#discussion_r433752781, a ValueError is possible too. Since we will want to undo any half-processed shape change regardless of the exception, we just catch them all (they will be
re-raised anyway). 

Note that I put no-changelog-entry-required, since I could not think of any way it would be possible to trigger the `ValueError` and end up with a corrupted `Time` or `Representation` (i.e., one in which some parts had their shape changed and others not). The fix is really more a matter of principle, which makes the code and tests clearer.

fixes #10426
