### PR TITLE
Raise TypeError when scalar column added to empty table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1230,6 +1230,11 @@ astropy.table
 
 - Avoid crash when reading a FITS table that contains mixin info and PyYAML
   is missing. [#10485]
+- Raise a TypeError when a scalar column is added to an unsized table. [#3811]
+
+
+astropy.tests
+^^^^^^^^^^^^^
 
 astropy.time
 ^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ astropy.cosmology
 ^^^^^^^^^^^^^^^^^
 
 - The final version of the Planck 2018 cosmological parameters are included
-  as the ``Planck18`` object, which is now the default cosmology.  The 
+  as the ``Planck18`` object, which is now the default cosmology.  The
   parameters are identical to those of the ``Planck18_arXiv_v2`` object,
   which is now deprecated and will be removed in a future release. [#10915]
 
@@ -278,6 +278,9 @@ astropy.table
   as ``Time``, ``TimeDelta``, ``SkyCoord`` or ``Quantity``, the ``info``
   attribute is no longer copied. This improves performance, especially when the
   object is an indexed column in a ``Table``. [#10889]
+
+- Raise a TypeError when a scalar column is added to an unsized table. [#10476]
+
 
 astropy.tests
 ^^^^^^^^^^^^^
@@ -1230,9 +1233,7 @@ astropy.table
 
 - Avoid crash when reading a FITS table that contains mixin info and PyYAML
   is missing. [#10485]
-- Raise a TypeError when a scalar column is added to an unsized table. [#3811]
 
-- Raise a TypeError when a scalar column is added to an unsized table. [#10476]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1232,6 +1232,7 @@ astropy.table
   is missing. [#10485]
 - Raise a TypeError when a scalar column is added to an unsized table. [#3811]
 
+- Raise a TypeError when a scalar column is added to an unsized table. [#10476]
 
 astropy.tests
 ^^^^^^^^^^^^^

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1957,7 +1957,6 @@ class Table:
                 col = col._apply(np.broadcast_to, shape=new_shape,
                                  subok=True)
 
-
             # broadcast_to() results in a read-only array.  Apparently it only changes
             # the view to look like the broadcasted array.  So copy.
             col = col_copy(col)

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1945,7 +1945,7 @@ class Table:
         # Assigning a scalar column to an empty table should result in an
         # exception (see #3811).
         if col.shape == () and len(self) == 0:
-            raise TypeError("Empty table cannot have column set to scalar value.")
+            raise TypeError('Empty table cannot have column set to scalar value')
         # Make col data shape correct for scalars.  The second test is to allow
         # broadcasting an N-d element to a column, e.g. t['new'] = [[1, 2]].
         elif (col.shape == () or col.shape[0] == 1) and len(self) > 0:

--- a/astropy/table/table.py
+++ b/astropy/table/table.py
@@ -1942,9 +1942,13 @@ class Table:
         col = self._convert_data_to_col(col, name=name, copy=copy,
                                         default_name=default_name)
 
+        # Assigning a scalar column to an empty table should result in an
+        # exception (see #3811).
+        if col.shape == () and len(self) == 0:
+            raise TypeError("Empty table cannot have column set to scalar value.")
         # Make col data shape correct for scalars.  The second test is to allow
         # broadcasting an N-d element to a column, e.g. t['new'] = [[1, 2]].
-        if (col.shape == () or col.shape[0] == 1) and len(self) > 0:
+        elif (col.shape == () or col.shape[0] == 1) and len(self) > 0:
             new_shape = (len(self),) + getattr(col, 'shape', ())[1:]
             if isinstance(col, np.ndarray):
                 col = np.broadcast_to(col, shape=new_shape,
@@ -1952,6 +1956,7 @@ class Table:
             elif isinstance(col, ShapedLikeNDArray):
                 col = col._apply(np.broadcast_to, shape=new_shape,
                                  subok=True)
+
 
             # broadcast_to() results in a read-only array.  Apparently it only changes
             # the view to look like the broadcasted array.  So copy.

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -250,6 +250,14 @@ class TestEmptyData():
         t.add_column(table_types.Column(name='a'))  # dtype is not specified
         assert len(t['a']) == 0
 
+    def test_scalar(self, table_types):
+        """Test related to #3811 where setting empty tables to scalar values
+        should raise an error instead of having an error raised when accessing
+        the table."""
+        t = table_types.Table()
+        with pytest.raises(TypeError):
+            t.add_column(0)
+
     def test_add_via_setitem_and_slice(self, table_types):
         """Test related to #3023 where a MaskedColumn is created with name=None
         and then gets changed to name='a'.  After PR #2790 this test fails

--- a/astropy/table/tests/test_table.py
+++ b/astropy/table/tests/test_table.py
@@ -255,7 +255,7 @@ class TestEmptyData():
         should raise an error instead of having an error raised when accessing
         the table."""
         t = table_types.Table()
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match='Empty table cannot have column set to scalar value'):
             t.add_column(0)
 
     def test_add_via_setitem_and_slice(self, table_types):


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the uninformative error message when a column in an empty table is assigned to a scalar. Now assigning a column in an empty table to a scalar will result in an TypeError at assignment with a relevant error message, rather than a TypeError on access with a more opaque error message.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #3811
