### PR TITLE
Added zeros class method in ICRS [#10241]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ astropy.convolution
 astropy.coordinates
 ^^^^^^^^^^^^^^^^^^^
 
+- Allow user to call ``ICRS.zeros()`` to construct ``ICRS`` class with arguments
+  ``ra``, ``dec``, ``pm_ra_cosdec``, ``pm_dec``, ``distance``, and
+  ``radial_velocity`` equal to 0. [#10559]
+
 - Numpy functions that broadcast, change shape, or index (like ``np.broadcast_to``,
   ``np.rot90``, or ``np.roll``) now work on coordinates, frames, and
   representations. [#10337]

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -4,6 +4,7 @@
 from astropy.utils.decorators import format_doc
 from astropy.coordinates.baseframe import base_doc
 from .baseradec import BaseRADecFrame, doc_components
+from astropy import units as u
 
 __all__ = ['ICRS']
 
@@ -22,9 +23,14 @@ class ICRS(BaseRADecFrame):
     the references provided in the  :ref:`astropy-coordinates-seealso` section
     of the documentation.
     """
+
     # Use if ICRS args ra, dec, pm_ra_codec, om_dec, distance, rad_velocity  are all zero
     # Avoids repetitive code
     @classmethod
     def zeros(cls):
-        return ICRS(0, 0, 0, 0, 0, 0)
-
+        """
+        Returns the ICRS class initialized with 6 zeros as arguments
+        """
+        return ICRS(ra=0 * u.degree, dec=0 * u.degree,
+                    pm_ra_cosdec=0 * u.mas / u.yr, pm_dec=0 * u.mas / u.yr,
+                    distance=0 * u.pc, radial_velocity=0 * u.km / u.s)

--- a/astropy/coordinates/builtin_frames/icrs.py
+++ b/astropy/coordinates/builtin_frames/icrs.py
@@ -22,3 +22,9 @@ class ICRS(BaseRADecFrame):
     the references provided in the  :ref:`astropy-coordinates-seealso` section
     of the documentation.
     """
+    # Use if ICRS args ra, dec, pm_ra_codec, om_dec, distance, rad_velocity  are all zero
+    # Avoids repetitive code
+    @classmethod
+    def zeros(cls):
+        return ICRS(0, 0, 0, 0, 0, 0)
+

--- a/astropy/coordinates/tests/test_frames.py
+++ b/astropy/coordinates/tests/test_frames.py
@@ -1473,3 +1473,19 @@ def test_galactocentric_references(reset_galactocentric_defaults):
                 assert k not in galcen_custom.frame_attribute_references
             else:
                 assert k in galcen_custom.frame_attribute_references
+
+
+def test_icrs_zeros():
+    # see https://github.com/astropy/astropy/issues/10241 for enhancement context
+    # test to see if using zeros() class method results in same expected output
+    from astropy.coordinates.builtin_frames import ICRS
+    i = ICRS.zeros()
+    assert repr(i) == '<ICRS Coordinate: (ra, dec, distance) in (deg, deg, pc)\n    (0., 0., 0.)\n ' \
+            '(pm_ra_cosdec, pm_dec, radial_velocity) in (mas / yr, mas / yr, km / s)\n' \
+            '    (0., 0., 0.)>'
+    assert i.ra == 0
+    assert i.dec == 0
+    assert i.distance == 0
+    assert i.pm_ra_cosdec == 0
+    assert i.pm_dec == 0
+    assert i.radial_velocity == 0


### PR DESCRIPTION
This pull request is to address #10241. I added a class method to the ICRS doc frame
which will eliminate the need to write repetitive code if the 6 arguments used are all
zeros. I have not started on implementing the ICRS random class method as I don't
know the range of values expected as arguments in ICRS. 

Contributes to #10241 
