### PR TITLE
Fixing issue #9384: Documenting long string representations for Time objects

### DIFF
--- a/docs/time/index.rst
+++ b/docs/time/index.rst
@@ -1067,6 +1067,25 @@ Note that two |Time| objects with a different ``scale`` can compare equally
 but still have different hash keys. This a practical consideration driven
 in by performance, but in most cases represents a desirable behavior.
 
+
+Printing Time Arrays
+^^^^^^^^^^^^^^^^^^^^
+
+If your ``times`` array contains a lot of elements, the ``value`` argument will
+display all the elements of the |Time| object ``t`` when it is called or
+printed. To control the number of elements to be displayed, set the
+``threshold`` argument with ``np.printoptions`` as follows:
+
+    >>> many_times = np.arange(1000)
+    >>> t = Time(many_times, format='cxcsec')
+    >>> with np.printoptions(threshold=10):
+    ...     print(repr(t))
+    ...     print(t.iso)
+    <Time object: scale='tt' format='cxcsec' value=[  0.   1.   2. ... 997. 998. 999.]>
+    ['1998-01-01 00:00:00.000' '1998-01-01 00:00:01.000'
+     '1998-01-01 00:00:02.000' ... '1998-01-01 00:16:37.000'
+     '1998-01-01 00:16:38.000' '1998-01-01 00:16:39.000']
+
 Sidereal Time
 -------------
 


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request is to address issue #9384. It adds documentation to the Getting Started section of the astropy.time documentation to inform users about an option to set the threshold for printing shorthand string representations of a Time object, similar to standard numpy representations of long length arrays. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

Fixes #9384 
