### PR TITLE
Fix Table.read/write.help when reader/writer has no docstring

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -897,6 +897,8 @@ astropy.io.misc
 astropy.io.registry
 ^^^^^^^^^^^^^^^^^^^
 
+- Fix ``Table.(read|write).help`` when reader or writer has no docstring. [#10460]
+
 astropy.io.votable
 ^^^^^^^^^^^^^^^^^^
 

--- a/astropy/io/registry.py
+++ b/astropy/io/registry.py
@@ -674,7 +674,8 @@ class UnifiedReadWrite:
             reader_doc += header
             reader_doc += re.sub('.', '=', header)
             reader_doc += os.linesep
-            reader_doc += inspect.cleandoc(doc)
+            if doc is not None:
+                reader_doc += inspect.cleandoc(doc)
 
         if out is None:
             import pydoc

--- a/astropy/io/tests/test_registry_help.py
+++ b/astropy/io/tests/test_registry_help.py
@@ -138,3 +138,18 @@ def test_ccddata_read_help_fits():
     assert "CCDData.read(format='fits') documentation" in doc
     assert "Generate a CCDData object from a FITS file" in doc
     assert "hdu_uncertainty : str or None, optional" in doc
+
+
+def test_table_write_help_jsviewer():
+    """
+    Test dynamically created documentation help via the I/O registry for
+    'jsviewer'.
+    """
+    out = StringIO()
+    Table.write.help('jsviewer', out)
+    doc = out.getvalue()
+
+    # Check a smattering of expected content
+    assert "Table.write general documentation" not in doc
+    assert "The available built-in formats" not in doc
+    assert "Table.write(format='jsviewer') documentation" in doc


### PR DESCRIPTION
The `jsviewer` writer has no docstring, which breaks `Table.write.help`:
```
In [1]: %astropy                                                                                         
Numpy 1.19.0rc2
Astropy 4.2.dev222+gd20175a31.d20200605

In [2]: t = Table([[1,2],[3,4]])                                                                         

In [3]: t.write.help('jsviewer')                                                                         
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-e3c3947780db> in <module>
----> 1 t.write.help('jsviewer')

~/dev/astropy/astropy/io/registry.py in help(self, format, out)
    675             reader_doc += re.sub('.', '=', header)
    676             reader_doc += os.linesep
--> 677             reader_doc += inspect.cleandoc(doc)
    678 
    679         if out is None:

~/.pyenv/versions/miniconda3-latest/envs/dragons38/lib/python3.8/inspect.py in cleandoc(doc)
    629     onwards is removed."""
    630     try:
--> 631         lines = doc.expandtabs().split('\n')
    632     except UnicodeError:
    633         return None

AttributeError: 'NoneType' object has no attribute 'expandtabs'
```