### PR TITLE
TST: Pin Sphinx so linkcheck works in cron job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,10 @@ deps =
     devdeps,mpldev: git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib
     devdeps: git+https://github.com/spacetelescope/asdf.git#egg=asdf
 
+    # Linkcheck is broken with cryptic error with Sphinx 3.1.0
+    # https://github.com/astropy/astropy/issues/10489
+    linkcheck: sphinx<3.1
+
 # The following indicates which extras_require from setup.cfg will be installed
 extras =
     test


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address linkcheck failing with cryptic message when using Sphinx 3.1.0. It is part of a cron job and is only used to sniff out broken links (that we don't ignore), so it doesn't really matter if we use older Sphinx version.

Don't really want to waste time trying to make it work with Sphinx 3.1.0 right now. If it turns out to be a upstream bug after all, we're just wasting time. Can revisit in the future if needed.

Need someone to check the `tox` syntax.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10489
