### PR TITLE
TST: Fix Sphinx warning for test runner

### DIFF
--- a/astropy/tests/runner.py
+++ b/astropy/tests/runner.py
@@ -56,12 +56,12 @@ class TestRunnerBase:
 
     A test runner can be constructed by creating a subclass of this class and
     defining 'keyword' methods. These are methods that have the
-    `~astropy.tests.runner.keyword` decorator, these methods are used to
+    :class:`~astropy.tests.runner.keyword` decorator, these methods are used to
     construct allowed keyword arguments to the
-    `~astropy.tests.runner.TestRunnerBase.run_tests` method as a way to allow
+    ``run_tests`` method as a way to allow
     customization of individual keyword arguments (and associated logic)
     without having to re-implement the whole
-    `~astropy.tests.runner.TestRunnerBase.run_tests` method.
+    ``run_tests`` method.
 
     Examples
     --------
@@ -188,7 +188,6 @@ class TestRunnerBase:
                     cls._missing_dependancy_error.format(module=module))
 
     def run_tests(self, **kwargs):
-
         # The following option will include eggs inside a .eggs folder in
         # sys.path when running the tests. This is possible so that when
         # runnning python setup.py test, test dependencies installed via e.g.
@@ -252,7 +251,7 @@ class TestRunnerBase:
         """
         Constructs a `TestRunner` to run in the given path, and returns a
         ``test()`` function which takes the same arguments as
-        `TestRunner.run_tests`.
+        ``TestRunner.run_tests``.
 
         The returned ``test()`` function will be defined in the module this
         was called from.  This is used to implement the ``astropy.test()``

--- a/docs/testhelpers.rst
+++ b/docs/testhelpers.rst
@@ -42,7 +42,7 @@ by the `astropy.tests.runner.TestRunner` class.
 The `~astropy.tests.runner.TestRunner` class is used to generate the
 `astropy.test` function, the test function generates a set of command line
 arguments to pytest. The arguments to pytest are defined in the
-`~astropy.tests.runner.TestRunner.run_tests` method, the arguments to
+``run_tests`` method, the arguments to
 ``run_tests`` and their respective logic are defined in methods of
 `~astropy.tests.runner.TestRunner` decorated with the
 `~astropy.tests.runner.keyword` decorator. For an example of this see
@@ -56,5 +56,9 @@ Reference/API
 
 .. module:: astropy.tests.runner
 
-.. automodapi:: astropy.tests.runner
-    :no-main-docstr:
+.. autoclass:: astropy.tests.runner.keyword
+    :no-undoc-members:
+
+.. autoclass:: astropy.tests.runner.TestRunnerBase
+
+.. autoclass:: astropy.tests.runner.TestRunner


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address Sphinx warning that started showing up when generating `automodapi` for `astropy.tests.runner`.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10473
