### PR TITLE
Transforming a frame to a class now preserves shared frame attributes

### DIFF
--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -459,11 +459,13 @@ def test_transform():
 
     f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
     f4 = f.transform_to(FK4)
-    f4_2 = f.transform_to(FK4(equinox=f.equinox))
+    f4_1 = f.transform_to(FK4())
+    f4_2 = f.transform_to(FK4(equinox=Time('J2010')))
 
     # make sure attributes are copied over correctly
-    assert f4.equinox == FK4.get_frame_attr_names()['equinox']
-    assert f4_2.equinox == f.equinox
+    assert f4.equinox == f.equinox
+    assert f4_1.equinox == FK4.get_frame_attr_names()['equinox']
+    assert f4_2.equinox == Time('J2010')
 
     # make sure self-transforms also work
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
@@ -473,7 +475,7 @@ def test_transform():
     assert_allclose(i.dec, i2.dec)
 
     f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
-    f2 = f.transform_to(FK5)  # default equinox, so should be *different*
+    f2 = f.transform_to(FK5())  # default equinox, so should be *different*
     assert f2.equinox == FK5().equinox
     with pytest.raises(AssertionError):
         assert_allclose(f.ra, f2.ra)


### PR DESCRIPTION
## The problem
When transforming a coordinate frame (not a `SkyCoord`) to a class, the destination frame is instantiated with default values for all of its frame attributes:
```python
>>> from astropy.coordinates import HeliocentricMeanEcliptic, HeliocentricTrueEcliptic
>>> import astropy.units as u
>>> hme = HeliocentricMeanEcliptic(0*u.deg, 0*u.deg, 0*u.AU,
...                                obstime='2020-02-02', equinox='J2015.5')
>>> hme
<HeliocentricMeanEcliptic Coordinate (equinox=J2015.500, obstime=2020-02-02 00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
    (0., 0., 0.)>

>>> hme.transform_to(HeliocentricTrueEcliptic)
<HeliocentricTrueEcliptic Coordinate (equinox=J2000.000, obstime=J2000.000): (lon, lat, distance) in (deg, deg, AU)
    (73.18417508, -0.94808555, 0.01062224)>
```
Note that the coordinate has been transformed to `equinox` and `obstime` at the default values of `J2000.0`, rather than preserving the original values.  This behavior is particularly annoying when a frame attribute has the default value of `None`.  Importantly, `SkyCoord` behaves differently with the analogous call because it carries over all frame attributes (with the default setting of `merge_attributes=True`):
```python
>>> from astropy.coordinates import SkyCoord
>>> SkyCoord(hme).transform_to(HeliocentricTrueEcliptic)
<SkyCoord (HeliocentricTrueEcliptic: equinox=J2015.500, obstime=2020-02-02 00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
    (0., 0., 0.)>
```

## This PR
This PR changes the behavior of `BaseCoordinateFrame.transform_to()` so that if it is provided a class, the target frame is instantiated with the values of any shared frame attributes if they are not default values.  All other frame attributes will have default values.  With this PR:
```python
>>> hme.transform_to(HeliocentricTrueEcliptic)
<HeliocentricTrueEcliptic Coordinate (equinox=J2015.500, obstime=2020-02-02 00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
    (0., 0., 0.)>
```

## Still not quite the same as `SkyCoord`
The way I have currently implemented it, this new behavior occurs only when transforming to a class.  `SkyCoord` is even more aggressive than that (with the default setting of `merge_attributes=True`) because it also preserves frame attributes when the target is a frame rather than just a class by overwriting any shared frame attributes that are still at their default values.  That is, even with this PR:
```python
# The target frame has been explicitly instantiated with default values, and these values are respected
>>> hme.transform_to(HeliocentricTrueEcliptic())
<HeliocentricTrueEcliptic Coordinate (equinox=J2000.000, obstime=J2000.000): (lon, lat, distance) in (deg, deg, AU)
    (73.18417508, -0.94808555, 0.01062224)>

# SkyCoord doesn't care
>>> SkyCoord(hme).transform_to(HeliocentricTrueEcliptic())
<HeliocentricTrueEcliptic Coordinate (equinox=J2015.500, obstime=2020-02-02 00:00:00.000): (lon, lat, distance) in (deg, deg, AU)
    (0., 0., 0.)>
```

Of course, this PR may have negative impacts that I'm not aware of.  Thoughts?