### PR TITLE
Convert 'ctype_name' to uppercase before appending to 'types'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -353,6 +353,9 @@ astropy.visualization
 astropy.wcs
 ^^^^^^^^^^^
 
+- Add .upper() to ctype or ctype names to wcsapi/fitwcs.py to mitigate bugs from
+  unintended lower/upper case issues [#10557]
+
 Other Changes and Additions
 ---------------------------
 

--- a/astropy/wcs/wcsapi/fitswcs.py
+++ b/astropy/wcs/wcsapi/fitswcs.py
@@ -250,7 +250,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
         types = []
         # TODO: need to support e.g. TT(TAI)
         for ctype in self.wcs.ctype:
-            if ctype.startswith(('UT(', 'TT(')):
+            if ctype.upper().startswith(('UT(', 'TT(')):
                 types.append('time')
             else:
                 ctype_name = ctype.split('-')[0]
@@ -259,7 +259,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
                         types.append(custom_mapping[ctype_name])
                         break
                 else:
-                    types.append(CTYPE_TO_UCD1.get(ctype_name, None))
+                    types.append(CTYPE_TO_UCD1.get(ctype_name.upper(), None))
         return types
 
     @property
@@ -396,6 +396,7 @@ class FITSWCSAPIMixin(BaseLowLevelWCS, HighLevelWCSMixin):
             # Find index of spectral coordinate
             ispec = self.wcs.spec
             ctype = self.wcs.ctype[ispec][:4]
+            ctype = ctype.upper()
 
             kwargs = {}
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address the problem of some error(s) in wcs auto-linking that could arise if the input `CTYPEn` is not in uppercase. During some work on the `glue-solar` project for GSoC 2020, it was found that the `world_axis_physical_types` of a `wcs` object would not pick up a keyword that is not in all uppercase, which in our case was the `CTYPE3 = 'Time    '` for an IRIS SJI data cube. This would not be picked up by `wcs.world_axis_physical_types` as a valid entry as all and would output a NoneType instead. But after we have edited the corresponding `FITS` header to read `CTYPE3 = 'TIME    '` in lieu of the original, we would get the `wcs.world_axis_physical_types` as expected. 

So in case of situations such as these, we (me at the suggestion of @Cadair) are proposing pre-processing at the `astropy`-level to turn the CTYPE into uppercase before further processing downstream. Any discussion regarding this matter is welcome. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

<!-- Fixes #<Issue Number> -->
