### PR TITLE
Add copy=False option to Quantity.to

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,8 @@ astropy.uncertainty
 
 astropy.units
 ^^^^^^^^^^^^^
+- ``Quantity.to`` has gained a ``copy`` option to allow copies to be avoided
+  when the units do not change. [#10517]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/units/quantity.py
+++ b/astropy/units/quantity.py
@@ -660,7 +660,7 @@ class Quantity(np.ndarray):
         return self.unit.to(unit, self.view(np.ndarray),
                             equivalencies=equivalencies)
 
-    def to(self, unit, equivalencies=[]):
+    def to(self, unit, equivalencies=[], copy=True):
         """
         Return a new `~astropy.units.Quantity` object with the specified unit.
 
@@ -679,6 +679,10 @@ class Quantity(np.ndarray):
             If `None`, no equivalencies will be applied at all, not even any
             set globally or within a context.
 
+        copy : bool, optional
+            If `True` (default), then the value is copied.  Otherwise, a copy
+            will only be made if necessary.
+
         See also
         --------
         to_value : get the numerical value in a given unit.
@@ -686,7 +690,14 @@ class Quantity(np.ndarray):
         # We don't use `to_value` below since we always want to make a copy
         # and don't want to slow down this method (esp. the scalar case).
         unit = Unit(unit)
-        return self._new_view(self._to_value(unit, equivalencies), unit)
+        if copy:
+            # Avoid using to_value to ensure that we make a copy. We also
+            # don't want to slow down this method (esp. the scalar case).
+            value = self._to_value(unit, equivalencies)
+        else:
+            # to_value only copies if necessary
+            value = self.to_value(unit, equivalencies)
+        return self._new_view(value, unit)
 
     def to_value(self, unit=None, equivalencies=[]):
         """

--- a/astropy/units/tests/test_quantity.py
+++ b/astropy/units/tests/test_quantity.py
@@ -702,10 +702,13 @@ def test_quantity_value_views():
     v3 = q1.to_value('m')
     v3[0] = 1.
     assert np.all(q1 == [1., 3.] * u.meter)
+    q2 = q1.to('m', copy=False)
+    q2[0] = 2 * u.meter
+    assert np.all(q1 == [2., 3.] * u.meter)
     v4 = q1.to_value('cm')
     v4[0] = 0.
     # copy if different unit.
-    assert np.all(q1 == [1., 3.] * u.meter)
+    assert np.all(q1 == [2., 3.] * u.meter)
 
 
 def test_quantity_conversion_with_equiv():


### PR DESCRIPTION
### Description

This allows the cost of making a copy to be avoided when there is no
change in units.

Closes #10514.