### PR TITLE
TST: Relax checks in wcsapi test

### DIFF
--- a/astropy/wcs/wcsapi/tests/test_fitswcs.py
+++ b/astropy/wcs/wcsapi/tests/test_fitswcs.py
@@ -273,18 +273,18 @@ def test_spectral_cube():
     coord, spec = wcs.pixel_to_world(29, 39, 44)
     assert isinstance(coord, SkyCoord)
     assert isinstance(coord.frame, Galactic)
-    assert coord.l.deg == 25
-    assert coord.b.deg == 10
+    assert_allclose(coord.l.deg, 25)
+    assert_allclose(coord.b.deg, 10)
     assert isinstance(spec, SpectralCoord)
-    assert spec.to_value(u.Hz) == 20
+    assert_allclose(spec.to_value(u.Hz), 20)
 
     coord, spec = wcs.array_index_to_world(44, 39, 29)
     assert isinstance(coord, SkyCoord)
     assert isinstance(coord.frame, Galactic)
-    assert coord.l.deg == 25
-    assert coord.b.deg == 10
+    assert_allclose(coord.l.deg, 25)
+    assert_allclose(coord.b.deg, 10)
     assert isinstance(spec, SpectralCoord)
-    assert spec.to_value(u.Hz) == 20
+    assert_allclose(spec.to_value(u.Hz), 20)
 
     coord = SkyCoord(25, 10, unit='deg', frame='galactic')
     spec = 20 * u.Hz


### PR DESCRIPTION
Fix #10537 -- I'll tentatively milestone to 4.1.1 given that the failure is not critical but if @eteq wants to put this in 4.1, feel free to remilestone.

cc @bnavigator 