### PR TITLE
Replace use of deprecated numpy aliases for python int, float, bool.

### DIFF
--- a/astropy/coordinates/tests/test_matching.py
+++ b/astropy/coordinates/tests/test_matching.py
@@ -187,12 +187,12 @@ def test_search_around():
     coo1 = ICRS([4.1, 2.1]*u.degree, [0, 0]*u.degree, distance=[1, 5] * u.kpc)
     idx1, idx2, d2d, d3d = search_around_sky(coo1, coo2, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(coo1, coo2, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
 
@@ -200,33 +200,33 @@ def test_search_around():
     empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
     idx1, idx2, d2d, d3d = search_around_sky(empty, coo2, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_sky(coo1, empty, 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     empty = ICRS(ra=[] * u.degree, dec=[] * u.degree, distance=[] * u.kpc)
     idx1, idx2, d2d, d3d = search_around_sky(empty, empty[:], 1*u.arcsec)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(empty, coo2, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(coo1, empty, 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
     idx1, idx2, d2d, d3d = search_around_3d(empty, empty[:], 1*u.m)
     assert idx1.size == idx2.size == d2d.size == d3d.size == 0
-    assert idx1.dtype == idx2.dtype == np.int
+    assert idx1.dtype == idx2.dtype == int
     assert d2d.unit == u.deg
     assert d3d.unit == u.kpc
 

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -902,9 +902,9 @@ def convert_numpy(numpy_type):
     ----------
     numpy_type : numpy data-type
         The numpy type required of an array returned by ``converter``. Must be a
-        valid `numpy type <https://docs.scipy.org/doc/numpy/user/basics.types.html>`_,
-        e.g. int, numpy.uint, numpy.int8, numpy.int64, numpy.float,
-        numpy.float64, numpy.str.
+        valid `numpy type <https://docs.scipy.org/doc/numpy/user/basics.types.html>`_
+        (e.g., numpy.uint, numpy.int8, numpy.int64, numpy.float64) or a python
+        type covered by a numpy type (e.g., int, float, str, bool).
 
     Returns
     -------

--- a/astropy/io/ascii/core.py
+++ b/astropy/io/ascii/core.py
@@ -846,7 +846,7 @@ class BaseData:
         """Replace string values in col.str_vals and set masks"""
         if self.fill_values:
             for col in (col for col in cols if col.fill_values):
-                col.mask = numpy.zeros(len(col.str_vals), dtype=numpy.bool)
+                col.mask = numpy.zeros(len(col.str_vals), dtype=bool)
                 for i, str_val in ((i, x) for i, x in enumerate(col.str_vals)
                                    if x in col.fill_values):
                     col.str_vals[i] = col.fill_values[str_val]
@@ -903,7 +903,7 @@ def convert_numpy(numpy_type):
     numpy_type : numpy data-type
         The numpy type required of an array returned by ``converter``. Must be a
         valid `numpy type <https://docs.scipy.org/doc/numpy/user/basics.types.html>`_,
-        e.g. numpy.int, numpy.uint, numpy.int8, numpy.int64, numpy.float,
+        e.g. int, numpy.uint, numpy.int8, numpy.int64, numpy.float,
         numpy.float64, numpy.str.
 
     Returns
@@ -1056,9 +1056,9 @@ class TableOutputter(BaseOutputter):
     Output the table as an astropy.table.Table object.
     """
 
-    default_converters = [convert_numpy(numpy.int),
-                          convert_numpy(numpy.float),
-                          convert_numpy(numpy.str)]
+    default_converters = [convert_numpy(int),
+                          convert_numpy(float),
+                          convert_numpy(str)]
 
     def __call__(self, cols, meta):
         # Sets col.data to numpy array and col.type to io.ascii Type class (e.g.

--- a/astropy/io/ascii/cparser.pyx
+++ b/astropy/io/ascii/cparser.pyx
@@ -802,7 +802,7 @@ cdef class CParser:
                 max_len = field_len
             row += 1
 
-        cdef np.ndarray col = np.array(fields_list, dtype=(np.str, max_len))
+        cdef np.ndarray col = np.array(fields_list, dtype=(str, max_len))
 
         if mask:
             return ma.masked_array(col, mask=[1 if i in mask else 0 for i in

--- a/astropy/io/ascii/html.py
+++ b/astropy/io/ascii/html.py
@@ -147,10 +147,9 @@ class HTMLOutputter(core.TableOutputter):
     of <th>).
     """
 
-    default_converters = [core.convert_numpy(numpy.int),
-                          core.convert_numpy(numpy.float),
-                          core.convert_numpy(numpy.str),
-                          core.convert_numpy(numpy.unicode)]
+    default_converters = [core.convert_numpy(int),
+                          core.convert_numpy(float),
+                          core.convert_numpy(str)]
 
     def __call__(self, cols, meta):
         """

--- a/astropy/io/ascii/tests/test_read.py
+++ b/astropy/io/ascii/tests/test_read.py
@@ -1571,8 +1571,8 @@ def test_include_names_rdb_fast():
     lines[0] = 'a\ta_2\ta_1\ta_3\ta_4'
     dat = ascii.read(lines, fast_reader='force', include_names=['a', 'a_2', 'a_3'])
     assert len(dat) == 2
-    assert dat['a'].dtype == np.int
-    assert dat['a_2'].dtype == np.int
+    assert dat['a'].dtype == int
+    assert dat['a_2'].dtype == int
 
 
 @pytest.mark.parametrize('fast_reader', [False, 'force'])

--- a/astropy/io/fits/tests/test_compression_failures.py
+++ b/astropy/io/fits/tests/test_compression_failures.py
@@ -10,7 +10,7 @@ from . import FitsTestCase
 
 
 MAX_INT = np.iinfo(np.intc).max
-MAX_LONG = np.iinfo(np.long).max
+MAX_LONG = np.iinfo(int).max
 MAX_LONGLONG = np.iinfo(np.longlong).max
 
 

--- a/astropy/io/misc/tests/test_pandas.py
+++ b/astropy/io/misc/tests/test_pandas.py
@@ -38,7 +38,7 @@ def test_read_write_format(fmt):
     # Explicitly provide dtype to avoid casting 'a' to int32.
     # See https://github.com/astropy/astropy/issues/8682
     t = Table([[1, 2, 3], [1.0, 2.5, 5.0], ['a', 'b', 'c']],
-              dtype=(np.int64, np.float64, np.str))
+              dtype=(np.int64, np.float64, str))
     buf = StringIO()
     t.write(buf, format=pandas_fmt)
 

--- a/astropy/table/_np_utils.pyx
+++ b/astropy/table/_np_utils.pyx
@@ -12,7 +12,7 @@ from numpy.lib.recfunctions import drop_fields
 
 cimport cython
 cimport numpy as np
-DTYPE = np.int
+DTYPE = int
 ctypedef np.intp_t DTYPE_t
 
 @cython.wraparound(False)

--- a/astropy/table/tests/test_row.py
+++ b/astropy/table/tests/test_row.py
@@ -340,7 +340,7 @@ def test_uint_indexing():
     """
     t = table.Table([[1., 2., 3.]], names='a')
     assert t['a'][1] == 2.
-    assert t['a'][np.int(1)] == 2.
+    assert t['a'][np.int_(1)] == 2.
     assert t['a'][np.uint(1)] == 2.
     assert t[np.uint(1)]['a'] == 2.
 
@@ -351,5 +351,5 @@ def test_uint_indexing():
              '    2.0']
 
     assert repr(t[1]).splitlines() == trepr
-    assert repr(t[np.int(1)]).splitlines() == trepr
+    assert repr(t[np.int_(1)]).splitlines() == trepr
     assert repr(t[np.uint(1)]).splitlines() == trepr

--- a/astropy/wcs/tests/helper.py
+++ b/astropy/wcs/tests/helper.py
@@ -37,7 +37,7 @@ class SimModelTAB:
         mbad = (x < px[0]) | (y < py[0]) | (x > px[-1]) | (y > py[-1])
         mgood = np.logical_not(mbad)
 
-        i = 2 * (x > xb).astype(np.int)
+        i = 2 * (x > xb).astype(int)
 
         psix = self.crval[0] + self.cdelt[0] * (x - self.crpix[0])
         psiy = self.crval[1] + self.cdelt[1] * (y - self.crpix[1])

--- a/astropy/wcs/wcsapi/high_level_api.py
+++ b/astropy/wcs/wcsapi/high_level_api.py
@@ -39,7 +39,7 @@ def _toindex(value):
     >>> _toindex(np.array([1.5, 2.49999]))
     array([2, 2])
     """
-    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=np.int)
+    indx = np.asarray(np.floor(np.asarray(value) + 0.5), dtype=int)
     return indx
 
 

--- a/docs/known_issues.rst
+++ b/docs/known_issues.rst
@@ -209,7 +209,7 @@ supported in the basic Python command-line interpreter on Windows.
 ``numpy.int64`` does not decompose input ``Quantity`` objects
 -------------------------------------------------------------
 
-Python's ``int()`` (and therefore ``numpy.int``) goes through ``__index__``
+Python's ``int()`` goes through ``__index__``
 while ``numpy.int64`` or ``numpy.int_`` do not go through ``__index__``. This
 means that an upstream fix in ``numpy` is required in order for
 ``astropy.units`` to control decomposing the input in these functions::
@@ -218,8 +218,6 @@ means that an upstream fix in ``numpy` is required in order for
     1
     >>> np.int_((15 * u.km) / (15 * u.imperial.foot))
     1
-    >>> np.int((15 * u.km) / (15 * u.imperial.foot))
-    3280
     >>> int((15 * u.km) / (15 * u.imperial.foot))
     3280
 


### PR DESCRIPTION
I'm actually not sure why our `numpy-dev` builds using `NIGHTLY` are not picking this up -- is anaconda that far behind? -- but in my own packages, tests against `astropy-dev` and `numpy-dev` are now failing because of astropy. So, might as well fix it...

Note that this can be backported safely: `np.int` always was just an alias for `int`, and similarly for `float`, `bool`, `str` and `unicode`.

EDIT: failures now happening also with `NIGHTLY` - and I think I recall it is actually weekly, so that makes sense.