### PR TITLE
Split setup.cfg test and all into types; use in tox.ini

### DIFF
--- a/docs/development/codeguide.rst
+++ b/docs/development/codeguide.rst
@@ -36,7 +36,9 @@ Interface and Dependencies
   methods, the optional dependency should use a normal ``import``
   statement, which will raise an ``ImportError`` if the dependency is
   not available. In the astropy core package, such optional dependencies should
-  be recorded in the ``setup.cfg`` file in the ``extras_require`` entry.
+  be recorded in the ``setup.cfg`` file in the ``extras_require``
+  entry, under ``all`` (or ``test_all`` if the dependency is only
+  needed for testing).
 
   At the module level, one can subclass a class from an optional dependency
   like so::

--- a/docs/development/docguide.rst
+++ b/docs/development/docguide.rst
@@ -71,7 +71,8 @@ the standard Astropy docstring format.
 
 * Any external package dependencies must be explicitly mentioned in the
   documentation. They should also be recorded in the ``setup.cfg`` file in the
-  root of the astropy repository using an ``extras_require`` entry.
+  root of the astropy repository using an entry in ``extras_require``,
+  under ``all``.
 
 * Configuration options using the :mod:`astropy.config` mechanisms must be
   explicitly mentioned in the documentation.

--- a/docs/development/testguide.rst
+++ b/docs/development/testguide.rst
@@ -659,6 +659,14 @@ These variables should exist for all of Astropy's optional dependencies; a
 complete list of supported flags can be found in
 ``astropy.utils.compat.optional_deps``.
 
+Any new optional dependencies should be added to that file, as well as to
+relevant entries in ``setup.cfg`` under ``options.extras_require``:
+typically, under ``all`` for dependencies used in user-facing code
+(e.g., ``h5py``, which is used to write tables to HDF5 format),
+and in ``test_all`` for dependencies only used in tests (e.g.,
+``skyfield``, which is used to cross-check the accuracy of coordinate
+transforms).
+
 Using pytest helper functions
 =============================
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -29,8 +29,13 @@ can also do::
 
     pip install astropy --no-deps
 
-On the other hand, if you want to install ``astropy`` along with all of the
-available optional dependencies, you can do::
+On the other hand, if you want to install ``astropy`` along with recommended
+or even all of the available optional :ref:`dependencies <astropy-main-req>`,
+you can do::
+
+    pip install astropy[recommended]
+
+or::
 
     pip install astropy[all]
 
@@ -72,11 +77,16 @@ There may be a delay of a day or two between when a new version of ``astropy``
 is released and when a package is available for conda. You can check
 for the list of available versions with ``conda search astropy``.
 
-It is highly recommended that you install all of the optional dependencies with::
+If you want to install ``astropy`` along with recommended or all of the
+available optional :ref:`dependencies <astropy-main-req>`, you can do::
 
-    conda install -c astropy -c defaults \
-      scipy h5py beautifulsoup4 html5lib bleach pyyaml pandas sortedcontainers \
-      pytz matplotlib setuptools mpmath bottleneck jplephem asdf
+    conda install -c astropy -c defaults scipy pyyaml matplotlib
+
+or::
+
+    conda install -c astropy -c defaults scipy pyyaml matplotlib \
+      h5py beautifulsoup4 html5lib bleach pandas sortedcontainers \
+      pytz setuptools mpmath bottleneck jplephem asdf
 
 To also be able to run tests (see below) and support :ref:`builddocs` use the
 following. We use ``pip`` for these packages to ensure getting the latest
@@ -129,10 +139,21 @@ Requirements
 
 - `PyERFA`_ |minimum_pyerfa_version| or later
 
-``astropy`` also depends on other packages for optional features:
+``astropy`` also depends on a number of other packages for optional features.
+The following three are particularly recommended:
 
 - `scipy`_ |minimum_scipy_version| or later: To power a variety of features
   in several modules.
+
+- `matplotlib <https://matplotlib.org/>`_ |minimum_matplotlib_version| or later: To provide plotting
+  functionality that `astropy.visualization` enhances.
+
+- `PyYAML <https://pyyaml.org>`_ |minimum_pyyaml_version| or later: To read/write
+  :class:`~astropy.table.Table` objects from/to the Enhanced CSV ASCII table
+  format and to serialize mixins such as |Time| and |SkyCoord| for FITS, HDF5,
+  and other formats.
+
+The further dependencies provide more specific features:
 
 - `h5py <http://www.h5py.org/>`_: To read/write
   :class:`~astropy.table.Table` objects from/to HDF5 files.
@@ -146,10 +167,6 @@ Requirements
 
 - `bleach <https://bleach.readthedocs.io/>`_: Used to sanitize text when
   disabling HTML escaping in the :class:`~astropy.table.Table` HTML writer.
-
-- `PyYAML <https://pyyaml.org>`_ |minimum_pyyaml_version| or later: To read/write
-  :class:`~astropy.table.Table` objects from/to the Enhanced CSV ASCII table
-  format and to serialize mixins for various formats.
 
 - `xmllint <http://www.xmlsoft.org/>`_: To validate VOTABLE XML files.
   This is a command line tool installed outside of Python.
@@ -168,9 +185,6 @@ Requirements
 
 - `jplephem <https://pypi.org/project/jplephem/>`_: To retrieve JPL
   ephemeris of Solar System objects.
-
-- `matplotlib <https://matplotlib.org/>`_ |minimum_matplotlib_version| or later: To provide plotting
-  functionality that `astropy.visualization` enhances.
 
 - `setuptools <https://setuptools.readthedocs.io>`_: Used for discovery of
   entry points which are used to insert fitters into `astropy.modeling.fitting`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,15 +50,19 @@ asdf_extensions =
     astropy-asdf = astropy.io.misc.asdf.extension:AstropyAsdfExtension
 
 [options.extras_require]
-test =
+test =  # Required to run the astropy test suite.
     pytest-astropy>=0.8
     pytest-xdist
+    packaging
+test_all =  # Required for testing, plus packages used by particular tests.
+    pytest-astropy>=0.8
+    pytest-xdist
+    packaging
     objgraph
     ipython>=4.2
     coverage
     skyfield>=1.20
     sgp4>=2.3
-    packaging
 all =
     scipy>=1.1
     certifi

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,20 +63,24 @@ test_all =  # Required for testing, plus packages used by particular tests.
     coverage
     skyfield>=1.20
     sgp4>=2.3
+recommended =
+    scipy>=1.1
+    matplotlib>=3.0,!=3.4.0
+    PyYAML>=3.13
 all =
     scipy>=1.1
+    matplotlib>=3.0,!=3.4.0
+    PyYAML>=3.13
     certifi
     dask[array]
     h5py
     beautifulsoup4
     html5lib
     bleach
-    PyYAML>=3.13
     pandas
     sortedcontainers
     pytz
     jplephem
-    matplotlib>=3.0,!=3.4.0
     mpmath
     asdf>=2.6
     bottleneck

--- a/tox.ini
+++ b/tox.ini
@@ -95,8 +95,9 @@ deps =
 
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
-    test
+    test: test
     alldeps: all
+    alldeps: test_all
 
 commands =
     pip freeze

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,dev}-test{,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}{,-clocale}
+    py{37,38,39,dev}-test{,-recdeps,-alldeps,-oldestdeps,-devdeps,-numpy117,-numpy118,-numpy119}{,-cov}{,-clocale}
     build_docs
     linkcheck
     codestyle
@@ -45,7 +45,8 @@ changedir = .tmp/{envname}
 #
 description =
     run tests
-    alldeps: with all optional dependencies
+    recdeps: with recommended optional dependencies
+    alldeps: with all optional and test dependencies
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
@@ -96,6 +97,7 @@ deps =
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test: test
+    recdeps: recommended
     alldeps: all
     alldeps: test_all
 


### PR DESCRIPTION
As a start to address #10342. Two commits just to have something concrete to discuss.
1. Split the `test` dependencies into those that are needed to *do* the testing, and a new `test_all` that includes packages used for comparison purposes.
2. Split off a new `rec` set of recommended packages from `all`; the objective criterion is that these are all listed as "key" dependencies in `devdeps` - though they also happen to match more or less what I would pick.

p.s. Cancelled all tests, though checked locally that things work. Can adapt `.travis.yml` if we find there is a use for it.