### PR TITLE
Removing hardcoded filepaths in tests.

### DIFF
--- a/astropy/io/ascii/tests/test_connect.py
+++ b/astropy/io/ascii/tests/test_connect.py
@@ -6,10 +6,10 @@ import pytest
 from astropy.table import Table, Column
 
 from astropy.table.table_helpers import simple_table
+from astropy.utils.data import get_pkg_data_filename
 
 import numpy as np
 
-ROOT = os.path.abspath(os.path.dirname(__file__))
 
 files = ['data/cds.dat', 'data/ipac.dat', 'data/daophot.dat', 'data/latex1.tex',
          'data/simple_csv.csv']
@@ -34,7 +34,7 @@ if HAS_BEAUTIFUL_SOUP:
 
 @pytest.mark.parametrize('filename', files)
 def test_read_generic(filename):
-    Table.read(os.path.join(ROOT, filename), format='ascii')
+    Table.read(get_pkg_data_filename(filename), format='ascii')
 
 
 def test_write_generic(tmpdir):
@@ -45,23 +45,23 @@ def test_write_generic(tmpdir):
 
 
 def test_read_ipac():
-    Table.read(os.path.join(ROOT, 'data/ipac.dat'), format='ipac')
+    Table.read(get_pkg_data_filename('data/ipac.dat'), format='ipac')
 
 
 def test_read_cds():
-    Table.read(os.path.join(ROOT, 'data/cds.dat'), format='cds')
+    Table.read(get_pkg_data_filename('data/cds.dat'), format='cds')
 
 
 def test_read_dapphot():
-    Table.read(os.path.join(ROOT, 'data/daophot.dat'), format='daophot')
+    Table.read(get_pkg_data_filename('data/daophot.dat'), format='daophot')
 
 
 def test_read_latex():
-    Table.read(os.path.join(ROOT, 'data/latex1.tex'), format='latex')
+    Table.read(get_pkg_data_filename('data/latex1.tex'), format='latex')
 
 
 def test_read_latex_noformat():
-    Table.read(os.path.join(ROOT, 'data/latex1.tex'))
+    Table.read(get_pkg_data_filename('data/latex1.tex'))
 
 
 def test_write_latex(tmpdir):
@@ -82,12 +82,12 @@ def test_write_latex_noformat(tmpdir):
 
 @pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
 def test_read_html():
-    Table.read(os.path.join(ROOT, 'data/html.html'), format='html')
+    Table.read(get_pkg_data_filename('data/html.html'), format='html')
 
 
 @pytest.mark.skipif('not HAS_BEAUTIFUL_SOUP')
 def test_read_html_noformat():
-    Table.read(os.path.join(ROOT, 'data/html.html'))
+    Table.read(get_pkg_data_filename('data/html.html'))
 
 
 def test_write_html(tmpdir):
@@ -107,11 +107,11 @@ def test_write_html_noformat(tmpdir):
 
 
 def test_read_rdb():
-    Table.read(os.path.join(ROOT, 'data/short.rdb'), format='rdb')
+    Table.read(get_pkg_data_filename('data/short.rdb'), format='rdb')
 
 
 def test_read_rdb_noformat():
-    Table.read(os.path.join(ROOT, 'data/short.rdb'))
+    Table.read(get_pkg_data_filename('data/short.rdb'))
 
 
 def test_write_rdb(tmpdir):
@@ -135,7 +135,7 @@ def test_read_csv():
 
     #3189
     '''
-    Table.read(os.path.join(ROOT, 'data/simple_csv.csv'))
+    Table.read(get_pkg_data_filename('data/simple_csv.csv'))
 
 
 def test_write_csv(tmpdir):

--- a/astropy/io/fits/tests/test_connect.py
+++ b/astropy/io/fits/tests/test_connect.py
@@ -19,6 +19,7 @@ from astropy import units as u
 from astropy.table import Table, QTable, NdarrayMixin, Column
 from astropy.table.table_helpers import simple_table
 from astropy.units.format.fits import UnitScaleError
+from astropy.utils.data import get_pkg_data_filename
 from astropy.utils.exceptions import (AstropyUserWarning,
                                       AstropyDeprecationWarning)
 
@@ -33,8 +34,6 @@ try:
     HAS_YAML = True
 except ImportError:
     HAS_YAML = False
-
-DATA = os.path.join(os.path.dirname(__file__), 'data')
 
 
 def equal_data(a, b):
@@ -458,7 +457,7 @@ def test_masking_regression_1795():
     Regression test for #1795 - this bug originally caused columns where TNULL
     was not defined to have their first element masked.
     """
-    t = Table.read(os.path.join(DATA, 'tb.fits'))
+    t = Table.read(get_pkg_data_filename('data/tb.fits'))
     assert np.all(t['c1'].mask == np.array([False, False]))
     assert np.all(t['c2'].mask == np.array([False, False]))
     assert np.all(t['c3'].mask == np.array([False, False]))
@@ -577,7 +576,7 @@ def test_convert_comment_convention(tmpdir):
     """
     Regression test for https://github.com/astropy/astropy/issues/6079
     """
-    filename = os.path.join(DATA, 'stddata.fits')
+    filename = get_pkg_data_filename('data/stddata.fits')
     with pytest.warns(AstropyUserWarning, match=r'hdu= was not specified but '
                       r'multiple tables are present'):
         t = Table.read(filename)

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -726,7 +726,7 @@ class TestHDUListFunctions(FitsTestCase):
                         np.testing.assert_array_equal(hdul[idx].data,
                                                       hdul2[idx].data)
 
-        for filename in get_pkg_data_filenames('data', pattern = '*.fits'):
+        for filename in get_pkg_data_filenames('data', pattern='*.fits'):
             if sys.platform == 'win32' and filename.endswith('zerowidth.fits'):
                 # Running this test on this file causes a crash in some
                 # versions of Numpy on Windows.  See ticket:

--- a/astropy/io/fits/tests/test_hdulist.py
+++ b/astropy/io/fits/tests/test_hdulist.py
@@ -13,6 +13,7 @@ import numpy as np
 from astropy.io.fits.verify import VerifyError, VerifyWarning
 from astropy.io import fits
 from astropy.utils.exceptions import AstropyUserWarning, AstropyDeprecationWarning
+from astropy.utils.data import get_pkg_data_filenames
 
 from . import FitsTestCase
 
@@ -725,8 +726,8 @@ class TestHDUListFunctions(FitsTestCase):
                         np.testing.assert_array_equal(hdul[idx].data,
                                                       hdul2[idx].data)
 
-        for filename in glob.glob(os.path.join(self.data_dir, '*.fits')):
-            if sys.platform == 'win32' and filename == 'zerowidth.fits':
+        for filename in get_pkg_data_filenames('data', pattern = '*.fits'):
+            if sys.platform == 'win32' and filename.endswith('zerowidth.fits'):
                 # Running this test on this file causes a crash in some
                 # versions of Numpy on Windows.  See ticket:
                 # https://aeon.stsci.edu/ssb/trac/pyfits/ticket/174

--- a/astropy/io/fits/tests/test_image.py
+++ b/astropy/io/fits/tests/test_image.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_equal
 from astropy.io import fits
 from astropy.io.fits.hdu.compressed import SUBTRACTIVE_DITHER_1, DITHER_SEED_CHECKSUM
 from astropy.utils.exceptions import AstropyUserWarning
+from astropy.utils.data import get_pkg_data_filename
 from .test_table import comparerecords
 
 from . import FitsTestCase
@@ -1855,8 +1856,7 @@ def test_bzero_implicit_casting_compressed():
     # case BZERO should be 32768. But if the keyword is stored as 32768.0, then
     # it was possible to trigger the implicit casting error.
 
-    filename = os.path.join(os.path.dirname(__file__),
-                            'data', 'compressed_float_bzero.fits')
+    filename = get_pkg_data_filename('data/compressed_float_bzero.fits')
 
     with fits.open(filename) as hdul:
         hdu = hdul[1]

--- a/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
+++ b/astropy/visualization/wcsaxes/tests/test_coordinate_helpers.py
@@ -7,12 +7,12 @@ import pytest
 import matplotlib.pyplot as plt
 from astropy.wcs import WCS
 from astropy.io import fits
+from astropy.utils.data import get_pkg_data_filename
 
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy import units as u
 
-ROOT = os.path.join(os.path.dirname(__file__))
-MSX_HEADER = fits.Header.fromtextfile(os.path.join(ROOT, 'data', 'msx_header'))
+MSX_HEADER = fits.Header.fromtextfile(get_pkg_data_filename('data/msx_header'))
 
 
 def teardown_function(function):

--- a/astropy/visualization/wcsaxes/tests/test_images.py
+++ b/astropy/visualization/wcsaxes/tests/test_images.py
@@ -25,21 +25,19 @@ class BaseImageTests:
     @classmethod
     def setup_class(cls):
 
-        cls._data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
-
-        msx_header = os.path.join(cls._data_dir, 'msx_header')
+        msx_header = get_pkg_data_filename('data/msx_header')
         cls.msx_header = fits.Header.fromtextfile(msx_header)
 
-        rosat_header = os.path.join(cls._data_dir, 'rosat_header')
+        rosat_header = get_pkg_data_filename('data/rosat_header')
         cls.rosat_header = fits.Header.fromtextfile(rosat_header)
 
-        twoMASS_k_header = os.path.join(cls._data_dir, '2MASS_k_header')
+        twoMASS_k_header = get_pkg_data_filename('data/2MASS_k_header')
         cls.twoMASS_k_header = fits.Header.fromtextfile(twoMASS_k_header)
 
-        cube_header = os.path.join(cls._data_dir, 'cube_header')
+        cube_header = get_pkg_data_filename('data/cube_header')
         cls.cube_header = fits.Header.fromtextfile(cube_header)
 
-        slice_header = os.path.join(cls._data_dir, 'slice_header')
+        slice_header = get_pkg_data_filename('data/slice_header')
         cls.slice_header = fits.Header.fromtextfile(slice_header)
 
     def teardown_method(self, method):

--- a/astropy/visualization/wcsaxes/tests/test_misc.py
+++ b/astropy/visualization/wcsaxes/tests/test_misc.py
@@ -15,6 +15,8 @@ from astropy.wcs import WCS
 from astropy.io import fits
 from astropy.coordinates import SkyCoord
 
+from astropy.utils.data import get_pkg_data_filename
+
 from astropy.visualization.wcsaxes.core import WCSAxes
 from astropy.visualization.wcsaxes.frame import (
     EllipticalFrame, RectangularFrame, RectangularFrame1D)
@@ -24,8 +26,6 @@ from astropy.visualization.wcsaxes.transforms import CurvedTransform
 mpl_version = Version(matplotlib.__version__)
 MATPLOTLIB_LT_31 = mpl_version < Version('3.1')
 TEX_UNAVAILABLE = not matplotlib.checkdep_usetex(True)
-
-DATA = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
 
 
 def teardown_function(function):
@@ -113,7 +113,7 @@ def test_invalid_frame_overlay(ignore_matplotlibrc):
 
 def test_plot_coord_transform(ignore_matplotlibrc):
 
-    twoMASS_k_header = os.path.join(DATA, '2MASS_k_header')
+    twoMASS_k_header = get_pkg_data_filename('data/2MASS_k_header')
     twoMASS_k_header = fits.Header.fromtextfile(twoMASS_k_header)
     fig = plt.figure(figsize=(6, 6))
     ax = fig.add_axes([0.15, 0.15, 0.8, 0.8],

--- a/astropy/visualization/wcsaxes/tests/test_wcsapi.py
+++ b/astropy/visualization/wcsaxes/tests/test_wcsapi.py
@@ -17,6 +17,7 @@ from astropy.coordinates import SkyCoord
 from astropy.time import Time
 from astropy.units import Quantity
 from astropy.tests.image_tests import IMAGE_REFERENCE_DIR
+from astropy.utils.data import get_pkg_data_filename
 from astropy.wcs import WCS
 from astropy.visualization.wcsaxes.frame import RectangularFrame, RectangularFrame1D
 from astropy.visualization.wcsaxes.wcsapi import (WCSWorld2PixelTransform,
@@ -77,8 +78,7 @@ def wcs_4d():
 
 @pytest.fixture
 def cube_wcs():
-    data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
-    cube_header = os.path.join(data_dir, 'cube_header')
+    cube_header = get_pkg_data_filename('data/cube_header')
     header = fits.Header.fromtextfile(cube_header)
     return WCS(header=header)
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request follows #10344 and is attempting to remove hardcoded filepaths in tests in situations where `get_pkg_data_filename` or `get_pkg_data_fileobj` can be better used instead.

One problem I'm having right now is with` FitsTestCase ` in  **/io/fits/tests/__init__.py**
It carries an attribute **data_dir** that uses a os.path() for the data path. I have removed this attribute in this PR but it's referenced elsewhere. Once on line 733 in **/fits/tests/test_hdulist.py**, here I believe I've written the correct equivalent without using _data_dir. 
And again in 
`def test_path(self, capsys)` in **/fits/tests/test_fitsdiff.py** , there I haven't figured out a correct equivalent. 
Do we think it's beneficial to remove this data_dir attribute?  

Overall, this is the work I've done so far, so feel free to tell me if there's something you want added/removed/changed. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #10344 
