### PR TITLE
Make finding home directory more general

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -915,6 +915,9 @@ Bug fixes
 astropy.config
 ^^^^^^^^^^^^^^
 
+- Added an extra fallback to ``os.expanduser('~')`` when trying to find the
+  user home directory. [#10570]
+
 astropy.constants
 ^^^^^^^^^^^^^^^^^
 

--- a/astropy/config/paths.py
+++ b/astropy/config/paths.py
@@ -33,8 +33,11 @@ def _find_home():
         if 'HOME' in os.environ:
             homedir = os.environ['HOME']
         else:
-            raise OSError('Could not find unix home directory to search for '
-                          'astropy config dir')
+            try:
+                return os.path.expanduser('~')
+            except Exception as e:
+                raise OSError('Could not find unix home directory to search for '
+                              'astropy config dir')
     elif os.name == 'nt':  # This is for all modern Windows (NT or after)
         if 'MSYSTEM' in os.environ and os.environ.get('HOME'):
             # Likely using an msys shell; use whatever it is using for its


### PR DESCRIPTION
In sunpy we are seeing CI failures due to astropy not being able to find the home directory on macos: https://dev.azure.com/sunpy/sunpy/_build/results?buildId=8869&view=logs&jobId=6e7bd578-a810-548b-8fbf-8fa6b1a2d4f6&j=8b26c057-390d-57e7-9a94-ed463b57befe&t=7cf2f17d-5054-541f-491b-2e6078562aef

This seems to be because the 'HOME' environment variable isn't set. This PR makes finding home more lenient by trying to use `os.path.expanduser('~')` as a backup if the 'HOME' environment variable isn't set. This is in line with what IPython now do, which according to the comments this function is based on
https://github.com/ipython/ipython/blob/f8c9ea7db42d9830f16318a4ceca0ac1c3688697/IPython/utils/path.py#L190