### PR TITLE
TST: Use Python 3.9 dev, not 3.10 from nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -171,7 +171,7 @@ matrix:
 
         # Test against Python dev in cron job.
         - language: python
-          python: nightly
+          python: 3.9-dev
           dist: bionic
           name: Python dev with basic dependencies
           stage: Cron tests


### PR DESCRIPTION
See if this will fix #10451 based on idea from @dhomeier .