### PR TITLE
Do not issue datfix warning when MJDREF has default value

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -889,6 +889,8 @@ astropy.wcs
 
 - Handled WCS 360 -> 0 deg crossover in ``fit_wcs_from_points`` [#10155]
 
+- Do not issue ``DATREF`` warning when ``MJDREF`` has default value. [#10440]
+
 Other Changes and Additions
 ---------------------------
 

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -704,6 +704,9 @@ reduce these to 2 dimensions using the naxis kwarg.
             fixes = self.wcs.fix(translate_units, naxis)
             for key, val in fixes.items():
                 if val != "No change":
+                    if (key == 'datfix' and '1858-11-17' in val and
+                            not np.count_nonzero(self.wcs.mjdref)):
+                        continue
                     warnings.warn(
                         ("'{0}' made the change '{1}'.").
                         format(key, val),


### PR DESCRIPTION
This PR removes the `datfix` warning when setting `DATREF` to the default value from a default value of `MJDREF`. This PR, in part, addresses  https://github.com/astropy/astropy/issues/10397

CC: @nden