### PR TITLE
TST: Fix stats doctest failures due to upstream changes

### DIFF
--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -216,39 +216,40 @@ def binom_conf_interval(k, n, confidence_level=0.68269, interval='wilson'):
     --------
     Integer inputs return an array with shape (2,):
 
-    >>> binom_conf_interval(4, 5, interval='wilson')
+    >>> binom_conf_interval(4, 5, interval='wilson')  # doctest: +FLOAT_CMP
     array([0.57921724, 0.92078259])
 
     Arrays of arbitrary dimension are supported. The Wilson and Jeffreys
     intervals give similar results, even for small k, N:
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wilson')
+    >>> result = binom_conf_interval([0, 1, 2, 5], 5, interval='wilson')
+    >>> print(np.array_repr(result, precision=8, suppress_small=True))  # doctest: +FLOAT_CMP
     array([[0.        , 0.07921741, 0.21597328, 0.83333304],
            [0.16666696, 0.42078276, 0.61736012, 1.        ]])
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='jeffreys')
+    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='jeffreys')  # doctest: +FLOAT_CMP
     array([[0.        , 0.0842525 , 0.21789949, 0.82788246],
            [0.17211754, 0.42218001, 0.61753691, 1.        ]])
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='flat')
+    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='flat')  # doctest: +FLOAT_CMP
     array([[0.        , 0.12139799, 0.24309021, 0.73577037],
            [0.26422963, 0.45401727, 0.61535699, 1.        ]])
 
     In contrast, the Wald interval gives poor results for small k, N.
     For k = 0 or k = N, the interval always has zero length.
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald')
+    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald')  # doctest: +FLOAT_CMP
     array([[0.        , 0.02111437, 0.18091075, 1.        ],
            [0.        , 0.37888563, 0.61908925, 1.        ]])
 
     For confidence intervals approaching 1, the Wald interval for
     0 < k < N can give intervals that extend outside [0, 1]:
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald', confidence_level=0.99)
+    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald', confidence_level=0.99)  # doctest: +FLOAT_CMP
     array([[ 0.        , -0.26077835, -0.16433593,  1.        ],
            [ 0.        ,  0.66077835,  0.96433593,  1.        ]])
 
-    """
+    """  # noqa
     if confidence_level < 0. or confidence_level > 1.:
         raise ValueError('confidence_level must be between 0. and 1.')
     alpha = 1. - confidence_level
@@ -525,7 +526,6 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
         Confidence level between 0 and 1; only supported for the
         'kraft-burrows-nousek' mode.
 
-
     Returns
     -------
     conf_interval : numpy.ndarray
@@ -703,7 +703,7 @@ def poisson_conf_interval(n, interval='root-n', sigma=1, background=0,
     ...     interval='kraft-burrows-nousek').T  # doctest: +FLOAT_CMP
     array([[ 3.47894005, 16.113329533]])
 
-    """
+    """  # noqa
 
     if not np.isscalar(n):
         n = np.asanyarray(n)

--- a/astropy/stats/funcs.py
+++ b/astropy/stats/funcs.py
@@ -222,32 +222,31 @@ def binom_conf_interval(k, n, confidence_level=0.68269, interval='wilson'):
     Arrays of arbitrary dimension are supported. The Wilson and Jeffreys
     intervals give similar results, even for small k, N:
 
-    >>> result = binom_conf_interval([0, 1, 2, 5], 5, interval='wilson')
-    >>> print(np.array_repr(result, precision=8, suppress_small=True))  # doctest: +FLOAT_CMP
-    array([[0.        , 0.07921741, 0.21597328, 0.83333304],
-           [0.16666696, 0.42078276, 0.61736012, 1.        ]])
+    >>> binom_conf_interval([1, 2], 5, interval='wilson')  # doctest: +FLOAT_CMP
+    array([[0.07921741, 0.21597328],
+           [0.42078276, 0.61736012]])
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='jeffreys')  # doctest: +FLOAT_CMP
-    array([[0.        , 0.0842525 , 0.21789949, 0.82788246],
-           [0.17211754, 0.42218001, 0.61753691, 1.        ]])
+    >>> binom_conf_interval([1, 2,], 5, interval='jeffreys')  # doctest: +FLOAT_CMP
+    array([[0.0842525 , 0.21789949],
+           [0.42218001, 0.61753691]])
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='flat')  # doctest: +FLOAT_CMP
-    array([[0.        , 0.12139799, 0.24309021, 0.73577037],
-           [0.26422963, 0.45401727, 0.61535699, 1.        ]])
+    >>> binom_conf_interval([1, 2], 5, interval='flat')  # doctest: +FLOAT_CMP
+    array([[0.12139799, 0.24309021],
+           [0.45401727, 0.61535699]])
 
     In contrast, the Wald interval gives poor results for small k, N.
     For k = 0 or k = N, the interval always has zero length.
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald')  # doctest: +FLOAT_CMP
-    array([[0.        , 0.02111437, 0.18091075, 1.        ],
-           [0.        , 0.37888563, 0.61908925, 1.        ]])
+    >>> binom_conf_interval([1, 2], 5, interval='wald')  # doctest: +FLOAT_CMP
+    array([[0.02111437, 0.18091075],
+           [0.37888563, 0.61908925]])
 
     For confidence intervals approaching 1, the Wald interval for
     0 < k < N can give intervals that extend outside [0, 1]:
 
-    >>> binom_conf_interval([0, 1, 2, 5], 5, interval='wald', confidence_level=0.99)  # doctest: +FLOAT_CMP
-    array([[ 0.        , -0.26077835, -0.16433593,  1.        ],
-           [ 0.        ,  0.66077835,  0.96433593,  1.        ]])
+    >>> binom_conf_interval([1, 2], 5, interval='wald', confidence_level=0.99)  # doctest: +FLOAT_CMP
+    array([[-0.26077835, -0.16433593],
+           [ 0.66077835,  0.96433593]])
 
     """  # noqa
     if confidence_level < 0. or confidence_level > 1.:


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address `stats` doctest suddenly failing, possibly due to new ~numpy 1.19.0 release (not even on conda yet but already on PyPI)~ upstream changes. Could be numpy, scipy, pytest... not sure. I cannot reproduce the new results locally but I also don't have time to clone the env.

p.s. Not sure how these tests passed all these years without `FLOAT_CMP`.

Jobs in initial stage looking for
```
    array([[1.38777878e-17, 7.92174125e-02, 2.15973276e-01, 8.33333042e-01],
           [1.66666958e-01, 4.20782762e-01, 6.17360116e-01, 1.00000000e+00]])
```
while the job with older dependencies wants
```
    array([[0.        , 0.07921741, 0.21597328, 0.83333304],
           [0.16666696, 0.42078276, 0.61736012, 1.        ]])
```
even though the two sets of data pass `np.isclose()` check. 🤷 

UPDATE: Looks like the failure is a manifestation of astropy/pytest-doctestplus#92 .

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

🤞 