### PR TITLE
Fix regression for np.diff(time) and np.sum(timedelta) no longer working

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,7 @@ astropy.time
   epoch time). [#10406]
 
 - Numpy functions that broadcast, change shape, or index (like ``np.broadcast_to``,
-  ``np.rot90``, or ``np.roll``) now work on times. [#10337]
+  ``np.rot90``, or ``np.roll``) now work on times. [#10337, #10502]
 
 astropy.timeseries
 ^^^^^^^^^^^^^^^^^^

--- a/astropy/time/tests/test_functions.py
+++ b/astropy/time/tests/test_functions.py
@@ -1,0 +1,45 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+import pytest
+import numpy as np
+
+from astropy.time import Time, TimeDelta
+
+
+class TestFunctionsTime:
+
+    def setup_class(cls):
+        cls.t = Time(50000, np.arange(8).reshape(4, 2), format='mjd',
+                     scale='tai')
+
+    def check(self, func, cls=None, scale=None, format=None, *args, **kwargs):
+        if cls is None:
+            cls = self.t.__class__
+        if scale is None:
+            scale = self.t.scale
+        if format is None:
+            format = self.t.format
+        out = func(self.t, *args, **kwargs)
+        jd1 = func(self.t.jd1, *args, **kwargs)
+        jd2 = func(self.t.jd2, *args, **kwargs)
+        expected = cls(jd1, jd2, format=format, scale=scale)
+        if isinstance(out, np.ndarray):
+            expected = np.array(expected)
+
+        assert np.all(out == expected)
+
+    @pytest.mark.parametrize('axis', (0, 1))
+    def test_diff(self, axis):
+        self.check(np.diff, axis=axis, cls=TimeDelta, format='jd')
+
+
+class TestFunctionsTimeDelta(TestFunctionsTime):
+
+    def setup_class(cls):
+        cls.t = TimeDelta(np.arange(8).reshape(4, 2), format='jd',
+                          scale='tai')
+
+    @pytest.mark.parametrize('axis', (0, 1, None))
+    @pytest.mark.parametrize('func', (np.sum, np.mean, np.median))
+    def test_sum_like(self, func, axis):
+        self.check(func, axis=axis)

--- a/astropy/utils/shapes.py
+++ b/astropy/utils/shapes.py
@@ -211,21 +211,16 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
         np.roll, np.delete,
         }
 
-    # Functions that for now should just pass through since they
-    # (sort of) work.  TODO: create a proper implementation.
-    _PASSTHROUGH_FUNCTIONS = {
-        np.where, np.compress, np.extract,
-        }
-
     # Could be made to work with a bit of effort:
     # np.where, np.compress, np.extract,
     # np.diag_indices_from, np.triu_indices_from, np.tril_indices_from
     # np.tile, np.repeat (need .repeat method)
-
+    # TODO: create a proper implementation.
+    # Furthermore, some arithmetic functions such as np.mean, np.median,
+    # could work for Time, and many more for TimeDelta, so those should
+    # override __array_function__.
     def __array_function__(self, function, types, args, kwargs):
         """Wrap numpy functions that make sense."""
-        if function in self._PASSTHROUGH_FUNCTIONS:
-            return function.__wrapped__(*args, **kwargs)
         if function in self._APPLICABLE_FUNCTIONS:
             if function is np.broadcast_to:
                 # Ensure that any ndarray subclasses used are
@@ -251,7 +246,9 @@ class ShapedLikeNDArray(metaclass=abc.ABCMeta):
             if method is not None:
                 return method(*args[1:], **kwargs)
 
-        return NotImplemented
+        # Fall-back, just pass the arguments on since perhaps the function
+        # works already (see above).
+        return function.__wrapped__(*args, **kwargs)
 
 
 class IncompatibleShapeError(ValueError):


### PR DESCRIPTION
In #10337, an `__array_function__` override was introduced, which allows some numpy functions to behave as expected on `SkyCoord` and `Time`. It was a strict whitelist, however, which breaks numpy functions that sort-of worked already (sort-of, since often an object array was returned).

This PR returns to the old behaviour by passing on arguments to bare numpy function if it is not among the known functions.

fixes #10501 

@taldcroft - I must admit I had no idea that `np.diff(time)` and `np.sum(timedelta)` even worked (if *very* slowly). Obviously, the final goal should be to support those properly, but this PR is just to fix the regression caused by #10337.
