### PR TITLE
still use `out` even if out.dtype is not float64

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -214,6 +214,9 @@ astropy.io.votable
 astropy.modeling
 ^^^^^^^^^^^^^^^^
 
+- Fixed an issue of ``Model.render`` when the input ``out`` datatype is not 
+  float64. [#10542]
+
 astropy.nddata
 ^^^^^^^^^^^^^^
 

--- a/astropy/modeling/core.py
+++ b/astropy/modeling/core.py
@@ -1494,7 +1494,7 @@ class Model(metaclass=_ModelMeta):
                 out = np.zeros(coords[0].shape)
 
         if out is not None:
-            out = np.asanyarray(out, dtype=float)
+            out = np.asanyarray(out)
             if out.ndim != ndim:
                 raise ValueError('the array and model must have the same '
                                  'number of dimensions.')
@@ -3256,7 +3256,7 @@ class CompoundModel(Model):
                 out = np.zeros(coords[0].shape)
 
         if out is not None:
-            out = np.asanyarray(out, dtype=float)
+            out = np.asanyarray(out)
             if out.ndim != ndim:
                 raise ValueError('the array and model must have the same '
                                  'number of dimensions.')

--- a/astropy/modeling/tests/test_core.py
+++ b/astropy/modeling/tests/test_core.py
@@ -359,6 +359,19 @@ def test_render_model_3d():
                     assert (np.sum(expected) - np.sum(boxed)) == 0
 
 
+def test_render_model_out_dtype():
+    """Test different out.dtype for model.render."""
+    for model in [models.Gaussian2D(), models.Gaussian2D() + models.Planar2D()]:
+        for dtype in [np.float64, np.float32, np.complex64]:
+            im = np.zeros((40, 40), dtype=dtype)
+            imout = model.render(out=im)
+            assert imout is im
+            assert imout.sum() != 0
+        with pytest.raises(TypeError):
+            im = np.zeros((40, 40), dtype=np.int32)
+            imout = model.render(out=im)
+
+
 def test_custom_bounding_box_1d():
     """
     Tests that the bounding_box setter works.


### PR DESCRIPTION


<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

`model.render(out=)` still creates a new array when out.dtype is not float64 (see below).
In such a situation, models will not be rendered into the existing array.

```python
In [1]: from astropy.modeling import models as apmodels 
   ...: import numpy as np 
   ...: g=apmodels.Gaussian2D(x_mean=20,y_mean=20)                                              

In [2]: out=np.zeros((40,40)) 
   ...: g.render(out) 
   ...: print(out.sum())                                                                        
6.2831853741872

In [3]: out=np.zeros((40,40),dtype=np.float32) 
   ...: g.render(out) 
   ...: print(out.sum())                                                                        
0.0
```

This pull request is supposed to address the issue.

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->
