### PR TITLE
Change parsec definition to small-angle (linear) approximation following IAU 2015 B2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1009,6 +1009,8 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
+- Corrected definition of parsec to 648 000 / pi AU following IAU 2015 B2 [#10569]
+
 astropy.utils
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -857,6 +857,8 @@ astropy.config
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 
+- Corrected definition of parsec to 648 000 / pi AU following IAU 2015 B2 [#10569]
+
 astropy.convolution
 ^^^^^^^^^^^^^^^^^^^
 
@@ -1009,7 +1011,7 @@ astropy.uncertainty
 astropy.units
 ^^^^^^^^^^^^^
 
-- Corrected definition of parsec to 648 000 / pi AU following IAU 2015 B2 [#10569]
+- Refined test_parallax to resolve difference between 2012 and 2015 definitions. [#10569]
 
 astropy.utils
 ^^^^^^^^^^^^^

--- a/astropy/constants/iau2015.py
+++ b/astropy/constants/iau2015.py
@@ -26,15 +26,15 @@ au = IAU2015('au', "Astronomical Unit", 1.49597870700e11, 'm', 0.0,
 
 # Parsec
 
-pc = IAU2015('pc', "Parsec", au.value / np.tan(np.radians(1. / 3600.)), 'm',
-             au.uncertainty / np.tan(np.radians(1. / 3600.)),
-             "Derived from au", system='si')
+pc = IAU2015('pc', "Parsec", au.value / np.radians(1. / 3600.), 'm',
+             au.uncertainty / np.radians(1. / 3600.),
+             "Derived from au + IAU 2015 Resolution B 2 note [4]", system='si')
 
 # Kiloparsec
 kpc = IAU2015('kpc', "Kiloparsec",
-              1000. * au.value / np.tan(np.radians(1. / 3600.)), 'm',
-              1000. * au.uncertainty / np.tan(np.radians(1. / 3600.)),
-              "Derived from au", system='si')
+              1000. * au.value / np.radians(1. / 3600.), 'm',
+              1000. * au.uncertainty / np.radians(1. / 3600.),
+              "Derived from au + IAU 2015 Resolution B 2 note [4]", system='si')
 
 # Luminosity
 L_bol0 = IAU2015('L_bol0', "Luminosity for absolute bolometric magnitude 0",

--- a/astropy/constants/tests/test_prior_version.py
+++ b/astropy/constants/tests/test_prior_version.py
@@ -3,6 +3,7 @@
 import copy
 
 import pytest
+import numpy as np
 
 from astropy.constants import Constant
 from astropy.units import Quantity as Q
@@ -93,6 +94,16 @@ def test_b_wien():
     t = 5778 * u.K
     w = (b_wien / t).to(u.nm)
     assert round(w.value) == 502
+
+
+def test_pc():
+    """Parsec is defined to use small-angle limit per IAU 2015 Resolution B 2.
+    iau2012 version still uses tan(parallax).
+    """
+    from astropy.constants import iau2012
+    from astropy import units as u
+    plx = np.radians(1 / 3600)
+    assert np.allclose(u.pc.to('m') / iau2012.pc.si.value, np.tan(plx) / plx, rtol=1.e-14, atol=0)
 
 
 def test_masses():

--- a/astropy/units/tests/test_equivalencies.py
+++ b/astropy/units/tests/test_equivalencies.py
@@ -219,14 +219,14 @@ def test_is_equivalent():
 
 def test_parallax():
     a = u.arcsecond.to(u.pc, 10, u.parallax())
-    assert_allclose(a, 0.10)
+    assert_allclose(a, 0.10, rtol=1.e-12)
     b = u.pc.to(u.arcsecond, a, u.parallax())
-    assert_allclose(b, 10)
+    assert_allclose(b, 10, rtol=1.e-12)
 
     a = u.arcminute.to(u.au, 1, u.parallax())
-    assert_allclose(a, 3437.7467916)
+    assert_allclose(a, 3437.746770785, rtol=1.e-12)
     b = u.au.to(u.arcminute, a, u.parallax())
-    assert_allclose(b, 1)
+    assert_allclose(b, 1, rtol=1.e-12)
 
     val = (-1 * u.mas).to(u.pc, u.parallax())
     assert np.isnan(val.value)
@@ -237,7 +237,7 @@ def test_parallax():
 
 def test_parallax2():
     a = u.arcsecond.to(u.pc, [0.1, 2.5], u.parallax())
-    assert_allclose(a, [10, 0.4])
+    assert_allclose(a, [10, 0.4], rtol=1.e-12)
 
 
 def test_spectral():

--- a/docs/units/conversion.rst
+++ b/docs/units/conversion.rst
@@ -18,7 +18,7 @@ new units are returned.
 
   >>> from astropy import units as u
   >>> u.pc.to(u.m, 3.26)
-  1.0059308915583043e+17
+  1.0059308915661856e+17
 
 This converts 3.26 parsecs to meters.
 


### PR DESCRIPTION
Addresses #10568 – this replaces the `np.tan` in the definition of `constants.iau2015.pc` with the linear angle, making 1 pc exactly `(648 000/np.pi) constants.au` as noted in the IAU resolution.

This commit only changes `iau2015.py`, it remains open if `iau2012.py` should adopt the same definition. If not, an additional test in `test_prior_version.py` might check for the differences between the 2.
So far the `u.arcminute.to(u.au, 1, u.parallax())` check in `test_parallax` detects the difference with tightened `rtol`.

Lastly for discussion, the `parallax_converter` in `equivalencies` already uses the linear form; one might argue that this should in fact use the trigonometric function for really large parallaxes(as in the `u.arcminute` test), but since the equivalency is defined commutative in angle and distance, there is no direct way to implement this – and maybe would go beyond the concept of an equivalency.
EDIT: I have worked out how to use `np.tan` and `np.arctan`, respectively, in `parallax_converter` when used as the `forward` or `backward` converter function, so this _could_ be implemented, but would of course change results. Might be better to implement this through an optional argument to `u.parallax`, if at all.