### PR TITLE
Modifications to transforming frames with data as opposed to SkyCoord

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -213,6 +213,12 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Fixed a bug in the coordinate-frame attribute ``CoordinateAttribute`` where
+  the internal transformation could behave differently depending on whether
+  the input was a low-level coordinate frame or a high-level ``SkyCoord``.
+  ``CoordinateAttribute`` now always performs a ``SkyCoord``-style internal
+  transformation, including the by-default merging of frame attributes. [#10475]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,12 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- The passing of frame classes (as opposed to frame instances) to the
+  ``transform_to()`` methods of low-level coordinate-frame classes has been
+  deprecated.  Frame classes can still be passed to the ``transform_to()``
+  method of the high-level ``SkyCoord`` class, and using ``SkyCoord`` is
+  recommended for all typical use cases of transforming coordinates. [#10475]
+
 astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -397,9 +397,12 @@ class EarthLocationAttribute(Attribute):
 
 class CoordinateAttribute(Attribute):
     """
-    A frame attribute which is a coordinate object. It can be given as a
-    low-level frame class *or* a `~astropy.coordinates.SkyCoord`, but will
-    always be converted to the low-level frame class when accessed.
+    A frame attribute which is a coordinate object.  It can be given as a
+    `~astropy.coordinates.SkyCoord` or a low-level frame instance.  If a
+    low-level frame instance is provided, it will always be upgraded to be a
+    `~astropy.coordinates.SkyCoord` to ensure consistent transformation
+    behavior.  The coordinate object will always be returned as a low-level
+    frame instance when accessed.
 
     Parameters
     ----------
@@ -437,19 +440,16 @@ class CoordinateAttribute(Attribute):
         ValueError
             If the input is not valid for this attribute.
         """
+        from astropy.coordinates import SkyCoord
+
         if value is None:
             return None, False
         elif isinstance(value, self._frame):
             return value, False
         else:
-            if not hasattr(value, 'transform_to'):
-                raise ValueError('"{}" was passed into a '
-                                 'CoordinateAttribute, but it does not have '
-                                 '"transform_to" method'.format(value))
+            value = SkyCoord(value)  # always make the value a SkyCoord
             transformedobj = value.transform_to(self._frame)
-            if hasattr(transformedobj, 'frame'):
-                transformedobj = transformedobj.frame
-            return transformedobj, True
+            return transformedobj.frame, True
 
 
 class DifferentialAttribute(Attribute):

--- a/astropy/coordinates/attributes.py
+++ b/astropy/coordinates/attributes.py
@@ -391,7 +391,7 @@ class EarthLocationAttribute(Attribute):
                 raise ValueError('"{}" was passed into an '
                                  'EarthLocationAttribute, but it does not have '
                                  '"transform_to" method'.format(value))
-            itrsobj = value.transform_to(ITRS)
+            itrsobj = value.transform_to(ITRS())
             return itrsobj.earth_location, True
 
 

--- a/astropy/coordinates/baseframe.py
+++ b/astropy/coordinates/baseframe.py
@@ -1172,7 +1172,7 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
 
         Parameters
         ----------
-        new_frame : class or frame object or SkyCoord object
+        new_frame : frame object or SkyCoord object
             The frame to transform this coordinate frame into.
 
         Returns
@@ -1201,6 +1201,12 @@ class BaseCoordinateFrame(ShapedLikeNDArray, metaclass=FrameMeta):
                                       'please comment at https://github.com/astropy/astropy/issues/6280')
 
         if inspect.isclass(new_frame):
+            warnings.warn("Transforming a frame instance to a frame class (as opposed to another "
+                          "frame instance) will not be supported in the future.  Either "
+                          "explicitly instantiate the target frame, or first convert the source "
+                          "frame instance to a `astropy.coordinates.SkyCoord` and use its "
+                          "`transform_to()` method.",
+                          AstropyDeprecationWarning)
             # Use the default frame attributes for this class
             new_frame = new_frame()
 

--- a/astropy/coordinates/builtin_frames/galactic.py
+++ b/astropy/coordinates/builtin_frames/galactic.py
@@ -87,7 +87,7 @@ class Galactic(BaseCoordinateFrame):
     # These are *not* from Reid & Brunthaler 2004 - instead, they were
     # derived by doing:
     #
-    # >>> FK4NoETerms(ra=192.25*u.degree, dec=27.4*u.degree).transform_to(FK5)
+    # >>> FK4NoETerms(ra=192.25*u.degree, dec=27.4*u.degree).transform_to(FK5())
     #
     # This gives better consistency with other codes than using the values
     # from Reid & Brunthaler 2004 and the best self-consistency between FK5

--- a/astropy/coordinates/builtin_frames/galactocentric.py
+++ b/astropy/coordinates/builtin_frames/galactocentric.py
@@ -217,50 +217,52 @@ doc_footer = """
 
     To transform to the Galactocentric frame with the default
     frame attributes, pass the uninstantiated class name to the
-    ``transform_to()`` method of a coordinate frame or
-    `~astropy.coordinates.SkyCoord` object::
+    ``transform_to()`` method of a `~astropy.coordinates.SkyCoord` object::
 
         >>> import astropy.units as u
         >>> import astropy.coordinates as coord
-        >>> c = coord.ICRS(ra=[158.3122, 24.5] * u.degree,
-        ...                dec=[-17.3, 81.52] * u.degree,
-        ...                distance=[11.5, 24.12] * u.kpc)
+        >>> c = coord.SkyCoord(ra=[158.3122, 24.5] * u.degree,
+        ...                    dec=[-17.3, 81.52] * u.degree,
+        ...                    distance=[11.5, 24.12] * u.kpc,
+        ...                    frame='icrs')
         >>> c.transform_to(coord.Galactocentric) # doctest: +FLOAT_CMP
-        <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+        <SkyCoord (Galactocentric: galcen_coord=<ICRS Coordinate: (ra, dec) in deg
             (266.4051, -28.936175)>, galcen_distance=8.122 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg): (x, y, z) in kpc
             [( -9.43489286, -9.40062188, 6.51345359),
-            (-21.11044918, 18.76334013, 7.83175149)]>
+             (-21.11044918, 18.76334013, 7.83175149)]>
 
 
     To specify a custom set of parameters, you have to include extra keyword
     arguments when initializing the Galactocentric frame object::
 
         >>> c.transform_to(coord.Galactocentric(galcen_distance=8.1*u.kpc)) # doctest: +FLOAT_CMP
-        <Galactocentric Coordinate (galcen_coord=<ICRS Coordinate: (ra, dec) in deg
+        <SkyCoord (Galactocentric: galcen_coord=<ICRS Coordinate: (ra, dec) in deg
             (266.4051, -28.936175)>, galcen_distance=8.1 kpc, galcen_v_sun=(12.9, 245.6, 7.78) km / s, z_sun=20.8 pc, roll=0.0 deg): (x, y, z) in kpc
             [( -9.41284763, -9.40062188, 6.51346272),
-                (-21.08839478, 18.76334013, 7.83184184)]>
+             (-21.08839478, 18.76334013, 7.83184184)]>
 
     Similarly, transforming from the Galactocentric frame to another coordinate frame::
 
-        >>> c = coord.Galactocentric(x=[-8.3, 4.5] * u.kpc,
-        ...                          y=[0., 81.52] * u.kpc,
-        ...                          z=[0.027, 24.12] * u.kpc)
+        >>> c = coord.SkyCoord(x=[-8.3, 4.5] * u.kpc,
+        ...                    y=[0., 81.52] * u.kpc,
+        ...                    z=[0.027, 24.12] * u.kpc,
+        ...                    frame=coord.Galactocentric)
         >>> c.transform_to(coord.ICRS) # doctest: +FLOAT_CMP
-        <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
+        <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
             [( 88.22423301, 29.88672864,  0.17813456),
-            (289.72864549, 49.9865043 , 85.93949064)]>
+             (289.72864549, 49.9865043 , 85.93949064)]>
 
     Or, with custom specification of the Galactic center::
 
-        >>> c = coord.Galactocentric(x=[-8.0, 4.5] * u.kpc,
-        ...                          y=[0., 81.52] * u.kpc,
-        ...                          z=[21.0, 24120.0] * u.pc,
-        ...                          z_sun=21 * u.pc, galcen_distance=8. * u.kpc)
+        >>> c = coord.SkyCoord(x=[-8.0, 4.5] * u.kpc,
+        ...                    y=[0., 81.52] * u.kpc,
+        ...                    z=[21.0, 24120.0] * u.pc,
+        ...                    frame=coord.Galactocentric,
+        ...                    z_sun=21 * u.pc, galcen_distance=8. * u.kpc)
         >>> c.transform_to(coord.ICRS) # doctest: +FLOAT_CMP
-        <ICRS Coordinate: (ra, dec, distance) in (deg, deg, kpc)
+        <SkyCoord (ICRS): (ra, dec, distance) in (deg, deg, kpc)
             [( 86.2585249 , 28.85773187, 2.75625475e-05),
-            (289.77285255, 50.06290457, 8.59216010e+01)]>
+             (289.77285255, 50.06290457, 8.59216010e+01)]>
 
 """
 

--- a/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
+++ b/astropy/coordinates/builtin_frames/icrs_cirs_transforms.py
@@ -114,7 +114,7 @@ def cirs_to_cirs(from_coo, to_frame):
         # current time*.  This has some subtle implications in terms of GR, but
         # is sort of glossed over in the current scheme because we are dropping
         # distances anyway.
-        return from_coo.transform_to(ICRS).transform_to(to_frame)
+        return from_coo.transform_to(ICRS()).transform_to(to_frame)
 
 
 # Now the GCRS-related transforms to/from ICRS
@@ -218,7 +218,7 @@ def gcrs_to_gcrs(from_coo, to_frame):
         return to_frame.realize_frame(from_coo.data)
     else:
         # like CIRS, we do this self-transform via ICRS
-        return from_coo.transform_to(ICRS).transform_to(to_frame)
+        return from_coo.transform_to(ICRS()).transform_to(to_frame)
 
 
 @frame_transform_graph.transform(FunctionTransformWithFiniteDifference, GCRS, HCRS)
@@ -333,4 +333,4 @@ def hcrs_to_hcrs(from_coo, to_frame):
         return to_frame.realize_frame(from_coo.data)
     else:
         # like CIRS, we do this self-transform via ICRS
-        return from_coo.transform_to(ICRS).transform_to(to_frame)
+        return from_coo.transform_to(ICRS()).transform_to(to_frame)

--- a/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
+++ b/astropy/coordinates/builtin_frames/intermediate_rotation_transforms.py
@@ -116,7 +116,7 @@ def itrs_to_cirs(itrs_coo, cirs_frame):
 def itrs_to_itrs(from_coo, to_frame):
     # this self-transform goes through CIRS right now, which implicitly also
     # goes back to ICRS
-    return from_coo.transform_to(CIRS).transform_to(to_frame)
+    return from_coo.transform_to(CIRS()).transform_to(to_frame)
 
 # TODO: implement GCRS<->CIRS if there's call for it.  The thing that's awkward
 # is that they both have obstimes, so an extra set of transformations are necessary.

--- a/astropy/coordinates/builtin_frames/lsr.py
+++ b/astropy/coordinates/builtin_frames/lsr.py
@@ -191,7 +191,7 @@ class LSRK(BaseRADecFrame):
 # offsets here. The code to generate the offsets is provided for reproducibility.
 # GORDON1975_V_BARY = 20*u.km/u.s
 # GORDON1975_DIRECTION = FK4(ra=270*u.deg, dec=30*u.deg, equinox='B1900')
-# V_OFFSET_LSRK = ((GORDON1975_V_BARY * GORDON1975_DIRECTION.transform_to(ICRS).data)
+# V_OFFSET_LSRK = ((GORDON1975_V_BARY * GORDON1975_DIRECTION.transform_to(ICRS()).data)
 #                  .represent_as(r.CartesianDifferential))
 
 V_OFFSET_LSRK = r.CartesianDifferential([0.28999706839034606,
@@ -242,7 +242,7 @@ class LSRD(BaseRADecFrame):
 # NOTE: To avoid a performance penalty at import time, we hard-code the ICRS
 # offsets here. The code to generate the offsets is provided for reproducibility.
 # V_BARY_DELHAYE1965 = r.CartesianDifferential([9, 12, 7] * u.km/u.s)
-# V_OFFSET_LSRD = (Galactic(V_BARY_DELHAYE1965.to_cartesian()).transform_to(ICRS).data
+# V_OFFSET_LSRD = (Galactic(V_BARY_DELHAYE1965.to_cartesian()).transform_to(ICRS()).data
 #                  .represent_as(r.CartesianDifferential))
 
 V_OFFSET_LSRD = r.CartesianDifferential([-0.6382306360182073,

--- a/astropy/coordinates/orbital_elements.py
+++ b/astropy/coordinates/orbital_elements.py
@@ -242,4 +242,4 @@ def calc_moon(t):
     ecliptic_coo = GeocentricTrueEcliptic(lon, lat, distance=dist,
                                           obstime=t, equinox=t)
 
-    return SkyCoord(ecliptic_coo.transform_to(ICRS))
+    return SkyCoord(ecliptic_coo.transform_to(ICRS()))

--- a/astropy/coordinates/spectral_coordinate.py
+++ b/astropy/coordinates/spectral_coordinate.py
@@ -104,8 +104,8 @@ def update_differentials_to_match(original, velocity_reference, preserve_observe
     # it's a simple frame that is not time-dependent (it could be that both
     # the original and velocity_reference frame are time-dependent)
 
-    original_icrs = original.transform_to(ICRS)
-    velocity_reference_icrs = velocity_reference.transform_to(ICRS)
+    original_icrs = original.transform_to(ICRS())
+    velocity_reference_icrs = velocity_reference.transform_to(ICRS())
 
     differentials = velocity_reference_icrs.data.represent_as(CartesianRepresentation,
                                                               CartesianDifferential).differentials
@@ -295,7 +295,7 @@ class SpectralCoord(SpectralQuantity):
         # The generated observer or target will be set up along the same y and z
         # coordinates as the target or observer, but offset along the x direction
 
-        observer_icrs = observer.transform_to(ICRS)
+        observer_icrs = observer.transform_to(ICRS())
 
         d = observer_icrs.cartesian.norm()
         drep = CartesianRepresentation([DEFAULT_DISTANCE.to(d.unit),
@@ -554,8 +554,8 @@ class SpectralCoord(SpectralQuantity):
 
         # Convert observer and target to ICRS to avoid finite differencing
         # calculations that lack numerical precision.
-        observer_icrs = observer.transform_to(ICRS)
-        target_icrs = target.transform_to(ICRS)
+        observer_icrs = observer.transform_to(ICRS())
+        target_icrs = target.transform_to(ICRS())
 
         pos_hat = SpectralCoord._norm_d_pos(observer_icrs, target_icrs)
 
@@ -812,8 +812,8 @@ class SpectralCoord(SpectralQuantity):
             if observer_shift.unit.physical_type == 'dimensionless':
                 observer_shift = _redshift_to_velocity(observer_shift)
 
-        target_icrs = self._target.transform_to(ICRS)
-        observer_icrs = self._observer.transform_to(ICRS)
+        target_icrs = self._target.transform_to(ICRS())
+        observer_icrs = self._observer.transform_to(ICRS())
 
         pos_hat = SpectralCoord._norm_d_pos(observer_icrs, target_icrs)
 

--- a/astropy/coordinates/tests/accuracy/test_ecliptic.py
+++ b/astropy/coordinates/tests/accuracy/test_ecliptic.py
@@ -36,8 +36,8 @@ def test_ecliptic_heliobary():
     """
     icrs = ICRS(1*u.deg, 2*u.deg, distance=1.5*R_sun)
 
-    bary = icrs.transform_to(BarycentricMeanEcliptic)
-    helio = icrs.transform_to(HeliocentricMeanEcliptic)
+    bary = icrs.transform_to(BarycentricMeanEcliptic())
+    helio = icrs.transform_to(HeliocentricMeanEcliptic())
 
     # make sure there's a sizable distance shift - in 3d hundreds of km, but
     # this is 1D so we allow it to be somewhat smaller
@@ -60,9 +60,9 @@ def test_ecliptic_roundtrips(trueframe, meanframe):
     """
     icrs = ICRS(1*u.deg, 2*u.deg, distance=1.5*R_sun)
 
-    truecoo = icrs.transform_to(trueframe)
-    meancoo = truecoo.transform_to(meanframe)
-    truecoo2 = meancoo.transform_to(trueframe)
+    truecoo = icrs.transform_to(trueframe())
+    meancoo = truecoo.transform_to(meanframe())
+    truecoo2 = meancoo.transform_to(trueframe())
 
     assert not quantity_allclose(truecoo.cartesian.xyz, meancoo.cartesian.xyz)
     assert quantity_allclose(truecoo.cartesian.xyz, truecoo2.cartesian.xyz)
@@ -77,7 +77,7 @@ def test_ecliptic_true_mean_preserve_latitude(trueframe, meanframe):
     Check that the ecliptic true/mean transformations preserve latitude
     """
     truecoo = trueframe(90*u.deg, 0*u.deg, distance=1*u.AU)
-    meancoo = truecoo.transform_to(meanframe)
+    meancoo = truecoo.transform_to(meanframe())
 
     assert not quantity_allclose(truecoo.lon, meancoo.lon)
     assert quantity_allclose(truecoo.lat, meancoo.lat, atol=1e-10*u.arcsec)
@@ -90,7 +90,7 @@ def test_ecl_geo():
     geocentric/GCRS comparison we want to do here.  Contributions welcome!
     """
     gcrs = GCRS(10*u.deg, 20*u.deg, distance=1.5*R_earth)
-    gecl = gcrs.transform_to(GeocentricMeanEcliptic)
+    gecl = gcrs.transform_to(GeocentricMeanEcliptic())
 
     assert quantity_allclose(gecl.distance, gcrs.distance)
 
@@ -107,23 +107,23 @@ def test_arraytransforms():
     test_icrs = ICRS(ra=ra, dec=dec, distance=distance)
     test_gcrs = GCRS(test_icrs.data)
 
-    bary_arr = test_icrs.transform_to(BarycentricMeanEcliptic)
+    bary_arr = test_icrs.transform_to(BarycentricMeanEcliptic())
     assert bary_arr.shape == ra.shape
 
-    helio_arr = test_icrs.transform_to(HeliocentricMeanEcliptic)
+    helio_arr = test_icrs.transform_to(HeliocentricMeanEcliptic())
     assert helio_arr.shape == ra.shape
 
-    geo_arr = test_gcrs.transform_to(GeocentricMeanEcliptic)
+    geo_arr = test_gcrs.transform_to(GeocentricMeanEcliptic())
     assert geo_arr.shape == ra.shape
 
     # now check that we also can go back the other way without shape problems
-    bary_icrs = bary_arr.transform_to(ICRS)
+    bary_icrs = bary_arr.transform_to(ICRS())
     assert bary_icrs.shape == test_icrs.shape
 
-    helio_icrs = helio_arr.transform_to(ICRS)
+    helio_icrs = helio_arr.transform_to(ICRS())
     assert helio_icrs.shape == test_icrs.shape
 
-    geo_gcrs = geo_arr.transform_to(GCRS)
+    geo_gcrs = geo_arr.transform_to(GCRS())
     assert geo_gcrs.shape == test_gcrs.shape
 
 
@@ -131,13 +131,13 @@ def test_roundtrip_scalar():
     icrs = ICRS(ra=1*u.deg, dec=2*u.deg, distance=3*u.au)
     gcrs = GCRS(icrs.cartesian)
 
-    bary = icrs.transform_to(BarycentricMeanEcliptic)
-    helio = icrs.transform_to(HeliocentricMeanEcliptic)
-    geo = gcrs.transform_to(GeocentricMeanEcliptic)
+    bary = icrs.transform_to(BarycentricMeanEcliptic())
+    helio = icrs.transform_to(HeliocentricMeanEcliptic())
+    geo = gcrs.transform_to(GeocentricMeanEcliptic())
 
-    bary_icrs = bary.transform_to(ICRS)
-    helio_icrs = helio.transform_to(ICRS)
-    geo_gcrs = geo.transform_to(GCRS)
+    bary_icrs = bary.transform_to(ICRS())
+    helio_icrs = helio.transform_to(ICRS())
+    geo_gcrs = geo.transform_to(GCRS())
 
     assert quantity_allclose(bary_icrs.cartesian.xyz, icrs.cartesian.xyz)
     assert quantity_allclose(helio_icrs.cartesian.xyz, icrs.cartesian.xyz)

--- a/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_fk4_no_e_fk4.py
@@ -37,7 +37,7 @@ def test_fk4_no_e_fk4():
         # FK4 to FK4NoETerms
         c1 = FK4(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
                  obstime=Time(r['obstime']))
-        c2 = c1.transform_to(FK4NoETerms)
+        c2 = c1.transform_to(FK4NoETerms())
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,
@@ -48,7 +48,7 @@ def test_fk4_no_e_fk4():
         # FK4NoETerms to FK4
         c1 = FK4NoETerms(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
                          obstime=Time(r['obstime']))
-        c2 = c1.transform_to(FK4)
+        c2 = c1.transform_to(FK4())
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,

--- a/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
+++ b/astropy/coordinates/tests/accuracy/test_galactic_fk4.py
@@ -46,7 +46,7 @@ def test_galactic_fk4():
         c1 = FK4(ra=r['lon_in']*u.deg, dec=r['lat_in']*u.deg,
                  obstime=Time(r['obstime']),
                  equinox=Time(r['equinox_fk4']))
-        c2 = c1.transform_to(Galactic)
+        c2 = c1.transform_to(Galactic())
 
         # Find difference
         diff = angular_separation(c2.l.radian, c2.b.radian,

--- a/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
+++ b/astropy/coordinates/tests/accuracy/test_icrs_fk5.py
@@ -45,7 +45,7 @@ def test_icrs_fk5():
         # FK5 to ICRS
         c1 = FK5(ra=r['ra_in']*u.deg, dec=r['dec_in']*u.deg,
                  equinox=Time(r['equinox_fk5']))
-        c2 = c1.transform_to(ICRS)
+        c2 = c1.transform_to(ICRS())
 
         # Find difference
         diff = angular_separation(c2.ra.radian, c2.dec.radian,

--- a/astropy/coordinates/tests/test_angular_separation.py
+++ b/astropy/coordinates/tests/test_angular_separation.py
@@ -85,11 +85,11 @@ def test_proj_separations():
 
     # if there is a defined conversion between the relevant coordinate systems,
     # it will be automatically performed to get the right angular separation
-    assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
+    assert_allclose(ncp.separation(ngp.transform_to(ICRS())).degree,
                     ncp.separation(ngp).degree)
 
     # distance from the north galactic pole to celestial pole
-    assert_allclose(ncp.separation(ngp.transform_to(ICRS)).degree,
+    assert_allclose(ncp.separation(ngp.transform_to(ICRS())).degree,
                     62.87174758503201)
 
 

--- a/astropy/coordinates/tests/test_api_ape5.py
+++ b/astropy/coordinates/tests/test_api_ape5.py
@@ -266,22 +266,15 @@ def test_transform_api():
     newfk5 = fk5.transform_to(fk5_J2001_frame)
     assert newfk5.equinox == J2001
 
-    # classes can also be given to `transform_to`, which then uses the defaults for
-    # the frame information:
-    samefk5 = fk5.transform_to(FK5)
-    # `fk5` was initialized using default `obstime` and `equinox`, so:
-    assert_allclose(samefk5.ra, fk5.ra, atol=1e-10*u.deg)
-    assert_allclose(samefk5.dec, fk5.dec, atol=1e-10*u.deg)
-
     # transforming to a new frame necessarily loses framespec information if that
     # information is not applicable to the new frame.  This means transforms are not
     # always round-trippable:
     fk5_2 = FK5(ra=8*u.hour, dec=5*u.deg, equinox=J2001)
-    ic_trans = fk5_2.transform_to(ICRS)
+    ic_trans = fk5_2.transform_to(ICRS())
 
     # `ic_trans` does not have an `equinox`, so now when we transform back to FK5,
     # it's a *different* RA and Dec
-    fk5_trans = ic_trans.transform_to(FK5)
+    fk5_trans = ic_trans.transform_to(FK5())
     assert not allclose(fk5_2.ra, fk5_trans.ra, rtol=0, atol=1e-10*u.deg)
 
     # But if you explicitly give the right equinox, all is fine
@@ -290,7 +283,7 @@ def test_transform_api():
 
     # Trying to transforming a frame with no data is of course an error:
     with pytest.raises(ValueError):
-        FK5(equinox=J2001).transform_to(ICRS)
+        FK5(equinox=J2001).transform_to(ICRS())
 
     # To actually define a new transformation, the same scheme as in the
     # 0.2/0.3 coordinates framework can be re-used - a graph of transform functions

--- a/astropy/coordinates/tests/test_arrays.py
+++ b/astropy/coordinates/tests/test_arrays.py
@@ -150,7 +150,7 @@ def test_array_coordinates_transformations(arrshape, distance):
 
     print(raarr, decarr, distance)
     c = ICRS(ra=raarr*u.deg, dec=decarr*u.deg, distance=distance)
-    g = c.transform_to(Galactic)
+    g = c.transform_to(Galactic())
 
     assert g.l.shape == arrshape
 
@@ -161,7 +161,7 @@ def test_array_coordinates_transformations(arrshape, distance):
         assert g.distance.unit == c.distance.unit
 
     # now make sure round-tripping works through FK5
-    c2 = c.transform_to(FK5).transform_to(ICRS)
+    c2 = c.transform_to(FK5()).transform_to(ICRS())
     npt.assert_array_almost_equal(c.ra.radian, c2.ra.radian)
     npt.assert_array_almost_equal(c.dec.radian, c2.dec.radian)
 
@@ -171,7 +171,7 @@ def test_array_coordinates_transformations(arrshape, distance):
         assert c2.distance.unit == c.distance.unit
 
     # also make sure it's possible to get to FK4, which uses a direct transform function.
-    fk4 = c.transform_to(FK4)
+    fk4 = c.transform_to(FK4())
 
     npt.assert_array_almost_equal(fk4.ra.degree, 10.0004, decimal=4)
     npt.assert_array_almost_equal(fk4.dec.degree, 40.9953, decimal=4)
@@ -181,7 +181,7 @@ def test_array_coordinates_transformations(arrshape, distance):
         assert fk4.distance.unit == c.distance.unit
 
     # now check the reverse transforms run
-    cfk4 = fk4.transform_to(ICRS)
+    cfk4 = fk4.transform_to(ICRS())
     assert cfk4.ra.shape == arrshape
 
 

--- a/astropy/coordinates/tests/test_celestial_transformations.py
+++ b/astropy/coordinates/tests/test_celestial_transformations.py
@@ -39,7 +39,7 @@ def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
     catalog location of M31 from NED.
     """
     coo1 = fromsys(ra=fromcoo[0]*u.deg, dec=fromcoo[1]*u.deg, distance=m31_dist)
-    coo2 = coo1.transform_to(tosys)
+    coo2 = coo1.transform_to(tosys())
     if tosys is FK4:
         coo2_prec = coo2.transform_to(FK4(equinox=Time('B1950')))
         assert (coo2_prec.spherical.lon - tocoo[0]*u.deg) < convert_precision  # <1 arcsec
@@ -53,7 +53,7 @@ def test_m31_coord_transforms(fromsys, tosys, fromcoo, tocoo):
     assert (coo2.distance - m31_dist) < dist_precision
 
     # check round-tripping
-    coo1_2 = coo2.transform_to(fromsys)
+    coo1_2 = coo2.transform_to(fromsys())
     assert (coo1_2.spherical.lon - fromcoo[0]*u.deg) < roundtrip_precision
     assert (coo1_2.spherical.lat - fromcoo[1]*u.deg) < roundtrip_precision
     assert (coo1_2.distance - m31_dist) < dist_precision
@@ -86,13 +86,13 @@ def test_fk5_galactic():
 
     fk5 = FK5(ra=1*u.deg, dec=2*u.deg)
 
-    direct = fk5.transform_to(Galactic)
-    indirect = fk5.transform_to(FK4).transform_to(Galactic)
+    direct = fk5.transform_to(Galactic())
+    indirect = fk5.transform_to(FK4()).transform_to(Galactic())
 
     assert direct.separation(indirect).degree < 1.e-10
 
-    direct = fk5.transform_to(Galactic)
-    indirect = fk5.transform_to(FK4NoETerms).transform_to(Galactic)
+    direct = fk5.transform_to(Galactic())
+    indirect = fk5.transform_to(FK4NoETerms()).transform_to(Galactic())
 
     assert direct.separation(indirect).degree < 1.e-10
 
@@ -103,7 +103,7 @@ def test_galactocentric():
                       dec=np.linspace(-90, 90, 10)*u.deg,
                       distance=1.*u.kpc)
 
-    g_xyz = icrs_coord.transform_to(Galactic).cartesian.xyz
+    g_xyz = icrs_coord.transform_to(Galactic()).cartesian.xyz
     with galactocentric_frame_defaults.set('pre-v4.0'):
         gc_xyz = icrs_coord.transform_to(Galactocentric(z_sun=0*u.kpc)).cartesian.xyz
     diff = np.abs(g_xyz - gc_xyz)
@@ -136,8 +136,8 @@ def test_galactocentric():
         g2 = Galactocentric(x=x.reshape(100, 1, 1), y=y.reshape(100, 1, 1),
                             z=z.reshape(100, 1, 1))
 
-        g1t = g1.transform_to(Galactic)
-        g2t = g2.transform_to(Galactic)
+        g1t = g1.transform_to(Galactic())
+        g2t = g2.transform_to(Galactic())
 
         assert_allclose(g1t.cartesian.xyz, g2t.cartesian.xyz[:, :, 0, 0])
 
@@ -145,8 +145,8 @@ def test_galactocentric():
         g2 = Galactic(l=l.reshape(100, 1, 1), b=b.reshape(100, 1, 1),
                       distance=d.reshape(100, 1, 1))
 
-        g1t = g1.transform_to(Galactocentric)
-        g2t = g2.transform_to(Galactocentric)
+        g1t = g1.transform_to(Galactocentric())
+        g2t = g2.transform_to(Galactocentric())
 
         np.testing.assert_almost_equal(g1t.cartesian.xyz.value,
                                        g2t.cartesian.xyz.value[:, :, 0, 0])
@@ -158,11 +158,11 @@ def test_supergalactic():
     """
     # Check supergalactic North pole.
     npole = Galactic(l=47.37*u.degree, b=+6.32*u.degree)
-    assert allclose(npole.transform_to(Supergalactic).sgb.deg, +90, atol=1e-9)
+    assert allclose(npole.transform_to(Supergalactic()).sgb.deg, +90, atol=1e-9)
 
     # Check the origin of supergalactic longitude.
     lon0 = Supergalactic(sgl=0*u.degree, sgb=0*u.degree)
-    lon0_gal = lon0.transform_to(Galactic)
+    lon0_gal = lon0.transform_to(Galactic())
     assert allclose(lon0_gal.l.deg, 137.37, atol=1e-9)
     assert allclose(lon0_gal.b.deg, 0, atol=1e-9)
 
@@ -273,12 +273,12 @@ def test_lsr_sanity():
     icrs = ICRS(ra=15.1241*u.deg, dec=17.5143*u.deg, distance=150.12*u.pc,
                 pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr,
                 radial_velocity=0*u.km/u.s)
-    lsr = icrs.transform_to(LSR)
+    lsr = icrs.transform_to(LSR())
 
     lsr_diff = lsr.data.differentials['s']
     cart_lsr_vel = lsr_diff.represent_as(CartesianRepresentation, base=lsr.data)
     lsr_vel = ICRS(cart_lsr_vel)
-    gal_lsr = lsr_vel.transform_to(Galactic).cartesian.xyz
+    gal_lsr = lsr_vel.transform_to(Galactic()).cartesian.xyz
     assert allclose(gal_lsr.to(u.km/u.s, u.dimensionless_angles()),
                     lsr.v_bary.d_xyz)
 
@@ -286,12 +286,12 @@ def test_lsr_sanity():
     lsr = LSR(ra=15.1241*u.deg, dec=17.5143*u.deg, distance=150.12*u.pc,
               pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr,
               radial_velocity=0*u.km/u.s)
-    icrs = lsr.transform_to(ICRS)
+    icrs = lsr.transform_to(ICRS())
 
     icrs_diff = icrs.data.differentials['s']
     cart_vel = icrs_diff.represent_as(CartesianRepresentation, base=icrs.data)
     vel = ICRS(cart_vel)
-    gal_icrs = vel.transform_to(Galactic).cartesian.xyz
+    gal_icrs = vel.transform_to(Galactic()).cartesian.xyz
     assert allclose(gal_icrs.to(u.km/u.s, u.dimensionless_angles()),
                     -lsr.v_bary.d_xyz)
 
@@ -302,13 +302,13 @@ def test_hcrs_icrs_differentials():
     hcrs = HCRS(ra=8.67*u.deg, dec=53.09*u.deg, distance=117*u.pc,
                 pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
                 radial_velocity=23.42*u.km/u.s)
-    icrs = hcrs.transform_to(ICRS)
+    icrs = hcrs.transform_to(ICRS())
 
     # The position and velocity should not change much
     assert allclose(hcrs.cartesian.xyz, icrs.cartesian.xyz, rtol=1e-8)
     assert allclose(hcrs.velocity.d_xyz, icrs.velocity.d_xyz, rtol=1e-2)
 
-    hcrs2 = icrs.transform_to(HCRS)
+    hcrs2 = icrs.transform_to(HCRS())
 
     # The values should round trip
     assert allclose(hcrs.cartesian.xyz, hcrs2.cartesian.xyz, rtol=1e-12)

--- a/astropy/coordinates/tests/test_finite_difference_velocities.py
+++ b/astropy/coordinates/tests/test_finite_difference_velocities.py
@@ -62,7 +62,7 @@ def test_faux_lsr(dt, symmetric):
                pm_ra_cosdec=0*u.marcsec/u.yr, pm_dec=10*u.marcsec/u.yr,
                radial_velocity=1000*u.km/u.s)
     lsrc2 = ic2.transform_to(LSR2())
-    ic2_roundtrip = lsrc2.transform_to(ICRS)
+    ic2_roundtrip = lsrc2.transform_to(ICRS())
 
     tot = np.sum(lsrc2.cartesian.differentials['s'].d_xyz**2)**0.5
     assert np.abs(tot.to('km/s') - 1000*u.km/u.s) < 20*u.km/u.s
@@ -99,8 +99,8 @@ def test_faux_fk5_galactic():
     c1 = FK5(ra=150*u.deg, dec=-17*u.deg, radial_velocity=83*u.km/u.s,
              pm_ra_cosdec=-41*u.mas/u.yr, pm_dec=16*u.mas/u.yr,
              distance=150*u.pc)
-    c2 = c1.transform_to(Galactic2)
-    c3 = c1.transform_to(Galactic)
+    c2 = c1.transform_to(Galactic2())
+    c3 = c1.transform_to(Galactic())
 
     # compare the matrix and finite-difference calculations
     assert quantity_allclose(c2.pm_l_cosb, c3.pm_l_cosb, rtol=1e-4)
@@ -138,9 +138,9 @@ def test_gcrs_diffs():
     assert np.abs(qtrsung.radial_velocity) < 40*u.km/u.s
     assert np.abs(sung.radial_velocity) < 1*u.km/u.s
 
-    suni2 = sung.transform_to(ICRS)
+    suni2 = sung.transform_to(ICRS())
     assert np.all(np.abs(suni2.data.differentials['s'].d_xyz) < 3e-5*u.km/u.s)
-    qtrisun2 = qtrsung.transform_to(ICRS)
+    qtrisun2 = qtrsung.transform_to(ICRS())
     assert np.all(np.abs(qtrisun2.data.differentials['s'].d_xyz) < 3e-5*u.km/u.s)
 
 

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -260,8 +260,8 @@ def test_converting_units():
     # converting from FK5 to ICRS and back changes the *internal* representation,
     # but it should still come out in the preferred form
 
-    i4 = i2.transform_to(FK5).transform_to(ICRS)
-    i4_many = i2_many.transform_to(FK5).transform_to(ICRS)
+    i4 = i2.transform_to(FK5()).transform_to(ICRS())
+    i4_many = i2_many.transform_to(FK5()).transform_to(ICRS())
 
     ri2 = ''.join(rexrepr.split(repr(i2)))
     ri4 = ''.join(rexrepr.split(repr(i4)))
@@ -442,8 +442,8 @@ def test_transform():
     from astropy.time import Time
 
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
-    f = i.transform_to(FK5)
-    i2 = f.transform_to(ICRS)
+    f = i.transform_to(FK5())
+    i2 = f.transform_to(ICRS())
 
     assert i2.data.__class__ == r.UnitSphericalRepresentation
 
@@ -451,28 +451,28 @@ def test_transform():
     assert_allclose(i.dec, i2.dec)
 
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg, distance=[5, 6]*u.kpc)
-    f = i.transform_to(FK5)
-    i2 = f.transform_to(ICRS)
+    f = i.transform_to(FK5())
+    i2 = f.transform_to(ICRS())
 
     assert i2.data.__class__ != r.UnitSphericalRepresentation
 
     f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
-    f4 = f.transform_to(FK4)
+    f4 = f.transform_to(FK4())
     f4_2 = f.transform_to(FK4(equinox=f.equinox))
 
     # make sure attributes are copied over correctly
-    assert f4.equinox == FK4.get_frame_attr_names()['equinox']
+    assert f4.equinox == FK4().equinox
     assert f4_2.equinox == f.equinox
 
     # make sure self-transforms also work
     i = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
-    i2 = i.transform_to(ICRS)
+    i2 = i.transform_to(ICRS())
 
     assert_allclose(i.ra, i2.ra)
     assert_allclose(i.dec, i2.dec)
 
     f = FK5(ra=1*u.deg, dec=2*u.deg, equinox=Time('J2001'))
-    f2 = f.transform_to(FK5)  # default equinox, so should be *different*
+    f2 = f.transform_to(FK5())  # default equinox, so should be *different*
     assert f2.equinox == FK5().equinox
     with pytest.raises(AssertionError):
         assert_allclose(f.ra, f2.ra)
@@ -481,7 +481,7 @@ def test_transform():
 
     # finally, check Galactic round-tripping
     i1 = ICRS(ra=[1, 2]*u.deg, dec=[3, 4]*u.deg)
-    i2 = i1.transform_to(Galactic).transform_to(ICRS)
+    i2 = i1.transform_to(Galactic()).transform_to(ICRS())
 
     assert_allclose(i1.ra, i2.ra)
     assert_allclose(i1.dec, i2.dec)

--- a/astropy/coordinates/tests/test_frames_with_velocity.py
+++ b/astropy/coordinates/tests/test_frames_with_velocity.py
@@ -25,13 +25,13 @@ def test_api():
         # transform a set of ICRS proper motions to Galactic
         icrs = ICRS(ra=151.*u.deg, dec=-16*u.deg,
                     pm_ra_cosdec=21*u.mas/u.yr, pm_dec=-71*u.mas/u.yr)
-        icrs.transform_to(Galactic)
+        icrs.transform_to(Galactic())
 
         # transform a Barycentric RV to a GSR RV
         icrs = ICRS(ra=151.*u.deg, dec=-16*u.deg, distance=1.*u.pc,
                     pm_ra_cosdec=0*u.mas/u.yr, pm_dec=0*u.mas/u.yr,
                     radial_velocity=71*u.km/u.s)
-        icrs.transform_to(Galactocentric)
+        icrs.transform_to(Galactocentric())
 
 
 all_kwargs = [
@@ -73,7 +73,7 @@ def test_all_arg_options(kwargs):
     # Here we do a simple thing and just verify that passing them in, we have
     # access to the relevant attributes from the resulting object
     icrs = ICRS(**kwargs)
-    gal = icrs.transform_to(Galactic)
+    gal = icrs.transform_to(Galactic())
     repr_gal = repr(gal)
 
     for k in kwargs:
@@ -144,7 +144,7 @@ def test_xhip_galactic(hip, ra, dec, pmra, pmdec, glon, glat, dist, pmglon, pmgl
     i = ICRS(ra*u.deg, dec*u.deg, dist*u.pc,
              pm_ra_cosdec=pmra*u.marcsec/u.yr, pm_dec=pmdec*u.marcsec/u.yr,
              radial_velocity=rv*u.km/u.s)
-    g = i.transform_to(Galactic)
+    g = i.transform_to(Galactic())
 
     # precision is limited by 2-deciimal digit string representation of pms
     assert quantity_allclose(g.pm_l_cosb, pmglon*u.marcsec/u.yr, atol=.01*u.marcsec/u.yr)
@@ -183,11 +183,11 @@ def test_frame_affinetransform(kwargs, expect_success):
         icrs = ICRS(**kwargs)
 
         if expect_success:
-            _ = icrs.transform_to(Galactocentric)
+            _ = icrs.transform_to(Galactocentric())
 
         else:
             with pytest.raises(ConvertError):
-                icrs.transform_to(Galactocentric)
+                icrs.transform_to(Galactocentric())
 
 
 def test_differential_type_arg():
@@ -324,5 +324,5 @@ def test_velocity_units():
 
 def test_frame_with_velocity_without_distance_can_be_transformed():
     frame = CIRS(1*u.deg, 2*u.deg, pm_dec=1*u.mas/u.yr, pm_ra_cosdec=2*u.mas/u.yr)
-    rep = frame.transform_to(ICRS)
+    rep = frame.transform_to(ICRS())
     assert "<ICRS Coordinate: (ra, dec, distance) in" in repr(rep)

--- a/astropy/coordinates/tests/test_iau_fullstack.py
+++ b/astropy/coordinates/tests/test_iau_fullstack.py
@@ -107,7 +107,7 @@ def test_iau_fullstack(fullstack_icrs, fullstack_fiducial_altaz,
         tol = 750*u.milliarcsecond
 
     # now make sure the full stack round-tripping works
-    icrs2 = aacoo.transform_to(ICRS)
+    icrs2 = aacoo.transform_to(ICRS())
 
     adras = np.abs(fullstack_icrs.ra - icrs2.ra)[msk]
     addecs = np.abs(fullstack_icrs.dec - icrs2.dec)[msk]
@@ -144,7 +144,7 @@ def test_fiducial_roudtrip(fullstack_icrs, fullstack_fiducial_altaz):
     aacoo = fullstack_icrs.transform_to(fullstack_fiducial_altaz)
 
     # make sure the round-tripping works
-    icrs2 = aacoo.transform_to(ICRS)
+    icrs2 = aacoo.transform_to(ICRS())
     npt.assert_allclose(fullstack_icrs.ra.deg, icrs2.ra.deg)
     npt.assert_allclose(fullstack_icrs.dec.deg, icrs2.dec.deg)
 

--- a/astropy/coordinates/tests/test_intermediate_transformations.py
+++ b/astropy/coordinates/tests/test_intermediate_transformations.py
@@ -45,7 +45,7 @@ def test_icrs_cirs():
     cframe1 = CIRS()
     cirsnod = inod.transform_to(cframe1)  # uses the default time
     # first do a round-tripping test
-    inod2 = cirsnod.transform_to(ICRS)
+    inod2 = cirsnod.transform_to(ICRS())
     assert_allclose(inod.ra, inod2.ra)
     assert_allclose(inod.dec, inod2.dec)
 
@@ -88,7 +88,7 @@ def test_icrs_gcrs(icoo):
     """
     gcrscoo = icoo.transform_to(gcrs_frames[0])  # uses the default time
     # first do a round-tripping test
-    icoo2 = gcrscoo.transform_to(ICRS)
+    icoo2 = gcrscoo.transform_to(ICRS())
     assert_allclose(icoo.distance, icoo2.distance)
     assert_allclose(icoo.ra, icoo2.ra)
     assert_allclose(icoo.dec, icoo2.dec)
@@ -118,7 +118,7 @@ def test_icrs_gcrs(icoo):
     gcrscoo6 = icoo.transform_to(gframe3)  # should be different
     assert not allclose(gcrscoo.ra, gcrscoo6.ra, rtol=1e-8, atol=1e-10*u.deg)
     assert not allclose(gcrscoo.dec, gcrscoo6.dec, rtol=1e-8, atol=1e-10*u.deg)
-    icooviag3 = gcrscoo6.transform_to(ICRS)  # and now back to the original
+    icooviag3 = gcrscoo6.transform_to(ICRS())  # and now back to the original
     assert_allclose(icoo.ra, icooviag3.ra)
     assert_allclose(icoo.dec, icooviag3.dec)
 
@@ -172,8 +172,8 @@ def test_gcrs_itrs():
     gcrs = GCRS(ra=ra, dec=dec, obstime='J2000')
     gcrs6 = GCRS(ra=ra, dec=dec, obstime='J2006')
 
-    gcrs2 = gcrs.transform_to(ITRS).transform_to(gcrs)
-    gcrs6_2 = gcrs6.transform_to(ITRS).transform_to(gcrs)
+    gcrs2 = gcrs.transform_to(ITRS()).transform_to(gcrs)
+    gcrs6_2 = gcrs6.transform_to(ITRS()).transform_to(gcrs)
 
     assert_allclose(gcrs.ra, gcrs2.ra)
     assert_allclose(gcrs.dec, gcrs2.dec)
@@ -183,7 +183,7 @@ def test_gcrs_itrs():
     # also try with the cartesian representation
     gcrsc = gcrs.realize_frame(gcrs.data)
     gcrsc.representation_type = CartesianRepresentation
-    gcrsc2 = gcrsc.transform_to(ITRS).transform_to(gcrsc)
+    gcrsc2 = gcrsc.transform_to(ITRS()).transform_to(gcrsc)
     assert_allclose(gcrsc.spherical.lon.deg, gcrsc2.ra.deg)
     assert_allclose(gcrsc.spherical.lat, gcrsc2.dec)
 
@@ -196,8 +196,8 @@ def test_cirs_itrs():
     cirs = CIRS(ra=ra, dec=dec, obstime='J2000')
     cirs6 = CIRS(ra=ra, dec=dec, obstime='J2006')
 
-    cirs2 = cirs.transform_to(ITRS).transform_to(cirs)
-    cirs6_2 = cirs6.transform_to(ITRS).transform_to(cirs)  # different obstime
+    cirs2 = cirs.transform_to(ITRS()).transform_to(cirs)
+    cirs6_2 = cirs6.transform_to(ITRS()).transform_to(cirs)  # different obstime
 
     # just check round-tripping
     assert_allclose(cirs.ra, cirs2.ra)
@@ -215,8 +215,8 @@ def test_gcrs_cirs():
     gcrs = GCRS(ra=ra, dec=dec, obstime='J2000')
     gcrs6 = GCRS(ra=ra, dec=dec, obstime='J2006')
 
-    gcrs2 = gcrs.transform_to(CIRS).transform_to(gcrs)
-    gcrs6_2 = gcrs6.transform_to(CIRS).transform_to(gcrs)
+    gcrs2 = gcrs.transform_to(CIRS()).transform_to(gcrs)
+    gcrs6_2 = gcrs6.transform_to(CIRS()).transform_to(gcrs)
 
     assert_allclose(gcrs.ra, gcrs2.ra)
     assert_allclose(gcrs.dec, gcrs2.dec)
@@ -224,11 +224,11 @@ def test_gcrs_cirs():
     assert not allclose(gcrs.dec, gcrs6_2.dec)
 
     # now try explicit intermediate pathways and ensure they're all consistent
-    gcrs3 = gcrs.transform_to(ITRS).transform_to(CIRS).transform_to(ITRS).transform_to(gcrs)
+    gcrs3 = gcrs.transform_to(ITRS()).transform_to(CIRS()).transform_to(ITRS()).transform_to(gcrs)
     assert_allclose(gcrs.ra, gcrs3.ra)
     assert_allclose(gcrs.dec, gcrs3.dec)
 
-    gcrs4 = gcrs.transform_to(ICRS).transform_to(CIRS).transform_to(ICRS).transform_to(gcrs)
+    gcrs4 = gcrs.transform_to(ICRS()).transform_to(CIRS()).transform_to(ICRS()).transform_to(gcrs)
     assert_allclose(gcrs.ra, gcrs4.ra)
     assert_allclose(gcrs.dec, gcrs4.dec)
 
@@ -250,8 +250,8 @@ def test_gcrs_altaz():
     aaframe = AltAz(obstime=times, location=loc)
 
     aa1 = gcrs.transform_to(aaframe)
-    aa2 = gcrs.transform_to(ICRS).transform_to(CIRS).transform_to(aaframe)
-    aa3 = gcrs.transform_to(ITRS).transform_to(CIRS).transform_to(aaframe)
+    aa2 = gcrs.transform_to(ICRS()).transform_to(CIRS()).transform_to(aaframe)
+    aa3 = gcrs.transform_to(ITRS()).transform_to(CIRS()).transform_to(aaframe)
 
     # make sure they're all consistent
     assert_allclose(aa1.alt, aa2.alt)
@@ -264,12 +264,12 @@ def test_precessed_geocentric():
     assert PrecessedGeocentric().equinox.jd == Time('J2000').jd
 
     gcrs_coo = GCRS(180*u.deg, 2*u.deg, distance=10000*u.km)
-    pgeo_coo = gcrs_coo.transform_to(PrecessedGeocentric)
+    pgeo_coo = gcrs_coo.transform_to(PrecessedGeocentric())
     assert np.abs(gcrs_coo.ra - pgeo_coo.ra) > 10*u.marcsec
     assert np.abs(gcrs_coo.dec - pgeo_coo.dec) > 10*u.marcsec
     assert_allclose(gcrs_coo.distance, pgeo_coo.distance)
 
-    gcrs_roundtrip = pgeo_coo.transform_to(GCRS)
+    gcrs_roundtrip = pgeo_coo.transform_to(GCRS())
     assert_allclose(gcrs_coo.ra, gcrs_roundtrip.ra)
     assert_allclose(gcrs_coo.dec, gcrs_roundtrip.dec)
     assert_allclose(gcrs_coo.distance, gcrs_roundtrip.distance)
@@ -279,7 +279,7 @@ def test_precessed_geocentric():
     assert np.abs(gcrs_coo.dec - pgeo_coo2.dec) > 0.5*u.deg
     assert_allclose(gcrs_coo.distance, pgeo_coo2.distance)
 
-    gcrs2_roundtrip = pgeo_coo2.transform_to(GCRS)
+    gcrs2_roundtrip = pgeo_coo2.transform_to(GCRS())
     assert_allclose(gcrs_coo.ra, gcrs2_roundtrip.ra)
     assert_allclose(gcrs_coo.dec, gcrs2_roundtrip.dec)
     assert_allclose(gcrs_coo.distance, gcrs2_roundtrip.distance)
@@ -345,11 +345,11 @@ def test_gcrs_altaz_bothroutes(testframe):
     routes through the coordinate graph are consistent with each other
     """
     sun = get_sun(testframe.obstime)
-    sunaa_viaicrs = sun.transform_to(ICRS).transform_to(testframe)
+    sunaa_viaicrs = sun.transform_to(ICRS()).transform_to(testframe)
     sunaa_viaitrs = sun.transform_to(ITRS(obstime=testframe.obstime)).transform_to(testframe)
 
     moon = GCRS(MOONDIST_CART, obstime=testframe.obstime)
-    moonaa_viaicrs = moon.transform_to(ICRS).transform_to(testframe)
+    moonaa_viaicrs = moon.transform_to(ICRS()).transform_to(testframe)
     moonaa_viaitrs = moon.transform_to(ITRS(obstime=testframe.obstime)).transform_to(testframe)
 
     assert_allclose(sunaa_viaicrs.cartesian.xyz, sunaa_viaitrs.cartesian.xyz)
@@ -392,7 +392,7 @@ def test_cirs_icrs_moonish(testframe):
     ICRS origin when starting from CIRS
     """
     moonish = CIRS(MOONDIST_CART, obstime=testframe.obstime)
-    moonicrs = moonish.transform_to(ICRS)
+    moonicrs = moonish.transform_to(ICRS())
 
     assert 0.97*u.au < moonicrs.distance < 1.03*u.au
 
@@ -404,7 +404,7 @@ def test_gcrs_icrs_moonish(testframe):
     ICRS origin when starting from GCRS
     """
     moonish = GCRS(MOONDIST_CART, obstime=testframe.obstime)
-    moonicrs = moonish.transform_to(ICRS)
+    moonicrs = moonish.transform_to(ICRS())
 
     assert 0.97*u.au < moonicrs.distance < 1.03*u.au
 

--- a/astropy/coordinates/tests/test_regression.py
+++ b/astropy/coordinates/tests/test_regression.py
@@ -275,7 +275,7 @@ def test_regression_4293():
     fk4noe_ra = fk4.ra - (Dc*np.cos(fk4.ra) +
                           Dd*np.sin(fk4.ra)) / np.cos(fk4.dec)
 
-    fk4noe = fk4.transform_to(FK4NoETerms)
+    fk4noe = fk4.transform_to(FK4NoETerms())
     # Tolerance here just set to how well the coordinates match, which is much
     # better than the claimed accuracy of <1 mas for this first-order in
     # v_earth/c approximation.
@@ -491,7 +491,7 @@ def test_gcrs_itrs_cartesian_repr():
     # Cartesian
     gcrs = GCRS(CartesianRepresentation((859.07256, -4137.20368,  5295.56871),
                                         unit='km'), representation_type='cartesian')
-    gcrs.transform_to(ITRS)
+    gcrs.transform_to(ITRS())
 
 
 @pytest.mark.skipif('not HAS_YAML')

--- a/astropy/coordinates/tests/test_sky_coord.py
+++ b/astropy/coordinates/tests/test_sky_coord.py
@@ -34,7 +34,7 @@ from astropy.io.misc.asdf.tags.helpers import skycoord_equal
 RA = 1.0 * u.deg
 DEC = 2.0 * u.deg
 C_ICRS = ICRS(RA, DEC)
-C_FK5 = C_ICRS.transform_to(FK5)
+C_FK5 = C_ICRS.transform_to(FK5())
 J2001 = Time('J2001')
 
 
@@ -64,8 +64,8 @@ def teardown_function(func):
 
 
 def test_transform_to():
-    for frame in (FK5, FK5(equinox=Time('J1975.0')),
-                  FK4, FK4(equinox=Time('J1975.0')),
+    for frame in (FK5(), FK5(equinox=Time('J1975.0')),
+                  FK4(), FK4(equinox=Time('J1975.0')),
                   SkyCoord(RA, DEC, frame='fk4', equinox='J1980')):
         c_frame = C_ICRS.transform_to(frame)
         s_icrs = SkyCoord(RA, DEC, frame='icrs')

--- a/astropy/coordinates/tests/test_skyoffset_transformations.py
+++ b/astropy/coordinates/tests/test_skyoffset_transformations.py
@@ -55,7 +55,7 @@ def test_skyoffset_functional_ra():
         actual_xyz = actual.cartesian.xyz
 
         # back to ICRS
-        roundtrip = actual.transform_to(ICRS)
+        roundtrip = actual.transform_to(ICRS())
         roundtrip_xyz = roundtrip.cartesian.xyz
 
         # Verify
@@ -99,7 +99,7 @@ def test_skyoffset_functional_dec():
         actual_xyz = actual.cartesian.xyz
 
         # back to ICRS
-        roundtrip = actual.transform_to(ICRS)
+        roundtrip = actual.transform_to(ICRS())
 
         # Verify
         assert_allclose(actual_xyz, expected_xyz, atol=1E-5*u.kpc)
@@ -145,7 +145,7 @@ def test_skyoffset_functional_ra_dec():
             actual_xyz = actual.cartesian.xyz
 
             # back to ICRS
-            roundtrip = actual.transform_to(ICRS)
+            roundtrip = actual.transform_to(ICRS())
 
             # Verify
             assert_allclose(actual_xyz, expected_xyz, atol=1E-5*u.kpc)

--- a/astropy/coordinates/tests/test_spectral_coordinate.py
+++ b/astropy/coordinates/tests/test_spectral_coordinate.py
@@ -77,8 +77,8 @@ LSRD = Galactic(u=0.1 * u.km, v=0.1 * u.km, w=0.1 * u.km,
 LSRD_EQUIV = [
               LSRD,
               SkyCoord(LSRD),  # as a SkyCoord
-              LSRD.transform_to(ICRS),  # different frame
-              LSRD.transform_to(ICRS).transform_to(Galactic)  # different representation
+              LSRD.transform_to(ICRS()),  # different frame
+              LSRD.transform_to(ICRS()).transform_to(Galactic())  # different representation
               ]
 
 

--- a/astropy/coordinates/tests/test_transformations.py
+++ b/astropy/coordinates/tests/test_transformations.py
@@ -40,7 +40,7 @@ def test_transform_classes():
                             register_graph=frame_transform_graph)
 
     c1 = TCoo1(ra=1*u.radian, dec=0.5*u.radian)
-    c2 = c1.transform_to(TCoo2)
+    c2 = c1.transform_to(TCoo2())
     assert_allclose(c2.ra.radian, 1)
     assert_allclose(c2.dec.radian, 0.5)
 
@@ -52,7 +52,7 @@ def test_transform_classes():
     trans2.register(frame_transform_graph)
 
     c3 = TCoo1(ra=1*u.deg, dec=2*u.deg)
-    c4 = c3.transform_to(TCoo2)
+    c4 = c3.transform_to(TCoo2())
 
     assert_allclose(c4.ra.degree, 1)
     assert_allclose(c4.ra.degree, 1)
@@ -72,7 +72,7 @@ def test_transform_decos():
     def trans(coo1, f):
         return TCoo2(ra=coo1.ra, dec=coo1.dec * 2)
 
-    c2 = c1.transform_to(TCoo2)
+    c2 = c1.transform_to(TCoo2())
     assert_allclose(c2.ra.degree, 1)
     assert_allclose(c2.dec.degree, 4)
 
@@ -84,7 +84,7 @@ def test_transform_decos():
                 [0, 1, 0],
                 [0, 0, 1]]
 
-    c4 = c3.transform_to(TCoo2)
+    c4 = c3.transform_to(TCoo2())
 
     assert_allclose(c4.cartesian.x, 2*u.pc)
     assert_allclose(c4.cartesian.y, 1*u.pc)
@@ -202,8 +202,8 @@ def test_obstime():
     fk4_50 = FK4(ra=1*u.deg, dec=2*u.deg, obstime=b1950)
     fk4_75 = FK4(ra=1*u.deg, dec=2*u.deg, obstime=j1975)
 
-    icrs_50 = fk4_50.transform_to(ICRS)
-    icrs_75 = fk4_75.transform_to(ICRS)
+    icrs_50 = fk4_50.transform_to(ICRS())
+    icrs_75 = fk4_75.transform_to(ICRS())
 
     # now check that the resulting coordinates are *different* - they should be,
     # because the obstime is different
@@ -292,7 +292,7 @@ def test_affine_transform_succeed(transfunc, rep):
     trans = t.AffineTransform(transfunc, TCoo1, TCoo2)
     trans.register(frame_transform_graph)
 
-    c2 = c.transform_to(TCoo2)
+    c2 = c.transform_to(TCoo2())
 
     assert quantity_allclose(c2.data.to_cartesian().xyz,
                              expected_pos.to_cartesian().xyz)
@@ -322,7 +322,7 @@ def test_affine_transform_fail(transfunc):
     trans.register(frame_transform_graph)
 
     with pytest.raises(ValueError):
-        c.transform_to(TCoo2)
+        c.transform_to(TCoo2())
 
     trans.unregister(frame_transform_graph)
 
@@ -345,7 +345,7 @@ def test_too_many_differentials():
     c = TCoo1(rep.without_differentials())
     c._data = c._data.with_differentials({'s': dif1, 's2': dif2})
     with pytest.raises(ValueError):
-        c.transform_to(TCoo2)
+        c.transform_to(TCoo2())
 
     trans.unregister(frame_transform_graph)
 
@@ -370,7 +370,7 @@ def test_unit_spherical_with_differentials(rep):
     # register and do the transformation and check against expected
     trans = t.AffineTransform(transfunc.just_matrix, TCoo1, TCoo2)
     trans.register(frame_transform_graph)
-    c2 = c.transform_to(TCoo2)
+    c2 = c.transform_to(TCoo2())
 
     assert 's' in rep.differentials
     assert isinstance(c2.data.differentials['s'],
@@ -386,7 +386,7 @@ def test_unit_spherical_with_differentials(rep):
     trans.register(frame_transform_graph)
 
     with pytest.raises(TypeError):
-        c.transform_to(TCoo2)
+        c.transform_to(TCoo2())
 
     trans.unregister(frame_transform_graph)
 
@@ -431,7 +431,7 @@ def test_function_transform_with_differentials():
                pm_dec=1*u.marcsec/u.yr,)
 
     with pytest.warns(AstropyWarning, match=r'.*they have been dropped.*') as w:
-        t3.transform_to(TCoo2)
+        t3.transform_to(TCoo2())
     assert len(w) == 1
 
 
@@ -492,9 +492,9 @@ def test_static_matrix_combine_paths():
     t4.register(frame_transform_graph)
 
     c = Galactic(123*u.deg, 45*u.deg)
-    c1 = c.transform_to(BFrame)  # direct
-    c2 = c.transform_to(AFrame).transform_to(BFrame)  # thru A
-    c3 = c.transform_to(ICRS).transform_to(BFrame)  # thru ICRS
+    c1 = c.transform_to(BFrame())  # direct
+    c2 = c.transform_to(AFrame()).transform_to(BFrame())  # thru A
+    c3 = c.transform_to(ICRS()).transform_to(BFrame())  # thru ICRS
 
     assert quantity_allclose(c1.lon, c2.lon)
     assert quantity_allclose(c1.lat, c2.lat)

--- a/astropy/coordinates/tests/test_unit_representation.py
+++ b/astropy/coordinates/tests/test_unit_representation.py
@@ -75,7 +75,7 @@ def test_unit_representation_subclass():
     assert isinstance(f._data, UnitSphericalWrap180Representation)
     assert isinstance(f.ra, Longitude180)
 
-    g = f.transform_to(astropy.coordinates.ICRS)
+    g = f.transform_to(astropy.coordinates.ICRS())
     assert isinstance(g, astropy.coordinates.ICRS)
     assert isinstance(g._data, UnitSphericalWrap180Representation)
 

--- a/docs/coordinates/frames.rst
+++ b/docs/coordinates/frames.rst
@@ -288,12 +288,12 @@ Transforming between Frames
 
 To transform a frame object with data into another frame, use the
 ``transform_to`` method of an object, and provide it the frame you wish to
-transform to. This frame can either be a frame *class*, in which case
-the default attributes will be used, or a frame object (with or without
-data)::
+transform to.  This frame should be a frame object (with or without coordinate
+data).  If you wish to use all default frame attributes, you can instantiate
+the frame class with no arguments (i.e., empty parentheses)::
 
     >>> cooi = ICRS(1.5*u.deg, 2.5*u.deg)
-    >>> cooi.transform_to(FK5)  # doctest: +FLOAT_CMP
+    >>> cooi.transform_to(FK5())  # doctest: +FLOAT_CMP
     <FK5 Coordinate (equinox=J2000.000): (ra, dec) in deg
         (1.50000661, 2.50000238)>
     >>> cooi.transform_to(FK5(equinox='J1975'))  # doctest: +FLOAT_CMP

--- a/docs/coordinates/velocities.rst
+++ b/docs/coordinates/velocities.rst
@@ -282,7 +282,7 @@ To transform a coordinate frame that contains velocity data::
     >>> from astropy.coordinates import Galactic
     >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
     ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr)  # doctest: +FLOAT_CMP
-    >>> icrs.transform_to(Galactic) # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(Galactic()) # doctest: +FLOAT_CMP
     <Galactic Coordinate: (l, b) in deg
         (120.38084191, -9.69872044)
      (pm_l_cosb, pm_b) in mas / yr
@@ -328,7 +328,7 @@ To perform a matrix-only transformation::
     >>> icrs = ICRS(ra=8.67*u.degree, dec=53.09*u.degree,
     ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
     ...             radial_velocity=23.42*u.km/u.s)
-    >>> icrs.transform_to(Galactic)  # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(Galactic())  # doctest: +FLOAT_CMP
     <Galactic Coordinate: (l, b) in deg
         (120.38084191, -9.69872044)
      (pm_l_cosb, pm_b, radial_velocity) in (mas / yr, mas / yr, km / s)
@@ -344,7 +344,7 @@ for example, `~astropy.coordinates.ICRS` to `~astropy.coordinates.LSR`::
     ...             distance=117*u.pc,
     ...             pm_ra_cosdec=4.8*u.mas/u.yr, pm_dec=-15.16*u.mas/u.yr,
     ...             radial_velocity=23.42*u.km/u.s)
-    >>> icrs.transform_to(LSR)  # doctest: +FLOAT_CMP
+    >>> icrs.transform_to(LSR())  # doctest: +FLOAT_CMP
     <LSR Coordinate (v_bary=(11.1, 12.24, 7.25) km / s): (ra, dec, distance) in (deg, deg, pc)
         (8.67, 53.09, 117.)
      (pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)

--- a/examples/coordinates/plot_galactocentric-frame.py
+++ b/examples/coordinates/plot_galactocentric-frame.py
@@ -50,11 +50,12 @@ import astropy.units as u
 # We'll use the data for the star HD 39881 from the `Simbad
 # <simbad.harvard.edu/simbad/>`_ database:
 
-c1 = coord.ICRS(ra=89.014303*u.degree, dec=13.924912*u.degree,
-                distance=(37.59*u.mas).to(u.pc, u.parallax()),
-                pm_ra_cosdec=372.72*u.mas/u.yr,
-                pm_dec=-483.69*u.mas/u.yr,
-                radial_velocity=0.37*u.km/u.s)
+c1 = coord.SkyCoord(ra=89.014303*u.degree, dec=13.924912*u.degree,
+                    distance=(37.59*u.mas).to(u.pc, u.parallax()),
+                    pm_ra_cosdec=372.72*u.mas/u.yr,
+                    pm_dec=-483.69*u.mas/u.yr,
+                    radial_velocity=0.37*u.km/u.s,
+                    frame='icrs')
 
 ##############################################################################
 # This is a high proper-motion star; suppose we'd like to transform its position
@@ -142,7 +143,7 @@ ring_dif = coord.CylindricalDifferential(
 )
 
 ring_rep = ring_rep.with_differentials(ring_dif)
-gc_rings = coord.Galactocentric(ring_rep)
+gc_rings = coord.SkyCoord(ring_rep, frame=coord.Galactocentric)
 
 ##############################################################################
 # First, let's visualize the geometry in Galactocentric coordinates. Here are
@@ -172,6 +173,8 @@ axes[1].set_ylabel('$v_y$ [{0}]'.format((u.km/u.s).to_string("latex_inline")))
 
 fig.tight_layout()
 
+plt.show()
+
 ##############################################################################
 # Now we can transform to Galactic coordinates and visualize the rings in
 # observable coordinates:
@@ -188,3 +191,5 @@ ax.set_xlabel('$l$ [deg]')
 ax.set_ylabel(r'$\mu_l \, \cos b$ [{0}]'.format((u.mas/u.yr).to_string('latex_inline')))
 
 ax.legend()
+
+plt.show()

--- a/examples/coordinates/plot_sgr-coordinate-frame.py
+++ b/examples/coordinates/plot_sgr-coordinate-frame.py
@@ -168,7 +168,7 @@ def sgr_to_galactic():
 # transform to `~astropy.coordinates.Galactic`). For example, to transform from
 # ICRS coordinates to ``Sagittarius``, we would do:
 
-icrs = coord.ICRS(280.161732*u.degree, 11.91934*u.degree)
+icrs = coord.SkyCoord(280.161732*u.degree, 11.91934*u.degree, frame='icrs')
 sgr = icrs.transform_to(Sagittarius)
 print(sgr)
 
@@ -176,8 +176,8 @@ print(sgr)
 # Or, to transform from the ``Sagittarius`` frame to ICRS coordinates (in this
 # case, a line along the ``Sagittarius`` x-y plane):
 
-sgr = Sagittarius(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
-                  Beta=np.zeros(128)*u.radian)
+sgr = coord.SkyCoord(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
+                     Beta=np.zeros(128)*u.radian, frame='sagittarius')
 icrs = sgr.transform_to(coord.ICRS)
 print(icrs)
 
@@ -203,10 +203,11 @@ plt.show()
 # transformation of velocity components is therefore natively supported as
 # well:
 
-sgr = Sagittarius(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
-                  Beta=np.zeros(128)*u.radian,
-                  pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128)*u.mas/u.yr,
-                  pm_Beta=np.zeros(128)*u.mas/u.yr)
+sgr = coord.SkyCoord(Lambda=np.linspace(0, 2*np.pi, 128)*u.radian,
+                     Beta=np.zeros(128)*u.radian,
+                     pm_Lambda_cosBeta=np.random.uniform(-5, 5, 128)*u.mas/u.yr,
+                     pm_Beta=np.zeros(128)*u.mas/u.yr,
+                     frame='sagittarius')
 icrs = sgr.transform_to(coord.ICRS)
 print(icrs)
 

--- a/examples/coordinates/rv-to-gsr.py
+++ b/examples/coordinates/rv-to-gsr.py
@@ -36,8 +36,8 @@ coord.galactocentric_frame_defaults.set('latest')
 # For this example, let's work with the coordinates and barycentric radial
 # velocity of the star HD 155967, as obtained from
 # `Simbad <http://simbad.harvard.edu/simbad/>`_:
-icrs = coord.ICRS(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
-                  radial_velocity=-16.1*u.km/u.s)
+icrs = coord.SkyCoord(ra=258.58356362*u.deg, dec=14.55255619*u.deg,
+                      radial_velocity=-16.1*u.km/u.s, frame='icrs')
 
 ################################################################################
 # We next need to decide on the velocity of the Sun in the assumed GSR frame.


### PR DESCRIPTION
The coordinates transformation framework is currently a bit confusing/inconsistent because users can work with either `SkyCoord` instances or frame instances with data.  Frame instances with data behave differently from `SkyCoord` because they lack the ability to merge frame attributes across a transformation path.  This is particularly confusing when transforming a frame instance with data to a frame *class*, because the behavior is significantly different from the seemingly analogous call when using `SkyCoord`.  See the discussion in #10453.

This PR makes the following changes:

1. Modify `CoordinateAttribute` so that it always uses `SkyCoord` for the internal transformation (with the default setting of `merge_attributes=True`).
2. Revise any documentation examples that instantiate frames directly with data to instead use `SkyCoord`, unless there is some strong reason to avoid using `SkyCoord`.
3. Deprecate being able to pass a class to `BaseCoordinateFrame.transform_to()`, and point users to `SkyCoord`.

To do:
- [x] Add tests for the new behavior of `CoordinateAttribute`
- [x] Find all of the examples of non-use of `SkyCoord`
- [x] Add changelog entries