### PR TITLE
DOC: Bump Python version on RTD build and fix failure

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ sphinx:
 # Install regular dependencies.
 # Then, install special pinning for RTD.
 python:
-  version: 3.6
+  version: 3.8
   install:
     - method: pip
       path: .

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -95,15 +95,15 @@ The first three (the distortion corrections) are done in parallel.
 
 Parameters
 ----------
-pixcrd : double array[ncoord][nelem]
-    Array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
 Returns
 -------
-world : double array[ncoord][nelem]
-    Returns an array of world coordinates.
+world : numpy.ndarray
+    Returns an array of world coordinates as ``double array[ncoord][nelem]``.
 
 Raises
 ------
@@ -824,7 +824,7 @@ coordinate : coordinate pair
 """
 
 get_cdelt = """
-get_cdelt() -> double array[naxis]
+get_cdelt() -> ``double array[naxis]``
 
 Coordinate increments (``CDELTia``) for each coord axis.
 
@@ -837,7 +837,7 @@ specified in the header.
 """
 
 get_pc = """
-get_pc() -> double array[naxis][naxis]
+get_pc() -> ``double array[naxis][naxis]``
 
 Returns the ``PC`` matrix in read-only form.  Unlike the
 `~astropy.wcs.Wcsprm.pc` property, this works even when the header
@@ -1128,15 +1128,15 @@ viter : int
     the search recommenced.  *viter* controls how many times the step
     size is halved.  The allowed range is 5 - 10.
 
-world : double array[naxis]
-    World coordinate elements.  ``world[self.lng]`` and
+world : numpy.ndarray
+    World coordinate elements as ``double array[naxis]``.  ``world[self.lng]`` and
     ``world[self.lat]`` are the celestial longitude and latitude, in
     degrees.  Which is given and which returned depends on the value
     of *mixcel*.  All other elements are given.  The results will be
     written to this array in-place.
 
-pixcrd : double array[naxis].
-    Pixel coordinates.  The element indicated by *mixpix* is given and
+pixcrd : numpy.ndarray
+    Pixel coordinates as ``double array[naxis]``.  The element indicated by *mixpix* is given and
     the remaining elements will be written in-place.
 
 {}
@@ -1147,20 +1147,20 @@ result : dict
 
     Returns a dictionary with the following keys:
 
-    - *phi* (double array[naxis])
+    - *phi* (``double array[naxis]``)
 
-    - *theta* (double array[naxis])
+    - *theta* (``double array[naxis]``)
 
         - Longitude and latitude in the native coordinate system of
           the projection, in degrees.
 
-    - *imgcrd* (double array[naxis])
+    - *imgcrd* (``double array[naxis]``)
 
         - Image coordinate elements.  ``imgcrd[self.lng]`` and
           ``imgcrd[self.lat]`` are the projected *x*- and
           *y*-coordinates, in decimal degrees.
 
-    - *world* (double array[naxis])
+    - *world* (``double array[naxis]``)
 
         - Another reference to the *world* argument passed in.
 
@@ -1318,8 +1318,8 @@ Converts pixel to world coordinates.
 Parameters
 ----------
 
-pixcrd : double array[ncoord][nelem]
-    Array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
@@ -1328,32 +1328,34 @@ Returns
 result : dict
     Returns a dictionary with the following keys:
 
-    - *imgcrd*: double array[ncoord][nelem]
+    - *imgcrd*: numpy.ndarray
 
-      - Array of intermediate world coordinates.  For celestial axes,
+      - Array of intermediate world coordinates as ``double array[ncoord][nelem]``.  For celestial axes,
         ``imgcrd[][self.lng]`` and ``imgcrd[][self.lat]`` are the
         projected *x*-, and *y*-coordinates, in pseudo degrees.  For
         spectral axes, ``imgcrd[][self.spec]`` is the intermediate
         spectral coordinate, in SI units.
 
-    - *phi*: double array[ncoord]
+    - *phi*: numpy.ndarray
 
-    - *theta*: double array[ncoord]
+      - Array as ``double array[ncoord]``.
+
+    - *theta*: numpy.ndarray
 
       - Longitude and latitude in the native coordinate system of the
-        projection, in degrees.
+        projection, in degrees, as ``double array[ncoord]``.
 
-    - *world*: double array[ncoord][nelem]
+    - *world*: numpy.ndarray
 
-      - Array of world coordinates.  For celestial axes,
+      - Array of world coordinates as ``double array[ncoord][nelem]``.  For celestial axes,
         ``world[][self.lng]`` and ``world[][self.lat]`` are the
         celestial longitude and latitude, in degrees.  For spectral
         axes, ``world[][self.spec]`` is the intermediate spectral
         coordinate, in SI units.
 
-    - *stat*: int array[ncoord]
+    - *stat*: numpy.ndarray
 
-      - Status return value for each coordinate. ``0`` for success,
+      - Status return value for each coordinate as ``int array[ncoord]``. ``0`` for success,
         ``1+`` for invalid pixel coordinate.
 
 Raises
@@ -1387,22 +1389,22 @@ astropy.wcs.Wcsprm.lat, astropy.wcs.Wcsprm.lng
 """.format(ORIGIN())
 
 p4_pix2foc = """
-p4_pix2foc(*pixcrd, origin*) -> double array[ncoord][nelem]
+p4_pix2foc(*pixcrd, origin*) -> ``double array[ncoord][nelem]``
 
 Convert pixel coordinates to focal plane coordinates using `distortion
 paper`_ lookup-table correction.
 
 Parameters
 ----------
-pixcrd : double array[ncoord][nelem].
-    Array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
 Returns
 -------
-foccrd : double array[ncoord][nelem]
-    Returns an array of focal plane coordinates.
+foccrd : numpy.ndarray
+    Returns an array of focal plane coordinates as ``double array[ncoord][nelem]``.
 
 Raises
 ------
@@ -1455,22 +1457,22 @@ astropy.wcs.Wcsprm.theta0
 """
 
 pix2foc = """
-pix2foc(*pixcrd, origin*) -> double array[ncoord][nelem]
+pix2foc(*pixcrd, origin*) -> ``double array[ncoord][nelem]``
 
 Perform both `SIP`_ polynomial and `distortion paper`_ lookup-table
 correction in parallel.
 
 Parameters
 ----------
-pixcrd : double array[ncoord][nelem]
-    Array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
 Returns
 -------
-foccrd : double array[ncoord][nelem]
-    Returns an array of focal plane coordinates.
+foccrd : numpy.ndarray
+    Returns an array of focal plane coordinates as ``double array[ncoord][nelem]``.
 
 Raises
 ------
@@ -1549,8 +1551,8 @@ Transforms world coordinates to pixel coordinates.
 
 Parameters
 ----------
-world : double array[ncoord][nelem]
-    Array of world coordinates, in decimal degrees.
+world : numpy.ndarray
+    Array of world coordinates, in decimal degrees, as ``double array[ncoord][nelem]``.
 
 {}
 
@@ -1559,14 +1561,14 @@ Returns
 result : dict
     Returns a dictionary with the following keys:
 
-    - *phi*: double array[ncoord]
+    - *phi*: ``double array[ncoord]``
 
-    - *theta*: double array[ncoord]
+    - *theta*: ``double array[ncoord]``
 
         - Longitude and latitude in the native coordinate system of
           the projection, in degrees.
 
-    - *imgcrd*: double array[ncoord][nelem]
+    - *imgcrd*: ``double array[ncoord][nelem]``
 
        - Array of intermediate world coordinates.  For celestial axes,
          ``imgcrd[][self.lng]`` and ``imgcrd[][self.lat]`` are the
@@ -1576,12 +1578,12 @@ result : dict
          spectral axes, ``imgcrd[][self.spec]`` is the intermediate
          spectral coordinate, in SI units.
 
-    - *pixcrd*: double array[ncoord][nelem]
+    - *pixcrd*: ``double array[ncoord][nelem]``
 
         - Array of pixel coordinates.  Pixel coordinates are
           zero-based.
 
-    - *stat*: int array[ncoord]
+    - *stat*: ``int array[ncoord]``
 
         - Status return value for each coordinate. ``0`` for success,
           ``1+`` for invalid pixel coordinate.
@@ -1742,24 +1744,24 @@ using the `SIP`_ convention in both directions.
 
 Parameters
 ----------
-a : double array[m+1][m+1]
-    The ``A_i_j`` polynomial for pixel to focal plane transformation.
+a : numpy.ndarray
+    The ``A_i_j`` polynomial for pixel to focal plane transformation as ``double array[m+1][m+1]``.
     Its size must be (*m* + 1, *m* + 1) where *m* = ``A_ORDER``.
 
-b : double array[m+1][m+1]
-    The ``B_i_j`` polynomial for pixel to focal plane transformation.
+b : numpy.ndarray
+    The ``B_i_j`` polynomial for pixel to focal plane transformation as ``double array[m+1][m+1]``.
     Its size must be (*m* + 1, *m* + 1) where *m* = ``B_ORDER``.
 
-ap : double array[m+1][m+1]
-    The ``AP_i_j`` polynomial for pixel to focal plane transformation.
+ap : numpy.ndarray
+    The ``AP_i_j`` polynomial for pixel to focal plane transformation as ``double array[m+1][m+1]``.
     Its size must be (*m* + 1, *m* + 1) where *m* = ``AP_ORDER``.
 
-bp : double array[m+1][m+1]
-    The ``BP_i_j`` polynomial for pixel to focal plane transformation.
+bp : numpy.ndarray
+    The ``BP_i_j`` polynomial for pixel to focal plane transformation as ``double array[m+1][m+1]``.
     Its size must be (*m* + 1, *m* + 1) where *m* = ``BP_ORDER``.
 
-crpix : double array[2]
-    The reference pixel.
+crpix : numpy.ndarray
+    The reference pixel as ``double array[2]``.
 
 Notes
 -----
@@ -1769,22 +1771,22 @@ Headers."  ADASS XIV.
 """
 
 sip_foc2pix = """
-sip_foc2pix(*foccrd, origin*) -> double array[ncoord][nelem]
+sip_foc2pix(*foccrd, origin*) -> ``double array[ncoord][nelem]``
 
 Convert focal plane coordinates to pixel coordinates using the `SIP`_
 polynomial distortion convention.
 
 Parameters
 ----------
-foccrd : double array[ncoord][nelem]
-    Array of focal plane coordinates.
+foccrd : numpy.ndarray
+    Array of focal plane coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
 Returns
 -------
-pixcrd : double array[ncoord][nelem]
-    Returns an array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Returns an array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 Raises
 ------
@@ -1796,22 +1798,22 @@ ValueError
 """.format(ORIGIN())
 
 sip_pix2foc = """
-sip_pix2foc(*pixcrd, origin*) -> double array[ncoord][nelem]
+sip_pix2foc(*pixcrd, origin*) -> ``double array[ncoord][nelem]``
 
 Convert pixel coordinates to focal plane coordinates using the `SIP`_
 polynomial distortion convention.
 
 Parameters
 ----------
-pixcrd : double array[ncoord][nelem]
-    Array of pixel coordinates.
+pixcrd : numpy.ndarray
+    Array of pixel coordinates as ``double array[ncoord][nelem]``.
 
 {}
 
 Returns
 -------
-foccrd : double array[ncoord][nelem]
-    Returns an array of focal plane coordinates.
+foccrd : numpy.ndarray
+    Returns an array of focal plane coordinates as ``double array[ncoord][nelem]``.
 
 Raises
 ------

--- a/astropy/wcs/docstrings.py
+++ b/astropy/wcs/docstrings.py
@@ -848,13 +848,13 @@ specified in the header.
 """
 
 get_ps = """
-get_ps() -> list of tuples
+get_ps() -> list of tuple
 
 Returns ``PSi_ma`` keywords for each *i* and *m*.
 
 Returns
 -------
-ps : list of tuples
+ps : list of tuple
 
     Returned as a list of tuples of the form (*i*, *m*, *value*):
 
@@ -870,7 +870,7 @@ astropy.wcs.Wcsprm.set_ps : Set ``PSi_ma`` values
 """
 
 get_pv = """
-get_pv() -> list of tuples
+get_pv() -> list of tuple
 
 Returns ``PVi_ma`` keywords for each *i* and *m*.
 
@@ -1715,7 +1715,7 @@ Sets ``PVi_ma`` keywords for each *i* and *m*.
 
 Parameters
 ----------
-pv : list of tuples
+pv : list of tuple
 
     The input must be a sequence of tuples of the form (*i*, *m*,
     *value*):

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ all =
     pytest
 docs =
     sphinx-astropy>=1.3
+    numpydoc<1.1.0
     pytest
     PyYAML>=3.12
     scipy


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

RTD complained about `astropy/table/table.py:docstring of astropy.table.TableColumns.keys::py:class reference target not found: a set-like object providing a view on D's keys` on `latest` build even though the PR merged reported successful RTD build. Hoping that bumping the Python version will fix the problem if it is due to some incompatibilities with older dependencies that cannot be upgraded because Python being used is too old.

UPDATE: I think the failure is real. I think we inherited something from Python that doesn't play well with Sphinx.

Looks like there is also `astropy/timeseries/__init__.py:docstring of astropy.timeseries.BoxLeastSquaresResults.clear::py:class reference target not found: None.  Remove all items from D.`.

UPDATE: Comparing the logs from last successful build and the failed build on `master` branch, I noticed the following:

* numpydoc 1.0.0 -> 1.1.0 (biggest suspect!) -- Let's pin until we get an answer from numpy/numpydoc#275
* pillow 7.1.2 -> 7.2.0
* sphinx-build removed -E option -- Don’t use a saved environment (the structure caching all cross-references), but rebuild it completely. The default is to only read and parse source files that are new or have changed since the last run.

UPDATE: Tried to pin using `docs/requirements.txt` and have it installed via `.readthedocs.yml` before editable install part but didn't work. A later download somehow upgraded it back to 1.1.0.

TODO:

- [ ] After this is merged, open a follow-up issue to unpin when numpy/numpydoc#275 is resolved.