### PR TITLE
Store sub-WCS created by sub() to get correct naxis estimate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -256,7 +256,6 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
-
 Other Changes and Additions
 ---------------------------
 
@@ -1046,6 +1045,8 @@ astropy.wcs
 
 - Do not issue ``DATREF`` warning when ``MJDREF`` has default value. [#10440]
 
+- Fixed a bug due to which ``naxis`` argument was ignored if ``header``
+  was supplied during the initialization of a WCS object. [#10532]
 
 Other Changes and Additions
 ---------------------------

--- a/astropy/wcs/tests/test_wcs.py
+++ b/astropy/wcs/tests/test_wcs.py
@@ -779,6 +779,16 @@ def test_sip():
     assert_allclose(200, y1, 1e-3)
 
 
+def test_sub_3d_with_sip():
+    # See #10527
+    header = get_pkg_data_contents('data/irac_sip.hdr', encoding='binary')
+    header = fits.Header.fromstring(header)
+    header['NAXIS'] = 3
+    header.set('NAXIS3', 64, after=header.index('NAXIS2'))
+    w = wcs.WCS(header, naxis=2)
+    assert w.naxis == 2
+
+
 def test_printwcs(capsys):
     """
     Just make sure that it runs

--- a/astropy/wcs/wcs.py
+++ b/astropy/wcs/wcs.py
@@ -437,6 +437,7 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                 raise AssertionError("'fobj' must be either None or an "
                                      "astropy.io.fits.HDUList object.")
 
+            est_naxis = 2
             try:
                 tmp_header = fits.Header.fromstring(header_string)
                 self._remove_sip_kw(tmp_header)
@@ -447,23 +448,19 @@ class WCS(FITSWCSAPIMixin, WCSBase):
                                          relax=relax, keysel=keysel_flags,
                                          colsel=colsel, warnings=False,
                                          hdulist=fobj)
-            except _wcs.NoWcsKeywordsFoundError:
-                est_naxis = 0
-            else:
                 if naxis is not None:
                     try:
-                        tmp_wcsprm.sub(naxis)
+                        tmp_wcsprm = tmp_wcsprm.sub(naxis)
                     except ValueError:
                         pass
-                    est_naxis = tmp_wcsprm.naxis
-                else:
-                    est_naxis = 2
+                    est_naxis = tmp_wcsprm.naxis if tmp_wcsprm.naxis else 2
+
+            except _wcs.NoWcsKeywordsFoundError:
+                pass
+
+            self.naxis = est_naxis
 
             header = fits.Header.fromstring(header_string)
-
-            if est_naxis == 0:
-                est_naxis = 2
-            self.naxis = est_naxis
 
             det2im = self._read_det2im_kw(header, fobj, err=minerr)
             cpdis = self._read_distortion_kw(


### PR DESCRIPTION
Fixes #10527

Symptoms: When user provides image header when creating a WCS object (this is the typical situation) and wants to limit the number of axes of the created WCS to a number smaller than indicated by `'NAXIS'` header keyword using `naxis` argument, this argument is effectively ignored. Also see #10527 

Diagnostic: `est_naxis` was computed using "old" WCS (pre-`sub`) because sub-WCS was not assigned to a variable.