### PR TITLE
DOC: Fix linkcheck ref target not found

### DIFF
--- a/docs/nitpick-exceptions
+++ b/docs/nitpick-exceptions
@@ -81,7 +81,6 @@ py:obj distutils.version.LooseVersion
 py:obj pkg_resources.parse_version
 py:class pandas.DataFrame
 
-
 # Pending on python docs links issue #11975
 py:class list
 py:obj list.append
@@ -111,3 +110,6 @@ py:class v, remove specified key and return the corresponding value.
 py:class None.  Update D from dict/iterable E and F.
 py:class an object providing a view on D's values
 py:class a shallow copy of D
+
+# This extends the numpydoc list above to fix lincheck warning
+py:class reference target not found: (k, v)


### PR DESCRIPTION
For some reason, this only appears in the link check (cron) job. 🤷 

```
Warning, treated as error:
astropy/timeseries/__init__.py:docstring of astropy.timeseries.BoxLeastSquaresResults.popitem::py:class reference target not found: (k, v), remove and return some (key, value) pair as a
ERROR: InvocationError for command .../sphinx-build -W -b linkcheck . _build/html (exited with code 2)
```

Example log: https://travis-ci.org/github/astropy/astropy/jobs/707690795