### PR TITLE
Fix certificate error for IERS data download on Windows

### DIFF
--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1282,9 +1282,9 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         downloading from HTTPS or TLS+FTP sources.  This can be used provide
         alternative paths to root CA certificates.  Additionally, if the key
         ``'certfile'`` and optionally ``'keyfile'`` and ``'password'`` are
-        included, they are passed to passed to a call to
-        `ssl.SSLContext.load_cert_chain`.  This can be used for performing
-        SSL/TLS client certificate authentication.
+        included, they are passed to `ssl.SSLContext.load_cert_chain`.  This
+        can be used for performing SSL/TLS client certificate authentication
+        for servers that require it.
 
     allow_insecure : bool, optional
         Allow downloading files over a TLS/SSL connection even when the server

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -78,10 +78,6 @@ class Conf(_config.ConfigNamespace):
         'Default User-Agent for HTTP request headers. This can be overwritten '
         'for a particular call via http_headers option, where available. '
         'This only provides the default value when not set by https_headers.')
-    default_allow_insecure = _config.ConfigItem(
-        False,
-        'Whether or not to allow insecure TLS/SSL connections to hosts with '
-        'unverifiable certificates.')
     remote_timeout = _config.ConfigItem(
         10.,
         'Time to wait for remote data queries (in seconds). Set this to zero '
@@ -1218,7 +1214,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
                   sources=None, pkgname='astropy', http_headers=None,
-                  ssl_context=None, allow_insecure=None):
+                  ssl_context=None, allow_insecure=False):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1293,13 +1289,12 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         Allow downloading files over a TLS/SSL connection even when the server
         certificate verification failed.  When set to `True` the potentially
         insecure download is allowed to proceed, but an
-        `~astropy.utils.exceptions.AstropyWarning` is issued.  The default
-        value for this can be set by
-        ``astropy.utils.data.conf.default_allow_insecure``.  If you are getting
-        frequently certificate verification warnings, consider installing or
-        upgrading `certifi`_ package, which provides frequently updated
-        certificates for common root CAs (i.e., a set similar to those used by
-        web browsers).  If installed, Astropy will use it automatically.
+        `~astropy.utils.exceptions.AstropyWarning` is issued.  If you are
+        frequently getting certificate verification warnings, consider
+        installing or upgrading `certifi`_ package, which provides frequently
+        updated certificates for common root CAs (i.e., a set similar to those
+        used by web browsers).  If installed, Astropy will use it
+        automatically.
 
         .. _certifi: https://pypi.org/project/certifi/
 
@@ -1329,8 +1324,6 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     if http_headers is None:
         http_headers = {'User-Agent': conf.default_http_user_agent,
                         'Accept': '*/*'}
-    if allow_insecure is None:
-        allow_insecure = conf.default_allow_insecure
 
     missing_cache = ""
 

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1071,12 +1071,16 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
             else:
                 raise
 
-    if ftp_tls:
-        urlopener = urllib.request.build_opener(_FTPTLSHandler())
+    if os.name == 'nt':
+        ssl_context = ssl.create_default_context(cafile=certifi.where())
     else:
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        ssl_context.load_verify_locations(certifi.where())
-        https_handler = urllib.request.HTTPSHandler(context=ssl_context)
+        ssl_context = ssl.create_default_context()
+
+    https_handler = urllib.request.HTTPSHandler(context=ssl_context)
+
+    if ftp_tls:
+        urlopener = urllib.request.build_opener(_FTPTLSHandler(), https_handler)
+    else:
         urlopener = urllib.request.build_opener(https_handler)
 
     req = urllib.request.Request(source_url, headers=http_headers)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -23,16 +23,14 @@ import ftplib
 from tempfile import NamedTemporaryFile, gettempdir, TemporaryDirectory, mkdtemp
 from warnings import warn
 
+import certifi
+
 import astropy.config.paths
 from astropy import config as _config
 from astropy.utils.decorators import deprecated_renamed_argument
 from astropy.utils.exceptions import AstropyWarning
 from astropy.utils.introspection import find_current_module, resolve_name
 
-# Use certifi CA certificate store on Windows due to unreliable CA
-# certificate system store
-if os.name == 'nt':
-    import certifi
 
 # Order here determines order in the autosummary
 __all__ = [
@@ -1071,11 +1069,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
             else:
                 raise
 
-    if os.name == 'nt':
-        ssl_context = ssl.create_default_context(cafile=certifi.where())
-    else:
-        ssl_context = ssl.create_default_context()
-
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
     https_handler = urllib.request.HTTPSHandler(context=ssl_context)
 
     if ftp_tls:

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1093,7 +1093,7 @@ def _try_url_open(source_url, timeout=None, http_headers=None, ftp_tls=False,
         reason = exc.reason
         if (isinstance(reason, ssl.SSLError)
                 and reason.reason == 'CERTIFICATE_VERIFY_FAILED'):
-            msg = (f'verification of TLS/SSL certificate at {source_url} '
+            msg = (f'Verification of TLS/SSL certificate at {source_url} '
                    f'failed: this can mean either the server is '
                    f'misconfigured or your local root CA certificates are '
                    f'out-of-date; in the latter case this can usually be '
@@ -1106,6 +1106,7 @@ def _try_url_open(source_url, timeout=None, http_headers=None, ftp_tls=False,
                         f'was: {reason}')
                 raise urllib.error.URLError(msg)
             else:
+                msg += '. Re-trying with allow_insecure=True.'
                 warn(msg, AstropyWarning)
                 # Try again with a new urlopener allowing insecure connections
                 urlopener = _build_urlopener(ftp_tls=ftp_tls,

--- a/astropy/utils/misc.py
+++ b/astropy/utils/misc.py
@@ -231,9 +231,9 @@ def find_api_page(obj, version=None, openinbrowser=True, timeout=None):
     # Custom request headers; see
     # https://github.com/astropy/astropy/issues/8990
     url = baseurl + 'objects.inv'
-    headers={'User-Agent': f'Astropy/{version}'}
+    headers = {'User-Agent': f'Astropy/{version}'}
     with get_readable_fileobj(url, encoding='binary', remote_timeout=timeout,
-            http_headers=headers) as uf:
+                              http_headers=headers) as uf:
         oiread = uf.read()
 
         # need to first read/remove the first four lines, which have info before

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -650,7 +650,7 @@ def test_download_certificate_verification_failed():
     # certificate verification error; we simulate this by passing a bogus
     # CA directory to the ssl_context argument
     ssl_context = {'cafile': None, 'capath': '/does/not/exist'}
-    msg = f'verification of TLS/SSL certificate at {TESTURL_SSL} failed'
+    msg = f'Verification of TLS/SSL certificate at {TESTURL_SSL} failed'
     with pytest.raises(urllib.error.URLError, match=msg):
         download_file(TESTURL_SSL, cache=False, ssl_context=ssl_context)
 

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -650,18 +650,16 @@ def test_download_certificate_verification_failed():
     # certificate verification error; we simulate this by passing a bogus
     # CA directory to the ssl_context argument
     ssl_context = {'cafile': None, 'capath': '/does/not/exist'}
-    with pytest.raises(urllib.error.URLError) as exc:
+    msg = f'verification of TLS/SSL certificate at {TESTURL_SSL} failed'
+    with pytest.raises(urllib.error.URLError, match=msg):
         download_file(TESTURL_SSL, cache=False, ssl_context=ssl_context)
 
-    msg = f'verification of TLS/SSL certificate at {TESTURL_SSL} failed'
-    assert msg in str(exc.value)
-
-    with pytest.warns(AstropyWarning) as warning_lines:
+    with pytest.warns(AstropyWarning, match=msg) as warning_lines:
         fnout = download_file(TESTURL_SSL, cache=False,
                 ssl_context=ssl_context, allow_insecure=True)
 
+    assert len(warning_lines) == 1
     assert os.path.isfile(fnout)
-    assert len(warning_lines) == 1 and msg in str(warning_lines[0])
 
 
 def test_download_cache_after_clear(tmpdir, temp_cache, valid_urls):

--- a/astropy/utils/tests/test_misc.py
+++ b/astropy/utils/tests/test_misc.py
@@ -3,7 +3,7 @@
 import json
 import locale
 import os
-import socket
+import urllib.error
 from datetime import datetime
 
 import pytest
@@ -29,9 +29,10 @@ def test_signal_number_to_name_no_failure():
 @pytest.mark.remote_data
 def test_api_lookup():
     try:
-        strurl = misc.find_api_page('astropy.utils.misc', 'dev', False, timeout=3)
-        objurl = misc.find_api_page(misc, 'dev', False, timeout=3)
-    except socket.timeout:
+        strurl = misc.find_api_page('astropy.utils.misc', 'dev', False,
+                                    timeout=5)
+        objurl = misc.find_api_page(misc, 'dev', False, timeout=5)
+    except urllib.error.URLError:
         if os.environ.get('CI', False):
             pytest.xfail('Timed out in CI')
         else:

--- a/docs/changes/utils/10434.feature.rst
+++ b/docs/changes/utils/10434.feature.rst
@@ -1,0 +1,4 @@
+Added ``ssl_context`` and ``allow_insecure`` options to ``download_file``,
+as well as the ability to optionally use the ``certifi`` package to
+provide root CA certificates when downloading from sites secured with
+TLS/SSL.

--- a/docs/changes/utils/10434.feature.rst
+++ b/docs/changes/utils/10434.feature.rst
@@ -1,4 +1,3 @@
 Added ``ssl_context`` and ``allow_insecure`` options to ``download_file``,
-as well as the ability to optionally use the ``certifi`` package to
-provide root CA certificates when downloading from sites secured with
-TLS/SSL.
+as well as the ability to optionally use the ``certifi`` package to provide
+root CA certificates when downloading from sites secured with TLS/SSL.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -195,8 +195,9 @@ Requirements
 
 - `certifi <https://pypi.org/project/certifi/>`_: Useful when downloading
   files from HTTPS or FTP+TLS sites in case Python is not able to locate
-  up-to-date root CA certificates on your system; this package is already
-  included in many Python installations.
+  up-to-date root CA certificates on your system; this package is usually
+  already included in many Python installations (e.g. as a dependency of
+  the ``requests`` package).
 
 However, note that these packages require installation only if those particular
 features are needed. ``astropy`` will import even if these dependencies are not

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -196,7 +196,7 @@ Requirements
 - `certifi <https://pypi.org/project/certifi/>`_: Useful when downloading
   files from HTTPS or FTP+TLS sites in case Python is not able to locate
   up-to-date root CA certificates on your system; this package is usually
-  already included in many Python installations (e.g. as a dependency of
+  already included in many Python installations (e.g., as a dependency of
   the ``requests`` package).
 
 However, note that these packages require installation only if those particular

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -193,6 +193,11 @@ Requirements
   of sigma-clipping and other functionality that may require computing
   statistics on arrays with NaN values.
 
+- `certifi <https://pypi.org/project/certifi/>`_: Useful when downloading
+  files from HTTPS or FTP+TLS sites in case Python is not able to locate
+  up-to-date root CA certificates on your system; this package is already
+  included in many Python installations.
+
 However, note that these packages require installation only if those particular
 features are needed. ``astropy`` will import even if these dependencies are not
 installed.

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -79,6 +79,23 @@ conveniently with the ``get_pkg_data_*`` functions::
    # these are all mappings from the name in sites.json (which is ASCII-only) to the "true" unicode names
    TUBITAK->TÜBİTAK
 
+
+.. note::
+
+    Sometimes when downloading files from internet resources secured with
+    TLS/SSL, you may get an exception regarding a certificate verification
+    error.  Typically this indicates that Python could not find an
+    up-to-date collection of `root certificates`_ on your system.  This is
+    especially common on Windows.  This problem can usually be resolved
+    by installing the `certifi`_ package, which Astropy will use if
+    available to verify remote connections.  In rare cases, certificate
+    verification may still fail if the remote server is misconfigured (e.g.,
+    with expired certificates).  In this case, you may pass the
+    ``allow_insecure=True`` argument to :func:`~astropy.utils.data.download_file`,
+    or add the setting ``astropy.utils.iers.conf.default_allow_insecure =
+    True`` in the :ref:`astropy config file <astropy_config>`.
+
+
 Usage From Outside Astropy
 ==========================
 
@@ -130,6 +147,8 @@ will be stored in the cache under the original URL requested::
    |========================================|  65M/ 65M (100.00%)        19s
 
 .. _Astropy data server: https://www.astropy.org/astropy-data/
+.. _root certificates: https://en.wikipedia.org/wiki/Root_certificate
+.. _certifi: https://pypi.org/project/certifi/
 
 Cache Management
 ================

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -79,7 +79,6 @@ conveniently with the ``get_pkg_data_*`` functions::
    # these are all mappings from the name in sites.json (which is ASCII-only) to the "true" unicode names
    TUBITAK->TÜBİTAK
 
-
 .. note::
 
     Sometimes when downloading files from internet resources secured with
@@ -93,7 +92,8 @@ conveniently with the ``get_pkg_data_*`` functions::
     with expired certificates).  In this case, you may pass the
     ``allow_insecure=True`` argument to
     :func:`~astropy.utils.data.download_file` to allow the download with a
-    warning instead.
+    warning instead (not recommended unless you understand the `potential
+    risks <https://en.wikipedia.org/wiki/Man-in-the-middle_attack>`_).
 
 
 Usage From Outside Astropy

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -91,9 +91,9 @@ conveniently with the ``get_pkg_data_*`` functions::
     available to verify remote connections.  In rare cases, certificate
     verification may still fail if the remote server is misconfigured (e.g.,
     with expired certificates).  In this case, you may pass the
-    ``allow_insecure=True`` argument to :func:`~astropy.utils.data.download_file`,
-    or add the setting ``astropy.utils.iers.conf.default_allow_insecure =
-    True`` in the :ref:`astropy config file <astropy_config>`.
+    ``allow_insecure=True`` argument to
+    :func:`~astropy.utils.data.download_file` to allow the download with a
+    warning instead.
 
 
 Usage From Outside Astropy

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ test =
     packaging
 all =
     scipy>=1.1
+    certifi;platform_system=='Windows'
     dask[array]
     h5py
     beautifulsoup4

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ test =
     packaging
 all =
     scipy>=1.1
-    certifi;platform_system=='Windows'
+    certifi
     dask[array]
     h5py
     beautifulsoup4


### PR DESCRIPTION
Across different machines Windows often has intermittent problems of fetching data from datacenter.iers.org due to the CA certificate missing on Windows. (visiting the webpage via internet explorer will temporarily fetch the certificate, but that's rather clumsy and unreliable).

### Description

Use certifi certificate store for reliable CA root certificate fetching on all platforms.

Fixes #9640 

Close #10448