### PR TITLE
Lock-free cache implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -849,6 +849,8 @@ astropy.utils
 
 - ``astropy.utils.data.download_file`` now supports FTPS/FTP over TLS. [#9964]
 
+- ``astropy.utils.data`` now uses a lock-free mechanism for caching. [#10437]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -849,7 +849,22 @@ astropy.utils
 
 - ``astropy.utils.data.download_file`` now supports FTPS/FTP over TLS. [#9964]
 
-- ``astropy.utils.data`` now uses a lock-free mechanism for caching. [#10437]
+- ``astropy.utils.data`` now uses a lock-free mechanism for caching. This new
+  mechanism uses a new cache layout and so ignores caches created using earlier
+  mechanisms (which were causing lockups on clusters). The two cache formats can
+  coexist but do not share any files. [#10437]
+
+- ``astropy.utils.data`` now ignores the config item
+  ``astropy.utils.data.conf.download_cache_lock_attempts`` since no locking is
+  done. [#10437]
+
+- ``astropy.utils.data.download_file`` and related functions now interpret the
+  parameter or config file setting ``timeout=0`` to mean they should make no
+  attempt to download files. [#10437]
+
+- ``astropy.utils.import_file_to_cache`` now accepts a keyword-only argument
+  ``replace``, defaulting to True, to determine whether it should replace existing
+  files in the cache, in a way as close to atomic as possible. [#10437]
 
 astropy.wcs
 ^^^^^^^^^^^

--- a/astropy/coordinates/tests/test_name_resolve.py
+++ b/astropy/coordinates/tests/test_name_resolve.py
@@ -143,33 +143,25 @@ def test_names():
 
 @pytest.mark.remote_data
 def test_name_resolve_cache(tmpdir):
-    from astropy.utils.data import _get_download_cache_locs, get_cached_urls
-    import shelve
+    from astropy.utils.data import get_cached_urls
 
     target_name = "castor"
 
     temp_cache_dir = str(tmpdir.mkdir('cache'))
     with paths.set_temp_cache(temp_cache_dir, delete=True):
-        download_dir, urlmapfn = _get_download_cache_locs()
-
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 0
+        assert len(get_cached_urls()) == 0
 
         icrs1 = get_icrs_coordinates(target_name, cache=True)
 
-        # This is a weak test: we just check to see that a url is added to the
-        #  cache!
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
-            url = get_cached_urls()[0]
-            assert 'http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/' in url
+        urls = get_cached_urls()
+        assert len(urls) == 1
+        assert 'http://cdsweb.u-strasbg.fr/cgi-bin/nph-sesame/' in urls[0]
 
         # Try reloading coordinates, now should just reload cached data:
         with no_internet():
             icrs2 = get_icrs_coordinates(target_name, cache=True)
 
-        with shelve.open(urlmapfn) as url2hash:
-            assert len(url2hash) == 1
+        assert len(get_cached_urls()) == 1
 
         assert u.allclose(icrs1.ra, icrs2.ra)
         assert u.allclose(icrs1.dec, icrs2.dec)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -23,7 +23,8 @@ import shelve
 import zipfile
 import ftplib
 
-from tempfile import NamedTemporaryFile, gettempdir, TemporaryDirectory
+from collections import defaultdict
+from tempfile import NamedTemporaryFile, gettempdir, TemporaryDirectory, mkdtemp
 from warnings import warn
 
 import astropy.config.paths
@@ -82,6 +83,7 @@ class Conf(_config.ConfigNamespace):
         'Number of bytes of remote data to download per step.')
     download_cache_lock_attempts = _config.ConfigItem(
         5,
+        'Unused; cache no longer locked. Was: '
         'Number of seconds to wait for the cache lock to be free. It should '
         'normally only ever be held long enough to copy an already-downloaded '
         'file into the cache, so this will normally only run over if '
@@ -903,15 +905,10 @@ def _find_hash_fn(hexdigest, pkgname='astropy'):
     Looks for a local file by hash - returns file name if found and a valid
     file, otherwise returns None.
     """
-
-    with _cache(pkgname) as (dldir, url2hash):
-        if dldir is None:
-            return None
-        hashfn = os.path.join(dldir, hexdigest)
-        if os.path.isfile(hashfn):
-            return hashfn
-        else:
-            return None
+    for k, v in cache_contents(pkgname=pkgname).items():
+        if compute_hash(v) == hexdigest:
+            return v
+    return None
 
 
 def get_free_space_in_dir(path):
@@ -998,9 +995,6 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
     req = urllib.request.Request(source_url, headers=http_headers)
     with urlopener.open(req, timeout=timeout) as remote:
-        # keep a hash to rename the local file to the hashed name
-        hasher = hashlib.md5()
-
         info = remote.info()
         try:
             size = int(info['Content-Length'])
@@ -1010,8 +1004,8 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
         if size is not None:
             check_free_space_in_dir(gettempdir(), size)
             if cache:
-                with _cache(pkgname) as (dldir, url2hash):
-                    check_free_space_in_dir(dldir, size)
+                dldir = _get_download_cache_loc(pkgname)
+                check_free_space_in_dir(dldir, size)
 
         if show_progress and sys.stdout.isatty():
             progress_stream = sys.stdout
@@ -1030,7 +1024,6 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
                     block = remote.read(conf.download_block_size)
                     while block:
                         f.write(block)
-                        hasher.update(block)
                         bytes_read += len(block)
                         p.update(bytes_read)
                         block = remote.read(conf.download_block_size)
@@ -1051,7 +1044,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
                         except OSError:
                             pass
                     raise
-    return f.name, hasher.hexdigest()
+    return f.name
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
@@ -1062,6 +1055,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     It returns the filename of a file containing the URL's contents.
     If ``cache=True`` and the file is present in the cache, just
     returns the filename; if the file had to be downloaded, add it
+    to the cache. If ``cache="update"`` always download and add it
     to the cache.
 
     The cache is effectively a dictionary mapping URLs to files; by default the
@@ -1073,10 +1067,9 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     to look them up or otherwise manipulate them.
 
     The files in the cache directory are named according to a cryptographic
-    hash of their contents (currently MD5, so hackers can cause collisions).
-    Thus files with the same content share storage. The modification times on
-    these files normally indicate when they were last downloaded from the
-    Internet.
+    hash of their URLs (currently MD5, so hackers can cause collisions).
+    The modification times on these files normally indicate when they were
+    last downloaded from the Internet.
 
     Parameters
     ----------
@@ -1103,7 +1096,8 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         will *not* be tried unless it is in this list; this is to prevent
         long waits for a primary server that is known to be inaccessible
         at the moment. If an empty list is passed, then ``download_file``
-        will not attempt to connect to the Internet.
+        will not attempt to connect to the Internet, that is, if the file
+        is not in the cache a KeyError will be raised.
 
     pkgname : `str`, optional
         The package name to use to locate the download cache. i.e. for
@@ -1119,6 +1113,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
 
     ftp_tls : bool
         If True, use TLS with ftp URLs instead of the standard unsecured FTP.
+        Certain servers require this.
 
     Returns
     -------
@@ -1129,10 +1124,13 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     ------
     urllib.error.URLError
         Whenever there's a problem getting the remote file.
+    KeyError
+        When a file was requested from the cache but is missing and no
+        sources were provided to obtain it from the Internet.
 
     Notes
     -----
-    Because this returns a filename, another process could run
+    Because `download_file` returns a filename, another process could run
     clear_download_cache before you actually open the file, leaving
     you with a filename that no longer points to a usable file.
     """
@@ -1149,20 +1147,30 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     url_key = remote_url
 
     if cache:
-        with _cache(pkgname) as (dldir, url2hash):
-            if dldir is None:
-                cache = False
-                missing_cache = (
-                    "Cache directory cannot be read or created, "
-                    "providing data in temporary file instead."
-                )
-            elif cache != "update" and url_key in url2hash:
-                return url2hash[url_key]
+        try:
+            dldir = _get_download_cache_loc(pkgname)
+        except OSError:
+            cache = False
+            missing_cache = (
+                "Cache directory cannot be read or created, "
+                "providing data in temporary file instead."
+            )
+        else:
+            if cache == "update":
+                pass
+            elif isinstance(cache, str):
+                raise ValueError(f"Cache value '{cache}' was requested but "
+                                 f"'update' is the only recognized string; "
+                                 f"otherwise use a boolean")
+            else:
+                filename = os.path.join(dldir, _url_to_dirname(url_key), "contents")
+                if os.path.exists(filename):
+                    return os.path.abspath(filename)
 
     errors = {}
     for source_url in sources:
         try:
-            f_name, hexdigest = _download_file_from_source(
+            f_name = _download_file_from_source(
                     source_url,
                     timeout=timeout,
                     show_progress=show_progress,
@@ -1207,26 +1215,23 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
     if cache:
         try:
             return import_file_to_cache(url_key, f_name,
-                                        hexdigest=hexdigest,
                                         remove_original=True,
+                                        replace=(cache == 'update'),
                                         pkgname=pkgname)
-        except WrongDBMModule as e:
-            missing_cache = (
-                f"{e}; Unable to use cache, providing data in temporary file "
-                f"{f_name} instead.")
         except PermissionError:
             # Cache is readonly, we can't update it
             missing_cache = (
                 f"Cache directory appears to be read-only, unable to import "
                 f"downloaded file, providing data in temporary file {f_name} "
                 f"instead.")
+        # FIXME: other kinds of cache problem can occur?
 
     if missing_cache:
         warn(CacheMissingWarning(missing_cache, f_name))
     if conf.delete_temporary_downloads_at_exit:
         global _tempfilestodel
         _tempfilestodel.append(f_name)
-    return f_name
+    return os.path.abspath(f_name)
 
 
 def is_url_in_cache(url_key, pkgname='astropy'):
@@ -1256,15 +1261,21 @@ def is_url_in_cache(url_key, pkgname='astropy'):
     --------
     cache_contents : obtain a dictionary listing everything in the cache
     """
-    with _cache(pkgname) as (dldir, url2hash):
-        return url_key in url2hash
+    try:
+        dldir = _get_download_cache_loc(pkgname)
+    except OSError:
+        return False
+    filename = os.path.join(dldir, _url_to_dirname(url_key), "contents")
+    return os.path.exists(filename)
 
 
 def cache_total_size(pkgname='astropy'):
     """Return the total size in bytes of all files in the cache."""
-    with _cache(pkgname) as (dldir, url2hash):
-        return sum(os.path.getsize(os.path.join(dldir, h))
-                   for h in url2hash.values())
+    size = 0
+    dldir = _get_download_cache_loc(pkgname=pkgname)
+    for root, dirs, files in os.walk(dldir):
+        size += sum(os.path.getsize(os.path.join(root, name)) for name in files)
+    return size
 
 
 def _do_download_files_in_parallel(kwargs):
@@ -1417,6 +1428,12 @@ def _deltemps():
                     # oh well we tried
                     # could be held open by some process, on Windows
                     pass
+            elif os.path.isdir(fn):
+                try:
+                    shutil.rmtree(fn)
+                except OSError:
+                    # sigh
+                    pass
 
 
 def clear_download_cache(hashorurl=None, pkgname='astropy'):
@@ -1443,73 +1460,47 @@ def clear_download_cache(hashorurl=None, pkgname='astropy'):
         ``pkgname='astropy'`` the default cache location is
         ``~/.astropy/cache``.
     """
-    zapped_cache = False
     try:
-        with contextlib.ExitStack() as stack:
-            try:
-                dldir, url2hash = stack.enter_context(
-                    _cache(pkgname, write=True))
-            except (RuntimeError, WrongDBMModule):  # Couldn't get lock
-                if hashorurl is None:
-                    # Release lock by blowing away cache
-                    # Need to get locations
-                    dldir, _ = _get_download_cache_locs(pkgname)
-                else:
-                    # Can't do specific deletion without the lock
-                    raise
-            except OSError as e:
-                # Problem arose when trying to open the cache
-                msg = 'Not clearing data cache - cache inaccessible due to '
-                estr = '' if len(e.args) < 1 else (': ' + str(e))
-                warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
-                return
-            if hashorurl is None:
-                if os.path.exists(dldir):
-                    shutil.rmtree(dldir)
-                    zapped_cache = True
-            elif _is_url(hashorurl):
-                try:
-                    filepath = url2hash.pop(hashorurl)
-                    if not any(v == filepath for v in url2hash.values()):
-                        try:
-                            os.unlink(filepath)
-                        except FileNotFoundError:
-                            # Maybe someone else got it first
-                            pass
-                    return
-                except KeyError:
-                    pass
-            else:  # it's a path
-                filepath = os.path.join(dldir, hashorurl)
-                if not _is_inside(filepath, dldir):
-                    # Should this be ValueError? IOError?
-                    raise RuntimeError(
-                        f"attempted to use clear_download_cache on the path "
-                        f"{filepath} outside the data cache directory {dldir}")
-                if os.path.exists(filepath):
-                    # Convert to list because we'll be modifying it as we go
-                    for k, v in list(url2hash.items()):
-                        if v == filepath:
-                            del url2hash[k]
-                    os.unlink(filepath)
-                    return
-                # Otherwise could not find file or url, but no worries.
-                # Clearing download cache just makes sure that the file or url
-                # is no longer in the cache regardless of starting condition.
+        dldir = _get_download_cache_loc(pkgname)
     except OSError as e:
-        if zapped_cache and e.errno == errno.ENOENT:
-            # We just deleted the directory and, on Windows (?) the "dumb"
-            # backend tried to write itself out to a nonexistent directory.
-            # It's fine for this to fail.
-            return
+        # Problem arose when trying to open the cache
+        # Just a warning, though
+        msg = 'Not clearing data cache - cache inaccessible due to '
+        estr = '' if len(e.args) < 1 else (': ' + str(e))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        return
+    try:
+        if hashorurl is None:
+            _rmtree(dldir)
+        elif _is_url(hashorurl):
+            filepath = os.path.join(dldir, _url_to_dirname(hashorurl))
+            _rmtree(filepath)
         else:
-            msg = 'Not clearing data from cache - problem arose '
-            estr = '' if len(e.args) < 1 else (': ' + str(e))
-            warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
-            return
+            filepath = os.path.join(dldir, hashorurl)
+            if not _is_inside(filepath, dldir):
+                # Should this be ValueError? IOError?
+                raise RuntimeError(
+                    f"attempted to use clear_download_cache on the path "
+                    f"{filepath} outside the data cache directory {dldir}")
+            dirname, basename = os.path.split(filepath)
+            if basename in ["contents", "url"]:
+                # It's a filename not the hash of a URL
+                filepath = dirname
+            if os.path.isdir(filepath):
+                _rmtree(filepath)
+            elif (len(hashorurl) == 2*hashlib.md5().digest_size
+                    and re.match("[0-9a-f]+", hashorurl)):
+                # It's the hash of some file contents, we have to find the right file
+                filename = _find_hash_fn(hashorurl)
+                if filename is not None:
+                    clear_download_cache(filename)
+    except OSError as e:
+        msg = 'Not clearing data from cache - problem arose '
+        estr = '' if len(e.args) < 1 else (': ' + str(e))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
 
 
-def _get_download_cache_locs(pkgname='astropy'):
+def _get_download_cache_loc(pkgname='astropy'):
     """Finds the path to the cache directory and makes them if they don't exist.
 
     Parameters
@@ -1528,117 +1519,28 @@ def _get_download_cache_locs(pkgname='astropy'):
     """
     from astropy.config.paths import get_cache_dir
 
-    # datadir includes both the download files and the shelveloc.  This structure
-    # is required since we cannot know a priori the actual file name corresponding
-    # to the shelve map named shelveloc.  (The backend can vary and is allowed to
-    # do whatever it wants with the filename.  Filename munging can and does happen
-    # in practice).
-    py_version = 'py' + str(sys.version_info.major)
-    datadir = os.path.join(get_cache_dir(pkgname), 'download', py_version)
-    shelveloc = os.path.join(datadir, 'urlmap')
-
-    if not os.path.exists(datadir):
-        try:
-            os.makedirs(datadir)
-        except OSError:
-            if not os.path.exists(datadir):
-                raise
-    elif not os.path.isdir(datadir):
-        raise OSError(f'Data cache directory {datadir} is not a directory')
-
-    if os.path.isdir(shelveloc):
-        raise OSError(
-            f'Data cache shelve object location {shelveloc} is a directory')
-
-    return datadir, shelveloc
-
-
-def _keep_trying(timeout):
-    waited = 0.
-    yield waited
-    while waited < timeout:
-        pid_based_random = (hash(str(os.getpid()))
-                            / 2.**sys.hash_info.width)
-        dt = 0.05*(1+pid_based_random)
-        time.sleep(dt)
-        waited += dt
-        yield waited
-
-
-# the cache directory must be locked before any writes are performed.  Same for
-# the hash shelve, so this should be used for both.
-#
-# In fact the shelve, if you're using gdbm (the default on Linux), it can't
-# be open for reading if someone has it open for writing. So we need to lock
-# access to the shelve even for reading.
-@contextlib.contextmanager
-def _cache_lock(pkgname, need_write=False):
-    lockdir = os.path.join(_get_download_cache_locs(pkgname)[0], 'lock')
-    pidfn = os.path.join(lockdir, 'pid')
-    got_lock = False
     try:
-        msg = f"Config file requests {conf.download_cache_lock_attempts} tries"
-        for waited in _keep_trying(conf.download_cache_lock_attempts):
+        datadir = os.path.join(get_cache_dir(pkgname), 'download', 'url')
+
+        if not os.path.exists(datadir):
             try:
-                os.mkdir(lockdir)
-            except FileExistsError:
-                # It is not safe to open and inspect the pid file here
-                # on Windows, because while it is open that prevents its
-                # deletion and that of the directory containing it. This
-                # gets in the way of useful error messages.
-                msg = (
-                    f"Cache is locked after {waited:.2f} s. This may indicate "
-                    f"an astropy bug or that kill -9 was used. If you want to "
-                    f"unlock the cache remove the directory {lockdir}.")
-            except OSError as e:
-                # PermissionError doesn't cover all read-only-ness, just EACCES
-                if e.errno in [errno.EPERM,    # Operation not permitted
-                               errno.EACCES,   # Permission denied
-                               errno.EROFS]:   # File system is read-only
-                    if need_write:
-                        raise
-                    else:
-                        break
-                else:
-                    raise
-            else:
-                got_lock = True
-                # write the pid of this process for informational purposes
-                with open(pidfn, 'w') as f:
-                    f.write(str(os.getpid()))
-                break
-        else:
-            # Never did get the lock.
-            try:
-                # Might as well try to read and report the PID file, at
-                # this point it's unlikely we'll block someone else trying
-                # to exit cleanly.
-                pid = get_file_contents(pidfn)
+                os.makedirs(datadir)
             except OSError:
-                pass
-            else:
-                msg += f" Lock claims to be held by process {pid}."
-            raise RuntimeError(msg)
+                if not os.path.exists(datadir):
+                    raise
+        elif not os.path.isdir(datadir):
+            raise OSError(f'Data cache directory {datadir} is not a directory')
 
-        yield
+        return datadir
+    except OSError as e:
+        msg = 'Remote data cache could not be accessed due to '
+        estr = '' if len(e.args) < 1 else (': ' + str(e))
+        warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
+        raise
 
-    finally:
-        # clear_download_cache might have deleted the lockdir
-        if got_lock and os.path.exists(lockdir):
-            if os.path.isdir(lockdir):
-                # if the pid file is present, be sure to remove it
-                if os.path.exists(pidfn):
-                    os.remove(pidfn)
-                os.rmdir(lockdir)
-            else:
-                raise RuntimeError(
-                    f'Error releasing lock. {lockdir} exists but is not '
-                    f'a directory.')
-        else:
-            # Just in case we were called from _clear_download_cache
-            # or something went wrong before creating the directory
-            # or the cache was readonly; no need to clean it up then.
-            pass
+
+def _url_to_dirname(url):
+    return hashlib.md5(url.encode("utf-8")).hexdigest()
 
 
 class ReadOnlyDict(dict):
@@ -1646,105 +1548,10 @@ class ReadOnlyDict(dict):
         raise TypeError("This object is read-only.")
 
 
-_NOTHING = ReadOnlyDict()  # might as well share.
+_NOTHING = ReadOnlyDict({})
 
 
-class WrongDBMModule(dbm.error[0]):
-    pass
-
-
-class WrongDBMModuleWarning(CacheMissingWarning):
-    """
-    This warning indicates the standard cache directory is not accessible,
-    specifically because it exists but is in a format that the current python
-    interpreter cannot understand.
-    """
-
-
-@contextlib.contextmanager
-def _cache(pkgname, write=False):
-    """Download cache context manager.
-
-    Yields a pair consisting of the download cache directory and a dict-like
-    object that maps downloaded URLs to the filenames that contain their
-    contents; these files reside in the download cache directory.
-
-    If writing is requested, this holds the lock and yields a modifiable
-    dict-like object (actually a shelve object from the shelve module).  If
-    there is something wrong with the cache setup, an appropriate exception
-    will be raised.
-
-    If reading is requested, the lock will be briefly acquired, the URL map
-    will be copied into a read-only dict-like object which is yielded, and the
-    lock will be released. If some problem occurs and the cache is inaccessible
-    or non-functional, a CacheMissingWarning will be emitted and this context
-    manager will yield an empty dict-like object and None as the download
-    directory.
-
-    Although this cache lives behind a lock, and files are not normally
-    modified, it is possible to break concurrent access - most easily by using
-    clear_download_cache on a URL while someone has the filename and wants to
-    read the file. Since download_file returns a filename, there is not much we
-    can do about this.  get_readable_fileobj doesn't quite avoid the problem,
-    though it almost immediately opens the filename, preserving the contents
-    from deletion.
-    """
-    try:
-        dldir, urlmapfn = _get_download_cache_locs(pkgname)
-    except OSError as e:
-        if write:
-            raise
-        else:
-            msg = 'Remote data cache could not be accessed due to '
-            estr = '' if len(e.args) < 1 else (': ' + str(e))
-            warn(CacheMissingWarning(msg + e.__class__.__name__ + estr))
-            yield None, _NOTHING
-            return
-    wrong_dbm_message = (
-        "Existing astropy cache is in an unsupported format, "
-        "either install the appropriate package or use "
-        "astropy.utils.data.clear_download_cache() to delete the "
-        "whole cache; ")
-    if write:
-        try:
-            with _cache_lock(pkgname, need_write=True), \
-                    shelve.open(urlmapfn, flag="c") as url2hash:
-                yield dldir, url2hash
-        except dbm.error as e:
-            if "module is not available" in str(e):
-                raise WrongDBMModule(wrong_dbm_message + str(e))
-            else:
-                raise
-    else:
-        try:
-            with _cache_lock(pkgname), shelve.open(urlmapfn, flag="r") as url2hash:
-                # Copy so we can release the lock.
-                d = ReadOnlyDict(url2hash.items())
-        except dbm.error as e:
-            # Might be a "file not found" - that is, an un-initialized cache,
-            # might be something serious, no way to tell as shelve just gives
-            # you a plain dbm.error
-            # Also the file doesn't have a platform-independent name, so good
-            # luck diagnosing the problem if it is one.
-            if "module is not available" in str(e):
-                warn(WrongDBMModuleWarning(wrong_dbm_message + str(e)))
-            d = _NOTHING
-        yield dldir, d
-
-
-class CacheDamaged(ValueError):
-    """Record the URL or file that was a problem.
-
-    Using clear_download_cache on the .bad_file or .bad_url attribute,
-    whichever is not None, should resolve this particular problem.
-    """
-    def __init__(self, *args, bad_urls=None, bad_files=None, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.bad_urls = bad_urls if bad_urls is not None else []
-        self.bad_files = bad_files if bad_files is not None else []
-
-
-def check_download_cache(check_hashes=False, pkgname='astropy'):
+def check_download_cache(pkgname='astropy'):
     """Do a consistency check on the cache.
 
     Because the cache is shared by all versions of astropy in all virtualenvs
@@ -1765,10 +1572,6 @@ def check_download_cache(check_hashes=False, pkgname='astropy'):
 
     Parameters
     ----------
-    check_hashes : bool, optional
-        Whether to compute the hashes of the contents of all files in the
-        cache and compare them to the names. This can take some time if
-        the cache contains large files.
     pkgname : `str`, optional
         The package name to use to locate the download cache. i.e. for
         ``pkgname='astropy'`` the default cache location is
@@ -1792,61 +1595,82 @@ def check_download_cache(check_hashes=False, pkgname='astropy'):
         `clear_download_cache` to resolve, or may indicate some kind of
         misconfiguration.
     """
-    with _cache(pkgname) as (dldir, url2hash):
-        if dldir is None:
-            raise OSError("Cache directory cannot be created or accessed")
-        nonexistent_targets = {}
-        bad_locations = {}
-        bad_hashes = {}
-        abandoned_files = set()
-        leftover_files = set(os.path.join(dldir, k)
-                             for k in os.listdir(dldir))
-        leftover_files.discard(os.path.join(dldir, "urlmap"))
-        leftover_files.discard(os.path.join(dldir, "lock"))
-        for u, h in url2hash.items():
-            if not os.path.exists(h):
-                nonexistent_targets[u] = h
-            leftover_files.discard(h)
-            d, hexdigest = os.path.split(h)
-            if dldir != d:
-                bad_locations[u] = h
-            if check_hashes:
-                hexdigest_file = compute_hash(h)
-                if hexdigest_file != hexdigest:
-                    bad_hashes[u] = h
-        for h in leftover_files:
-            h_base = os.path.basename(h)
-            if len(h_base) >= 32 and re.match(r"[0-9a-f]+", h_base):
-                abandoned_files.add(h)
-        leftover_files -= abandoned_files
+    dldir = _get_download_cache_loc(pkgname=pkgname)
+    with os.scandir(dldir) as it:
+        for entry in it:
+            if entry.name.startswith("rmtree-"):
+                if os.path.abspath(os.path.join(dldir, entry.name)) not in _tempfilestodel:
+                    raise ValueError(f"Cache entry {entry.name} not scheduled for deletion")
+            elif entry.is_dir:
+                url = get_file_contents(os.path.join(dldir, entry.name, "url"), encoding="utf-8")
+                if not _is_url(url):
+                    raise ValueError(f"Malformed URL: {url}")
+                hashname = _url_to_dirname(url)
+                if entry.name != hashname:
+                    raise ValueError(f"URL hashes to {hashname} but is stored in {entry.name}")
+                if not os.path.exists(os.path.join(dldir, entry.name, "contents")):
+                    raise ValueError(f"URL {url} with hash {entry.name} is missing contents")
+            else:
+                raise ValueError(f"Left-over non-directory {entry.name} in cache")
+    return set()
 
-        msgs = []
-        if nonexistent_targets:
-            msgs.append(
-                f"URL(s) point(s) to nonexistent file(s): {nonexistent_targets}")
-        if bad_locations:
-            msgs.append(
-                f"URL(s) point(s) to file(s) outside {dldir}: {bad_locations}")
-        if bad_hashes:
-            msgs.append(
-                f"Filename(s) does not match hash(es) of contents: {bad_hashes}")
-        if abandoned_files:
-            msgs.append(
-                f"Apparently abandoned files: {abandoned_files}")
-        if msgs:
-            raise CacheDamaged(
-                "\n".join(msgs),
-                bad_urls=(list(nonexistent_targets.keys())
-                          + list(bad_locations.keys())),
-                bad_files=(list(bad_hashes.values())
-                           + list(abandoned_files)))
-        else:
-            return leftover_files
+
+@contextlib.contextmanager
+def _SafeTemporaryDirectory(suffix=None, prefix=None, dir=None):
+    """Temporary directory context manager
+
+    This will not raise an exception if the temporary directory goes away
+    before it's supposed to be deleted. Specifically, what is deleted will
+    be the directory *name* produced; if no such directory exists, no
+    exception will be raised.
+
+    It would be safer to delete it only if it's really the same directory
+    - checked by file descriptor - and if it's still called the same thing.
+    But that opens a platform-specific can of worms.
+
+    It would also be more robust to use ExitStack and TemporaryDirectory,
+    which is more aggressive about removing readonly things.
+    """
+    d = mkdtemp(suffix=suffix, prefix=prefix, dir=dir)
+    try:
+        yield d
+    finally:
+        try:
+            shutil.rmtree(d)
+        except OSError:
+            pass
+
+
+def _rmtree(path, replace=None):
+    """More-atomic rmtree. Ignores missing directory."""
+    with TemporaryDirectory(prefix="rmtree-",
+                            dir=os.path.dirname(os.path.abspath(path))) as d:
+        try:
+            os.rename(path, os.path.join(d, "to-zap"))
+        except FileNotFoundError:
+            pass
+        except PermissionError:
+            warn(CacheMissingWarning(
+                f"Unable to remove directory {path} because a file in it "
+                f"is in use and you are on Windows", path))
+            raise
+        if replace is not None:
+            try:
+                os.rename(replace, path)
+            except FileExistsError:
+                # already there, fine
+                pass
+            except OSError as e:
+                if e.errno == errno.ENOTEMPTY:
+                    # already there, fine
+                    pass
+                else:
+                    raise
 
 
 def import_file_to_cache(url_key, filename,
-                         hexdigest=None,
                          remove_original=False,
+                         replace=True,
                          pkgname='astropy'):
     """Import the on-disk file specified by filename to the cache.
 
@@ -1858,11 +1682,7 @@ def import_file_to_cache(url_key, filename,
 
     If ``url_key`` already exists in the cache, it will be updated to point to
     these imported contents, and its old contents will be deleted from the
-    cache if nothing else points there.
-
-    If a file already exists in the cache with the same contents (no matter the
-    ``url_key``), its modification time will be updated but this file will not
-    be copied/moved over it.
+    cache.
 
     Parameters
     ----------
@@ -1873,55 +1693,42 @@ def import_file_to_cache(url_key, filename,
         location.
     filename : str
         The file whose contents you want to import.
-    hexdigest : str, optional
-        The cryptographic hash of the file, as computed by
-        `compute_hash`. If it is not provided, `compute_hash`
-        will be called. This argument is available in case
-        it is easier to compute the hash progressively as
-        the file is downloaded.
     remove_original : bool
         Whether to remove the original file (``filename``) once import is
-        complete. If the original is to be removed, and if the cache lives
-        on the same filesystem as the file to be imported, a simple rename
-        operation will move the file into the cache. Otherwise the file
-        will be copied and then the original deleted if appropriate.
+        complete.
     pkgname : `str`, optional
         The package name to use to locate the download cache. i.e. for
         ``pkgname='astropy'`` the default cache location is
         ``~/.astropy/cache``.
     """
-    if hexdigest is None:
-        hexdigest = compute_hash(filename, pkgname=pkgname)
-    with _cache(pkgname, write=True) as (dldir, url2hash):
-        # We check now to see if another process has
-        # inadvertently written the file underneath us
-        # already
-        local_path = os.path.join(dldir, hexdigest)
-        if os.path.exists(local_path):
-            # Same hash, no problem
-            if remove_original:
-                os.remove(filename)
-            # Update file modification time.
-            try:
-                with open(local_path, "ab"):
-                    pass
-            except OSError:
-                pass
-        elif remove_original:
-            shutil.move(filename, local_path)
+    cache_dir = _get_download_cache_loc(pkgname=pkgname)
+    cache_dirname = _url_to_dirname(url_key)
+    local_dirname = os.path.join(cache_dir, cache_dirname)
+    local_filename = os.path.join(local_dirname, "contents")
+    with _SafeTemporaryDirectory(prefix="temp_dir", dir=cache_dir) as temp_dir:
+        temp_filename = os.path.join(temp_dir, "contents")
+        # Make sure we're on the same filesystem
+        # This will raise an exception if the url_key doesn't turn into a valid filename
+        shutil.copy(filename, temp_filename)
+        with open(os.path.join(temp_dir, "url"), "wt", encoding="utf-8") as f:
+            f.write(url_key)
+        if replace:
+            _rmtree(local_dirname, replace=temp_dir)
         else:
-            shutil.copy(filename, local_path)
-        old_hash = url2hash.get(url_key, None)
-        url2hash[url_key] = local_path
-        if old_hash is not None:
-            if old_hash not in url2hash.values():
-                try:
-                    os.remove(os.path.join(dldir, old_hash))
-                except OSError as e:
-                    warn(f"Unable to remove no-longer-referenced previous "
-                         f"contents of {url_key} because of: {e}",
-                         AstropyWarning)
-        return url2hash[url_key]
+            try:
+                os.rename(temp_dir, local_dirname)
+            except FileExistsError:
+                # already there, fine
+                pass
+            except OSError as e:
+                if e.errno == errno.ENOTEMPTY:
+                    # already there, fine
+                    pass
+                else:
+                    raise
+    if remove_original:
+        os.remove(filename)
+    return os.path.abspath(local_filename)
 
 
 def get_cached_urls(pkgname='astropy'):
@@ -1949,8 +1756,7 @@ def get_cached_urls(pkgname='astropy'):
     --------
     cache_contents : obtain a dictionary listing everything in the cache
     """
-    with _cache(pkgname) as (dldir, url2hash):
-        return list(url2hash.keys())
+    return list(cache_contents(pkgname=pkgname).keys())
 
 
 def cache_contents(pkgname='astropy'):
@@ -1963,9 +1769,17 @@ def cache_contents(pkgname='astropy'):
     busy with many running astropy processes, although the same issues apply to
     most functions in this module.
     """
-    with _cache(pkgname) as (dldir, url2hash):
-        return ReadOnlyDict((k, os.path.join(dldir, v))
-                            for (k, v) in url2hash.items())
+    r = {}
+    try:
+        dldir = _get_download_cache_loc(pkgname=pkgname)
+    except OSError:
+        return _NOTHING
+    with os.scandir(dldir) as it:
+        for entry in it:
+            if entry.is_dir:
+                url = get_file_contents(os.path.join(dldir, entry.name, "url"), encoding="utf-8")
+                r[url] = os.path.abspath(os.path.join(dldir, entry.name, "contents"))
+    return ReadOnlyDict(r)
 
 
 def export_download_cache(filename_or_obj, urls=None, overwrite=False, pkgname='astropy'):
@@ -2048,14 +1862,10 @@ def import_download_cache(filename_or_obj, urls=None, update_cache=False, pkgnam
                 continue
             f_temp_name = os.path.join(d, str(i))
             with z.open(zf) as f_zip, open(f_temp_name, "wb") as f_temp:
-                hasher = hashlib.md5()
                 block = f_zip.read(conf.download_block_size)
                 while block:
                     f_temp.write(block)
-                    hasher.update(block)
                     block = f_zip.read(conf.download_block_size)
-                hexdigest = hasher.hexdigest()
             import_file_to_cache(url, f_temp_name,
-                                 hexdigest=hexdigest,
                                  remove_original=True,
                                  pkgname=pkgname)

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1072,8 +1072,7 @@ def _download_file_from_source(source_url, show_progress=True, timeout=None,
 
 
 def download_file(remote_url, cache=False, show_progress=True, timeout=None,
-                  sources=None, pkgname='astropy', http_headers=None,
-                  ftp_tls=None):
+                  sources=None, pkgname='astropy', http_headers=None):
     """Downloads a URL and optionally caches the result.
 
     It returns the filename of a file containing the URL's contents.
@@ -1135,11 +1134,6 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
         is not a remote HTTP URL.) In the default case (None), the headers are
         ``User-Agent: some_value`` and ``Accept: */*``, where ``some_value``
         is set by ``astropy.utils.data.conf.default_http_user_agent``.
-
-    ftp_tls : bool
-        If True, use TLS with ftp URLs instead of the standard unsecured FTP.
-        Certain servers require this. If None, try without TLS first then try
-        with TLS.
 
     Returns
     -------

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1349,7 +1349,6 @@ def download_files_in_parallel(urls,
         configurable `astropy.utils.data.Conf.remote_timeout`). Set this to
         zero to prevent any attempt to download anything.
 
-
     sources : dict, optional
         If provided, for each URL a list of URLs to try to obtain the
         file from. The result will be stored under the original URL.
@@ -1509,7 +1508,7 @@ def clear_download_cache(hashorurl=None, pkgname='astropy'):
             d, f = os.path.split(rp)
             if d and f in ["contents", "url"]:
                 # It's a filename not the hash of a URL
-                # so we wamt to zap the directory containing the
+                # so we want to zap the directory containing the
                 # files "url" and "contents"
                 filepath = os.path.join(dldir, d)
             if os.path.exists(filepath):

--- a/astropy/utils/data.py
+++ b/astropy/utils/data.py
@@ -1197,8 +1197,7 @@ def download_file(remote_url, cache=False, show_progress=True, timeout=None,
                     cache=cache,
                     remote_url=remote_url,
                     pkgname=pkgname,
-                    http_headers=http_headers,
-                    ftp_tls=ftp_tls)
+                    http_headers=http_headers)
             # Success!
             break
 

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -747,9 +747,8 @@ class IERS_Auto(IERS_A):
 
             # Get the latest version
             try:
-                clear_download_cache(all_urls[0])
                 filename = download_file(
-                    all_urls[0], sources=all_urls, cache=True)
+                    all_urls[0], sources=all_urls, cache="update")
             except Exception as err:
                 # Issue a warning here, perhaps user is offline.  An exception
                 # will be raised downstream when actually trying to interpolate

--- a/astropy/utils/iers/iers.py
+++ b/astropy/utils/iers/iers.py
@@ -87,7 +87,6 @@ def download_file(*args, **kwargs):
     """
     kwargs.setdefault('http_headers', {'User-Agent': 'astropy/iers',
                                        'Accept': '*/*'})
-    kwargs.setdefault('ftp_tls', True)
 
     with utils.data.conf.set_temp('remote_timeout', conf.remote_timeout):
         return utils.data.download_file(*args, **kwargs)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2083,12 +2083,6 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
 
 
 @pytest.mark.remote_data
-def test_ftp_tls(temp_cache):
-    url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"
-    download_file(url, ftp_tls=True)
-
-
-@pytest.mark.remote_data
 def test_ftp_tls_auto(temp_cache):
     url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"
     download_file(url)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -3,7 +3,6 @@
 
 import io
 import os
-import dbm
 import sys
 import stat
 import errno
@@ -14,14 +13,13 @@ import hashlib
 import pathlib
 import platform
 import tempfile
-import importlib
+import warnings
 import itertools
 import contextlib
 import urllib.error
 import urllib.parse
 import urllib.request
 from itertools import islice
-from importlib import import_module
 from concurrent.futures import ThreadPoolExecutor
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 
@@ -30,13 +28,10 @@ import pytest
 
 from astropy.utils import data
 from astropy.config import paths
-from astropy.utils.compat.context import nullcontext
+import astropy.utils.data
 from astropy.utils.data import (
     CacheMissingWarning,
-    CacheDamaged,
     conf,
-    _cache,
-    _cache_lock,
     compute_hash,
     download_file,
     cache_contents,
@@ -49,14 +44,14 @@ from astropy.utils.data import (
     clear_download_cache,
     get_pkg_data_fileobj,
     get_readable_fileobj,
+    import_file_to_cache,
     export_download_cache,
     get_pkg_data_contents,
     get_pkg_data_filename,
     import_download_cache,
     get_free_space_in_dir,
-    WrongDBMModuleWarning,
     check_free_space_in_dir,
-    _get_download_cache_locs,
+    _get_download_cache_loc,
     download_files_in_parallel,
 )
 
@@ -83,11 +78,11 @@ else:
 FEW = 5
 
 # For stress testing the locking system using multiprocessing
-N_PARALLEL_HAMMER = 10  # as high as 500 to replicate a bug
+N_PARALLEL_HAMMER = 5  # as high as 500 to replicate a bug
 
 # For stress testing the locking system using threads
 # (cheaper, works with coverage)
-N_THREAD_HAMMER = 20  # as high as 1000 to replicate a bug
+N_THREAD_HAMMER = 10  # as high as 1000 to replicate a bug
 
 
 def url_to(path):
@@ -123,7 +118,7 @@ def invalid_urls(tmpdir):
 def temp_cache(tmpdir):
     with paths.set_temp_cache(tmpdir):
         yield None
-        check_download_cache(check_hashes=True)
+        check_download_cache()
 
 
 def change_tree_permission(d, writable=False):
@@ -171,14 +166,25 @@ def readonly_cache(tmpdir, valid_urls):
                     pytest.skip("Unable to make directory readonly")
                 yield urls
             assert set(d.iterdir()) == files
-            check_download_cache(check_hashes=True)
+            check_download_cache()
 
 
 @pytest.fixture
 def fake_readonly_cache(tmpdir, valid_urls, monkeypatch):
-    def no_mkdir(p):
+    def no_mkdir(p, perm=None):
         raise OSError(errno.EPERM,
                       "os.mkdir monkeypatched out")
+
+    def no_mkdtemp(*args, **kwargs):
+        """On Windows, mkdtemp uses mkdir in a loop and therefore hangs
+        with it monkeypatched out.
+        """
+        raise OSError(errno.EPERM,
+                      "os.mkdtemp monkeypatched out")
+
+    def no_TemporaryDirectory(*args, **kwargs):
+        raise OSError(errno.EPERM,
+                      "_SafeTemporaryDirectory monkeypatched out")
 
     with TemporaryDirectory(dir=tmpdir) as d:
         # other fixtures use the same tmpdir so we need a subdirectory
@@ -189,50 +195,77 @@ def fake_readonly_cache(tmpdir, valid_urls, monkeypatch):
             urls = {u: download_file(u, cache=True) for u in us}
             files = set(d.iterdir())
             monkeypatch.setattr(os, "mkdir", no_mkdir)
+            monkeypatch.setattr(tempfile, "mkdtemp", no_mkdtemp)
+            monkeypatch.setattr(astropy.utils.data,
+                                "_SafeTemporaryDirectory",
+                                no_TemporaryDirectory)
             yield urls
             assert set(d.iterdir()) == files
-            check_download_cache(check_hashes=True)
+            check_download_cache()
 
 
-_shelve_possible_backends = ["dbm.dumb", "dbm.ndbm", "dbm.gnu"]
-for n in _shelve_possible_backends:
-    if n not in dbm._modules:
+def can_rename_directory_in_use():
+    with TemporaryDirectory() as d:
+        d1 = os.path.join(d, "a")
+        d2 = os.path.join(d, "b")
+        f1 = os.path.join(d1, "file")
+        os.mkdir(d1)
+        with open(f1, "wt") as f:
+            f.write("some contents\n")
         try:
-            dbm._modules[n] = import_module(n)
-        except ImportError:
-            pass
+            with open(f1, "rt"):
+                os.rename(d1, d2)
+        except PermissionError:
+            return False
+        return True
 
 
-def create_cache_with_backend(name, pkgname='astropy'):
-    dldir, urlmapfn = _get_download_cache_locs(pkgname)
-    e = dbm.whichdb(urlmapfn)
-    if e is not None:
-        raise IOError(f"Cache already exists in format {e} ({name} requested)")
-    try:
-        m = import_module(name)
-    except ImportError:
-        pytest.skip(f"Module {name} not available")
-    with m.open(urlmapfn, "c"):
-        pass
+def test_download_file_basic(valid_urls, temp_cache):
+    u, c = next(valid_urls)
+    assert get_file_contents(download_file(u)) == c
+    assert get_file_contents(download_file(u, cache=True)) == c
+    assert get_file_contents(download_file(u, cache=True)) == c
+    assert get_file_contents(download_file(u, cache=True, sources=[])) == c
 
 
-@contextlib.contextmanager
-def shelve_backend(name):
-    """Ensure that shelve has access only to one backend."""
-    # WARNING: there is something weird and fragile about this.
-    # Using it can cause weird order-dependent test failures in
-    # the second shelve_backend test if the two meet certain
-    # mysterious criteria.
-    try:
-        m = dbm._modules[name]
-    except KeyError:
-        pytest.skip(f"Backend {name} not available")
-    defaultmod, modules = dbm._defaultmod, dbm._modules
-    try:
-        dbm._defaultmod, dbm._modules = m, {name: m}
-        yield
-    finally:
-        dbm._defaultmod, dbm._modules = defaultmod, modules
+def test_download_file_absolute_path(valid_urls, temp_cache):
+
+    def is_abs(p):
+        return p == os.path.abspath(p)
+
+    u, c = next(valid_urls)
+    assert is_abs(download_file(u))   # no cache
+    assert is_abs(download_file(u, cache=True))  # not in cache
+    assert is_abs(download_file(u, cache=True))  # in cache
+    for k, v in cache_contents().items():
+        assert is_abs(v)
+
+
+def test_unicode_url(valid_urls, temp_cache):
+    u, c = next(valid_urls)
+    unicode_url = "http://é—☃—è.com"
+    download_file(unicode_url, cache=False, sources=[u])
+    download_file(unicode_url, cache=True, sources=[u])
+    download_file(unicode_url, cache=True, sources=[])
+    assert is_url_in_cache(unicode_url)
+    assert unicode_url in cache_contents()
+
+
+def test_too_long_url(valid_urls, temp_cache):
+    u, c = next(valid_urls)
+    long_url = "http://"+"a"*256+".com"
+    download_file(long_url, cache=False, sources=[u])
+    download_file(long_url, cache=True, sources=[u])
+    download_file(long_url, cache=True, sources=[])
+
+
+def test_case_collision(valid_urls, temp_cache):
+    u, c = next(valid_urls)
+    u2, c2 = next(valid_urls)
+    f1 = download_file("http://example.com/", cache=True, sources=[u])
+    f2 = download_file("http://EXAMPLE.com/", cache=True, sources=[u2])
+    assert f1 != f2
+    assert get_file_contents(f1) != get_file_contents(f2)
 
 
 @pytest.mark.remote_data(source="astropy")
@@ -260,41 +293,35 @@ def a_file(tmp_path):
 
 
 def test_temp_cache(tmpdir):
-    dldir0, urlmapfn0 = _get_download_cache_locs()
-    check_download_cache(check_hashes=True)
+    dldir0 = _get_download_cache_loc()
+    check_download_cache()
 
     with paths.set_temp_cache(tmpdir):
-        dldir1, urlmapfn1 = _get_download_cache_locs()
-        check_download_cache(check_hashes=True)
+        dldir1 = _get_download_cache_loc()
+        check_download_cache()
         assert dldir1 != dldir0
-        assert urlmapfn1 != urlmapfn0
 
-    dldir2, urlmapfn2 = _get_download_cache_locs()
-    check_download_cache(check_hashes=True)
+    dldir2 = _get_download_cache_loc()
+    check_download_cache()
     assert dldir2 != dldir1
-    assert urlmapfn2 != urlmapfn1
     assert dldir2 == dldir0
-    assert urlmapfn2 == urlmapfn0
 
     # Check that things are okay even if we exit via an exception
     class Special(Exception):
         pass
     try:
         with paths.set_temp_cache(tmpdir):
-            dldir3, urlmapfn3 = _get_download_cache_locs()
-            check_download_cache(check_hashes=True)
+            dldir3 = _get_download_cache_loc()
+            check_download_cache()
             assert dldir3 == dldir1
-            assert urlmapfn3 == urlmapfn1
             raise Special
     except Special:
         pass
 
-    dldir4, urlmapfn4 = _get_download_cache_locs()
-    check_download_cache(check_hashes=True)
+    dldir4 = _get_download_cache_loc()
+    check_download_cache()
     assert dldir4 != dldir3
-    assert urlmapfn4 != urlmapfn3
     assert dldir4 == dldir0
-    assert urlmapfn4 == urlmapfn0
 
 
 @pytest.mark.parametrize("parallel", [False, True])
@@ -344,16 +371,13 @@ def test_download_with_sources_and_bogus_original(
 
 @pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
                     reason="causes mystery segfault! possibly bug #10008")
-@pytest.mark.parametrize("b", _shelve_possible_backends)
-def test_download_file_threaded_many(b, temp_cache, valid_urls):
+def test_download_file_threaded_many(temp_cache, valid_urls):
     """Hammer download_file with multiple threaded requests.
 
     The goal is to stress-test the locking system. Normal parallel downloading
     also does this but coverage tools lose track of which paths are explored.
 
     """
-    create_cache_with_backend(b)
-
     urls = list(islice(valid_urls, N_THREAD_HAMMER))
     with ThreadPoolExecutor(max_workers=len(urls)) as P:
         r = list(P.map(lambda u: download_file(u, cache=True),
@@ -415,6 +439,35 @@ def test_download_file_threaded_many_partial_success(
             assert r is None
 
 
+def test_clear_download_cache(valid_urls):
+    u1, c1 = next(valid_urls)
+    download_file(u1, cache=True)
+
+    u2, c2 = next(valid_urls)
+    download_file(u2, cache=True)
+
+    assert is_url_in_cache(u2)
+    clear_download_cache(u2)
+    assert not is_url_in_cache(u2)
+    assert is_url_in_cache(u1)
+
+    u3, c3 = next(valid_urls)
+    f3 = download_file(u3, cache=True)
+
+    assert is_url_in_cache(u3)
+    clear_download_cache(f3)
+    assert not is_url_in_cache(u3)
+    assert is_url_in_cache(u1)
+
+    u4, c4 = next(valid_urls)
+    f4 = download_file(u4, cache=True)
+
+    assert is_url_in_cache(u4)
+    clear_download_cache(compute_hash(f4))
+    assert not is_url_in_cache(u4)
+    assert is_url_in_cache(u1)
+
+
 def test_clear_download_multiple_references_doesnt_corrupt_storage(temp_cache, tmpdir):
     """Check that files with the same hash don't confuse the storage."""
     content = "Test data; doesn't matter much.\n"
@@ -424,18 +477,18 @@ def test_clear_download_multiple_references_doesnt_corrupt_storage(temp_cache, t
             f.write(content)
         url = url_to(f.name)
         clear_download_cache(url)
-        hash = download_file(url, cache=True)
-        return url, hash
+        filename = download_file(url, cache=True)
+        return url, filename
 
-    a_url, a_hash = make_url()
-    clear_download_cache(a_hash)
+    a_url, a_filename = make_url()
+    clear_download_cache(a_filename)
     assert not is_url_in_cache(a_url)
 
-    f_url, f_hash = make_url()
-    g_url, g_hash = make_url()
+    f_url, f_filename = make_url()
+    g_url, g_filename = make_url()
 
     assert f_url != g_url
-    assert f_hash == g_hash
+    # assert f_hash == g_hash #  Not anymore!
     assert is_url_in_cache(f_url)
     assert is_url_in_cache(g_url)
 
@@ -443,19 +496,13 @@ def test_clear_download_multiple_references_doesnt_corrupt_storage(temp_cache, t
     assert not is_url_in_cache(f_url)
     assert is_url_in_cache(g_url)
     assert os.path.exists(
-        g_hash
+        g_filename
     ), "Contents should not be deleted while a reference exists"
 
     clear_download_cache(g_url)
     assert not os.path.exists(
-        g_hash
+        g_filename
     ), "No reference exists any more, file should be deleted"
-
-
-def test_download_file_basic(valid_urls):
-    primary, contents = next(valid_urls)
-    f = download_file(primary, cache=False)
-    assert get_file_contents(f) == contents
 
 
 @pytest.mark.parametrize("use_cache", [False, True])
@@ -562,7 +609,7 @@ def test_download_noprogress():
 @pytest.mark.remote_data(source="astropy")
 def test_download_cache():
 
-    download_dir = _get_download_cache_locs()[0]
+    download_dir = _get_download_cache_loc()
 
     # Download the test URL and make sure it exists, then clear just that
     # URL and make sure it got deleted.
@@ -584,7 +631,7 @@ def test_download_cache_after_clear(tmpdir, temp_cache, valid_urls):
     testurl, contents = next(valid_urls)
     # Test issues raised in #4427 with clear_download_cache() without a URL,
     # followed by subsequent download.
-    download_dir = _get_download_cache_locs()[0]
+    download_dir = _get_download_cache_loc()
 
     fnout = download_file(testurl, cache=True)
     assert os.path.isfile(fnout)
@@ -759,13 +806,52 @@ def test_download_parallel_update(temp_cache, tmpdir):
         assert get_file_contents(r_3) == c_plus
 
 
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+                    reason="causes mystery segfault! possibly bug #10008")
+def test_update_parallel(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    u2, c2 = next(valid_urls)
+
+    f = download_file(u, cache=True)
+    assert get_file_contents(f) == c
+
+    def update(i):
+        return download_file(u, cache="update", sources=[u2])
+
+    with ThreadPoolExecutor(max_workers=N_THREAD_HAMMER) as P:
+        r = set(P.map(update, range(N_THREAD_HAMMER)))
+
+    check_download_cache()
+    for f in r:
+        assert get_file_contents(f) == c2
+
+
+@pytest.mark.skipif((3, 7) <= sys.version_info < (3, 8),
+                    reason="causes mystery segfault! possibly bug #10008")
+def test_update_parallel_multi(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    iucs = list(islice(valid_urls, N_THREAD_HAMMER))
+
+    f = download_file(u, cache=True)
+    assert get_file_contents(f) == c
+
+    def update(uc):
+        u2, c2 = uc
+        return download_file(u, cache="update", sources=[u2]), c2
+
+    with ThreadPoolExecutor(max_workers=len(iucs)) as P:
+        r = list(P.map(update, iucs))
+
+    check_download_cache()
+    assert any(get_file_contents(f) == c for (f, c) in r)
+
+
 @pytest.mark.remote_data(source="astropy")
 def test_url_nocache():
     with get_readable_fileobj(TESTURL, cache=False, encoding="utf-8") as page:
         assert page.read().find("Astropy") > -1
 
 
-@pytest.mark.remote_data(source="astropy")
 def test_find_by_hash(valid_urls, temp_cache):
     testurl, contents = next(valid_urls)
     p = download_file(testurl, cache=True)
@@ -775,11 +861,8 @@ def test_find_by_hash(valid_urls, temp_cache):
 
     fnout = get_pkg_data_filename(hashstr)
     assert os.path.isfile(fnout)
-    clear_download_cache(hashstr[5:])
+    clear_download_cache(fnout)
     assert not os.path.isfile(fnout)
-
-    lockdir = os.path.join(_get_download_cache_locs()[0], "lock")
-    assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
 
 
 @pytest.mark.remote_data(source="astropy")
@@ -931,9 +1014,6 @@ def test_data_noastropy_fallback(monkeypatch):
     be located is correct
     """
 
-    # needed for testing the *real* lock at the end
-    lockdir = os.path.join(_get_download_cache_locs('astropy')[0], 'lock')
-
     # better yet, set the configuration to make sure the temp files are deleted
     conf.delete_temporary_downloads_at_exit = True
 
@@ -998,9 +1078,6 @@ def test_data_noastropy_fallback(monkeypatch):
     fnnocache = data.download_file(TESTURL, cache=False)
     with open(fnnocache, "rb") as page:
         assert page.read().decode("utf-8").find("Astropy") > -1
-
-    # lockdir determined above as the *real* lockdir, not the temp one
-    assert not os.path.isdir(lockdir), "Cache dir lock was not released!"
 
 
 @pytest.mark.parametrize(
@@ -1109,8 +1186,8 @@ def test_is_url_in_cache_local(temp_cache, valid_urls, invalid_urls):
     assert not is_url_in_cache(nonexistent)
 
 
-# TODO: Un-skip this test when non-deterministic failure is fixed.
-@pytest.mark.skip(reason='https://github.com/astropy/astropy/issues/9765')
+# TODO: Remove this comment if the non-deterministic failure does not return
+# @pytest.mark.skip(reason='https://github.com/astropy/astropy/issues/9765')
 def test_check_download_cache(tmpdir, temp_cache, valid_urls, invalid_urls):
     testurl, testurl_contents = next(valid_urls)
     testurl2, testurl2_contents = next(valid_urls)
@@ -1126,13 +1203,13 @@ def test_check_download_cache(tmpdir, temp_cache, valid_urls, invalid_urls):
     assert check_download_cache() == normal
 
     export_download_cache(zip_file_name, [testurl, testurl2])
-    assert check_download_cache(check_hashes=True) == normal
+    assert check_download_cache() == normal
 
     clear_download_cache(testurl2)
     assert check_download_cache() == normal
 
     import_download_cache(zip_file_name, [testurl])
-    assert check_download_cache(check_hashes=True) == normal
+    assert check_download_cache() == normal
 
 
 def test_export_import_roundtrip_one(tmpdir, temp_cache, valid_urls):
@@ -1152,7 +1229,7 @@ def test_export_import_roundtrip_one(tmpdir, temp_cache, valid_urls):
         get_file_contents(download_file(testurl, cache=True, show_progress=False))
         == contents
     )
-    assert check_download_cache(check_hashes=True) == normal
+    assert check_download_cache() == normal
 
 
 def test_export_url_not_present(temp_cache, valid_urls):
@@ -1191,7 +1268,7 @@ def test_export_import_roundtrip(tmpdir, temp_cache, valid_urls):
     import_download_cache(zip_file_name)
 
     assert set(get_cached_urls()) == initial_urls_in_cache
-    assert check_download_cache(check_hashes=True) == normal
+    assert check_download_cache() == normal
 
 
 def test_export_import_roundtrip_stream(temp_cache, valid_urls):
@@ -1208,7 +1285,7 @@ def test_export_import_roundtrip_stream(temp_cache, valid_urls):
         import_download_cache(f)
 
     assert set(get_cached_urls()) == initial_urls_in_cache
-    assert check_download_cache(check_hashes=True) == normal
+    assert check_download_cache() == normal
 
 
 def test_export_overwrite_flag_works(temp_cache, valid_urls, tmpdir):
@@ -1244,7 +1321,7 @@ def test_export_import_roundtrip_different_location(tmpdir, valid_urls):
     os.mkdir(new_cache)
     with paths.set_temp_cache(new_cache):
         import_download_cache(zip_file_name)
-        check_download_cache(check_hashes=True)
+        check_download_cache()
         assert set(get_cached_urls()) == initial_urls_in_cache
         for (u, c) in urls:
             assert get_file_contents(download_file(u, cache=True)) == c
@@ -1262,7 +1339,7 @@ def test_cache_size_changes_correctly_when_files_are_added_and_removed(
     clear_download_cache(u)
     s_i = cache_total_size()
     download_file(u, cache=True)
-    assert cache_total_size() == s_i + len(c)
+    assert cache_total_size() == s_i + len(c) + len(u.encode("utf-8"))
     clear_download_cache(u)
     assert cache_total_size() == s_i
 
@@ -1321,46 +1398,15 @@ def test_clear_download_cache_refuses_to_delete_outside_the_cache(tmpdir):
     assert os.path.exists(fn)
 
 
-def test_check_download_cache_finds_unreferenced_files(temp_cache, valid_urls):
-    u, c = next(valid_urls)
-    download_file(u, cache=True)
-    with _cache(pkgname='astropy', write=True) as (dldir, urlmap):
-        del urlmap[u]
-    with pytest.raises(ValueError):
-        check_download_cache()
-    clear_download_cache()
-
-
-def test_check_download_cache_finds_missing_files(temp_cache, valid_urls):
-    u, c = next(valid_urls)
-    os.remove(download_file(u, cache=True))
-    with pytest.raises(ValueError):
-        check_download_cache()
-    clear_download_cache()
-
-
 def test_check_download_cache_finds_bogus_entries(temp_cache, valid_urls):
     u, c = next(valid_urls)
     download_file(u, cache=True)
-    with _cache(pkgname='astropy', write=True) as (dldir, urlmap):
-        bd = os.path.join(dldir, "bogus")
-        os.mkdir(bd)
-        bf = os.path.join(bd, "file")
-        with open(bf, "wt") as f:
-            f.write("bogus file that exists")
-        urlmap[u] = bf
-    with pytest.raises(ValueError):
+    dldir = _get_download_cache_loc()
+    bf = os.path.join(dldir, "bogus")
+    with open(bf, "wt") as f:
+        f.write("bogus file that exists")
+    with pytest.raises(OSError):
         check_download_cache()
-    clear_download_cache()
-
-
-def test_check_download_cache_finds_bogus_hashes(temp_cache, valid_urls):
-    u, c = next(valid_urls)
-    fn = download_file(u, cache=True)
-    with open(fn, "w") as f:
-        f.write("bogus contents")
-    with pytest.raises(ValueError):
-        check_download_cache(check_hashes=True)
     clear_download_cache()
 
 
@@ -1403,7 +1449,7 @@ def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
             with pytest.raises(OSError):
                 check_download_cache()
 
-    dldir, urlmapfn = _get_download_cache_locs()
+    dldir = _get_download_cache_loc()
     # set_temp_cache acts weird if it is pointed at a file (see below)
     # but we want to see what happens when the cache is pointed
     # at a file instead of a directory, so make a directory we can
@@ -1418,14 +1464,14 @@ def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
         with pytest.raises(OSError):
             paths.get_cache_dir()
         check_quietly_ignores_bogus_cache()
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
+    assert dldir == _get_download_cache_loc()
     assert get_file_contents(fn) == ct, "File should not be harmed."
 
     # See what happens when set_temp_cache is pointed at a file
     with pytest.raises(OSError):
         with paths.set_temp_cache(fn):
             pass
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
+    assert dldir == _get_download_cache_loc()
     assert get_file_contents(str(fn)) == ct
 
     # Now the cache directory is normal but the subdirectory it wants
@@ -1435,7 +1481,7 @@ def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
         f.write(ct)
     with paths.set_temp_cache(tmpdir):
         check_quietly_ignores_bogus_cache()
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
+    assert dldir == _get_download_cache_loc()
     assert get_file_contents(cd) == ct
     os.remove(cd)
 
@@ -1446,31 +1492,20 @@ def test_cache_dir_is_actually_a_file(tmpdir, valid_urls):
         f.write(ct)
     with paths.set_temp_cache(tmpdir):
         check_quietly_ignores_bogus_cache()
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
+    assert dldir == _get_download_cache_loc()
     assert get_file_contents(cd) == ct
     os.remove(cd)
 
     # Ditto another level deeper
     os.makedirs(cd)
-    py_version = "py" + str(sys.version_info.major)
-    cd = str(tmpdir / "astropy" / "download" / py_version)
+    cd = str(tmpdir / "astropy" / "download" / "url")
     with open(cd, "w") as f:
         f.write(ct)
     with paths.set_temp_cache(tmpdir):
         check_quietly_ignores_bogus_cache()
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
+    assert dldir == _get_download_cache_loc()
     assert get_file_contents(cd) == ct
     os.remove(cd)
-
-    # Now interfere with creating the shelve object; this might actually
-    # be okay if the shelve object has a funny naming convention
-    # (the relation between the string you hand shelve and the names of
-    # any files it may create is explicitly system-dependent)
-    cd = str(tmpdir / "astropy" / "download" / py_version / "urlmap")
-    os.makedirs(cd)
-    with paths.set_temp_cache(tmpdir):
-        check_quietly_ignores_bogus_cache()
-    assert (dldir, urlmapfn) == _get_download_cache_locs()
 
 
 def test_get_fileobj_str(a_file):
@@ -1531,19 +1566,7 @@ def test_cache_contents_not_writable(temp_cache, valid_urls):
         c["foo"] = 7
 
 
-def test_cache_read_not_writable(temp_cache, valid_urls):
-    with _cache(pkgname='astropy') as (dldir, urlmap):
-        with pytest.raises(TypeError):
-            urlmap["foo"] = 7
-    u, _ = next(valid_urls)
-    download_file(u, cache=True)
-    with _cache(pkgname='astropy') as (dldir, urlmap):
-        assert u in urlmap
-        with pytest.raises(TypeError):
-            urlmap["foo"] = 7
-
-
-def test_cache_not_relocatable(tmpdir, valid_urls):
+def test_cache_relocatable(tmpdir, valid_urls):
     u, c = next(valid_urls)
     d1 = tmpdir / "1"
     d2 = tmpdir / "2"
@@ -1559,12 +1582,10 @@ def test_cache_not_relocatable(tmpdir, valid_urls):
     with paths.set_temp_cache(d2):
         assert is_url_in_cache(u)
         p2 = download_file(u, cache=True)
-        assert p1 == p2
-        assert not os.path.exists(p2)
-        with pytest.raises(RuntimeError):
-            clear_download_cache(p2)
-        with pytest.raises(CacheDamaged):
-            check_download_cache()
+        assert p1 != p2
+        assert os.path.exists(p2)
+        clear_download_cache(p2)
+        check_download_cache()
 
 
 def test_get_readable_fileobj_cleans_up_temporary_files(tmpdir, monkeypatch):
@@ -1705,6 +1726,18 @@ def test_download_file_cache_readonly(readonly_cache):
         assert f == readonly_cache[u]
 
 
+def test_import_file_cache_readonly(readonly_cache, tmpdir):
+    filename = os.path.join(tmpdir, "test-file")
+    content = "Some text or other"
+    url = "http://example.com/"
+    with open(filename, "wt") as f:
+        f.write(content)
+
+    with pytest.raises(OSError):
+        import_file_to_cache(url, filename, remove_original=True)
+    assert not is_url_in_cache(url)
+
+
 def test_download_file_cache_readonly_cache_miss(readonly_cache, valid_urls):
     u, c = next(valid_urls)
     with pytest.warns(CacheMissingWarning):
@@ -1718,11 +1751,11 @@ def test_download_file_cache_readonly_update(readonly_cache):
         with pytest.warns(CacheMissingWarning):
             f = download_file(u, cache="update")
         assert f != readonly_cache[u]
-        assert compute_hash(f) == os.path.basename(readonly_cache[u])
+        assert compute_hash(f) == compute_hash(readonly_cache[u])
 
 
 def test_check_download_cache_works_if_readonly(readonly_cache):
-    check_download_cache(check_hashes=True)
+    check_download_cache()
 
 
 # On Windows I can't make directories readonly. On CircleCI I can't make
@@ -1744,12 +1777,35 @@ def test_download_file_cache_fake_readonly(fake_readonly_cache):
         assert f == fake_readonly_cache[u]
 
 
+def test_mkdtemp_cache_fake_readonly(fake_readonly_cache):
+    with pytest.raises(OSError):
+        tempfile.mkdtemp()
+
+
+def test_TD_cache_fake_readonly(fake_readonly_cache):
+    with pytest.raises(OSError):
+        with TemporaryDirectory():
+            pass
+
+
+def test_import_file_cache_fake_readonly(fake_readonly_cache, tmpdir):
+    filename = os.path.join(tmpdir, "test-file")
+    content = "Some text or other"
+    url = "http://example.com/"
+    with open(filename, "wt") as f:
+        f.write(content)
+
+    with pytest.raises(OSError):
+        import_file_to_cache(url, filename, remove_original=True)
+    assert not is_url_in_cache(url)
+
+
 def test_download_file_cache_fake_readonly_cache_miss(fake_readonly_cache, valid_urls):
     u, c = next(valid_urls)
     with pytest.warns(CacheMissingWarning):
         f = download_file(u, cache=True)
-    assert get_file_contents(f) == c
     assert not is_url_in_cache(u)
+    assert get_file_contents(f) == c
 
 
 def test_download_file_cache_fake_readonly_update(fake_readonly_cache):
@@ -1757,11 +1813,11 @@ def test_download_file_cache_fake_readonly_update(fake_readonly_cache):
         with pytest.warns(CacheMissingWarning):
             f = download_file(u, cache="update")
         assert f != fake_readonly_cache[u]
-        assert compute_hash(f) == os.path.basename(fake_readonly_cache[u])
+        assert compute_hash(f) == compute_hash(fake_readonly_cache[u])
 
 
 def test_check_download_cache_works_if_fake_readonly(fake_readonly_cache):
-    check_download_cache(check_hashes=True)
+    check_download_cache()
 
 
 def test_pkgname_isolation(temp_cache, valid_urls):
@@ -1879,96 +1935,72 @@ def test_download_parallel_respects_pkgname(temp_cache, valid_urls):
     assert len(get_cached_urls(pkgname=a)) == FEW
 
 
-@pytest.mark.parametrize("b", _shelve_possible_backends)
-def test_cache_with_different_shelve_backends(b, temp_cache, valid_urls):
-    """Without special handling this emits a warning for dbm.dumb."""
-    create_cache_with_backend(b)
-
-    uc = list(islice(valid_urls, FEW))
-    for u, c in uc:
-        download_file(u, cache=True)
-        assert is_url_in_cache(u)
-
-    for u, _ in uc:
-        assert is_url_in_cache(u)
-
+def test_removal_of_open_files(temp_cache, valid_urls):
+    if not can_rename_directory_in_use():
+        pytest.skip("This platform is not able to remove files while in use.")
+    u, c = next(valid_urls)
+    with open(download_file(u, cache=True)):
+        clear_download_cache(u)
+        assert not is_url_in_cache(u)
+        check_download_cache()
     check_download_cache()
 
-    for u, _ in uc:
-        assert is_url_in_cache(u)
 
-    for u, c in uc:
-        assert get_file_contents(
-            download_file(u, cache=True, sources=[])) == c
-
-    clear_download_cache()
-
-
-@pytest.mark.parametrize("b", _shelve_possible_backends)
-def test_lock_behaviour_if_directory_disappears(b, temp_cache):
-    dldir, urlmapfn = _get_download_cache_locs()
-    try:
-        dbm = importlib.import_module(b)
-    except ImportError:
-        pytest.skip(f"module {b} not available")
-    if b == "dbm.dumb":
-        c = pytest.raises(FileNotFoundError)
-    else:
-        c = nullcontext()
-    with dbm.open(urlmapfn, "c"):
-        pass
-    with c:
-        with _cache("astropy", write=True) as (dldir, url2hash):
-            url2hash["1"] = 2
-            shutil.rmtree(dldir)
-
-
-@pytest.mark.parametrize("b1b2", [(b1, b2)
-                                  for b1 in _shelve_possible_backends
-                                  for b2 in _shelve_possible_backends
-                                  if b1 != b2
-                                  ])
-def test_wrong_backend_reports_useful_error(b1b2, temp_cache, valid_urls):
-    b1, b2 = b1b2
-    create_cache_with_backend(b1)
-    for u, c in islice(valid_urls, FEW):
-        download_file(u, cache=True)
-    with shelve_backend(b2):
-        for u, c in islice(valid_urls, FEW):
-            with pytest.warns(WrongDBMModuleWarning) as w:
-                f = download_file(u, cache=True)
-                assert get_file_contents(f) == c
-            for wi in w:
-                assert "module" in str(wi.message.args[0])
-                assert b1 in str(wi.message.args[0])
-        with pytest.raises(CacheDamaged):
-            with pytest.warns(WrongDBMModuleWarning):
-                check_download_cache()
-        # We should still be able to wipe out the cache!
-        clear_download_cache()
-
-
-# What happens when the lock can't be obtained in a timely manner?
-def test_lock_unavailable_raises_runtimeerror_and_clear_frees_lock(
-        temp_cache, valid_urls):
+def test_update_of_open_files(temp_cache, valid_urls):
+    if not can_rename_directory_in_use():
+        pytest.skip("This platform is not able to remove files while in use.")
     u, c = next(valid_urls)
-    download_file(u, cache=True)
-    with _cache_lock("astropy", need_write=True):
-        with conf.set_temp("download_cache_lock_attempts", 0):
-            with pytest.raises(RuntimeError):
-                with _cache_lock("astropy", need_write=True):
-                    pass
-            # Ensure that the cache doesn't accidentally get unlocked!
-            with pytest.raises(RuntimeError):
-                with _cache_lock("astropy", need_write=True):
-                    pass
-            # Trying to do anything should raise an exception
-            with pytest.raises(RuntimeError):
-                is_url_in_cache(u)
-            with pytest.raises(RuntimeError):
-                download_file(u, cache=True, sources=[])
-            with pytest.raises(RuntimeError):
-                download_file(u, cache=True)
-            clear_download_cache()  # breaks lock
-            is_url_in_cache(u)  # False but doesn't raise an exception
-    # Exiting the lock should succeed even though it was broken open
+    with open(download_file(u, cache=True)):
+        u2, c2 = next(valid_urls)
+        f = download_file(u, cache='update', sources=[u2])
+        check_download_cache()
+        assert is_url_in_cache(u)
+        assert get_file_contents(f) == c2
+    assert is_url_in_cache(u)
+    check_download_cache()
+
+
+def test_removal_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
+    def no_rmtree(*args, **kwargs):
+        warnings.warn(CacheMissingWarning("in use", ""))
+        raise PermissionError
+    if can_rename_directory_in_use():
+        # This platform is able to remove files while in use.
+        monkeypatch.setattr(astropy.utils.data, "_rmtree", no_rmtree)
+
+    u, c = next(valid_urls)
+    with open(download_file(u, cache=True)):
+        with catch_warnings(CacheMissingWarning) as ws:
+            clear_download_cache(u)
+        in_use = False
+        for w in ws:
+            if "in use" in str(w.message):
+                in_use = True
+        assert in_use, "No warning mentions that a file is in use"
+    check_download_cache()
+
+
+def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
+    def no_rmtree(*args, **kwargs):
+        warnings.warn(CacheMissingWarning("in use", ""))
+        raise PermissionError
+    if can_rename_directory_in_use():
+        # This platform is able to remove files while in use.
+        monkeypatch.setattr(astropy.utils.data, "_rmtree", no_rmtree)
+
+    u, c = next(valid_urls)
+    with open(download_file(u, cache=True)):
+        u2, c2 = next(valid_urls)
+        with catch_warnings(CacheMissingWarning) as ws:
+            f = download_file(u, cache='update', sources=[u2])
+        check_download_cache()
+        assert is_url_in_cache(u)
+        assert get_file_contents(f) == c2
+        in_use = False
+        for w in ws:
+            if "in use" in str(w.message):
+                in_use = True
+        assert in_use, "No warning mentions that a file is in use"
+    assert is_url_in_cache(u)
+    assert get_file_contents(download_file(u, cache=True, sources=[])) == c
+    check_download_cache()

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2080,3 +2080,17 @@ def test_clear_download_cache_variants(temp_cache, valid_urls):
     h = compute_hash(f)
     clear_download_cache(h)
     assert not is_url_in_cache(u)
+
+
+@pytest.mark.remote_data
+def test_ftp_tls(temp_cache):
+    url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"
+    download_file(url, ftp_tls=True)
+
+
+@pytest.mark.remote_data
+def test_ftp_tls_auto(temp_cache):
+    url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"
+    download_file(url)
+
+

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2004,3 +2004,13 @@ def test_update_of_open_files_windows(temp_cache, valid_urls, monkeypatch):
     assert is_url_in_cache(u)
     assert get_file_contents(download_file(u, cache=True, sources=[])) == c
     check_download_cache()
+
+
+def test_zero_remote_timeout(temp_cache, valid_urls):
+    u, c = next(valid_urls)
+    with pytest.raises(urllib.error.URLError):
+        download_file(u, timeout=0)
+    assert not is_url_in_cache(u)
+    with pytest.raises(urllib.error.URLError):
+        # This will trigger the remote data error if it's allowed to touch the internet
+        download_file(TESTURL, timeout=0)

--- a/astropy/utils/tests/test_data.py
+++ b/astropy/utils/tests/test_data.py
@@ -2092,5 +2092,3 @@ def test_ftp_tls(temp_cache):
 def test_ftp_tls_auto(temp_cache):
     url = "ftp://anonymous:mail%40astropy.org@gdc.cddis.eosdis.nasa.gov/pub/products/iers/finals2000A.all"
     download_file(url)
-
-

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -184,8 +184,8 @@ these old cache directories, you can run::
    >>> from shutil import rmtree
    >>> from os.path import join
    >>> from astropy.config.paths import get_cache_dir
-   >>> rmtree(join(get_cache_dir(), 'download', 'py2'))  # doctest: +SKIP
-   >>> rmtree(join(get_cache_dir(), 'download', 'py3'))  # doctest: +SKIP
+   >>> rmtree(join(get_cache_dir(), 'download', 'py2'), ignore_errors=True)  # doctest: +SKIP
+   >>> rmtree(join(get_cache_dir(), 'download', 'py3'), ignore_errors=True)  # doctest: +SKIP
 
 Using Astropy With Limited or No Internet Access
 ================================================

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -173,6 +173,20 @@ produce a ZIP file listing some or all of the cache contents, and
 `~astropy.utils.data.import_download_cache` to load the ``astropy`` cache from such a
 ZIP file.
 
+The Astropy cache has changed format - once in the Python 2 to Python
+3 transition, and again before Astropy version 4.0.2 to resolve some
+concurrency problems that arose on some compute clusters. Each version of the
+cache is in its own subdirectory, so the old versions do not interfere with the
+new versions and vice versa, but their contents are not used by this version
+and are not cleared by `~astropy.utils.data.clear_download_cache`. To remove
+these old cache directories you can simply run::
+
+   >>> from shutil import rmtree
+   >>> from os.path import join
+   >>> from astropy.config.paths import get_cache_dir
+   >>> rmtree(join(get_cache_dir(), 'download', 'py2'))  # doctest: +SKIP
+   >>> rmtree(join(get_cache_dir(), 'download', 'py3'))  # doctest: +SKIP
+
 Using Astropy With Limited or No Internet Access
 ================================================
 

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -227,15 +227,16 @@ Astropy Data and Clusters
 Astronomical calculations often require the use of a large number of different
 processes on different machines with a shared home filesystem. This can pose
 certain complexities. In particular, if the many different processes attempt to
-download a file simultaneous this can overload a server or trigger security
+download a file simultaneously this can overload a server or trigger security
 systems. The parallel access to the home directory can also trigger concurrency
 problems in the Astropy data cache, though we have tried to minimize these. We
 therefore recommend the following guidelines:
 
  * Write a simple script that sets ``astropy.utils.iers.conf.auto_download = True``
    and then accesses all cached resources your code will need, including source name
-   lookups and IERS tables. Run it on the head node from time to time (at least twice
-   a month) to ensure all data is up to date.
+   lookups and IERS tables. Run it on the head node from time to time (frequently
+   enough to beat the timeout ``astropy.utils.iers.conf.auto_max_age``, which
+   defaults to 30 days) to ensure all data is up to date.
 
  * Make an Astropy config file (see :ref:`astropy_config`) that sets
    ``astropy.utils.iers.conf.auto_download = False`` so that the worker jobs will
@@ -243,7 +244,7 @@ therefore recommend the following guidelines:
    to download it.
 
  * Optionally, in this file, set ``astropy.utils.data.conf.remote_timeout = 0`` to
-   prevent any attempt to download any file from the worker nodes; if you do this
+   prevent any attempt to download any file from the worker nodes; if you do this,
    you will need to override this setting in your script that does the actual
    downloading.
 

--- a/docs/utils/data.rst
+++ b/docs/utils/data.rst
@@ -179,7 +179,7 @@ concurrency problems that arose on some compute clusters. Each version of the
 cache is in its own subdirectory, so the old versions do not interfere with the
 new versions and vice versa, but their contents are not used by this version
 and are not cleared by `~astropy.utils.data.clear_download_cache`. To remove
-these old cache directories you can simply run::
+these old cache directories, you can run::
 
    >>> from shutil import rmtree
    >>> from os.path import join


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address #9970 - for a number of computing clusters the locking in the astropy cache mechanism was causing problems, presumably because their NFS home directories did not provide an atomic `os.mkdir()`. This implementation, currently experimental, replaces the cache mechanism with one that does not require any locking. To the extent it needs anything from the filesystem it needs `os.rename()` to be atomic, which is supposedly guaranteed under POSIX. This atomicity is only required when a file is actually being downloaded simultaneously on multiple machines, and failure is only a problem if the file is mangled by being renamed over.

In this setup, the cache is simply a directory of directories. Each directory is named by a hashed version of the URL key, and it contains two files, `url` containing the URL key, and `contents` containing the actual file. This avoids any need for a separate index. The absence of a separate index removes the need to keep the index in sync with the filesystem, and I believe that the only synchronization we need is that provided by the filesystem itself. Cache entries are moved into and out of place with `os.rename`, which is required to be atomic by POSIX.

This setup has minor downsides - the URL is not apparent in the filesystem, you have to open a file, and it can be a little slow to index through and find all the URLs stored in the cache (you have to read one file per URL). Also you use three inodes per cache entry, and the cache directory has as many subdirectories as you have entries in your cache, so caching a really large number of files might stress your filesystem.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

EDIT: Fix #9970 and close #10430 and fix #10114 and fix #10401 and fix #10523