### PR TITLE
Fix extension conf when using system libraries

### DIFF
--- a/astropy/io/fits/setup_package.py
+++ b/astropy/io/fits/setup_package.py
@@ -23,7 +23,8 @@ def _get_compression_extension():
 
     if (int(os.environ.get('ASTROPY_USE_SYSTEM_CFITSIO', 0)) or
             int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
-        cfg.update(pkg_config(['cfitsio'], ['cfitsio']))
+        for k, v in pkg_config(['cfitsio'], ['cfitsio']).items():
+            cfg[k].extend(v)
     else:
         if get_compiler() == 'msvc':
             # These come from the CFITSIO vcc makefile, except the last

--- a/astropy/utils/xml/setup_package.py
+++ b/astropy/utils/xml/setup_package.py
@@ -18,7 +18,8 @@ def get_extensions(build_type='release'):
 
     if (int(os.environ.get('ASTROPY_USE_SYSTEM_EXPAT', 0)) or
             int(os.environ.get('ASTROPY_USE_SYSTEM_ALL', 0))):
-        cfg.update(pkg_config(['expat'], ['expat']))
+        for k, v in pkg_config(['expat'], ['expat']).items():
+            cfg[k].extend(v)
     else:
         EXPAT_DIR = 'cextern/expat/lib'
         cfg['sources'].extend([

--- a/astropy/wcs/setup_package.py
+++ b/astropy/wcs/setup_package.py
@@ -191,7 +191,8 @@ def get_wcslib_cfg(cfg, wcslib_files, include_paths):
         wcsconfig_h_path = join(WCSROOT, 'include', 'wcsconfig.h')
         if os.path.exists(wcsconfig_h_path):
             os.unlink(wcsconfig_h_path)
-        cfg.update(pkg_config(['wcslib'], ['wcs']))
+        for k, v in pkg_config(['wcslib'], ['wcs']).items():
+            cfg[k].extend(v)
     else:
         write_wcsconfig_h(include_paths)
 


### PR DESCRIPTION
Fix #10534 : compiler arguments from `pkg_config` were overwriting the options already defined, e.g. `include_dirs`.

Not sure if this needs a changelog entry, I think this issue came with the helpers change in 4.1 ?