### PR TITLE
Set/get correct coord.axislabel with axes.set_xlabel for EllipticalFrame plots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -884,6 +884,9 @@ astropy.visualization
 - Fixed a bug where the ``ImageNormalize`` ``clip`` keyword was
   ignored when used with calling the object on data. [#10098]
 
+- Fixed a bug where ``axes.xlabel``/``axes.ylabel`` where not correctly set
+  nor returned on an ``EllipticalFrame`` class ``WCSAxes`` plot. [#10446]
+
 astropy.wcs
 ^^^^^^^^^^^
 

--- a/astropy/visualization/wcsaxes/core.py
+++ b/astropy/visualization/wcsaxes/core.py
@@ -470,7 +470,8 @@ class WCSAxes(Axes):
             if xlabel is None:
                 raise TypeError("set_xlabel() missing 1 required positional argument: 'xlabel'")
         for coord in self.coords:
-            if 'b' in coord.axislabels.get_visible_axes():
+            if ('b' in coord.axislabels.get_visible_axes() or
+                'h' in coord.axislabels.get_visible_axes()):
                 coord.set_axislabel(xlabel, minpad=labelpad, **kwargs)
                 break
 
@@ -484,13 +485,15 @@ class WCSAxes(Axes):
             return super().set_ylabel(ylabel, labelpad=labelpad, **kwargs)
 
         for coord in self.coords:
-            if 'l' in coord.axislabels.get_visible_axes():
+            if ('l' in coord.axislabels.get_visible_axes() or
+                'c' in coord.axislabels.get_visible_axes()):
                 coord.set_axislabel(ylabel, minpad=labelpad, **kwargs)
                 break
 
     def get_xlabel(self):
         for coord in self.coords:
-            if 'b' in coord.axislabels.get_visible_axes():
+            if ('b' in coord.axislabels.get_visible_axes() or
+                'h' in coord.axislabels.get_visible_axes()):
                 return coord.get_axislabel()
 
     def get_ylabel(self):
@@ -498,7 +501,8 @@ class WCSAxes(Axes):
             return super().get_ylabel()
 
         for coord in self.coords:
-            if 'l' in coord.axislabels.get_visible_axes():
+            if ('l' in coord.axislabels.get_visible_axes() or
+                'c' in coord.axislabels.get_visible_axes()):
                 return coord.get_axislabel()
 
     def get_coords_overlay(self, frame, coord_meta=None):

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -471,3 +471,35 @@ def test_simplify_labels_usetex(ignore_matplotlibrc, tmpdir):
     ax.grid()
 
     fig.savefig(tmpdir / 'plot.png')
+
+
+@pytest.mark.parametrize('frame_class', [RectangularFrame, EllipticalFrame])
+def test_set_labels_with_coords(ignore_matplotlibrc, frame_class):
+    """Test if ``axis.set_xlabel()`` calls the correct ``coords[i]_set_axislabel()`` in a
+    WCS plot. Regression test for https://github.com/astropy/astropy/issues/10435.
+    """
+
+    labels = ['RA', 'Declination']
+    header = {
+        'NAXIS': 2,
+        'NAXIS1': 360,
+        'NAXIS2': 180,
+        'CRPIX1': 180.5,
+        'CRPIX2': 90.5,
+        'CRVAL1': 180.0,
+        'CRVAL2': 0.0,
+        'CDELT1': -2 * np.sqrt(2) / np.pi,
+        'CDELT2': 2 * np.sqrt(2) / np.pi,
+        'CTYPE1': 'RA---AIT',
+        'CTYPE2': 'DEC--AIT'}
+
+    wcs = WCS(header)
+    fig, ax = plt.subplots(
+        subplot_kw=dict(frame_class=frame_class, projection=wcs))
+    ax.set_xlabel(labels[0])
+    ax.set_ylabel(labels[1])
+
+    assert ax.get_xlabel() == labels[0]
+    assert ax.get_ylabel() == labels[1]
+    for i in range(2):
+        assert ax.coords[i].get_axislabel() == labels[i]


### PR DESCRIPTION
Co-authored-by:  giang-nghg@users.noreply.github.com

### Description
#10435 has exposed a bug where both `axes.xlabel` and `axes.ylabel` remain set to `None` in a 
`(projection = WCS(hdr), frame_class=EllipticalFrame)` plot, causing any function that subsequently tries to access the labels to raise an error.
https://github.com/astropy/astropy/issues/10435#issuecomment-638429656 has identified the underlying reason as `WCSAxes.set_xlabel()` and colleagues only checking for the associated `coord.axislabels` under their `RectangularFrame` labels, not the `EllipticalFrame` ones.

This patch has the functions always checking for both versions of the corresponding label; since the labels are unique and the two frame types above seem to be the only valid `frame_class`s for these plots, this _should_ have all configurations covered. Test is checking the correct label settings for both.
Tested with Matplotlib 3.2.1 on Python 3.7.7 and 3.8.3, and with MPL 2.1.1 on Python 3.6.10.


#### Note
The label references in `get_coords_overlay` also seem to be specific to `RectangularFrame` (`RectangularFrame` plots have `axes.frame_class.spine_names` `'brtl'`, `EllipticalFrame` ones `'chv'`), but I have not looked further into whether they should be extended as well, or how.

**EDIT:** fixes #10435 