### PR TITLE
Use system libraries on apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,10 @@ env:
 
         # For installing without tox, we can rely mostly on what Debian already
         # includes.  This is only used if SETUP_METHOD='apt'.
-        - APT_DEPENDENCIES="python3-pip python3-dev libpython3.8-dev python3.8-dev libexpat1-dev zlib1g-dev libc6-dev python3-venv python3-setuptools cython3 python3-astropy python3-numpy python3-pytest-astropy ipython3 python3-pytest-cov python3-pytest-xdist python3-objgraph python3-coverage python3-attr python3-colorama tzdata"
+        # Note that this also means it can be used to test whether astropy can
+        # properly use the system libraries, since the python3-astropy package
+        # pulls those in (i.e., one can and should use ASTROPY_USE_SYSTEM_ALL=1).
+        - APT_DEPENDENCIES="python3-pip python3-dev libpython3.8-dev python3.8-dev libexpat1-dev zlib1g-dev libc6-dev python3-venv python3-setuptools cython3 python3-astropy python3-numpy wcslib-dev libcfitsio-dev python3-pytest-astropy ipython3 python3-pytest-cov python3-pytest-xdist python3-objgraph python3-coverage python3-attr python3-colorama tzdata"
 
         # The following is needed to avoid issues if e.g. Matplotlib tries
         # to open a GUI window.
@@ -187,6 +190,7 @@ matrix:
           dist: bionic
           stage: Cron tests
           env: SETUP_METHOD='apt'
+               ASTROPY_USE_SYSTEM_ALL=1
 
         # And with an arm64 processor, again with apt for convenience.
         - name: arm64 architecture with apt
@@ -195,6 +199,7 @@ matrix:
           dist: bionic
           stage: Cron tests
           env: SETUP_METHOD='apt'
+               ASTROPY_USE_SYSTEM_ALL=1
 
         # Temporarily with amd64 and apt, to check.
         - name: amd64 architecture with apt
@@ -202,6 +207,7 @@ matrix:
           dist: bionic
           stage: Initial tests
           env: SETUP_METHOD='apt'
+               ASTROPY_USE_SYSTEM_ALL=1
 
         # Regularly make sure that astropy can be used in application bundles
         - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -201,14 +201,6 @@ matrix:
           env: SETUP_METHOD='apt'
                ASTROPY_USE_SYSTEM_ALL=1
 
-        # Temporarily with amd64 and apt, to check.
-        - name: amd64 architecture with apt
-          language: c
-          dist: bionic
-          stage: Initial tests
-          env: SETUP_METHOD='apt'
-               ASTROPY_USE_SYSTEM_ALL=1
-
         # Regularly make sure that astropy can be used in application bundles
         - language: python
           python: 3.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ env:
 
         # For installing without tox, we can rely mostly on what Debian already
         # includes.  This is only used if SETUP_METHOD='apt'.
-        - APT_DEPENDENCIES="python3-pip python3-dev python3-venv python3-setuptools cython3 ipython3 python3-jinja2 python3-numpy python3-pytest-astropy python3-pytest-cov python3-pytest-xdist python3-pytest-filter-subpackage python3-objgraph python3-coverage python3-attr tzdata"
+        - APT_DEPENDENCIES="python3-pip python3-dev libpython3.8-dev python3.8-dev libexpat1-dev zlib1g-dev libc6-dev python3-venv python3-setuptools cython3 python3-astropy python3-numpy python3-pytest-astropy ipython3 python3-pytest-cov python3-pytest-xdist python3-objgraph python3-coverage python3-attr python3-colorama tzdata"
 
         # The following is needed to avoid issues if e.g. Matplotlib tries
         # to open a GUI window.
@@ -196,6 +196,13 @@ matrix:
           stage: Cron tests
           env: SETUP_METHOD='apt'
 
+        # Temporarily with amd64 and apt, to check.
+        - name: amd64 architecture with apt
+          language: c
+          dist: bionic
+          stage: Initial tests
+          env: SETUP_METHOD='apt'
+
         # Regularly make sure that astropy can be used in application bundles
         - language: python
           python: 3.8
@@ -243,7 +250,7 @@ install:
         curl https://ftp-master.debian.org/keys/archive-key-10.asc | sudo apt-key add -;
         echo "deb http://ftp.us.debian.org/debian testing main" | sudo tee -a /etc/apt/sources.list;
         sudo apt-get -qq update;
-        sudo apt-get install -y --no-install-recommends ${APT_DEPENDENCIES};
+        sudo apt-get install -t testing -y --no-install-recommends ${APT_DEPENDENCIES};
       fi
 
 script:
@@ -254,7 +261,7 @@ script:
         python3 -m venv --system-site-packages tests;
         source tests/bin/activate;
         pip3 install -e .[test];
-        pytest-3;
+        python3 -m pytest;
       fi
 
 after_success:

--- a/astropy/wcs/tests/extension/setup.py
+++ b/astropy/wcs/tests/extension/setup.py
@@ -26,17 +26,17 @@ if __name__ == '__main__':
     else:
         define_macros = []
 
-    try:
-        numpy_include = np.get_include()
-    except AttributeError:
-        numpy_include = np.get_numpy_include()
-
+    # Below, we include a typical system include in case astropy was
+    # installed with ASTROPY_USE_SYSTEM_WCSLIB.  Good enough for the
+    # test, but a proper implementation would need to look better at
+    # where wcslib might be stalled.
     wcsapi_test_module = Extension(
         'wcsapi_test',
         include_dirs=[
-            numpy_include,
+            np.get_include(),
             os.path.join(wcs.get_include(), 'astropy_wcs'),
-            os.path.join(wcs.get_include(), 'wcslib')
+            os.path.join(wcs.get_include(), 'wcslib'),
+            os.path.join('/usr/include', 'wcslib'),
         ],
         # Use the *full* name to the c file, since we can't change the cwd
         # during testing


### PR DESCRIPTION
This fixes the problem with the apt build. I'm not 100% happy with having to keep on overwriting outdated stuff in ubuntu, but it seems most important now to just having working builds again. I'll experiment with a more permanent solution in #10455 

Since Debian uses system libraries for astropy, this is the perfect place to test it.

fixes #10539
fixes #10561

note: just running an `amd64` CI now, since `s390x` and `arm64` seem very slow. Once, approved, I'll remove that run.

EDIT: on purpose cancelled Circle-CI and most travis runs. Relevant run is at
~https://travis-ci.org/github/astropy/astropy/jobs/707078463~ https://travis-ci.org/github/astropy/astropy/jobs/707174503